### PR TITLE
feat(tui): preserve cursor goal across vertical movement

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -26,9 +26,10 @@ pub struct Config {
     pub startup_file_count: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CursorShape {
+    #[default]
     Default,
     BlinkingBlock,
     SteadyBlock,
@@ -36,12 +37,6 @@ pub enum CursorShape {
     SteadyUnderscore,
     BlinkingBar,
     SteadyBar,
-}
-
-impl Default for CursorShape {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9,8 +9,9 @@ use std::{
 };
 
 use crate::unicode_utils::{
-    char_prefix, char_slice, char_suffix, char_to_grapheme, display_width, grapheme_len,
-    grapheme_to_byte, grapheme_to_char, next_grapheme_boundary, prev_grapheme_boundary,
+    char_prefix, char_slice, char_suffix, char_to_grapheme, column_to_grapheme, display_width,
+    grapheme_len, grapheme_to_byte, grapheme_to_char, grapheme_to_column, next_grapheme_boundary,
+    prev_grapheme_boundary,
 };
 
 /// Editor is the main component that handles:
@@ -346,6 +347,18 @@ pub enum GoToLinePosition {
     Bottom,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum CursorGoal {
+    DisplayCol(usize),
+    LineEnd,
+}
+
+impl Default for CursorGoal {
+    fn default() -> Self {
+        Self::DisplayCol(0)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum Mode {
     Normal,
@@ -584,6 +597,9 @@ pub struct Editor {
 
     /// Cursor y position (line)
     cy: usize,
+
+    /// Display-column goal used when moving vertically.
+    cursor_goal: CursorGoal,
 
     /// Previous cursor y position (for line highlighting)
     prev_highlight_y: Option<usize>,
@@ -968,6 +984,7 @@ impl Editor {
             vleft: 0,
             cx: 0,
             cy: 0,
+            cursor_goal: CursorGoal::default(),
             prev_highlight_y: None,
             vx,
             mode: Mode::Normal,
@@ -1046,6 +1063,7 @@ impl Editor {
             self.vleft = window.vleft;
             self.cx = window.cx;
             self.cy = window.cy;
+            self.cursor_goal = window.cursor_goal;
             self.vx = window.vx;
         }
     }
@@ -1058,6 +1076,7 @@ impl Editor {
             window.vleft = self.vleft;
             window.cx = self.cx;
             window.cy = self.cy;
+            window.cursor_goal = self.cursor_goal;
             window.vx = self.vx;
         }
     }
@@ -1541,8 +1560,94 @@ impl Editor {
         }
     }
 
-    // TODO: in neovim, when you are at an x position and you move to a shorter line, the cursor
-    //       goes back to the max x but returns to the previous x position if the line is longer
+    fn current_cursor_display_col(&self) -> usize {
+        if let Some(line) = self.current_line_contents() {
+            return grapheme_to_column(line.trim_end_matches('\n'), self.cx);
+        }
+
+        self.cx
+    }
+
+    fn refresh_cursor_goal(&mut self) {
+        self.cursor_goal = CursorGoal::DisplayCol(self.current_cursor_display_col());
+    }
+
+    fn line_goal_limit(&self, line: &str) -> usize {
+        let line_width = display_width(line);
+        if self.is_insert() {
+            line_width
+        } else {
+            line_width.saturating_sub(1)
+        }
+    }
+
+    pub(crate) fn display_col_for_cursor_goal(&self, line: &str, goal: CursorGoal) -> usize {
+        match goal {
+            CursorGoal::DisplayCol(display_col) => display_col.min(self.line_goal_limit(line)),
+            CursorGoal::LineEnd => self.line_goal_limit(line),
+        }
+    }
+
+    fn grapheme_for_cursor_goal(&self, line: &str, goal: CursorGoal) -> usize {
+        match goal {
+            CursorGoal::DisplayCol(display_col) => {
+                let max_cursor_x = self.max_cursor_x_for_line_length(grapheme_len(line));
+                column_to_grapheme(line, display_col).min(max_cursor_x)
+            }
+            CursorGoal::LineEnd => self.max_cursor_x_for_line_length(grapheme_len(line)),
+        }
+    }
+
+    fn apply_cursor_goal_to_current_line(&mut self) {
+        if let Some(line) = self.current_line_contents() {
+            let line = line.trim_end_matches('\n');
+            self.cx = self.grapheme_for_cursor_goal(line, self.cursor_goal);
+        }
+    }
+
+    fn recompute_window_cursor_goals(&mut self) {
+        let buffers = &self.buffers;
+        for window in self.window_manager.windows_mut() {
+            let buffer_y = window.vtop + window.cy;
+            let display_col = buffers
+                .get(window.buffer_index)
+                .and_then(|buffer| buffer.get(buffer_y))
+                .map(|line| grapheme_to_column(line.trim_end_matches('\n'), window.cx))
+                .unwrap_or(window.cx);
+            window.cursor_goal = CursorGoal::DisplayCol(display_col);
+        }
+    }
+
+    fn should_refresh_cursor_goal_after(action: &Action) -> bool {
+        !matches!(
+            action,
+            Action::MoveUp
+                | Action::MoveDown
+                | Action::PageUp
+                | Action::PageDown
+                | Action::MoveToLineEnd
+                | Action::Command(_)
+                | Action::PluginCommand(_)
+                | Action::Quit(_)
+                | Action::Save
+                | Action::SaveAs(_)
+                | Action::DumpHistory
+                | Action::DumpBuffer
+                | Action::DumpDiagnostics
+                | Action::DumpCapabilities
+                | Action::DumpTimers
+                | Action::DoPing
+                | Action::RefreshDiagnostics
+                | Action::Refresh
+                | Action::Hover
+                | Action::Print(_)
+                | Action::ShowProgress(_)
+                | Action::NotifyPlugins(_, _)
+                | Action::ViewLogs
+                | Action::SetWaitingKey(_)
+        )
+    }
+
     fn last_navigable_line(&self) -> usize {
         self.current_buffer().last_navigable_line()
     }
@@ -3256,12 +3361,14 @@ impl Editor {
                     // scroll up
                     if self.vtop > 0 {
                         self.vtop -= 1;
+                        self.apply_cursor_goal_to_current_line();
                         self.render(buffer)?;
                         self.notify_cursor_move(runtime).await?;
                     }
                 } else {
                     self.cy = self.cy.saturating_sub(1);
-                    self.draw_cursor()?;
+                    self.apply_cursor_goal_to_current_line();
+                    self.draw_cursor_preserving_cursor_goal()?;
                     self.notify_cursor_move(runtime).await?;
                 }
             }
@@ -3272,11 +3379,14 @@ impl Editor {
                         // scroll if possible
                         self.vtop += 1;
                         self.cy -= 1;
+                        self.apply_cursor_goal_to_current_line();
                         self.render(buffer)?;
+                    } else {
+                        self.apply_cursor_goal_to_current_line();
                     }
                     self.notify_cursor_move(runtime).await?;
                 } else {
-                    self.draw_cursor()?;
+                    self.draw_cursor_preserving_cursor_goal()?;
                 }
             }
             Action::MoveLeft => {
@@ -3329,6 +3439,7 @@ impl Editor {
             }
             Action::MoveToLineEnd => {
                 self.cx = self.line_length().saturating_sub(1);
+                self.cursor_goal = CursorGoal::LineEnd;
             }
             Action::MoveToFirstLineChar => {
                 if let Some(line) = self.current_line_contents() {
@@ -3357,6 +3468,7 @@ impl Editor {
                     .min(self.last_navigable_line());
                 self.vtop = target_line.saturating_sub(self.vheight().saturating_sub(1));
                 self.cy = target_line.saturating_sub(self.vtop);
+                self.apply_cursor_goal_to_current_line();
                 self.render(buffer)?;
             }
             Action::PageDown => {
@@ -3364,6 +3476,7 @@ impl Editor {
                     (self.buffer_line() + self.vheight()).min(self.last_navigable_line());
                 self.vtop = target_line.saturating_sub(self.vheight().saturating_sub(1));
                 self.cy = target_line.saturating_sub(self.vtop);
+                self.apply_cursor_goal_to_current_line();
                 self.render(buffer)?;
             }
             Action::EnterMode(new_mode) => {
@@ -4797,7 +4910,13 @@ impl Editor {
             }
         }
 
-        if self.check_bounds() {
+        let bounds_changed = self.check_bounds();
+
+        if Self::should_refresh_cursor_goal_after(action) {
+            self.refresh_cursor_goal();
+        }
+
+        if bounds_changed {
             self.render(buffer)?;
         }
 
@@ -5308,6 +5427,7 @@ impl Editor {
                 window.buffer_index = 0;
                 window.cx = 0;
                 window.cy = 0;
+                window.cursor_goal = CursorGoal::default();
                 window.vtop = 0;
                 window.vleft = 0;
                 window.vx = self.vx;
@@ -5342,6 +5462,7 @@ impl Editor {
                 window.buffer_index = target_index;
                 window.cx = target_cx;
                 window.cy = target_cy;
+                window.cursor_goal = CursorGoal::default();
                 window.vtop = target_vtop;
                 window.vleft = 0;
                 window.vx = target_vx;
@@ -5907,6 +6028,8 @@ impl Editor {
                 (self.size.0 as usize, self.size.1 as usize),
             )
         });
+
+        self.recompute_window_cursor_goals();
 
         if let Some(active_window) = self.window_manager.active_window() {
             self.current_buffer_index = active_window.buffer_index;
@@ -7095,6 +7218,30 @@ mod test {
             editor.render_cursor_position(),
             Some((start.0 + 1, start.1))
         );
+    }
+
+    #[test]
+    fn render_diff_preserves_line_end_cursor_goal() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(
+            None,
+            "abcdefghijklmnop\nabcdefghijkl\nabcdefghijklmnop".to_string(),
+        );
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+
+        editor.cy = 1;
+        editor.cx = 11;
+        editor.cursor_goal = CursorGoal::LineEnd;
+        editor.sync_to_window();
+
+        editor.render_diff(Vec::new()).unwrap();
+        editor.cy = 2;
+        editor.apply_cursor_goal_to_current_line();
+
+        assert_eq!(editor.cx, 15);
     }
 
     #[test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -869,12 +869,13 @@ impl Editor {
 
     pub fn render_diff(&mut self, change_set: Vec<Change<'_>>) -> anyhow::Result<()> {
         if !self.terminal_output_enabled {
+            self.draw_cursor_preserving_cursor_goal()?;
             return Ok(());
         }
 
         if change_set.is_empty() {
             self.set_cursor_style()?;
-            self.draw_cursor()?;
+            self.draw_cursor_preserving_cursor_goal()?;
             self.stdout.flush()?;
             return Ok(());
         }
@@ -923,7 +924,7 @@ impl Editor {
         self.stdout.queue(cursor::Show)?;
 
         self.set_cursor_style()?;
-        self.draw_cursor()?;
+        self.draw_cursor_preserving_cursor_goal()?;
         self.stdout.flush()?;
 
         Ok(())
@@ -1145,6 +1146,17 @@ impl Editor {
     }
 
     pub fn draw_cursor(&mut self) -> anyhow::Result<()> {
+        self.draw_cursor_with_goal_refresh(true)
+    }
+
+    pub(crate) fn draw_cursor_preserving_cursor_goal(&mut self) -> anyhow::Result<()> {
+        self.draw_cursor_with_goal_refresh(false)
+    }
+
+    fn draw_cursor_with_goal_refresh(&mut self, refresh_goal: bool) -> anyhow::Result<()> {
+        if refresh_goal {
+            self.refresh_cursor_goal();
+        }
         self.fix_cursor_pos();
         self.sync_to_window();
 
@@ -1202,7 +1214,7 @@ impl Editor {
                 let display_col =
                     if let Some(line) = self.buffers[window.buffer_index].get(buffer_y) {
                         let line = line.trim_end_matches('\n');
-                        crate::unicode_utils::grapheme_to_column(line, window_cx)
+                        self.display_col_for_cursor_goal(line, window.cursor_goal)
                     } else {
                         window_cx
                     };
@@ -1217,7 +1229,7 @@ impl Editor {
                 // Fallback to old behavior if no active window
                 let display_col = if let Some(line) = self.viewport_line(self.cy) {
                     let line = line.trim_end_matches('\n');
-                    crate::unicode_utils::grapheme_to_column(line, self.cx)
+                    self.display_col_for_cursor_goal(line, self.cursor_goal)
                 } else {
                     self.cx
                 };

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,4 @@
-use crate::editor::Point;
+use crate::editor::{CursorGoal, Point};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -34,6 +34,9 @@ pub struct Window {
     /// Cursor y position (line) within the viewport
     pub cy: usize,
 
+    /// Display-column goal used when moving vertically.
+    pub(crate) cursor_goal: CursorGoal,
+
     /// Whether this window is currently active
     pub active: bool,
 
@@ -52,6 +55,7 @@ impl Window {
             vleft: 0,
             cx: 0,
             cy: 0,
+            cursor_goal: CursorGoal::default(),
             active: false,
             vx: 0,
         }

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use std::collections::HashMap;
 
 use common::EditorHarness;
 use red::{
@@ -8,6 +9,18 @@ use red::{
     config::{Config, KeyAction},
     editor::Action,
 };
+
+async fn type_normal_keys(harness: &mut EditorHarness, keys: &str) {
+    for key in keys.chars() {
+        harness
+            .execute_event(Event::Key(KeyEvent::new(
+                KeyCode::Char(key),
+                KeyModifiers::NONE,
+            )))
+            .await
+            .unwrap();
+    }
+}
 
 #[tokio::test]
 async fn test_basic_cursor_movement() {
@@ -231,6 +244,135 @@ async fn test_normal_cursor_clamps_when_moving_to_shorter_line() {
     harness.execute_action(Action::MoveDown).await.unwrap();
 
     harness.assert_cursor_at(1, 1); // On 'y', not one past the line
+}
+
+#[tokio::test]
+async fn test_vertical_movement_restores_cursor_goal_after_empty_line() {
+    let mut harness = EditorHarness::with_content("abcdef\n\nabcdefghijkl");
+
+    for _ in 0..5 {
+        harness.execute_action(Action::MoveRight).await.unwrap();
+    }
+    harness.assert_cursor_at(5, 0);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.assert_cursor_at(0, 1);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.assert_cursor_at(5, 2);
+}
+
+#[tokio::test]
+async fn test_vertical_movement_restores_cursor_goal_after_short_line() {
+    let mut harness = EditorHarness::with_content("abcdef\nxy\nabcdefghijkl");
+
+    for _ in 0..5 {
+        harness.execute_action(Action::MoveRight).await.unwrap();
+    }
+    harness.assert_cursor_at(5, 0);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.assert_cursor_at(1, 1);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.assert_cursor_at(5, 2);
+}
+
+#[tokio::test]
+async fn test_line_end_goal_tracks_each_target_line_end() {
+    let mut harness = EditorHarness::with_content("x\na much longer line");
+
+    harness.execute_action(Action::MoveToLineEnd).await.unwrap();
+    harness.assert_cursor_at(0, 0);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+
+    harness.assert_cursor_at(17, 1);
+}
+
+#[tokio::test]
+async fn test_line_end_goal_survives_shorter_intermediate_line() {
+    let mut harness =
+        EditorHarness::with_content("abcdefghijklmnop\nabcdefghijkl\nabcdefghijklmnop");
+
+    harness.execute_action(Action::MoveToLineEnd).await.unwrap();
+    harness.assert_cursor_at(15, 0);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.assert_cursor_at(11, 1);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.assert_cursor_at(15, 2);
+}
+
+#[tokio::test]
+async fn test_line_end_goal_survives_shorter_intermediate_line_from_keys() {
+    let mut config = Config {
+        scrolloff: Some(3),
+        ..Default::default()
+    };
+    config.keys.normal.extend(HashMap::from([
+        (
+            "g".to_string(),
+            KeyAction::Nested(HashMap::from([(
+                "g".to_string(),
+                KeyAction::Single(Action::MoveToTop),
+            )])),
+        ),
+        ("j".to_string(), KeyAction::Single(Action::MoveDown)),
+        ("$".to_string(), KeyAction::Single(Action::MoveToLineEnd)),
+    ]));
+    let buffer = Buffer::new(
+        None,
+        "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nabcdefghijklmnop\nabcdefghijkl\nabcdefghijklmnop\ntail"
+            .to_string(),
+    );
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    type_normal_keys(&mut harness, "gg8j$jj").await;
+
+    harness.assert_cursor_at(15, 10);
+}
+
+#[tokio::test]
+async fn test_last_line_char_resets_line_end_goal_to_display_column() {
+    let mut harness = EditorHarness::with_content("abc   \nabcdefghijkl");
+
+    harness.execute_action(Action::MoveToLineEnd).await.unwrap();
+    harness
+        .execute_action(Action::MoveToLastLineChar)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(2, 0);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+
+    harness.assert_cursor_at(2, 1);
+}
+
+#[tokio::test]
+async fn test_vertical_goal_can_render_inside_wide_grapheme() {
+    let mut harness = EditorHarness::with_content("abc\n你");
+
+    harness.execute_action(Action::MoveRight).await.unwrap();
+    harness.execute_action(Action::MoveRight).await.unwrap();
+    harness.assert_cursor_at(2, 0);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+
+    harness.assert_cursor_at(0, 1);
+    assert_eq!(harness.render_cursor_position(), Some((4, 1)));
+}
+
+#[tokio::test]
+async fn test_line_end_goal_renders_on_final_wide_grapheme_cell() {
+    let mut harness = EditorHarness::with_content("x\na你");
+
+    harness.execute_action(Action::MoveToLineEnd).await.unwrap();
+    harness.execute_action(Action::MoveDown).await.unwrap();
+
+    harness.assert_cursor_at(1, 1);
+    assert_eq!(harness.render_cursor_position(), Some((5, 1)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

Neovim preserves horizontal cursor intent while moving vertically, including the special line-end intent created by `$`. Red could clamp the cursor when passing through a shorter line, but a subsequent redraw treated that clamped position as the new desired column. That meant moving from a line end through a shorter intermediate line did not return to the end of a later line with the original length.

## What Changed

- Add cursor goal state that distinguishes a concrete display column from line-end intent.
- Apply the cursor goal during vertical movement and page movement instead of deriving it from the currently clamped cursor position.
- Store cursor goal per window so split/window switching keeps the correct horizontal intent.
- Preserve cursor goal during diff rendering so redraws do not accidentally reset `$` line-end behavior.
- Add focused movement regressions for empty lines, shorter intermediate lines, wide graphemes, and the `gg8j$jj` key sequence.

## How to Test

1. Open a file where line 9 and line 11 are the same length, and line 10 is shorter.
2. In normal mode, press `gg8j$jj`.
3. Confirm the cursor ends at the end of line 11, for example status `11:16` when lines 9 and 11 are 16 columns wide.
4. Also move to a non-end display column, move through an empty or shorter line, and confirm vertical movement restores the original display column once the target line is long enough.

Targeted tests:

- `cargo test test_line_end_goal_survives_shorter_intermediate_line_from_keys`
- `cargo test render_diff_preserves_line_end_cursor_goal`
