### PR TITLE
fix(tui): preserve blank line indentation

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2938,25 +2938,28 @@ impl Editor {
         self.current_buffer().get(self.buffer_line())
     }
 
+    fn leading_indentation(line: &str) -> usize {
+        line.trim_end_matches(&['\r', '\n'][..])
+            .chars()
+            .take_while(|c| c.is_whitespace())
+            .count()
+    }
+
     fn previous_line_indentation(&self) -> usize {
         if self.buffer_line() > 0 {
-            self.current_buffer()
-                .get(self.buffer_line() - 1)
-                .unwrap_or_default()
-                .chars()
-                .position(|c| !c.is_whitespace())
-                .unwrap_or(0)
+            Self::leading_indentation(
+                &self
+                    .current_buffer()
+                    .get(self.buffer_line() - 1)
+                    .unwrap_or_default(),
+            )
         } else {
             0
         }
     }
 
     fn current_line_indentation(&self) -> usize {
-        self.current_line_contents()
-            .unwrap_or_default()
-            .chars()
-            .position(|c| !c.is_whitespace())
-            .unwrap_or(0)
+        Self::leading_indentation(&self.current_line_contents().unwrap_or_default())
     }
 
     /// Executes a single editor action
@@ -3334,20 +3337,26 @@ impl Editor {
                 let spaces = self.current_line_indentation();
 
                 let current_line = self.current_line_contents().unwrap_or_default();
-                let current_line = current_line.trim_end();
-                let current_line_len = grapheme_len(current_line);
+                let current_line_without_ending = current_line.trim_end_matches(&['\r', '\n'][..]);
+                let current_line_for_split =
+                    if current_line_without_ending.chars().all(char::is_whitespace) {
+                        current_line_without_ending
+                    } else {
+                        current_line_without_ending.trim_end()
+                    };
+                let current_line_len = grapheme_len(current_line_for_split);
                 if self.cx > current_line_len {
                     self.cx = current_line_len;
                 }
-                let cursor_char = grapheme_to_char(current_line, self.cx);
-                let before_cursor = char_prefix(current_line, cursor_char).to_string();
-                let after_cursor = char_suffix(current_line, cursor_char).to_string();
+                let cursor_char = grapheme_to_char(current_line_for_split, self.cx);
+                let before_cursor = char_prefix(current_line_for_split, cursor_char).to_string();
+                let after_cursor = char_suffix(current_line_for_split, cursor_char).to_string();
 
                 let line = self.buffer_line();
                 self.replace_range(
                     TextRange::new(
                         TextPosition::new(line, 0),
-                        TextPosition::new(line, current_line.chars().count()),
+                        TextPosition::new(line, current_line_without_ending.chars().count()),
                     ),
                     &format!("{}\n{}{}", before_cursor, " ".repeat(spaces), after_cursor),
                 );

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2844,10 +2844,11 @@ impl Editor {
                 let Some(open_idx) = stack.pop() else {
                     continue;
                 };
-                if open_idx <= cursor && cursor <= idx {
-                    if best_pair.is_none_or(|(best_open_idx, _)| open_idx > best_open_idx) {
-                        best_pair = Some((open_idx, idx));
-                    }
+                if open_idx <= cursor
+                    && cursor <= idx
+                    && best_pair.is_none_or(|(best_open_idx, _)| open_idx > best_open_idx)
+                {
+                    best_pair = Some((open_idx, idx));
                 }
             }
         }

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -361,7 +361,7 @@ impl Editor {
         // Pass 2: Refine intersections based on adjacent cells
         let mut final_grid: HashMap<(usize, usize), char> = HashMap::new();
 
-        for ((x, y), _) in &temp_grid {
+        for (x, y) in temp_grid.keys() {
             // Check adjacent cells
             let connects_up = if *y > 0 {
                 temp_grid

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -135,6 +135,37 @@ async fn test_open_line_below() {
 }
 
 #[tokio::test]
+async fn test_enter_on_opened_indented_blank_line_preserves_indentation() {
+    let mut harness = EditorHarness::with_content("fn name() {\n    let a = 1;\n}");
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(4, 2);
+
+    harness.execute_action(Action::InsertNewLine).await.unwrap();
+
+    harness.assert_cursor_at(4, 3);
+    harness.assert_buffer_contents("fn name() {\n    let a = 1;\n    \n    \n}");
+}
+
+#[tokio::test]
+async fn test_enter_on_existing_whitespace_only_line_preserves_indentation() {
+    let mut harness = EditorHarness::with_content("    \nnext");
+
+    harness
+        .execute_action(Action::SetCursor(3, 0))
+        .await
+        .unwrap();
+    harness.execute_action(Action::InsertNewLine).await.unwrap();
+
+    harness.assert_cursor_at(4, 1);
+    harness.assert_buffer_contents("   \n     \nnext");
+}
+
+#[tokio::test]
 async fn test_open_line_above() {
     let mut harness = EditorHarness::with_content("Line 1\nLine 2");
 


### PR DESCRIPTION
## Summary

Fixes #64.

When users open an indented blank line with `o` and press Enter before typing, Red previously treated the whitespace-only line as having no indentation. The cursor jumped to column 0 and the new line lost the expected indent.

This change counts leading whitespace after trimming only line endings, so whitespace-only lines report their visible indentation. `InsertNewLine` now splits whitespace-only lines without trimming them while still removing trailing whitespace from non-blank lines.

## How to Test

1. Open a Rust-like buffer containing:

```rust
fn name() {
    let a = 1;
}
```

2. Put the cursor on `let a = 1;`, press `o`, then press Enter without typing.
3. Confirm the cursor remains at the four-space indentation column on the new blank line, and both blank lines stay indented.
4. Also verify that pressing Enter on a pre-existing whitespace-only line keeps the cursor at that line's indentation level.

Targeted tests:

- `cargo test --test editing --quiet`
- `cargo test --test movement --quiet`
- `cargo test --test unicode --quiet`
