### PR TITLE
docs(core): copy plugins during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cargo install --path .
 ```shell
 mkdir -p ~/.config/red
 cp default_config.toml ~/.config/red/config.toml
-cp -R themes ~/.config/red
+cp -R themes plugins ~/.config/red
 ```
 
 ### Quick Start


### PR DESCRIPTION
## Summary

The default config enables bundled plugins such as `theme_browser`, but the manual setup instructions only copied `themes` into `~/.config/red`. A fresh install following the README could therefore miss the plugin scripts referenced by `default_config.toml`.

This updates the setup snippet to copy both `themes` and `plugins` into the config directory.

This addresses the install-doc gap noted while reviewing #67.

## How to Test

1. Follow the README setup commands after `cargo install --path .`.
2. Confirm both `~/.config/red/themes` and `~/.config/red/plugins` exist.
3. Confirm plugin entries in `~/.config/red/config.toml`, such as `theme_browser = "theme_browser.js"`, have corresponding files under `~/.config/red/plugins`.

Targeted verification:

- Documentation-only change; reviewed the README snippet against `default_config.toml` and the repository's `plugins/` directory.
