### PR TITLE
feat: LSP document symbols browser

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -4,12 +4,14 @@ on:
   push:
     paths:
       - 'src/plugin/**'
+      - 'plugins/**'
       - 'examples/**'
       - 'test-harness/**'
       - 'types/**'
   pull_request:
     paths:
       - 'src/plugin/**'
+      - 'plugins/**'
       - 'examples/**'
       - 'test-harness/**'
       - 'types/**'
@@ -78,6 +80,15 @@ jobs:
             fi
           done
 
+      - name: Lint bundled plugins
+        run: |
+          for file in plugins/*.js plugins/*.ts; do
+            if [ -f "$file" ]; then
+              echo "Linting $file..."
+              eslint "$file" || true
+            fi
+          done
+
       - name: Lint test harness
         run: eslint test-harness/*.js || true
 
@@ -116,6 +127,7 @@ jobs:
             },
             "include": [
               "types/**/*",
+              "plugins/*.ts",
               "examples/*.ts",
               "examples/*.js"
             ],

--- a/default_config.toml
+++ b/default_config.toml
@@ -118,6 +118,7 @@ Esc = { EnterMode = "Normal" }
 "Ctrl-p" = "FilePicker"
 "Ctrl-z" = "Suspend"
 "Ctrl-e" = { PluginCommand = "NeoTree" }
+"Ctrl-t" = { PluginCommand = "LspDocumentSymbols" }
 "K" = "Hover"
 # "W" = "ToggleWrap"
 # "L" = "DecreaseLeft"
@@ -215,6 +216,7 @@ Esc = { EnterMode = "Normal" }
 [plugins]
 buffer_picker = "buffer_picker.js"
 fidget = "fidget.js"
+lsp_symbols = "lsp_symbols.ts"
 neotree = "neotree.js"
 session_restore = "session_restore.js"
 theme_browser = "theme_browser.js"

--- a/plugins/lsp_symbols.ts
+++ b/plugins/lsp_symbols.ts
@@ -1,0 +1,85 @@
+/// <reference path="../types/red.d.ts" />
+
+function symbolPrefix(kindName: string): string {
+  switch (kindName) {
+    case "Class":
+      return "[class]";
+    case "Method":
+      return "[method]";
+    case "Function":
+      return "[fn]";
+    case "Constructor":
+      return "[ctor]";
+    case "Interface":
+      return "[iface]";
+    case "Enum":
+      return "[enum]";
+    case "Struct":
+      return "[struct]";
+    case "Property":
+      return "[prop]";
+    case "Field":
+      return "[field]";
+    case "Variable":
+      return "[var]";
+    case "Constant":
+      return "[const]";
+    case "Module":
+      return "[mod]";
+    default:
+      return `[${kindName.toLowerCase()}]`;
+  }
+}
+
+function symbolLabel(symbol: Red.DocumentSymbol): string {
+  const indent = "  ".repeat(symbol.depth);
+  const line = symbol.selectionRange.start.line + 1;
+  const character = symbol.selectionRange.start.character + 1;
+  const detail = symbol.detail ? ` ${symbol.detail}` : "";
+  return `${indent}${symbolPrefix(symbol.kindName)} ${symbol.name}${detail} - ${line}:${character}`;
+}
+
+function uniqueLabel(base: string, counts: Map<string, number>): string {
+  const count = (counts.get(base) || 0) + 1;
+  counts.set(base, count);
+  return count === 1 ? base : `${base} [${count}]`;
+}
+
+export async function activate(red: Red.RedAPI): Promise<void> {
+  red.addCommand("LspDocumentSymbols", async () => {
+    const result = await red.lsp.documentSymbols();
+    if (!result.ok) {
+      red.execute("Print", `Document symbols unavailable: ${result.error}`);
+      return;
+    }
+
+    if (result.symbols.length === 0) {
+      red.execute("Print", "No document symbols found");
+      return;
+    }
+
+    const counts = new Map<string, number>();
+    const symbolsByLabel = new Map<string, Red.DocumentSymbol>();
+    const labels = result.symbols.map((symbol) => {
+      const label = uniqueLabel(symbolLabel(symbol), counts);
+      symbolsByLabel.set(label, symbol);
+      return label;
+    });
+
+    const selected = await red.pick("Document Symbols", labels);
+    if (!selected) {
+      return;
+    }
+
+    const symbol = symbolsByLabel.get(selected);
+    if (!symbol) {
+      return;
+    }
+
+    red.execute("MoveToFilePos", [
+      symbol.file,
+      symbol.selectionRange.start.character,
+      symbol.selectionRange.start.line + 1,
+    ]);
+  });
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,31 @@ pub struct Args {
     #[clap(short, long)]
     pub root: Option<String>,
 
+    /// Inline TOML config override. Can be provided multiple times.
+    #[clap(short = 'c', long = "config-override", value_name = "TOML")]
+    pub config_overrides: Vec<String>,
+
     /// Files to edit
     pub files: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_repeated_config_overrides() {
+        let args = Args::try_parse_from([
+            "red",
+            "-c",
+            r#"theme = "nightfox.json""#,
+            "--config-override",
+            r#"keys.normal."Ctrl-t" = { PluginCommand = "LspDocumentSymbols" }"#,
+            "src/editor.rs",
+        ])
+        .unwrap();
+
+        assert_eq!(args.config_overrides.len(), 2);
+        assert_eq!(args.files, vec!["src/editor.rs"]);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -348,6 +348,22 @@ impl Config {
             .join(p)
     }
 
+    pub fn from_toml_with_overrides(contents: &str, overrides: &[String]) -> anyhow::Result<Self> {
+        let mut value: toml::Value = toml::from_str(contents)
+            .map_err(|err| anyhow::anyhow!("failed to parse config.toml: {err}"))?;
+
+        for (index, override_toml) in overrides.iter().enumerate() {
+            let override_value: toml::Value = toml::from_str(override_toml).map_err(|err| {
+                anyhow::anyhow!("failed to parse config override #{}: {err}", index + 1)
+            })?;
+            merge_toml_values(&mut value, override_value);
+        }
+
+        value
+            .try_into()
+            .map_err(|err| anyhow::anyhow!("failed to deserialize merged config: {err}"))
+    }
+
     pub fn persist_theme(theme_name: &str) -> anyhow::Result<()> {
         let config_path = Self::path("config.toml");
         let contents = fs::read_to_string(&config_path)?;
@@ -356,6 +372,24 @@ impl Config {
             update_theme_config_contents(&contents, theme_name)?,
         )?;
         Ok(())
+    }
+}
+
+fn merge_toml_values(base: &mut toml::Value, override_value: toml::Value) {
+    match (base, override_value) {
+        (toml::Value::Table(base), toml::Value::Table(override_table)) => {
+            for (key, value) in override_table {
+                match base.get_mut(&key) {
+                    Some(base_value) => merge_toml_values(base_value, value),
+                    None => {
+                        base.insert(key, value);
+                    }
+                }
+            }
+        }
+        (base, override_value) => {
+            *base = override_value;
+        }
     }
 }
 
@@ -531,6 +565,85 @@ theme = "theme/nightfox.json"
     }
 
     #[test]
+    fn config_overrides_replace_scalars_and_merge_nested_tables() {
+        let config = Config::from_toml_with_overrides(
+            r#"
+theme = "mocha.json"
+mouse_scroll_lines = 3
+
+[keys.normal]
+"Ctrl-p" = "FilePicker"
+
+[plugins]
+buffer_picker = "buffer_picker.js"
+"#,
+            &[
+                r#"theme = "nightfox.json""#.to_string(),
+                r#"keys.normal."Ctrl-t" = { PluginCommand = "LspDocumentSymbols" }"#.to_string(),
+                r#"plugins.lsp_symbols = "/tmp/lsp_symbols.ts""#.to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(config.theme, "nightfox.json");
+        assert_eq!(config.mouse_scroll_lines, Some(3));
+        assert_eq!(
+            config.keys.normal.get("Ctrl-p"),
+            Some(&KeyAction::Single(Action::FilePicker))
+        );
+        assert_eq!(
+            config.keys.normal.get("Ctrl-t"),
+            Some(&KeyAction::Single(Action::PluginCommand(
+                "LspDocumentSymbols".to_string()
+            )))
+        );
+        assert_eq!(
+            config.plugins.get("buffer_picker").map(String::as_str),
+            Some("buffer_picker.js")
+        );
+        assert_eq!(
+            config.plugins.get("lsp_symbols").map(String::as_str),
+            Some("/tmp/lsp_symbols.ts")
+        );
+    }
+
+    #[test]
+    fn later_config_overrides_win() {
+        let config = Config::from_toml_with_overrides(
+            r#"
+theme = "mocha.json"
+
+[keys]
+"#,
+            &[
+                r#"theme = "nightfox.json""#.to_string(),
+                r#"theme = "latte.json""#.to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(config.theme, "latte.json");
+    }
+
+    #[test]
+    fn config_override_errors_include_override_index() {
+        let err = Config::from_toml_with_overrides(
+            r#"
+theme = "mocha.json"
+
+[keys]
+"#,
+            &[
+                r#"theme = "nightfox.json""#.to_string(),
+                "theme =".to_string(),
+            ],
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("config override #2"));
+    }
+
+    #[test]
     fn default_config_maps_star_to_search_word_under_cursor() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 
@@ -574,6 +687,22 @@ theme = "theme/nightfox.json"
         assert_eq!(
             ctrl_w.get("_"),
             Some(&KeyAction::Single(Action::MaximizeWindow))
+        );
+    }
+
+    #[test]
+    fn default_config_maps_ctrl_t_to_lsp_document_symbols() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.keys.normal.get("Ctrl-t"),
+            Some(&KeyAction::Single(Action::PluginCommand(
+                "LspDocumentSymbols".to_string()
+            )))
+        );
+        assert_eq!(
+            config.plugins.get("lsp_symbols").map(String::as_str),
+            Some("lsp_symbols.ts")
         );
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -54,7 +54,7 @@ use crate::{
     lsp::{
         get_client_capabilities, Command as LspCommand, CompletionResponse, CompletionResponseItem,
         Diagnostic, InboundMessage, InsertTextFormat, LspClient, ParsedNotification,
-        ProgressParams, ProgressToken, ResponseMessage, ServerCapabilities,
+        ProgressParams, ProgressToken, Range, ResponseMessage, ServerCapabilities,
         TextEdit as LspTextEdit,
     },
     plugin::{self, PluginRegistry, Runtime},
@@ -74,6 +74,13 @@ const JUMPLIST_SIZE: usize = 100;
 
 fn expanded_path_string(path: &str) -> anyhow::Result<String> {
     Ok(expand_user_path(path)?.to_string_lossy().into_owned())
+}
+
+fn plugin_lsp_error(message: &str) -> Value {
+    json!({
+        "ok": false,
+        "error": message,
+    })
 }
 
 pub enum PluginRequest {
@@ -120,6 +127,9 @@ pub enum PluginRequest {
     RestoreEditorState {
         request_id: i32,
         snapshot: EditorStateSnapshot,
+    },
+    DocumentSymbols {
+        request_id: i32,
     },
     GetTextDisplayWidth {
         text: String,
@@ -686,6 +696,8 @@ pub struct Editor {
     panel_manager: plugin::PanelManager,
 
     directory_watchers: HashMap<i32, DirectoryWatcher>,
+
+    pending_plugin_document_symbols: HashMap<i64, i32>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1007,6 +1019,7 @@ impl Editor {
             overlay_manager: plugin::OverlayManager::new(),
             panel_manager: plugin::PanelManager::default(),
             directory_watchers: HashMap::new(),
+            pending_plugin_document_symbols: HashMap::new(),
         })
     }
 
@@ -2008,6 +2021,52 @@ impl Editor {
                                     .await?;
                                 self.render(&mut buffer)?;
                             }
+                            PluginRequest::DocumentSymbols { request_id } => {
+                                let event = format!("lsp:document_symbols:{request_id}");
+                                let Some(file) = self.current_buffer().file.clone() else {
+                                    self.plugin_registry
+                                        .notify(
+                                            &mut runtime,
+                                            &event,
+                                            plugin_lsp_error("current buffer is not file-backed"),
+                                        )
+                                        .await?;
+                                    continue;
+                                };
+
+                                let request_result: anyhow::Result<i64> = async {
+                                    self.ensure_current_buffer_lsp_opened().await?;
+                                    Ok(self.lsp.document_symbols(&file).await?)
+                                }
+                                .await;
+
+                                match request_result {
+                                    Ok(lsp_request_id) if lsp_request_id > 0 => {
+                                        self.pending_plugin_document_symbols
+                                            .insert(lsp_request_id, request_id);
+                                    }
+                                    Ok(_) => {
+                                        self.plugin_registry
+                                            .notify(
+                                                &mut runtime,
+                                                &event,
+                                                plugin_lsp_error(
+                                                    "no language server is available for this file",
+                                                ),
+                                            )
+                                            .await?;
+                                    }
+                                    Err(err) => {
+                                        self.plugin_registry
+                                            .notify(
+                                                &mut runtime,
+                                                &event,
+                                                plugin_lsp_error(&err.to_string()),
+                                            )
+                                            .await?;
+                                    }
+                                }
+                            }
                             PluginRequest::GetTextDisplayWidth { text } => {
                                 let width = crate::unicode_utils::display_width(&text);
                                 self.plugin_registry
@@ -2304,6 +2363,21 @@ impl Editor {
                     if method == "textDocument/diagnostic" && self.config.show_diagnostics {
                         if let Some((uri, diagnostics)) = parse_diagnostics(msg) {
                             return self.add_diagnostics(Some(&uri), &diagnostics);
+                        }
+                    }
+
+                    if method == "textDocument/documentSymbol" {
+                        if let Some(request_id) =
+                            self.pending_plugin_document_symbols.remove(&msg.id)
+                        {
+                            let payload = match self.plugin_document_symbols_payload(msg) {
+                                Ok(payload) => payload,
+                                Err(err) => plugin_lsp_error(&err.to_string()),
+                            };
+                            return Some(Action::NotifyPlugins(
+                                format!("lsp:document_symbols:{request_id}"),
+                                payload,
+                            ));
                         }
                     }
 
@@ -5632,9 +5706,98 @@ impl Editor {
         Some(Action::MoveToFilePos(file, character, line + 1))
     }
 
+    fn plugin_document_symbols_payload(&self, response: &ResponseMessage) -> anyhow::Result<Value> {
+        let file = response_text_document_uri(response)
+            .map(|uri| self.uri_to_file(uri))
+            .or_else(|| self.current_file_name())
+            .ok_or_else(|| anyhow::anyhow!("document symbol response did not include a file"))?;
+        let symbols = self.normalize_document_symbols(&response.result, &file)?;
+
+        Ok(json!({
+            "ok": true,
+            "file": file,
+            "symbols": symbols,
+        }))
+    }
+
+    fn normalize_document_symbols(
+        &self,
+        result: &Value,
+        fallback_file: &str,
+    ) -> anyhow::Result<Vec<PluginDocumentSymbol>> {
+        if result.is_null() {
+            return Ok(Vec::new());
+        }
+
+        let values = result
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("document symbol response was not an array"))?;
+        let mut symbols = Vec::new();
+        for value in values {
+            self.push_normalized_symbol(value, fallback_file, 0, &mut symbols)?;
+        }
+        Ok(symbols)
+    }
+
+    fn push_normalized_symbol(
+        &self,
+        value: &Value,
+        fallback_file: &str,
+        depth: usize,
+        symbols: &mut Vec<PluginDocumentSymbol>,
+    ) -> anyhow::Result<()> {
+        if value.get("location").is_some() {
+            symbols.push(self.normalized_symbol_information(value, depth)?);
+            return Ok(());
+        }
+
+        let symbol = normalized_document_symbol(value, fallback_file, depth)?;
+        symbols.push(symbol);
+
+        if let Some(children) = value.get("children").and_then(Value::as_array) {
+            for child in children {
+                self.push_normalized_symbol(child, fallback_file, depth + 1, symbols)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn normalized_symbol_information(
+        &self,
+        value: &Value,
+        depth: usize,
+    ) -> anyhow::Result<PluginDocumentSymbol> {
+        let location = value
+            .get("location")
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow::anyhow!("symbol information did not include a location"))?;
+        let uri = required_string(location, "uri")?;
+        let range = required_range(location.get("range"), "location.range")?;
+        let kind = required_kind(value)?;
+
+        Ok(PluginDocumentSymbol {
+            name: required_string_value(value, "name")?.to_string(),
+            detail: value
+                .get("containerName")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            kind,
+            kind_name: symbol_kind_name(kind).to_string(),
+            file: self.uri_to_file(uri),
+            range: range.clone(),
+            selection_range: range,
+            depth,
+        })
+    }
+
     fn uri_to_file(&self, uri: &str) -> String {
         let prefix = format!("{}/", get_workspace_uri());
         if let Some(file) = uri.strip_prefix(&prefix) {
+            return file.to_string();
+        }
+
+        if let Some(file) = uri.strip_prefix("file://") {
             return file.to_string();
         }
 
@@ -6422,6 +6585,94 @@ fn response_text_document_uri(response: &ResponseMessage) -> Option<&str> {
         .as_str()
 }
 
+fn normalized_document_symbol(
+    value: &Value,
+    file: &str,
+    depth: usize,
+) -> anyhow::Result<PluginDocumentSymbol> {
+    let range = required_range(value.get("range"), "range")?;
+    let selection_range = required_range(value.get("selectionRange"), "selectionRange")
+        .unwrap_or_else(|_| range.clone());
+    let kind = required_kind(value)?;
+
+    Ok(PluginDocumentSymbol {
+        name: required_string_value(value, "name")?.to_string(),
+        detail: value
+            .get("detail")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        kind,
+        kind_name: symbol_kind_name(kind).to_string(),
+        file: file.to_string(),
+        range,
+        selection_range,
+        depth,
+    })
+}
+
+fn required_string<'a>(value: &'a Map<String, Value>, key: &str) -> anyhow::Result<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("missing string field `{key}`"))
+}
+
+fn required_string_value<'a>(value: &'a Value, key: &str) -> anyhow::Result<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("missing string field `{key}`"))
+}
+
+fn required_kind(value: &Value) -> anyhow::Result<i32> {
+    let kind = value
+        .get("kind")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow::anyhow!("missing numeric field `kind`"))?;
+    if (1..=26).contains(&kind) {
+        Ok(kind as i32)
+    } else {
+        Err(anyhow::anyhow!("invalid symbol kind `{kind}`"))
+    }
+}
+
+fn required_range(value: Option<&Value>, label: &str) -> anyhow::Result<Range> {
+    let value = value.ok_or_else(|| anyhow::anyhow!("missing range field `{label}`"))?;
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+fn symbol_kind_name(kind: i32) -> &'static str {
+    match kind {
+        1 => "File",
+        2 => "Module",
+        3 => "Namespace",
+        4 => "Package",
+        5 => "Class",
+        6 => "Method",
+        7 => "Property",
+        8 => "Field",
+        9 => "Constructor",
+        10 => "Enum",
+        11 => "Interface",
+        12 => "Function",
+        13 => "Variable",
+        14 => "Constant",
+        15 => "String",
+        16 => "Number",
+        17 => "Boolean",
+        18 => "Array",
+        19 => "Object",
+        20 => "Key",
+        21 => "Null",
+        22 => "EnumMember",
+        23 => "Struct",
+        24 => "Event",
+        25 => "Operator",
+        26 => "TypeParameter",
+        _ => "Unknown",
+    }
+}
+
 fn compare_text_positions_desc(a: TextPosition, b: TextPosition) -> Ordering {
     b.line.cmp(&a.line).then(b.character.cmp(&a.character))
 }
@@ -6611,6 +6862,19 @@ pub struct SkippedFile {
     pub reason: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginDocumentSymbol {
+    pub name: String,
+    pub detail: Option<String>,
+    pub kind: i32,
+    pub kind_name: String,
+    pub file: String,
+    pub range: Range,
+    pub selection_range: Range,
+    pub depth: usize,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct EditorInfo {
     buffers: Vec<BufferInfo>,
@@ -6775,6 +7039,15 @@ impl Editor {
     #[doc(hidden)]
     pub async fn test_ensure_current_buffer_lsp_opened(&mut self) -> anyhow::Result<()> {
         self.ensure_current_buffer_lsp_opened().await
+    }
+
+    #[doc(hidden)]
+    pub async fn test_request_document_symbols(&mut self) -> anyhow::Result<i64> {
+        let Some(file) = self.current_buffer().file.clone() else {
+            return Ok(0);
+        };
+        self.ensure_current_buffer_lsp_opened().await?;
+        Ok(self.lsp.document_symbols(&file).await?)
     }
 
     #[doc(hidden)]
@@ -7161,6 +7434,106 @@ mod test {
         editor.render(&mut overlay_buffer).unwrap();
 
         assert_eq!(overlay_buffer.cells[cursor_index].style, cursor_style);
+    }
+
+    #[test]
+    fn document_symbols_payload_flattens_hierarchical_symbols() {
+        let editor = test_editor(40, 10);
+        let response = ResponseMessage {
+            id: 1,
+            result: serde_json::json!([
+                {
+                    "name": "App",
+                    "detail": "struct",
+                    "kind": 23,
+                    "range": {
+                        "start": { "line": 1, "character": 0 },
+                        "end": { "line": 8, "character": 1 }
+                    },
+                    "selectionRange": {
+                        "start": { "line": 1, "character": 7 },
+                        "end": { "line": 1, "character": 10 }
+                    },
+                    "children": [
+                        {
+                            "name": "render",
+                            "kind": 6,
+                            "range": {
+                                "start": { "line": 3, "character": 4 },
+                                "end": { "line": 7, "character": 5 }
+                            },
+                            "selectionRange": {
+                                "start": { "line": 3, "character": 7 },
+                                "end": { "line": 3, "character": 13 }
+                            }
+                        }
+                    ]
+                }
+            ]),
+            request: Some(crate::lsp::Request::new(
+                "textDocument/documentSymbol",
+                serde_json::json!({
+                    "textDocument": {
+                        "uri": "file:///tmp/project/src/app.ts"
+                    }
+                }),
+            )),
+        };
+
+        let payload = editor.plugin_document_symbols_payload(&response).unwrap();
+        let symbols = payload["symbols"].as_array().unwrap();
+
+        assert_eq!(payload["ok"], true);
+        assert_eq!(payload["file"], "/tmp/project/src/app.ts");
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0]["name"], "App");
+        assert_eq!(symbols[0]["kindName"], "Struct");
+        assert_eq!(symbols[0]["depth"], 0);
+        assert_eq!(symbols[0]["selectionRange"]["start"]["character"], 7);
+        assert_eq!(symbols[1]["name"], "render");
+        assert_eq!(symbols[1]["kindName"], "Method");
+        assert_eq!(symbols[1]["depth"], 1);
+    }
+
+    #[test]
+    fn document_symbols_payload_accepts_flat_symbol_information() {
+        let editor = test_editor(40, 10);
+        let response = ResponseMessage {
+            id: 1,
+            result: serde_json::json!([
+                {
+                    "name": "build",
+                    "kind": 12,
+                    "containerName": "tools",
+                    "location": {
+                        "uri": "file:///tmp/project/src/build.ts",
+                        "range": {
+                            "start": { "line": 4, "character": 2 },
+                            "end": { "line": 9, "character": 3 }
+                        }
+                    }
+                }
+            ]),
+            request: Some(crate::lsp::Request::new(
+                "textDocument/documentSymbol",
+                serde_json::json!({
+                    "textDocument": {
+                        "uri": "file:///tmp/project/src/index.ts"
+                    }
+                }),
+            )),
+        };
+
+        let payload = editor.plugin_document_symbols_payload(&response).unwrap();
+        let symbols = payload["symbols"].as_array().unwrap();
+
+        assert_eq!(payload["file"], "/tmp/project/src/index.ts");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0]["name"], "build");
+        assert_eq!(symbols[0]["detail"], "tools");
+        assert_eq!(symbols[0]["kindName"], "Function");
+        assert_eq!(symbols[0]["file"], "/tmp/project/src/build.ts");
+        assert_eq!(symbols[0]["selectionRange"]["start"]["line"], 4);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use red::{log, LOGGER};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
     let config_file = Config::path("config.toml");
     if !config_file.exists() {
         let config_dir = config_file
@@ -32,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let toml = fs::read_to_string(config_file)?;
-    let mut config: Config = toml::from_str(&toml)?;
+    let mut config = Config::from_toml_with_overrides(&toml, &args.config_overrides)?;
 
     if let Some(log_file) = &config.log_file {
         LOGGER.get_or_init(|| Some(Logger::new(log_file)));
@@ -41,7 +42,6 @@ async fn main() -> anyhow::Result<()> {
     }
     let preferences = PreferencesStore::load(Config::path("preferences.json"));
 
-    let args = Args::parse();
     config.startup_file_count = args.files.len();
 
     if let Some(root) = args.root {

--- a/src/plugin/runtime.js
+++ b/src/plugin/runtime.js
@@ -42,6 +42,9 @@ class RedContext {
       set: async (key, value) => ops.op_plugin_storage_set(this.requirePluginName(), key, value),
       delete: async (key) => ops.op_plugin_storage_delete(this.requirePluginName(), key),
     };
+    this.lsp = {
+      documentSymbols: () => this.documentSymbols(),
+    };
   }
 
   requirePluginName() {
@@ -256,6 +259,16 @@ class RedContext {
       };
       this.once("buffer:text", handler);
       ops.op_get_buffer_text(startLine, endLine);
+    });
+  }
+
+  documentSymbols() {
+    return new Promise((resolve, _reject) => {
+      const reqId = nextReqId++;
+      this.once(`lsp:document_symbols:${reqId}`, (result) => {
+        resolve(result);
+      });
+      ops.op_lsp_document_symbols(reqId);
     });
   }
 

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -290,6 +290,12 @@ fn op_open_live_picker(
     Ok(())
 }
 
+#[op2(fast)]
+fn op_lsp_document_symbols(request_id: i32) -> Result<(), PluginOpError> {
+    ACTION_DISPATCHER.send_request(PluginRequest::DocumentSymbols { request_id });
+    Ok(())
+}
+
 #[op2]
 #[serde]
 fn op_list_themes() -> Result<serde_json::Value, PluginOpError> {
@@ -831,6 +837,7 @@ extension!(
         op_editor_info,
         op_open_picker,
         op_open_live_picker,
+        op_lsp_document_symbols,
         op_list_themes,
         op_trigger_action,
         op_log,

--- a/tests/common/mock_lsp.rs
+++ b/tests/common/mock_lsp.rs
@@ -16,6 +16,7 @@ pub enum LspEvent {
     RequestDiagnostics(String),
     Hover(String),
     GotoDefinition(String),
+    DocumentSymbols(String),
     RequestCompletion {
         uri: String,
         line: usize,
@@ -222,8 +223,9 @@ impl LspClient for RecordingLsp {
         Ok(0)
     }
 
-    async fn document_symbols(&mut self, _file: &str) -> Result<i64, LspError> {
-        Ok(0)
+    async fn document_symbols(&mut self, file: &str) -> Result<i64, LspError> {
+        self.record(LspEvent::DocumentSymbols(file.to_string()));
+        Ok(42)
     }
 
     async fn code_action(

--- a/tests/lsp_lazy.rs
+++ b/tests/lsp_lazy.rs
@@ -110,6 +110,25 @@ async fn hover_opens_active_lsp_buffer_before_request() {
 }
 
 #[tokio::test]
+async fn document_symbols_opens_active_lsp_buffer_before_request() {
+    let (mut editor, events) = recording_editor(vec![Buffer::new(
+        Some("src/main.rs".to_string()),
+        "fn main() {}".to_string(),
+    )]);
+
+    let request_id = editor.test_request_document_symbols().await.unwrap();
+
+    assert_eq!(request_id, 42);
+    assert_eq!(
+        recorded(&events),
+        vec![
+            LspEvent::DidOpen("src/main.rs".to_string()),
+            LspEvent::DocumentSymbols("src/main.rs".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
 async fn split_with_file_opens_new_active_lsp_buffer() {
     let (mut editor, events) = recording_editor(vec![Buffer::new(None, "notes".to_string())]);
 

--- a/types/red.d.ts
+++ b/types/red.d.ts
@@ -1,3 +1,5 @@
+export {};
+
 /**
  * Red Editor Plugin API Type Definitions
  * 
@@ -5,7 +7,8 @@
  * Plugins can reference this file to get full type safety and IntelliSense support.
  */
 
-declare namespace Red {
+declare global {
+namespace Red {
   /**
    * Style configuration for text rendering
    */
@@ -172,6 +175,42 @@ declare namespace Red {
     };
   }
 
+  interface Position {
+    line: number;
+    character: number;
+  }
+
+  interface Range {
+    start: Position;
+    end: Position;
+  }
+
+  interface DocumentSymbol {
+    name: string;
+    detail?: string;
+    kind: number;
+    kindName: string;
+    file: string;
+    range: Range;
+    selectionRange: Range;
+    depth: number;
+  }
+
+  type DocumentSymbolsResult =
+    | {
+        ok: true;
+        file: string;
+        symbols: DocumentSymbol[];
+      }
+    | {
+        ok: false;
+        error: string;
+      };
+
+  interface LspAPI {
+    documentSymbols(): Promise<DocumentSymbolsResult>;
+  }
+
   /**
    * Editor resize event data
    */
@@ -205,6 +244,7 @@ declare namespace Red {
    */
   interface RedAPI {
     storage: PluginStorage;
+    lsp: LspAPI;
     /**
      * Register a new command
      * @param name Command name
@@ -447,6 +487,9 @@ declare namespace Red {
     clearInterval(id: string): Promise<void>;
   }
 }
+}
+
+export type RedAPI = Red.RedAPI;
 
 /**
  * Plugin activation function
@@ -458,9 +501,9 @@ export function activate(red: Red.RedAPI): void | Promise<void>;
  * Plugin deactivation function (optional)
  * @param red The Red editor API object
  */
-export function deactivate?(red: Red.RedAPI): void | Promise<void>;
+export function deactivate(red: Red.RedAPI): void | Promise<void>;
 
-export function beforeExit?(
+export function beforeExit(
   red: Red.RedAPI,
   state: Red.EditorStateSnapshot,
 ): void | Promise<void>;


### PR DESCRIPTION
## Why

Red should have the same fast, keyboard-first symbol browser workflow that Neovim users expect: press `Ctrl-t`, see the current document symbols, filter/select one, and jump directly to it. This PR also makes that workflow easier to smoke-test locally by adding inline TOML config overrides with `-c` / `--config-override`, so reviewers can inject a mapping or plugin path without editing their personal `config.toml`.

## What Changed

- Adds a bundled TypeScript plugin at `plugins/lsp_symbols.ts` that registers `LspDocumentSymbols`, shows a `Document Symbols` picker, and jumps to the selected symbol with `MoveToFilePos`.
- Exposes `red.lsp.documentSymbols()` to plugins, including TypeScript definitions in `types/red.d.ts`, runtime wiring, and editor-side request/response handling for both hierarchical `DocumentSymbol[]` and flat `SymbolInformation[]` LSP responses.
- Maps normal-mode `Ctrl-t` to the bundled symbols plugin in `default_config.toml` and registers the plugin in the default plugin table.
- Adds repeatable CLI config overrides via `-c` / `--config-override`, merging nested TOML tables while letting later overrides win.
- Extends the plugin check workflow so the bundled TypeScript plugin and type definitions are checked together.

## How to Test

1. From the repo root, run `cargo run -- -c 'keys.normal."Ctrl-t" = { PluginCommand = "LspDocumentSymbols" }' -c 'plugins.lsp_symbols = "plugins/lsp_symbols.ts"' src/editor.rs`.
2. Wait for `rust-analyzer` to finish loading for `src/editor.rs`.
3. Press `Ctrl-t` in normal mode and confirm the `Document Symbols` picker opens with symbols from the current file.
4. Select a symbol and confirm the editor jumps to that symbol location.
5. For the focused unavailable-state check, open a buffer without an active LSP server and press `Ctrl-t`; the editor should show a document-symbols unavailable message rather than opening an empty or broken picker.

Targeted tests:

- `cargo test document_symbols`
- `cargo test config_override`
- `cargo test default_config_`
