### PR TITLE
Add cool search highlight clearing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ Red uses Vim-style modal editing. Here are the essential key bindings:
 - `?` - Backward search with live preview and highlighted matches
 - `n/N` - Repeat search in the same/opposite direction
 
-Search patterns use Rust regex syntax. `:noh` or `:nohlsearch` clears the current search highlights until the next search.
+Search patterns use Rust regex syntax. The bundled `cool_search` plugin clears
+search highlights automatically after you move away from a committed match or
+enter Insert mode. `:noh` or `:nohlsearch` still clears the current search
+highlights manually until the next search.
 
 ### Insert Mode
 - `Esc` - Return to Normal mode

--- a/default_config.toml
+++ b/default_config.toml
@@ -227,6 +227,7 @@ Esc = { EnterMode = "Normal" }
 
 [plugins]
 buffer_picker = "buffer_picker.js"
+cool_search = "cool_search.js"
 fidget = "fidget.js"
 lsp_symbols = "lsp_symbols.ts"
 neotree = "neotree.js"

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -128,8 +128,14 @@ Subscribes to editor events. Available events include:
 - `editor:resize` - Editor window resize events
 - `buffer:changed` - Buffer content changes (includes cursor position and buffer info)
 - `picker:selected:${id}` - Picker selection events
-- `mode:changed` - Editor mode changes (Normal, Insert, Visual, etc.)
-- `cursor:moved` - Cursor position changes (may fire frequently)
+- `mode:changed` - Editor mode changes. Payload includes `from`, `to`,
+  compatibility aliases `old_mode`/`new_mode`, and `cause`.
+- `cursor:moved` - Cursor position changes (may fire frequently). Payload
+  includes `from`, `to`, `mode`, `cause`, `viewportTop`, and `bufferIndex`,
+  plus compatibility aliases `x`, `y`, `viewport_top`, and `buffer_index`.
+- `search:highlighted` - A committed search activated visible highlights.
+  Payload includes `term`, `direction`, and `source`.
+- `search:cleared` - Search highlights were cleared. Payload includes `term`.
 - `file:opened` - File opened in a buffer
 - `file:saved` - File saved from a buffer
 - `editor:ready` - Plugins have loaded and startup work can begin
@@ -253,8 +259,11 @@ const text = await red.getBufferText(startLine?: number, endLine?: number)
 #### Action Execution
 ```javascript
 red.execute(command: string, args?: any)
+red.clearSearchHighlight()
 ```
 Executes any editor action programmatically.
+`red.clearSearchHighlight()` is a convenience wrapper for the
+`ClearSearchHighlight` action.
 
 #### Command Discovery
 ```javascript

--- a/plugins/cool_search.js
+++ b/plugins/cool_search.js
@@ -1,0 +1,58 @@
+const SEARCH_CAUSES = new Set([
+  "CommitSearch",
+  "FindNext",
+  "FindPrevious",
+  "RepeatSearch",
+  "RepeatSearchOpposite",
+  "SearchWordUnderCursor",
+]);
+
+export function createCoolSearchController(red) {
+  let highlightActive = false;
+
+  const clear = () => {
+    if (!highlightActive) return;
+    highlightActive = false;
+    red.clearSearchHighlight();
+  };
+
+  const onSearchHighlighted = () => {
+    highlightActive = true;
+  };
+
+  const onSearchCleared = () => {
+    highlightActive = false;
+  };
+
+  const onModeChanged = (event = {}) => {
+    const mode = event.to || event.new_mode;
+    if (mode === "Insert") clear();
+  };
+
+  const onCursorMoved = (event = {}) => {
+    if (!highlightActive) return;
+    if (event.mode && event.mode !== "Normal") return;
+    if (SEARCH_CAUSES.has(event.cause)) return;
+    clear();
+  };
+
+  const isHighlightActive = () => highlightActive;
+
+  return {
+    clear,
+    isHighlightActive,
+    onCursorMoved,
+    onModeChanged,
+    onSearchCleared,
+    onSearchHighlighted,
+  };
+}
+
+export function activate(red) {
+  const controller = createCoolSearchController(red);
+
+  red.on("search:highlighted", controller.onSearchHighlighted);
+  red.on("search:cleared", controller.onSearchCleared);
+  red.on("mode:changed", controller.onModeChanged);
+  red.on("cursor:moved", controller.onCursorMoved);
+}

--- a/plugins/cool_search.test.js
+++ b/plugins/cool_search.test.js
@@ -1,0 +1,47 @@
+describe("CoolSearch", () => {
+  test("arms on search highlight and clears on normal movement", async (red) => {
+    const controller = plugin.createCoolSearchController(red);
+
+    controller.onSearchHighlighted();
+    controller.onCursorMoved({ mode: "Normal", cause: "MoveToNextWord" });
+
+    expect(red.getLogs()).toContain("execute: ClearSearchHighlight {}");
+    expect(controller.isHighlightActive()).toBe(false);
+  });
+
+  test("does not clear on search-caused movement", async (red) => {
+    const controller = plugin.createCoolSearchController(red);
+
+    controller.onSearchHighlighted();
+    controller.onCursorMoved({ mode: "Normal", cause: "RepeatSearch" });
+
+    expect(red.getLogs().length).toBe(0);
+    expect(controller.isHighlightActive()).toBe(true);
+  });
+
+  test("clears when entering insert mode", async (red) => {
+    const controller = plugin.createCoolSearchController(red);
+
+    controller.onSearchHighlighted();
+    controller.onModeChanged({ to: "Insert" });
+
+    expect(red.getLogs()).toContain("execute: ClearSearchHighlight {}");
+    expect(controller.isHighlightActive()).toBe(false);
+  });
+
+  test("ignores repeated clear events while inactive", async (red) => {
+    const controller = plugin.createCoolSearchController(red);
+
+    controller.onCursorMoved({ mode: "Normal", cause: "MoveRight" });
+    controller.onModeChanged({ to: "Insert" });
+
+    expect(red.getLogs().length).toBe(0);
+  });
+
+  test("activation wires editor events", async (red) => {
+    red.emit("search:highlighted", { term: "alpha" });
+    red.emit("cursor:moved", { mode: "Normal", cause: "MoveRight" });
+
+    expect(red.getLogs()).toContain("execute: ClearSearchHighlight {}");
+  });
+});

--- a/src/config.rs
+++ b/src/config.rs
@@ -759,6 +759,10 @@ theme = "mocha.json"
             config.plugins.get("lsp_symbols").map(String::as_str),
             Some("lsp_symbols.ts")
         );
+        assert_eq!(
+            config.plugins.get("cool_search").map(String::as_str),
+            Some("cool_search.js")
+        );
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -245,6 +245,7 @@ pub enum Action {
     RepeatSearch,
     RepeatSearchOpposite,
     CommitSearch,
+    CancelSearch,
     ClearSearchHighlight,
     SearchWordUnderCursor,
 
@@ -763,6 +764,15 @@ struct SearchSession {
     direction: SearchDirection,
     draft: String,
     preview: Option<SearchMatch>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EditorEventSnapshot {
+    mode: Mode,
+    cx: usize,
+    y: usize,
+    vtop: usize,
+    buffer_index: usize,
 }
 
 impl HistoryEntry {
@@ -1701,6 +1711,79 @@ impl Editor {
                 | Action::SetCursor(_, _)
                 | Action::SetWaitingKey(_)
         )
+    }
+
+    fn event_snapshot(&self) -> EditorEventSnapshot {
+        EditorEventSnapshot {
+            mode: self.mode,
+            cx: self.cx,
+            y: self.cy + self.vtop,
+            vtop: self.vtop,
+            buffer_index: self.current_buffer_index,
+        }
+    }
+
+    fn action_cause(action: &Action) -> String {
+        let debug = format!("{action:?}");
+        debug
+            .split(['(', '{', ' '])
+            .next()
+            .unwrap_or("Action")
+            .to_string()
+    }
+
+    async fn notify_editor_event_changes(
+        &mut self,
+        before: EditorEventSnapshot,
+        runtime: &mut Runtime,
+        cause: &str,
+    ) -> anyhow::Result<()> {
+        let after = self.event_snapshot();
+
+        if before.mode != after.mode {
+            let from = format!("{:?}", before.mode);
+            let to = format!("{:?}", after.mode);
+            let mode_info = serde_json::json!({
+                "from": &from,
+                "to": &to,
+                "old_mode": &from,
+                "new_mode": &to,
+                "cause": cause,
+            });
+            self.plugin_registry
+                .notify(runtime, "mode:changed", mode_info)
+                .await?;
+        }
+
+        if before.cx != after.cx
+            || before.y != after.y
+            || before.vtop != after.vtop
+            || before.buffer_index != after.buffer_index
+        {
+            let cursor_info = serde_json::json!({
+                "from": {
+                    "x": before.cx,
+                    "y": before.y,
+                },
+                "to": {
+                    "x": after.cx,
+                    "y": after.y,
+                },
+                "x": after.cx,
+                "y": after.y,
+                "mode": format!("{:?}", after.mode),
+                "cause": cause,
+                "viewportTop": after.vtop,
+                "viewport_top": after.vtop,
+                "bufferIndex": after.buffer_index,
+                "buffer_index": after.buffer_index,
+            });
+            self.plugin_registry
+                .notify(runtime, "cursor:moved", cursor_info)
+                .await?;
+        }
+
+        Ok(())
     }
 
     fn last_navigable_line(&self) -> usize {
@@ -3094,7 +3177,7 @@ impl Editor {
         &mut self,
         direction: SearchDirection,
         buffer: &mut RenderBuffer,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         let pattern = self
             .active_search
             .as_ref()
@@ -3102,7 +3185,7 @@ impl Editor {
             .unwrap_or(&self.search_term)
             .to_string();
         if pattern.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
         let matches = match self.search_matches(&pattern) {
@@ -3110,7 +3193,7 @@ impl Editor {
             Err(err) => {
                 self.last_error = Some(err.to_string());
                 self.render(buffer)?;
-                return Ok(());
+                return Ok(false);
             }
         };
         let origin = self.current_history_entry();
@@ -3127,12 +3210,13 @@ impl Editor {
                 active_search.preview = Some(match_);
             }
             self.render(buffer)?;
+            return Ok(true);
         } else {
             self.last_error = Some(format!("pattern not found: {pattern}"));
             self.render(buffer)?;
         }
 
-        Ok(())
+        Ok(false)
     }
 
     fn reset_command_history_navigation(&mut self) {
@@ -3243,8 +3327,7 @@ impl Editor {
 
                 match (code, modifiers) {
                     (KeyCode::Esc, _) => {
-                        self.cancel_active_search();
-                        return Some(KeyAction::None);
+                        return Some(KeyAction::Single(Action::CancelSearch));
                     }
                     (KeyCode::Backspace, _) => {
                         if let Some(active_search) = &mut self.active_search {
@@ -3786,6 +3869,8 @@ impl Editor {
         self.actions.push(action.clone());
 
         let mut add_to_history = tracking;
+        let event_snapshot_before_action = self.event_snapshot();
+        let action_cause = Self::action_cause(action);
         let history_entry_before_action = self.current_history_entry();
 
         match action {
@@ -3810,13 +3895,11 @@ impl Editor {
                         self.vtop -= 1;
                         self.apply_cursor_goal_to_current_line();
                         self.render(buffer)?;
-                        self.notify_cursor_move(runtime).await?;
                     }
                 } else {
                     self.cy = self.cy.saturating_sub(1);
                     self.apply_cursor_goal_to_current_line();
                     self.draw_cursor_preserving_cursor_goal()?;
-                    self.notify_cursor_move(runtime).await?;
                 }
             }
             Action::MoveDown => {
@@ -3831,7 +3914,6 @@ impl Editor {
                     } else {
                         self.apply_cursor_goal_to_current_line();
                     }
-                    self.notify_cursor_move(runtime).await?;
                 } else {
                     self.draw_cursor_preserving_cursor_goal()?;
                 }
@@ -3855,7 +3937,6 @@ impl Editor {
                     }
                 }
                 self.draw_cursor()?;
-                self.notify_cursor_move(runtime).await?;
             }
             Action::MoveRight => {
                 // Move by grapheme clusters
@@ -3879,7 +3960,6 @@ impl Editor {
                     }
                 }
                 self.draw_cursor()?;
-                self.notify_cursor_move(runtime).await?;
             }
             Action::MoveToLineStart => {
                 self.cx = 0;
@@ -3992,15 +4072,6 @@ impl Editor {
                 if !matches!(old_mode, Mode::Normal) && matches!(new_mode, Mode::Normal) {
                     self.request_diagnostics().await?;
                 }
-
-                // Notify plugins about mode change
-                let mode_info = serde_json::json!({
-                    "old_mode": format!("{:?}", old_mode),
-                    "new_mode": format!("{:?}", new_mode)
-                });
-                self.plugin_registry
-                    .notify(runtime, "mode:changed", mode_info)
-                    .await?;
 
                 self.draw_statusline(buffer);
             }
@@ -4820,68 +4891,95 @@ impl Editor {
                     self.active_search = None;
                     self.mode = Mode::Normal;
                     self.render(buffer)?;
-                    return Ok(false);
-                }
-
-                let matches = match self.search_matches(&session.draft) {
-                    Ok(matches) => matches,
-                    Err(err) => {
+                } else {
+                    let matches = match self.search_matches(&session.draft) {
+                        Ok(matches) => matches,
+                        Err(err) => {
+                            self.restore_search_origin(&session.origin, session.origin_vtop);
+                            self.last_error = Some(err.to_string());
+                            self.render(buffer)?;
+                            return Ok(false);
+                        }
+                    };
+                    let Some(match_) = self.search_match_in_direction(
+                        &matches,
+                        &session.origin,
+                        session.direction,
+                        self.config.search.wrapscan,
+                    ) else {
                         self.restore_search_origin(&session.origin, session.origin_vtop);
-                        self.last_error = Some(err.to_string());
+                        self.last_error = Some(format!("pattern not found: {}", session.draft));
                         self.render(buffer)?;
                         return Ok(false);
-                    }
-                };
-                let Some(match_) = self.search_match_in_direction(
-                    &matches,
-                    &session.origin,
-                    session.direction,
-                    self.config.search.wrapscan,
-                ) else {
-                    self.restore_search_origin(&session.origin, session.origin_vtop);
-                    self.last_error = Some(format!("pattern not found: {}", session.draft));
-                    self.render(buffer)?;
-                    return Ok(false);
-                };
+                    };
 
-                self.search_term = session.draft;
-                self.search_direction = session.direction;
-                self.search_highlights_suppressed = false;
-                self.active_search = None;
-                self.mode = Mode::Normal;
-                self.move_to_search_match(match_);
-                self.save_to_history(session.origin);
+                    self.search_term = session.draft;
+                    self.search_direction = session.direction;
+                    self.search_highlights_suppressed = false;
+                    self.active_search = None;
+                    self.mode = Mode::Normal;
+                    self.move_to_search_match(match_);
+                    self.save_to_history(session.origin);
+                    self.render(buffer)?;
+                    self.notify_search_highlighted(runtime, "CommitSearch")
+                        .await?;
+                }
+            }
+            Action::CancelSearch => {
+                add_to_history = false;
+                self.cancel_active_search();
                 self.render(buffer)?;
             }
             Action::FindPrevious => {
                 if self.active_search.is_some() {
                     add_to_history = false;
                 }
-                self.execute_search_direction(SearchDirection::Backward, buffer)?;
+                let persistent_search = self.active_search.is_none();
+                if self.execute_search_direction(SearchDirection::Backward, buffer)?
+                    && persistent_search
+                {
+                    self.notify_search_highlighted(runtime, "FindPrevious")
+                        .await?;
+                }
             }
             Action::FindNext => {
                 if self.active_search.is_some() {
                     add_to_history = false;
                 }
-                self.execute_search_direction(SearchDirection::Forward, buffer)?;
+                let persistent_search = self.active_search.is_none();
+                if self.execute_search_direction(SearchDirection::Forward, buffer)?
+                    && persistent_search
+                {
+                    self.notify_search_highlighted(runtime, "FindNext").await?;
+                }
             }
             Action::RepeatSearch => {
-                self.execute_search_direction(self.search_direction, buffer)?;
+                if self.execute_search_direction(self.search_direction, buffer)? {
+                    self.notify_search_highlighted(runtime, "RepeatSearch")
+                        .await?;
+                }
             }
             Action::RepeatSearchOpposite => {
-                self.execute_search_direction(self.search_direction.opposite(), buffer)?;
+                if self.execute_search_direction(self.search_direction.opposite(), buffer)? {
+                    self.notify_search_highlighted(runtime, "RepeatSearchOpposite")
+                        .await?;
+                }
             }
             Action::ClearSearchHighlight => {
                 self.search_highlights_suppressed = true;
                 self.active_search = None;
                 self.render(buffer)?;
+                self.notify_search_cleared(runtime).await?;
             }
             Action::SearchWordUnderCursor => {
                 if let Some(search_term) = self.word_under_cursor() {
                     self.search_term = search_term;
                     self.search_direction = SearchDirection::Forward;
                     self.search_highlights_suppressed = false;
-                    self.execute_search_direction(SearchDirection::Forward, buffer)?;
+                    if self.execute_search_direction(SearchDirection::Forward, buffer)? {
+                        self.notify_search_highlighted(runtime, "SearchWordUnderCursor")
+                            .await?;
+                    }
                 }
             }
             Action::DeleteWord => {
@@ -5437,6 +5535,9 @@ impl Editor {
             self.render(buffer)?;
         }
 
+        self.notify_editor_event_changes(event_snapshot_before_action, runtime, &action_cause)
+            .await?;
+
         Ok(false)
     }
 
@@ -5889,18 +5990,29 @@ impl Editor {
         }
     }
 
-    async fn notify_cursor_move(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
-        let cursor_info = serde_json::json!({
-            "x": self.cx,
-            "y": self.cy + self.vtop,
-            "viewport_top": self.vtop,
-            "buffer_index": self.current_buffer_index
+    async fn notify_search_highlighted(
+        &mut self,
+        runtime: &mut Runtime,
+        source: &str,
+    ) -> anyhow::Result<()> {
+        let payload = serde_json::json!({
+            "term": &self.search_term,
+            "direction": format!("{:?}", self.search_direction),
+            "source": source,
         });
-
         self.plugin_registry
-            .notify(runtime, "cursor:moved", cursor_info)
+            .notify(runtime, "search:highlighted", payload)
             .await?;
+        Ok(())
+    }
 
+    async fn notify_search_cleared(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
+        let payload = serde_json::json!({
+            "term": &self.search_term,
+        });
+        self.plugin_registry
+            .notify(runtime, "search:cleared", payload)
+            .await?;
         Ok(())
     }
 
@@ -7862,6 +7974,52 @@ mod test {
     use super::*;
     use std::path::PathBuf;
 
+    fn drain_plugin_requests() {
+        while ACTION_DISPATCHER.try_recv_request().is_some() {}
+    }
+
+    fn collect_print_requests() -> Vec<String> {
+        let mut prints = Vec::new();
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            if let PluginRequest::Action(Action::Print(message)) = request {
+                prints.push(message);
+            }
+        }
+        prints
+    }
+
+    async fn install_event_recorder(editor: &mut Editor, runtime: &mut Runtime) {
+        drain_plugin_requests();
+        let plugin_path =
+            std::env::temp_dir().join(format!("red-event-recorder-{}.js", uuid::Uuid::new_v4()));
+        std::fs::write(
+            &plugin_path,
+            r#"
+                export function activate(red) {
+                    red.on("cursor:moved", (event) => {
+                        red.execute("Print", `cursor:${event.cause}:${event.from.x},${event.from.y}->${event.to.x},${event.to.y}:${event.mode}`);
+                    });
+                    red.on("mode:changed", (event) => {
+                        red.execute("Print", `mode:${event.cause}:${event.from}->${event.to}`);
+                    });
+                    red.on("search:highlighted", (event) => {
+                        red.execute("Print", `search:${event.source}:${event.term}:${event.direction}`);
+                    });
+                    red.on("search:cleared", (event) => {
+                        red.execute("Print", `cleared:${event.term}`);
+                    });
+                }
+            "#,
+        )
+        .unwrap();
+
+        editor
+            .plugin_registry
+            .add("event_recorder", plugin_path.to_string_lossy().as_ref());
+        editor.plugin_registry.initialize(runtime).await.unwrap();
+        drain_plugin_requests();
+    }
+
     fn test_editor(width: usize, height: usize) -> Editor {
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
@@ -8220,6 +8378,97 @@ mod test {
 
         assert_eq!(render_buffer.cells[clicked_index].style, cursor_style);
         assert_ne!(render_buffer.cells[stale_goal_index].style, cursor_style);
+    }
+
+    #[tokio::test]
+    async fn cursor_moved_event_fires_for_next_word_motion() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "alpha beta".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+        let mut runtime = Runtime::new();
+        install_event_recorder(&mut editor, &mut runtime).await;
+
+        editor
+            .execute(&Action::MoveToNextWord, &mut render_buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(collect_print_requests()
+            .iter()
+            .any(|message| message == "cursor:MoveToNextWord:0,0->6,0:Normal"));
+    }
+
+    #[tokio::test]
+    async fn search_highlight_and_clear_emit_plugin_events() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "alpha beta\nalpha gamma".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+        let mut runtime = Runtime::new();
+        install_event_recorder(&mut editor, &mut runtime).await;
+
+        editor
+            .execute(
+                &Action::SearchWordUnderCursor,
+                &mut render_buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        let prints = collect_print_requests();
+        assert!(prints
+            .iter()
+            .any(|message| message == "search:SearchWordUnderCursor:alpha:Forward"));
+
+        editor
+            .execute(
+                &Action::ClearSearchHighlight,
+                &mut render_buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        let prints = collect_print_requests();
+        assert!(prints.iter().any(|message| message == "cleared:alpha"));
+    }
+
+    #[tokio::test]
+    async fn cancel_search_emits_mode_changed_event() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "alpha".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+        let mut runtime = Runtime::new();
+        install_event_recorder(&mut editor, &mut runtime).await;
+
+        editor
+            .execute(
+                &Action::EnterSearch(SearchDirection::Forward),
+                &mut render_buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        collect_print_requests();
+
+        editor
+            .execute(&Action::CancelSearch, &mut render_buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(collect_print_requests()
+            .iter()
+            .any(|message| message == "mode:CancelSearch:Search->Normal"));
     }
 
     #[tokio::test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7974,6 +7974,9 @@ mod test {
     use super::*;
     use std::path::PathBuf;
 
+    static EVENT_RECORDER_TEST_LOCK: Lazy<tokio::sync::Mutex<()>> =
+        Lazy::new(|| tokio::sync::Mutex::new(()));
+
     fn drain_plugin_requests() {
         while ACTION_DISPATCHER.try_recv_request().is_some() {}
     }
@@ -8382,6 +8385,7 @@ mod test {
 
     #[tokio::test]
     async fn cursor_moved_event_fires_for_next_word_motion() {
+        let _guard = EVENT_RECORDER_TEST_LOCK.lock().await;
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
         let buffer = Buffer::new(None, "alpha beta".to_string());
@@ -8404,6 +8408,7 @@ mod test {
 
     #[tokio::test]
     async fn search_highlight_and_clear_emit_plugin_events() {
+        let _guard = EVENT_RECORDER_TEST_LOCK.lock().await;
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
         let buffer = Buffer::new(None, "alpha beta\nalpha gamma".to_string());
@@ -8441,6 +8446,7 @@ mod test {
 
     #[tokio::test]
     async fn cancel_search_emits_mode_changed_event() {
+        let _guard = EVENT_RECORDER_TEST_LOCK.lock().await;
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
         let buffer = Buffer::new(None, "alpha".to_string());

--- a/src/plugin/runtime.js
+++ b/src/plugin/runtime.js
@@ -93,6 +93,10 @@ class RedContext {
     ops.op_trigger_action(command, args);
   }
 
+  clearSearchHighlight() {
+    this.execute("ClearSearchHighlight");
+  }
+
   getEditorInfo() {
     return new Promise((resolve, _reject) => {
       const reqId = nextReqId++;

--- a/test-harness/mock-red.js
+++ b/test-harness/mock-red.js
@@ -157,7 +157,15 @@ class MockRedAPI {
     // Emit cursor moved event
     this.emit("cursor:moved", {
       from: oldPos,
-      to: { x, y }
+      to: { x, y },
+      x,
+      y,
+      mode: "Normal",
+      cause: "setCursorPosition",
+      viewportTop: 0,
+      viewport_top: 0,
+      bufferIndex: this.mockState.current_buffer_index,
+      buffer_index: this.mockState.current_buffer_index
     });
   }
 
@@ -169,6 +177,10 @@ class MockRedAPI {
 
   execute(command, args) {
     this.logs.push(`execute: ${command} ${JSON.stringify(args || {})}`);
+  }
+
+  clearSearchHighlight() {
+    this.execute("ClearSearchHighlight");
   }
 
   getCommands() {

--- a/types/red.d.ts
+++ b/types/red.d.ts
@@ -121,6 +121,12 @@ namespace Red {
     from: string;
     /** New mode */
     to: string;
+    /** Previous mode, retained for compatibility */
+    old_mode?: string;
+    /** New mode, retained for compatibility */
+    new_mode?: string;
+    /** Editor action or event that caused the transition */
+    cause?: string;
   }
 
   /**
@@ -131,6 +137,36 @@ namespace Red {
     from: CursorPosition;
     /** New position */
     to: CursorPosition;
+    /** New column position */
+    x: number;
+    /** New line position */
+    y: number;
+    /** Editor mode after the move */
+    mode: string;
+    /** Editor action or event that caused the move */
+    cause: string;
+    /** Viewport top after the move */
+    viewportTop: number;
+    /** Viewport top, retained for compatibility */
+    viewport_top?: number;
+    /** Active buffer index after the move */
+    bufferIndex: number;
+    /** Active buffer index, retained for compatibility */
+    buffer_index?: number;
+  }
+
+  interface SearchHighlightEvent {
+    /** Current search term */
+    term: string;
+    /** Search direction */
+    direction: "Forward" | "Backward" | string;
+    /** Editor action that activated the highlights */
+    source: string;
+  }
+
+  interface SearchClearedEvent {
+    /** Search term that was cleared */
+    term: string;
   }
 
   /**
@@ -260,6 +296,8 @@ namespace Red {
     on(event: "buffer:changed", callback: (data: BufferChangeEvent) => void): void;
     on(event: "mode:changed", callback: (data: ModeChangeEvent) => void): void;
     on(event: "cursor:moved", callback: (data: CursorMoveEvent) => void): void;
+    on(event: "search:highlighted", callback: (data: SearchHighlightEvent) => void): void;
+    on(event: "search:cleared", callback: (data: SearchClearedEvent) => void): void;
     on(event: "file:opened", callback: (data: FileEvent) => void): void;
     on(event: "file:saved", callback: (data: FileEvent) => void): void;
     on(event: "lsp:progress", callback: (data: LspProgressEvent) => void): void;
@@ -279,6 +317,11 @@ namespace Red {
      * @param callback Event handler to remove
      */
     off(event: string, callback: (data: any) => void): void;
+
+    /**
+     * Clear visible search highlights until the next successful search
+     */
+    clearSearchHighlight(): void;
 
     /**
      * Get editor information


### PR DESCRIPTION
Red's search highlights currently have the same persistent behavior as Vim's `hlsearch`, but the editor did not expose enough ordinary state-change signals for a plugin to implement the `vim-cool` style of clearing highlights once the user has moved on. This PR adds that behavior as a bundled plugin while also making the plugin-facing editor events more useful for future editor-core integrations.

The net change adds a bundled `cool_search` plugin and enables it in the default config. The plugin listens for committed search highlights, then clears them through the new `red.clearSearchHighlight()` helper when the user enters Insert mode or performs ordinary Normal-mode movement. Search-caused movements such as `n`, `N`, `/...<Enter>`, and `*` keep the highlights active so the match navigation still feels natural.

To support that cleanly, the editor now emits `search:highlighted` and `search:cleared` lifecycle events, sends richer `cursor:moved` and `mode:changed` payloads, and routes search cancellation through a real `CancelSearch` action. Existing compatibility fields on cursor and mode events are preserved, and `:noh` / `:nohlsearch` continue to work as before.

## How to Test

1. Start Red with the bundled plugin enabled from the default config.
2. Search for a term with `/term<Enter>` and confirm the visible matches remain highlighted immediately after the search commits.
3. Press `n` or `N` and confirm the highlight remains while moving through search matches.
4. Move with a normal motion such as `w`, `h`, `j`, `k`, or `l`, and confirm the search highlights clear automatically.
5. Repeat a search, then press `i`, and confirm entering Insert mode also clears the highlights.
6. Run `:noh` or `:nohlsearch` and confirm manual clearing still behaves as before.

Targeted tests:

- `node test-harness/test-runner.js plugins/cool_search.js plugins/cool_search.test.js`
- `RUSTC_WRAPPER= cargo test --lib`
- `RUSTC_WRAPPER= cargo test search`
