### PR TITLE
feat(tui): add cursor word search

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -89,6 +89,7 @@ Esc = { EnterMode = "Normal" }
 "Tab" = "JumpForward"
 "x" = "DeleteCharAtCursorPos"
 "z" = { "z" = "MoveLineToViewportCenter" }
+"*" = "SearchWordUnderCursor"
 "n" = [ "FindNext" ]
 "N" = [ "FindPrevious" ]
 "a" = [ { EnterMode = "Insert" }, "MoveRight" ]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -653,7 +653,7 @@ impl Buffer {
 
     /// Finds the previous occurrence of a search query
     pub fn find_prev(&self, query: &str, (x, y): (usize, usize)) -> Option<(usize, usize)> {
-        let (mut x, mut y) = self.find_word_start((x, y))?;
+        let (mut x, mut y) = (x, y);
 
         loop {
             if y > self.len() {
@@ -661,7 +661,7 @@ impl Buffer {
             }
 
             let line = self.get(y)?;
-            let prefix = crate::unicode_utils::char_prefix(&line, x);
+            let prefix = crate::unicode_utils::char_prefix(&line, x.min(line.chars().count()));
             if let Some(pos) = prefix.rfind(query) {
                 return Some((prefix[..pos].chars().count(), y));
             }
@@ -1000,6 +1000,14 @@ mod test {
         assert_eq!(buffer.find_prev_word((0, 15)), Some((21, 14))); // } -> " before ;
         assert_eq!(buffer.find_prev_word((4, 14)), Some((20, 13))); // } -> empty line
         assert_eq!(buffer.find_prev_word((0, 0)), None); // struct -> start of buffer
+    }
+
+    #[test]
+    fn test_find_prev_search_skips_current_match_start() {
+        let buffer = Buffer::new(None, "alpha beta alpha gamma alpha".to_string());
+
+        assert_eq!(buffer.find_prev("alpha", (23, 0)), Some((11, 0)));
+        assert_eq!(buffer.find_prev("alpha", (11, 0)), Some((0, 0)));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -383,7 +383,7 @@ pub struct Keys {
 
 #[cfg(test)]
 mod test {
-    use crate::editor::Mode;
+    use crate::editor::{Action, Mode};
 
     use super::*;
 
@@ -470,6 +470,16 @@ theme = "theme/nightfox.json"
         assert!(config.lsp.servers.contains_key("json"));
         assert!(config.lsp.servers.contains_key("toml"));
         assert!(config.lsp.servers.contains_key("yaml"));
+    }
+
+    #[test]
+    fn default_config_maps_star_to_search_word_under_cursor() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.keys.normal.get("*"),
+            Some(&KeyAction::Single(Action::SearchWordUnderCursor))
+        );
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -205,6 +205,7 @@ pub enum Action {
 
     FindNext,
     FindPrevious,
+    SearchWordUnderCursor,
 
     MoveUp,
     MoveDown,
@@ -2827,6 +2828,35 @@ impl Editor {
         ))
     }
 
+    fn word_under_cursor(&self) -> Option<String> {
+        let line_index = self.buffer_line();
+        let line = self.current_buffer().get(line_index)?;
+        let line = line.trim_end_matches('\n');
+        let chars = line.chars().collect::<Vec<_>>();
+        if chars.is_empty() {
+            return None;
+        }
+
+        let cursor = self
+            .grapheme_to_char_on_line(self.cx, line_index)
+            .min(chars.len().saturating_sub(1));
+        if !is_keyword_char(chars[cursor]) {
+            return None;
+        }
+
+        let mut start = cursor;
+        while start > 0 && is_keyword_char(chars[start - 1]) {
+            start -= 1;
+        }
+
+        let mut end = cursor + 1;
+        while end < chars.len() && is_keyword_char(chars[end]) {
+            end += 1;
+        }
+
+        Some(chars[start..end].iter().collect())
+    }
+
     fn delimited_text_object_range(
         &self,
         scope: TextObjectScope,
@@ -4005,6 +4035,19 @@ impl Editor {
                     self.cx = x;
                     self.go_to_line(y + 1, buffer, runtime, GoToLinePosition::Center)
                         .await?;
+                }
+            }
+            Action::SearchWordUnderCursor => {
+                if let Some(search_term) = self.word_under_cursor() {
+                    self.search_term = search_term;
+                    if let Some((x, y)) = self
+                        .current_buffer()
+                        .find_next(&self.search_term, (self.cx, self.vtop + self.cy))
+                    {
+                        self.cx = x;
+                        self.go_to_line(y + 1, buffer, runtime, GoToLinePosition::Center)
+                            .await?;
+                    }
                 }
             }
             Action::DeleteWord => {

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -130,6 +130,48 @@ async fn test_word_movement_preserves_visible_viewport() {
 }
 
 #[tokio::test]
+async fn test_search_word_under_cursor_moves_to_next_match() {
+    let mut harness = EditorHarness::with_content("alpha beta alpha gamma alpha");
+
+    harness
+        .execute_action(Action::SearchWordUnderCursor)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(11, 0);
+
+    harness.execute_action(Action::FindNext).await.unwrap();
+    harness.assert_cursor_at(23, 0);
+
+    harness.execute_action(Action::FindPrevious).await.unwrap();
+    harness.assert_cursor_at(11, 0);
+}
+
+#[tokio::test]
+async fn test_search_word_under_cursor_keeps_underscore_in_keyword() {
+    let mut harness = EditorHarness::with_content("foo_bar foo bar foo_bar");
+
+    harness
+        .execute_action(Action::SearchWordUnderCursor)
+        .await
+        .unwrap();
+
+    harness.assert_cursor_at(16, 0);
+}
+
+#[tokio::test]
+async fn test_search_word_under_cursor_ignores_punctuation() {
+    let mut harness = EditorHarness::with_content("alpha ! alpha");
+    harness.execute_action(Action::MoveTo(6, 0)).await.unwrap();
+
+    harness
+        .execute_action(Action::SearchWordUnderCursor)
+        .await
+        .unwrap();
+
+    harness.assert_cursor_at(6, 0);
+}
+
+#[tokio::test]
 async fn test_file_movement() {
     let mut harness = EditorHarness::with_content("Line 1\nLine 2\nLine 3\nLine 4\nLine 5");
 


### PR DESCRIPTION
## Summary

- add a normal-mode `SearchWordUnderCursor` action bound to `*`
- seed the existing search term so `n` and `N` continue the cursor-word search
- adjust previous search to skip the current match start

## Validation

- `cargo test`
