### PR TITLE
refactor(clippy): apply clippy suggestions

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -353,7 +353,7 @@ impl Buffer {
     }
 
     pub fn _delete_to_next_word(&mut self, (x, y): (usize, usize)) {
-        let (fx, fy) = self.find_word_end((x, y)).unwrap();
+        let (_fx, _fy) = self.find_word_end((x, y)).unwrap();
         let line = self.get(y).unwrap();
         let rest = line[x..].to_string();
         self.lines[y] = line[..x].to_string();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -100,7 +100,7 @@ impl Buffer {
             msg.diagnostics
                 .iter()
                 .filter(|d| d.is_for(&uri))
-                .map(|d| d.clone())
+                .cloned()
                 .collect::<Vec<_>>(),
         );
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -192,7 +192,8 @@ impl Buffer {
         let line = self.get(y)?;
         let mut x = x;
         let mut chars = line.chars().skip(x);
-        while let Some(c) = chars.next() {
+
+        for c in  chars {
             if x >= line.len() {
                 return Some((x, y));
             }
@@ -211,7 +212,7 @@ impl Buffer {
         let mut x = x;
         let mut chars = line.chars().rev().skip(line.len() - x);
 
-        while let Some(c) = chars.next() {
+        for c in chars {
             if x == 0 {
                 return Some((x, y));
             }
@@ -234,7 +235,7 @@ impl Buffer {
         loop {
             let mut chars = line.chars();
 
-            while let Some(c) = chars.next() {
+            for c in chars {
                 if c.is_alphanumeric() || c == '_' {
                     return Some((x, y));
                 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -23,7 +23,7 @@ pub struct Buffer {
 
 impl Buffer {
     pub fn new(file: Option<String>, contents: String) -> Self {
-        let has_newline_at_end = contents.ends_with("\n");
+        let has_newline_at_end = contents.ends_with('\n');
         let lines = contents.lines().map(|s| s.to_string()).collect();
         Self {
             file,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -352,8 +352,7 @@ impl Buffer {
         self.dirty = true;
     }
 
-    #[allow(unused)]
-    pub fn delete_to_next_word(&mut self, (x, y): (usize, usize)) {
+    pub fn _delete_to_next_word(&mut self, (x, y): (usize, usize)) {
         let (fx, fy) = self.find_word_end((x, y)).unwrap();
         let line = self.get(y).unwrap();
         let rest = line[x..].to_string();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -191,7 +191,7 @@ impl Buffer {
     pub fn find_word_end(&self, (x, y): (usize, usize)) -> Option<(usize, usize)> {
         let line = self.get(y)?;
         let mut x = x;
-        let mut chars = line.chars().skip(x);
+        let chars = line.chars().skip(x);
 
         for c in  chars {
             if x >= line.len() {
@@ -210,7 +210,7 @@ impl Buffer {
     pub fn find_word_start(&self, (x, y): (usize, usize)) -> Option<(usize, usize)> {
         let line = self.get(y)?;
         let mut x = x;
-        let mut chars = line.chars().rev().skip(line.len() - x);
+        let chars = line.chars().rev().skip(line.len() - x);
 
         for c in chars {
             if x == 0 {
@@ -233,7 +233,7 @@ impl Buffer {
         let mut line = line[x..].to_string();
 
         loop {
-            let mut chars = line.chars();
+            let chars = line.chars();
 
             for c in chars {
                 if c.is_alphanumeric() || c == '_' {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -142,7 +142,7 @@ impl Buffer {
 
     pub fn insert(&mut self, x: usize, y: usize, c: char) {
         if let Some(line) = self.lines.get_mut(y) {
-            (*line).insert(x as usize, c);
+            (*line).insert(x, c);
             self.dirty = true;
         }
     }
@@ -150,7 +150,7 @@ impl Buffer {
     /// removes a character from the buffer
     pub fn remove(&mut self, x: usize, y: usize) {
         if let Some(line) = self.lines.get_mut(y) {
-            (*line).remove(x as usize);
+            (*line).remove(x);
             self.dirty = true;
         }
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -77,7 +77,7 @@ impl Buffer {
         };
         Ok(Some(format!(
             "file://{}",
-            Path::new(&file).absolutize()?.to_string_lossy().to_string()
+            Path::new(&file).absolutize()?.to_string_lossy()
         )))
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1676,10 +1676,11 @@ impl Editor {
 
                 mappings.get(&key).cloned()
             }
-            event::Event::Mouse(mev) => match mev {
-                MouseEvent {
+            event::Event::Mouse(mev) => {
+                let MouseEvent {
                     kind, column, row, ..
-                } => match kind {
+                } = mev;
+                match kind {
                     MouseEventKind::Down(MouseButton::Left) => {
                         let x = (*column as usize).saturating_sub(self.gutter_width() + 1);
                         Some(KeyAction::Single(Action::MoveTo(
@@ -1689,8 +1690,9 @@ impl Editor {
                     }
                     MouseEventKind::ScrollUp => Some(KeyAction::Single(Action::ScrollUp)),
                     MouseEventKind::ScrollDown => Some(KeyAction::Single(Action::ScrollDown)),
+
                     _ => None,
-                },
+                }
             },
             _ => None,
         }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1320,7 +1320,7 @@ impl Editor {
 
                 if distance_to_center > 0 {
                     // if distance > 0 we need to scroll up
-                    let distance_to_center = distance_to_center.abs() as usize;
+                    let distance_to_center = distance_to_center.unsigned_abs();
                     if self.vtop > distance_to_center {
                         let new_vtop = self.vtop + distance_to_center;
                         self.vtop = new_vtop;
@@ -1329,7 +1329,7 @@ impl Editor {
                     }
                 } else if distance_to_center < 0 {
                     // if distance < 0 we need to scroll down
-                    let distance_to_center = distance_to_center.abs() as usize;
+                    let distance_to_center = distance_to_center.unsigned_abs();
                     let new_vtop = self.vtop.saturating_sub(distance_to_center);
                     let distance_to_go = self.vtop + distance_to_center;
                     if self.current_buffer().len() > distance_to_go && new_vtop != self.vtop {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1208,11 +1208,10 @@ impl Editor {
                 if self.is_normal() && matches!(new_mode, Mode::Insert) {
                     self.insert_undo_actions = Vec::new();
                 }
-                if self.is_insert() && matches!(new_mode, Mode::Normal) {
-                    if !self.insert_undo_actions.is_empty() {
-                        let actions = mem::take(&mut self.insert_undo_actions);
-                        self.undo_actions.push(Action::UndoMultiple(actions));
-                    }
+                if self.is_insert() && matches!(new_mode, Mode::Normal) && !self.insert_undo_actions.is_empty() {
+                    let actions = mem::take(&mut self.insert_undo_actions);
+                    self.undo_actions.push(Action::UndoMultiple(actions));
+                    
                 }
                 if self.has_term() {
                     self.draw_commandline(buffer);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -91,7 +91,7 @@ pub enum Action {
 pub enum _GoToLinePosition {
     Top,
     Center,
-    Bottom,
+    _Bottom,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -1605,7 +1605,7 @@ impl Editor {
                 self.cy = y - self.vtop;
                 self.draw_viewport(buffer)?;
             } else {
-                if matches!(pos, _GoToLinePosition::Bottom) {
+                if matches!(pos, _GoToLinePosition::_Bottom) {
                     self.vtop = y - self.vheight();
                     self.cy = self.buffer_line() - self.vtop;
                 } else {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1179,7 +1179,6 @@ impl Editor {
                 self.cx = self.cx.saturating_sub(1);
                 if self.cx < self.vleft {
                     self.cx = self.vleft;
-                } else {
                 }
             }
             Action::MoveRight => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -81,7 +81,7 @@ pub enum Action {
     DumpBuffer,
     Command(String),
     SetCursor(usize, usize),
-    SetWaitingKeyAction(Box<KeyAction>),
+    SetWaitingKey(Box<KeyAction>),
     OpenFile(String),
 
     NextBuffer,
@@ -1278,7 +1278,7 @@ impl Editor {
                 self.current_buffer_mut().insert_line(line, new_line);
                 self.draw_viewport(buffer)?;
             }
-            Action::SetWaitingKeyAction(key_action) => {
+            Action::SetWaitingKey(key_action) => {
                 self.waiting_key_action = Some(*(key_action.clone()));
             }
             Action::DeleteCurrentLine => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -343,7 +343,7 @@ impl Editor {
     }
 
     fn buffer_line(&self) -> usize {
-        self.vtop + self.cy as usize
+        self.vtop + self.cy
     }
 
     fn viewport_line(&self, n: usize) -> Option<String> {
@@ -386,8 +386,8 @@ impl Editor {
             .bg
             .unwrap_or(self.theme.style.bg.expect("bg is defined for theme"));
 
-        for n in 0..self.vheight() as usize {
-            let line_number = n + 1 + self.vtop as usize;
+        for n in 0..self.vheight() {
+            let line_number = n + 1 + self.vtop;
             let text = if line_number <= self.current_buffer().len() {
                 line_number.to_string()
             } else {
@@ -414,7 +414,7 @@ impl Editor {
         self.check_bounds();
 
         let cursor_pos = if self.has_term() {
-            (self.term().len() as u16 + 1, (self.size.1 - 1) as u16)
+            (self.term().len() as u16 + 1, (self.size.1 - 1))
         } else {
             ((self.vx + self.cx) as u16, self.cy as u16)
         };
@@ -471,9 +471,7 @@ impl Editor {
     }
 
     pub fn draw_viewport(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
-        let vbuffer = self
-            .current_buffer()
-            .viewport(self.vtop, self.vheight() as usize);
+        let vbuffer = self.current_buffer().viewport(self.vtop, self.vheight());
         let style_info = self.highlight(&vbuffer)?;
         let vheight = self.vheight();
         let default_style = self.theme.style.clone();
@@ -689,7 +687,7 @@ impl Editor {
 
         // check if cy is after the end of the buffer
         // the end of the buffer is less than vtop + cy
-        let line_on_buffer = self.cy as usize + self.vtop;
+        let line_on_buffer = self.cy + self.vtop;
         if line_on_buffer > self.current_buffer().len().saturating_sub(1) {
             self.cy = self.current_buffer().len() - self.vtop - 1;
         }
@@ -1202,13 +1200,13 @@ impl Editor {
             }
             Action::PageUp => {
                 if self.vtop > 0 {
-                    self.vtop = self.vtop.saturating_sub(self.vheight() as usize);
+                    self.vtop = self.vtop.saturating_sub(self.vheight());
                     self.draw_viewport(buffer)?;
                 }
             }
             Action::PageDown => {
-                if self.current_buffer().len() > self.vtop + self.vheight() as usize {
-                    self.vtop += self.vheight() as usize;
+                if self.current_buffer().len() > self.vtop + self.vheight() {
+                    self.vtop += self.vheight();
                     self.draw_viewport(buffer)?;
                 }
             }
@@ -1333,7 +1331,7 @@ impl Editor {
                     // if distance < 0 we need to scroll down
                     let distance_to_center = distance_to_center.abs() as usize;
                     let new_vtop = self.vtop.saturating_sub(distance_to_center);
-                    let distance_to_go = self.vtop as usize + distance_to_center;
+                    let distance_to_go = self.vtop + distance_to_center;
                     if self.current_buffer().len() > distance_to_go && new_vtop != self.vtop {
                         self.vtop = new_vtop;
                         self.cy = viewport_center;
@@ -1380,9 +1378,9 @@ impl Editor {
                 self.draw_viewport(buffer)?;
             }
             Action::MoveToBottom => {
-                if self.current_buffer().len() > self.vheight() as usize {
+                if self.current_buffer().len() > self.vheight() {
                     self.cy = self.vheight() - 1;
-                    self.vtop = self.current_buffer().len() - self.vheight() as usize;
+                    self.vtop = self.current_buffer().len() - self.vheight();
                     self.draw_viewport(buffer)?;
                 } else {
                     self.cy = self.current_buffer().len() - 1;
@@ -1446,7 +1444,7 @@ impl Editor {
                 }
             }
             Action::ScrollDown => {
-                if self.current_buffer().len() > self.vtop + self.vheight() as usize {
+                if self.current_buffer().len() > self.vtop + self.vheight() {
                     self.vtop += self.config.mouse_scroll_lines.unwrap_or(3);
                     let desired_cy = self
                         .cy

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1718,7 +1718,7 @@ impl Editor {
     }
 }
 
-fn determine_style_for_position(style_info: &Vec<StyleInfo>, pos: usize) -> Option<Style> {
+fn determine_style_for_position(style_info: &[StyleInfo], pos: usize) -> Option<Style> {
     if let Some(s) = style_info.iter().find(|si| si.contains(pos)) {
         return Some(s.style.clone());
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -904,7 +904,7 @@ impl Editor {
             }
             InboundMessage::Notification(msg) => match msg {
                 ParsedNotification::PublishDiagnostics(msg) => {
-                    _ = self.current_buffer_mut().offer_diagnostics(&msg);
+                    _ = self.current_buffer_mut().offer_diagnostics(msg);
                     None
                 }
             },
@@ -932,7 +932,7 @@ impl Editor {
         self.draw_statusline(buffer);
         self.draw_commandline(buffer);
         self.draw_diagnostics(buffer);
-        self.render_diff(buffer.diff(&current_buffer))?;
+        self.render_diff(buffer.diff(current_buffer))?;
         self.draw_cursor(buffer)?;
         self.stdout.execute(Show)?;
         Ok(())
@@ -1080,11 +1080,11 @@ impl Editor {
             panic!("expected nested mappings");
         };
 
-        self.event_to_key_action(&nested_mappings, &ev)
+        self.event_to_key_action(&nested_mappings, ev)
     }
 
     fn handle_insert_event(&self, ev: &event::Event) -> Option<KeyAction> {
-        if let Some(ka) = self.event_to_key_action(&self.config.keys.insert, &ev) {
+        if let Some(ka) = self.event_to_key_action(&self.config.keys.insert, ev) {
             return Some(ka);
         }
 
@@ -1098,7 +1098,7 @@ impl Editor {
     }
 
     fn handle_normal_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
-        self.event_to_key_action(&self.config.keys.normal, &ev)
+        self.event_to_key_action(&self.config.keys.normal, ev)
     }
 
     pub fn cleanup(&mut self) -> anyhow::Result<()> {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -271,7 +271,7 @@ impl Editor {
         theme: Theme,
         buffers: Vec<Buffer>,
     ) -> anyhow::Result<Self> {
-        let mut stdout = stdout();
+        let stdout = stdout();
         let vx = buffers
             .get(0)
             .map(|b| b.len().to_string().len())

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -88,8 +88,7 @@ pub enum Action {
     PreviousBuffer,
 }
 
-#[allow(unused)]
-pub enum GoToLinePosition {
+pub enum _GoToLinePosition {
     Top,
     Center,
     Bottom,
@@ -126,13 +125,11 @@ struct Cell {
 pub struct RenderBuffer {
     cells: Vec<Cell>,
     width: usize,
-    #[allow(unused)]
-    height: usize,
+    _height: usize,
 }
 
 impl RenderBuffer {
-    #[allow(unused)]
-    fn new_with_contents(width: usize, height: usize, style: Style, contents: Vec<String>) -> Self {
+    fn _new_with_contents(width: usize, height: usize, style: Style, contents: Vec<String>) -> Self {
         let mut cells = vec![];
 
         for line in contents {
@@ -153,7 +150,7 @@ impl RenderBuffer {
         RenderBuffer {
             cells,
             width,
-            height,
+            _height: height,
         }
     }
 
@@ -169,7 +166,7 @@ impl RenderBuffer {
         RenderBuffer {
             cells,
             width,
-            height,
+            _height: height,
         }
     }
 
@@ -223,8 +220,7 @@ impl RenderBuffer {
         s
     }
 
-    #[allow(unused)]
-    fn apply(&mut self, diff: Vec<Change<'_>>) {
+    fn _apply(&mut self, diff: Vec<Change<'_>>) {
         for change in diff {
             let pos = (change.y * self.width) + change.x;
             self.cells[pos] = Cell {
@@ -267,7 +263,6 @@ pub struct Editor {
 }
 
 impl Editor {
-    #[allow(unused)]
     pub fn with_size(
         lsp: LspClient,
         width: usize,
@@ -1404,7 +1399,7 @@ impl Editor {
                 }
             }
             Action::GoToLine(line) => {
-                self.go_to_line(*line, buffer, GoToLinePosition::Center)
+                self.go_to_line(*line, buffer, _GoToLinePosition::Center)
                     .await?
             }
             Action::GoToDefinition => {
@@ -1415,7 +1410,7 @@ impl Editor {
                 }
             }
             Action::MoveTo(x, y) => {
-                self.go_to_line(*y, buffer, GoToLinePosition::Center)
+                self.go_to_line(*y, buffer, _GoToLinePosition::Center)
                     .await?;
                 self.cx = std::cmp::min(*x, self.line_length().saturating_sub(1));
             }
@@ -1451,7 +1446,7 @@ impl Editor {
 
                 if let Some((x, y)) = next_word {
                     self.cx = x;
-                    self.go_to_line(y + 1, buffer, GoToLinePosition::Top)
+                    self.go_to_line(y + 1, buffer, _GoToLinePosition::Top)
                         .await?;
                     self.draw_cursor(buffer)?;
                 }
@@ -1463,7 +1458,7 @@ impl Editor {
 
                 if let Some((x, y)) = previous_word {
                     self.cx = x;
-                    self.go_to_line(y + 1, buffer, GoToLinePosition::Top)
+                    self.go_to_line(y + 1, buffer, _GoToLinePosition::Top)
                         .await?;
                     self.draw_cursor(buffer)?;
                 }
@@ -1501,7 +1496,7 @@ impl Editor {
                     .find_prev(&self.search_term, (self.cx, self.vtop + self.cy))
                 {
                     self.cx = x;
-                    self.go_to_line(y + 1, buffer, GoToLinePosition::Center)
+                    self.go_to_line(y + 1, buffer, _GoToLinePosition::Center)
                         .await?;
                 }
             }
@@ -1511,7 +1506,7 @@ impl Editor {
                     .find_next(&self.search_term, (self.cx, self.vtop + self.cy))
                 {
                     self.cx = x;
-                    self.go_to_line(y + 1, buffer, GoToLinePosition::Center)
+                    self.go_to_line(y + 1, buffer, _GoToLinePosition::Center)
                         .await?;
                 }
             }
@@ -1589,7 +1584,7 @@ impl Editor {
         &mut self,
         line: usize,
         buffer: &mut RenderBuffer,
-        pos: GoToLinePosition,
+        pos: _GoToLinePosition,
     ) -> anyhow::Result<()> {
         if line == 0 {
             self.execute(&Action::MoveToTop, buffer).await?;
@@ -1610,13 +1605,13 @@ impl Editor {
                 self.cy = y - self.vtop;
                 self.draw_viewport(buffer)?;
             } else {
-                if matches!(pos, GoToLinePosition::Bottom) {
+                if matches!(pos, _GoToLinePosition::Bottom) {
                     self.vtop = y - self.vheight();
                     self.cy = self.buffer_line() - self.vtop;
                 } else {
                     self.vtop = y;
                     self.cy = 0;
-                    if matches!(pos, GoToLinePosition::Center) {
+                    if matches!(pos, _GoToLinePosition::Center) {
                         self.execute(&Action::MoveLineToViewportCenter, buffer)
                             .await?;
                     }
@@ -1907,8 +1902,8 @@ mod test {
         let contents1 = vec![" 1:2 ".to_string()];
         let contents2 = vec![" 1:3 ".to_string()];
 
-        let buffer1 = RenderBuffer::new_with_contents(5, 1, Style::default(), contents1);
-        let buffer2 = RenderBuffer::new_with_contents(5, 1, Style::default(), contents2);
+        let buffer1 = RenderBuffer::_new_with_contents(5, 1, Style::default(), contents1);
+        let buffer2 = RenderBuffer::_new_with_contents(5, 1, Style::default(), contents2);
         let diff = buffer2.diff(&buffer1);
 
         assert_eq!(diff.len(), 1);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -999,8 +999,7 @@ impl Editor {
     }
 
     fn handle_command_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
-        match ev {
-            Event::Key(ref event) => {
+        if let event::Event::Key(ref event) = ev {
                 let code = event.code;
                 let _modifiers = event.modifiers;
 
@@ -1030,46 +1029,40 @@ impl Editor {
                     _ => {}
                 }
             }
-            _ => {}
-        }
 
         None
     }
 
     fn handle_search_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
-        match ev {
-            Event::Key(ref event) => {
-                let code = event.code;
-                let _modifiers = event.modifiers;
+        if let event::Event::Key(ref event) = ev {
+            let code = event.code;
+            let _modifiers = event.modifiers;
 
-                match code {
-                    KeyCode::Esc => {
-                        self.search_term = String::new();
-                        return Some(KeyAction::Single(Action::EnterMode(Mode::Normal)));
-                    }
-                    KeyCode::Backspace => {
-                        if self.search_term.len() < 2 {
-                            self.search_term = String::new();
-                        } else {
-                            self.search_term =
-                                self.search_term[..self.search_term.len() - 1].to_string();
-                        }
-                    }
-                    KeyCode::Enter => {
-                        return Some(KeyAction::Multiple(vec![
-                            Action::EnterMode(Mode::Normal),
-                            Action::FindNext,
-                        ]));
-                    }
-                    KeyCode::Char(c) => {
-                        self.search_term = format!("{}{c}", self.search_term);
-                        // TODO: real-time search
-                        // return Some(KeyAction::Search);
-                    }
-                    _ => {}
+            match code {
+                KeyCode::Esc => {
+                    self.search_term = String::new();
+                    return Some(KeyAction::Single(Action::EnterMode(Mode::Normal)));
                 }
+                KeyCode::Backspace => {
+                    if self.search_term.len() < 2 {
+                        self.search_term = String::new();
+                    } else {
+                        self.search_term = self.search_term[..self.search_term.len() - 1].to_string()
+                    }
+                }
+                KeyCode::Enter => {
+                    return Some(KeyAction::Multiple(vec![
+                        Action::EnterMode(Mode::Normal),
+                        Action::FindNext,
+                    ]));
+                }
+                KeyCode::Char(c) => {
+                    self.search_term = format!("{}{c}", self.search_term);
+                    // TODO: real-time search
+                    // return Some(KeyAction::Search);
+                }
+                _ => {}
             }
-            _ => {}
         }
 
         None

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -25,7 +25,7 @@ impl Highlighter {
     }
 
     pub fn highlight(&mut self, code: &str) -> anyhow::Result<Vec<StyleInfo>> {
-        let tree = self.parser.parse(&code, None).expect("parse works");
+        let tree = self.parser.parse(code, None).expect("parse works");
 
         let mut colors = Vec::new();
         let mut cursor = QueryCursor::new();

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 use std::{
     fs::{File, OpenOptions},
     io::Write,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -13,7 +13,6 @@ impl Logger {
     pub fn new(file: &str) -> Self {
         let file = OpenOptions::new()
             .create(true)
-            .write(true)
             .append(true)
             .open(file)
             .expect("log file opens fine");

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -424,7 +424,7 @@ impl LspClient {
             }
         });
 
-        Ok(self.send_request("textDocument/definition", params).await?)
+        self.send_request("textDocument/definition", params).await
     }
 }
 

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -86,15 +86,15 @@ pub struct ResponseMessage {
 
 #[derive(Debug)]
 pub struct Notification {
-    method: String,
-    params: Value,
+    _method: String,
+    _params: Value,
 }
 
 #[derive(Debug)]
 pub struct ResponseError {
-    code: i64,
-    message: String,
-    data: Option<Value>,
+    _code: i64,
+    _message: String,
+    _data: Option<Value>,
 }
 
 #[derive(Debug)]
@@ -227,9 +227,9 @@ pub async fn start_lsp() -> anyhow::Result<LspClient> {
                         let data = error.get("data").cloned();
 
                         rtx.send(InboundMessage::Error(ResponseError {
-                            code,
-                            message,
-                            data,
+                            _code: code,
+                            _message: message,
+                            _data: data,
                         }))
                         .await
                         .unwrap();
@@ -261,8 +261,8 @@ pub async fn start_lsp() -> anyhow::Result<LspClient> {
                             }
                             Ok(None) => {
                                 rtx.send(InboundMessage::UnknownNotification(Notification {
-                                    method,
-                                    params,
+                                    _method: method,
+                                    _params: params,
                                 }))
                                 .await
                                 .unwrap();

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -326,7 +326,7 @@ impl LspClient {
 
     pub async fn send_request(&mut self, method: &str, params: Value) -> anyhow::Result<i64> {
         let req = Request::new(method, params);
-        let id = req.id.clone();
+        let id = req.id;
 
         self.pending_responses.insert(id, method.to_string());
         self.request_tx.send(OutboundMessage::Request(req)).await?;

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -59,7 +59,7 @@ pub enum DiagnosticCode {
 }
 
 impl DiagnosticCode {
-    pub fn as_string(&self) -> String {
+    pub fn _as_string(&self) -> String {
         match self {
             DiagnosticCode::Int(i) => i.to_string(),
             DiagnosticCode::String(s) => s.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ mod logger;
 mod lsp;
 mod theme;
 
-#[allow(unused)]
 static LOGGER: OnceCell<Option<Logger>> = OnceCell::new();
 
 #[macro_export]

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -205,7 +205,7 @@ fn translate_scope(vscode_scope: String) -> String {
         .map(|s| s.to_string())
         .unwrap_or(vscode_scope);
 
-    return vscode_scope;
+    vscode_scope
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -73,12 +73,12 @@ pub fn parse_vscode_theme(file: &str) -> anyhow::Result<Theme> {
         fg: vscode_theme
             .colors
             .iter()
-            .find(|(c, _)| **c == "editorLineNumber.foreground".to_string())
+            .find(|(c, _)| **c == "editorLineNumber.foreground")
             .map(|(_, hex)| parse_rgb(hex.as_str().expect("colors are an hex string")).unwrap()),
         bg: vscode_theme
             .colors
             .iter()
-            .find(|(c, _)| **c == "editorLineNumber.background".to_string())
+            .find(|(c, _)| **c == "editorLineNumber.background")
             .map(|(_, hex)| parse_rgb(hex.as_str().expect("colors are an hex string")).unwrap()),
         ..Default::default()
     };


### PR DESCRIPTION
- refactor(clippy): `clippy::needless_return`
- refactor(clippy): `clippy::cmp_owned`
- refactor(clippy): `clippy::needless_question_mark`
- refactor(clippy): `clippy::clone_on_copy`
- refactor(clippy): `clippy::needless_borrows_for_generic_args`
- refactor(clippy): `clippy::ptr_arg`
- refactor(clippy): `clippy::match_single_binding`
- refactor(clippy): `clippy::unnecessary_cast`
- refactor(clippy): `clippy::cast_abs_to_unsigned`
- refactor(clippy): `clippy::ineffective_open_options`
- refactor(clippy): `clippy::needless_borrow`
- refactor(clippy): `clippy::while_let_on_iterator`
- refactor(clippy): `clippy::single_match`
- refactor(clippy): `clippy::map_clone`
- refactor(clippy): `clippy::to_string_in_format_args`
- refactor(clippy): `clippy::needless_else`
- refactor(clippy): `clippy::enum_variant_names`
- refactor(clippy): `clippy::single_char_pattern`
- refactor(clippy): `clippy::collapsible_if`
- refactor(clippy): `unused`
- refactor(clippy): `unused_mut`
- refactor(clippy): `dead_code`
- refactor(clippy): `unused_variables`
- refactor(clippy): `clippy::comparison_chain`

closes #27
