### PR TITLE
feat(tui): lazy load file picker entries

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -798,9 +798,16 @@ mod test {
         std::env::temp_dir().join(format!("red-{name}-{}", uuid::Uuid::new_v4()))
     }
 
+    fn test_home_dir() -> PathBuf {
+        std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .expect("HOME or USERPROFILE should be set for tests")
+    }
+
     #[tokio::test]
     async fn load_or_create_expands_home_paths() {
-        let home = PathBuf::from(std::env::var("HOME").expect("HOME should be set for tests"));
+        let home = test_home_dir();
         let dir_name = format!(".red-load-home-{}", uuid::Uuid::new_v4());
         let dir = home.join(&dir_name);
         fs::create_dir_all(&dir).unwrap();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -6144,9 +6144,16 @@ mod test {
             .collect()
     }
 
+    fn test_home_dir() -> PathBuf {
+        std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .expect("HOME or USERPROFILE should be set for tests")
+    }
+
     #[tokio::test]
     async fn open_file_action_expands_home_path_once() {
-        let home = PathBuf::from(std::env::var("HOME").expect("HOME should be set for tests"));
+        let home = test_home_dir();
         let dir_name = format!(".red-open-home-{}", uuid::Uuid::new_v4());
         let dir = home.join(&dir_name);
         std::fs::create_dir_all(&dir).unwrap();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1589,6 +1589,15 @@ impl Editor {
                             .await?;
                     }
 
+                    let dialog_changed = if let Some(current_dialog) = &mut self.current_dialog {
+                        current_dialog.tick()?
+                    } else {
+                        false
+                    };
+                    if dialog_changed {
+                        self.render(&mut buffer)?;
+                    }
+
                     // if self.sync_state.should_notify() {
                     //     for file in self.sync_state.get_changes().unwrap_or_default() {
                     //         // FIXME: not current buffer!

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::mpsc::{self, Receiver, TryRecvError},
 };
 
 use crossterm::event::{self};
@@ -15,37 +16,68 @@ use super::{Component, Picker};
 
 pub struct FilePicker {
     picker: Picker,
+    receiver: Option<Receiver<Result<Vec<String>, String>>>,
 }
 
 impl FilePicker {
     pub fn new(editor: &Editor, root_path: PathBuf) -> anyhow::Result<Self> {
-        let root_path = root_path.to_string_lossy().to_string();
-        let ignore = read_gitignore(&root_path)?;
-        let mut files = list_files(&root_path)?
-            .iter()
-            .filter(|f| !is_ignored(&ignore, f))
-            .map(|f| {
-                f.strip_prefix(&root_path)
-                    .unwrap()
-                    .trim_start_matches('/')
-                    .to_string()
-            })
-            .collect::<Vec<_>>();
-        files.sort();
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = load_file_picker_items(&root_path).map_err(|err| err.to_string());
+            _ = sender.send(result);
+        });
 
-        log!("files: {:?}", files);
+        Ok(Self::loading(editor, receiver))
+    }
 
-        let picker = Picker::builder()
+    fn loading(editor: &Editor, receiver: Receiver<Result<Vec<String>, String>>) -> Self {
+        let mut picker = Picker::builder()
             .title("Find Files")
-            .items(files)
+            .items(vec![])
             .select_action(Action::OpenFile)
             .build(editor);
+        picker.set_empty_message(Some("Loading files...".to_string()));
 
-        Ok(FilePicker { picker })
+        FilePicker {
+            picker,
+            receiver: Some(receiver),
+        }
     }
 }
 
 impl Component for FilePicker {
+    fn tick(&mut self) -> anyhow::Result<bool> {
+        let Some(receiver) = self.receiver.take() else {
+            return Ok(false);
+        };
+
+        match receiver.try_recv() {
+            Ok(Ok(files)) => {
+                self.picker.replace_items(files);
+                self.picker
+                    .set_empty_message(Some("No matching files".to_string()));
+                Ok(true)
+            }
+            Ok(Err(err)) => {
+                log!("file picker load failed: {}", err);
+                self.picker.replace_items(vec![]);
+                self.picker
+                    .set_empty_message(Some("Failed to load files".to_string()));
+                Ok(true)
+            }
+            Err(TryRecvError::Empty) => {
+                self.receiver = Some(receiver);
+                Ok(false)
+            }
+            Err(TryRecvError::Disconnected) => {
+                self.picker.replace_items(vec![]);
+                self.picker
+                    .set_empty_message(Some("Failed to load files".to_string()));
+                Ok(true)
+            }
+        }
+    }
+
     fn handle_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
         self.picker.handle_event(ev)
     }
@@ -57,6 +89,25 @@ impl Component for FilePicker {
     fn cursor_position(&self) -> Option<(usize, usize)> {
         self.picker.cursor_position()
     }
+}
+
+fn load_file_picker_items(root_path: &Path) -> anyhow::Result<Vec<String>> {
+    let root_path = root_path.to_string_lossy().to_string();
+    let ignore = read_gitignore(&root_path)?;
+    let mut files = list_files(&root_path)?
+        .iter()
+        .filter(|f| !is_ignored(&ignore, f))
+        .map(|f| {
+            f.strip_prefix(&root_path)
+                .unwrap()
+                .trim_start_matches('/')
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    files.sort();
+
+    log!("files: {:?}", files);
+    Ok(files)
 }
 
 fn read_gitignore<P: AsRef<Path>>(dir: P) -> anyhow::Result<Vec<String>> {
@@ -95,4 +146,85 @@ fn list_files<P: AsRef<Path>>(dir: P) -> anyhow::Result<Vec<String>> {
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+    use crate::{
+        buffer::Buffer,
+        config::{Config, KeyAction},
+        editor::Editor,
+        lsp::LspManager,
+        theme::{Style, Theme},
+    };
+
+    fn test_editor() -> Editor {
+        let config = Config::default();
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, String::new());
+
+        Editor::with_size(lsp, 80, 24, config, Theme::default(), vec![buffer]).unwrap()
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn buffer_text(buffer: &RenderBuffer) -> String {
+        buffer
+            .cells
+            .chunks(buffer.width)
+            .map(|row| row.iter().map(|cell| cell.c).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn file_picker_draws_loading_message_before_files_arrive() {
+        let editor = test_editor();
+        let (_sender, receiver) = mpsc::channel();
+        let picker = FilePicker::loading(&editor, receiver);
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        picker.draw(&mut buffer).unwrap();
+
+        assert!(buffer_text(&buffer).contains("Loading files..."));
+    }
+
+    #[test]
+    fn file_picker_populates_items_after_load_finishes() {
+        let editor = test_editor();
+        let (sender, receiver) = mpsc::channel();
+        let mut picker = FilePicker::loading(&editor, receiver);
+
+        picker.handle_event(&key(KeyCode::Char('m')));
+        sender.send(Ok(vec!["src/main.rs".to_string()])).unwrap();
+
+        assert!(picker.tick().unwrap());
+        assert_eq!(
+            picker.handle_event(&key(KeyCode::Enter)),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::OpenFile("src/main.rs".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn file_picker_draws_error_message_after_load_fails() {
+        let editor = test_editor();
+        let (sender, receiver) = mpsc::channel();
+        let mut picker = FilePicker::loading(&editor, receiver);
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        sender.send(Err("boom".to_string())).unwrap();
+
+        assert!(picker.tick().unwrap());
+        picker.draw(&mut buffer).unwrap();
+
+        assert!(buffer_text(&buffer).contains("Failed to load files"));
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -21,6 +21,10 @@ use crate::{
 pub trait Component: Send {
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()>;
 
+    fn tick(&mut self) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+
     fn handle_event(&mut self, ev: &Event) -> Option<crate::config::KeyAction> {
         match ev {
             Event::Key(event) => match event.code {

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -8,7 +8,7 @@ use crate::{
     config::KeyAction,
     editor::{Action, Editor, RenderBuffer},
     theme::Theme,
-    unicode_utils::display_width,
+    unicode_utils::{display_width, fit_display_width},
 };
 
 use super::{dialog::BorderStyle, Component, Dialog, List};
@@ -27,6 +27,7 @@ pub struct Picker {
     matcher: SkimMatcherV2,
     select_action: Option<SelectAction>,
     search: String,
+    empty_message: Option<String>,
     theme: Theme,
     live: bool,
 }
@@ -82,6 +83,7 @@ impl Picker {
             matcher: SkimMatcherV2::default(),
             select_action: None,
             search: String::new(),
+            empty_message: None,
             theme: editor.theme.clone(),
             live: false,
         }
@@ -107,6 +109,11 @@ impl Picker {
     }
 
     pub fn filter(&mut self, term: &str) {
+        if term.is_empty() {
+            self.list.set_items(self.items.clone());
+            return;
+        }
+
         let mut new_items = self
             .items
             .iter()
@@ -125,6 +132,16 @@ impl Picker {
             .map(|(item, _)| item.to_string())
             .collect::<Vec<_>>();
         self.list.set_items(new_items);
+    }
+
+    pub fn replace_items(&mut self, items: Vec<String>) {
+        self.items = items;
+        let search = self.search.clone();
+        self.filter(&search);
+    }
+
+    pub fn set_empty_message(&mut self, message: Option<String>) {
+        self.empty_message = message;
     }
 
     fn selected_item(&self) -> Option<String> {
@@ -245,6 +262,17 @@ impl Component for Picker {
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         self.dialog.draw(buffer)?;
         self.list.draw(buffer)?;
+        if self.list.items().is_empty() {
+            if let Some(message) = &self.empty_message {
+                let line = fit_display_width(message, self.width.saturating_sub(2));
+                buffer.set_text(
+                    self.x + 2,
+                    self.y + 1,
+                    &line,
+                    &self.theme.ui_style.picker_item,
+                );
+            }
+        }
 
         let dy = self.y + self.height.saturating_sub(2);
         let border_style = &self.theme.ui_style.popup_border;
@@ -357,6 +385,13 @@ mod tests {
 
     fn select(picker: &mut Picker) -> Option<KeyAction> {
         picker.handle_event(&key(KeyCode::Enter, KeyModifiers::NONE))
+    }
+
+    fn render_row(buffer: &RenderBuffer, y: usize) -> String {
+        buffer.cells[y * buffer.width..(y + 1) * buffer.width]
+            .iter()
+            .map(|cell| cell.c)
+            .collect()
     }
 
     #[test]
@@ -487,6 +522,37 @@ mod tests {
                 Action::Picked("jay".to_string(), None),
             ]))
         );
+    }
+
+    #[test]
+    fn replace_items_reapplies_current_search() {
+        let editor = test_editor();
+        let mut picker = Picker::new(Some("Files".to_string()), &editor, &[], None);
+
+        picker.handle_event(&key(KeyCode::Char('s'), KeyModifiers::NONE));
+        picker.handle_event(&key(KeyCode::Char('r'), KeyModifiers::NONE));
+        picker.handle_event(&key(KeyCode::Char('c'), KeyModifiers::NONE));
+        picker.replace_items(vec!["src/main.rs".to_string(), "README.md".to_string()]);
+
+        assert_eq!(
+            select(&mut picker),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::Picked("src/main.rs".to_string(), None),
+            ]))
+        );
+    }
+
+    #[test]
+    fn picker_draws_empty_message_when_no_items_are_visible() {
+        let editor = test_editor();
+        let mut picker = Picker::new(Some("Files".to_string()), &editor, &[], None);
+        picker.set_empty_message(Some("Loading files...".to_string()));
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        picker.draw(&mut buffer).unwrap();
+
+        assert!(render_row(&buffer, picker.y + 1).contains("Loading files..."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- open the file picker immediately with a loading message
- load file entries on a background thread and update the picker on dialog tick
- preserve typed search when entries arrive and add empty/error picker states

## Testing
- `cargo fmt --check && timeout 180 cargo test`
