### PR TITLE
feat(tui): enable LSP autocomplete

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -58,6 +58,7 @@ log_file = "/tmp/red.log"
 Enter = "InsertNewLine"
 Backspace = "DeletePreviousChar"
 Tab = "InsertTab"
+"Ctrl-Space" = "RequestCompletion"
 Esc = { EnterMode = "Normal" }
 
 [keys.normal]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2084,6 +2084,31 @@ impl Editor {
         Some(Action::ShowProgress(progress_params.clone()))
     }
 
+    fn completion_filter_for_response(&self, msg: &ResponseMessage) -> Option<String> {
+        let req = msg.request.as_ref()?;
+        let params = req.params.as_object()?;
+        let position = params.get("position")?.as_object()?;
+        let request_line = position.get("line")?.as_u64()? as usize;
+        let request_character = position.get("character")?.as_u64()? as usize;
+
+        if request_line != self.buffer_line() {
+            return None;
+        }
+
+        let current_character = self.grapheme_to_char_on_line(self.cx, self.buffer_line());
+        if current_character < request_character {
+            return None;
+        }
+
+        let line = self.current_buffer().get(request_line)?;
+        Some(
+            line.chars()
+                .skip(request_character)
+                .take(current_character - request_character)
+                .collect(),
+        )
+    }
+
     fn handle_lsp_message(
         &mut self,
         msg: &InboundMessage,
@@ -2151,6 +2176,9 @@ impl Editor {
                                     self.size.0 as usize,
                                     self.size.1 as usize,
                                 );
+                                if let Some(filter) = self.completion_filter_for_response(msg) {
+                                    self.completion_ui.set_filter(&filter);
+                                }
                                 self.current_dialog = Some(Box::new(self.completion_ui.clone()));
                                 return Some(Action::ShowDialog);
                             }
@@ -2250,7 +2278,10 @@ impl Editor {
         }
 
         if let Some(current_dialog) = &mut self.current_dialog {
-            return Ok(current_dialog.handle_event(ev));
+            let action = current_dialog.handle_event(ev);
+            if action.is_some() || !current_dialog.allows_event_passthrough() {
+                return Ok(action);
+            }
         }
 
         if self.panel_manager.focused_panel_id().is_some() {
@@ -3301,7 +3332,16 @@ impl Editor {
 
                 log!("Cursor after insert: cx = {}", self.cx);
 
-                self.draw_line(buffer);
+                if self
+                    .current_dialog
+                    .as_ref()
+                    .map(|dialog| dialog.allows_event_passthrough())
+                    .unwrap_or(false)
+                {
+                    self.render(buffer)?;
+                } else {
+                    self.draw_line(buffer);
+                }
             }
             Action::DeleteCharAt(x, y) => {
                 self.begin_transaction("delete char");
@@ -3990,7 +4030,16 @@ impl Editor {
                 if started_transaction {
                     self.commit_transaction(self.cursor_snapshot());
                 }
-                self.draw_line(buffer);
+                if self
+                    .current_dialog
+                    .as_ref()
+                    .map(|dialog| dialog.allows_event_passthrough())
+                    .unwrap_or(false)
+                {
+                    self.render(buffer)?;
+                } else {
+                    self.draw_line(buffer);
+                }
             }
             Action::Save => {
                 let resume_insert_transaction = self.commit_active_transaction_before_save();
@@ -6546,6 +6595,183 @@ mod test {
             .or_else(|| std::env::var_os("USERPROFILE"))
             .map(PathBuf::from)
             .expect("HOME or USERPROFILE should be set for tests")
+    }
+
+    fn completion_item(label: &str) -> CompletionResponseItem {
+        CompletionResponseItem {
+            label: label.to_string(),
+            kind: None,
+            detail: None,
+            documentation: None,
+            deprecated: None,
+            preselect: None,
+            sort_text: None,
+            filter_text: None,
+            insert_text: None,
+            insert_text_format: None,
+            text_edit: None,
+            additional_text_edits: None,
+            command: None,
+            data: None,
+            commit_characters: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn completion_dialog_allows_typing_to_continue() {
+        let mut editor = test_editor(40, 10);
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .execute(
+                &Action::EnterMode(Mode::Insert),
+                &mut render_buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        let mut completion = CompletionUI::new();
+        completion.show(vec![completion_item("alpha")], 0, 0);
+        editor.current_dialog = Some(Box::new(completion));
+
+        let event = Event::Key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+        if let Some(action) = editor.handle_event(&event).unwrap() {
+            editor
+                .handle_key_action(&event, &action, &mut render_buffer, &mut runtime)
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(editor.current_buffer().contents(), "zhello");
+    }
+
+    #[tokio::test]
+    async fn completion_dialog_redraws_typed_text_in_active_window() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let content = (0..30)
+            .map(|line| {
+                if line == 22 {
+                    "    config_file.".to_string()
+                } else {
+                    format!("line {line}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let buffer = Buffer::new(None, content);
+        let mut editor =
+            Editor::with_size(lsp, 60, 12, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        let mut render_buffer = RenderBuffer::new(60, 12, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor.render(&mut render_buffer).unwrap();
+        for _ in 0..22 {
+            editor
+                .execute(&Action::MoveDown, &mut render_buffer, &mut runtime)
+                .await
+                .unwrap();
+        }
+        editor
+            .execute(&Action::MoveToLineEnd, &mut render_buffer, &mut runtime)
+            .await
+            .unwrap();
+        editor
+            .execute(
+                &Action::EnterMode(Mode::Insert),
+                &mut render_buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        editor.cx += 1;
+        editor.sync_to_window();
+        let (completion_x, completion_y) = editor.render_cursor_position().unwrap();
+        let mut completion = CompletionUI::new();
+        completion.show(vec![completion_item("alpha")], completion_x, completion_y);
+        editor.current_dialog = Some(Box::new(completion));
+        editor.render(&mut render_buffer).unwrap();
+
+        let event = Event::Key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE));
+        if let Some(action) = editor.handle_event(&event).unwrap() {
+            editor
+                .handle_key_action(&event, &action, &mut render_buffer, &mut runtime)
+                .await
+                .unwrap();
+        }
+
+        let active_row = editor.window_manager.active_window().unwrap().cy;
+        let rendered_row = render_row(&render_buffer, active_row);
+        assert!(
+            rendered_row.contains("config_file.e"),
+            "expected active row {active_row} to show typed text, got {rendered_row:?}"
+        );
+    }
+
+    #[test]
+    fn completion_response_filter_uses_text_typed_after_request_position() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "config_file.as".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 60, 12, config, Theme::default(), vec![buffer]).unwrap();
+        editor.cx = "config_file.as".chars().count();
+
+        let request = crate::lsp::Request {
+            id: 1,
+            method: "textDocument/completion".to_string(),
+            params: serde_json::json!({
+                "position": {
+                    "line": 0,
+                    "character": "config_file.".chars().count()
+                }
+            }),
+            timestamp: std::time::Instant::now(),
+        };
+        let response = ResponseMessage {
+            id: 1,
+            result: serde_json::Value::Null,
+            request: Some(request),
+        };
+
+        assert_eq!(
+            editor.completion_filter_for_response(&response).as_deref(),
+            Some("as")
+        );
+    }
+
+    #[test]
+    fn completion_dialog_keeps_editor_cursor_visible() {
+        let mut editor = test_editor(40, 10);
+        let cursor_before = editor.render_cursor_position();
+
+        let mut completion = CompletionUI::new();
+        completion.show(vec![completion_item("alpha")], 0, 0);
+        editor.current_dialog = Some(Box::new(completion));
+
+        assert_eq!(editor.render_cursor_position(), cursor_before);
+    }
+
+    #[test]
+    fn completion_dialog_keeps_synthetic_cursor_painted() {
+        let mut editor = test_editor(40, 10);
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+
+        editor.render(&mut render_buffer).unwrap();
+        let (x, y) = editor.render_cursor_position().unwrap();
+        let cursor_index = y * render_buffer.width + x;
+        let cursor_style = render_buffer.cells[cursor_index].style.clone();
+
+        let mut completion = CompletionUI::new();
+        completion.show(vec![completion_item("alpha")], x, y);
+        editor.current_dialog = Some(Box::new(completion));
+
+        let mut overlay_buffer = RenderBuffer::new(40, 10, &Style::default());
+        editor.render(&mut overlay_buffer).unwrap();
+
+        assert_eq!(overlay_buffer.cells[cursor_index].style, cursor_style);
     }
 
     #[tokio::test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -51,8 +51,10 @@ use crate::{
     highlighter::Highlighter,
     log,
     lsp::{
-        get_client_capabilities, CompletionResponse, Diagnostic, InboundMessage, LspClient,
-        ParsedNotification, ProgressParams, ProgressToken, ResponseMessage, ServerCapabilities,
+        get_client_capabilities, Command as LspCommand, CompletionResponse, CompletionResponseItem,
+        Diagnostic, InboundMessage, InsertTextFormat, LspClient, ParsedNotification,
+        ProgressParams, ProgressToken, ResponseMessage, ServerCapabilities,
+        TextEdit as LspTextEdit,
     },
     plugin::{self, PluginRegistry, Runtime},
     theme::{parse_vscode_theme, Style, Theme},
@@ -304,6 +306,11 @@ pub enum Action {
     BufferText(Value),
 
     RequestCompletion,
+    RequestCompletionWithTrigger(char),
+    ApplyCompletion {
+        item: Box<CompletionResponseItem>,
+        commit_character: Option<char>,
+    },
     ShowProgress(ProgressParams),
     NotifyPlugins(String, Value),
     ViewLogs,
@@ -2118,13 +2125,27 @@ impl Editor {
                             return None;
                         }
 
+                        if let Some(request_uri) = response_text_document_uri(msg) {
+                            let current_uri = self.current_buffer().uri().ok().flatten();
+                            if current_uri.as_deref() != Some(request_uri) {
+                                log!(
+                                    "ignoring stale completion response for {request_uri}: current uri is {current_uri:?}"
+                                );
+                                return None;
+                            }
+                        }
+
                         match serde_json::from_value::<CompletionResponse>(msg.result.clone()) {
                             Ok(completion_response) => {
+                                let items = completion_response.items();
+                                if items.is_empty() || self.mode != Mode::Insert {
+                                    return None;
+                                }
                                 let (completion_x, completion_y) =
                                     self.render_cursor_position().unwrap_or((self.cx, self.cy));
                                 self.completion_ui.set_theme(&self.theme);
                                 self.completion_ui.show_with_bounds(
-                                    completion_response.items,
+                                    items,
                                     completion_x,
                                     completion_y,
                                     self.size.0 as usize,
@@ -4284,12 +4305,18 @@ impl Editor {
                 self.draw_line(buffer);
             }
             Action::RequestCompletion => {
-                // if let Some(uri) = self.current_buffer().uri()? {
-                //     let (_, col) = self.cursor_position();
-                //     self.lsp
-                //         .request_completion(&uri, self.buffer_line(), col)
-                //         .await?;
-                // }
+                self.request_completion(None).await?;
+            }
+            Action::RequestCompletionWithTrigger(trigger_character) => {
+                self.request_completion(Some(*trigger_character)).await?;
+            }
+            Action::ApplyCompletion {
+                item,
+                commit_character,
+            } => {
+                self.apply_completion(item, *commit_character, runtime)
+                    .await?;
+                self.render(buffer)?;
             }
             Action::ShowProgress(progress) => {
                 add_to_history = false;
@@ -5221,6 +5248,7 @@ impl Editor {
                 code, modifiers, ..
             }) => {
                 let key = match code {
+                    KeyCode::Char(' ') => "Space".to_string(),
                     KeyCode::Char(c) => format!("{c}"),
                     _ => format!("{code:?}"),
                 };
@@ -5793,8 +5821,334 @@ impl Editor {
 
         Ok(Some(KeyAction::Multiple(vec![
             Action::InsertCharAtCursorPos(c),
-            Action::RequestCompletion,
+            Action::RequestCompletionWithTrigger(c),
         ])))
+    }
+
+    async fn request_completion(&mut self, trigger_character: Option<char>) -> anyhow::Result<()> {
+        if !self.is_insert() {
+            return Ok(());
+        }
+
+        if let Some(uri) = self.current_buffer().uri()? {
+            self.ensure_current_buffer_lsp_opened().await?;
+            let line = self.buffer_line();
+            let character = self.grapheme_to_char_on_line(self.cx, line);
+            self.lsp
+                .request_completion(&uri, line, character, trigger_character)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn apply_completion(
+        &mut self,
+        item: &CompletionResponseItem,
+        commit_character: Option<char>,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let resume_insert_transaction = self.transaction_active();
+        if resume_insert_transaction {
+            self.commit_transaction(self.cursor_snapshot());
+        }
+
+        self.begin_transaction("apply completion");
+
+        let mut edits = Vec::new();
+        if let Some(text_edit) = &item.text_edit {
+            edits.push(completion_edit_from_lsp(
+                text_edit,
+                item.insert_text_format.as_ref(),
+                true,
+            ));
+        } else {
+            let text = item.insert_text.as_deref().unwrap_or(&item.label);
+            let line = self.buffer_line();
+            let character = self.grapheme_to_char_on_line(self.cx, line);
+            edits.push(completion_edit(
+                TextRange::insertion(TextPosition::new(line, character)),
+                text,
+                item.insert_text_format.as_ref(),
+                true,
+            ));
+        }
+        if let Some(additional_text_edits) = &item.additional_text_edits {
+            for text_edit in additional_text_edits {
+                edits.push(completion_edit_from_lsp(text_edit, None, false));
+            }
+        }
+
+        edits.sort_by(|a, b| compare_text_positions_desc(a.range.start, b.range.start));
+
+        let mut cursor_position = None;
+        for edit in edits {
+            self.replace_range(edit.range, &edit.new_text);
+
+            if edit.is_main {
+                let cursor_offset = edit
+                    .cursor_offset
+                    .unwrap_or_else(|| edit.new_text.chars().count());
+                cursor_position = Some(offset_text_position(
+                    edit.range.start,
+                    &edit.new_text,
+                    cursor_offset,
+                ));
+            } else if let Some(cursor) = cursor_position {
+                cursor_position = Some(transform_text_position_after_edit(
+                    cursor,
+                    edit.range,
+                    &edit.new_text,
+                ));
+            }
+        }
+
+        let cursor_position = cursor_position.unwrap_or_else(|| self.cursor_text_position());
+        self.move_to_text_position(cursor_position);
+
+        if let Some(c) = commit_character {
+            let line = self.buffer_line();
+            let character = self.grapheme_to_char_on_line(self.cx, line);
+            self.replace_range(
+                TextRange::insertion(TextPosition::new(line, character)),
+                &c.to_string(),
+            );
+            self.move_to_text_position(TextPosition::new(line, character + 1));
+        }
+
+        self.notify_change(runtime).await?;
+        self.commit_transaction(self.cursor_snapshot());
+
+        if resume_insert_transaction && self.is_insert() {
+            self.begin_transaction("insert");
+        }
+
+        if let Some(command) = &item.command {
+            self.execute_lsp_command(command).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn execute_lsp_command(&mut self, command: &LspCommand) -> anyhow::Result<()> {
+        let params = json!({
+            "command": command.command,
+            "arguments": command.arguments.clone().unwrap_or_default(),
+        });
+
+        self.lsp
+            .send_request("workspace/executeCommand", params, false)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct CompletionEdit {
+    range: TextRange,
+    new_text: String,
+    cursor_offset: Option<usize>,
+    is_main: bool,
+}
+
+fn completion_edit_from_lsp(
+    text_edit: &LspTextEdit,
+    insert_text_format: Option<&InsertTextFormat>,
+    is_main: bool,
+) -> CompletionEdit {
+    completion_edit(
+        text_range_from_lsp(&text_edit.range),
+        &text_edit.new_text,
+        insert_text_format,
+        is_main,
+    )
+}
+
+fn completion_edit(
+    range: TextRange,
+    text: &str,
+    insert_text_format: Option<&InsertTextFormat>,
+    is_main: bool,
+) -> CompletionEdit {
+    let (new_text, cursor_offset) = if matches!(insert_text_format, Some(InsertTextFormat::Snippet))
+    {
+        snippet_to_plain_text(text)
+    } else {
+        (text.to_string(), None)
+    };
+
+    CompletionEdit {
+        range,
+        new_text,
+        cursor_offset,
+        is_main,
+    }
+}
+
+fn text_range_from_lsp(range: &crate::lsp::Range) -> TextRange {
+    TextRange::new(
+        TextPosition::new(range.start.line, range.start.character),
+        TextPosition::new(range.end.line, range.end.character),
+    )
+}
+
+fn response_text_document_uri(response: &ResponseMessage) -> Option<&str> {
+    response
+        .request
+        .as_ref()?
+        .params
+        .as_object()?
+        .get("textDocument")?
+        .as_object()?
+        .get("uri")?
+        .as_str()
+}
+
+fn compare_text_positions_desc(a: TextPosition, b: TextPosition) -> Ordering {
+    b.line.cmp(&a.line).then(b.character.cmp(&a.character))
+}
+
+fn offset_text_position(start: TextPosition, text: &str, char_offset: usize) -> TextPosition {
+    let mut line = start.line;
+    let mut character = start.character;
+
+    for c in text.chars().take(char_offset) {
+        if c == '\n' {
+            line += 1;
+            character = 0;
+        } else {
+            character += 1;
+        }
+    }
+
+    TextPosition::new(line, character)
+}
+
+fn transform_text_position_after_edit(
+    position: TextPosition,
+    range: TextRange,
+    new_text: &str,
+) -> TextPosition {
+    if compare_text_positions(position, range.start).is_lt() {
+        return position;
+    }
+
+    let new_end = offset_text_position(range.start, new_text, new_text.chars().count());
+    if compare_text_positions(position, range.end).is_le() {
+        return new_end;
+    }
+
+    if position.line == range.end.line {
+        return TextPosition::new(
+            new_end.line,
+            new_end
+                .character
+                .saturating_add(position.character.saturating_sub(range.end.character)),
+        );
+    }
+
+    let old_lines = range.end.line.saturating_sub(range.start.line);
+    let new_lines = new_end.line.saturating_sub(range.start.line);
+    let line = if new_lines >= old_lines {
+        position.line.saturating_add(new_lines - old_lines)
+    } else {
+        position.line.saturating_sub(old_lines - new_lines)
+    };
+
+    TextPosition::new(line, position.character)
+}
+
+fn compare_text_positions(a: TextPosition, b: TextPosition) -> Ordering {
+    a.line.cmp(&b.line).then(a.character.cmp(&b.character))
+}
+
+fn snippet_to_plain_text(snippet: &str) -> (String, Option<usize>) {
+    let chars = snippet.chars().collect::<Vec<_>>();
+    let mut output = String::new();
+    let mut first_placeholder = None;
+    let mut final_cursor = None;
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] != '$' {
+            output.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        if i + 1 >= chars.len() {
+            output.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        match chars[i + 1] {
+            '$' => {
+                output.push('$');
+                i += 2;
+            }
+            '0' => {
+                final_cursor = Some(output.chars().count());
+                i += 2;
+            }
+            c if c.is_ascii_digit() => {
+                first_placeholder.get_or_insert(output.chars().count());
+                i += 2;
+            }
+            '{' => {
+                if let Some((next, index, default_text)) = parse_snippet_placeholder(&chars, i + 2)
+                {
+                    let cursor = output.chars().count();
+                    if index == 0 {
+                        final_cursor = Some(cursor);
+                    } else {
+                        first_placeholder.get_or_insert(cursor);
+                    }
+                    output.push_str(&default_text);
+                    i = next;
+                } else {
+                    output.push(chars[i]);
+                    i += 1;
+                }
+            }
+            _ => {
+                output.push(chars[i]);
+                i += 1;
+            }
+        }
+    }
+
+    let cursor = first_placeholder.or(final_cursor);
+    (output, cursor)
+}
+
+fn parse_snippet_placeholder(chars: &[char], start: usize) -> Option<(usize, usize, String)> {
+    let mut i = start;
+    let mut index = String::new();
+    while i < chars.len() && chars[i].is_ascii_digit() {
+        index.push(chars[i]);
+        i += 1;
+    }
+
+    if index.is_empty() {
+        return None;
+    }
+
+    let index = index.parse::<usize>().ok()?;
+    let mut default_text = String::new();
+
+    match chars.get(i) {
+        Some('}') => Some((i + 1, index, default_text)),
+        Some(':') => {
+            i += 1;
+            while i < chars.len() && chars[i] != '}' {
+                default_text.push(chars[i]);
+                i += 1;
+            }
+            (i < chars.len()).then_some((i + 1, index, default_text))
+        }
+        _ => None,
     }
 }
 

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -113,8 +113,14 @@ impl Editor {
     }
 
     fn uses_synthetic_block_cursor(&self) -> bool {
+        let dialog_allows_editor_cursor = self
+            .current_dialog
+            .as_ref()
+            .map(|dialog| dialog.allows_event_passthrough())
+            .unwrap_or(true);
+
         self.is_focused
-            && self.current_dialog.is_none()
+            && dialog_allows_editor_cursor
             && !self.has_term()
             && self.waiting_key_action.is_none()
             && matches!(
@@ -1156,8 +1162,15 @@ impl Editor {
 
     pub(crate) fn render_cursor_position(&self) -> Option<(usize, usize)> {
         if let Some(current_dialog) = &self.current_dialog {
-            current_dialog.cursor_position()
-        } else if self.has_term() {
+            if let Some(cursor_position) = current_dialog.cursor_position() {
+                return Some(cursor_position);
+            }
+            if !current_dialog.allows_event_passthrough() {
+                return None;
+            }
+        }
+
+        if self.has_term() {
             Some((
                 display_width(self.term()) + 1,
                 (self.size.1 as usize).saturating_sub(1),

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -600,7 +600,19 @@ impl LspClient for RealLspClient {
         file_uri: &str,
         line: usize,
         character: usize,
+        trigger_character: Option<char>,
     ) -> Result<i64, LspError> {
+        let context = if let Some(trigger_character) = trigger_character {
+            json!({
+                "triggerKind": 2,
+                "triggerCharacter": trigger_character.to_string(),
+            })
+        } else {
+            json!({
+                "triggerKind": 1,
+            })
+        };
+
         let params = json!({
             "textDocument": {
                 "uri": file_uri,
@@ -609,6 +621,7 @@ impl LspClient for RealLspClient {
                 "line": line,
                 "character": character,
             },
+            "context": context,
         });
 
         log!("request_completion: params={}", params);
@@ -1370,8 +1383,22 @@ mod test {
         let json_str = include_str!("../fixtures/lsp-completion-response.json");
         let json = serde_json::from_str::<CompletionResponse>(json_str).unwrap();
 
-        assert!(json.is_incomplete);
-        assert_eq!(json.items.len(), 225);
+        assert!(json.is_incomplete());
+        assert_eq!(json.items().len(), 225);
+    }
+
+    #[test]
+    fn test_parse_completion_response_array() {
+        let json = serde_json::json!([
+            {
+                "label": "alpha",
+                "kind": 1
+            }
+        ]);
+        let response = serde_json::from_value::<CompletionResponse>(json).unwrap();
+
+        assert!(!response.is_incomplete());
+        assert_eq!(response.items().len(), 1);
     }
 
     #[test]

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -254,11 +254,13 @@ async fn process_lsp_message(
     let res = serde_json::from_str::<serde_json::Value>(&body).map_err(LspError::JsonError)?;
 
     if let Some(error) = res.get("error") {
+        let id = res.get("id").and_then(Value::as_i64);
         let code = error["code"].as_i64().unwrap();
         let message = error["message"].as_str().unwrap().to_string();
         let data = error.get("data").cloned();
 
         rtx.send(InboundMessage::Error(ResponseError {
+            id,
             code,
             message,
             data,
@@ -269,8 +271,9 @@ async fn process_lsp_message(
         return Ok(());
     }
 
-    // if there's an id, it's a response
-    if let Some(id) = res.get("id") {
+    // Responses have an id and no method. Server-to-client requests also have
+    // an id, but must not be matched against our pending client requests.
+    if let Some(id) = res.get("id").filter(|_| res.get("method").is_none()) {
         let id = id.as_i64().unwrap();
         let result = res["result"].clone();
 
@@ -298,16 +301,25 @@ async fn process_lsp_message(
         }))
         .await
         .map_err(|e| LspError::ChannelInboundError(e.to_string()))?;
-    } else {
-        // if there's no id, it's a notification
-        let method = res["method"].as_str().unwrap().to_string();
-        let params = res["params"].clone();
+    } else if let Some(method) = res.get("method").and_then(Value::as_str) {
+        // if there's a method, it's a notification or a server-to-client request
+        let method = method.to_string();
+        let params = res.get("params").cloned().unwrap_or(Value::Null);
 
-        log!(
-            "[lsp] incoming notification: method={}, params={}",
-            method,
-            params
-        );
+        if let Some(id) = res.get("id").and_then(Value::as_i64) {
+            log!(
+                "[lsp] incoming request: id={}, method={}, params={}",
+                id,
+                method,
+                params
+            );
+        } else {
+            log!(
+                "[lsp] incoming notification: method={}, params={}",
+                method,
+                params
+            );
+        }
 
         match parse_notification(&method, &params) {
             Ok(Some(parsed_notification)) => {
@@ -329,6 +341,8 @@ async fn process_lsp_message(
                     .map_err(|e| LspError::ChannelInboundError(e.to_string()))?;
             }
         }
+    } else {
+        log!("[lsp] unknown message: {}", res);
     }
 
     Ok(())
@@ -676,53 +690,76 @@ impl LspClient for RealLspClient {
 
         match self.response_rx.try_recv() {
             Ok(mut msg) => {
-                if let InboundMessage::Message(msg) = &mut msg {
-                    if let Some(req) = self.pending_responses.remove(&msg.id) {
-                        log!("[lsp] rcv_response: id={} method={}", msg.id, req.method);
-                        if req.method == "initialize" {
-                            log!("[lsp] server initialized");
+                match &mut msg {
+                    InboundMessage::Message(msg) => {
+                        if let Some(req) = self.pending_responses.remove(&msg.id) {
+                            log!("[lsp] rcv_response: id={} method={}", msg.id, req.method);
+                            if req.method == "initialize" {
+                                log!("[lsp] server initialized");
 
-                            // Parse the initialize result
-                            // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized
-                            let init_result: InitializeResult =
-                                serde_json::from_value(msg.result.clone())
-                                    .map_err(LspError::JsonError)?;
+                                // Parse the initialize result
+                                // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized
+                                let init_result: InitializeResult =
+                                    serde_json::from_value(msg.result.clone())
+                                        .map_err(LspError::JsonError)?;
 
-                            // log!("[lsp] server capabilities: {:#?}", init_result.capabilities);
-                            self.server_capabilities = Some(init_result.capabilities);
+                                // log!("[lsp] server capabilities: {:#?}", init_result.capabilities);
+                                self.server_capabilities = Some(init_result.capabilities);
 
-                            if let Some(server_info) = &init_result.server_info {
+                                if let Some(server_info) = &init_result.server_info {
+                                    log!(
+                                        "[lsp] server info: {} {}",
+                                        server_info.name,
+                                        server_info.version.as_deref().unwrap_or("unknown version")
+                                    );
+                                }
+
+                                self.send_notification("initialized", json!({}), true)
+                                    .await?;
+                                // self.send_notification(
+                                //     "$/setTrace",
+                                //     json!({ "value": "verbose" }),
+                                //     true,
+                                // )
+                                // .await?;
+                                self.initialized = true;
+
                                 log!(
-                                    "[lsp] server info: {} {}",
-                                    server_info.name,
-                                    server_info.version.as_deref().unwrap_or("unknown version")
+                                    "[lsp] sending {} pending messages",
+                                    self.pending_messages.len()
                                 );
+                                for msg in self.pending_messages.drain(..) {
+                                    self.request_tx.send(msg).await?;
+                                }
                             }
 
-                            self.send_notification("initialized", json!({}), true)
-                                .await?;
-                            // self.send_notification(
-                            //     "$/setTrace",
-                            //     json!({ "value": "verbose" }),
-                            //     true,
-                            // )
-                            // .await?;
-                            self.initialized = true;
+                            let method = req.method.clone();
+                            msg.request = Some(req);
 
-                            log!(
-                                "[lsp] sending {} pending messages",
-                                self.pending_messages.len()
-                            );
-                            for msg in self.pending_messages.drain(..) {
-                                self.request_tx.send(msg).await?;
+                            return Ok(Some((InboundMessage::Message(msg.clone()), Some(method))));
+                        }
+                    }
+                    InboundMessage::Error(error) => {
+                        if let Some(id) = error.id {
+                            if let Some(request) = self.pending_responses.get(&id) {
+                                let method = request.method.clone();
+                                log!(
+                                    "[lsp] rcv_error: id={} method={} code={} message={}",
+                                    id,
+                                    method,
+                                    error.code,
+                                    error.message
+                                );
+
+                                if !error.is_retrigger_cancellation() {
+                                    self.pending_responses.remove(&id);
+                                }
+
+                                return Ok(Some((msg, Some(method))));
                             }
                         }
-
-                        let method = req.method.clone();
-                        msg.request = Some(req);
-
-                        return Ok(Some((InboundMessage::Message(msg.clone()), Some(method))));
                     }
+                    _ => {}
                 }
                 Ok(Some((msg, None)))
             }
@@ -1207,6 +1244,8 @@ pub async fn lsp_send_notification(
 
 #[cfg(test)]
 mod test {
+    use std::time::Instant;
+
     use crate::config::default_language_servers;
     use crate::lsp::{get_client_capabilities, ParsedNotification};
 
@@ -1260,6 +1299,171 @@ mod test {
         let diag = &msg.diagnostics[0];
         let code = diag.code.as_ref().unwrap();
         assert_eq!(code.as_string(), "unused_imports");
+    }
+
+    #[tokio::test]
+    async fn retrigger_cancellation_keeps_pending_completion_request() {
+        let (request_tx, _request_rx) = mpsc::channel(1);
+        let (response_tx, response_rx) = mpsc::channel(4);
+        let request = Request {
+            id: 42,
+            method: "textDocument/completion".to_string(),
+            params: json!({}),
+            timestamp: Instant::now(),
+        };
+        let mut client = RealLspClient {
+            request_tx,
+            response_rx,
+            files_versions: HashMap::new(),
+            files_content: HashMap::new(),
+            pending_responses: HashMap::from([(request.id, request)]),
+            initialize_id: None,
+            initialized: true,
+            pending_messages: Vec::new(),
+            server_capabilities: None,
+            child: None,
+            config: default_language_servers()
+                .remove("rust")
+                .expect("default Rust LSP config must exist"),
+            workspace_root: std::env::current_dir().unwrap(),
+        };
+
+        response_tx
+            .send(InboundMessage::Error(ResponseError {
+                id: Some(42),
+                code: -32802,
+                message: "server cancelled the request".to_string(),
+                data: Some(json!({ "retriggerRequest": true })),
+            }))
+            .await
+            .unwrap();
+        response_tx
+            .send(InboundMessage::Message(ResponseMessage {
+                id: 42,
+                result: json!({
+                    "isIncomplete": false,
+                    "items": [{ "label": "add_extension" }]
+                }),
+                request: None,
+            }))
+            .await
+            .unwrap();
+
+        let Some((first_message, first_method)) = client.recv_response().await.unwrap() else {
+            panic!("expected retrigger cancellation response");
+        };
+        assert_eq!(first_method.as_deref(), Some("textDocument/completion"));
+        assert!(matches!(first_message, InboundMessage::Error(_)));
+        assert!(client.pending_responses.contains_key(&42));
+
+        let Some((second_message, second_method)) = client.recv_response().await.unwrap() else {
+            panic!("expected completion response");
+        };
+        assert_eq!(second_method.as_deref(), Some("textDocument/completion"));
+        let InboundMessage::Message(response) = second_message else {
+            panic!("expected completion message");
+        };
+        assert_eq!(response.id, 42);
+        assert_eq!(
+            response
+                .request
+                .as_ref()
+                .map(|request| request.method.as_str()),
+            Some("textDocument/completion")
+        );
+        assert!(!client.pending_responses.contains_key(&42));
+    }
+
+    #[tokio::test]
+    async fn process_lsp_message_preserves_error_response_id() {
+        let (response_tx, mut response_rx) = mpsc::channel(1);
+        let body = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "error": {
+                "code": -32802,
+                "message": "server cancelled the request",
+                "data": { "retriggerRequest": true }
+            }
+        }))
+        .unwrap();
+
+        process_lsp_message(&body, &response_tx).await.unwrap();
+
+        let Some(InboundMessage::Error(error)) = response_rx.recv().await else {
+            panic!("expected error response");
+        };
+        assert_eq!(error.id, Some(42));
+        assert!(error.is_retrigger_cancellation());
+    }
+
+    #[tokio::test]
+    async fn server_request_id_does_not_complete_pending_client_request() {
+        let (request_tx, _request_rx) = mpsc::channel(1);
+        let (response_tx, response_rx) = mpsc::channel(4);
+        let request = Request {
+            id: 31,
+            method: "textDocument/completion".to_string(),
+            params: json!({}),
+            timestamp: Instant::now(),
+        };
+        let mut client = RealLspClient {
+            request_tx,
+            response_rx,
+            files_versions: HashMap::new(),
+            files_content: HashMap::new(),
+            pending_responses: HashMap::from([(request.id, request)]),
+            initialize_id: None,
+            initialized: true,
+            pending_messages: Vec::new(),
+            server_capabilities: None,
+            child: None,
+            config: default_language_servers()
+                .remove("rust")
+                .expect("default Rust LSP config must exist"),
+            workspace_root: std::env::current_dir().unwrap(),
+        };
+
+        let server_request = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": 31,
+            "method": "workspace/configuration",
+            "params": { "items": [] }
+        }))
+        .unwrap();
+        process_lsp_message(&server_request, &response_tx)
+            .await
+            .unwrap();
+
+        let completion_response = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": 31,
+            "result": {
+                "isIncomplete": true,
+                "items": [{ "label": "symlink_metadata" }]
+            }
+        }))
+        .unwrap();
+        process_lsp_message(&completion_response, &response_tx)
+            .await
+            .unwrap();
+
+        let Some((first_message, first_method)) = client.recv_response().await.unwrap() else {
+            panic!("expected server request");
+        };
+        assert!(matches!(
+            first_message,
+            InboundMessage::UnknownNotification(_)
+        ));
+        assert_eq!(first_method, None);
+        assert!(client.pending_responses.contains_key(&31));
+
+        let Some((second_message, second_method)) = client.recv_response().await.unwrap() else {
+            panic!("expected completion response");
+        };
+        assert_eq!(second_method.as_deref(), Some("textDocument/completion"));
+        assert!(matches!(second_message, InboundMessage::Message(_)));
+        assert!(!client.pending_responses.contains_key(&31));
     }
 
     #[test]

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -369,9 +369,12 @@ impl LspClient for LspManager {
         file_uri: &str,
         line: usize,
         character: usize,
+        trigger_character: Option<char>,
     ) -> Result<i64, LspError> {
         if let Some(client) = self.client_for_uri_mut(file_uri) {
-            return client.request_completion(file_uri, line, character).await;
+            return client
+                .request_completion(file_uri, line, character, trigger_character)
+                .await;
         }
         Ok(0)
     }

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -144,9 +144,22 @@ pub struct Notification {
 #[derive(Debug)]
 #[allow(unused)]
 pub struct ResponseError {
-    code: i64,
-    message: String,
-    data: Option<Value>,
+    pub(crate) id: Option<i64>,
+    pub(crate) code: i64,
+    pub(crate) message: String,
+    pub(crate) data: Option<Value>,
+}
+
+impl ResponseError {
+    pub(crate) fn is_retrigger_cancellation(&self) -> bool {
+        self.code == -32802
+            && self
+                .data
+                .as_ref()
+                .and_then(|data| data.get("retriggerRequest"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+    }
 }
 
 #[derive(Debug)]

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -248,6 +248,7 @@ pub trait LspClient: std::any::Any + Send {
         file_uri: &str,
         line: usize,
         character: usize,
+        trigger_character: Option<char>,
     ) -> Result<i64, LspError>;
 
     /// Pull diagnostics if this capability is enabled, returns None otherwise

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -162,14 +162,14 @@ pub enum ProgressToken {
     String(String),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Range {
     pub start: Position,
     pub end: Position,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Position {
     pub line: usize,
@@ -1096,7 +1096,7 @@ pub struct CompletionItemKindCapability {
     pub value_set: Option<Vec<CompletionItemKind>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(from = "i32", into = "i32")]
 pub enum CompletionItemKind {
     Text = 1,
@@ -1165,7 +1165,7 @@ impl From<CompletionItemKind> for i32 {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum MarkupKind {
     Plaintext,
@@ -1627,13 +1627,36 @@ pub struct MarkdownClientCapabilities {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompletionResponse {
+    List(CompletionList),
+    Items(Vec<CompletionResponseItem>),
+}
+
+impl CompletionResponse {
+    pub fn items(self) -> Vec<CompletionResponseItem> {
+        match self {
+            Self::List(list) => list.items,
+            Self::Items(items) => items,
+        }
+    }
+
+    pub fn is_incomplete(&self) -> bool {
+        match self {
+            Self::List(list) => list.is_incomplete,
+            Self::Items(_) => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CompletionResponse {
+pub struct CompletionList {
     pub is_incomplete: bool,
     pub items: Vec<CompletionResponseItem>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionResponseItem {
     pub label: String,
@@ -1653,21 +1676,21 @@ pub struct CompletionResponseItem {
     pub commit_characters: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Documentation {
     String(String),
     MarkupContent(MarkupContent),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkupContent {
     pub kind: MarkupKind,
     pub value: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(from = "i32", into = "i32")]
 pub enum InsertTextFormat {
     Plaintext = 1,
@@ -1690,14 +1713,14 @@ impl From<InsertTextFormat> for i32 {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TextEdit {
     pub range: Range,
     pub new_text: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Command {
     pub title: String,

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -15,10 +15,13 @@ use super::Component;
 
 const MAX_WIDTH: usize = 80;
 const PAGE_SIZE: usize = 10;
+const PREVIEW_MAX_ROWS: usize = 7;
 
 #[derive(Default, Clone)]
 pub struct CompletionUI {
+    all_items: Vec<CompletionResponseItem>,
     items: Vec<CompletionResponseItem>,
+    filter: String,
     selected: usize,
     scroll_offset: usize,
     visible: bool,
@@ -82,7 +85,9 @@ impl CompletionUI {
             .position(|item| item.preselect.unwrap_or(false))
             .unwrap_or(0);
 
-        let width = self.calculate_width().min(bounds_width.max(2)).max(2);
+        let width = Self::calculate_width_for(&items)
+            .min(bounds_width.max(2))
+            .max(2);
         let unbounded_height = bounds_height == usize::MAX;
         let max_rows = if unbounded_height {
             usize::MAX
@@ -105,7 +110,9 @@ impl CompletionUI {
             x = 0;
         }
 
+        self.all_items = items.clone();
         self.items = items;
+        self.filter.clear();
         self.selected = selected;
         self.scroll_offset = 0;
         self.visible = true;
@@ -118,7 +125,9 @@ impl CompletionUI {
 
     pub fn hide(&mut self) {
         self.visible = false;
+        self.all_items.clear();
         self.items.clear();
+        self.filter.clear();
     }
 
     pub fn is_visible(&self) -> bool {
@@ -129,9 +138,14 @@ impl CompletionUI {
         self.items.get(self.selected)
     }
 
-    fn calculate_width(&self) -> usize {
-        let max_item_width = self
-            .items
+    pub fn set_filter(&mut self, filter: &str) {
+        self.filter.clear();
+        self.filter.push_str(filter);
+        self.refilter_items();
+    }
+
+    fn calculate_width_for(items: &[CompletionResponseItem]) -> usize {
+        let max_item_width = items
             .iter()
             .map(|item| {
                 let kind_width = item
@@ -144,6 +158,66 @@ impl CompletionUI {
             .unwrap_or(20);
 
         max_item_width.clamp(40, MAX_WIDTH)
+    }
+
+    fn item_filter_score(item: &CompletionResponseItem, filter: &str) -> Option<usize> {
+        if filter.is_empty() {
+            return Some(0);
+        }
+
+        let filter = filter.to_ascii_lowercase();
+        [
+            item.filter_text.as_deref(),
+            Some(item.label.as_str()),
+            item.sort_text.as_deref(),
+            item.insert_text.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .filter_map(|candidate| {
+            let candidate = candidate.to_ascii_lowercase();
+            if candidate.starts_with(&filter) {
+                Some(0)
+            } else {
+                candidate.contains(&filter).then_some(1)
+            }
+        })
+        .min()
+    }
+
+    fn refilter_items(&mut self) {
+        if self.filter.is_empty() {
+            self.items = self.all_items.clone();
+        } else {
+            let mut matches = self
+                .all_items
+                .iter()
+                .cloned()
+                .enumerate()
+                .filter_map(|(idx, item)| {
+                    Self::item_filter_score(&item, &self.filter).map(|score| (score, idx, item))
+                })
+                .collect::<Vec<_>>();
+            matches.sort_by_key(|(score, idx, _)| (*score, *idx));
+            self.items = matches.into_iter().map(|(_, _, item)| item).collect();
+        }
+
+        self.selected = 0;
+        self.scroll_offset = 0;
+        self.max_height = min(
+            min(self.items.len(), PAGE_SIZE),
+            self.max_rows.saturating_sub(2),
+        );
+    }
+
+    fn push_filter_char(&mut self, c: char) {
+        self.filter.push(c);
+        self.refilter_items();
+    }
+
+    fn pop_filter_char(&mut self) {
+        self.filter.pop();
+        self.refilter_items();
     }
 
     pub fn move_selection(&mut self, delta: isize) {
@@ -206,8 +280,49 @@ impl CompletionUI {
         }
     }
 
-    fn row(content: &str, width: usize) -> String {
-        format!("│{}│", fit_display_width(content, width.saturating_sub(2)))
+    fn row_segments(
+        &self,
+        y_offset: usize,
+        content: &str,
+        content_style: Style,
+    ) -> Vec<(usize, usize, String, Style)> {
+        let y = self.y + y_offset;
+        let inner_width = self.width.saturating_sub(2);
+
+        vec![
+            (self.x, y, "│".to_string(), self.styles.popup_border.clone()),
+            (
+                self.x + 1,
+                y,
+                fit_display_width(content, inner_width),
+                content_style,
+            ),
+            (
+                self.x + self.width.saturating_sub(1),
+                y,
+                "│".to_string(),
+                self.styles.popup_border.clone(),
+            ),
+        ]
+    }
+
+    fn separator_segments(&self, y_offset: usize) -> Vec<(usize, usize, String, Style)> {
+        let y = self.y + y_offset;
+        vec![
+            (self.x, y, "├".to_string(), self.styles.popup_border.clone()),
+            (
+                self.x + 1,
+                y,
+                "─".repeat(self.width.saturating_sub(2)),
+                self.styles.popup_border.clone(),
+            ),
+            (
+                self.x + self.width.saturating_sub(1),
+                y,
+                "┤".to_string(),
+                self.styles.popup_border.clone(),
+            ),
+        ]
     }
 
     fn ellipsize(content: &str, width: usize) -> String {
@@ -230,12 +345,8 @@ impl CompletionUI {
         }
 
         let mut output = Vec::new();
-        let visible_items = self
-            .items
-            .iter()
-            .skip(self.scroll_offset)
-            .take(self.max_height);
         let mut y_offset = 1;
+        let last_row_offset = self.max_rows.saturating_sub(1);
 
         // Draw top border
         output.push((
@@ -252,26 +363,65 @@ impl CompletionUI {
             self.max_height
         );
 
-        // Render completion items
-        for (idx, item) in visible_items.enumerate() {
-            let is_selected = idx + self.scroll_offset == self.selected;
-            let prefix = if is_selected { ">" } else { " " };
+        let selected_preview_rows = self
+            .selected_item()
+            .map(|item| self.preview_rows(item, PREVIEW_MAX_ROWS))
+            .unwrap_or_default();
+        let has_preview = !selected_preview_rows.is_empty();
+        let available_content_rows = last_row_offset.saturating_sub(y_offset);
+        let min_list_rows = self
+            .items
+            .len()
+            .min(self.max_height)
+            .min(5)
+            .min(available_content_rows);
+        let available_preview_rows = available_content_rows.saturating_sub(min_list_rows);
+        let preview_row_count = if has_preview && available_preview_rows >= 2 {
+            1 + selected_preview_rows
+                .len()
+                .min(PREVIEW_MAX_ROWS)
+                .min(available_preview_rows - 1)
+        } else {
+            0
+        };
+        let list_capacity = last_row_offset
+            .saturating_sub(y_offset)
+            .saturating_sub(preview_row_count);
+        let visible_count = self.max_height.min(list_capacity);
+        let scroll_offset = if visible_count == 0 {
+            self.scroll_offset
+        } else {
+            let max_scroll_offset = self.items.len().saturating_sub(visible_count);
+            let offset = if self.selected < self.scroll_offset {
+                self.selected
+            } else if self.selected >= self.scroll_offset + visible_count {
+                self.selected - visible_count + 1
+            } else {
+                self.scroll_offset
+            };
+            offset.min(max_scroll_offset)
+        };
+        let visible_items = self.items.iter().skip(scroll_offset).take(visible_count);
 
+        // Render completion items.
+        for (idx, item) in visible_items.enumerate() {
+            let is_selected = idx + scroll_offset == self.selected;
+            let marker = if is_selected { ">" } else { " " };
             // Format item with icon and handle deprecated items
             let is_deprecated = item.deprecated.unwrap_or(false);
 
             let display = if let Some(kind) = &item.kind {
                 format!(
-                    "{}{} {} {}",
-                    prefix,
+                    "{} {} {}{}",
+                    marker,
                     Self::kind_to_icon(kind),
                     if is_deprecated { "⚠ " } else { "" },
                     item.label
                 )
             } else {
                 format!(
-                    "{}  {} {}",
-                    prefix,
+                    "{}   {}{}",
+                    marker,
                     if is_deprecated { "⚠ " } else { "" },
                     item.label
                 )
@@ -279,86 +429,27 @@ impl CompletionUI {
 
             let display = Self::ellipsize(&display, self.width.saturating_sub(2));
 
-            output.push((
-                self.x,
-                self.y + y_offset,
-                format!("│{display}│"),
-                if is_deprecated {
-                    self.styles.deprecated.clone()
-                } else if is_selected {
-                    self.styles.picker_selected_item.clone()
-                } else {
-                    self.styles.popup.clone()
-                },
-            ));
+            let style = if is_deprecated {
+                self.styles.deprecated.clone()
+            } else if is_selected {
+                self.styles.picker_selected_item.clone()
+            } else {
+                self.styles.picker_item.clone()
+            };
+            output.extend(self.row_segments(y_offset, &display, style));
+            y_offset += 1;
+        }
+
+        if has_preview && y_offset < last_row_offset {
+            output.extend(self.separator_segments(y_offset));
             y_offset += 1;
 
-            // Show detail and documentation for selected item
-            if is_selected {
-                if y_offset < self.max_rows {
-                    if let Some(detail) = &item.detail {
-                        output.push((
-                            self.x,
-                            self.y + y_offset,
-                            Self::row(&format!("  {}", detail), self.width),
-                            self.styles.muted.clone(),
-                        ));
-                        y_offset += 1;
-                    }
+            for row in selected_preview_rows.into_iter().take(PREVIEW_MAX_ROWS) {
+                if y_offset >= last_row_offset {
+                    break;
                 }
-
-                if y_offset < self.max_rows {
-                    // Show commit characters if available
-                    if let Some(chars) = &item.commit_characters {
-                        let commit_text = format!(
-                            "│  Complete with: {}",
-                            chars
-                                .iter()
-                                .map(|c| format!("'{}'", c))
-                                .collect::<Vec<_>>()
-                                .join(", ")
-                        );
-                        output.push((
-                            self.x,
-                            self.y + y_offset,
-                            Self::row(&commit_text, self.width),
-                            self.styles.muted.clone(),
-                        ));
-                        y_offset += 1;
-                    }
-                }
-
-                if y_offset < self.max_rows {
-                    if let Some(doc) = &item.documentation {
-                        let doc_text = match doc {
-                            Documentation::String(s) => s.clone(),
-                            Documentation::MarkupContent(content) => content.value.clone(),
-                        };
-
-                        // Add separator line
-                        output.push((
-                            self.x,
-                            self.y + y_offset,
-                            format!("│{}│", "─".repeat(self.width - 2)),
-                            self.styles.popup_border.clone(),
-                        ));
-                        y_offset += 1;
-
-                        // Split documentation into wrapped lines
-                        for line in textwrap::wrap(&doc_text, self.width.saturating_sub(4).max(1)) {
-                            if y_offset >= self.max_rows {
-                                break;
-                            }
-                            output.push((
-                                self.x,
-                                self.y + y_offset,
-                                Self::row(&format!("  {}", line), self.width),
-                                self.styles.muted.clone(),
-                            ));
-                            y_offset += 1;
-                        }
-                    }
-                }
+                output.extend(self.row_segments(y_offset, &row, self.styles.muted.clone()));
+                y_offset += 1;
             }
         }
 
@@ -371,17 +462,17 @@ impl CompletionUI {
         ));
 
         // Show scroll indicators
-        if self.scroll_offset > 0 {
+        if scroll_offset > 0 {
             output.push((
-                self.x + 2,
+                self.x + 1,
                 self.y + 1,
                 "↑".to_string(),
                 self.styles.muted.clone(),
             ));
         }
-        if self.scroll_offset + self.max_height < self.items.len() {
+        if scroll_offset + visible_count < self.items.len() && y_offset > 1 {
             output.push((
-                self.x + 2,
+                self.x + 1,
                 self.y + y_offset - 1,
                 "↓".to_string(),
                 self.styles.muted.clone(),
@@ -389,6 +480,43 @@ impl CompletionUI {
         }
 
         output
+    }
+
+    fn preview_rows(&self, item: &CompletionResponseItem, max_rows: usize) -> Vec<String> {
+        let mut rows = Vec::new();
+        let width = self.width.saturating_sub(4).max(1);
+
+        if let Some(detail) = &item.detail {
+            rows.push(format!("  {}", Self::ellipsize(detail, width)));
+        }
+
+        if let Some(chars) = &item.commit_characters {
+            let commit_text = format!(
+                "Complete with: {}",
+                chars
+                    .iter()
+                    .map(|c| format!("'{}'", c))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            rows.push(format!("  {}", Self::ellipsize(&commit_text, width)));
+        }
+
+        if let Some(doc) = &item.documentation {
+            let doc_text = match doc {
+                Documentation::String(s) => s,
+                Documentation::MarkupContent(content) => &content.value,
+            };
+
+            for line in textwrap::wrap(doc_text, width) {
+                if rows.len() >= max_rows {
+                    break;
+                }
+                rows.push(format!("  {line}"));
+            }
+        }
+
+        rows
     }
 }
 
@@ -404,6 +532,11 @@ impl Component for CompletionUI {
         match ev {
             Event::Key(KeyEvent {
                 code: KeyCode::Up, ..
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Char('k'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
             }) => {
                 self.move_selection(-1);
                 Some(KeyAction::None)
@@ -422,6 +555,11 @@ impl Component for CompletionUI {
             }
             Event::Key(KeyEvent {
                 code: KeyCode::Down,
+                ..
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Char('j'),
+                modifiers: KeyModifiers::CONTROL,
                 ..
             })
             | Event::Key(KeyEvent {
@@ -479,8 +617,28 @@ impl Component for CompletionUI {
                     Some(KeyAction::Single(Action::CloseDialog))
                 }
             }
+            Event::Key(KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers,
+                ..
+            }) if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
+                self.push_filter_char(*c);
+                None
+            }
+            Event::Key(KeyEvent {
+                code: KeyCode::Backspace,
+                modifiers,
+                ..
+            }) if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
+                self.pop_filter_char();
+                None
+            }
             _ => None,
         }
+    }
+
+    fn allows_event_passthrough(&self) -> bool {
+        true
     }
 }
 
@@ -488,6 +646,14 @@ impl Component for CompletionUI {
 mod tests {
     use super::*;
     use crate::{color::Color, unicode_utils::display_width};
+
+    fn assert_segments_within_popup(ui: &CompletionUI, rows: &[(usize, usize, String, Style)]) {
+        for (x, _, row, _) in rows {
+            assert!(*x >= ui.x);
+            assert!(x + display_width(row) <= ui.x + ui.width);
+            assert!(row.is_char_boundary(row.len()));
+        }
+    }
 
     fn item(label: &str, kind: Option<CompletionItemKind>) -> CompletionResponseItem {
         CompletionResponseItem {
@@ -509,6 +675,10 @@ mod tests {
         }
     }
 
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> Event {
+        Event::Key(KeyEvent::new(code, modifiers))
+    }
+
     #[test]
     fn completion_rows_fit_display_width_with_wide_labels() {
         let mut ui = CompletionUI::new();
@@ -523,10 +693,7 @@ mod tests {
 
         let rows = ui.render_completion();
 
-        for (_, _, row, _) in rows {
-            assert_eq!(display_width(&row), ui.width);
-            assert!(row.is_char_boundary(row.len()));
-        }
+        assert_segments_within_popup(&ui, &rows);
     }
 
     #[test]
@@ -542,9 +709,7 @@ mod tests {
         assert!(rows
             .iter()
             .any(|(_, _, row, _)| row.contains("returns 👋 世界")));
-        for (_, _, row, _) in rows {
-            assert_eq!(display_width(&row), ui.width);
-        }
+        assert_segments_within_popup(&ui, &rows);
     }
 
     #[test]
@@ -616,6 +781,85 @@ mod tests {
     }
 
     #[test]
+    fn completion_selected_row_keeps_border_style() {
+        let mut theme = Theme::default();
+        theme.ui_style.popup_border = Style {
+            fg: Some(Color::Rgb { r: 1, g: 2, b: 3 }),
+            bg: Some(Color::Rgb { r: 4, g: 5, b: 6 }),
+            ..Default::default()
+        };
+        theme.ui_style.picker_selected_item = Style {
+            fg: Some(Color::Rgb { r: 7, g: 8, b: 9 }),
+            bg: Some(Color::Rgb {
+                r: 10,
+                g: 11,
+                b: 12,
+            }),
+            ..Default::default()
+        };
+
+        let mut ui = CompletionUI::with_theme(&theme);
+        ui.show(vec![item("hello", Some(CompletionItemKind::Text))], 0, 0);
+
+        let rows = ui.render_completion();
+
+        assert!(rows
+            .iter()
+            .any(|(_, _, row, style)| row == "│" && *style == theme.ui_style.popup_border));
+        assert!(rows.iter().any(|(_, _, row, style)| {
+            row.contains("hello") && *style == theme.ui_style.picker_selected_item
+        }));
+    }
+
+    #[test]
+    fn completion_preview_renders_below_visible_list() {
+        let mut completion = item("alpha", Some(CompletionItemKind::Function));
+        completion.detail = Some("fn alpha()".to_string());
+        let mut items = vec![completion];
+        items
+            .extend((0..8).map(|idx| item(&format!("item_{idx}"), Some(CompletionItemKind::Text))));
+
+        let mut ui = CompletionUI::new();
+        ui.show_with_bounds(items, 0, 0, 80, 16);
+
+        let rows = ui.render_completion();
+        let detail_y = rows
+            .iter()
+            .find_map(|(_, y, row, _)| row.contains("fn alpha()").then_some(*y))
+            .expect("selected item detail should render");
+        let last_item_y = rows
+            .iter()
+            .filter_map(|(_, y, row, _)| row.contains("item_").then_some(*y))
+            .max()
+            .expect("list items should render");
+
+        assert!(detail_y > last_item_y);
+    }
+
+    #[test]
+    fn completion_selected_item_stays_visible_when_preview_reduces_list_rows() {
+        let mut items = Vec::new();
+        for idx in 0..12 {
+            let mut completion = item(&format!("item_{idx}"), Some(CompletionItemKind::Text));
+            completion.detail = Some(format!("detail {idx}"));
+            items.push(completion);
+        }
+
+        let mut ui = CompletionUI::new();
+        ui.show_with_bounds(items, 0, 0, 80, 16);
+        for _ in 0..8 {
+            ui.move_selection(1);
+        }
+        let selected_label = ui.selected_item().unwrap().label.clone();
+
+        let rows = ui.render_completion();
+
+        assert!(rows
+            .iter()
+            .any(|(_, _, row, _)| row.contains(&selected_label)));
+    }
+
+    #[test]
     fn tab_and_backtab_move_completion_selection() {
         let mut ui = CompletionUI::new();
         ui.show(
@@ -633,5 +877,107 @@ mod tests {
 
         ui.handle_event(&Event::Key(KeyEvent::from(KeyCode::BackTab)));
         assert_eq!(ui.selected_item().unwrap().label, "alpha");
+    }
+
+    #[test]
+    fn ctrl_j_and_ctrl_k_move_completion_selection() {
+        let mut ui = CompletionUI::new();
+        ui.show(
+            vec![
+                item("alpha", Some(CompletionItemKind::Text)),
+                item("beta", Some(CompletionItemKind::Text)),
+                item("gamma", Some(CompletionItemKind::Text)),
+            ],
+            0,
+            0,
+        );
+
+        ui.handle_event(&key(KeyCode::Char('j'), KeyModifiers::CONTROL));
+        assert_eq!(ui.selected_item().unwrap().label, "beta");
+
+        ui.handle_event(&key(KeyCode::Char('k'), KeyModifiers::CONTROL));
+        assert_eq!(ui.selected_item().unwrap().label, "alpha");
+    }
+
+    #[test]
+    fn plain_typing_keys_pass_through_completion_popup() {
+        let mut ui = CompletionUI::new();
+        ui.show(vec![item("alpha", Some(CompletionItemKind::Text))], 0, 0);
+
+        assert!(ui.allows_event_passthrough());
+        assert_eq!(
+            ui.handle_event(&key(KeyCode::Char('a'), KeyModifiers::NONE)),
+            None
+        );
+        assert_eq!(
+            ui.handle_event(&key(KeyCode::Backspace, KeyModifiers::NONE)),
+            None
+        );
+    }
+
+    #[test]
+    fn typing_filters_completion_items_without_capturing_keys() {
+        let mut ui = CompletionUI::new();
+        ui.show(
+            vec![
+                item("ancestors", Some(CompletionItemKind::Function)),
+                item("as_mut_os_str", Some(CompletionItemKind::Function)),
+                item("as_os_str", Some(CompletionItemKind::Function)),
+                item("canonicalize", Some(CompletionItemKind::Function)),
+                item("components", Some(CompletionItemKind::Function)),
+            ],
+            0,
+            0,
+        );
+
+        assert_eq!(
+            ui.handle_event(&key(KeyCode::Char('a'), KeyModifiers::NONE)),
+            None
+        );
+        assert_eq!(
+            ui.handle_event(&key(KeyCode::Char('s'), KeyModifiers::NONE)),
+            None
+        );
+
+        let labels = ui
+            .items
+            .iter()
+            .map(|item| item.label.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(labels, vec!["as_mut_os_str", "as_os_str"]);
+        assert_eq!(ui.selected_item().unwrap().label, "as_mut_os_str");
+    }
+
+    #[test]
+    fn backspace_restores_completion_filter_matches() {
+        let mut ui = CompletionUI::new();
+        ui.show(
+            vec![
+                item("add_extension", Some(CompletionItemKind::Function)),
+                item("ancestors", Some(CompletionItemKind::Function)),
+                item("exists", Some(CompletionItemKind::Function)),
+            ],
+            0,
+            0,
+        );
+
+        ui.handle_event(&key(KeyCode::Char('e'), KeyModifiers::NONE));
+        ui.handle_event(&key(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert_eq!(
+            ui.items
+                .iter()
+                .map(|item| item.label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["exists", "add_extension"]
+        );
+
+        ui.handle_event(&key(KeyCode::Backspace, KeyModifiers::NONE));
+        assert_eq!(
+            ui.items
+                .iter()
+                .map(|item| item.label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["exists", "add_extension", "ancestors"]
+        );
     }
 }

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -1,12 +1,12 @@
 use std::cmp::min;
 
-use crossterm::event::{Event, KeyCode, KeyEvent};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
 use crate::{
     config::KeyAction,
     editor::{Action, RenderBuffer},
     log,
-    lsp::types::{CompletionItemKind, CompletionResponseItem, Documentation, InsertTextFormat},
+    lsp::types::{CompletionItemKind, CompletionResponseItem, Documentation},
     theme::{Style, Theme, UiStyle},
     unicode_utils::{display_width, fit_display_width, truncate_display_width},
 };
@@ -409,8 +409,23 @@ impl Component for CompletionUI {
                 Some(KeyAction::None)
             }
             Event::Key(KeyEvent {
+                code: KeyCode::BackTab,
+                ..
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Tab,
+                modifiers: KeyModifiers::SHIFT,
+                ..
+            }) => {
+                self.move_selection(-1);
+                Some(KeyAction::None)
+            }
+            Event::Key(KeyEvent {
                 code: KeyCode::Down,
                 ..
+            })
+            | Event::Key(KeyEvent {
+                code: KeyCode::Tab, ..
             }) => {
                 self.move_selection(1);
                 Some(KeyAction::None)
@@ -434,23 +449,11 @@ impl Component for CompletionUI {
                 ..
             }) => {
                 if let Some(item) = self.selected_item() {
-                    let text = if let Some(text_edit) = &item.text_edit {
-                        text_edit.new_text.clone()
-                    } else if let Some(insert_text) = &item.insert_text {
-                        match item.insert_text_format {
-                            Some(InsertTextFormat::Snippet) => {
-                                // TODO: Implement snippet parsing and expansion
-                                // For now, just insert the text as-is
-                                insert_text.clone()
-                            }
-                            _ => insert_text.clone(),
-                        }
-                    } else {
-                        item.label.clone()
-                    };
-
                     Some(KeyAction::Multiple(vec![
-                        Action::InsertString(text),
+                        Action::ApplyCompletion {
+                            item: Box::new(item.clone()),
+                            commit_character: None,
+                        },
                         Action::CloseDialog,
                     ]))
                 } else {
@@ -465,20 +468,11 @@ impl Component for CompletionUI {
                 ..
             }) if self.commit_chars.contains(c) => {
                 if let Some(item) = self.selected_item() {
-                    let text = if let Some(text_edit) = &item.text_edit {
-                        text_edit.new_text.clone()
-                    } else if let Some(insert_text) = &item.insert_text {
-                        match item.insert_text_format {
-                            Some(InsertTextFormat::Snippet) => insert_text.clone(),
-                            _ => insert_text.clone(),
-                        }
-                    } else {
-                        item.label.clone()
-                    };
-
                     Some(KeyAction::Multiple(vec![
-                        Action::InsertString(text),
-                        Action::InsertString(c.to_string()),
+                        Action::ApplyCompletion {
+                            item: Box::new(item.clone()),
+                            commit_character: Some(*c),
+                        },
                         Action::CloseDialog,
                     ]))
                 } else {
@@ -619,5 +613,25 @@ mod tests {
         assert!(rows.iter().any(|(_, _, row, style)| {
             row.contains("hello") && *style == theme.ui_style.picker_selected_item
         }));
+    }
+
+    #[test]
+    fn tab_and_backtab_move_completion_selection() {
+        let mut ui = CompletionUI::new();
+        ui.show(
+            vec![
+                item("alpha", Some(CompletionItemKind::Text)),
+                item("beta", Some(CompletionItemKind::Text)),
+                item("gamma", Some(CompletionItemKind::Text)),
+            ],
+            0,
+            0,
+        );
+
+        ui.handle_event(&Event::Key(KeyEvent::from(KeyCode::Tab)));
+        assert_eq!(ui.selected_item().unwrap().label, "beta");
+
+        ui.handle_event(&Event::Key(KeyEvent::from(KeyCode::BackTab)));
+        assert_eq!(ui.selected_item().unwrap().label, "alpha");
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -42,6 +42,10 @@ pub trait Component: Send {
         }
     }
 
+    fn allows_event_passthrough(&self) -> bool {
+        false
+    }
+
     fn cursor_position(&self) -> Option<(usize, usize)> {
         None
     }

--- a/tests/common/mock_lsp.rs
+++ b/tests/common/mock_lsp.rs
@@ -16,6 +16,16 @@ pub enum LspEvent {
     RequestDiagnostics(String),
     Hover(String),
     GotoDefinition(String),
+    RequestCompletion {
+        uri: String,
+        line: usize,
+        character: usize,
+        trigger_character: Option<char>,
+    },
+    SendRequest {
+        method: String,
+        params: Value,
+    },
 }
 
 #[derive(Clone, Default)]
@@ -150,6 +160,7 @@ impl LspClient for MockLsp {
         _file_uri: &str,
         _line: usize,
         _character: usize,
+        _trigger_character: Option<char>,
     ) -> Result<i64, LspError> {
         Ok(0)
     }
@@ -272,10 +283,14 @@ impl LspClient for RecordingLsp {
 
     async fn send_request(
         &mut self,
-        _method: &str,
-        _params: Value,
+        method: &str,
+        params: Value,
         _: bool,
     ) -> Result<i64, LspError> {
+        self.record(LspEvent::SendRequest {
+            method: method.to_string(),
+            params,
+        });
         Ok(0)
     }
 
@@ -290,10 +305,17 @@ impl LspClient for RecordingLsp {
 
     async fn request_completion(
         &mut self,
-        _file_uri: &str,
-        _line: usize,
-        _character: usize,
+        file_uri: &str,
+        line: usize,
+        character: usize,
+        trigger_character: Option<char>,
     ) -> Result<i64, LspError> {
+        self.record(LspEvent::RequestCompletion {
+            uri: file_uri.to_string(),
+            line,
+            character,
+            trigger_character,
+        });
         Ok(0)
     }
 

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -1,0 +1,239 @@
+mod common;
+
+use std::sync::{Arc, Mutex};
+
+use common::{LspEvent, RecordingLsp};
+use red::{
+    buffer::Buffer,
+    config::Config,
+    editor::{Action, Editor, Mode},
+    lsp::{
+        Command, CompletionResponseItem, InsertTextFormat, LspClient, Position, Range, TextEdit,
+    },
+    test_utils::EditorTestExt,
+    theme::Theme,
+};
+use serde_json::json;
+
+fn recording_editor(buffer: Buffer) -> (Editor, Arc<Mutex<Vec<LspEvent>>>) {
+    let lsp = RecordingLsp::default();
+    let events = lsp.events();
+    let lsp = Box::new(lsp) as Box<dyn LspClient + Send>;
+    let config = Config::default();
+    let theme = Theme::default();
+    let mut editor = Editor::with_size(lsp, 80, 24, config, theme, vec![buffer]).unwrap();
+    editor.test_disable_terminal_output();
+    (editor, events)
+}
+
+fn recorded(events: &Arc<Mutex<Vec<LspEvent>>>) -> Vec<LspEvent> {
+    events.lock().unwrap().clone()
+}
+
+fn item(label: &str) -> CompletionResponseItem {
+    CompletionResponseItem {
+        label: label.to_string(),
+        kind: None,
+        detail: None,
+        documentation: None,
+        deprecated: None,
+        preselect: None,
+        sort_text: None,
+        filter_text: None,
+        insert_text: None,
+        insert_text_format: None,
+        text_edit: None,
+        additional_text_edits: None,
+        command: None,
+        data: None,
+        commit_characters: None,
+    }
+}
+
+fn range(start_line: usize, start: usize, end_line: usize, end: usize) -> Range {
+    Range {
+        start: Position {
+            line: start_line,
+            character: start,
+        },
+        end: Position {
+            line: end_line,
+            character: end,
+        },
+    }
+}
+
+fn text_edit(range: Range, new_text: &str) -> TextEdit {
+    TextEdit {
+        range,
+        new_text: new_text.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn request_completion_sends_invoked_context_from_insert_mode() {
+    let (mut editor, events) = recording_editor(Buffer::new(
+        Some("src/main.rs".to_string()),
+        "foo".to_string(),
+    ));
+
+    editor
+        .test_execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::SetCursor(3, 0))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::RequestCompletion)
+        .await
+        .unwrap();
+
+    assert!(
+        recorded(&events).iter().any(|event| {
+            matches!(
+                event,
+                LspEvent::RequestCompletion {
+                    line: 0,
+                    character: 3,
+                    trigger_character: None,
+                    ..
+                }
+            )
+        }),
+        "expected manual completion request, got {:?}",
+        recorded(&events)
+    );
+}
+
+#[tokio::test]
+async fn request_completion_sends_trigger_character_context() {
+    let (mut editor, events) = recording_editor(Buffer::new(
+        Some("src/main.rs".to_string()),
+        "value.".to_string(),
+    ));
+
+    editor
+        .test_execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::SetCursor(6, 0))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::RequestCompletionWithTrigger('.'))
+        .await
+        .unwrap();
+
+    assert!(
+        recorded(&events).iter().any(|event| {
+            matches!(
+                event,
+                LspEvent::RequestCompletion {
+                    line: 0,
+                    character: 6,
+                    trigger_character: Some('.'),
+                    ..
+                }
+            )
+        }),
+        "expected trigger completion request, got {:?}",
+        recorded(&events)
+    );
+}
+
+#[tokio::test]
+async fn apply_completion_uses_text_edit_additional_edits_and_one_undo_step() {
+    let (mut editor, _) = recording_editor(Buffer::new(None, "mod stuff;\nfoo\n".to_string()));
+    let mut completion = item("Foo");
+    completion.text_edit = Some(text_edit(range(1, 0, 1, 3), "Foo"));
+    completion.additional_text_edits =
+        Some(vec![text_edit(range(0, 0, 0, 0), "use crate::Foo;\n")]);
+
+    editor
+        .test_execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::SetCursor(3, 1))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::ApplyCompletion {
+            item: Box::new(completion),
+            commit_character: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        editor.test_buffer_contents(),
+        "use crate::Foo;\nmod stuff;\nFoo\n"
+    );
+    assert_eq!(editor.test_cursor_position(), (3, 2));
+
+    editor.test_execute_action(Action::Undo).await.unwrap();
+    assert_eq!(editor.test_buffer_contents(), "mod stuff;\nfoo\n");
+}
+
+#[tokio::test]
+async fn apply_completion_strips_basic_snippet_markers() {
+    let (mut editor, _) = recording_editor(Buffer::new(None, "call".to_string()));
+    let mut completion = item("println");
+    completion.insert_text = Some("println!(\"${1:value}\");$0".to_string());
+    completion.insert_text_format = Some(InsertTextFormat::Snippet);
+
+    editor
+        .test_execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::ApplyCompletion {
+            item: Box::new(completion),
+            commit_character: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(editor.test_buffer_contents(), "println!(\"value\");call");
+    assert_eq!(editor.test_cursor_position(), (10, 0));
+}
+
+#[tokio::test]
+async fn apply_completion_runs_lsp_command_after_edits() {
+    let (mut editor, events) = recording_editor(Buffer::new(None, "foo".to_string()));
+    let mut completion = item("bar");
+    completion.text_edit = Some(text_edit(range(0, 0, 0, 3), "bar"));
+    completion.command = Some(Command {
+        title: "organize imports".to_string(),
+        command: "rust-analyzer.applySourceChange".to_string(),
+        arguments: Some(vec![json!({ "id": 1 })]),
+    });
+
+    editor
+        .test_execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::ApplyCompletion {
+            item: Box::new(completion),
+            commit_character: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        recorded(&events).iter().any(|event| {
+            matches!(
+                event,
+                LspEvent::SendRequest { method, params }
+                    if method == "workspace/executeCommand"
+                        && params["command"] == "rust-analyzer.applySourceChange"
+            )
+        }),
+        "expected executeCommand request, got {:?}",
+        recorded(&events)
+    );
+}


### PR DESCRIPTION
## Why

Red already had pieces of completion support, but `RequestCompletion` was effectively a no-op and accepted completion items were inserted as plain text. That meant users could not manually invoke autocomplete, LSP trigger characters did not produce a usable popup, and richer server responses such as `textEdit`, `additionalTextEdits`, commit characters, snippets, and completion commands were lost.

## What Changed

- Wire insert-mode completion requests to the active LSP client, including manual `Ctrl-Space` invocation and server trigger-character context.
- Show completion responses only for the current insert-mode buffer and ignore stale completion responses from older requests.
- Accept completion items through editor-owned LSP edit application so main edits, additional edits, commit characters, basic snippet placeholders, and `workspace/executeCommand` run as one undoable action.
- Update completion popup controls so Enter accepts, Tab moves to the next item, Shift-Tab/BackTab moves to the previous item, and Esc closes.
- Parse both LSP `CompletionList` responses and raw completion item arrays.

## How to Test

1. Open a Rust file in Red with `rust-analyzer` available and enter insert mode.
2. Press `Ctrl-Space` and confirm a completion popup appears for the cursor position.
3. Use Tab and Shift-Tab to move through items, then press Enter and confirm the selected completion is inserted.
4. Type an LSP trigger character such as `.` or `::` in insert mode and confirm completion is requested automatically after the typed character.
5. Accept a completion that adds an import or other extra edit, then press undo once and confirm the accepted completion and extra edit are undone together.

Targeted tests:

- `cargo test completion`