### PR TITLE
feat(core): support filetype syntax and lsp routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,9 +364,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.87"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3286b845d0fccbdd15af433f61c5970e711987036cb468f437ff6badd70f4e24"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cexpr"
@@ -826,6 +830,12 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -1919,7 +1929,14 @@ dependencies = [
  "tokio",
  "toml",
  "tree-sitter",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-md",
+ "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-toml-ng",
+ "tree-sitter-typescript",
+ "tree-sitter-yaml",
  "unicode-segmentation",
  "unicode-width 0.2.1",
  "uuid",
@@ -1936,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1948,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1959,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2383,6 +2400,12 @@ name = "str_indices"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_enum"
@@ -3120,22 +3143,102 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,6 +1929,7 @@ dependencies = [
  "tokio",
  "toml",
  "tree-sitter",
+ "tree-sitter-bash",
  "tree-sitter-javascript",
  "tree-sitter-json",
  "tree-sitter-md",
@@ -3152,6 +3153,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,15 @@ textwrap = "0.16"
 thiserror = "1.0"
 tokio = { version = "1.41.0", features = ["full"] }
 toml = "0.8.10"
-tree-sitter = "0.20.10"
-tree-sitter-rust = "0.20.4"
+tree-sitter = "0.25"
+tree-sitter-javascript = "0.25.0"
+tree-sitter-json = "0.24.8"
+tree-sitter-md = "0.5.3"
+tree-sitter-python = "0.25.0"
+tree-sitter-rust = "0.24.2"
+tree-sitter-toml-ng = "0.7.0"
+tree-sitter-typescript = "0.23.2"
+tree-sitter-yaml = "0.7.2"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2"
 uuid = { version = "1.12.0", features = ["v4"] }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "1.0"
 tokio = { version = "1.41.0", features = ["full"] }
 toml = "0.8.10"
 tree-sitter = "0.25"
+tree-sitter-bash = "0.25.1"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-json = "0.24.8"
 tree-sitter-md = "0.5.3"

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ cursor_line = true
 enabled = true
 
 # Built-in syntax highlighting covers Rust, Markdown, JavaScript,
-# TypeScript/TSX, JSON, TOML, YAML, and Python. LSP defaults are provided for
-# those file types and start only when a matching file is opened.
+# TypeScript/TSX, JSON, TOML, YAML, Python, and Bash. LSP defaults are
+# provided for common language-server-backed file types and start only when a
+# matching file is opened.
 
 [lsp.servers.typescript]
 command = "typescript-language-server"

--- a/README.md
+++ b/README.md
@@ -89,12 +89,26 @@ cursor_line = true
 [lsp]
 enabled = true
 
+# Built-in syntax highlighting covers Rust, Markdown, JavaScript,
+# TypeScript/TSX, JSON, TOML, YAML, and Python. LSP defaults are provided for
+# those file types and start only when a matching file is opened.
+
 [lsp.servers.typescript]
 command = "typescript-language-server"
 args = ["--stdio"]
+root_markers = ["package.json", "tsconfig.json", "jsconfig.json", ".git"]
+
+[[lsp.servers.typescript.documents]]
 language_id = "typescript"
-file_extensions = ["ts", "tsx"]
-root_markers = ["package.json", ".git"]
+file_extensions = ["ts"]
+
+[[lsp.servers.typescript.documents]]
+language_id = "typescriptreact"
+file_extensions = ["tsx"]
+
+[[lsp.servers.typescript.documents]]
+language_id = "javascript"
+file_extensions = ["js", "mjs", "cjs"]
 
 # Plugin settings
 [plugins]

--- a/default_config.toml
+++ b/default_config.toml
@@ -24,6 +24,32 @@ log_file = "/tmp/red.log"
 # them.
 #show_diagnostics = false 
 
+# Language servers are selected by file extension. The built-in defaults cover
+# Rust, Markdown, JavaScript/TypeScript, JSON, TOML, YAML, and Python. You can
+# override or add servers here. Existing single-language configs still work:
+#
+# [lsp.servers.rust]
+# command = "rust-analyzer"
+# args = ["-v"]
+# language_id = "rust"
+# file_extensions = ["rs"]
+# root_markers = ["Cargo.toml", ".git"]
+#
+# Servers that handle multiple language ids can use document selectors:
+#
+# [lsp.servers.typescript]
+# command = "typescript-language-server"
+# args = ["--stdio"]
+# root_markers = ["package.json", "tsconfig.json", "jsconfig.json", ".git"]
+#
+# [[lsp.servers.typescript.documents]]
+# language_id = "typescript"
+# file_extensions = ["ts"]
+#
+# [[lsp.servers.typescript.documents]]
+# language_id = "javascript"
+# file_extensions = ["js", "mjs", "cjs"]
+
 [keys.insert]
 Enter = "InsertNewLine"
 Backspace = "DeletePreviousChar"

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,9 +46,12 @@ pub struct LanguageServerConfig {
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
+    #[serde(default)]
     pub language_id: String,
     #[serde(default)]
     pub file_extensions: Vec<String>,
+    #[serde(default)]
+    pub documents: Vec<LanguageDocumentConfig>,
     #[serde(default)]
     pub root_markers: Vec<String>,
     #[serde(default)]
@@ -58,20 +61,138 @@ pub struct LanguageServerConfig {
     pub workspace_name: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct LanguageDocumentConfig {
+    pub language_id: String,
+    #[serde(default)]
+    pub file_extensions: Vec<String>,
+}
+
+impl LanguageServerConfig {
+    pub fn documents(&self) -> Vec<LanguageDocumentConfig> {
+        if !self.documents.is_empty() {
+            return self.documents.clone();
+        }
+
+        if self.language_id.is_empty() || self.file_extensions.is_empty() {
+            return Vec::new();
+        }
+
+        vec![LanguageDocumentConfig {
+            language_id: self.language_id.clone(),
+            file_extensions: self.file_extensions.clone(),
+        }]
+    }
+}
+
 pub fn default_language_servers() -> HashMap<String, LanguageServerConfig> {
-    HashMap::from([(
-        "rust".to_string(),
-        LanguageServerConfig {
-            command: "rust-analyzer".to_string(),
-            args: vec!["-v".to_string()],
-            language_id: "rust".to_string(),
-            file_extensions: vec!["rs".to_string()],
-            root_markers: vec!["Cargo.toml".to_string(), ".git".to_string()],
-            env: HashMap::new(),
-            initialization_options: Some(rust_analyzer_initialization_options()),
-            workspace_name: Some("red".to_string()),
-        },
-    )])
+    HashMap::from([
+        (
+            "rust".to_string(),
+            LanguageServerConfig {
+                command: "rust-analyzer".to_string(),
+                args: vec!["-v".to_string()],
+                language_id: "rust".to_string(),
+                file_extensions: vec!["rs".to_string()],
+                documents: Vec::new(),
+                root_markers: vec!["Cargo.toml".to_string(), ".git".to_string()],
+                env: HashMap::new(),
+                initialization_options: Some(rust_analyzer_initialization_options()),
+                workspace_name: Some("red".to_string()),
+            },
+        ),
+        (
+            "typescript".to_string(),
+            server(
+                "typescript-language-server",
+                &["--stdio"],
+                &[
+                    document("typescript", &["ts"]),
+                    document("typescriptreact", &["tsx"]),
+                    document("javascript", &["js", "mjs", "cjs"]),
+                    document("javascriptreact", &["jsx"]),
+                ],
+                &["package.json", "tsconfig.json", "jsconfig.json", ".git"],
+            ),
+        ),
+        (
+            "python".to_string(),
+            server(
+                "pyright-langserver",
+                &["--stdio"],
+                &[document("python", &["py", "pyw"])],
+                &["pyproject.toml", "setup.py", "requirements.txt", ".git"],
+            ),
+        ),
+        (
+            "markdown".to_string(),
+            server(
+                "marksman",
+                &["server"],
+                &[document("markdown", &["md", "markdown"])],
+                &[".marksman.toml", ".git"],
+            ),
+        ),
+        (
+            "json".to_string(),
+            server(
+                "vscode-json-language-server",
+                &["--stdio"],
+                &[document("json", &["json"])],
+                &["package.json", ".git"],
+            ),
+        ),
+        (
+            "toml".to_string(),
+            server(
+                "taplo",
+                &["lsp", "stdio"],
+                &[document("toml", &["toml"])],
+                &["taplo.toml", "Cargo.toml", ".git"],
+            ),
+        ),
+        (
+            "yaml".to_string(),
+            server(
+                "yaml-language-server",
+                &["--stdio"],
+                &[document("yaml", &["yaml", "yml"])],
+                &[".git"],
+            ),
+        ),
+    ])
+}
+
+fn server(
+    command: &str,
+    args: &[&str],
+    documents: &[LanguageDocumentConfig],
+    root_markers: &[&str],
+) -> LanguageServerConfig {
+    LanguageServerConfig {
+        command: command.to_string(),
+        args: args.iter().map(|arg| arg.to_string()).collect(),
+        language_id: String::new(),
+        file_extensions: Vec::new(),
+        documents: documents.to_vec(),
+        root_markers: root_markers
+            .iter()
+            .map(|marker| marker.to_string())
+            .collect(),
+        env: HashMap::new(),
+        initialization_options: None,
+        workspace_name: None,
+    }
+}
+
+fn document(language_id: &str, file_extensions: &[&str]) -> LanguageDocumentConfig {
+    LanguageDocumentConfig {
+        language_id: language_id.to_string(),
+        file_extensions: file_extensions
+            .iter()
+            .map(|extension| extension.to_string())
+            .collect(),
+    }
 }
 
 fn deserialize_language_servers<'de, D>(
@@ -247,11 +368,18 @@ theme = "theme/nightfox.json"
         .unwrap();
 
         let rust = config.lsp.servers.get("rust").unwrap();
+        let typescript = config.lsp.servers.get("typescript").unwrap();
         assert!(config.lsp.enabled);
         assert_eq!(rust.command, "rust-analyzer");
         assert_eq!(rust.args, vec!["-v"]);
         assert_eq!(rust.language_id, "rust");
         assert_eq!(rust.file_extensions, vec!["rs"]);
+        assert_eq!(typescript.command, "typescript-language-server");
+        assert!(config.lsp.servers.contains_key("markdown"));
+        assert!(config.lsp.servers.contains_key("python"));
+        assert!(config.lsp.servers.contains_key("json"));
+        assert!(config.lsp.servers.contains_key("toml"));
+        assert!(config.lsp.servers.contains_key("yaml"));
     }
 
     #[test]
@@ -282,7 +410,51 @@ workspace_name = "frontend"
         assert_eq!(server.args, vec!["--stdio"]);
         assert_eq!(server.language_id, "typescript");
         assert_eq!(server.file_extensions, vec!["ts", "tsx"]);
+        assert_eq!(server.documents()[0].language_id, "typescript");
+        assert_eq!(server.documents()[0].file_extensions, vec!["ts", "tsx"]);
         assert_eq!(server.root_markers, vec!["package.json", ".git"]);
         assert_eq!(server.workspace_name.as_deref(), Some("frontend"));
+    }
+
+    #[test]
+    fn test_lsp_config_accepts_document_selectors() {
+        let config: Config = toml::from_str(
+            r#"
+theme = "theme/nightfox.json"
+
+[keys]
+
+[lsp.servers.web]
+command = "typescript-language-server"
+args = ["--stdio"]
+root_markers = ["package.json", ".git"]
+
+[[lsp.servers.web.documents]]
+language_id = "typescript"
+file_extensions = ["ts"]
+
+[[lsp.servers.web.documents]]
+language_id = "javascript"
+file_extensions = ["js"]
+"#,
+        )
+        .unwrap();
+
+        let server = config.lsp.servers.get("web").unwrap();
+        assert_eq!(server.language_id, "");
+        assert_eq!(server.file_extensions, Vec::<String>::new());
+        assert_eq!(
+            server.documents(),
+            vec![
+                LanguageDocumentConfig {
+                    language_id: "typescript".to_string(),
+                    file_extensions: vec!["ts".to_string()],
+                },
+                LanguageDocumentConfig {
+                    language_id: "javascript".to_string(),
+                    file_extensions: vec!["js".to_string()],
+                },
+            ]
+        );
     }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -4594,11 +4594,26 @@ fn directory_listing(path: &str) -> Value {
 }
 
 fn determine_style_for_position(style_info: &[StyleInfo], pos: usize) -> Option<Style> {
-    if let Some(s) = style_info.iter().find(|si| si.contains(pos)) {
-        return Some(s.style.clone());
+    let mut best = None;
+
+    for (index, style) in style_info.iter().enumerate() {
+        if !style.contains(pos) {
+            continue;
+        }
+
+        let range_len = style.end.saturating_sub(style.start);
+        let should_replace = best
+            .map(|(best_index, best_len): (usize, usize)| {
+                range_len < best_len || (range_len == best_len && index > best_index)
+            })
+            .unwrap_or(true);
+
+        if should_replace {
+            best = Some((index, range_len));
+        }
     }
 
-    None
+    best.map(|(index, _)| style_info[index].style.clone())
 }
 
 fn adjust_color_brightness(color: Option<Color>, percentage: i32) -> Option<Color> {
@@ -4803,6 +4818,48 @@ mod test {
         assert_eq!(entries[1]["name"], "README.md");
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn style_for_position_prefers_narrower_and_later_spans() {
+        let outer_style = Style {
+            fg: Some(Color::Rgb { r: 1, g: 1, b: 1 }),
+            ..Style::default()
+        };
+        let inner_style = Style {
+            fg: Some(Color::Rgb { r: 2, g: 2, b: 2 }),
+            ..Style::default()
+        };
+        let later_style = Style {
+            fg: Some(Color::Rgb { r: 3, g: 3, b: 3 }),
+            ..Style::default()
+        };
+        let style_info = vec![
+            StyleInfo {
+                start: 0,
+                end: 20,
+                style: outer_style.clone(),
+            },
+            StyleInfo {
+                start: 5,
+                end: 10,
+                style: inner_style.clone(),
+            },
+            StyleInfo {
+                start: 5,
+                end: 10,
+                style: later_style.clone(),
+            },
+        ];
+
+        assert_eq!(
+            determine_style_for_position(&style_info, 2),
+            Some(outer_style)
+        );
+        assert_eq!(
+            determine_style_for_position(&style_info, 6),
+            Some(later_style)
+        );
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -973,8 +973,8 @@ impl Editor {
         self.gutter_width_for_buffer_index(window.buffer_index)
     }
 
-    pub fn highlight(&mut self, code: &str) -> anyhow::Result<Vec<StyleInfo>> {
-        self.highlighter.highlight(code)
+    pub fn highlight(&mut self, file: Option<&str>, code: &str) -> anyhow::Result<Vec<StyleInfo>> {
+        self.highlighter.highlight_for_file(file, code)
     }
 
     fn fill_line(&mut self, buffer: &mut RenderBuffer, x: usize, y: usize, style: &Style) {
@@ -985,7 +985,8 @@ impl Editor {
 
     fn draw_line(&mut self, buffer: &mut RenderBuffer) {
         let line = self.viewport_line(self.cy).unwrap_or_default();
-        let style_info = self.highlight(&line).unwrap_or_default();
+        let file = self.current_buffer().file.clone();
+        let style_info = self.highlight(file.as_deref(), &line).unwrap_or_default();
         let default_style = self.theme.style.clone();
 
         let mut x = self.vx;

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -551,7 +551,8 @@ impl Editor {
             }
         }
 
-        let style_info = self.highlight(&viewport_content)?;
+        let file = window_buffer.file.clone();
+        let style_info = self.highlight(file.as_deref(), &viewport_content)?;
         let theme_style = self.theme.style.clone();
 
         // Start at window position, accounting for gutter

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -244,6 +244,7 @@ fn language_id_for_name(name: &str) -> Option<&'static str> {
         "yaml" | "yml" => Some("yaml"),
         "py" | "python" => Some("python"),
         "md" | "markdown" => Some("markdown"),
+        "bash" | "sh" | "shell" | "zsh" => Some("bash"),
         _ => None,
     }
 }
@@ -317,6 +318,13 @@ fn language_definitions() -> Vec<LanguageDefinition> {
             extensions: &["py", "pyw"],
             language: || tree_sitter_python::LANGUAGE.into(),
             highlight_query: tree_sitter_python::HIGHLIGHTS_QUERY,
+            injection_query: None,
+        },
+        LanguageDefinition {
+            id: "bash",
+            extensions: &["sh", "bash", "zsh"],
+            language: || tree_sitter_bash::LANGUAGE.into(),
+            highlight_query: tree_sitter_bash::HIGHLIGHT_QUERY,
             injection_query: None,
         },
     ]
@@ -426,6 +434,10 @@ mod tests {
             highlighter.language_id_for_file(Some("config.yml")),
             Some("yaml")
         );
+        assert_eq!(
+            highlighter.language_id_for_file(Some("script.sh")),
+            Some("bash")
+        );
         assert_eq!(highlighter.language_id_for_file(Some("LICENSE")), None);
     }
 
@@ -441,6 +453,7 @@ mod tests {
             ("toml", "value = true\n"),
             ("yaml", "value: true\n"),
             ("python", "def main():\n    return True\n"),
+            ("bash", "if [ -f Cargo.toml ]; then\n  echo yes\nfi\n"),
         ];
         let mut highlighter = highlighter();
 
@@ -461,6 +474,8 @@ mod tests {
         assert_eq!(highlighter.language_id_for_name("py"), Some("python"));
         assert_eq!(highlighter.language_id_for_name("yml"), Some("yaml"));
         assert_eq!(highlighter.language_id_for_name("ts"), Some("typescript"));
+        assert_eq!(highlighter.language_id_for_name("sh"), Some("bash"));
+        assert_eq!(highlighter.language_id_for_name("shell"), Some("bash"));
         assert_eq!(highlighter.language_id_for_name("unknown"), None);
     }
 
@@ -525,6 +540,30 @@ mod tests {
                 .iter()
                 .any(|style| style.start <= bool_start && style.end >= bool_start + 4),
             "fenced JSON boolean should be highlighted at Markdown byte offsets"
+        );
+    }
+
+    #[test]
+    fn markdown_highlights_bash_fenced_code() {
+        let mut highlighter = highlighter();
+        let code = "```sh\nif [ -f Cargo.toml ]; then\n  echo yes\nfi\n```\n";
+        let styles = highlighter
+            .highlight_for_file(Some("README.md"), code)
+            .unwrap();
+        let if_start = code.find("if").unwrap();
+        let echo_start = code.find("echo").unwrap();
+
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= if_start && style.end >= if_start + 2),
+            "fenced shell `if` keyword should be highlighted at Markdown byte offsets"
+        );
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= echo_start && style.end >= echo_start + 4),
+            "fenced shell command should be highlighted at Markdown byte offsets"
         );
     }
 

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -13,11 +13,25 @@ struct LanguageDefinition {
     extensions: &'static [&'static str],
     language: fn() -> Language,
     highlight_query: &'static str,
+    injection_query: Option<&'static str>,
 }
 
 struct LanguageHighlighter {
     parser: Parser,
     query: Query,
+    injection_query: Option<Query>,
+}
+
+struct Injection {
+    language_id: &'static str,
+    content_start: usize,
+    content_end: usize,
+}
+
+struct RawInjection {
+    language_name: String,
+    content_start: usize,
+    content_end: usize,
 }
 
 pub struct Highlighter {
@@ -26,6 +40,8 @@ pub struct Highlighter {
     highlighters: HashMap<&'static str, LanguageHighlighter>,
     theme: Theme,
 }
+
+const MAX_INJECTION_DEPTH: usize = 3;
 
 impl Highlighter {
     pub fn new(theme: &Theme) -> anyhow::Result<Self> {
@@ -61,6 +77,10 @@ impl Highlighter {
         self.extensions.get(extension.as_str()).copied()
     }
 
+    pub fn language_id_for_name(&self, name: &str) -> Option<&'static str> {
+        language_id_for_name(name).or_else(|| self.language_id_for_extension(name))
+    }
+
     pub fn highlight_for_file(
         &mut self,
         file: Option<&str>,
@@ -73,6 +93,15 @@ impl Highlighter {
     }
 
     pub fn highlight(&mut self, language_id: &str, code: &str) -> anyhow::Result<Vec<StyleInfo>> {
+        self.highlight_with_depth(language_id, code, 0)
+    }
+
+    fn highlight_with_depth(
+        &mut self,
+        language_id: &str,
+        code: &str,
+        depth: usize,
+    ) -> anyhow::Result<Vec<StyleInfo>> {
         let Some(definition) = self.languages.get(language_id).copied() else {
             return Ok(Vec::new());
         };
@@ -82,35 +111,140 @@ impl Highlighter {
             let mut parser = Parser::new();
             parser.set_language(&language)?;
             let query = Query::new(&language, definition.highlight_query)?;
-            self.highlighters
-                .insert(definition.id, LanguageHighlighter { parser, query });
+            let injection_query = definition
+                .injection_query
+                .map(|query| Query::new(&language, query))
+                .transpose()?;
+            self.highlighters.insert(
+                definition.id,
+                LanguageHighlighter {
+                    parser,
+                    query,
+                    injection_query,
+                },
+            );
         }
 
-        let Some(highlighter) = self.highlighters.get_mut(definition.id) else {
-            return Ok(Vec::new());
-        };
-        let Some(tree) = highlighter.parser.parse(code, None) else {
-            return Ok(Vec::new());
-        };
-
         let mut colors = Vec::new();
-        let mut cursor = QueryCursor::new();
-        let mut matches = cursor.matches(&highlighter.query, tree.root_node(), code.as_bytes());
+        let mut raw_injections = Vec::new();
 
-        while let Some(mat) = matches.next() {
-            for cap in mat.captures {
-                let node = cap.node;
-                let start = node.start_byte();
-                let end = node.end_byte();
-                let scope = highlighter.query.capture_names()[cap.index as usize];
+        {
+            let Some(highlighter) = self.highlighters.get_mut(definition.id) else {
+                return Ok(Vec::new());
+            };
+            let Some(tree) = highlighter.parser.parse(code, None) else {
+                return Ok(Vec::new());
+            };
 
-                if let Some(style) = self.theme.get_style(scope) {
-                    colors.push(StyleInfo { start, end, style });
+            let mut cursor = QueryCursor::new();
+            let mut matches = cursor.matches(&highlighter.query, tree.root_node(), code.as_bytes());
+
+            while let Some(mat) = matches.next() {
+                for cap in mat.captures {
+                    let node = cap.node;
+                    let start = node.start_byte();
+                    let end = node.end_byte();
+                    let scope = highlighter.query.capture_names()[cap.index as usize];
+
+                    if let Some(style) = self.theme.get_style(scope) {
+                        colors.push(StyleInfo { start, end, style });
+                    }
+                }
+            }
+
+            if depth < MAX_INJECTION_DEPTH {
+                if let Some(injection_query) = &highlighter.injection_query {
+                    raw_injections = collect_injections(injection_query, tree.root_node(), code);
                 }
             }
         }
 
+        let injections = raw_injections
+            .into_iter()
+            .filter_map(|injection| {
+                let language_id = self.language_id_for_name(&injection.language_name)?;
+                Some(Injection {
+                    language_id,
+                    content_start: injection.content_start,
+                    content_end: injection.content_end,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for injection in injections {
+            let Some(injected_code) = code.get(injection.content_start..injection.content_end)
+            else {
+                continue;
+            };
+            let mut injected_colors =
+                self.highlight_with_depth(injection.language_id, injected_code, depth + 1)?;
+            for color in &mut injected_colors {
+                color.start += injection.content_start;
+                color.end += injection.content_start;
+            }
+            colors.extend(injected_colors);
+        }
+
         Ok(colors)
+    }
+}
+
+fn collect_injections(
+    query: &Query,
+    root_node: tree_sitter::Node<'_>,
+    code: &str,
+) -> Vec<RawInjection> {
+    let mut injections = Vec::new();
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, root_node, code.as_bytes());
+
+    while let Some(mat) = matches.next() {
+        let mut language_name = None;
+        let mut content = None;
+
+        for capture in mat.captures {
+            let capture_name = query.capture_names()[capture.index as usize];
+            match capture_name {
+                "injection.language" => {
+                    language_name = capture.node.utf8_text(code.as_bytes()).ok();
+                }
+                "injection.content" => {
+                    content = Some((capture.node.start_byte(), capture.node.end_byte()));
+                }
+                _ => {}
+            }
+        }
+
+        let (Some(language_name), Some((content_start, content_end))) = (language_name, content)
+        else {
+            continue;
+        };
+
+        injections.push(RawInjection {
+            language_name: language_name.to_string(),
+            content_start,
+            content_end,
+        });
+    }
+
+    injections
+}
+
+fn language_id_for_name(name: &str) -> Option<&'static str> {
+    let name = name.trim().to_ascii_lowercase();
+    let name = name.split_whitespace().next().unwrap_or_default();
+
+    match name {
+        "rs" | "rust" => Some("rust"),
+        "js" | "javascript" | "mjs" | "cjs" => Some("javascript"),
+        "ts" | "typescript" => Some("typescript"),
+        "tsx" => Some("tsx"),
+        "json" => Some("json"),
+        "toml" => Some("toml"),
+        "yaml" | "yml" => Some("yaml"),
+        "py" | "python" => Some("python"),
+        "md" | "markdown" => Some("markdown"),
+        _ => None,
     }
 }
 
@@ -127,54 +261,63 @@ fn language_definitions() -> Vec<LanguageDefinition> {
             extensions: &["rs"],
             language: || tree_sitter_rust::LANGUAGE.into(),
             highlight_query: tree_sitter_rust::HIGHLIGHTS_QUERY,
+            injection_query: None,
         },
         LanguageDefinition {
             id: "markdown",
             extensions: &["md", "markdown"],
             language: || tree_sitter_md::LANGUAGE.into(),
             highlight_query: MARKDOWN_HIGHLIGHT_QUERY,
+            injection_query: Some(MARKDOWN_INJECTION_QUERY),
         },
         LanguageDefinition {
             id: "javascript",
             extensions: &["js", "jsx", "mjs", "cjs"],
             language: || tree_sitter_javascript::LANGUAGE.into(),
             highlight_query: tree_sitter_javascript::HIGHLIGHT_QUERY,
+            injection_query: None,
         },
         LanguageDefinition {
             id: "typescript",
             extensions: &["ts"],
             language: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
             highlight_query: tree_sitter_typescript::HIGHLIGHTS_QUERY,
+            injection_query: None,
         },
         LanguageDefinition {
             id: "tsx",
             extensions: &["tsx"],
             language: || tree_sitter_typescript::LANGUAGE_TSX.into(),
             highlight_query: tree_sitter_typescript::HIGHLIGHTS_QUERY,
+            injection_query: None,
         },
         LanguageDefinition {
             id: "json",
             extensions: &["json"],
             language: || tree_sitter_json::LANGUAGE.into(),
             highlight_query: tree_sitter_json::HIGHLIGHTS_QUERY,
+            injection_query: None,
         },
         LanguageDefinition {
             id: "toml",
             extensions: &["toml"],
             language: || tree_sitter_toml_ng::LANGUAGE.into(),
             highlight_query: tree_sitter_toml_ng::HIGHLIGHTS_QUERY,
+            injection_query: None,
         },
         LanguageDefinition {
             id: "yaml",
             extensions: &["yml", "yaml"],
             language: || tree_sitter_yaml::LANGUAGE.into(),
             highlight_query: tree_sitter_yaml::HIGHLIGHTS_QUERY,
+            injection_query: None,
         },
         LanguageDefinition {
             id: "python",
             extensions: &["py", "pyw"],
             language: || tree_sitter_python::LANGUAGE.into(),
             highlight_query: tree_sitter_python::HIGHLIGHTS_QUERY,
+            injection_query: None,
         },
     ]
 }
@@ -237,6 +380,13 @@ const MARKDOWN_HIGHLIGHT_QUERY: &str = r#"
 ] @punctuation.definition.quote.begin.markdown
 
 (backslash_escape) @escape
+"#;
+
+const MARKDOWN_INJECTION_QUERY: &str = r#"
+(fenced_code_block
+  (info_string
+    (language) @injection.language)
+  (code_fence_content) @injection.content)
 "#;
 
 pub fn normalized_extension(file: &str) -> Option<String> {
@@ -304,6 +454,17 @@ mod tests {
     }
 
     #[test]
+    fn resolves_fenced_code_language_aliases() {
+        let highlighter = highlighter();
+
+        assert_eq!(highlighter.language_id_for_name("rs"), Some("rust"));
+        assert_eq!(highlighter.language_id_for_name("py"), Some("python"));
+        assert_eq!(highlighter.language_id_for_name("yml"), Some("yaml"));
+        assert_eq!(highlighter.language_id_for_name("ts"), Some("typescript"));
+        assert_eq!(highlighter.language_id_for_name("unknown"), None);
+    }
+
+    #[test]
     fn markdown_uses_theme_compatible_scopes() {
         let mut highlighter = highlighter();
         let styles = highlighter
@@ -323,6 +484,81 @@ mod tests {
         assert!(
             styles.iter().any(|style| style.start == 14),
             "markdown list marker should be highlighted"
+        );
+    }
+
+    #[test]
+    fn markdown_highlights_rust_fenced_code() {
+        let mut highlighter = highlighter();
+        let code = "# Example\n\n```rust\nfn main() {\n    let value = true;\n}\n```\n";
+        let styles = highlighter
+            .highlight_for_file(Some("README.md"), code)
+            .unwrap();
+        let fn_start = code.find("fn").unwrap();
+        let let_start = code.find("let").unwrap();
+
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= fn_start && style.end >= fn_start + 2),
+            "fenced Rust `fn` keyword should be highlighted at Markdown byte offsets"
+        );
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= let_start && style.end >= let_start + 3),
+            "fenced Rust `let` keyword should be highlighted at Markdown byte offsets"
+        );
+    }
+
+    #[test]
+    fn markdown_highlights_json_fenced_code() {
+        let mut highlighter = highlighter();
+        let code = "```json\n{\"enabled\": true}\n```\n";
+        let styles = highlighter
+            .highlight_for_file(Some("README.md"), code)
+            .unwrap();
+        let bool_start = code.find("true").unwrap();
+
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= bool_start && style.end >= bool_start + 4),
+            "fenced JSON boolean should be highlighted at Markdown byte offsets"
+        );
+    }
+
+    #[test]
+    fn markdown_resolves_fenced_code_by_registered_extension() {
+        let mut highlighter = highlighter();
+        let code = "```pyw\nprint(True)\n```\n";
+        let styles = highlighter
+            .highlight_for_file(Some("README.md"), code)
+            .unwrap();
+        let true_start = code.find("True").unwrap();
+
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= true_start && style.end >= true_start + 4),
+            "fenced language names should resolve through registered extensions"
+        );
+    }
+
+    #[test]
+    fn markdown_ignores_unknown_fenced_code_language() {
+        let mut highlighter = highlighter();
+        let code = "```madeup\nhello\n```\n";
+        let styles = highlighter
+            .highlight_for_file(Some("README.md"), code)
+            .unwrap();
+        let content_start = code.find("hello").unwrap();
+
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= content_start && style.end >= content_start + 5),
+            "unknown fenced language should keep Markdown raw block styling"
         );
     }
 

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -1,50 +1,342 @@
-use tree_sitter::{Parser, Query, QueryCursor};
-use tree_sitter_rust::{language, HIGHLIGHT_QUERY};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use tree_sitter::{Language, Parser, Query, QueryCursor, StreamingIterator};
 
 use crate::{editor::StyleInfo, theme::Theme};
 
-pub struct Highlighter {
+#[derive(Clone, Copy)]
+struct LanguageDefinition {
+    id: &'static str,
+    extensions: &'static [&'static str],
+    language: fn() -> Language,
+    highlight_query: &'static str,
+}
+
+struct LanguageHighlighter {
     parser: Parser,
     query: Query,
+}
+
+pub struct Highlighter {
+    languages: HashMap<&'static str, LanguageDefinition>,
+    extensions: HashMap<&'static str, &'static str>,
+    highlighters: HashMap<&'static str, LanguageHighlighter>,
     theme: Theme,
 }
 
 impl Highlighter {
     pub fn new(theme: &Theme) -> anyhow::Result<Self> {
-        let mut parser = Parser::new();
-        let language = language();
-        parser.set_language(language)?;
-        let query = Query::new(language, HIGHLIGHT_QUERY)?;
-        let theme = theme.clone();
+        let languages = language_definitions()
+            .into_iter()
+            .map(|definition| (definition.id, definition))
+            .collect::<HashMap<_, _>>();
+        let extensions = languages
+            .values()
+            .flat_map(|definition| {
+                definition
+                    .extensions
+                    .iter()
+                    .map(|extension| (*extension, definition.id))
+            })
+            .collect::<HashMap<_, _>>();
 
         Ok(Self {
-            parser,
-            query,
-            theme,
+            languages,
+            extensions,
+            highlighters: HashMap::new(),
+            theme: theme.clone(),
         })
     }
 
-    pub fn highlight(&mut self, code: &str) -> anyhow::Result<Vec<StyleInfo>> {
-        let tree = self.parser.parse(code, None).expect("parse works");
+    pub fn language_id_for_file(&self, file: Option<&str>) -> Option<&'static str> {
+        let extension = file_extension(file?)?;
+        self.language_id_for_extension(&extension)
+    }
+
+    pub fn language_id_for_extension(&self, extension: &str) -> Option<&'static str> {
+        let extension = extension.trim_start_matches('.').to_ascii_lowercase();
+        self.extensions.get(extension.as_str()).copied()
+    }
+
+    pub fn highlight_for_file(
+        &mut self,
+        file: Option<&str>,
+        code: &str,
+    ) -> anyhow::Result<Vec<StyleInfo>> {
+        let Some(language_id) = self.language_id_for_file(file) else {
+            return Ok(Vec::new());
+        };
+        self.highlight(language_id, code)
+    }
+
+    pub fn highlight(&mut self, language_id: &str, code: &str) -> anyhow::Result<Vec<StyleInfo>> {
+        let Some(definition) = self.languages.get(language_id).copied() else {
+            return Ok(Vec::new());
+        };
+
+        if !self.highlighters.contains_key(definition.id) {
+            let language = (definition.language)();
+            let mut parser = Parser::new();
+            parser.set_language(&language)?;
+            let query = Query::new(&language, definition.highlight_query)?;
+            self.highlighters
+                .insert(definition.id, LanguageHighlighter { parser, query });
+        }
+
+        let Some(highlighter) = self.highlighters.get_mut(definition.id) else {
+            return Ok(Vec::new());
+        };
+        let Some(tree) = highlighter.parser.parse(code, None) else {
+            return Ok(Vec::new());
+        };
 
         let mut colors = Vec::new();
         let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&self.query, tree.root_node(), code.as_bytes());
+        let mut matches = cursor.matches(&highlighter.query, tree.root_node(), code.as_bytes());
 
-        for mat in matches {
+        while let Some(mat) = matches.next() {
             for cap in mat.captures {
                 let node = cap.node;
                 let start = node.start_byte();
                 let end = node.end_byte();
-                let scope = self.query.capture_names()[cap.index as usize].as_str();
-                let style = self.theme.get_style(scope);
+                let scope = highlighter.query.capture_names()[cap.index as usize];
 
-                if let Some(style) = style {
+                if let Some(style) = self.theme.get_style(scope) {
                     colors.push(StyleInfo { start, end, style });
                 }
             }
         }
 
         Ok(colors)
+    }
+}
+
+fn file_extension(file: &str) -> Option<String> {
+    Path::new(file)
+        .extension()
+        .map(|extension| extension.to_string_lossy().to_ascii_lowercase())
+}
+
+fn language_definitions() -> Vec<LanguageDefinition> {
+    vec![
+        LanguageDefinition {
+            id: "rust",
+            extensions: &["rs"],
+            language: || tree_sitter_rust::LANGUAGE.into(),
+            highlight_query: tree_sitter_rust::HIGHLIGHTS_QUERY,
+        },
+        LanguageDefinition {
+            id: "markdown",
+            extensions: &["md", "markdown"],
+            language: || tree_sitter_md::LANGUAGE.into(),
+            highlight_query: MARKDOWN_HIGHLIGHT_QUERY,
+        },
+        LanguageDefinition {
+            id: "javascript",
+            extensions: &["js", "jsx", "mjs", "cjs"],
+            language: || tree_sitter_javascript::LANGUAGE.into(),
+            highlight_query: tree_sitter_javascript::HIGHLIGHT_QUERY,
+        },
+        LanguageDefinition {
+            id: "typescript",
+            extensions: &["ts"],
+            language: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            highlight_query: tree_sitter_typescript::HIGHLIGHTS_QUERY,
+        },
+        LanguageDefinition {
+            id: "tsx",
+            extensions: &["tsx"],
+            language: || tree_sitter_typescript::LANGUAGE_TSX.into(),
+            highlight_query: tree_sitter_typescript::HIGHLIGHTS_QUERY,
+        },
+        LanguageDefinition {
+            id: "json",
+            extensions: &["json"],
+            language: || tree_sitter_json::LANGUAGE.into(),
+            highlight_query: tree_sitter_json::HIGHLIGHTS_QUERY,
+        },
+        LanguageDefinition {
+            id: "toml",
+            extensions: &["toml"],
+            language: || tree_sitter_toml_ng::LANGUAGE.into(),
+            highlight_query: tree_sitter_toml_ng::HIGHLIGHTS_QUERY,
+        },
+        LanguageDefinition {
+            id: "yaml",
+            extensions: &["yml", "yaml"],
+            language: || tree_sitter_yaml::LANGUAGE.into(),
+            highlight_query: tree_sitter_yaml::HIGHLIGHTS_QUERY,
+        },
+        LanguageDefinition {
+            id: "python",
+            extensions: &["py", "pyw"],
+            language: || tree_sitter_python::LANGUAGE.into(),
+            highlight_query: tree_sitter_python::HIGHLIGHTS_QUERY,
+        },
+    ]
+}
+
+const MARKDOWN_HIGHLIGHT_QUERY: &str = r#"
+(atx_heading
+  (atx_h1_marker) @punctuation.definition.heading.markdown
+  (inline) @heading.1.markdown)
+
+(atx_heading
+  (atx_h2_marker) @punctuation.definition.heading.markdown
+  (inline) @heading.2.markdown)
+
+(atx_heading
+  (atx_h3_marker) @punctuation.definition.heading.markdown
+  (inline) @heading.3.markdown)
+
+(atx_heading
+  (atx_h4_marker) @punctuation.definition.heading.markdown
+  (inline) @heading.4.markdown)
+
+(atx_heading
+  (atx_h5_marker) @punctuation.definition.heading.markdown
+  (inline) @heading.5.markdown)
+
+(atx_heading
+  (atx_h6_marker) @punctuation.definition.heading.markdown
+  (inline) @heading.6.markdown)
+
+(setext_heading
+  (paragraph) @markup.heading.setext.1.markdown
+  (setext_h1_underline) @punctuation.definition.heading.markdown)
+
+(setext_heading
+  (paragraph) @markup.heading.setext.2.markdown
+  (setext_h2_underline) @punctuation.definition.heading.markdown)
+
+[
+  (list_marker_plus)
+  (list_marker_minus)
+  (list_marker_star)
+  (list_marker_dot)
+  (list_marker_parenthesis)
+] @punctuation.definition.list.begin.markdown
+
+[
+  (indented_code_block)
+  (fenced_code_block)
+] @markup.raw.block.markdown
+
+(fenced_code_block_delimiter) @punctuation.definition.raw.markdown
+
+(link_destination) @markup.underline.link.markdown
+(link_label) @constant.other.reference.link.markdown
+(thematic_break) @meta.separator.markdown
+
+[
+  (block_continuation)
+  (block_quote_marker)
+] @punctuation.definition.quote.begin.markdown
+
+(backslash_escape) @escape
+"#;
+
+pub fn normalized_extension(file: &str) -> Option<String> {
+    PathBuf::from(file)
+        .extension()
+        .map(|extension| extension.to_string_lossy().to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::theme::parse_vscode_theme;
+
+    use super::*;
+
+    fn highlighter() -> Highlighter {
+        let theme = parse_vscode_theme("themes/mocha.json").unwrap();
+        Highlighter::new(&theme).unwrap()
+    }
+
+    #[test]
+    fn resolves_language_by_file_extension() {
+        let highlighter = highlighter();
+
+        assert_eq!(
+            highlighter.language_id_for_file(Some("main.rs")),
+            Some("rust")
+        );
+        assert_eq!(
+            highlighter.language_id_for_file(Some("README.MD")),
+            Some("markdown")
+        );
+        assert_eq!(
+            highlighter.language_id_for_file(Some("component.tsx")),
+            Some("tsx")
+        );
+        assert_eq!(
+            highlighter.language_id_for_file(Some("config.yml")),
+            Some("yaml")
+        );
+        assert_eq!(highlighter.language_id_for_file(Some("LICENSE")), None);
+    }
+
+    #[test]
+    fn highlights_supported_languages() {
+        let samples = [
+            ("rust", "fn main() { let value = true; }\n"),
+            ("markdown", "# Heading\n\n```rust\nfn main() {}\n```\n"),
+            ("javascript", "const value = true;\n"),
+            ("typescript", "const value: boolean = true;\n"),
+            ("tsx", "export const View = () => <div />;\n"),
+            ("json", r#"{"value": true}"#),
+            ("toml", "value = true\n"),
+            ("yaml", "value: true\n"),
+            ("python", "def main():\n    return True\n"),
+        ];
+        let mut highlighter = highlighter();
+
+        for (language_id, code) in samples {
+            let styles = highlighter.highlight(language_id, code).unwrap();
+            assert!(
+                !styles.is_empty(),
+                "{language_id} should produce syntax highlight spans"
+            );
+        }
+    }
+
+    #[test]
+    fn markdown_uses_theme_compatible_scopes() {
+        let mut highlighter = highlighter();
+        let styles = highlighter
+            .highlight_for_file(Some("CLAUDE.md"), "### Debugging\n- `dh` - History\n")
+            .unwrap();
+
+        assert!(
+            !styles.is_empty(),
+            "markdown should produce themed highlight spans"
+        );
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= 4 && style.end >= 13),
+            "markdown heading text should be highlighted"
+        );
+        assert!(
+            styles.iter().any(|style| style.start == 14),
+            "markdown list marker should be highlighted"
+        );
+    }
+
+    #[test]
+    fn unknown_languages_do_not_error() {
+        let mut highlighter = highlighter();
+
+        assert!(highlighter
+            .highlight("unknown", "plain text")
+            .unwrap()
+            .is_empty());
+        assert!(highlighter
+            .highlight_for_file(Some("notes.txt"), "plain text")
+            .unwrap()
+            .is_empty());
     }
 }

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -497,6 +497,23 @@ impl RealLspClient {
 
         changes
     }
+
+    pub async fn did_open_with_language_id(
+        &mut self,
+        file: &str,
+        contents: &str,
+        language_id: &str,
+    ) -> Result<(), LspError> {
+        log!("[lsp] did_open file: {} language_id: {}", file, language_id);
+        let params = did_open_params(file, contents, language_id)?;
+
+        self.files_content
+            .insert(file.to_string(), contents.to_string());
+        self.files_versions.insert(file.to_string(), 1);
+        <Self as LspClient>::send_notification(self, "textDocument/didOpen", params, false).await?;
+
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -715,16 +732,9 @@ impl LspClient for RealLspClient {
     }
 
     async fn did_open(&mut self, file: &str, contents: &str) -> Result<(), LspError> {
-        log!("[lsp] did_open file: {}", file);
-        let params = did_open_params(file, contents, &self.config.language_id)?;
-
-        self.files_content
-            .insert(file.to_string(), contents.to_string());
-        self.files_versions.insert(file.to_string(), 1);
-        self.send_notification("textDocument/didOpen", params, false)
-            .await?;
-
-        Ok(())
+        let language_id = self.config.language_id.clone();
+        self.did_open_with_language_id(file, contents, &language_id)
+            .await
     }
 
     async fn did_change(&mut self, file: &str, contents: &str) -> Result<(), LspError> {

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -1,12 +1,16 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
 use path_absolutize::Absolutize;
 use serde_json::Value;
 
-use crate::config::{LanguageServerConfig, LspConfig};
+use crate::{
+    config::{LanguageServerConfig, LspConfig},
+    highlighter::normalized_extension,
+    log,
+};
 
 use super::{
     Diagnostic, InboundMessage, LspClient, LspError, Range, RealLspClient, ServerCapabilities,
@@ -24,6 +28,7 @@ pub struct DocumentInfo {
 pub struct LspManager {
     config: LspConfig,
     clients: HashMap<String, RealLspClient>,
+    failed_clients: HashSet<String>,
 }
 
 impl LspManager {
@@ -31,6 +36,7 @@ impl LspManager {
         Self {
             config,
             clients: HashMap::new(),
+            failed_clients: HashSet::new(),
         }
     }
 
@@ -39,16 +45,23 @@ impl LspManager {
             return None;
         }
 
-        let path = Path::new(file);
-        let extension = path.extension()?.to_string_lossy().to_ascii_lowercase();
-        let (server_name, server) = self.config.servers.iter().find(|(_, server)| {
-            server.file_extensions.iter().any(|candidate| {
-                candidate
-                    .trim_start_matches('.')
-                    .eq_ignore_ascii_case(&extension)
-            })
-        })?;
+        let extension = normalized_extension(file)?;
+        let (server_name, server, document) =
+            self.config
+                .servers
+                .iter()
+                .find_map(|(server_name, server)| {
+                    let document = server.documents().into_iter().find(|document| {
+                        document.file_extensions.iter().any(|candidate| {
+                            candidate
+                                .trim_start_matches('.')
+                                .eq_ignore_ascii_case(&extension)
+                        })
+                    })?;
+                    Some((server_name, server, document))
+                })?;
 
+        let path = Path::new(file);
         let path = path.absolutize().ok()?.to_path_buf();
         let workspace_root = find_workspace_root(&path, server);
         let uri = file_uri(&path);
@@ -56,7 +69,7 @@ impl LspManager {
         Some(DocumentInfo {
             path,
             uri,
-            language_id: server.language_id.clone(),
+            language_id: document.language_id,
             workspace_root,
             server_name: server_name.clone(),
         })
@@ -70,6 +83,9 @@ impl LspManager {
             return Ok(None);
         };
         let key = client_key(&document);
+        if self.failed_clients.contains(&key) {
+            return Ok(None);
+        }
 
         if !self.clients.contains_key(&key) {
             let config = self
@@ -84,8 +100,19 @@ impl LspManager {
                     ))
                 })?;
 
-            let mut client = RealLspClient::start(config, document.workspace_root).await?;
-            client.initialize().await?;
+            let mut client = match RealLspClient::start(config, document.workspace_root).await {
+                Ok(client) => client,
+                Err(err) => {
+                    log!("[lsp] failed to start client {}: {}", key, err);
+                    self.failed_clients.insert(key);
+                    return Ok(None);
+                }
+            };
+            if let Err(err) = client.initialize().await {
+                log!("[lsp] failed to initialize client {}: {}", key, err);
+                self.failed_clients.insert(key);
+                return Ok(None);
+            }
             self.clients.insert(key.clone(), client);
         }
 
@@ -139,9 +166,15 @@ impl LspClient for LspManager {
     }
 
     async fn did_open(&mut self, file: &str, contents: &str) -> Result<(), LspError> {
-        if let Some(client) = self.client_for_file(file).await? {
-            client.did_open(file, contents).await?;
-        }
+        let Some(document) = self.resolve_document(file) else {
+            return Ok(());
+        };
+        let Some(client) = self.client_for_file(file).await? else {
+            return Ok(());
+        };
+        client
+            .did_open_with_language_id(file, contents, &document.language_id)
+            .await?;
         Ok(())
     }
 
@@ -353,7 +386,7 @@ impl LspClient for LspManager {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::config::LanguageServerConfig;
+    use crate::config::{LanguageDocumentConfig, LanguageServerConfig};
 
     use super::*;
 
@@ -363,6 +396,27 @@ mod tests {
             args: Vec::new(),
             language_id: language_id.to_string(),
             file_extensions: extensions.iter().map(|ext| ext.to_string()).collect(),
+            documents: Vec::new(),
+            root_markers: vec![".git".to_string()],
+            env: HashMap::new(),
+            initialization_options: None,
+            workspace_name: None,
+        }
+    }
+
+    fn multi_document_server(documents: &[(&str, &[&str])]) -> LanguageServerConfig {
+        LanguageServerConfig {
+            command: "mock-lsp".to_string(),
+            args: Vec::new(),
+            language_id: String::new(),
+            file_extensions: Vec::new(),
+            documents: documents
+                .iter()
+                .map(|(language_id, extensions)| LanguageDocumentConfig {
+                    language_id: language_id.to_string(),
+                    file_extensions: extensions.iter().map(|ext| ext.to_string()).collect(),
+                })
+                .collect(),
             root_markers: vec![".git".to_string()],
             env: HashMap::new(),
             initialization_options: None,
@@ -394,6 +448,26 @@ mod tests {
         });
 
         assert!(manager.resolve_document("README.md").is_none());
+    }
+
+    #[test]
+    fn resolves_document_selector_language_by_extension() {
+        let manager = LspManager::new(LspConfig {
+            enabled: true,
+            servers: HashMap::from([(
+                "web".to_string(),
+                multi_document_server(&[
+                    ("typescript", &["ts"]),
+                    ("typescriptreact", &["tsx"]),
+                    ("javascript", &["js"]),
+                    ("javascriptreact", &["jsx"]),
+                ]),
+            )]),
+        });
+
+        let document = manager.resolve_document("component.TSX").unwrap();
+        assert_eq!(document.language_id, "typescriptreact");
+        assert_eq!(document.server_name, "web");
     }
 
     #[test]


### PR DESCRIPTION
## Why

Red previously treated syntax highlighting and language-server startup as effectively Rust-centered behavior. That made Markdown files appear mostly unhighlighted, made non-Rust files miss language-aware rendering, and made it difficult to route files to the right language server when a single server handles multiple document types. This PR makes filetype detection explicit so syntax highlighting, Markdown code fences, and LSP document selection can follow the file being edited.

## What Changed

- Added a Tree-sitter highlighter registry in `src/highlighter.rs` with compiled-in support for Rust, Markdown, JavaScript, TypeScript/TSX, JSON, TOML, YAML, Python, and Bash.
- Replaced the Markdown highlight query with theme-compatible scopes and added Markdown fenced-code injections so `rust`, `json`, and `sh` fenced blocks receive nested syntax highlighting.
- Updated rendering style selection in `src/editor.rs` so narrower injected spans override broad Markdown raw-block styling.
- Expanded LSP configuration in `src/config.rs` and `src/lsp/manager.rs` to support document selectors, extension-based language IDs, workspace-root detection, and lazy per-workspace server startup.
- Added default LSP configs and sample config documentation for the supported common file types.

## How to Test

1. Start `red` on a Markdown file that contains a heading, a list item, and fenced code blocks using languages such as `rust` and `sh`.
2. Confirm the Markdown heading/list syntax is colored and the code inside each fenced block receives the nested language highlighting instead of a single raw-block style.
3. Open representative files such as `main.rs`, `README.md`, `script.sh`, `config.toml`, and `package.json`, and confirm each file renders with syntax highlighting appropriate to its extension.
4. With the relevant language servers installed, open files with configured extensions and confirm the matching LSP starts only for matching documents. For TypeScript-family files, verify `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, and `.cjs` route through the TypeScript server with the appropriate language ID.
5. As a regression check, open an unknown extension and a Markdown fence with an unknown language name; both should remain usable and skip language-specific highlighting rather than erroring.

Targeted tests:

- `cargo test highlighter`
- `cargo test`
