### PR TITLE
fix: NeoTree look and theme colors

### DIFF
--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -142,7 +142,9 @@ Returns an object containing:
 - `buffers` - Array of buffer information (id, name, path, language_id)
 - `current_buffer_index` - Index of the active buffer
 - `size` - Editor dimensions (rows, cols)
-- `theme` - Current theme information
+- `theme` - Current theme information. `theme.colors` contains parsed VS Code
+  workbench colors keyed by their original names, such as
+  `gitDecoration.modifiedResourceForeground` or `list.highlightForeground`.
 
 #### Session State
 ```javascript
@@ -176,31 +178,44 @@ red.openBuffer(name: string)
 red.drawText(x: number, y: number, text: string, style?: object)
 
 // Create and update a persistent side panel
-red.createPanel("tree", { side: "left", width: 32, title: "Files" })
+red.createPanel("tree", { side: "left", width: 32 })
 red.updatePanel("tree", [{
   id: "/repo/src",
-  label: "src",
   path: "/repo/src",
-  depth: 0,
   expanded: true,
-  kind: "directory"
+  kind: "directory",
+  segments: [
+    { text: "│ ", style: mutedStyle },
+    { text: " ", style: directoryStyle },
+    { text: "src", style: directoryStyle }
+  ],
+  right_segments: [
+    { text: "", style: modifiedStyle }
+  ]
 }])
 red.focusPanel("tree")
 red.focusEditor()
 red.closePanel("tree")
 red.onPanelEvent("tree", (event) => {
-  // event.action is "up", "down", "expand", "collapse", or "activate"
+  // event.action is "up", "down", "expand", "collapse", "activate",
+  // "toggle", "close", "refresh", or "select"
 })
 ```
 
 Panel rows are rendered by the editor and receive focused keyboard input
 while the panel is active. Plugins can call `focusEditor()` to return input
 to the editor after handling a panel action. Pressing `Esc` also returns
-focus to the editor.
+focus to the editor. Focused panels own normal-mode input and hide the editor
+cursor; command and search prompts still receive input after `:` or `/`.
+
+Rows are segment-based: `segments` render from the left, and
+`right_segments` render flush-right when space allows. Segment text is clipped
+by terminal display width, so plugins can use Unicode/Nerd Font glyphs safely.
 
 #### Filesystem
 ```javascript
 const { entries, error } = await red.listDirectory(".")
+const git = await red.getGitStatus(".")
 const watchId = red.watchDirectory(".", async (snapshot) => {
   // snapshot has the same shape as listDirectory()
 })
@@ -211,6 +226,10 @@ red.openFile("src/main.rs")
 `listDirectory` returns entries sorted with directories before files. Plugins
 do not receive arbitrary filesystem access; they request directory listings
 and directory watches through editor-owned APIs.
+
+`getGitStatus` returns `{ root, statuses, error }` for the Git repository that
+contains the requested path. Each status has `path`, `absolute_path`, and a
+normalized `status` such as `modified`, `untracked`, `ignored`, or `conflict`.
 
 #### Buffer Manipulation
 ```javascript

--- a/plugins/neotree.js
+++ b/plugins/neotree.js
@@ -45,13 +45,19 @@ const FILE_ICONS = {
 
 let redApi = null;
 const watches = new Map();
+const DEFAULT_STYLE = {
+  fg: null,
+  bg: null,
+  bold: false,
+  italic: false,
+};
 
 function rgb(r, g, b) {
   return { Rgb: { r, g, b } };
 }
 
 function style(base, overrides = {}) {
-  return { ...(base || {}), ...overrides };
+  return { ...DEFAULT_STYLE, ...(base || {}), ...overrides };
 }
 
 function colorStyle(colors, keys, base, overrides = {}) {
@@ -62,9 +68,9 @@ function colorStyle(colors, keys, base, overrides = {}) {
   return null;
 }
 
-function stylesFor(info) {
+export function stylesFor(info) {
   const theme = info?.theme ?? {};
-  const fallback = theme.style ?? {};
+  const fallback = style(theme.style);
   const ui = theme.ui_style ?? theme.uiStyle ?? {};
   const colors = theme.colors ?? {};
   const normal = colorStyle(colors, ["sideBar.foreground"], fallback) ?? fallback;
@@ -252,6 +258,21 @@ function statusSegments(status, styles) {
   const symbol = STATUS_SYMBOLS[status];
   if (!symbol) return [];
   return [{ text: symbol, style: styles.status[status] ?? styles.normal }];
+}
+
+function loadingRows(styles) {
+  return [
+    {
+      id: "loading",
+      path: ROOT,
+      kind: "directory",
+      expanded: false,
+      segments: [
+        { text: " ", style: styles.normal },
+        { text: "Loading...", style: styles.ignored ?? styles.normal },
+      ],
+    },
+  ];
 }
 
 function branchPrefix(ancestors, isLast, styles) {
@@ -452,6 +473,7 @@ export async function activate(red) {
         side: "left",
         width: 30,
       });
+      red.updatePanel(PANEL_ID, loadingRows(currentStyles));
       created = true;
     }
 

--- a/plugins/neotree.js
+++ b/plugins/neotree.js
@@ -1,21 +1,368 @@
 const PANEL_ID = "neotree";
 const ROOT = ".";
 
-let redApi = null;
+const STATUS_PRECEDENCE = [
+  "conflict",
+  "renamed",
+  "deleted",
+  "added",
+  "modified",
+  "untracked",
+  "ignored",
+  "staged",
+];
 
-// Directory watches live outside a single activation callback so deactivate()
-// can clean them up even if the panel was closed by editor shutdown.
+const STATUS_SYMBOLS = {
+  added: "✚",
+  deleted: "✖",
+  modified: "",
+  renamed: "",
+  untracked: "",
+  ignored: "",
+  staged: "",
+  conflict: "",
+};
+
+const FILE_ICONS = {
+  js: "",
+  mjs: "",
+  cjs: "",
+  ts: "",
+  tsx: "",
+  jsx: "",
+  json: "",
+  toml: "",
+  rs: "",
+  lua: "",
+  md: "",
+  markdown: "",
+  lock: "",
+  sh: "",
+  zsh: "",
+  fish: "",
+  txt: "󰈙",
+};
+
+let redApi = null;
 const watches = new Map();
+
+function rgb(r, g, b) {
+  return { Rgb: { r, g, b } };
+}
+
+function style(base, overrides = {}) {
+  return { ...(base || {}), ...overrides };
+}
+
+function colorStyle(colors, keys, base, overrides = {}) {
+  for (const key of keys) {
+    const fg = colors?.[key];
+    if (fg) return style(base, { ...overrides, fg });
+  }
+  return null;
+}
+
+function stylesFor(info) {
+  const theme = info?.theme ?? {};
+  const fallback = theme.style ?? {};
+  const ui = theme.ui_style ?? theme.uiStyle ?? {};
+  const colors = theme.colors ?? {};
+  const normal = colorStyle(colors, ["sideBar.foreground"], fallback) ?? fallback;
+  const guide =
+    colorStyle(colors, ["tree.indentGuidesStroke"], fallback) ??
+    ui.muted ??
+    style(fallback, { fg: rgb(108, 112, 134) });
+  const directory =
+    colorStyle(
+      colors,
+      [
+        "symbolIcon.folderForeground",
+        "sideBarTitle.foreground",
+        "list.highlightForeground",
+      ],
+      fallback,
+    ) ?? style(fallback, { fg: rgb(137, 180, 250) });
+  const root =
+    colorStyle(
+      colors,
+      [
+        "sideBarTitle.foreground",
+        "symbolIcon.folderForeground",
+        "list.highlightForeground",
+      ],
+      fallback,
+      { bold: true },
+    ) ?? style(fallback, { fg: rgb(198, 160, 246), bold: true });
+  const ignored =
+    colorStyle(colors, ["gitDecoration.ignoredResourceForeground"], fallback) ??
+    ui.muted ??
+    style(fallback, { fg: rgb(108, 112, 134) });
+
+  return {
+    root,
+    normal,
+    guide,
+    directory,
+    ignored,
+    status: {
+      added:
+        colorStyle(
+          colors,
+          [
+            "gitDecoration.addedResourceForeground",
+            "gitDecoration.untrackedResourceForeground",
+          ],
+          fallback,
+        ) ??
+        style(fallback, { fg: rgb(166, 227, 161) }),
+      deleted:
+        colorStyle(
+          colors,
+          [
+            "gitDecoration.deletedResourceForeground",
+            "gitDecoration.stageDeletedResourceForeground",
+          ],
+          fallback,
+        ) ??
+        style(fallback, { fg: rgb(243, 139, 168) }),
+      modified:
+        colorStyle(
+          colors,
+          [
+            "gitDecoration.modifiedResourceForeground",
+            "gitDecoration.stageModifiedResourceForeground",
+          ],
+          fallback,
+        ) ??
+        style(fallback, { fg: rgb(249, 226, 175) }),
+      renamed:
+        colorStyle(
+          colors,
+          [
+            "gitDecoration.renamedResourceForeground",
+            "gitDecoration.modifiedResourceForeground",
+          ],
+          fallback,
+        ) ??
+        style(fallback, { fg: rgb(137, 220, 235) }),
+      untracked:
+        colorStyle(
+          colors,
+          [
+            "gitDecoration.untrackedResourceForeground",
+            "gitDecoration.addedResourceForeground",
+          ],
+          fallback,
+        ) ??
+        ui.muted ??
+        style(fallback, { fg: rgb(108, 112, 134) }),
+      ignored,
+      staged:
+        colorStyle(
+          colors,
+          [
+            "gitDecoration.stageModifiedResourceForeground",
+            "gitDecoration.addedResourceForeground",
+          ],
+          fallback,
+        ) ??
+        style(fallback, { fg: rgb(166, 227, 161) }),
+      conflict:
+        colorStyle(colors, ["gitDecoration.conflictingResourceForeground"], fallback, { bold: true }) ??
+        style(fallback, { fg: rgb(243, 139, 168), bold: true }),
+    },
+  };
+}
+
+function normalizePath(path) {
+  return String(path || ".").replace(/\\/g, "/").replace(/\/+/g, "/").replace(/\/$/, "");
+}
+
+function displayPath(path, cwd) {
+  const normalized = normalizePath(path);
+  const home = globalThis.Deno?.env?.get?.("HOME");
+  if (home && normalized.startsWith(normalizePath(home) + "/")) {
+    return `~/${normalized.slice(normalizePath(home).length + 1)}`;
+  }
+  if (cwd && normalized === normalizePath(cwd)) {
+    return normalized.split("/").filter(Boolean).pop() || normalized;
+  }
+  return normalized;
+}
+
+function fileIcon(name) {
+  const lower = name.toLowerCase();
+  const extension = lower.includes(".") ? lower.split(".").pop() : lower;
+  return FILE_ICONS[extension] ?? "󰈙";
+}
+
+function statusRank(status) {
+  const index = STATUS_PRECEDENCE.indexOf(status);
+  return index === -1 ? STATUS_PRECEDENCE.length : index;
+}
+
+function preferredStatus(statuses) {
+  let best = null;
+  for (const status of statuses) {
+    if (!best || statusRank(status) < statusRank(best)) {
+      best = status;
+    }
+  }
+  return best;
+}
+
+function makeStatusIndex(result) {
+  const entries = Array.isArray(result?.statuses) ? result.statuses : [];
+  const root = normalizePath(result?.root || "");
+  return {
+    root,
+    entries: entries.map((entry) => ({
+      path: normalizePath(entry.path),
+      absolutePath: normalizePath(entry.absolute_path ?? entry.absolutePath ?? entry.path),
+      status: entry.status,
+    })),
+  };
+}
+
+function statusForPath(statusIndex, path, kind) {
+  const normalized = normalizePath(path);
+  const relative = normalized.replace(/^\.\//, "");
+  const absolute = normalized.startsWith("/")
+    ? normalized
+    : relative === "."
+      ? statusIndex.root
+      : normalizePath(`${statusIndex.root}/${relative}`);
+
+  const matches = [];
+  for (const entry of statusIndex.entries) {
+    if (entry.absolutePath === absolute) {
+      matches.push(entry.status);
+      continue;
+    }
+
+    if (kind === "directory" && entry.absolutePath.startsWith(`${absolute}/`)) {
+      matches.push(entry.status);
+    }
+  }
+
+  return preferredStatus(matches);
+}
+
+function statusSegments(status, styles) {
+  const symbol = STATUS_SYMBOLS[status];
+  if (!symbol) return [];
+  return [{ text: symbol, style: styles.status[status] ?? styles.normal }];
+}
+
+function branchPrefix(ancestors, isLast, styles) {
+  const segments = [];
+  for (const ancestor of ancestors) {
+    segments.push({
+      text: ancestor.visible && !ancestor.last ? "│ " : "  ",
+      style: styles.guide,
+    });
+  }
+  if (ancestors.length > 0) {
+    segments.push({
+      text: isLast ? "└ " : "├ ",
+      style: styles.guide,
+    });
+  } else {
+    segments.push({ text: "  ", style: styles.guide });
+  }
+  return segments;
+}
+
+export function buildNeoTreeRows({
+  root,
+  cwd,
+  children,
+  expanded,
+  statusIndex,
+  styles,
+}) {
+  const rows = [];
+  const rootStatus = statusForPath(statusIndex, root, "directory");
+  rows.push({
+    id: root,
+    path: root,
+    kind: "directory",
+    expanded: expanded.has(root),
+    segments: [
+      { text: " ", style: styles.root },
+      { text: " ", style: styles.directory },
+      { text: displayPath(cwd || root, cwd), style: styles.root },
+    ],
+    right_segments: statusSegments(rootStatus, styles),
+  });
+
+  if (!expanded.has(root)) return rows;
+
+  appendRows(root, [], rows, { children, expanded, statusIndex, styles });
+  return rows;
+}
+
+function appendRows(path, ancestors, rows, context) {
+  const entries = (context.children.get(path) || []).filter((entry) =>
+    entry.kind === "directory" || entry.kind === "file"
+  );
+
+  entries.forEach((entry, index) => {
+    const isLast = index === entries.length - 1;
+    const isDirectory = entry.kind === "directory";
+    const isExpanded = isDirectory && context.expanded.has(entry.path);
+    const entryStatus = statusForPath(context.statusIndex, entry.path, entry.kind);
+    const rowStyle = entryStatus === "ignored" ? context.styles.ignored : context.styles.normal;
+    const icon = isDirectory ? (isExpanded ? "" : "") : fileIcon(entry.name);
+
+    rows.push({
+      id: entry.path,
+      path: entry.path,
+      kind: entry.kind,
+      expanded: isDirectory ? isExpanded : false,
+      segments: [
+        ...branchPrefix(ancestors, isLast, context.styles),
+        {
+          text: `${icon} `,
+          style: isDirectory ? context.styles.directory : rowStyle,
+        },
+        {
+          text: entry.name,
+          style: isDirectory ? context.styles.directory : rowStyle,
+        },
+      ],
+      right_segments: statusSegments(entryStatus, context.styles),
+    });
+
+    if (isExpanded) {
+      appendRows(
+        entry.path,
+        [...ancestors, { last: isLast, visible: ancestors.length > 0 }],
+        rows,
+        context,
+      );
+    }
+  });
+}
 
 export async function activate(red) {
   redApi = red;
 
-  // `expanded` is the source of truth for tree state. `children` caches the
-  // last directory listing for each loaded path so rendering can rebuild rows
-  // without hitting the filesystem for every visible parent.
   const expanded = new Set([ROOT]);
   const children = new Map();
+  let statusIndex = makeStatusIndex(null);
   let created = false;
+  let cwd = ROOT;
+  let currentStyles = stylesFor(null);
+
+  async function updateEditorContext() {
+    const [info, configCwd] = await Promise.all([
+      red.getEditorInfo(),
+      red.getConfig("cwd"),
+    ]);
+    cwd = configCwd || cwd;
+    currentStyles = stylesFor(info);
+  }
 
   async function loadDirectory(path) {
     const result = await red.listDirectory(path);
@@ -28,13 +375,20 @@ export async function activate(red) {
     return result.entries;
   }
 
+  async function refreshGitStatus() {
+    const result = await red.getGitStatus(ROOT);
+    if (result?.error) {
+      red.logWarn("NeoTree failed to read git status", result.error);
+    }
+    statusIndex = makeStatusIndex(result);
+  }
+
   function watchDirectory(path) {
     if (watches.has(path)) return;
 
-    // Watch only directories that have been loaded. When a watched directory
-    // changes, refresh its cached listing and rebuild the panel rows.
     const watchId = red.watchDirectory(path, async () => {
       await loadDirectory(path);
+      await refreshGitStatus();
       await refresh();
     });
     watches.set(path, watchId);
@@ -44,45 +398,37 @@ export async function activate(red) {
     if (!children.has(path)) {
       await loadDirectory(path);
     }
-
-    // Loading and watching are tied together: if a directory can contribute
-    // rows, changes under it should be reflected in the tree.
     watchDirectory(path);
     return children.get(path) || [];
   }
 
-  async function buildRows(path, depth = 0, rows = []) {
-    const entries = await ensureLoaded(path);
+  async function ensureExpandedLoaded(path) {
+    await ensureLoaded(path);
+    const entries = children.get(path) || [];
     for (const entry of entries) {
-      if (entry.kind !== "directory" && entry.kind !== "file") {
-        continue;
-      }
-
-      // Panel rows are intentionally flat. `depth` lets the renderer indent
-      // them, while `expanded` tells it which directory icon/state to show.
-      const isDirectory = entry.kind === "directory";
-      rows.push({
-        id: entry.path,
-        label: entry.name,
-        path: entry.path,
-        depth,
-        expanded: isDirectory ? expanded.has(entry.path) : false,
-        kind: isDirectory ? "directory" : "file",
-      });
-
-      if (isDirectory && expanded.has(entry.path)) {
-        await buildRows(entry.path, depth + 1, rows);
+      if (entry.kind === "directory" && expanded.has(entry.path)) {
+        await ensureExpandedLoaded(entry.path);
       }
     }
-    return rows;
   }
 
   async function refresh() {
-    const rows = await buildRows(ROOT);
-
-    // The panel manager owns selection/scroll state; this call only replaces
-    // the model rows that should be rendered.
+    await updateEditorContext();
+    const rows = buildNeoTreeRows({
+      root: ROOT,
+      cwd,
+      children,
+      expanded,
+      statusIndex,
+      styles: currentStyles,
+    });
     red.updatePanel(PANEL_ID, rows);
+  }
+
+  async function reloadVisibleTree() {
+    await ensureExpandedLoaded(ROOT);
+    await refreshGitStatus();
+    await refresh();
   }
 
   function stopWatchingDirectories() {
@@ -102,18 +448,14 @@ export async function activate(red) {
 
   async function show() {
     if (!created) {
-      // Create the panel lazily so the command acts as a lightweight toggle
-      // and startup does not allocate UI until the user asks for the tree.
       red.createPanel(PANEL_ID, {
         side: "left",
-        width: 32,
-        title: "Files",
+        width: 30,
       });
       created = true;
     }
 
-    await ensureLoaded(ROOT);
-    await refresh();
+    await reloadVisibleTree();
     red.focusPanel(PANEL_ID);
   }
 
@@ -125,6 +467,7 @@ export async function activate(red) {
     } else {
       expanded.delete(path);
     }
+    await refreshGitStatus();
     await refresh();
   }
 
@@ -138,16 +481,25 @@ export async function activate(red) {
 
   red.onPanelEvent(PANEL_ID, async (event) => {
     const row = event.row;
+
+    if (event.action === "close") {
+      close();
+      return;
+    }
+
+    if (event.action === "refresh") {
+      await reloadVisibleTree();
+      return;
+    }
+
     if (!row) return;
 
-    // `activate` is the generic "open/toggle" action. Direct expand/collapse
-    // events keep keyboard-driven tree navigation explicit.
-    if (event.action === "activate") {
+    if (event.action === "activate" || event.action === "toggle") {
       if (row.kind === "directory") {
         await toggleDirectory(row.path);
       } else if (row.path) {
         red.openFile(row.path);
-        red.focusEditor();
+        close();
       }
       return;
     }
@@ -165,8 +517,6 @@ export async function activate(red) {
 export async function deactivate() {
   if (!redApi) return;
 
-  // Deactivation may happen without the NeoTree command closing the panel, so
-  // repeat cleanup here rather than relying only on close().
   for (const watchId of watches.values()) redApi.unwatchDirectory(watchId);
   watches.clear();
   redApi.closePanel(PANEL_ID);

--- a/plugins/neotree.test.js
+++ b/plugins/neotree.test.js
@@ -1,0 +1,107 @@
+function testStyles() {
+  const base = { fg: { Rgb: { r: 255, g: 255, b: 255 } } };
+  return {
+    root: base,
+    normal: base,
+    guide: base,
+    directory: base,
+    ignored: base,
+    status: {
+      modified: base,
+      untracked: base,
+      ignored: base,
+    },
+  };
+}
+
+describe("NeoTree", () => {
+  test("builds root, icons, guides, and right git badges", async () => {
+    const children = new Map();
+    children.set(".", [
+      { name: "src", path: "./src", kind: "directory" },
+      { name: "README.md", path: "./README.md", kind: "file" },
+    ]);
+    children.set("./src", [
+      { name: "editor", path: "./src/editor", kind: "directory" },
+      { name: "editor.rs", path: "./src/editor.rs", kind: "file" },
+    ]);
+
+    const rows = plugin.buildNeoTreeRows({
+      root: ".",
+      cwd: "/Users/fcoury/code/red",
+      children,
+      expanded: new Set([".", "./src"]),
+      statusIndex: {
+        root: "/Users/fcoury/code/red",
+        entries: [
+          {
+            absolutePath: "/Users/fcoury/code/red/src/editor.rs",
+            status: "modified",
+          },
+          {
+            absolutePath: "/Users/fcoury/code/red/README.md",
+            status: "untracked",
+          },
+        ],
+      },
+      styles: testStyles(),
+    });
+
+    expect(rows[0].segments.map((segment) => segment.text).join("")).toContain(" red");
+    expect(rows[1].segments.map((segment) => segment.text).join("")).toContain(" src");
+    expect(rows[1].right_segments[0].text).toBe("");
+    const nestedDirectoryText = rows[2].segments.map((segment) => segment.text).join("");
+    expect(nestedDirectoryText).toContain("  ├ ");
+    expect(nestedDirectoryText.includes("│ ├ ")).toBe(false);
+    expect(nestedDirectoryText).toContain(" editor");
+    const nestedFileText = rows[3].segments.map((segment) => segment.text).join("");
+    expect(nestedFileText).toContain("  └ ");
+    expect(nestedFileText.includes("│ └ ")).toBe(false);
+    expect(nestedFileText).toContain(" editor.rs");
+    expect(rows[4].right_segments[0].text).toBe("");
+  });
+
+  test("creates the panel and closes it after opening a file", async (red) => {
+    red.setMockState({
+      config: {
+        ...red.getMockState().config,
+        cwd: "/Users/fcoury/code/red",
+      },
+      theme: {
+        ...red.getMockState().theme,
+        colors: {
+          "gitDecoration.modifiedResourceForeground": { Rgb: { r: 1, g: 2, b: 3 } },
+        },
+      },
+    });
+    red.setDirectoryListing(".", [
+      { name: "README.md", path: "./README.md", kind: "file" },
+    ]);
+    red.setGitStatus({
+      root: "/Users/fcoury/code/red",
+      statuses: [
+        {
+          path: "README.md",
+          absolute_path: "/Users/fcoury/code/red/README.md",
+          status: "modified",
+        },
+      ],
+      error: null,
+    });
+
+    await red.executeCommand("NeoTree");
+    const panel = red.getPanel("neotree");
+
+    expect(panel.config.width).toBe(30);
+    expect(panel.rows[1].right_segments[0].text).toBe("");
+    expect(panel.rows[1].right_segments[0].style.fg).toEqual({ Rgb: { r: 1, g: 2, b: 3 } });
+
+    await red.emitPanelEvent("neotree", {
+      action: "activate",
+      row: panel.rows[1],
+    });
+
+    expect(red.getLogs()).toContain("openFile: ./README.md");
+    expect(red.getLogs()).toContain("closePanel: neotree");
+  });
+});

--- a/plugins/neotree.test.js
+++ b/plugins/neotree.test.js
@@ -15,6 +15,19 @@ function testStyles() {
 }
 
 describe("NeoTree", () => {
+  test("fallback styles are complete Rust Style payloads", async () => {
+    const styles = plugin.stylesFor(null);
+
+    expect(styles.normal).toEqual({
+      fg: null,
+      bg: null,
+      bold: false,
+      italic: false,
+    });
+    expect(styles.status.modified.bold).toBe(false);
+    expect(styles.status.modified.italic).toBe(false);
+  });
+
   test("builds root, icons, guides, and right git badges", async () => {
     const children = new Map();
     children.set(".", [

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7150,18 +7150,18 @@ fn git_status_listing(path: &str) -> Value {
         Ok(output) if output.status.success() => {
             let statuses = parse_git_status_records(&output.stdout, &root);
             json!({
-                "root": root,
+                "root": normalize_plugin_path(&root),
                 "statuses": statuses,
                 "error": null,
             })
         }
         Ok(output) => json!({
-            "root": root,
+            "root": normalize_plugin_path(&root),
             "statuses": [],
             "error": String::from_utf8_lossy(&output.stderr).trim(),
         }),
         Err(err) => json!({
-            "root": root,
+            "root": normalize_plugin_path(&root),
             "statuses": [],
             "error": err.to_string(),
         }),
@@ -7196,8 +7196,8 @@ fn parse_git_status_records(output: &[u8], root: &str) -> Vec<Value> {
         let x = record[0] as char;
         let y = record[1] as char;
         let status = classify_git_status(x, y);
-        let path = String::from_utf8_lossy(&record[3..]).to_string();
-        let absolute_path = Path::new(root).join(&path).to_string_lossy().into_owned();
+        let path = normalize_plugin_path(&String::from_utf8_lossy(&record[3..]));
+        let absolute_path = normalize_plugin_path(&Path::new(root).join(&path).to_string_lossy());
         statuses.push(json!({
             "path": path,
             "absolute_path": absolute_path,
@@ -7212,6 +7212,10 @@ fn parse_git_status_records(output: &[u8], root: &str) -> Vec<Value> {
     }
 
     statuses
+}
+
+fn normalize_plugin_path(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 fn classify_git_status(x: char, y: char) -> &'static str {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -5,6 +5,8 @@ use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet, VecDeque},
     io::{stdout, Write as _},
+    path::Path,
+    process::Command,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -175,6 +177,10 @@ pub enum PluginRequest {
         id: String,
     },
     ListDirectory {
+        path: String,
+        request_id: i32,
+    },
+    GetGitStatus {
         path: String,
         request_id: i32,
     },
@@ -2153,6 +2159,16 @@ impl Editor {
                                     )
                                     .await?;
                             }
+                            PluginRequest::GetGitStatus { path, request_id } => {
+                                let payload = git_status_listing(&path);
+                                self.plugin_registry
+                                    .notify(
+                                        &mut runtime,
+                                        &format!("git:status:{request_id}"),
+                                        payload,
+                                    )
+                                    .await?;
+                            }
                             PluginRequest::WatchDirectory { path, watch_id } => {
                                 self.directory_watchers.insert(watch_id, DirectoryWatcher {
                                     snapshot: directory_listing(&path),
@@ -2524,13 +2540,34 @@ impl Editor {
             }
         }
 
+        if self.is_command() {
+            return Ok(self.handle_command_event(ev));
+        }
+
+        if self.is_search() {
+            return Ok(self.handle_search_event(ev));
+        }
+
         if self.panel_manager.focused_panel_id().is_some() {
             if let Some(action) = self.handle_panel_event(ev) {
                 return Ok(Some(action));
             }
 
-            let normal = self.config.keys.normal.clone();
-            return Ok(self.event_to_key_action(&normal, ev));
+            if let Some(action) = self.panel_global_key_action(ev) {
+                return Ok(Some(action));
+            }
+
+            if matches!(ev, Event::Mouse(_)) {
+                self.panel_manager.focus_editor();
+            } else {
+                return Ok(None);
+            }
+        }
+
+        if matches!(ev, Event::Mouse(_)) {
+            if let Some(action) = self.handle_panel_event(ev) {
+                return Ok(Some(action));
+            }
         }
 
         Ok(match self.mode {
@@ -2571,34 +2608,118 @@ impl Editor {
     }
 
     fn handle_panel_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
-        let Event::Key(ref event) = ev else {
+        match ev {
+            Event::Key(event) => {
+                let action = match event.code {
+                    KeyCode::Esc => {
+                        self.panel_manager.focus_editor();
+                        return Some(KeyAction::Single(Action::Refresh));
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => "up",
+                    KeyCode::Down | KeyCode::Char('j') => "down",
+                    KeyCode::Left | KeyCode::Char('h') => "collapse",
+                    KeyCode::Right | KeyCode::Char('l') => "expand",
+                    KeyCode::Enter => "activate",
+                    KeyCode::Char(' ') => "toggle",
+                    KeyCode::Char('q') => "close",
+                    KeyCode::Char('R') => "refresh",
+                    _ => return None,
+                };
+
+                let height = self.size.1 as usize;
+                self.panel_manager
+                    .handle_focused_key(action, height)
+                    .and_then(Self::panel_event_key_action)
+            }
+            Event::Mouse(event) => self.handle_panel_mouse_event(event),
+            _ => None,
+        }
+    }
+
+    fn handle_panel_mouse_event(&mut self, event: &MouseEvent) -> Option<KeyAction> {
+        let x = event.column as usize;
+        let y = event.row as usize;
+        let width = self.size.0 as usize;
+        let height = self.size.1 as usize;
+
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Left) => self
+                .panel_manager
+                .focus_panel_at_position(x, y, width, height)
+                .and_then(Self::panel_event_key_action),
+            MouseEventKind::ScrollUp => {
+                let id = self
+                    .panel_manager
+                    .panel_at_position(x, y, width, height)?
+                    .id;
+                self.panel_manager.focus_panel(&id);
+                self.panel_manager
+                    .handle_focused_key("up", height)
+                    .and_then(Self::panel_event_key_action)
+            }
+            MouseEventKind::ScrollDown => {
+                let id = self
+                    .panel_manager
+                    .panel_at_position(x, y, width, height)?
+                    .id;
+                self.panel_manager.focus_panel(&id);
+                self.panel_manager
+                    .handle_focused_key("down", height)
+                    .and_then(Self::panel_event_key_action)
+            }
+            _ => None,
+        }
+    }
+
+    fn panel_event_key_action(event: plugin::panel::PanelEvent) -> Option<KeyAction> {
+        serde_json::to_value(&event).ok().map(|payload| {
+            KeyAction::Multiple(vec![
+                Action::NotifyPlugins(format!("panel:event:{}", event.panel_id), payload),
+                Action::Refresh,
+            ])
+        })
+    }
+
+    fn panel_global_key_action(&self, ev: &event::Event) -> Option<KeyAction> {
+        let key = Self::key_string_for_event(ev)?;
+        let action = self.config.keys.normal.get(&key).cloned().or_else(|| {
+            matches!(key.as_str(), "Tab")
+                .then(|| self.config.keys.normal.get("Tab").cloned())
+                .flatten()
+        })?;
+
+        Self::key_action_enters_term(&action).then_some(action)
+    }
+
+    fn key_action_enters_term(action: &KeyAction) -> bool {
+        match action {
+            KeyAction::Single(Action::EnterMode(Mode::Command | Mode::Search)) => true,
+            KeyAction::Multiple(actions) => actions
+                .iter()
+                .any(|action| matches!(action, Action::EnterMode(Mode::Command | Mode::Search))),
+            _ => false,
+        }
+    }
+
+    fn key_string_for_event(ev: &Event) -> Option<String> {
+        let Event::Key(KeyEvent {
+            code, modifiers, ..
+        }) = ev
+        else {
             return None;
         };
 
-        let action = match event.code {
-            KeyCode::Esc => {
-                self.panel_manager.focus_editor();
-                return Some(KeyAction::Single(Action::Refresh));
-            }
-            KeyCode::Up | KeyCode::Char('k') => "up",
-            KeyCode::Down | KeyCode::Char('j') => "down",
-            KeyCode::Left | KeyCode::Char('h') => "collapse",
-            KeyCode::Right | KeyCode::Char('l') => "expand",
-            KeyCode::Enter => "activate",
-            _ => return None,
+        let key = match code {
+            KeyCode::Char(' ') => "Space".to_string(),
+            KeyCode::Char(c) => format!("{c}"),
+            _ => format!("{code:?}"),
         };
 
-        let height = self.size.1 as usize;
-        self.panel_manager
-            .handle_focused_key(action, height)
-            .and_then(|event| {
-                serde_json::to_value(&event).ok().map(|payload| {
-                    KeyAction::Multiple(vec![
-                        Action::NotifyPlugins(format!("panel:event:{}", event.panel_id), payload),
-                        Action::Refresh,
-                    ])
-                })
-            })
+        Some(match *modifiers {
+            KeyModifiers::CONTROL => format!("Ctrl-{key}"),
+            KeyModifiers::ALT => format!("Alt-{key}"),
+            _ => key,
+        })
     }
 
     fn poll_directory_watchers(&mut self) -> Vec<(i32, Value)> {
@@ -6976,6 +7097,151 @@ fn directory_listing(path: &str) -> Value {
     })
 }
 
+fn git_status_listing(path: &str) -> Value {
+    let search_dir = git_search_dir(path);
+    let root_output = Command::new("git")
+        .arg("-C")
+        .arg(&search_dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output();
+
+    let root_output = match root_output {
+        Ok(output) if output.status.success() => output,
+        Ok(_) => {
+            return json!({
+                "root": null,
+                "statuses": [],
+                "error": null,
+            });
+        }
+        Err(err) => {
+            return json!({
+                "root": null,
+                "statuses": [],
+                "error": err.to_string(),
+            });
+        }
+    };
+
+    let root = String::from_utf8_lossy(&root_output.stdout)
+        .trim()
+        .to_string();
+    if root.is_empty() {
+        return json!({
+            "root": null,
+            "statuses": [],
+            "error": null,
+        });
+    }
+
+    let status_output = Command::new("git")
+        .arg("-C")
+        .arg(&root)
+        .args([
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--ignored=matching",
+            "--untracked-files=normal",
+        ])
+        .output();
+
+    match status_output {
+        Ok(output) if output.status.success() => {
+            let statuses = parse_git_status_records(&output.stdout, &root);
+            json!({
+                "root": root,
+                "statuses": statuses,
+                "error": null,
+            })
+        }
+        Ok(output) => json!({
+            "root": root,
+            "statuses": [],
+            "error": String::from_utf8_lossy(&output.stderr).trim(),
+        }),
+        Err(err) => json!({
+            "root": root,
+            "statuses": [],
+            "error": err.to_string(),
+        }),
+    }
+}
+
+fn git_search_dir(path: &str) -> String {
+    let path = Path::new(path);
+    if path.is_dir() {
+        return path.to_string_lossy().into_owned();
+    }
+    path.parent()
+        .map(|parent| parent.to_string_lossy().into_owned())
+        .unwrap_or_else(|| ".".to_string())
+}
+
+fn parse_git_status_records(output: &[u8], root: &str) -> Vec<Value> {
+    let mut statuses = Vec::new();
+    let records = output
+        .split(|byte| *byte == b'\0')
+        .filter(|record| !record.is_empty())
+        .collect::<Vec<_>>();
+    let mut index = 0;
+
+    while index < records.len() {
+        let record = records[index];
+        if record.len() < 4 {
+            index += 1;
+            continue;
+        }
+
+        let x = record[0] as char;
+        let y = record[1] as char;
+        let status = classify_git_status(x, y);
+        let path = String::from_utf8_lossy(&record[3..]).to_string();
+        let absolute_path = Path::new(root).join(&path).to_string_lossy().into_owned();
+        statuses.push(json!({
+            "path": path,
+            "absolute_path": absolute_path,
+            "status": status,
+        }));
+
+        index += if matches!(x, 'R' | 'C') || matches!(y, 'R' | 'C') {
+            2
+        } else {
+            1
+        };
+    }
+
+    statuses
+}
+
+fn classify_git_status(x: char, y: char) -> &'static str {
+    if x == '?' && y == '?' {
+        return "untracked";
+    }
+    if x == '!' && y == '!' {
+        return "ignored";
+    }
+    if matches!(x, 'U' | 'A' | 'D') && matches!(y, 'U' | 'A' | 'D') {
+        return "conflict";
+    }
+    if matches!(x, 'R' | 'C') || matches!(y, 'R' | 'C') {
+        return "renamed";
+    }
+    if x == 'D' || y == 'D' {
+        return "deleted";
+    }
+    if x == 'A' || y == 'A' {
+        return "added";
+    }
+    if matches!(x, 'M' | 'T') || matches!(y, 'M' | 'T') {
+        return "modified";
+    }
+    if x != ' ' {
+        return "staged";
+    }
+    "modified"
+}
+
 fn adjust_color_brightness(color: Option<Color>, percentage: i32) -> Option<Color> {
     let color = color?;
 
@@ -7095,6 +7361,33 @@ impl Editor {
     #[doc(hidden)]
     pub fn test_create_panel(&mut self, id: &str, config: plugin::PanelConfig) {
         self.panel_manager.create_panel(id.to_string(), config);
+        self.apply_panel_layout();
+        self.sync_with_window();
+    }
+
+    #[doc(hidden)]
+    pub fn test_update_panel(&mut self, id: &str, rows: Vec<plugin::PanelRow>) {
+        self.panel_manager.update_panel(id, rows);
+    }
+
+    #[doc(hidden)]
+    pub fn test_focus_panel(&mut self, id: &str) -> bool {
+        self.panel_manager.focus_panel(id)
+    }
+
+    #[doc(hidden)]
+    pub fn test_focused_panel_id(&self) -> Option<&str> {
+        self.panel_manager.focused_panel_id()
+    }
+
+    #[doc(hidden)]
+    pub fn test_focused_panel_selected_index(&self, id: &str) -> Option<usize> {
+        self.panel_manager.selected_index(id)
+    }
+
+    #[doc(hidden)]
+    pub fn test_close_panel(&mut self, id: &str) {
+        self.panel_manager.close_panel(id);
         self.apply_panel_layout();
         self.sync_with_window();
     }
@@ -7253,6 +7546,28 @@ mod test {
             .iter()
             .map(|cell| cell.c)
             .collect()
+    }
+
+    #[test]
+    fn parse_git_status_records_normalizes_statuses() {
+        let output = b" M src/editor.rs\0?? plugins/neotree.js\0!! target/\0";
+        let statuses = parse_git_status_records(output, "/repo");
+
+        assert_eq!(statuses[0]["path"], "src/editor.rs");
+        assert_eq!(statuses[0]["absolute_path"], "/repo/src/editor.rs");
+        assert_eq!(statuses[0]["status"], "modified");
+        assert_eq!(statuses[1]["status"], "untracked");
+        assert_eq!(statuses[2]["status"], "ignored");
+    }
+
+    #[test]
+    fn parse_git_status_records_skips_rename_source() {
+        let output = b"R  new-name.rs\0old-name.rs\0";
+        let statuses = parse_git_status_records(output, "/repo");
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0]["path"], "new-name.rs");
+        assert_eq!(statuses[0]["status"], "renamed");
     }
 
     fn test_home_dir() -> PathBuf {

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -138,6 +138,7 @@ impl Editor {
         self.is_focused
             && dialog_allows_editor_cursor
             && !self.has_term()
+            && !self.panel_manager.has_focused_panel()
             && !self.is_waiting_for_key_sequence()
             && matches!(
                 self.mode,
@@ -1195,6 +1196,10 @@ impl Editor {
             if !current_dialog.allows_event_passthrough() {
                 return None;
             }
+        }
+
+        if self.panel_manager.has_focused_panel() && !self.has_term() {
+            return None;
         }
 
         if self.has_term() {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -8,6 +8,6 @@ pub mod timer_stats;
 
 pub use metadata::PluginMetadata;
 pub use overlay::{OverlayAlignment, OverlayConfig, OverlayManager};
-pub use panel::{PanelConfig, PanelManager, PanelRow, PanelRowKind, PanelSide};
+pub use panel::{PanelConfig, PanelManager, PanelRow, PanelRowKind, PanelSegment, PanelSide};
 pub use registry::PluginRegistry;
 pub use runtime::{poll_timer_callbacks, Runtime};

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     editor::{render_buffer::RenderBuffer, Point},
     theme::Style,
-    unicode_utils::fit_display_width,
+    unicode_utils::{display_width, fit_display_width, truncate_display_width},
 };
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -43,11 +43,18 @@ fn default_panel_width() -> usize {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PanelRow {
     pub id: String,
-    pub label: String,
     pub path: Option<String>,
-    pub depth: usize,
     pub expanded: Option<bool>,
     pub kind: PanelRowKind,
+    #[serde(default)]
+    pub segments: Vec<PanelSegment>,
+    #[serde(default)]
+    pub right_segments: Vec<PanelSegment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PanelSegment {
+    pub text: String,
     pub style: Option<Style>,
 }
 
@@ -120,6 +127,22 @@ impl PluginPanel {
     pub fn selected_row(&self) -> Option<PanelRow> {
         self.rows.get(self.selected).cloned()
     }
+
+    fn rows_start(&self) -> usize {
+        usize::from(self.config.title.is_some())
+    }
+
+    fn select_screen_row(&mut self, screen_y: usize) {
+        let rows_start = self.rows_start();
+        if screen_y < rows_start || self.rows.is_empty() {
+            return;
+        }
+
+        let row_index = self.scroll + screen_y - rows_start;
+        if row_index < self.rows.len() {
+            self.selected = row_index;
+        }
+    }
 }
 
 #[derive(Default)]
@@ -169,6 +192,14 @@ impl PanelManager {
         self.focused.as_deref()
     }
 
+    pub fn has_focused_panel(&self) -> bool {
+        self.focused.is_some()
+    }
+
+    pub fn selected_index(&self, id: &str) -> Option<usize> {
+        self.panels.get(id).map(|panel| panel.selected)
+    }
+
     pub fn reserved_left_width(&self) -> usize {
         self.panels
             .values()
@@ -203,6 +234,88 @@ impl PanelManager {
         })
     }
 
+    pub fn focus_panel_at_position(
+        &mut self,
+        x: usize,
+        y: usize,
+        terminal_width: usize,
+        terminal_height: usize,
+    ) -> Option<PanelEvent> {
+        let placement = self.panel_at_position(x, y, terminal_width, terminal_height)?;
+        let panel = self.panels.get_mut(&placement.id)?;
+
+        self.focused = Some(placement.id.clone());
+        panel.select_screen_row(y.saturating_sub(placement.y));
+
+        Some(PanelEvent {
+            panel_id: panel.id.clone(),
+            action: "select".to_string(),
+            selected_index: panel.selected,
+            row: panel.selected_row(),
+        })
+    }
+
+    pub fn panel_at_position(
+        &self,
+        x: usize,
+        y: usize,
+        terminal_width: usize,
+        terminal_height: usize,
+    ) -> Option<PanelPlacement> {
+        if y >= terminal_height.saturating_sub(2) {
+            return None;
+        }
+
+        self.panel_placements(terminal_width, terminal_height)
+            .into_iter()
+            .find(|placement| {
+                y >= placement.y
+                    && y < placement.y + placement.height
+                    && x >= placement.x
+                    && x < placement.x + placement.width
+            })
+    }
+
+    fn panel_placements(
+        &self,
+        terminal_width: usize,
+        terminal_height: usize,
+    ) -> Vec<PanelPlacement> {
+        let mut placements = Vec::new();
+        let mut left_x: usize = 0;
+        let mut right_x = terminal_width;
+        let height = terminal_height.saturating_sub(2);
+
+        for id in &self.z_order {
+            let Some(panel) = self.panels.get(id) else {
+                continue;
+            };
+
+            let width = panel.config.width.min(terminal_width);
+            let x = match panel.config.side {
+                PanelSide::Left => {
+                    let x = left_x;
+                    left_x = left_x.saturating_add(width.saturating_add(1));
+                    x
+                }
+                PanelSide::Right => {
+                    right_x = right_x.saturating_sub(width);
+                    right_x
+                }
+            };
+
+            placements.push(PanelPlacement {
+                id: id.clone(),
+                x,
+                y: 0,
+                width,
+                height,
+            });
+        }
+
+        placements
+    }
+
     pub fn render(&self, buffer: &mut RenderBuffer, editor_style: &Style) {
         let mut left_x: usize = 0;
         let mut right_x = buffer.width;
@@ -228,6 +341,15 @@ impl PanelManager {
             render_panel(buffer, panel, Point::new(x, 0), width, editor_style);
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PanelPlacement {
+    pub id: String,
+    pub x: usize,
+    pub y: usize,
+    pub width: usize,
+    pub height: usize,
 }
 
 fn render_panel(
@@ -272,19 +394,12 @@ fn render_panel(
     {
         let y = rows_start + screen_row;
         let index = panel.scroll + screen_row;
-        let style = if index == panel.selected {
-            selected_style.clone()
-        } else {
-            row.style.clone().unwrap_or_else(|| editor_style.clone())
-        };
-        let icon = match row.kind {
-            PanelRowKind::Directory if row.expanded.unwrap_or(false) => "-",
-            PanelRowKind::Directory => "+",
-            PanelRowKind::File => " ",
-        };
-        let indent = "  ".repeat(row.depth);
-        let text = format!("{indent}{icon} {}", row.label);
-        buffer.set_text(position.x, y, &fit_display_width(&text, width), &style);
+        let selected = index == panel.selected;
+        if selected {
+            buffer.set_text(position.x, y, &" ".repeat(width), &selected_style);
+        }
+
+        render_row_segments(buffer, position.x, y, width, row, editor_style, selected);
     }
 
     if position.x + width < buffer.width {
@@ -294,20 +409,116 @@ fn render_panel(
     }
 }
 
+fn render_row_segments(
+    buffer: &mut RenderBuffer,
+    x: usize,
+    y: usize,
+    width: usize,
+    row: &PanelRow,
+    editor_style: &Style,
+    selected: bool,
+) {
+    let right_width = segments_width(&row.right_segments).min(width);
+    let gap = usize::from(right_width > 0 && right_width < width);
+    let left_width = width.saturating_sub(right_width).saturating_sub(gap);
+
+    render_segments(
+        buffer,
+        x,
+        y,
+        left_width,
+        &row.segments,
+        editor_style,
+        selected,
+    );
+
+    if right_width > 0 {
+        let right_x = x + width.saturating_sub(right_width);
+        render_segments(
+            buffer,
+            right_x,
+            y,
+            right_width,
+            &row.right_segments,
+            editor_style,
+            selected,
+        );
+    }
+}
+
+fn render_segments(
+    buffer: &mut RenderBuffer,
+    x: usize,
+    y: usize,
+    max_width: usize,
+    segments: &[PanelSegment],
+    editor_style: &Style,
+    selected: bool,
+) {
+    let mut used = 0;
+
+    for segment in segments {
+        if used >= max_width {
+            break;
+        }
+
+        let remaining = max_width - used;
+        let text = truncate_display_width(&segment.text, remaining);
+        if text.is_empty() {
+            continue;
+        }
+
+        let style = segment_style(segment, editor_style, selected);
+        buffer.set_text(x + used, y, &text, &style);
+        used += display_width(&text);
+    }
+}
+
+fn segment_style(segment: &PanelSegment, editor_style: &Style, selected: bool) -> Style {
+    let mut style = segment
+        .style
+        .clone()
+        .unwrap_or_else(|| editor_style.clone());
+    if selected {
+        let selected_style = editor_style.inverted();
+        style.bg = selected_style.bg;
+        if style.fg.is_none() {
+            style.fg = selected_style.fg;
+        }
+    }
+    style
+}
+
+fn segments_width(segments: &[PanelSegment]) -> usize {
+    segments
+        .iter()
+        .map(|segment| display_width(&segment.text))
+        .sum()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::color::Color;
 
     fn row(id: &str) -> PanelRow {
         PanelRow {
             id: id.to_string(),
-            label: id.to_string(),
             path: None,
-            depth: 0,
             expanded: None,
             kind: PanelRowKind::File,
-            style: None,
+            segments: vec![PanelSegment {
+                text: id.to_string(),
+                style: None,
+            }],
+            right_segments: Vec::new(),
         }
+    }
+
+    fn row_text(buffer: &RenderBuffer, y: usize) -> String {
+        (0..buffer.width)
+            .map(|x| buffer.cells[y * buffer.width + x].text.as_str())
+            .collect()
     }
 
     #[test]
@@ -363,5 +574,65 @@ mod tests {
 
         assert_eq!(panel.selected, 1);
         assert_eq!(panel.scroll, 1);
+    }
+
+    #[test]
+    fn render_panel_right_aligns_badges() {
+        let mut panel = PluginPanel::new("tree".to_string(), PanelConfig::default());
+        let mut row = row("src");
+        row.right_segments.push(PanelSegment {
+            text: "M".to_string(),
+            style: None,
+        });
+        panel.update_rows(vec![row]);
+
+        let style = Style::default();
+        let mut buffer = RenderBuffer::new(10, 5, &style);
+        render_panel(&mut buffer, &panel, Point::new(0, 0), 10, &style);
+
+        assert_eq!(row_text(&buffer, 0), "src      M");
+    }
+
+    #[test]
+    fn render_panel_fills_selected_row() {
+        let mut panel = PluginPanel::new("tree".to_string(), PanelConfig::default());
+        panel.update_rows(vec![row("src")]);
+
+        let style = Style {
+            fg: Some(Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255,
+            }),
+            bg: Some(Color::Rgb { r: 0, g: 0, b: 0 }),
+            bold: false,
+            italic: false,
+        };
+        let mut buffer = RenderBuffer::new(10, 5, &style);
+        render_panel(&mut buffer, &panel, Point::new(0, 0), 10, &style);
+
+        let selected_bg = Some(Color::Rgb {
+            r: 255,
+            g: 255,
+            b: 255,
+        });
+        assert_eq!(buffer.cells[9].style.bg, selected_bg);
+    }
+
+    #[test]
+    fn render_panel_clips_left_segments_for_right_badge() {
+        let mut panel = PluginPanel::new("tree".to_string(), PanelConfig::default());
+        let mut row = row("abcdef");
+        row.right_segments.push(PanelSegment {
+            text: "M".to_string(),
+            style: None,
+        });
+        panel.update_rows(vec![row]);
+
+        let style = Style::default();
+        let mut buffer = RenderBuffer::new(6, 5, &style);
+        render_panel(&mut buffer, &panel, Point::new(0, 0), 6, &style);
+
+        assert_eq!(row_text(&buffer, 0), "abcd M");
     }
 }

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -74,9 +74,10 @@ impl PluginRegistry {
         .to_string();
 
         for (i, (name, plugin)) in self.plugins.iter().enumerate() {
+            let plugin_specifier = plugin_import_specifier(plugin)?;
             code += &format!(
                 r#"
-                    import * as plugin_{i} from '{plugin}';
+                    import * as plugin_{i} from {};
                     const activate_{i} = plugin_{i}.activate;
                     const deactivate_{i} = plugin_{i}.deactivate || null;
                     const before_exit_{i} = plugin_{i}.beforeExit || null;
@@ -98,6 +99,7 @@ impl PluginRegistry {
                             .catch((error) => globalThis.log(`Error activating plugin {name}:`, error));
                     }}
                 "#,
+                json!(plugin_specifier),
             );
         }
 
@@ -241,6 +243,10 @@ impl PluginRegistry {
     }
 }
 
+fn plugin_import_specifier(plugin: &str) -> anyhow::Result<String> {
+    Ok(deno_core::resolve_url_or_path(plugin, Path::new("."))?.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -267,6 +273,15 @@ mod tests {
         assert!(message.contains("Could not load plugin `missing`."));
         assert!(message.contains("that file does not exist"));
         assert!(message.contains("`[plugins]`"));
+    }
+
+    #[test]
+    fn plugin_import_specifier_uses_file_url() {
+        let plugin_path = std::env::temp_dir().join("red-plugin-import-specifier.js");
+        let specifier = plugin_import_specifier(plugin_path.to_string_lossy().as_ref()).unwrap();
+
+        assert!(specifier.starts_with("file://"));
+        assert!(specifier.ends_with("red-plugin-import-specifier.js"));
     }
 
     #[tokio::test]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -135,10 +135,10 @@ impl PluginRegistry {
     pub async fn execute(&mut self, runtime: &mut Runtime, command: &str) -> anyhow::Result<()> {
         let code = format!(
             r#"
-                (async () => {{
-                    return await globalThis.execute('{command}');
-                }})();
+                Promise.resolve(globalThis.execute({}))
+                    .catch((error) => globalThis.log(`Error executing command {command}:`, error));
             "#,
+            json!(command),
         );
 
         runtime.run(&code).await?;
@@ -244,6 +244,12 @@ impl PluginRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::editor::{PluginRequest, ACTION_DISPATCHER};
+    use std::time::Duration;
+
+    fn drain_plugin_requests() {
+        while ACTION_DISPATCHER.try_recv_request().is_some() {}
+    }
 
     #[tokio::test]
     async fn initialize_explains_missing_plugin_file() {
@@ -261,5 +267,74 @@ mod tests {
         assert!(message.contains("Could not load plugin `missing`."));
         assert!(message.contains("that file does not exist"));
         assert!(message.contains("`[plugins]`"));
+    }
+
+    #[tokio::test]
+    async fn plugin_command_yields_while_awaiting_editor_response() {
+        drain_plugin_requests();
+
+        let plugin_path = std::env::temp_dir().join(format!(
+            "red-async-panel-command-{}.js",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(
+            &plugin_path,
+            r#"
+                export function activate(red) {
+                    red.addCommand("AsyncPanel", async () => {
+                        red.createPanel("tree", { side: "left", width: 10 });
+                        const cwd = await red.getConfig("cwd");
+                        red.updatePanel("tree", [{
+                            id: "root",
+                            path: cwd,
+                            kind: "directory",
+                            segments: [{ text: String(cwd) }],
+                        }]);
+                    });
+                }
+            "#,
+        )
+        .unwrap();
+
+        let mut registry = PluginRegistry::new();
+        registry.add("async_panel", plugin_path.to_string_lossy().as_ref());
+        let mut runtime = Runtime::new();
+        registry.initialize(&mut runtime).await.unwrap();
+
+        tokio::time::timeout(
+            Duration::from_millis(250),
+            registry.execute(&mut runtime, "AsyncPanel"),
+        )
+        .await
+        .expect("plugin command should not block the editor while awaiting config")
+        .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.try_recv_request(),
+            Some(PluginRequest::CreatePanel { id, .. }) if id == "tree"
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.try_recv_request(),
+            Some(PluginRequest::GetConfig { key }) if key.as_deref() == Some("cwd")
+        ));
+
+        registry
+            .notify(
+                &mut runtime,
+                "config:value",
+                json!({ "value": "/tmp/red-workspace" }),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.try_recv_request(),
+            Some(PluginRequest::UpdatePanel { id, rows })
+                if id == "tree"
+                    && rows.len() == 1
+                    && rows[0].segments[0].text == "/tmp/red-workspace"
+        ));
+
+        let _ = std::fs::remove_file(plugin_path);
     }
 }

--- a/src/plugin/runtime.js
+++ b/src/plugin/runtime.js
@@ -418,6 +418,16 @@ class RedContext {
     });
   }
 
+  getGitStatus(path = ".") {
+    return new Promise((resolve, _reject) => {
+      const reqId = nextReqId++;
+      this.once(`git:status:${reqId}`, (result) => {
+        resolve(result);
+      });
+      ops.op_get_git_status(path, reqId);
+    });
+  }
+
   watchDirectory(path, callback) {
     const watchId = nextReqId++;
     this.on(`filesystem:changed:${watchId}`, callback);

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -776,6 +776,12 @@ fn op_list_directory(#[string] path: String, request_id: i32) -> Result<(), Plug
 }
 
 #[op2(fast)]
+fn op_get_git_status(#[string] path: String, request_id: i32) -> Result<(), PluginOpError> {
+    ACTION_DISPATCHER.send_request(PluginRequest::GetGitStatus { path, request_id });
+    Ok(())
+}
+
+#[op2(fast)]
 fn op_watch_directory(#[string] path: String, watch_id: i32) -> Result<(), PluginOpError> {
     ACTION_DISPATCHER.send_request(PluginRequest::WatchDirectory { path, watch_id });
     Ok(())
@@ -867,6 +873,7 @@ extension!(
         op_focus_editor,
         op_close_panel,
         op_list_directory,
+        op_get_git_status,
         op_watch_directory,
         op_unwatch_directory,
     ],

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,5 +1,7 @@
 mod vscode;
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 pub use vscode::parse_vscode_theme;
 
@@ -9,6 +11,8 @@ use crate::color::Color;
 pub struct Theme {
     #[allow(unused)]
     pub name: String,
+    #[serde(default)]
+    pub colors: BTreeMap<String, Color>,
     pub style: Style,
     pub gutter_style: Style,
     pub statusline_style: StatuslineStyle,
@@ -47,6 +51,7 @@ impl Default for Theme {
     fn default() -> Self {
         Self {
             name: "default".to_string(),
+            colors: BTreeMap::new(),
             style: Style {
                 fg: Some(Color::Rgb {
                     r: 255,

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, fs};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+};
 
 use json_comments::StripComments;
 use once_cell::sync::Lazy;
@@ -143,9 +146,18 @@ pub fn parse_vscode_theme(file: &str) -> anyhow::Result<Theme> {
         .into_iter()
         .map(|tc| tc.try_into())
         .collect::<Result<Vec<TokenStyle>, _>>()?;
+    let colors = vscode_theme
+        .colors
+        .iter()
+        .filter_map(|(key, value)| {
+            let hex = value.as_str()?;
+            parse_rgb(hex).ok().map(|color| (key.to_string(), color))
+        })
+        .collect::<BTreeMap<_, _>>();
 
     Ok(Theme {
         name: vscode_theme.name.unwrap_or_default(),
+        colors,
         style: editor_style,
         ui_style,
         token_styles,
@@ -664,6 +676,28 @@ mod test {
                     b: 245,
                 }),
                 ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn test_exposes_raw_vscode_workbench_colors() {
+        let theme = parse_vscode_theme("./src/fixtures/mocha.json").unwrap();
+
+        assert_eq!(
+            theme.colors.get("gitDecoration.modifiedResourceForeground"),
+            Some(&Color::Rgb {
+                r: 249,
+                g: 226,
+                b: 175,
+            })
+        );
+        assert_eq!(
+            theme.colors.get("symbolIcon.folderForeground"),
+            Some(&Color::Rgb {
+                r: 203,
+                g: 166,
+                b: 247,
             })
         );
     }

--- a/test-harness/mock-red.js
+++ b/test-harness/mock-red.js
@@ -8,6 +8,10 @@ class MockRedAPI {
     this.eventListeners = new Map();
     this.logs = [];
     this.overlays = new Map();
+    this.panels = new Map();
+    this.directoryListings = new Map();
+    this.directoryWatches = new Map();
+    this.gitStatus = { root: null, statuses: [], error: null };
     this.timeouts = new Map();
     this.nextTimeoutId = 1;
     
@@ -254,6 +258,69 @@ class MockRedAPI {
     return this.overlays.get(id);
   }
 
+  createPanel(id, config = {}) {
+    this.logs.push(`createPanel: ${id} ${JSON.stringify(config)}`);
+    this.panels.set(id, { config, rows: [], focused: false });
+  }
+
+  updatePanel(id, rows) {
+    this.logs.push(`updatePanel: ${id} ${JSON.stringify(rows)}`);
+    const panel = this.panels.get(id) || { config: {}, rows: [], focused: false };
+    panel.rows = rows;
+    this.panels.set(id, panel);
+  }
+
+  focusPanel(id) {
+    this.logs.push(`focusPanel: ${id}`);
+    for (const panel of this.panels.values()) {
+      panel.focused = false;
+    }
+    const panel = this.panels.get(id);
+    if (panel) panel.focused = true;
+  }
+
+  focusEditor() {
+    this.logs.push("focusEditor");
+    for (const panel of this.panels.values()) {
+      panel.focused = false;
+    }
+  }
+
+  closePanel(id) {
+    this.logs.push(`closePanel: ${id}`);
+    this.panels.delete(id);
+  }
+
+  onPanelEvent(id, callback) {
+    this.on(`panel:event:${id}`, callback);
+  }
+
+  async listDirectory(path) {
+    return this.directoryListings.get(path) || { path, entries: [], error: null };
+  }
+
+  async getGitStatus(_path = ".") {
+    return this.gitStatus;
+  }
+
+  watchDirectory(path, callback) {
+    const id = `watch-${this.directoryWatches.size + 1}`;
+    this.directoryWatches.set(id, { path, callback });
+    return id;
+  }
+
+  unwatchDirectory(id) {
+    this.directoryWatches.delete(id);
+  }
+
+  openFile(path) {
+    this.logs.push(`openFile: ${path}`);
+  }
+
+  getPanel(id) {
+    return this.panels.get(id);
+  }
+
   // Test helper methods
   getLogs() {
     return this.logs;
@@ -281,6 +348,19 @@ class MockRedAPI {
 
   getMockState() {
     return this.mockState;
+  }
+
+  setDirectoryListing(path, entries, error = null) {
+    this.directoryListings.set(path, { path, entries, error });
+  }
+
+  setGitStatus(status) {
+    this.gitStatus = status;
+  }
+
+  async emitPanelEvent(id, event) {
+    const listeners = this.eventListeners.get(`panel:event:${id}`) || [];
+    await Promise.all(listeners.map((callback) => callback(event)));
   }
 }
 

--- a/test-harness/test-runner.js
+++ b/test-harness/test-runner.js
@@ -9,6 +9,7 @@
 const { MockRedAPI } = require('./mock-red.js');
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
 const { performance } = require('perf_hooks');
 
 // ANSI color codes
@@ -172,11 +173,43 @@ global.jest = {
 };
 
 // Run tests
+function loadPlugin(pluginPath) {
+  const resolved = path.resolve(pluginPath);
+  try {
+    return require(resolved);
+  } catch (error) {
+    const code = fs.readFileSync(resolved, 'utf8');
+    const exported = [];
+    const transformed = code.replace(
+      /export\s+(async\s+)?function\s+([A-Za-z0-9_]+)/g,
+      (_match, asyncKeyword = '', name) => {
+        exported.push(name);
+        return `${asyncKeyword || ''}function ${name}`;
+      }
+    );
+    const wrapped = `${transformed}\nmodule.exports = { ${exported.join(', ')} };`;
+    const module = { exports: {} };
+    const context = vm.createContext({
+      module,
+      exports: module.exports,
+      console,
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      globalThis,
+    });
+    new vm.Script(wrapped, { filename: resolved }).runInContext(context);
+    return module.exports;
+  }
+}
+
 async function runTests(pluginPath, testPath) {
   console.log(`${colors.blue}Red Editor Plugin Test Runner${colors.reset}\n`);
   
   // Load plugin
-  const plugin = require(path.resolve(pluginPath));
+  const plugin = loadPlugin(pluginPath);
+  global.plugin = plugin;
   
   // Load test file
   require(path.resolve(testPath));

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1,13 +1,15 @@
 mod common;
 
 use common::{EditorHarness, MockLsp};
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{
+    Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
 use red::{
     buffer::Buffer,
     config::{Config, KeyAction},
     editor::{Action, Content, Editor, Mode},
     lsp::LspClient,
-    plugin::{PanelConfig, PanelSide},
+    plugin::{PanelConfig, PanelRow, PanelRowKind, PanelSegment, PanelSide},
     preferences::PreferencesStore,
     theme::Theme,
 };
@@ -37,6 +39,43 @@ async fn type_normal_keys(harness: &mut EditorHarness, keys: &str) {
             .await
             .unwrap();
     }
+}
+
+fn default_key_config() -> Config {
+    toml::from_str(include_str!("../default_config.toml")).unwrap()
+}
+
+fn tree_rows() -> Vec<PanelRow> {
+    ["root", "src", "main.rs"]
+        .into_iter()
+        .map(|id| PanelRow {
+            id: id.to_string(),
+            path: Some(id.to_string()),
+            expanded: Some(false),
+            kind: if id.ends_with(".rs") {
+                PanelRowKind::File
+            } else {
+                PanelRowKind::Directory
+            },
+            segments: vec![PanelSegment {
+                text: id.to_string(),
+                style: None,
+            }],
+            right_segments: vec![],
+        })
+        .collect()
+}
+
+fn add_tree_panel(harness: &mut EditorHarness) {
+    harness.editor.test_create_panel(
+        "tree",
+        PanelConfig {
+            side: PanelSide::Left,
+            width: 20,
+            title: None,
+        },
+    );
+    harness.editor.test_update_panel("tree", tree_rows());
 }
 
 async fn command_key(harness: &mut EditorHarness, code: KeyCode) {
@@ -1589,6 +1628,125 @@ fn test_right_panel_reserves_editor_window_width() {
     let (position, size) = harness.editor.test_active_window_bounds().unwrap();
     assert_eq!(position.x, 0);
     assert_eq!(size.0, 59);
+}
+
+#[test]
+fn focused_panel_hides_editor_cursor_until_focus_returns() {
+    let mut harness = EditorHarness::with_content("abcdef");
+    let editor_cursor = harness.render_cursor_position();
+    add_tree_panel(&mut harness);
+
+    assert!(harness.editor.test_focus_panel("tree"));
+    assert_eq!(harness.render_cursor_position(), None);
+
+    harness.editor.test_close_panel("tree");
+    assert_eq!(harness.render_cursor_position(), editor_cursor);
+}
+
+#[tokio::test]
+async fn focused_panel_commandline_receives_text_before_panel_shortcuts() {
+    let buffer = Buffer::new(None, "abcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    add_tree_panel(&mut harness);
+    assert!(harness.editor.test_focus_panel("tree"));
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char(':'),
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+    harness.assert_mode(Mode::Command);
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('q'),
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.commandline_text(), "q");
+    assert_eq!(harness.editor.test_focused_panel_id(), Some("tree"));
+}
+
+#[tokio::test]
+async fn focused_panel_does_not_fall_through_to_editing_keys() {
+    let buffer = Buffer::new(None, "abcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    add_tree_panel(&mut harness);
+    assert!(harness.editor.test_focus_panel("tree"));
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+
+    harness.assert_buffer_contents("abcdef");
+    assert_eq!(harness.editor.test_focused_panel_id(), Some("tree"));
+}
+
+#[tokio::test]
+async fn escape_from_focused_panel_restores_editor_cursor() {
+    let mut harness = EditorHarness::with_content("abcdef");
+    add_tree_panel(&mut harness);
+    let editor_cursor = harness.render_cursor_position();
+    assert!(harness.editor.test_focus_panel("tree"));
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.editor.test_focused_panel_id(), None);
+    assert_eq!(harness.render_cursor_position(), editor_cursor);
+}
+
+#[tokio::test]
+async fn mouse_click_inside_panel_focuses_and_selects_row() {
+    let mut harness = EditorHarness::with_content("abcdef");
+    add_tree_panel(&mut harness);
+
+    harness
+        .execute_event(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 1,
+            row: 2,
+            modifiers: KeyModifiers::NONE,
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.editor.test_focused_panel_id(), Some("tree"));
+    assert_eq!(
+        harness.editor.test_focused_panel_selected_index("tree"),
+        Some(2)
+    );
+    assert_eq!(harness.render_cursor_position(), None);
+}
+
+#[tokio::test]
+async fn mouse_click_in_editor_clears_panel_focus() {
+    let mut harness = EditorHarness::with_content("abcdef");
+    add_tree_panel(&mut harness);
+    assert!(harness.editor.test_focus_panel("tree"));
+
+    harness
+        .execute_event(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 25,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.editor.test_focused_panel_id(), None);
+    assert!(harness.render_cursor_position().is_some());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

The built-in NeoTree plugin still looked and behaved like the older Red side panel rather than the Neovim `neo-tree.nvim` experience we are trying to mirror. It also had no way to reuse the exact workbench colors that already exist in our VS Code theme files, which meant folder and git status styling had to stay hardcoded instead of following the active theme.

## What Changed

This ports the NeoTree panel to a segment-based tree rendering model with root rows, branch guides, Nerd Font file/folder icons, right-aligned git status badges, refresh/close/toggle actions, and auto-close after opening a file. The editor panel renderer now accepts left and right styled segments, clips by terminal display width, preserves segment foregrounds on selected rows, and exposes git status to plugins through `red.getGitStatus(path)`.

The theme parser now preserves parsed VS Code workbench colors under `theme.colors`, keyed by their original names such as `gitDecoration.modifiedResourceForeground`, `tree.indentGuidesStroke`, and `symbolIcon.folderForeground`. NeoTree uses those keys for folder/root labels, guides, ignored files, and status badges while keeping fallbacks for themes that do not define them.

The plugin docs and JS test harness were updated to cover the new panel row shape, filesystem/git APIs, and simple ESM plugin loading used by the NeoTree tests.

## How to Test

1. From the repository root, start Red with the branch plugin override:

```sh
cargo run -- -c "plugins.neotree = \"$(pwd)/plugins/neotree.js\"" README.md
```

2. Press `Ctrl-e` to open NeoTree. Confirm the left panel has no `Files` title, shows a root row, folder/file icons, branch guides, and git badges aligned on the right when the repository has changed files.
3. Move to a file row and press Enter. Confirm the file opens and the NeoTree panel closes, returning focus to the editor.
4. Repeat with a different theme override, for example:

```sh
cargo run -- -c 'theme = "latte.json"' -c "plugins.neotree = \"$(pwd)/plugins/neotree.js\"" README.md
```

5. Confirm folder, guide, ignored, and git badge colors follow the active theme rather than the previous fixed palette.

Targeted tests:

- `node test-harness/test-runner.js plugins/neotree.js plugins/neotree.test.js`
- `cargo test theme::vscode::test::test_exposes_raw_vscode_workbench_colors`
