### PR TITLE
fix: prevent error message corruption during scrolling

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1975,8 +1975,13 @@ impl Editor {
         tracking: bool,
     ) -> anyhow::Result<bool> {
         // log!("Action: {action:?}");
-        self.last_error = None;
         self.actions.push(action.clone());
+
+        // Don't clear error on scroll actions to preserve error messages
+        match action {
+            Action::ScrollUp | Action::ScrollDown => {}
+            _ => self.last_error = None,
+        }
 
         let mut add_to_history = tracking;
 
@@ -2653,7 +2658,7 @@ impl Editor {
                 if self.vtop >= scroll_lines {
                     self.vtop -= scroll_lines;
                     let desired_cy = self.cy + scroll_lines;
-                    if desired_cy <= self.vheight() {
+                    if desired_cy < self.vheight() {
                         self.cy = desired_cy;
                     }
                     self.render(buffer)?;

--- a/src/editor/render_buffer.rs
+++ b/src/editor/render_buffer.rs
@@ -231,7 +231,7 @@ impl RenderBuffer {
         s
     }
 
-    pub fn diff(&self, other: &RenderBuffer) -> Vec<Change> {
+    pub fn diff(&self, other: &RenderBuffer) -> Vec<Change<'_>> {
         let mut changes = vec![];
         for (pos, cell) in self.cells.iter().enumerate() {
             if *cell != other.cells[pos] {

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -47,7 +47,26 @@ impl Editor {
         self.update_and_render_overlays(buffer)?;
 
         // Flush changes to terminal
-        let diff = buffer.diff(&current_buffer);
+        let mut diff = buffer.diff(&current_buffer);
+
+        // If there's an active error, ensure the error line is always included in the diff
+        // This prevents scrolling artifacts from corrupting the error display
+        if self.last_error.is_some() {
+            let error_line = self.size.1 as usize - 1;
+            let width = self.size.0 as usize;
+            // Force all cells on the error line to be included in the diff
+            for x in 0..width {
+                let pos = error_line * width + x;
+                if pos < buffer.cells.len() {
+                    diff.push(Change {
+                        x,
+                        y: error_line,
+                        cell: &buffer.cells[pos],
+                    });
+                }
+            }
+        }
+
         self.render_diff(diff)?;
 
         Ok(())
@@ -909,14 +928,22 @@ impl Editor {
 
         let mut skip_next = false;
         for (i, change) in sorted_changes.iter().enumerate() {
+            let x = change.x;
+            let y = change.y;
+
+            // Skip the bottom-right corner to prevent scrolling
+            if x == (self.size.0 as usize).saturating_sub(1)
+                && y == (self.size.1 as usize).saturating_sub(1)
+            {
+                continue;
+            }
+
             // Skip if this was a padding space after an emoji
             if skip_next {
                 skip_next = false;
                 continue;
             }
 
-            let x = change.x;
-            let y = change.y;
             let cell = change.cell;
 
             // Check if this is an emoji followed by a space (padding)
@@ -1086,7 +1113,8 @@ impl Editor {
             let wc = format!("{:<width$}", wc, width = 10);
 
             if let Some(ref last_error) = self.last_error {
-                let error = format!("{:width$}", last_error, width = self.size.0 as usize);
+                let clean_error = last_error.replace('\n', " ");
+                let error = format!("{:width$}", clean_error, width = self.size.0 as usize - 1);
                 buffer.set_text(0, self.size.1 as usize - 1, &error, style);
             } else {
                 let clear_line = " ".repeat(self.size.0 as usize - 10);


### PR DESCRIPTION
- Preserve error messages during scroll actions (ScrollUp/ScrollDown)
- Force error line to be included in render diff to prevent artifacts
- Skip bottom-right corner cell to prevent terminal scrolling
- Clean newlines from error messages and ensure proper width
- Fix scroll boundary check (< instead of <=)
- Add lifetime annotation to Change struct for better memory safety

The issue was that scrolling would corrupt the error display because
<img width="1131" height="801" alt="2025-12-31-16:54:45" src="https://github.com/user-attachments/assets/dd799a81-a8a3-40cd-8675-ea7488c5d2ea" />
