### PR TITLE
fix: prevent display corruption

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1975,8 +1975,13 @@ impl Editor {
         tracking: bool,
     ) -> anyhow::Result<bool> {
         // log!("Action: {action:?}");
-        self.last_error = None;
         self.actions.push(action.clone());
+
+        // Don't clear error on scroll actions to preserve error messages
+        match action {
+            Action::ScrollUp | Action::ScrollDown => {}
+            _ => self.last_error = None,
+        }
 
         let mut add_to_history = tracking;
 
@@ -2653,7 +2658,7 @@ impl Editor {
                 if self.vtop >= scroll_lines {
                     self.vtop -= scroll_lines;
                     let desired_cy = self.cy + scroll_lines;
-                    if desired_cy <= self.vheight() {
+                    if desired_cy < self.vheight() {
                         self.cy = desired_cy;
                     }
                     self.render(buffer)?;

--- a/src/editor/render_buffer.rs
+++ b/src/editor/render_buffer.rs
@@ -231,7 +231,7 @@ impl RenderBuffer {
         s
     }
 
-    pub fn diff(&self, other: &RenderBuffer) -> Vec<Change> {
+    pub fn diff(&self, other: &RenderBuffer) -> Vec<Change<'_>> {
         let mut changes = vec![];
         for (pos, cell) in self.cells.iter().enumerate() {
             if *cell != other.cells[pos] {

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -47,7 +47,26 @@ impl Editor {
         self.update_and_render_overlays(buffer)?;
 
         // Flush changes to terminal
-        let diff = buffer.diff(&current_buffer);
+        let mut diff = buffer.diff(&current_buffer);
+
+        // If there's an active error, ensure the error line is always included in the diff
+        // This prevents scrolling artifacts from corrupting the error display
+        if self.last_error.is_some() {
+            let error_line = self.size.1 as usize - 1;
+            let width = self.size.0 as usize;
+            // Force all cells on the error line to be included in the diff
+            for x in 0..width {
+                let pos = error_line * width + x;
+                if pos < buffer.cells.len() {
+                    diff.push(Change {
+                        x,
+                        y: error_line,
+                        cell: &buffer.cells[pos],
+                    });
+                }
+            }
+        }
+
         self.render_diff(diff)?;
 
         Ok(())


### PR DESCRIPTION
- Don't clear last_error on ScrollUp/ScrollDown actions
- Fix ScrollUp cursor boundary check (< instead of <=)
- Force error line to be included in render diff to prevent scrolling artifacts
- Change diff return type to use lifetime parameter for better memory efficiency

This fixes the issue where error messages would disappear when scrolling and prevents visual corruption of the error line during scroll operations.

<img width="1131" height="801" alt="2025-12-31-16:54:45" src="https://github.com/user-attachments/assets/d9c7eb92-b672-46d5-ae09-0a67c75db919" />

