### PR TITLE
feat(tui): persist command history

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -55,6 +55,7 @@ use crate::{
         ParsedNotification, ProgressParams, ProgressToken, ResponseMessage, ServerCapabilities,
     },
     plugin::{self, PluginRegistry, Runtime},
+    preferences::PreferencesStore,
     theme::{parse_vscode_theme, Style, Theme},
     ui::{CompletionUI, Component, FilePicker, Info, Picker},
     undo::{CursorSnapshot, TextPosition, TextRange},
@@ -608,6 +609,12 @@ pub struct Editor {
     /// Current command line content
     command: String,
 
+    /// Persistent preferences, including command-line history.
+    preferences: PreferencesStore,
+
+    /// Active command-history navigation state.
+    command_history_navigation: Option<CommandHistoryNavigation>,
+
     /// Current search term
     search_term: String,
 
@@ -662,6 +669,19 @@ struct HistoryEntry {
     file: String,
     x: usize,
     y: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandHistoryDirection {
+    Previous,
+    Next,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommandHistoryNavigation {
+    prefix: String,
+    original: String,
+    position: usize,
 }
 
 impl HistoryEntry {
@@ -873,6 +893,27 @@ impl Editor {
         theme: Theme,
         buffers: Vec<Buffer>,
     ) -> anyhow::Result<Self> {
+        Self::with_size_and_preferences(
+            lsp,
+            width,
+            height,
+            config,
+            theme,
+            buffers,
+            PreferencesStore::in_memory(),
+        )
+    }
+
+    #[allow(unused)]
+    pub fn with_size_and_preferences(
+        lsp: Box<dyn LspClient>,
+        width: usize,
+        height: usize,
+        config: Config,
+        theme: Theme,
+        buffers: Vec<Buffer>,
+        preferences: PreferencesStore,
+    ) -> anyhow::Result<Self> {
         let mut stdout = stdout();
         let vx = buffers
             .first()
@@ -920,6 +961,8 @@ impl Editor {
             pending_operator: None,
             actions: vec![],
             command: String::new(),
+            preferences,
+            command_history_navigation: None,
             search_term: String::new(),
             last_error: None,
             current_dialog: None,
@@ -955,14 +998,25 @@ impl Editor {
         theme: Theme,
         buffers: Vec<Buffer>,
     ) -> anyhow::Result<Self> {
+        Self::new_with_preferences(lsp, config, theme, buffers, PreferencesStore::in_memory())
+    }
+
+    pub fn new_with_preferences(
+        lsp: Box<dyn LspClient>,
+        config: Config,
+        theme: Theme,
+        buffers: Vec<Buffer>,
+        preferences: PreferencesStore,
+    ) -> anyhow::Result<Self> {
         let size = terminal::size()?;
-        Self::with_size(
+        Self::with_size_and_preferences(
             lsp,
             size.0 as usize,
             size.1 as usize,
             config,
             theme,
             buffers,
+            preferences,
         )
     }
 
@@ -2479,6 +2533,63 @@ impl Editor {
         text.pop();
     }
 
+    fn reset_command_history_navigation(&mut self) {
+        self.command_history_navigation = None;
+    }
+
+    fn command_history_matches(&self, prefix: &str) -> Vec<usize> {
+        self.preferences
+            .command_history()
+            .iter()
+            .enumerate()
+            .filter_map(|(index, command)| command.starts_with(prefix).then_some(index))
+            .collect()
+    }
+
+    fn navigate_command_history(&mut self, direction: CommandHistoryDirection) {
+        let mut navigation = self.command_history_navigation.take().unwrap_or_else(|| {
+            let prefix = self.command.clone();
+            let position = self.command_history_matches(&prefix).len();
+            CommandHistoryNavigation {
+                prefix,
+                original: self.command.clone(),
+                position,
+            }
+        });
+
+        let matches = self.command_history_matches(&navigation.prefix);
+        if matches.is_empty() {
+            self.command_history_navigation = None;
+            return;
+        }
+
+        match direction {
+            CommandHistoryDirection::Previous => {
+                navigation.position = navigation.position.saturating_sub(1);
+                self.command =
+                    self.preferences.command_history()[matches[navigation.position]].clone();
+            }
+            CommandHistoryDirection::Next => {
+                if navigation.position + 1 < matches.len() {
+                    navigation.position += 1;
+                    self.command =
+                        self.preferences.command_history()[matches[navigation.position]].clone();
+                } else {
+                    navigation.position = matches.len();
+                    self.command = navigation.original.clone();
+                }
+            }
+        }
+
+        self.command_history_navigation = Some(navigation);
+    }
+
+    fn record_command_history(&mut self, command: &str) {
+        if let Err(error) = self.preferences.record_command(command) {
+            log!("failed to save command history: {error}");
+        }
+    }
+
     fn handle_command_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
         if let Event::Key(ref event) = ev {
             let code = event.code;
@@ -2487,12 +2598,21 @@ impl Editor {
             match code {
                 KeyCode::Esc => {
                     self.command = String::new();
+                    self.reset_command_history_navigation();
                     return Some(KeyAction::Single(Action::EnterMode(Mode::Normal)));
                 }
                 KeyCode::Backspace => {
                     Self::delete_last_char(&mut self.command);
+                    self.reset_command_history_navigation();
+                }
+                KeyCode::Up => {
+                    self.navigate_command_history(CommandHistoryDirection::Previous);
+                }
+                KeyCode::Down => {
+                    self.navigate_command_history(CommandHistoryDirection::Next);
                 }
                 KeyCode::Enter => {
+                    self.reset_command_history_navigation();
                     if self.command.trim().is_empty() {
                         return Some(KeyAction::Single(Action::EnterMode(Mode::Normal)));
                     }
@@ -2502,7 +2622,8 @@ impl Editor {
                     ]));
                 }
                 KeyCode::Char(c) => {
-                    self.command = format!("{}{c}", self.command);
+                    self.command.push(c);
+                    self.reset_command_history_navigation();
                 }
                 _ => {}
             }
@@ -3213,6 +3334,10 @@ impl Editor {
                     self.search_term = String::new();
                 }
 
+                if matches!(new_mode, Mode::Command) {
+                    self.reset_command_history_navigation();
+                }
+
                 self.mode = *new_mode;
 
                 if matches!(
@@ -3809,6 +3934,7 @@ impl Editor {
             }
             Action::Command(cmd) => {
                 log!("Handling command: {cmd}");
+                self.record_command_history(cmd);
 
                 for action in self.handle_command(cmd) {
                     self.last_error = None;
@@ -6057,6 +6183,15 @@ impl Editor {
             Mode::Command => self.command = text.to_string(),
             Mode::Search => self.search_term = text.to_string(),
             _ => {}
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn test_commandline_text(&self) -> &str {
+        match self.mode {
+            Mode::Command => &self.command,
+            Mode::Search => &self.search_term,
+            _ => "",
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod logger;
 pub mod lsp;
 pub mod onboarding;
 pub mod plugin;
+pub mod preferences;
 pub mod sync;
 pub mod theme;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use red::editor::Editor;
 use red::logger::Logger;
 use red::lsp::{LspClient, LspManager};
 use red::onboarding;
+use red::preferences::PreferencesStore;
 use red::theme::parse_vscode_theme;
 use red::{log, LOGGER};
 
@@ -38,6 +39,7 @@ async fn main() -> anyhow::Result<()> {
     } else {
         LOGGER.get_or_init(|| None);
     }
+    let preferences = PreferencesStore::load(Config::path("preferences.json"));
 
     let args = Args::parse();
     config.startup_file_count = args.files.len();
@@ -66,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     }
     let theme = parse_vscode_theme(&theme_file.to_string_lossy())?;
-    let mut editor = Editor::new(lsp, config, theme, buffers)?;
+    let mut editor = Editor::new_with_preferences(lsp, config, theme, buffers, preferences)?;
 
     panic::set_hook(Box::new(|info| {
         let mut stdout = stdout();

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -1,0 +1,189 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::LOGGER;
+
+const COMMAND_HISTORY_LIMIT: usize = 100;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Preferences {
+    #[serde(default)]
+    command_history: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreferencesStore {
+    path: Option<PathBuf>,
+    preferences: Preferences,
+}
+
+impl PreferencesStore {
+    pub fn in_memory() -> Self {
+        Self {
+            path: None,
+            preferences: Preferences::default(),
+        }
+    }
+
+    pub fn load(path: impl AsRef<Path>) -> Self {
+        let path = path.as_ref().to_path_buf();
+        let preferences = load_preferences(&path).unwrap_or_else(|error| {
+            log_if_configured(&format!(
+                "failed to load preferences from {}: {error}",
+                path.display()
+            ));
+            Preferences::default()
+        });
+
+        Self {
+            path: Some(path),
+            preferences,
+        }
+    }
+
+    pub fn command_history(&self) -> &[String] {
+        &self.preferences.command_history
+    }
+
+    pub fn record_command(&mut self, command: &str) -> anyhow::Result<()> {
+        if command.trim().is_empty() {
+            return Ok(());
+        }
+
+        if self
+            .preferences
+            .command_history
+            .last()
+            .is_some_and(|last| last == command)
+        {
+            return Ok(());
+        }
+
+        self.preferences.command_history.push(command.to_string());
+        let overflow = self
+            .preferences
+            .command_history
+            .len()
+            .saturating_sub(COMMAND_HISTORY_LIMIT);
+        if overflow > 0 {
+            self.preferences.command_history.drain(0..overflow);
+        }
+
+        self.save()
+    }
+
+    pub fn save(&self) -> anyhow::Result<()> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::write(path, serde_json::to_string_pretty(&self.preferences)?)?;
+        Ok(())
+    }
+}
+
+fn load_preferences(path: &Path) -> anyhow::Result<Preferences> {
+    if !path.exists() {
+        return Ok(Preferences::default());
+    }
+
+    let contents = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&contents)?)
+}
+
+fn log_if_configured(message: &str) {
+    if let Some(Some(logger)) = LOGGER.get() {
+        logger.log(message);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("red-{name}-{}", uuid::Uuid::new_v4()))
+    }
+
+    #[test]
+    fn missing_file_loads_empty_preferences() {
+        let path = unique_temp_dir("missing-preferences").join("preferences.json");
+
+        let store = PreferencesStore::load(path);
+
+        assert!(store.command_history().is_empty());
+    }
+
+    #[test]
+    fn saving_creates_preferences_file() {
+        let dir = unique_temp_dir("preferences-save");
+        let path = dir.join("preferences.json");
+        let mut store = PreferencesStore::load(&path);
+
+        store.record_command("write").unwrap();
+
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("write"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn saved_command_history_reloads_in_order() {
+        let dir = unique_temp_dir("preferences-reload");
+        let path = dir.join("preferences.json");
+        let mut store = PreferencesStore::load(&path);
+        store.record_command("write").unwrap();
+        store.record_command("quit").unwrap();
+
+        let store = PreferencesStore::load(&path);
+
+        assert_eq!(store.command_history(), ["write", "quit"]);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn consecutive_duplicate_commands_are_not_repeated() {
+        let mut store = PreferencesStore::in_memory();
+
+        store.record_command("write").unwrap();
+        store.record_command("write").unwrap();
+        store.record_command("quit").unwrap();
+
+        assert_eq!(store.command_history(), ["write", "quit"]);
+    }
+
+    #[test]
+    fn command_history_is_capped_at_limit() {
+        let mut store = PreferencesStore::in_memory();
+
+        for i in 0..(COMMAND_HISTORY_LIMIT + 5) {
+            store.record_command(&format!("cmd-{i}")).unwrap();
+        }
+
+        assert_eq!(store.command_history().len(), COMMAND_HISTORY_LIMIT);
+        assert_eq!(store.command_history().first().unwrap(), "cmd-5");
+    }
+
+    #[test]
+    fn malformed_preferences_load_empty_preferences() {
+        let dir = unique_temp_dir("preferences-malformed");
+        let path = dir.join("preferences.json");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(&path, "not json").unwrap();
+
+        let store = PreferencesStore::load(&path);
+
+        assert!(store.command_history().is_empty());
+        fs::remove_dir_all(dir).ok();
+    }
+}

--- a/tests/common/editor_harness.rs
+++ b/tests/common/editor_harness.rs
@@ -197,6 +197,10 @@ impl EditorHarness {
         self.editor.test_commandline_row()
     }
 
+    pub fn commandline_text(&self) -> &str {
+        self.editor.test_commandline_text()
+    }
+
     pub fn statusline_row(&mut self) -> String {
         self.editor.test_statusline_row()
     }

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -8,6 +8,7 @@ use red::{
     editor::{Action, Content, Editor, Mode},
     lsp::LspClient,
     plugin::{PanelConfig, PanelSide},
+    preferences::PreferencesStore,
     theme::Theme,
 };
 use std::{
@@ -36,6 +37,128 @@ async fn type_normal_keys(harness: &mut EditorHarness, keys: &str) {
             .await
             .unwrap();
     }
+}
+
+async fn command_key(harness: &mut EditorHarness, code: KeyCode) {
+    harness
+        .execute_event(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn command_history_recalls_previous_commands_with_up_and_down() {
+    let mut harness = EditorHarness::with_content("");
+    harness
+        .execute_action(Action::Command("alpha-one".to_string()))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::Command("beta-two".to_string()))
+        .await
+        .unwrap();
+    harness.set_commandline(Mode::Command, "");
+
+    command_key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "beta-two");
+
+    command_key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "alpha-one");
+
+    command_key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "alpha-one");
+
+    command_key(&mut harness, KeyCode::Down).await;
+    assert_eq!(harness.commandline_text(), "beta-two");
+
+    command_key(&mut harness, KeyCode::Down).await;
+    assert_eq!(harness.commandline_text(), "");
+}
+
+#[tokio::test]
+async fn command_history_filters_by_typed_prefix() {
+    let mut harness = EditorHarness::with_content("");
+    for command in ["buffer-next", "write", "buffer-delete"] {
+        harness
+            .execute_action(Action::Command(command.to_string()))
+            .await
+            .unwrap();
+    }
+    harness.set_commandline(Mode::Command, "b");
+
+    command_key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "buffer-delete");
+
+    command_key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "buffer-next");
+
+    command_key(&mut harness, KeyCode::Down).await;
+    assert_eq!(harness.commandline_text(), "buffer-delete");
+
+    command_key(&mut harness, KeyCode::Down).await;
+    assert_eq!(harness.commandline_text(), "b");
+}
+
+#[tokio::test]
+async fn command_history_editing_recalled_command_resets_prefix_session() {
+    let mut harness = EditorHarness::with_content("");
+    harness
+        .execute_action(Action::Command("buffer-delete".to_string()))
+        .await
+        .unwrap();
+    harness.set_commandline(Mode::Command, "b");
+
+    command_key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "buffer-delete");
+
+    command_key(&mut harness, KeyCode::Char('x')).await;
+    assert_eq!(harness.commandline_text(), "buffer-deletex");
+
+    command_key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "buffer-deletex");
+}
+
+#[tokio::test]
+async fn whitespace_only_commands_are_not_saved_to_history() {
+    let mut harness = EditorHarness::with_content("");
+    harness
+        .execute_action(Action::Command("   ".to_string()))
+        .await
+        .unwrap();
+    harness.set_commandline(Mode::Command, "");
+
+    command_key(&mut harness, KeyCode::Up).await;
+
+    assert_eq!(harness.commandline_text(), "");
+}
+
+#[tokio::test]
+async fn submitted_commands_are_persisted_to_preferences() {
+    let dir = std::env::temp_dir().join(format!("red-command-history-{}", uuid::Uuid::new_v4()));
+    let path = dir.join("preferences.json");
+    let lsp = Box::new(MockLsp) as Box<dyn LspClient>;
+    let config = Config::default();
+    let buffer = Buffer::new(None, String::new());
+    let mut editor = Editor::with_size_and_preferences(
+        lsp,
+        80,
+        24,
+        config,
+        Theme::default(),
+        vec![buffer],
+        PreferencesStore::load(&path),
+    )
+    .unwrap();
+    editor.test_disable_terminal_output();
+
+    editor
+        .test_execute_production_action(Action::Command("persist-me".to_string()))
+        .await
+        .unwrap();
+
+    let store = PreferencesStore::load(&path);
+    assert_eq!(store.command_history(), ["persist-me"]);
+    fs::remove_dir_all(dir).ok();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

Command mode currently forgets every `:` command after it is submitted, which makes repeated editor workflows more tedious than they need to be. This adds a small persisted preferences store so command history survives editor restarts while keeping the new preferences API scoped to the immediate history use case.

## What Changed

- Added `preferences.json` storage for command history, loaded from Red's existing config directory via `Config::path("preferences.json")`.
- Records non-empty submitted `:` commands, skips consecutive duplicates, and caps history at 100 entries.
- Supports `Up`/`Down` command recall in command mode, including prefix filtering when text has already been typed.
- Resets history navigation after edits, `Esc`, `Enter`, or re-entering command mode.
- Added focused tests for persistence, malformed preferences fallback, prefix filtering, navigation, and whitespace-only submissions.

## How to Test

1. Start `red`, enter command mode with `:`, run a command such as `write` or another valid command for your current buffer.
2. Enter command mode again and press `Up`; confirm the most recent command is recalled.
3. Type a prefix such as `b`, then press `Up`; confirm only commands beginning with that prefix are cycled.
4. Restart `red`, enter command mode, and press `Up`; confirm the command history is still available from the previous session.
5. As a regression check, submit an empty or whitespace-only command and confirm it is not recalled later.

Targeted tests:

- `cargo test preferences`
- `cargo test command_history`
- `cargo test whitespace_only_commands_are_not_saved_to_history`
