### PR TITLE
feat: line wrapping and faster repeated motions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,13 @@
-# Pull requests
+# Pull Requests
 
-Use the good-pr skill for opening PRs.
+Before creating, editing, or marking a PR ready, read and follow
+`.agents/skills/good-pr/SKILL.md`.
+
+The `good-pr` instructions override generic GitHub/PR publishing defaults.
+Do not open draft PRs unless the user explicitly asks for a draft, and do not
+add title prefixes such as `[codex]` unless requested.
+
+# Validation
+
+Run `cargo clippy --all-targets --all-features -- -D warnings` before pushing
+Rust changes, and fix every warning or error it reports.

--- a/default_config.toml
+++ b/default_config.toml
@@ -18,6 +18,14 @@ mouse_scroll_lines = 3
 # when scrolling is possible. This matches Vim/Neovim's 'scrolloff'.
 scrolloff = 3
 
+# Wrap long lines at the window edge. This matches Vim/Neovim's 'wrap'.
+wrap = true
+
+# Horizontal scrolling behavior when wrap = false. These match
+# Vim/Neovim's 'sidescroll' and 'sidescrolloff'.
+sidescroll = 1
+sidescrolloff = 0
+
 [search]
 # Preview the next match while typing / or ?.
 incsearch = true
@@ -91,7 +99,7 @@ Esc = { EnterMode = "Normal" }
 "o" = [ { EnterMode = "Insert" }, "InsertLineBelowCursor" ]
 "O" = [ { EnterMode = "Insert" }, "InsertLineAtCursor" ]
 "G" = "MoveToBottom"
-"g" = { "g" = "MoveToTop", "d" = "GoToDefinition" }
+"g" = { "g" = "MoveToTop", "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd" }
 "u" = "Undo"
 "Ctrl-r" = "Redo"
 "Down" = "MoveDown"
@@ -113,7 +121,7 @@ Esc = { EnterMode = "Normal" }
 "Ctrl-o" = "JumpBack"
 "Tab" = "JumpForward"
 "x" = "DeleteCharAtCursorPos"
-"z" = { "z" = "MoveLineToViewportCenter" }
+"z" = { "z" = "MoveLineToViewportCenter", "h" = "ScrollViewLeft", "l" = "ScrollViewRight", "H" = "ScrollViewHalfPageLeft", "L" = "ScrollViewHalfPageRight", "s" = "ScrollCursorToViewStart", "e" = "ScrollCursorToViewEnd" }
 "*" = "SearchWordUnderCursor"
 "n" = "RepeatSearch"
 "N" = "RepeatSearchOpposite"

--- a/default_config.toml
+++ b/default_config.toml
@@ -140,7 +140,7 @@ Esc = { EnterMode = "Normal" }
 "Ctrl-e" = { PluginCommand = "NeoTree" }
 "Ctrl-t" = { PluginCommand = "LspDocumentSymbols" }
 "K" = "Hover"
-# "W" = "ToggleWrap"
+"W" = "ToggleWrap"
 # "L" = "DecreaseLeft"
 # "R" = "IncreaseLeft"
 "v" = { EnterMode = "Visual" }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -491,7 +491,7 @@ impl Buffer {
         let line = line.trim_end_matches('\n');
 
         // Check if we're at the last character of the buffer
-        let line_len = line.chars().count();
+        let line_len = Self::char_len(line);
         if y >= self.len() && x >= line_len.saturating_sub(1) {
             return None;
         }
@@ -506,10 +506,8 @@ impl Buffer {
             return Some((0, y));
         }
 
-        let chars: Vec<char> = line.chars().collect();
-
         // If we're at the end of current line, move to next line
-        if x >= chars.len() {
+        if x >= line_len {
             y += 1;
             if y > self.len() {
                 return None;
@@ -521,11 +519,8 @@ impl Buffer {
                 return Some((0, y));
             }
             // Find first non-whitespace on next line
-            let chars = next_line.chars().collect::<Vec<char>>();
-            for (i, &c) in chars.iter().enumerate() {
-                if Self::get_char_type(c) != CharType::Whitespace {
-                    return Some((i, y));
-                }
+            if let Some(i) = Self::first_non_whitespace_char(next_line) {
+                return Some((i, y));
             }
         }
 
@@ -535,28 +530,28 @@ impl Buffer {
             return Some((0, y));
         }
 
-        let chars = current_line.chars().collect::<Vec<char>>();
-        let last_char_position = chars.len().checked_sub(1).map(|last_x| (last_x, y));
+        let line_len = Self::char_len(current_line);
+        let last_char_position = line_len.checked_sub(1).map(|last_x| (last_x, y));
 
-        if x < chars.len() {
-            let start_type = Self::get_char_type(chars[x]);
+        if x < line_len {
+            let start_type = Self::char_type_at(current_line, x)?;
             x += 1;
 
-            while x < chars.len() && start_type != CharType::Whitespace {
-                let current_type = Self::get_char_type(chars[x]);
+            for (i, current_type) in Self::char_types(current_line).skip(x) {
+                if start_type == CharType::Whitespace {
+                    break;
+                }
                 if current_type != start_type {
                     break;
                 }
-                x += 1;
+                x = i + 1;
             }
         }
 
-        while x < chars.len() {
-            let current_type = Self::get_char_type(chars[x]);
+        for (i, current_type) in Self::char_types(current_line).skip(x) {
             if current_type != CharType::Whitespace {
-                return Some((x, y));
+                return Some((i, y));
             }
-            x += 1;
         }
 
         y += 1;
@@ -567,11 +562,8 @@ impl Buffer {
         // Find first non-whitespace on next line
         let next_line = self.get(y)?;
         let next_line = next_line.trim_end_matches('\n');
-        let chars = next_line.chars().collect::<Vec<char>>();
-        for (i, &c) in chars.iter().enumerate() {
-            if Self::get_char_type(c) != CharType::Whitespace {
-                return Some((i, y));
-            }
+        if let Some(i) = Self::first_non_whitespace_char(next_line) {
+            return Some((i, y));
         }
 
         Some((0, y))
@@ -581,17 +573,18 @@ impl Buffer {
     pub fn find_prev_word(&self, (mut x, mut y): (usize, usize)) -> Option<(usize, usize)> {
         // Get current line
         let line = self.get(y)?;
+        let line = line.trim_end_matches('\n');
 
         // Check if we're at start of buffer
         if y == 0 && x == 0 {
             return None;
         }
 
-        let chars: Vec<char> = line.chars().collect();
+        let line_len = Self::char_len(line);
 
         // If we're at the end of line, move back one
-        if x >= chars.len() {
-            x = chars.len().saturating_sub(1);
+        if x >= line_len {
+            x = line_len.saturating_sub(1);
         }
 
         // Move one character backward
@@ -602,62 +595,71 @@ impl Buffer {
             }
             y -= 1;
             let prev_line = self.get(y)?;
+            let prev_line = prev_line.trim_end_matches('\n');
             if prev_line.is_empty() {
                 return Some((0, y));
             }
-            let prev_chars: Vec<char> = prev_line.chars().collect();
-            x = prev_chars.len() - 1;
+            x = Self::char_len(prev_line) - 1;
         } else {
             x -= 1;
         }
 
         let current_line = self.get(y)?;
-        let chars: Vec<char> = current_line.chars().collect();
+        let current_line = current_line.trim_end_matches('\n');
 
         // Get the type of character we landed on
-        let start_type = Self::get_char_type(chars[x]);
+        let start_type = Self::char_type_at(current_line, x)?;
 
         // Skip whitespace backward
         if start_type == CharType::Whitespace {
-            while x > 0 && Self::get_char_type(chars[x]) == CharType::Whitespace {
-                x -= 1;
-            }
+            x = match Self::last_non_whitespace_at_or_before(current_line, x) {
+                Some(x) => x,
+                None => {
+                    if y == 0 {
+                        return None;
+                    }
+                    y -= 1;
+                    let prev_line = self.get(y)?;
+                    let prev_line = prev_line.trim_end_matches('\n');
+                    if prev_line.is_empty() {
+                        return Some((0, y));
+                    }
+                    Self::last_non_whitespace_at_or_before(
+                        prev_line,
+                        Self::char_len(prev_line).saturating_sub(1),
+                    )?
+                }
+            };
 
             // If we hit start of line while skipping whitespace, go to previous line
-            if x == 0 && Self::get_char_type(chars[0]) == CharType::Whitespace {
+            if x == 0 && Self::char_type_at(current_line, 0)? == CharType::Whitespace {
                 if y == 0 {
                     return None;
                 }
                 y -= 1;
                 let prev_line = self.get(y)?;
+                let prev_line = prev_line.trim_end_matches('\n');
                 if prev_line.is_empty() {
                     return Some((0, y));
                 }
-                let prev_chars: Vec<char> = prev_line.chars().collect();
-                x = prev_chars.len() - 1;
-                while x > 0 && Self::get_char_type(prev_chars[x]) == CharType::Whitespace {
-                    x -= 1;
-                }
+                x = Self::last_non_whitespace_at_or_before(
+                    prev_line,
+                    Self::char_len(prev_line).saturating_sub(1),
+                )?;
             }
         }
 
         let current_line = self.get(y)?;
-        let chars: Vec<char> = current_line.chars().collect();
-        let current_type = Self::get_char_type(chars[x]);
+        let current_line = current_line.trim_end_matches('\n');
+        let current_type = Self::char_type_at(current_line, x)?;
 
         // Move backward to start of current word/symbol
-        while x > 0 {
-            let prev_type = Self::get_char_type(chars[x - 1]);
-            if prev_type != current_type {
-                break;
-            }
-            x -= 1;
-        }
+        x = Self::word_start_at_or_before(current_line, x, current_type);
 
         // If we're at start of line, check previous line
         if x == 0 && y > 0 {
             let prev_line = self.get(y - 1)?;
-            if prev_line.is_empty() {
+            if prev_line.trim_end_matches('\n').is_empty() {
                 return Some((0, y - 1));
             }
         }
@@ -810,9 +812,59 @@ impl Buffer {
             CharType::Symbol
         }
     }
+
+    fn char_len(line: &str) -> usize {
+        line.chars().count()
+    }
+
+    fn char_types(line: &str) -> impl Iterator<Item = (usize, CharType)> + '_ {
+        line.chars()
+            .enumerate()
+            .map(|(i, c)| (i, Self::get_char_type(c)))
+    }
+
+    fn char_type_at(line: &str, x: usize) -> Option<CharType> {
+        line.chars().nth(x).map(Self::get_char_type)
+    }
+
+    fn first_non_whitespace_char(line: &str) -> Option<usize> {
+        Self::char_types(line)
+            .find(|(_, kind)| *kind != CharType::Whitespace)
+            .map(|(i, _)| i)
+    }
+
+    fn last_non_whitespace_at_or_before(line: &str, x: usize) -> Option<usize> {
+        let mut index = Self::char_len(line);
+        for c in line.chars().rev() {
+            index = index.saturating_sub(1);
+            if index > x {
+                continue;
+            }
+            if Self::get_char_type(c) != CharType::Whitespace {
+                return Some(index);
+            }
+        }
+        None
+    }
+
+    fn word_start_at_or_before(line: &str, x: usize, target_type: CharType) -> usize {
+        let mut start = x;
+        let mut index = Self::char_len(line);
+        for c in line.chars().rev() {
+            index = index.saturating_sub(1);
+            if index > x {
+                continue;
+            }
+            if Self::get_char_type(c) != target_type {
+                break;
+            }
+            start = index;
+        }
+        start
+    }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CharType {
     Whitespace,
     Word,

--- a/src/config.rs
+++ b/src/config.rs
@@ -712,6 +712,16 @@ theme = "mocha.json"
     }
 
     #[test]
+    fn default_config_maps_wrap_toggle_key() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.keys.normal.get("W"),
+            Some(&KeyAction::Single(Action::ToggleWrap))
+        );
+    }
+
+    #[test]
     fn default_config_enables_window_management_prefix() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
         let Some(KeyAction::Nested(ctrl_w)) = config.keys.normal.get("Ctrl-w") else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,9 @@ pub struct Config {
     pub log_file: Option<String>,
     pub mouse_scroll_lines: Option<usize>,
     pub scrolloff: Option<usize>,
+    pub wrap: Option<bool>,
+    pub sidescroll: Option<usize>,
+    pub sidescrolloff: Option<usize>,
     #[serde(default)]
     pub search: SearchConfig,
     #[serde(default)]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2844,7 +2844,7 @@ impl Editor {
         };
 
         Some(KeySignature {
-            code: code.clone(),
+            code: *code,
             modifiers: *modifiers,
         })
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -4524,23 +4524,23 @@ impl Editor {
             }
             Action::MoveScreenLineUp => {
                 self.move_screen_line(-1);
-                self.render(buffer)?;
+                self.finish_cursor_motion(buffer, false)?;
             }
             Action::MoveScreenLineDown => {
                 self.move_screen_line(1);
-                self.render(buffer)?;
+                self.finish_cursor_motion(buffer, false)?;
             }
             Action::MoveToScreenLineStart => {
                 self.move_to_screen_line_start();
-                self.render(buffer)?;
+                self.finish_cursor_motion(buffer, false)?;
             }
             Action::MoveToScreenLineFirstNonBlank => {
                 self.move_to_screen_line_first_non_blank();
-                self.render(buffer)?;
+                self.finish_cursor_motion(buffer, false)?;
             }
             Action::MoveToScreenLineEnd => {
                 self.move_to_screen_line_end();
-                self.render(buffer)?;
+                self.finish_cursor_motion(buffer, false)?;
             }
             Action::PageUp => {
                 let target_line = self

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3460,6 +3460,8 @@ impl Editor {
             "only",
             "noh",
             "nohlsearch",
+            "wrap",
+            "nowrap",
         ];
         let parsed = command::parse(commands, cmd);
 
@@ -3541,6 +3543,14 @@ impl Editor {
 
             if cmd == "noh" || cmd == "nohlsearch" {
                 actions.push(Action::ClearSearchHighlight);
+            }
+
+            if cmd == "wrap" {
+                actions.push(Action::SetWrap(true));
+            }
+
+            if cmd == "nowrap" {
+                actions.push(Action::SetWrap(false));
             }
         }
         actions

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -29,12 +29,10 @@ use crate::unicode_utils::{
 /// It maintains the terminal UI and coordinates all editor functionality.
 use crossterm::{
     event::{
-        self, Event, EventStream, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
-        MouseEventKind,
+        self, Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     },
     terminal, ExecutableCommand,
 };
-use futures::{future::FutureExt, select, StreamExt};
 #[cfg(unix)]
 use nix::sys::signal::{self, Signal};
 #[cfg(unix)]
@@ -77,6 +75,7 @@ pub static ACTION_DISPATCHER: Lazy<Dispatcher<PluginRequest, PluginResponse>> =
 
 pub const DEFAULT_REGISTER: char = '"';
 const JUMPLIST_SIZE: usize = 100;
+const REPEATED_MOTION_DRAIN_BUDGET_MS: u64 = 50;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EditorViewState {
@@ -85,6 +84,25 @@ struct EditorViewState {
     skipcol: usize,
     cy: usize,
     wrap: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct KeySignature {
+    code: KeyCode,
+    modifiers: KeyModifiers,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessedEvent {
+    quit: bool,
+    drain_repeated_motion: bool,
+    repeat_signature: Option<KeySignature>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventRenderMode {
+    Immediate,
+    DeferredMotion,
 }
 
 fn expanded_path_string(path: &str) -> anyhow::Result<String> {
@@ -647,6 +665,15 @@ pub struct Editor {
     /// Incremented after full renders so event handling can avoid duplicate frames.
     render_generation: u64,
 
+    /// Last terminal cursor cell painted into the render buffer.
+    last_rendered_cursor_position: Option<(usize, usize)>,
+
+    /// Suppresses per-step repainting while queued repeated motions are drained.
+    defer_motion_render: bool,
+
+    /// Tracks whether deferred motion changed the visible viewport.
+    deferred_motion_needs_full_render: bool,
+
     /// Terminal size (width, height)
     size: (u16, u16),
 
@@ -1075,6 +1102,9 @@ impl Editor {
             terminal_output_enabled: true,
             is_focused: true,
             render_generation: 0,
+            last_rendered_cursor_position: None,
+            defer_motion_render: false,
+            deferred_motion_needs_full_render: false,
             size,
             vtop: 0,
             vleft: 0,
@@ -1223,8 +1253,17 @@ impl Editor {
         self.fix_cursor_pos();
         self.sync_to_window();
 
+        if self.defer_motion_render {
+            if self.editor_view_state() != before {
+                self.deferred_motion_needs_full_render = true;
+            }
+            return Ok(());
+        }
+
         if self.editor_view_state() != before {
             self.render(buffer)
+        } else if self.can_render_cursor_motion_delta() {
+            self.render_cursor_motion_delta(buffer)
         } else if self.uses_synthetic_block_cursor() {
             self.render_motion_frame(buffer)
         } else {
@@ -2114,488 +2153,506 @@ impl Editor {
         self.ensure_current_buffer_lsp_opened().await?;
         self.render(&mut buffer)?;
 
-        let mut reader = EventStream::new();
+        'editor_loop: loop {
+            futures_timer::Delay::new(Duration::from_millis(10)).await;
 
-        loop {
-            let mut delay = futures_timer::Delay::new(Duration::from_millis(10)).fuse();
-            let mut event = reader.next().fuse();
-
-            select! {
-                _ = delay => {
-                    // Poll for timer callbacks
-                    let timer_callbacks = crate::plugin::poll_timer_callbacks();
-                    for callback_request in timer_callbacks {
-                        if let PluginRequest::TimeoutCallback { timer_id } = callback_request {
-                            log!("[TIMER] Processing timeout callback for timer: {}", timer_id);
-                            self.plugin_registry
-                                .notify(&mut runtime, "timeout:callback", json!({ "timerId": timer_id }))
-                                .await?;
-                        }
+            while event::poll(Duration::from_millis(0))? {
+                let ev = event::read()?;
+                let processed = self
+                    .process_editor_event(ev, &mut buffer, &mut runtime, EventRenderMode::Immediate)
+                    .await?;
+                if processed.quit {
+                    break 'editor_loop;
+                }
+                if let Some(signature) = processed
+                    .drain_repeated_motion
+                    .then_some(processed.repeat_signature)
+                    .flatten()
+                {
+                    if self
+                        .drain_repeated_motion_events(signature, &mut buffer, &mut runtime)
+                        .await?
+                    {
+                        break 'editor_loop;
                     }
+                }
+            }
 
-                    for (watch_id, payload) in self.poll_directory_watchers() {
+            // Poll for timer callbacks
+            let timer_callbacks = crate::plugin::poll_timer_callbacks();
+            for callback_request in timer_callbacks {
+                if let PluginRequest::TimeoutCallback { timer_id } = callback_request {
+                    log!(
+                        "[TIMER] Processing timeout callback for timer: {}",
+                        timer_id
+                    );
+                    self.plugin_registry
+                        .notify(
+                            &mut runtime,
+                            "timeout:callback",
+                            json!({ "timerId": timer_id }),
+                        )
+                        .await?;
+                }
+            }
+
+            for (watch_id, payload) in self.poll_directory_watchers() {
+                self.plugin_registry
+                    .notify(
+                        &mut runtime,
+                        &format!("filesystem:changed:{watch_id}"),
+                        payload,
+                    )
+                    .await?;
+            }
+
+            let dialog_changed = if let Some(current_dialog) = &mut self.current_dialog {
+                current_dialog.tick()?
+            } else {
+                false
+            };
+            if dialog_changed {
+                self.render(&mut buffer)?;
+            }
+
+            // if self.sync_state.should_notify() {
+            //     for file in self.sync_state.get_changes().unwrap_or_default() {
+            //         // FIXME: not current buffer!
+            //         self.lsp
+            //             .did_change(&file, &self.current_buffer().contents())
+            //             .await?;
+            //     }
+            //     //
+            //     // if let Some(uri) = self.current_buffer().uri()? {
+            //     //     self.lsp.request_diagnostics(&uri).await?;
+            //     // }
+            // }
+
+            // Always pump LSP responses. `recv_response` completes the
+            // initialize handshake and flushes queued didOpen/change
+            // messages, so it must not depend on diagnostic display.
+            match self.lsp.recv_response().await {
+                Ok(Some((msg, method))) => {
+                    if let Some(action) = self.handle_lsp_message(&msg, method) {
+                        // TODO: handle quit
+                        // let current_buffer = buffer.clone();
+                        self.execute(&action, &mut buffer, &mut runtime).await?;
+                        self.render(&mut buffer)?;
+                        // self.redraw(&mut runtime, &current_buffer, &mut buffer).await?;
+                    }
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    log!("ERROR: Lsp error: {err}");
+                }
+            }
+
+            if let Some(req) = ACTION_DISPATCHER.try_recv_request() {
+                match req {
+                    PluginRequest::Action(action) => {
+                        // let current_buffer = buffer.clone();
+                        self.execute(&action, &mut buffer, &mut runtime).await?;
+                        self.render(&mut buffer)?;
+                        // self.redraw(&mut runtime, &current_buffer, &mut buffer).await?;
+                    }
+                    PluginRequest::EditorInfo(id) => {
+                        let info = serde_json::to_value(self.info())?;
+                        let key = if let Some(id) = id {
+                            format!("editor:info:{}", id)
+                        } else {
+                            "editor:info".to_string()
+                        };
+                        self.plugin_registry
+                            .notify(&mut runtime, &key, info)
+                            .await?;
+                    }
+                    PluginRequest::OpenPicker(title, id, items) => {
+                        // let current_buffer = buffer.clone();
+                        let items = items
+                            .iter()
+                            .map(|v| match v {
+                                serde_json::Value::String(s) => s.clone(),
+                                val => val.to_string(),
+                            })
+                            .collect();
+                        self.execute(
+                            &Action::OpenPicker(title, items, id),
+                            &mut buffer,
+                            &mut runtime,
+                        )
+                        .await?;
+                        // self.render(buffer)?;
+                    }
+                    PluginRequest::OpenLivePicker(title, id, items, initial_selection) => {
+                        let items = items
+                            .iter()
+                            .map(|v| match v {
+                                serde_json::Value::String(s) => s.clone(),
+                                val => val.to_string(),
+                            })
+                            .collect();
+                        self.execute(
+                            &Action::OpenLivePicker(title, items, id, initial_selection),
+                            &mut buffer,
+                            &mut runtime,
+                        )
+                        .await?;
+                    }
+                    PluginRequest::BufferInsert { x, y, text } => {
+                        self.begin_transaction("plugin insert");
+                        self.replace_range(TextRange::insertion(TextPosition::new(y, x)), &text);
+                        self.commit_transaction(self.cursor_snapshot());
+                        self.notify_change(&mut runtime).await?;
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::BufferDelete { x, y, length } => {
+                        self.begin_transaction("plugin delete");
+                        self.replace_range(
+                            TextRange::new(
+                                TextPosition::new(y, x),
+                                TextPosition::new(y, x + length),
+                            ),
+                            "",
+                        );
+                        self.commit_transaction(self.cursor_snapshot());
+                        self.notify_change(&mut runtime).await?;
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::BufferReplace { x, y, length, text } => {
+                        self.begin_transaction("plugin replace");
+                        self.replace_range(
+                            TextRange::new(
+                                TextPosition::new(y, x),
+                                TextPosition::new(y, x + length),
+                            ),
+                            &text,
+                        );
+                        self.commit_transaction(self.cursor_snapshot());
+                        self.notify_change(&mut runtime).await?;
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::GetCursorPosition => {
+                        let pos = serde_json::json!({
+                            "x": self.cx,
+                            "y": self.cy + self.vtop
+                        });
+                        self.plugin_registry
+                            .notify(&mut runtime, "cursor:position", pos)
+                            .await?;
+                    }
+                    PluginRequest::GetCursorDisplayColumn => {
+                        let display_col = if let Some(line) = self.current_line_contents() {
+                            let line = line.trim_end_matches('\n');
+                            crate::unicode_utils::grapheme_to_column(line, self.cx)
+                        } else {
+                            self.cx
+                        };
+                        let pos = serde_json::json!({
+                            "column": display_col,
+                            "y": self.cy + self.vtop
+                        });
+                        self.plugin_registry
+                            .notify(&mut runtime, "cursor:display_position", pos)
+                            .await?;
+                    }
+                    PluginRequest::SetCursorPosition { x, y } => {
+                        self.cx = x;
+                        // Adjust viewport if needed
+                        if y < self.vtop {
+                            self.vtop = y;
+                            self.cy = 0;
+                        } else if y >= self.vtop + self.vheight() {
+                            self.vtop = y.saturating_sub(self.vheight() - 1);
+                            self.cy = self.vheight() - 1;
+                        } else {
+                            self.cy = y - self.vtop;
+                        }
+                        self.draw_cursor()?;
+                    }
+                    PluginRequest::SetCursorDisplayColumn { column, y } => {
+                        // Convert display column to character index
+                        if let Some(line) = self.viewport_line(y - self.vtop) {
+                            let line = line.trim_end_matches('\n');
+                            self.cx = crate::unicode_utils::column_to_grapheme(line, column);
+                        }
+                        // Adjust viewport if needed
+                        if y < self.vtop {
+                            self.vtop = y;
+                            self.cy = 0;
+                        } else if y >= self.vtop + self.vheight() {
+                            self.vtop = y.saturating_sub(self.vheight() - 1);
+                            self.cy = self.vheight() - 1;
+                        } else {
+                            self.cy = y - self.vtop;
+                        }
+                        self.draw_cursor()?;
+                    }
+                    PluginRequest::GetBufferText {
+                        start_line,
+                        end_line,
+                    } => {
+                        let current_buf = self.current_buffer();
+                        let start = start_line.unwrap_or(0);
+                        let end = end_line.unwrap_or(current_buf.len());
+                        let mut lines = Vec::new();
+                        for i in start..end.min(current_buf.len()) {
+                            if let Some(line) = current_buf.get(i) {
+                                lines.push(line);
+                            }
+                        }
+                        let text = lines.join("\n");
                         self.plugin_registry
                             .notify(
                                 &mut runtime,
-                                &format!("filesystem:changed:{watch_id}"),
+                                "buffer:text",
+                                serde_json::json!({ "text": text }),
+                            )
+                            .await?;
+                    }
+                    PluginRequest::GetConfig { key } => {
+                        let config_value = if let Some(key) = key {
+                            // Return specific config value
+                            match key.as_str() {
+                                "theme" => json!(self.config.theme),
+                                "plugins" => json!(self.config.plugins),
+                                "log_file" => json!(self.config.log_file),
+                                "mouse_scroll_lines" => json!(self.config.mouse_scroll_lines),
+                                "scrolloff" => json!(self.config.scrolloff),
+                                "show_diagnostics" => json!(self.config.show_diagnostics),
+                                "startup_file_count" => json!(self.config.startup_file_count),
+                                "cwd" => json!(std::env::current_dir()
+                                    .ok()
+                                    .map(|path| path.to_string_lossy().to_string())),
+                                "keys" => json!(self.config.keys),
+                                _ => json!(null),
+                            }
+                        } else {
+                            // Return entire config
+                            json!({
+                                "theme": self.config.theme,
+                                "plugins": self.config.plugins,
+                                "log_file": self.config.log_file,
+                                "mouse_scroll_lines": self.config.mouse_scroll_lines,
+                                "scrolloff": self.config.scrolloff,
+                                "show_diagnostics": self.config.show_diagnostics,
+                                "startup_file_count": self.config.startup_file_count,
+                                "cwd": std::env::current_dir().ok().map(|path| path.to_string_lossy().to_string()),
+                                "keys": self.config.keys,
+                            })
+                        };
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                "config:value",
+                                json!({ "value": config_value }),
+                            )
+                            .await?;
+                    }
+                    PluginRequest::GetEditorState { request_id } => {
+                        let snapshot = self.editor_state_snapshot();
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                &format!("editor:state:{request_id}"),
+                                serde_json::to_value(snapshot)?,
+                            )
+                            .await?;
+                    }
+                    PluginRequest::RestoreEditorState {
+                        request_id,
+                        snapshot,
+                    } => {
+                        let result = self.restore_editor_state(snapshot, &mut buffer).await;
+                        let payload = match result {
+                            Ok(result) => serde_json::to_value(result)?,
+                            Err(err) => json!({
+                                "restored": false,
+                                "openedFiles": [],
+                                "skippedFiles": [],
+                                "warnings": [err.to_string()],
+                            }),
+                        };
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                &format!("editor:restore:{request_id}"),
+                                payload,
+                            )
+                            .await?;
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::DocumentSymbols { request_id } => {
+                        let event = format!("lsp:document_symbols:{request_id}");
+                        let Some(file) = self.current_buffer().file.clone() else {
+                            self.plugin_registry
+                                .notify(
+                                    &mut runtime,
+                                    &event,
+                                    plugin_lsp_error("current buffer is not file-backed"),
+                                )
+                                .await?;
+                            continue;
+                        };
+
+                        let request_result: anyhow::Result<i64> = async {
+                            self.ensure_current_buffer_lsp_opened().await?;
+                            Ok(self.lsp.document_symbols(&file).await?)
+                        }
+                        .await;
+
+                        match request_result {
+                            Ok(lsp_request_id) if lsp_request_id > 0 => {
+                                self.pending_plugin_document_symbols
+                                    .insert(lsp_request_id, request_id);
+                            }
+                            Ok(_) => {
+                                self.plugin_registry
+                                    .notify(
+                                        &mut runtime,
+                                        &event,
+                                        plugin_lsp_error(
+                                            "no language server is available for this file",
+                                        ),
+                                    )
+                                    .await?;
+                            }
+                            Err(err) => {
+                                self.plugin_registry
+                                    .notify(
+                                        &mut runtime,
+                                        &event,
+                                        plugin_lsp_error(&err.to_string()),
+                                    )
+                                    .await?;
+                            }
+                        }
+                    }
+                    PluginRequest::GetTextDisplayWidth { text } => {
+                        let width = crate::unicode_utils::display_width(&text);
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                "text:display_width",
+                                json!({ "width": width }),
+                            )
+                            .await?;
+                    }
+                    PluginRequest::CharIndexToDisplayColumn { x, y } => {
+                        let display_col = if let Some(line) = self.current_buffer().get(y) {
+                            let line = line.trim_end_matches('\n');
+                            crate::unicode_utils::char_to_column(line, x)
+                        } else {
+                            x
+                        };
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                "char:display_column",
+                                json!({ "column": display_col }),
+                            )
+                            .await?;
+                    }
+                    PluginRequest::DisplayColumnToCharIndex { column, y } => {
+                        let char_index = if let Some(line) = self.current_buffer().get(y) {
+                            let line = line.trim_end_matches('\n');
+                            crate::unicode_utils::column_to_char(line, column)
+                        } else {
+                            column
+                        };
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                "display:char_index",
+                                json!({ "index": char_index }),
+                            )
+                            .await?;
+                    }
+                    PluginRequest::IntervalCallback { interval_id } => {
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                "interval:callback",
+                                json!({ "intervalId": interval_id }),
+                            )
+                            .await?;
+                    }
+                    PluginRequest::TimeoutCallback { timer_id } => {
+                        log!(
+                            "[TIMER] Processing timeout callback for timer: {}",
+                            timer_id
+                        );
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                "timeout:callback",
+                                json!({ "timerId": timer_id }),
+                            )
+                            .await?;
+                    }
+                    PluginRequest::CreateOverlay { id, config } => {
+                        log!("Creating overlay: {}", id);
+                        self.overlay_manager.create_overlay(id, config);
+                    }
+                    PluginRequest::UpdateOverlay { id, lines } => {
+                        log!("Updating overlay: {}", id);
+                        if let Some(overlay) = self.overlay_manager.get_overlay_mut(&id) {
+                            overlay.update_content(lines);
+                        }
+                    }
+                    PluginRequest::RemoveOverlay { id } => {
+                        log!("Removing overlay: {}", id);
+                        self.overlay_manager.remove_overlay(&id);
+                    }
+                    PluginRequest::CreatePanel { id, config } => {
+                        self.panel_manager.create_panel(id, config);
+                        self.apply_panel_layout();
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::UpdatePanel { id, rows } => {
+                        self.panel_manager.update_panel(&id, rows);
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::FocusPanel { id } => {
+                        self.panel_manager.focus_panel(&id);
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::FocusEditor => {
+                        self.panel_manager.focus_editor();
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::ClosePanel { id } => {
+                        self.panel_manager.close_panel(&id);
+                        self.apply_panel_layout();
+                        self.render(&mut buffer)?;
+                    }
+                    PluginRequest::ListDirectory { path, request_id } => {
+                        let payload = directory_listing(&path);
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                &format!("filesystem:directory:{request_id}"),
                                 payload,
                             )
                             .await?;
                     }
-
-                    let dialog_changed = if let Some(current_dialog) = &mut self.current_dialog {
-                        current_dialog.tick()?
-                    } else {
-                        false
-                    };
-                    if dialog_changed {
-                        self.render(&mut buffer)?;
+                    PluginRequest::GetGitStatus { path, request_id } => {
+                        let payload = git_status_listing(&path);
+                        self.plugin_registry
+                            .notify(&mut runtime, &format!("git:status:{request_id}"), payload)
+                            .await?;
                     }
-
-                    // if self.sync_state.should_notify() {
-                    //     for file in self.sync_state.get_changes().unwrap_or_default() {
-                    //         // FIXME: not current buffer!
-                    //         self.lsp
-                    //             .did_change(&file, &self.current_buffer().contents())
-                    //             .await?;
-                    //     }
-                    //     //
-                    //     // if let Some(uri) = self.current_buffer().uri()? {
-                    //     //     self.lsp.request_diagnostics(&uri).await?;
-                    //     // }
-                    // }
-
-                    // Always pump LSP responses. `recv_response` completes the
-                    // initialize handshake and flushes queued didOpen/change
-                    // messages, so it must not depend on diagnostic display.
-                    match self.lsp.recv_response().await {
-                        Ok(Some((msg, method))) => {
-                            if let Some(action) = self.handle_lsp_message(&msg, method) {
-                                // TODO: handle quit
-                                // let current_buffer = buffer.clone();
-                                self.execute(&action, &mut buffer, &mut runtime).await?;
-                                self.render(&mut buffer)?;
-                                // self.redraw(&mut runtime, &current_buffer, &mut buffer).await?;
-                            }
-                        }
-                        Ok(None) => {},
-                        Err(err) => {
-                            log!("ERROR: Lsp error: {err}");
-                        }
+                    PluginRequest::WatchDirectory { path, watch_id } => {
+                        self.directory_watchers.insert(
+                            watch_id,
+                            DirectoryWatcher {
+                                snapshot: directory_listing(&path),
+                                path,
+                                last_checked: Instant::now(),
+                            },
+                        );
                     }
-
-                    if let Some(req) = ACTION_DISPATCHER.try_recv_request() {
-                        match req {
-                            PluginRequest::Action(action) => {
-                                // let current_buffer = buffer.clone();
-                                self.execute(&action, &mut buffer, &mut runtime).await?;
-                                self.render(&mut buffer)?;
-                                // self.redraw(&mut runtime, &current_buffer, &mut buffer).await?;
-                            }
-                            PluginRequest::EditorInfo(id) => {
-                                let info = serde_json::to_value(self.info())?;
-                                let key = if let Some(id) = id {
-                                    format!("editor:info:{}", id)
-                                } else {
-                                    "editor:info".to_string()
-                                };
-                                self.plugin_registry
-                                    .notify(&mut runtime, &key, info)
-                                    .await?;
-                            }
-                            PluginRequest::OpenPicker(title, id, items) => {
-                                // let current_buffer = buffer.clone();
-                                let items = items.iter().map(|v| match v {
-                                    serde_json::Value::String(s) => s.clone(),
-                                    val => val.to_string(),
-                                }).collect();
-                                self.execute(&Action::OpenPicker(title, items, id), &mut buffer, &mut runtime).await?;
-                                // self.render(buffer)?;
-                            }
-                            PluginRequest::OpenLivePicker(title, id, items, initial_selection) => {
-                                let items = items.iter().map(|v| match v {
-                                    serde_json::Value::String(s) => s.clone(),
-                                    val => val.to_string(),
-                                }).collect();
-                                self.execute(&Action::OpenLivePicker(title, items, id, initial_selection), &mut buffer, &mut runtime).await?;
-                            }
-                            PluginRequest::BufferInsert { x, y, text } => {
-                                self.begin_transaction("plugin insert");
-                                self.replace_range(
-                                    TextRange::insertion(TextPosition::new(y, x)),
-                                    &text,
-                                );
-                                self.commit_transaction(self.cursor_snapshot());
-                                self.notify_change(&mut runtime).await?;
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::BufferDelete { x, y, length } => {
-                                self.begin_transaction("plugin delete");
-                                self.replace_range(
-                                    TextRange::new(
-                                        TextPosition::new(y, x),
-                                        TextPosition::new(y, x + length),
-                                    ),
-                                    "",
-                                );
-                                self.commit_transaction(self.cursor_snapshot());
-                                self.notify_change(&mut runtime).await?;
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::BufferReplace { x, y, length, text } => {
-                                self.begin_transaction("plugin replace");
-                                self.replace_range(
-                                    TextRange::new(
-                                        TextPosition::new(y, x),
-                                        TextPosition::new(y, x + length),
-                                    ),
-                                    &text,
-                                );
-                                self.commit_transaction(self.cursor_snapshot());
-                                self.notify_change(&mut runtime).await?;
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::GetCursorPosition => {
-                                let pos = serde_json::json!({
-                                    "x": self.cx,
-                                    "y": self.cy + self.vtop
-                                });
-                                self.plugin_registry
-                                    .notify(&mut runtime, "cursor:position", pos)
-                                    .await?;
-                            }
-                            PluginRequest::GetCursorDisplayColumn => {
-                                let display_col = if let Some(line) = self.current_line_contents() {
-                                    let line = line.trim_end_matches('\n');
-                                    crate::unicode_utils::grapheme_to_column(line, self.cx)
-                                } else {
-                                    self.cx
-                                };
-                                let pos = serde_json::json!({
-                                    "column": display_col,
-                                    "y": self.cy + self.vtop
-                                });
-                                self.plugin_registry
-                                    .notify(&mut runtime, "cursor:display_position", pos)
-                                    .await?;
-                            }
-                            PluginRequest::SetCursorPosition { x, y } => {
-                                self.cx = x;
-                                // Adjust viewport if needed
-                                if y < self.vtop {
-                                    self.vtop = y;
-                                    self.cy = 0;
-                                } else if y >= self.vtop + self.vheight() {
-                                    self.vtop = y.saturating_sub(self.vheight() - 1);
-                                    self.cy = self.vheight() - 1;
-                                } else {
-                                    self.cy = y - self.vtop;
-                                }
-                                self.draw_cursor()?;
-                            }
-                            PluginRequest::SetCursorDisplayColumn { column, y } => {
-                                // Convert display column to character index
-                                if let Some(line) = self.viewport_line(y - self.vtop) {
-                                    let line = line.trim_end_matches('\n');
-                                    self.cx = crate::unicode_utils::column_to_grapheme(line, column);
-                                }
-                                // Adjust viewport if needed
-                                if y < self.vtop {
-                                    self.vtop = y;
-                                    self.cy = 0;
-                                } else if y >= self.vtop + self.vheight() {
-                                    self.vtop = y.saturating_sub(self.vheight() - 1);
-                                    self.cy = self.vheight() - 1;
-                                } else {
-                                    self.cy = y - self.vtop;
-                                }
-                                self.draw_cursor()?;
-                            }
-                            PluginRequest::GetBufferText { start_line, end_line } => {
-                                let current_buf = self.current_buffer();
-                                let start = start_line.unwrap_or(0);
-                                let end = end_line.unwrap_or(current_buf.len());
-                                let mut lines = Vec::new();
-                                for i in start..end.min(current_buf.len()) {
-                                    if let Some(line) = current_buf.get(i) {
-                                        lines.push(line);
-                                    }
-                                }
-                                let text = lines.join("\n");
-                                self.plugin_registry
-                                    .notify(&mut runtime, "buffer:text", serde_json::json!({ "text": text }))
-                                    .await?;
-                            }
-                            PluginRequest::GetConfig { key } => {
-                                let config_value = if let Some(key) = key {
-                                    // Return specific config value
-                                    match key.as_str() {
-                                        "theme" => json!(self.config.theme),
-                                        "plugins" => json!(self.config.plugins),
-                                        "log_file" => json!(self.config.log_file),
-                                        "mouse_scroll_lines" => json!(self.config.mouse_scroll_lines),
-                                        "scrolloff" => json!(self.config.scrolloff),
-                                        "show_diagnostics" => json!(self.config.show_diagnostics),
-                                        "startup_file_count" => json!(self.config.startup_file_count),
-                                        "cwd" => json!(std::env::current_dir().ok().map(|path| path.to_string_lossy().to_string())),
-                                        "keys" => json!(self.config.keys),
-                                        _ => json!(null),
-                                    }
-                                } else {
-                                    // Return entire config
-                                    json!({
-                                        "theme": self.config.theme,
-                                        "plugins": self.config.plugins,
-                                        "log_file": self.config.log_file,
-                                        "mouse_scroll_lines": self.config.mouse_scroll_lines,
-                                        "scrolloff": self.config.scrolloff,
-                                        "show_diagnostics": self.config.show_diagnostics,
-                                        "startup_file_count": self.config.startup_file_count,
-                                        "cwd": std::env::current_dir().ok().map(|path| path.to_string_lossy().to_string()),
-                                        "keys": self.config.keys,
-                                    })
-                                };
-                                self.plugin_registry
-                                    .notify(&mut runtime, "config:value", json!({ "value": config_value }))
-                                    .await?;
-                            }
-                            PluginRequest::GetEditorState { request_id } => {
-                                let snapshot = self.editor_state_snapshot();
-                                self.plugin_registry
-                                    .notify(
-                                        &mut runtime,
-                                        &format!("editor:state:{request_id}"),
-                                        serde_json::to_value(snapshot)?,
-                                    )
-                                    .await?;
-                            }
-                            PluginRequest::RestoreEditorState { request_id, snapshot } => {
-                                let result = self
-                                    .restore_editor_state(snapshot, &mut buffer)
-                                    .await;
-                                let payload = match result {
-                                    Ok(result) => serde_json::to_value(result)?,
-                                    Err(err) => json!({
-                                        "restored": false,
-                                        "openedFiles": [],
-                                        "skippedFiles": [],
-                                        "warnings": [err.to_string()],
-                                    }),
-                                };
-                                self.plugin_registry
-                                    .notify(
-                                        &mut runtime,
-                                        &format!("editor:restore:{request_id}"),
-                                        payload,
-                                    )
-                                    .await?;
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::DocumentSymbols { request_id } => {
-                                let event = format!("lsp:document_symbols:{request_id}");
-                                let Some(file) = self.current_buffer().file.clone() else {
-                                    self.plugin_registry
-                                        .notify(
-                                            &mut runtime,
-                                            &event,
-                                            plugin_lsp_error("current buffer is not file-backed"),
-                                        )
-                                        .await?;
-                                    continue;
-                                };
-
-                                let request_result: anyhow::Result<i64> = async {
-                                    self.ensure_current_buffer_lsp_opened().await?;
-                                    Ok(self.lsp.document_symbols(&file).await?)
-                                }
-                                .await;
-
-                                match request_result {
-                                    Ok(lsp_request_id) if lsp_request_id > 0 => {
-                                        self.pending_plugin_document_symbols
-                                            .insert(lsp_request_id, request_id);
-                                    }
-                                    Ok(_) => {
-                                        self.plugin_registry
-                                            .notify(
-                                                &mut runtime,
-                                                &event,
-                                                plugin_lsp_error(
-                                                    "no language server is available for this file",
-                                                ),
-                                            )
-                                            .await?;
-                                    }
-                                    Err(err) => {
-                                        self.plugin_registry
-                                            .notify(
-                                                &mut runtime,
-                                                &event,
-                                                plugin_lsp_error(&err.to_string()),
-                                            )
-                                            .await?;
-                                    }
-                                }
-                            }
-                            PluginRequest::GetTextDisplayWidth { text } => {
-                                let width = crate::unicode_utils::display_width(&text);
-                                self.plugin_registry
-                                    .notify(&mut runtime, "text:display_width", json!({ "width": width }))
-                                    .await?;
-                            }
-                            PluginRequest::CharIndexToDisplayColumn { x, y } => {
-                                let display_col = if let Some(line) = self.current_buffer().get(y) {
-                                    let line = line.trim_end_matches('\n');
-                                    crate::unicode_utils::char_to_column(line, x)
-                                } else {
-                                    x
-                                };
-                                self.plugin_registry
-                                    .notify(&mut runtime, "char:display_column", json!({ "column": display_col }))
-                                    .await?;
-                            }
-                            PluginRequest::DisplayColumnToCharIndex { column, y } => {
-                                let char_index = if let Some(line) = self.current_buffer().get(y) {
-                                    let line = line.trim_end_matches('\n');
-                                    crate::unicode_utils::column_to_char(line, column)
-                                } else {
-                                    column
-                                };
-                                self.plugin_registry
-                                    .notify(&mut runtime, "display:char_index", json!({ "index": char_index }))
-                                    .await?;
-                            }
-                            PluginRequest::IntervalCallback { interval_id } => {
-                                self.plugin_registry
-                                    .notify(&mut runtime, "interval:callback", json!({ "intervalId": interval_id }))
-                                    .await?;
-                            }
-                            PluginRequest::TimeoutCallback { timer_id } => {
-                                log!("[TIMER] Processing timeout callback for timer: {}", timer_id);
-                                self.plugin_registry
-                                    .notify(&mut runtime, "timeout:callback", json!({ "timerId": timer_id }))
-                                    .await?;
-                            }
-                            PluginRequest::CreateOverlay { id, config } => {
-                                log!("Creating overlay: {}", id);
-                                self.overlay_manager.create_overlay(id, config);
-                            }
-                            PluginRequest::UpdateOverlay { id, lines } => {
-                                log!("Updating overlay: {}", id);
-                                if let Some(overlay) = self.overlay_manager.get_overlay_mut(&id) {
-                                    overlay.update_content(lines);
-                                }
-                            }
-                            PluginRequest::RemoveOverlay { id } => {
-                                log!("Removing overlay: {}", id);
-                                self.overlay_manager.remove_overlay(&id);
-                            }
-                            PluginRequest::CreatePanel { id, config } => {
-                                self.panel_manager.create_panel(id, config);
-                                self.apply_panel_layout();
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::UpdatePanel { id, rows } => {
-                                self.panel_manager.update_panel(&id, rows);
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::FocusPanel { id } => {
-                                self.panel_manager.focus_panel(&id);
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::FocusEditor => {
-                                self.panel_manager.focus_editor();
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::ClosePanel { id } => {
-                                self.panel_manager.close_panel(&id);
-                                self.apply_panel_layout();
-                                self.render(&mut buffer)?;
-                            }
-                            PluginRequest::ListDirectory { path, request_id } => {
-                                let payload = directory_listing(&path);
-                                self.plugin_registry
-                                    .notify(
-                                        &mut runtime,
-                                        &format!("filesystem:directory:{request_id}"),
-                                        payload,
-                                    )
-                                    .await?;
-                            }
-                            PluginRequest::GetGitStatus { path, request_id } => {
-                                let payload = git_status_listing(&path);
-                                self.plugin_registry
-                                    .notify(
-                                        &mut runtime,
-                                        &format!("git:status:{request_id}"),
-                                        payload,
-                                    )
-                                    .await?;
-                            }
-                            PluginRequest::WatchDirectory { path, watch_id } => {
-                                self.directory_watchers.insert(watch_id, DirectoryWatcher {
-                                    snapshot: directory_listing(&path),
-                                    path,
-                                    last_checked: Instant::now(),
-                                });
-                            }
-                            PluginRequest::UnwatchDirectory { watch_id } => {
-                                self.directory_watchers.remove(&watch_id);
-                            }
-                        }
-                    }
-                }
-                maybe_event = event => {
-                    match maybe_event {
-                        Some(Ok(ev)) => {
-                            // let current_buffer = buffer.clone();
-                            self.check_bounds();
-
-                            if let event::Event::Resize(width, height) = ev {
-                                self.size = (width, height);
-                                let max_y = height as usize - 2;
-                                if self.cy > max_y - 1 {
-                                    self.cy = max_y - 1;
-                                }
-                                self.resize_window_layout((width as usize, height as usize));
-                                buffer = RenderBuffer::new(
-                                    self.size.0 as usize,
-                                    self.size.1 as usize,
-                                    &Style::default(),
-                                );
-                                // TODO: handle dialog resize
-                                self.current_dialog = None;
-                                self.render(&mut buffer)?;
-
-                                let action = Action::NotifyPlugins(
-                                    "editor:resize".to_string(),
-                                    serde_json::to_value(self.size)?,
-                                );
-                                self.execute(&action, &mut buffer, &mut runtime).await?;
-                                continue;
-                            }
-
-                            if self.handle_focus_event(&ev, &mut buffer)? {
-                                continue;
-                            }
-
-                            let render_generation = self.render_generation;
-
-                            if let Some(action) = self.handle_event(&ev)? {
-                                if self.handle_key_action(&ev, &action, &mut buffer, &mut runtime).await? {
-                                    break;
-                                }
-                            }
-
-                            if self.render_generation == render_generation {
-                                self.render(&mut buffer)?;
-                            }
-                        },
-                        Some(Err(error)) => {
-                            log!("error: {error}");
-                        },
-                        None => {
-                        }
+                    PluginRequest::UnwatchDirectory { watch_id } => {
+                        self.directory_watchers.remove(&watch_id);
                     }
                 }
             }
@@ -2614,6 +2671,217 @@ impl Editor {
         }
 
         Ok(())
+    }
+
+    async fn process_editor_event(
+        &mut self,
+        ev: event::Event,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+        render_mode: EventRenderMode,
+    ) -> anyhow::Result<ProcessedEvent> {
+        self.check_bounds();
+
+        if let event::Event::Resize(width, height) = ev {
+            self.size = (width, height);
+            let max_y = height as usize - 2;
+            if self.cy > max_y - 1 {
+                self.cy = max_y - 1;
+            }
+            self.resize_window_layout((width as usize, height as usize));
+            *buffer = RenderBuffer::new(
+                self.size.0 as usize,
+                self.size.1 as usize,
+                &Style::default(),
+            );
+            // TODO: handle dialog resize
+            self.current_dialog = None;
+            self.render(buffer)?;
+
+            let action = Action::NotifyPlugins(
+                "editor:resize".to_string(),
+                serde_json::to_value(self.size)?,
+            );
+            self.execute(&action, buffer, runtime).await?;
+            return Ok(ProcessedEvent {
+                quit: false,
+                drain_repeated_motion: false,
+                repeat_signature: None,
+            });
+        }
+
+        if self.handle_focus_event(&ev, buffer)? {
+            return Ok(ProcessedEvent {
+                quit: false,
+                drain_repeated_motion: false,
+                repeat_signature: None,
+            });
+        }
+
+        let render_generation = self.render_generation;
+        let repeat_signature = Self::key_signature(&ev);
+        let mut drain_repeated_motion = false;
+
+        if let Some(action) = self.handle_event(&ev)? {
+            drain_repeated_motion = self.should_drain_repeated_motion(&ev, &action);
+            if self
+                .handle_key_action(&ev, &action, buffer, runtime)
+                .await?
+            {
+                return Ok(ProcessedEvent {
+                    quit: true,
+                    drain_repeated_motion: false,
+                    repeat_signature: None,
+                });
+            }
+        }
+
+        if render_mode == EventRenderMode::Immediate && self.render_generation == render_generation
+        {
+            self.render(buffer)?;
+        }
+
+        Ok(ProcessedEvent {
+            quit: false,
+            drain_repeated_motion,
+            repeat_signature,
+        })
+    }
+
+    async fn drain_repeated_motion_events(
+        &mut self,
+        signature: KeySignature,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        let started = Instant::now();
+        let mut deferred_motion = false;
+        while started.elapsed() < Duration::from_millis(REPEATED_MOTION_DRAIN_BUDGET_MS) {
+            if !event::poll(Duration::from_millis(0))? {
+                break;
+            }
+
+            let ev = event::read()?;
+            let same_key = Self::key_signature(&ev).is_some_and(|next| next == signature);
+            if !same_key {
+                if deferred_motion {
+                    self.flush_deferred_motion_render(buffer)?;
+                    deferred_motion = false;
+                }
+                let processed = self
+                    .process_editor_event(ev, buffer, runtime, EventRenderMode::Immediate)
+                    .await?;
+                if processed.quit {
+                    return Ok(true);
+                }
+                break;
+            }
+
+            self.defer_motion_render = true;
+            let processed_result = self
+                .process_editor_event(ev, buffer, runtime, EventRenderMode::DeferredMotion)
+                .await;
+            self.defer_motion_render = false;
+            let processed = processed_result?;
+            deferred_motion = true;
+            if processed.quit {
+                return Ok(true);
+            }
+            if !processed.drain_repeated_motion {
+                break;
+            }
+        }
+
+        // Repeated motion events are lossy once they exceed the frame budget.
+        // This keeps a released key from continuing to walk through stale input.
+        while event::poll(Duration::from_millis(0))? {
+            let ev = event::read()?;
+            if Self::key_signature(&ev).is_some_and(|next| next == signature) {
+                continue;
+            }
+
+            if deferred_motion {
+                self.flush_deferred_motion_render(buffer)?;
+                deferred_motion = false;
+            }
+
+            let processed = self
+                .process_editor_event(ev, buffer, runtime, EventRenderMode::Immediate)
+                .await?;
+            if processed.quit {
+                return Ok(true);
+            }
+            break;
+        }
+
+        if deferred_motion {
+            self.flush_deferred_motion_render(buffer)?;
+        }
+
+        Ok(false)
+    }
+
+    fn flush_deferred_motion_render(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.defer_motion_render = false;
+        if self.deferred_motion_needs_full_render {
+            self.deferred_motion_needs_full_render = false;
+            self.render(buffer)
+        } else if self.can_render_cursor_motion_delta() {
+            self.render_cursor_motion_delta(buffer)
+        } else if self.uses_synthetic_block_cursor() {
+            self.render_motion_frame(buffer)
+        } else {
+            self.draw_cursor_preserving_cursor_goal()
+        }
+    }
+
+    fn key_signature(ev: &event::Event) -> Option<KeySignature> {
+        let event::Event::Key(KeyEvent {
+            code, modifiers, ..
+        }) = ev
+        else {
+            return None;
+        };
+
+        Some(KeySignature {
+            code: code.clone(),
+            modifiers: *modifiers,
+        })
+    }
+
+    fn should_drain_repeated_motion(&self, ev: &event::Event, action: &KeyAction) -> bool {
+        Self::key_signature(ev).is_some()
+            && self.is_normal()
+            && self.repeater.is_none()
+            && self.pending_operator.is_none()
+            && self.waiting_key_action.is_none()
+            && self.key_action_is_pure_motion(action)
+    }
+
+    fn key_action_is_pure_motion(&self, action: &KeyAction) -> bool {
+        match action {
+            KeyAction::Single(action) => Self::action_is_pure_motion(action),
+            KeyAction::Multiple(actions) => actions.iter().all(Self::action_is_pure_motion),
+            KeyAction::Repeating(_, action) => self.key_action_is_pure_motion(action),
+            KeyAction::None | KeyAction::Nested(_) => false,
+        }
+    }
+
+    fn action_is_pure_motion(action: &Action) -> bool {
+        matches!(
+            action,
+            Action::MoveUp
+                | Action::MoveDown
+                | Action::MoveLeft
+                | Action::MoveRight
+                | Action::MoveScreenLineUp
+                | Action::MoveScreenLineDown
+                | Action::MoveToScreenLineEnd
+                | Action::MoveToScreenLineStart
+                | Action::MoveToScreenLineFirstNonBlank
+                | Action::MoveToNextWord
+                | Action::MoveToPreviousWord
+        )
     }
 
     #[async_recursion::async_recursion]
@@ -9033,6 +9301,39 @@ mod test {
             editor.render_cursor_position(),
             Some((start.0 + 1, start.1))
         );
+    }
+
+    #[test]
+    fn row_snapshot_diff_only_reports_requested_rows() {
+        let style = Style::default();
+        let mut buffer = RenderBuffer::new(8, 3, &style);
+        buffer.set_text(0, 0, "before", &style);
+        buffer.set_text(0, 1, "before", &style);
+
+        let snapshot = buffer.snapshot_rows(&[1]);
+        buffer.set_text(0, 0, "after", &style);
+        buffer.set_text(0, 1, "after", &style);
+
+        let changes = buffer.diff_row_snapshots(&snapshot);
+
+        assert!(!changes.is_empty());
+        assert!(changes.iter().all(|change| change.y == 1));
+    }
+
+    #[test]
+    fn repeated_motion_drain_only_accepts_plain_normal_motion() {
+        let mut editor = test_editor(20, 5);
+        let event = Event::Key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE));
+        let word_motion = KeyAction::Multiple(vec![Action::MoveToNextWord]);
+
+        assert!(editor.should_drain_repeated_motion(&event, &word_motion));
+        assert!(!editor.should_drain_repeated_motion(
+            &event,
+            &KeyAction::Multiple(vec![Action::EnterMode(Mode::Insert)])
+        ));
+
+        editor.repeater = Some(2);
+        assert!(!editor.should_drain_repeated_motion(&event, &word_motion));
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,3 +1,4 @@
+mod display_layout;
 pub mod render_buffer;
 pub mod rendering;
 
@@ -69,11 +70,22 @@ use crate::{
     window::{WindowManager, WindowManagerSnapshot},
 };
 
+use self::display_layout::{layout_lines, DisplayLayout, LayoutConfig};
+
 pub static ACTION_DISPATCHER: Lazy<Dispatcher<PluginRequest, PluginResponse>> =
     Lazy::new(Dispatcher::new);
 
 pub const DEFAULT_REGISTER: char = '"';
 const JUMPLIST_SIZE: usize = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EditorViewState {
+    vtop: usize,
+    vleft: usize,
+    skipcol: usize,
+    cy: usize,
+    wrap: bool,
+}
 
 fn expanded_path_string(path: &str) -> anyhow::Result<String> {
     Ok(expand_user_path(path)?.to_string_lossy().into_owned())
@@ -257,6 +269,11 @@ pub enum Action {
     MoveToLineStart,
     MoveToFirstLineChar,
     MoveToLastLineChar,
+    MoveScreenLineUp,
+    MoveScreenLineDown,
+    MoveToScreenLineEnd,
+    MoveToScreenLineStart,
+    MoveToScreenLineFirstNonBlank,
     MoveLineToViewportCenter,
     MoveLineToViewportBottom,
     MoveToBottom,
@@ -270,6 +287,14 @@ pub enum Action {
     PageUp,
     ScrollUp,
     ScrollDown,
+    ScrollViewLeft,
+    ScrollViewRight,
+    ScrollViewHalfPageLeft,
+    ScrollViewHalfPageRight,
+    ScrollCursorToViewStart,
+    ScrollCursorToViewEnd,
+    ToggleWrap,
+    SetWrap(bool),
 
     DeletePreviousChar,
     DeleteCharAtCursorPos,
@@ -630,6 +655,12 @@ pub struct Editor {
 
     /// Left column of viewport (for horizontal scrolling)
     vleft: usize,
+
+    /// First skipped display column for wrapped long-line scrolling.
+    skipcol: usize,
+
+    /// Whether the active window wraps long lines.
+    wrap: bool,
 
     /// Cursor x position (column)
     cx: usize,
@@ -1022,7 +1053,11 @@ impl Editor {
         let indentation =
             HashMap::from_iter(vec![("rs".to_string(), Indentation::new(4, 4, true))]);
 
-        let window_manager = WindowManager::new(0, (width, height));
+        let mut window_manager = WindowManager::new(0, (width, height));
+        let wrap = config.wrap.unwrap_or(true);
+        for window in window_manager.windows_mut() {
+            window.wrap = wrap;
+        }
         let completion_ui = CompletionUI::with_theme(&theme);
 
         Ok(Editor {
@@ -1043,6 +1078,8 @@ impl Editor {
             size,
             vtop: 0,
             vleft: 0,
+            skipcol: 0,
+            wrap,
             cx: 0,
             cy: 0,
             cursor_goal: CursorGoal::default(),
@@ -1126,6 +1163,8 @@ impl Editor {
             self.current_buffer_index = window.buffer_index;
             self.vtop = window.vtop;
             self.vleft = window.vleft;
+            self.skipcol = window.skipcol;
+            self.wrap = window.wrap;
             self.cx = window.cx;
             self.cy = window.cy;
             self.cursor_goal = window.cursor_goal;
@@ -1139,10 +1178,57 @@ impl Editor {
             window.buffer_index = self.current_buffer_index;
             window.vtop = self.vtop;
             window.vleft = self.vleft;
+            window.skipcol = self.skipcol;
+            window.wrap = self.wrap;
             window.cx = self.cx;
             window.cy = self.cy;
             window.cursor_goal = self.cursor_goal;
             window.vx = self.vx;
+        }
+    }
+
+    fn editor_view_state(&self) -> EditorViewState {
+        EditorViewState {
+            vtop: self.vtop,
+            vleft: self.vleft,
+            skipcol: self.skipcol,
+            cy: self.cy,
+            wrap: self.wrap,
+        }
+    }
+
+    fn active_window_with_editor_view(&self) -> Option<crate::window::Window> {
+        let mut window = self.window_manager.active_window()?.clone();
+        window.buffer_index = self.current_buffer_index;
+        window.vtop = self.vtop;
+        window.vleft = self.vleft;
+        window.skipcol = self.skipcol;
+        window.wrap = self.wrap;
+        window.cx = self.cx;
+        window.cy = self.cy;
+        window.cursor_goal = self.cursor_goal;
+        window.vx = self.vx;
+        Some(window)
+    }
+
+    fn finish_cursor_motion(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        preserve_cursor_goal: bool,
+    ) -> anyhow::Result<()> {
+        let before = self.editor_view_state();
+        if !preserve_cursor_goal {
+            self.refresh_cursor_goal();
+        }
+        self.fix_cursor_pos();
+        self.sync_to_window();
+
+        if self.editor_view_state() != before {
+            self.render(buffer)
+        } else if self.uses_synthetic_block_cursor() {
+            self.render_motion_frame(buffer)
+        } else {
+            self.draw_cursor_preserving_cursor_goal()
         }
     }
 
@@ -1249,20 +1335,17 @@ impl Editor {
         buf_x: usize,
         buf_y: usize,
     ) -> Option<(usize, usize)> {
-        // Check if the buffer position is within the viewport
-        if buf_y < window.vtop || buf_y >= window.vtop + window.inner_height() {
-            return None;
-        }
-
-        if buf_x < window.vleft || buf_x >= window.vleft + window.inner_width() {
-            return None;
-        }
-
-        // Convert to window-local coordinates
-        let window_x = buf_x - window.vleft;
-        let window_y = buf_y - window.vtop;
-
-        Some((window_x, window_y))
+        let line = self.buffers.get(window.buffer_index)?.get(buf_y)?;
+        let display_col = grapheme_to_column(line.trim_end_matches('\n'), buf_x);
+        let layout = self.layout_for_window(window);
+        let segment = layout.segment_for_cursor(buf_y, display_col)?;
+        Some((
+            self.gutter_width_for_window(window)
+                + 1
+                + segment
+                    .screen_col_for_display_col(display_col, self.window_content_width(window)),
+            segment.row,
+        ))
     }
 
     /// Get the effective viewport width for a window
@@ -1273,6 +1356,62 @@ impl Editor {
     /// Get the effective viewport height for a window
     pub fn window_vheight(&self, window: &crate::window::Window) -> usize {
         window.inner_height()
+    }
+
+    fn window_content_width(&self, window: &crate::window::Window) -> usize {
+        let gutter_width = self.gutter_width_for_window(window);
+        window.inner_width().saturating_sub(gutter_width + 1)
+    }
+
+    fn layout_for_window(&self, window: &crate::window::Window) -> DisplayLayout {
+        let Some(buffer) = self.buffers.get(window.buffer_index) else {
+            return DisplayLayout {
+                rows: Vec::new(),
+                text: String::new(),
+            };
+        };
+        let mut line_count = buffer.navigable_line_count();
+        if window.active && self.is_insert() {
+            line_count = line_count.max(self.buffer_line() + 1);
+        }
+        let end = window
+            .vtop
+            .saturating_add(window.inner_height())
+            .min(line_count);
+        let lines = (window.vtop..end)
+            .filter_map(|line| buffer.get(line))
+            .collect::<Vec<_>>();
+
+        layout_lines(
+            &lines,
+            line_count,
+            LayoutConfig {
+                content_width: self.window_content_width(window),
+                height: window.inner_height(),
+                wrap: window.wrap,
+                vtop: window.vtop,
+                vleft: window.vleft,
+                skipcol: window.skipcol,
+            },
+        )
+    }
+
+    fn active_content_width(&self) -> usize {
+        self.window_manager
+            .active_window()
+            .map(|window| self.window_content_width(window))
+            .unwrap_or_else(|| self.vwidth().saturating_sub(self.gutter_width() + 1))
+    }
+
+    fn sidescroll(&self) -> usize {
+        self.config.sidescroll.unwrap_or(1).max(1)
+    }
+
+    fn sidescrolloff(&self, width: usize) -> usize {
+        self.config
+            .sidescrolloff
+            .unwrap_or(0)
+            .min(width.saturating_sub(1))
     }
 
     pub fn cursor_position(&self) -> (usize, usize) {
@@ -1670,6 +1809,109 @@ impl Editor {
         }
     }
 
+    fn current_screen_segment_bounds(&self) -> Option<(usize, usize)> {
+        let line_index = self.buffer_line();
+        let line = self.current_line_contents()?;
+        let line = line.trim_end_matches('\n');
+        let display_col = grapheme_to_column(line, self.cx);
+        let window = self.window_manager.active_window()?;
+        let layout = self.layout_for_window(window);
+        let segment = layout.segment_for_cursor(line_index, display_col)?;
+        Some((segment.start_col, segment.end_col))
+    }
+
+    fn move_to_display_col_on_current_line(&mut self, display_col: usize) {
+        if let Some(line) = self.current_line_contents() {
+            let line = line.trim_end_matches('\n');
+            self.cx = self.grapheme_for_cursor_goal(line, CursorGoal::DisplayCol(display_col));
+        }
+    }
+
+    fn move_to_screen_line_start(&mut self) {
+        if let Some((start_col, _)) = self.current_screen_segment_bounds() {
+            self.move_to_display_col_on_current_line(start_col);
+        }
+    }
+
+    fn move_to_screen_line_end(&mut self) {
+        if let Some((_, end_col)) = self.current_screen_segment_bounds() {
+            self.move_to_display_col_on_current_line(end_col.saturating_sub(1));
+        }
+    }
+
+    fn move_to_screen_line_first_non_blank(&mut self) {
+        let Some((start_col, end_col)) = self.current_screen_segment_bounds() else {
+            return;
+        };
+        let Some(line) = self.current_line_contents() else {
+            return;
+        };
+        let line = line.trim_end_matches('\n');
+        let target = line
+            .graphemes(true)
+            .enumerate()
+            .find_map(|(index, grapheme)| {
+                let col = grapheme_to_column(line, index);
+                (col >= start_col && col < end_col && !grapheme.chars().all(char::is_whitespace))
+                    .then_some(col)
+            })
+            .unwrap_or(start_col);
+        self.move_to_display_col_on_current_line(target);
+    }
+
+    fn move_screen_line(&mut self, delta: isize) {
+        let Some(window) = self.window_manager.active_window().cloned() else {
+            return;
+        };
+        let line_index = self.buffer_line();
+        let display_col = self.current_cursor_display_col();
+        let layout = self.layout_for_window(&window);
+        let Some(current_index) = layout.rows.iter().position(|segment| {
+            segment.line == line_index && segment.contains_display_col(display_col)
+        }) else {
+            return;
+        };
+        let current = layout.rows[current_index];
+        if self.wrap {
+            if let Some(line) = self.current_line_contents() {
+                let line = line.trim_end_matches('\n');
+                let line_width = display_width(line);
+                let width = self.active_content_width();
+                let offset = display_col.saturating_sub(current.start_col);
+                let target_start = if delta > 0 && current.start_col + width < line_width {
+                    Some(current.start_col + width)
+                } else if delta < 0 && current.start_col >= width {
+                    Some(current.start_col - width)
+                } else {
+                    None
+                };
+
+                if let Some(target_start) = target_start {
+                    let target_col = target_start
+                        .saturating_add(offset)
+                        .min(line_width.saturating_sub(1));
+                    self.move_to_display_col_on_current_line(target_col);
+                    return;
+                }
+            }
+        }
+        let target_index = if delta < 0 {
+            current_index.saturating_sub(delta.unsigned_abs())
+        } else {
+            (current_index + delta as usize).min(layout.rows.len().saturating_sub(1))
+        };
+        let Some(target) = layout.rows.get(target_index) else {
+            return;
+        };
+        let target_display_col = target
+            .start_col
+            .saturating_add(display_col.saturating_sub(layout.rows[current_index].start_col))
+            .min(target.end_col.saturating_sub(1));
+        self.vtop = target.line.saturating_sub(self.cy);
+        self.cy = target.line.saturating_sub(self.vtop);
+        self.move_to_display_col_on_current_line(target_display_col);
+    }
+
     fn recompute_window_cursor_goals(&mut self) {
         let buffers = &self.buffers;
         for window in self.window_manager.windows_mut() {
@@ -1832,11 +2074,6 @@ impl Editor {
         if self.cx > max_cursor_x {
             self.cx = max_cursor_x;
         }
-        let viewport_width = self.vwidth();
-        if viewport_width > 0 && self.cx >= viewport_width {
-            self.cx = viewport_width - 1;
-        }
-
         old_position != (self.cx, self.cy, self.vtop)
     }
 
@@ -3895,12 +4132,12 @@ impl Editor {
                     if self.vtop > 0 {
                         self.vtop -= 1;
                         self.apply_cursor_goal_to_current_line();
-                        self.render(buffer)?;
+                        self.finish_cursor_motion(buffer, true)?;
                     }
                 } else {
                     self.cy = self.cy.saturating_sub(1);
                     self.apply_cursor_goal_to_current_line();
-                    self.draw_cursor_preserving_cursor_goal()?;
+                    self.finish_cursor_motion(buffer, true)?;
                 }
             }
             Action::MoveDown => {
@@ -3911,12 +4148,13 @@ impl Editor {
                         self.vtop += 1;
                         self.cy -= 1;
                         self.apply_cursor_goal_to_current_line();
-                        self.render(buffer)?;
+                        self.finish_cursor_motion(buffer, true)?;
                     } else {
                         self.apply_cursor_goal_to_current_line();
+                        self.finish_cursor_motion(buffer, true)?;
                     }
                 } else {
-                    self.draw_cursor_preserving_cursor_goal()?;
+                    self.finish_cursor_motion(buffer, true)?;
                 }
             }
             Action::MoveLeft => {
@@ -3932,12 +4170,8 @@ impl Editor {
                     } else if self.cx > 0 {
                         self.cx = 0;
                     }
-
-                    if self.cx < self.vleft {
-                        self.cx = self.vleft;
-                    }
                 }
-                self.draw_cursor()?;
+                self.finish_cursor_motion(buffer, false)?;
             }
             Action::MoveRight => {
                 // Move by grapheme clusters
@@ -3960,7 +4194,7 @@ impl Editor {
                         self.cx = max_cursor_x;
                     }
                 }
-                self.draw_cursor()?;
+                self.finish_cursor_motion(buffer, false)?;
             }
             Action::MoveToLineStart => {
                 self.cx = 0;
@@ -3988,6 +4222,26 @@ impl Editor {
                         .unwrap_or(0);
                     self.cx = grapheme_len(line).saturating_sub(trailing + 1);
                 }
+            }
+            Action::MoveScreenLineUp => {
+                self.move_screen_line(-1);
+                self.render(buffer)?;
+            }
+            Action::MoveScreenLineDown => {
+                self.move_screen_line(1);
+                self.render(buffer)?;
+            }
+            Action::MoveToScreenLineStart => {
+                self.move_to_screen_line_start();
+                self.render(buffer)?;
+            }
+            Action::MoveToScreenLineFirstNonBlank => {
+                self.move_to_screen_line_first_non_blank();
+                self.render(buffer)?;
+            }
+            Action::MoveToScreenLineEnd => {
+                self.move_to_screen_line_end();
+                self.render(buffer)?;
             }
             Action::PageUp => {
                 let target_line = self
@@ -4409,6 +4663,7 @@ impl Editor {
             Action::MoveToTop => {
                 self.vtop = 0;
                 self.cy = 0;
+                self.skipcol = 0;
                 self.render(buffer)?;
             }
             Action::MoveToBottom => {
@@ -4649,6 +4904,8 @@ impl Editor {
                 self.cx = 0;
                 self.cy = 0;
                 self.vtop = 0;
+                self.vleft = 0;
+                self.skipcol = 0;
             }
             Action::Command(cmd) => {
                 log!("Handling command: {cmd}");
@@ -4758,6 +5015,57 @@ impl Editor {
                     self.render(buffer)?;
                 }
             }
+            Action::ScrollViewLeft => {
+                if !self.wrap {
+                    self.vleft = self.vleft.saturating_sub(self.sidescroll());
+                    self.render(buffer)?;
+                }
+            }
+            Action::ScrollViewRight => {
+                if !self.wrap {
+                    self.vleft = self.vleft.saturating_add(self.sidescroll());
+                    self.render(buffer)?;
+                }
+            }
+            Action::ScrollViewHalfPageLeft => {
+                if !self.wrap {
+                    self.vleft = self.vleft.saturating_sub(self.active_content_width() / 2);
+                    self.render(buffer)?;
+                }
+            }
+            Action::ScrollViewHalfPageRight => {
+                if !self.wrap {
+                    self.vleft = self.vleft.saturating_add(self.active_content_width() / 2);
+                    self.render(buffer)?;
+                }
+            }
+            Action::ScrollCursorToViewStart => {
+                if !self.wrap {
+                    let display_col = self.current_cursor_display_col();
+                    self.vleft = display_col;
+                    self.render(buffer)?;
+                }
+            }
+            Action::ScrollCursorToViewEnd => {
+                if !self.wrap {
+                    let display_col = self.current_cursor_display_col();
+                    self.vleft =
+                        display_col.saturating_sub(self.active_content_width().saturating_sub(1));
+                    self.render(buffer)?;
+                }
+            }
+            Action::ToggleWrap => {
+                self.wrap = !self.wrap;
+                self.vleft = 0;
+                self.skipcol = 0;
+                self.render(buffer)?;
+            }
+            Action::SetWrap(wrap) => {
+                self.wrap = *wrap;
+                self.vleft = 0;
+                self.skipcol = 0;
+                self.render(buffer)?;
+            }
             Action::MoveToNextWord => {
                 let line = self.buffer_line();
                 let char_cx = self.next_word_search_char_on_line(self.cx, line);
@@ -4771,7 +5079,7 @@ impl Editor {
                         self.go_to_line(y + 1, buffer, runtime, GoToLinePosition::Top)
                             .await?;
                     }
-                    self.draw_cursor()?;
+                    self.finish_cursor_motion(buffer, false)?;
                 }
             }
             Action::MoveToPreviousWord => {
@@ -4787,7 +5095,7 @@ impl Editor {
                         self.go_to_line(y + 1, buffer, runtime, GoToLinePosition::Top)
                             .await?;
                     }
-                    self.draw_cursor()?;
+                    self.finish_cursor_motion(buffer, false)?;
                 }
             }
             Action::MoveLineToViewportBottom => {
@@ -6079,6 +6387,8 @@ impl Editor {
         self.cx = cx;
         self.cy = cy;
         self.vtop = vtop;
+        self.vleft = 0;
+        self.skipcol = 0;
         self.vx = self.gutter_width() + 1;
 
         self.prev_highlight_y = None;
@@ -6107,6 +6417,7 @@ impl Editor {
             self.cy = 0;
             self.vtop = 0;
             self.vleft = 0;
+            self.skipcol = 0;
             self.vx = self.gutter_width() + 1;
             self.prev_highlight_y = None;
 
@@ -6117,6 +6428,8 @@ impl Editor {
                 window.cursor_goal = CursorGoal::default();
                 window.vtop = 0;
                 window.vleft = 0;
+                window.skipcol = 0;
+                window.wrap = self.wrap;
                 window.vx = self.vx;
             }
 
@@ -6152,6 +6465,8 @@ impl Editor {
                 window.cursor_goal = CursorGoal::default();
                 window.vtop = target_vtop;
                 window.vleft = 0;
+                window.skipcol = 0;
+                window.wrap = self.wrap;
                 window.vx = target_vx;
             } else if window.buffer_index > removed_index {
                 window.buffer_index -= 1;
@@ -6216,6 +6531,7 @@ impl Editor {
         if line == 0 {
             self.vtop = 0;
             self.cy = 0;
+            self.skipcol = 0;
             self.render(buffer)?;
             return Ok(());
         }
@@ -6421,8 +6737,24 @@ impl Editor {
                                 // Adjust for the clicked window's gutter, not the active buffer's.
                                 let gutter_width =
                                     self.gutter_width_for_buffer_index(window_buffer_index);
-                                let buffer_x = local_x.saturating_sub(gutter_width + 1);
-                                let buffer_y = window_vtop + local_y;
+                                let content_x = local_x.saturating_sub(gutter_width + 1);
+                                let layout = self.layout_for_window(&window);
+                                let (buffer_x, buffer_y) =
+                                    if let Some(segment) = layout.row(local_y) {
+                                        let display_col = segment.start_col + content_x;
+                                        let line = self.buffers[window_buffer_index]
+                                            .get(segment.line)
+                                            .unwrap_or_default();
+                                        (
+                                            column_to_grapheme(
+                                                line.trim_end_matches('\n'),
+                                                display_col,
+                                            ),
+                                            segment.line,
+                                        )
+                                    } else {
+                                        (content_x, window_vtop + local_y)
+                                    };
 
                                 // Ensure y is within buffer bounds
                                 let window_buffer = &self.buffers[window_buffer_index];
@@ -6909,6 +7241,73 @@ impl Editor {
         if self.cx > max_cursor_x {
             self.cx = max_cursor_x;
         }
+
+        self.ensure_cursor_visible();
+    }
+
+    fn ensure_cursor_visible(&mut self) {
+        let width = self.active_content_width();
+        if width == 0 {
+            return;
+        }
+
+        let buffer_line = self.buffer_line();
+        let line = self.current_line_contents().unwrap_or_default();
+        let line = line.trim_end_matches('\n');
+        let display_col = grapheme_to_column(line, self.cx);
+
+        if !self.wrap {
+            self.skipcol = 0;
+            let off = self.sidescrolloff(width);
+            let right_edge = self.vleft + width;
+            if display_col < self.vleft + off {
+                self.vleft = display_col.saturating_sub(off + self.sidescroll().saturating_sub(1));
+            } else if display_col >= right_edge.saturating_sub(off) {
+                self.vleft = display_col
+                    .saturating_add(off)
+                    .saturating_add(self.sidescroll())
+                    .saturating_sub(width);
+            }
+            return;
+        }
+
+        self.vleft = 0;
+        let height = self.vheight().max(1);
+        if buffer_line < self.vtop {
+            self.vtop = buffer_line;
+            self.skipcol = 0;
+        }
+
+        if buffer_line == self.vtop {
+            let target_segment = display_col / width;
+            let first_segment = self.skipcol / width;
+            if target_segment < first_segment {
+                self.skipcol = target_segment * width;
+            } else if target_segment >= first_segment + height {
+                self.skipcol = target_segment
+                    .saturating_sub(height.saturating_sub(1))
+                    .saturating_mul(width);
+            }
+        } else {
+            let mut visible = false;
+            if let Some(window) = self.active_window_with_editor_view() {
+                let layout = self.layout_for_window(&window);
+                visible = layout
+                    .rows
+                    .iter()
+                    .any(|segment| segment.line == buffer_line);
+            }
+
+            if !visible {
+                self.vtop = buffer_line;
+                let target_segment = display_col / width;
+                self.skipcol = target_segment
+                    .saturating_sub(height.saturating_sub(1))
+                    .saturating_mul(width);
+            }
+        }
+
+        self.cy = buffer_line.saturating_sub(self.vtop);
     }
 
     fn start_selection(&mut self) {
@@ -7436,6 +7835,8 @@ pub struct EditorInfo {
     size: (u16, u16),
     vtop: usize,
     vleft: usize,
+    skipcol: usize,
+    wrap: bool,
     cx: usize,
     cy: usize,
     vx: usize,
@@ -7458,6 +7859,8 @@ impl From<&Editor> for EditorInfo {
             size: editor.size,
             vtop: editor.vtop,
             vleft: editor.vleft,
+            skipcol: editor.skipcol,
+            wrap: editor.wrap,
             cx: editor.cx,
             cy: editor.cy,
             vx: editor.vx,
@@ -7771,6 +8174,21 @@ impl Editor {
     #[doc(hidden)]
     pub fn test_vtop(&self) -> usize {
         self.vtop
+    }
+
+    #[doc(hidden)]
+    pub fn test_vleft(&self) -> usize {
+        self.vleft
+    }
+
+    #[doc(hidden)]
+    pub fn test_skipcol(&self) -> usize {
+        self.skipcol
+    }
+
+    #[doc(hidden)]
+    pub fn test_wrap(&self) -> bool {
+        self.wrap
     }
 
     #[doc(hidden)]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2080,7 +2080,11 @@ impl Editor {
             self.last_navigable_line()
         };
         let viewport_height = self.vheight().max(1);
-        let max_vtop = last_line.saturating_sub(viewport_height.saturating_sub(1));
+        let max_vtop = if self.wrap {
+            last_line
+        } else {
+            last_line.saturating_sub(viewport_height.saturating_sub(1))
+        };
 
         self.vtop = self.vtop.min(max_vtop);
 
@@ -2095,17 +2099,21 @@ impl Editor {
             .unwrap_or(0)
             .min(viewport_height.saturating_sub(1));
         if scrolloff > 0 {
-            if buffer_line < self.vtop + scrolloff {
-                self.vtop = buffer_line.saturating_sub(scrolloff);
-            } else if buffer_line >= self.vtop + viewport_height.saturating_sub(scrolloff) {
-                self.vtop = buffer_line
+            let mut scrolloff_vtop = self.vtop;
+            if buffer_line < scrolloff_vtop + scrolloff {
+                scrolloff_vtop = buffer_line.saturating_sub(scrolloff);
+            } else if buffer_line >= scrolloff_vtop + viewport_height.saturating_sub(scrolloff) {
+                scrolloff_vtop = buffer_line
                     .saturating_add(scrolloff)
                     .saturating_add(1)
                     .saturating_sub(viewport_height);
             }
 
-            self.vtop = self.vtop.min(max_vtop);
-            self.cy = buffer_line.saturating_sub(self.vtop);
+            scrolloff_vtop = scrolloff_vtop.min(max_vtop);
+            if !self.wrap || self.buffer_line_visible_from(scrolloff_vtop, buffer_line) {
+                self.vtop = scrolloff_vtop;
+                self.cy = buffer_line.saturating_sub(self.vtop);
+            }
         }
 
         let max_cursor_x = self.max_cursor_x_for_line_length(self.line_length());
@@ -2114,6 +2122,19 @@ impl Editor {
             self.cx = max_cursor_x;
         }
         old_position != (self.cx, self.cy, self.vtop)
+    }
+
+    fn buffer_line_visible_from(&self, vtop: usize, buffer_line: usize) -> bool {
+        let Some(mut window) = self.active_window_with_editor_view() else {
+            return (vtop..vtop + self.vheight()).contains(&buffer_line);
+        };
+        window.vtop = vtop;
+        window.cy = buffer_line.saturating_sub(vtop);
+
+        self.layout_for_window(&window)
+            .rows
+            .iter()
+            .any(|segment| segment.line == buffer_line)
     }
 
     /// Starts the main editor loop

--- a/src/editor/display_layout.rs
+++ b/src/editor/display_layout.rs
@@ -1,0 +1,234 @@
+use unicode_segmentation::UnicodeSegmentation as _;
+
+use crate::unicode_utils::{column_to_grapheme, display_width};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LineSegment {
+    pub line: usize,
+    pub row: usize,
+    pub start_col: usize,
+    pub end_col: usize,
+    pub start_grapheme: usize,
+    pub end_grapheme: usize,
+    pub source_offset: usize,
+    pub first_segment: bool,
+}
+
+impl LineSegment {
+    pub fn contains_display_col(&self, col: usize) -> bool {
+        if self.start_col == self.end_col {
+            return col == self.start_col;
+        }
+
+        col >= self.start_col && col < self.end_col
+    }
+
+    pub fn screen_col_for_display_col(&self, col: usize, width: usize) -> usize {
+        col.saturating_sub(self.start_col)
+            .min(width.saturating_sub(1))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DisplayLayout {
+    pub rows: Vec<LineSegment>,
+    pub text: String,
+}
+
+impl DisplayLayout {
+    pub fn row(&self, row: usize) -> Option<&LineSegment> {
+        self.rows.iter().find(|segment| segment.row == row)
+    }
+
+    pub fn segment_for_cursor(&self, line: usize, display_col: usize) -> Option<&LineSegment> {
+        self.rows
+            .iter()
+            .find(|segment| segment.line == line && segment.contains_display_col(display_col))
+            .or_else(|| self.rows.iter().rev().find(|segment| segment.line == line))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LayoutConfig {
+    pub content_width: usize,
+    pub height: usize,
+    pub wrap: bool,
+    pub vtop: usize,
+    pub vleft: usize,
+    pub skipcol: usize,
+}
+
+pub fn layout_lines(lines: &[String], line_count: usize, config: LayoutConfig) -> DisplayLayout {
+    let mut rows = Vec::new();
+    let mut text = String::new();
+
+    if config.content_width == 0 || config.height == 0 {
+        return DisplayLayout { rows, text };
+    }
+
+    let mut line_index = config.vtop;
+    let mut row = 0;
+    while row < config.height && line_index < line_count {
+        let line_with_newline = lines
+            .get(line_index.saturating_sub(config.vtop))
+            .map(String::as_str)
+            .unwrap_or_default();
+        let line = line_with_newline.trim_end_matches('\n');
+        let source_offset = text.len();
+        text.push_str(line_with_newline);
+
+        let segments = if config.wrap {
+            wrap_line_segments(line, line_index, config.content_width, config.skipcol)
+        } else {
+            nowrap_line_segment(line, line_index, config.content_width, config.vleft)
+        };
+
+        for mut segment in segments {
+            if row >= config.height {
+                break;
+            }
+            segment.row = row;
+            segment.source_offset += source_offset;
+            rows.push(segment);
+            row += 1;
+        }
+
+        line_index += 1;
+    }
+
+    DisplayLayout { rows, text }
+}
+
+pub fn wrap_line_segments(
+    line: &str,
+    line_index: usize,
+    width: usize,
+    skipcol: usize,
+) -> Vec<LineSegment> {
+    let mut segments = Vec::new();
+    if width == 0 {
+        return segments;
+    }
+
+    let mut start_col = 0;
+    let line_width = display_width(line);
+    let skipcol = skipcol.min(line_width);
+
+    while start_col <= line_width {
+        let end_col = if line_width == start_col {
+            start_col
+        } else {
+            next_wrap_end(line, start_col, width)
+        };
+
+        if end_col > skipcol || (line_width == 0 && skipcol == 0) {
+            let start_grapheme = column_to_grapheme(line, start_col);
+            let end_grapheme = column_to_grapheme(line, end_col);
+            segments.push(LineSegment {
+                line: line_index,
+                row: 0,
+                start_col,
+                end_col,
+                start_grapheme,
+                end_grapheme,
+                source_offset: 0,
+                first_segment: start_col == 0,
+            });
+        }
+
+        if end_col >= line_width {
+            break;
+        }
+        start_col = end_col;
+    }
+
+    if segments.is_empty() {
+        let start_col = skipcol - (skipcol % width);
+        segments.push(LineSegment {
+            line: line_index,
+            row: 0,
+            start_col,
+            end_col: start_col,
+            start_grapheme: column_to_grapheme(line, start_col),
+            end_grapheme: column_to_grapheme(line, start_col),
+            source_offset: 0,
+            first_segment: start_col == 0,
+        });
+    }
+
+    segments
+}
+
+fn nowrap_line_segment(
+    line: &str,
+    line_index: usize,
+    width: usize,
+    vleft: usize,
+) -> Vec<LineSegment> {
+    let line_width = display_width(line);
+    let start_col = vleft.min(line_width);
+    let end_col = (start_col + width).min(line_width);
+
+    vec![LineSegment {
+        line: line_index,
+        row: 0,
+        start_col,
+        end_col,
+        start_grapheme: column_to_grapheme(line, start_col),
+        end_grapheme: column_to_grapheme(line, end_col),
+        source_offset: 0,
+        first_segment: true,
+    }]
+}
+
+fn next_wrap_end(line: &str, start_col: usize, width: usize) -> usize {
+    let limit = start_col + width;
+    let mut col = 0;
+
+    for grapheme in line.graphemes(true) {
+        let grapheme_width = display_width(grapheme);
+        if col >= start_col && col + grapheme_width > limit {
+            return if col == start_col {
+                col + grapheme_width
+            } else {
+                col
+            };
+        }
+        col += grapheme_width;
+    }
+
+    col
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wraps_ascii_line_at_width() {
+        let segments = wrap_line_segments("abcdef", 0, 3, 0);
+
+        assert_eq!(segments.len(), 2);
+        assert_eq!((segments[0].start_col, segments[0].end_col), (0, 3));
+        assert_eq!((segments[1].start_col, segments[1].end_col), (3, 6));
+        assert!(!segments[1].first_segment);
+    }
+
+    #[test]
+    fn skipcol_starts_at_later_wrapped_segment() {
+        let segments = wrap_line_segments("abcdefghijklmnopqrstuvwxyz", 0, 10, 10);
+
+        assert_eq!(segments[0].start_col, 10);
+        assert_eq!(segments[0].end_col, 20);
+        assert!(!segments[0].first_segment);
+    }
+
+    #[test]
+    fn wide_grapheme_does_not_split_at_boundary() {
+        let segments = wrap_line_segments("ab🙂cd", 0, 3, 0);
+
+        assert_eq!(segments[0].end_col, 2);
+        assert_eq!(segments[1].start_col, 2);
+        assert_eq!(segments[1].end_col, 5);
+    }
+}

--- a/src/editor/render_buffer.rs
+++ b/src/editor/render_buffer.rs
@@ -263,6 +263,47 @@ impl RenderBuffer {
         changes
     }
 
+    pub fn snapshot_rows(&self, rows: &[usize]) -> Vec<(usize, Vec<Cell>)> {
+        let mut snapshots = Vec::with_capacity(rows.len());
+        let mut seen = Vec::with_capacity(rows.len());
+
+        for &row in rows {
+            if row >= self.height || seen.contains(&row) {
+                continue;
+            }
+            seen.push(row);
+
+            let start = row * self.width;
+            let end = start + self.width;
+            snapshots.push((row, self.cells[start..end].to_vec()));
+        }
+
+        snapshots
+    }
+
+    pub fn diff_row_snapshots(&self, snapshots: &[(usize, Vec<Cell>)]) -> Vec<Change<'_>> {
+        let mut changes = Vec::new();
+
+        for (row, old_cells) in snapshots {
+            if *row >= self.height {
+                continue;
+            }
+            let start = row * self.width;
+            for (x, old_cell) in old_cells.iter().enumerate().take(self.width) {
+                let pos = start + x;
+                if pos >= self.cells.len() {
+                    break;
+                }
+                let cell = &self.cells[pos];
+                if cell != old_cell {
+                    changes.push(Change { x, y: *row, cell });
+                }
+            }
+        }
+
+        changes
+    }
+
     pub fn dump(&self, show_style_changes: bool) -> String {
         let mut s = String::new();
         let mut current_syle = None;

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -122,6 +122,7 @@ impl Editor {
         self.update_and_render_overlays(buffer)?;
 
         self.render_cursor_cell(buffer);
+        self.last_rendered_cursor_position = self.render_cursor_position();
 
         // Flush changes to terminal
         let diff = buffer.diff(&current_buffer);
@@ -189,12 +190,241 @@ impl Editor {
         self.render_dialog(buffer)?;
         self.update_and_render_overlays(buffer)?;
         self.render_cursor_cell(buffer);
+        self.last_rendered_cursor_position = self.render_cursor_position();
 
         let diff = buffer.diff(&current_buffer);
         self.render_diff(diff)?;
         self.render_generation = self.render_generation.wrapping_add(1);
 
         Ok(())
+    }
+
+    pub(crate) fn can_render_cursor_motion_delta(&self) -> bool {
+        self.terminal_output_enabled
+            && self.uses_synthetic_block_cursor()
+            && self.current_dialog.is_none()
+            && !self.panel_manager.has_focused_panel()
+            && !self.is_visual()
+            && self.active_search.is_none()
+            && (self.search_term.is_empty()
+                || !self.config.search.hlsearch
+                || self.search_highlights_suppressed)
+            && self.overlay_manager.is_empty()
+            && !self.active_buffer_has_diagnostics()
+    }
+
+    fn active_buffer_has_diagnostics(&self) -> bool {
+        let Ok(Some(uri)) = self.current_buffer().uri() else {
+            return false;
+        };
+
+        self.diagnostics
+            .get(&uri)
+            .is_some_and(|diagnostics| !diagnostics.is_empty())
+    }
+
+    pub(crate) fn render_cursor_motion_delta(
+        &mut self,
+        buffer: &mut RenderBuffer,
+    ) -> anyhow::Result<()> {
+        self.update_gutter_width();
+        self.fix_cursor_pos();
+        self.sync_to_window();
+
+        let new_cursor_position = self.render_cursor_position();
+        let mut rows = Vec::with_capacity(4);
+        if let Some((_, y)) = self.last_rendered_cursor_position {
+            rows.push(y);
+        }
+        if let Some((_, y)) = new_cursor_position {
+            rows.push(y);
+        }
+
+        let status_y = (self.size.1 as usize).saturating_sub(2);
+        let command_y = (self.size.1 as usize).saturating_sub(1);
+        rows.push(status_y);
+        rows.push(command_y);
+
+        let snapshots = buffer.snapshot_rows(&rows);
+        let active_window_id = self.window_manager.active_window_id();
+        self.render_window_rows(buffer, active_window_id, &rows)?;
+        self.draw_statusline(buffer);
+        self.draw_commandline(buffer);
+        self.render_cursor_cell(buffer);
+
+        let diff = buffer.diff_row_snapshots(&snapshots);
+        self.render_diff(diff)?;
+        self.last_rendered_cursor_position = new_cursor_position;
+        self.render_generation = self.render_generation.wrapping_add(1);
+
+        Ok(())
+    }
+
+    fn render_window_rows(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        window_id: usize,
+        terminal_rows: &[usize],
+    ) -> anyhow::Result<()> {
+        let window_data = {
+            let windows = self.window_manager.windows();
+            windows.get(window_id).map(|window| (*window).clone())
+        };
+        let Some(window) = window_data else {
+            return Ok(());
+        };
+
+        let local_rows = terminal_rows
+            .iter()
+            .filter_map(|row| row.checked_sub(window.position.y))
+            .filter(|row| *row < window.inner_height())
+            .collect::<Vec<_>>();
+        if local_rows.is_empty() {
+            return Ok(());
+        }
+
+        self.render_gutter_rows_in_window(buffer, &window, window_id, &local_rows);
+        self.render_main_content_rows_in_window(buffer, &window, &local_rows)?;
+        self.render_line_highlight_rows_in_window(buffer, &window, &local_rows);
+
+        Ok(())
+    }
+
+    fn render_gutter_rows_in_window(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        window: &crate::window::Window,
+        window_id: usize,
+        local_rows: &[usize],
+    ) {
+        let width = self.gutter_width_for_window(window);
+        let gutter_style = self.theme.gutter_style.fallback_bg(&self.theme.style);
+        let layout = self.layout_for_window(window);
+        let window_buffer = &self.buffers[window.buffer_index];
+
+        for &row in local_rows {
+            let mut line_count = window_buffer.navigable_line_count();
+            if self.window_manager.active_window_id() == window_id && self.is_insert() {
+                line_count = line_count.max(window.vtop + window.cy + 1);
+            }
+            let text = layout
+                .row(row)
+                .filter(|segment| segment.first_segment)
+                .and_then(|segment| {
+                    let line_number = segment.line + 1;
+                    (line_number <= line_count).then(|| format!("{line_number:>width$} "))
+                })
+                .unwrap_or_else(|| " ".repeat(width + 1));
+
+            let term_x = window.position.x;
+            let term_y = window.position.y + row;
+            buffer.set_text(term_x, term_y, &text, &gutter_style);
+        }
+    }
+
+    fn render_main_content_rows_in_window(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        window: &crate::window::Window,
+        local_rows: &[usize],
+    ) -> anyhow::Result<()> {
+        let layout = self.layout_for_window(window);
+        let (file, revision) = {
+            let window_buffer = &self.buffers[window.buffer_index];
+            (window_buffer.file.clone(), window_buffer.revision())
+        };
+        let cache_key = HighlightCacheKey {
+            buffer_index: window.buffer_index,
+            revision,
+            file: file.clone(),
+            vtop: window.vtop,
+            height: window.inner_height(),
+        };
+        let style_info =
+            self.cached_viewport_highlight_spans(cache_key, file.as_deref(), &layout.text)?;
+        let theme_style = self.theme.style.clone();
+        let mut style_cursor = StyleCursor::new(&style_info);
+        let gutter_width = self.gutter_width_for_window(window);
+        let content_start = gutter_width + 1;
+        let content_width = self.window_content_width(window);
+
+        for &row in local_rows {
+            let term_y = self.window_to_terminal_y(window, row);
+            let term_x = self.window_to_terminal_x(window, content_start);
+            self.fill_line_in_window(buffer, term_x, term_y, content_width, &theme_style);
+
+            let Some(segment) = layout.row(row) else {
+                continue;
+            };
+            let Some(line) = self.buffers[window.buffer_index].get(segment.line) else {
+                continue;
+            };
+            let line = line.trim_end_matches('\n');
+            for (grapheme_index, (byte_offset, grapheme)) in line.grapheme_indices(true).enumerate()
+            {
+                if grapheme_index < segment.start_grapheme {
+                    continue;
+                }
+                if grapheme_index >= segment.end_grapheme {
+                    break;
+                }
+
+                let grapheme_col = grapheme_to_column(line, grapheme_index);
+                if grapheme_col < segment.start_col {
+                    continue;
+                }
+                let local_x = grapheme_col.saturating_sub(segment.start_col);
+                if local_x >= content_width {
+                    break;
+                }
+
+                let style = style_cursor
+                    .style_at(segment.source_offset + byte_offset)
+                    .unwrap_or(&theme_style);
+                let term_x = self.window_to_terminal_x(window, content_start + local_x);
+                buffer.set_text(term_x, term_y, grapheme, style);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn render_line_highlight_rows_in_window(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        window: &crate::window::Window,
+        local_rows: &[usize],
+    ) {
+        if self.is_visual() || self.current_dialog.is_some() || !window.active {
+            return;
+        }
+        let Some(ref style) = self.theme.line_highlight_style else {
+            return;
+        };
+        let Some(bg) = style.bg else {
+            return;
+        };
+
+        let layout = self.layout_for_window(window);
+        let buffer_y = window.vtop + window.cy;
+        let Some(segment) = layout
+            .rows
+            .iter()
+            .find(|segment| segment.line == buffer_y && local_rows.contains(&segment.row))
+        else {
+            return;
+        };
+
+        let term_y = self.window_to_terminal_y(window, segment.row);
+        let gutter_width = self.gutter_width_for_window(window);
+        let start_x = window.position.x + gutter_width + 1;
+        let end_x = window.position.x + window.inner_width() - 1;
+        buffer.set_bg_for_range(
+            Point::new(start_x, term_y),
+            Point::new(end_x, term_y),
+            &bg,
+            &self.theme,
+        );
     }
 
     /// Renders a single window

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -984,8 +984,8 @@ impl Editor {
                     continue;
                 }
 
-                let start_col = display_width(char_prefix(&line, start_x));
-                let end_col = display_width(char_prefix(&line, end_x));
+                let start_col = display_width(char_prefix(line, start_x));
+                let end_col = display_width(char_prefix(line, end_x));
                 let points =
                     self.display_col_range_points_in_window(window, line_index, start_col, end_col);
                 buffer.set_bg_for_points(points, bg, &self.theme);

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -7,6 +7,7 @@ use crossterm::{
     cursor::{self, MoveTo},
     style, terminal, QueueableCommand as _,
 };
+use unicode_segmentation::UnicodeSegmentation as _;
 
 use crate::{
     color::{blend_color, Color},
@@ -15,7 +16,7 @@ use crate::{
     lsp::Diagnostic,
     theme::Style,
     unicode_utils::{
-        char_display_width, char_prefix, display_width, fit_display_width, truncate_display_width,
+        char_prefix, display_width, fit_display_width, grapheme_to_column, truncate_display_width,
     },
 };
 
@@ -130,7 +131,7 @@ impl Editor {
         Ok(())
     }
 
-    fn uses_synthetic_block_cursor(&self) -> bool {
+    pub(crate) fn uses_synthetic_block_cursor(&self) -> bool {
         let dialog_allows_editor_cursor = self
             .current_dialog
             .as_ref()
@@ -174,6 +175,26 @@ impl Editor {
             .or(self.theme.style.fg);
         cell.style.bold = false;
         cell.style.italic = false;
+    }
+
+    pub(crate) fn render_motion_frame(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.update_gutter_width();
+        self.fix_cursor_pos();
+        self.sync_to_window();
+        let current_buffer = buffer.clone();
+
+        let active_window_id = self.window_manager.active_window_id();
+        self.render_window(buffer, active_window_id)?;
+        self.render_ui_chrome(buffer)?;
+        self.render_dialog(buffer)?;
+        self.update_and_render_overlays(buffer)?;
+        self.render_cursor_cell(buffer);
+
+        let diff = buffer.diff(&current_buffer);
+        self.render_diff(diff)?;
+        self.render_generation = self.render_generation.wrapping_add(1);
+
+        Ok(())
     }
 
     /// Renders a single window
@@ -511,13 +532,10 @@ impl Editor {
         buffer: &mut RenderBuffer,
         window: &crate::window::Window,
     ) -> anyhow::Result<()> {
-        let (viewport_content, file, revision) = {
+        let layout = self.layout_for_window(window);
+        let (file, revision) = {
             let window_buffer = &self.buffers[window.buffer_index];
-            (
-                window_buffer.viewport(window.vtop, window.inner_height()),
-                window_buffer.file.clone(),
-                window_buffer.revision(),
-            )
+            (window_buffer.file.clone(), window_buffer.revision())
         };
         let cache_key = HighlightCacheKey {
             buffer_index: window.buffer_index,
@@ -527,104 +545,54 @@ impl Editor {
             height: window.inner_height(),
         };
         let style_info =
-            self.cached_viewport_highlight_spans(cache_key, file.as_deref(), &viewport_content)?;
+            self.cached_viewport_highlight_spans(cache_key, file.as_deref(), &layout.text)?;
         let theme_style = self.theme.style.clone();
         let mut style_cursor = StyleCursor::new(&style_info);
 
-        // Start at window position, accounting for gutter
         let gutter_width = self.gutter_width_for_window(window);
-        let mut x = gutter_width + 1; // Content starts after gutter within window
-        let mut y = 0; // Window-local y coordinate
+        let content_start = gutter_width + 1;
+        let content_width = self.window_content_width(window);
 
-        // Render each character with appropriate styling
-        for (pos, c) in viewport_content.char_indices() {
-            if c == '\n' {
-                // Fill the rest of the line within the window
-                let term_x = self.window_to_terminal_x(window, x);
-                let term_y = self.window_to_terminal_y(window, y);
+        for segment in &layout.rows {
+            let term_y = self.window_to_terminal_y(window, segment.row);
+            let term_x = self.window_to_terminal_x(window, gutter_width + 1);
+            self.fill_line_in_window(buffer, term_x, term_y, content_width, &theme_style);
 
-                // Only fill if within window bounds
-                if x < window.inner_width() {
-                    self.fill_line_in_window(
-                        buffer,
-                        term_x,
-                        term_y,
-                        window.inner_width().saturating_sub(x),
-                        &theme_style,
-                    );
+            let Some(line) = self.buffers[window.buffer_index].get(segment.line) else {
+                continue;
+            };
+            let line = line.trim_end_matches('\n');
+            for (grapheme_index, (byte_offset, grapheme)) in line.grapheme_indices(true).enumerate()
+            {
+                if grapheme_index < segment.start_grapheme {
+                    continue;
                 }
-
-                x = gutter_width + 1;
-                y += 1;
-                if y >= window.inner_height() {
+                if grapheme_index >= segment.end_grapheme {
                     break;
                 }
-                continue;
-            }
 
-            let char_width = char_display_width(c);
-
-            // Skip if character would overflow the window width
-            if x + char_width > window.inner_width() {
-                continue;
-            }
-
-            let style = style_cursor.style_at(pos).unwrap_or(&theme_style);
-
-            // Convert to terminal coordinates
-            let term_x = self.window_to_terminal_x(window, x);
-            let term_y = self.window_to_terminal_y(window, y);
-
-            // For wide characters, we need to handle them specially
-            if char_width > 1 {
-                // Set the main character
-                buffer.set_char(term_x, term_y, c, style, &self.theme);
-                // Fill the remaining columns with spaces to maintain alignment
-                for i in 1..char_width {
-                    if x + i < window.inner_width() {
-                        buffer.set_char(term_x + i, term_y, ' ', style, &self.theme);
-                    }
+                let grapheme_col = grapheme_to_column(line, grapheme_index);
+                if grapheme_col < segment.start_col {
+                    continue;
                 }
-                x += char_width;
-            } else if char_width == 0 {
-                // Zero-width characters (like combining marks) - don't advance x
-                // TODO: These should ideally be combined with the previous character
-            } else {
-                buffer.set_char(term_x, term_y, c, style, &self.theme);
-                x += 1;
+                let local_x = grapheme_col.saturating_sub(segment.start_col);
+                if local_x >= content_width {
+                    break;
+                }
+
+                let style = style_cursor
+                    .style_at(segment.source_offset + byte_offset)
+                    .unwrap_or(&theme_style);
+                let term_x = self.window_to_terminal_x(window, content_start + local_x);
+                let term_y = self.window_to_terminal_y(window, segment.row);
+                buffer.set_text(term_x, term_y, grapheme, style);
             }
         }
 
-        if !viewport_content.is_empty()
-            && !viewport_content.ends_with('\n')
-            && y < window.inner_height()
-        {
-            let term_y = self.window_to_terminal_y(window, y);
-            if x < window.inner_width() {
-                let term_x = self.window_to_terminal_x(window, x);
-                self.fill_line_in_window(
-                    buffer,
-                    term_x,
-                    term_y,
-                    window.inner_width().saturating_sub(x),
-                    &theme_style,
-                );
-            }
-            y += 1;
-        }
-
-        // Fill any remaining lines within the window
-        while y < window.inner_height() {
+        for y in layout.rows.len()..window.inner_height() {
             let term_y = self.window_to_terminal_y(window, y);
             let term_x = self.window_to_terminal_x(window, gutter_width + 1);
-            self.fill_line_in_window(
-                buffer,
-                term_x,
-                term_y,
-                window.inner_width().saturating_sub(gutter_width + 1),
-                &theme_style,
-            );
-            y += 1;
+            self.fill_line_in_window(buffer, term_x, term_y, content_width, &theme_style);
         }
 
         Ok(())
@@ -661,12 +629,14 @@ impl Editor {
         // Render current line highlight
         if !self.is_visual() && self.current_dialog.is_none() && window.active {
             if let Some(ref style) = self.theme.line_highlight_style {
-                // Calculate window-relative cursor position
-                let window_cy = window.cy;
-                let term_y = self.window_to_terminal_y(window, window_cy);
-
-                // Only highlight if the line is within the window
-                if window_cy < window.inner_height() {
+                let layout = self.layout_for_window(window);
+                let buffer_y = window.vtop + window.cy;
+                if let Some(segment) = layout
+                    .rows
+                    .iter()
+                    .find(|segment| segment.line == buffer_y && segment.row < window.inner_height())
+                {
+                    let term_y = self.window_to_terminal_y(window, segment.row);
                     let gutter_width = self.gutter_width_for_window(window);
                     let start_x = window.position.x + gutter_width + 1;
                     let end_x = window.position.x + window.inner_width() - 1;
@@ -744,12 +714,14 @@ impl Editor {
             .as_ref()
             .and_then(|style| style.bg)
             .unwrap_or(match_bg);
-        let gutter_width = self.gutter_width_for_window(window);
-        let content_start = gutter_width + 1;
-        let content_end = window.inner_width();
-
         for match_ in matches {
-            if match_.end_y < window.vtop || match_.start_y >= window.vtop + window.inner_height() {
+            let layout = self.layout_for_window(window);
+            let visible_start = layout.rows.first().map(|segment| segment.line);
+            let visible_end = layout.rows.last().map(|segment| segment.line);
+            if visible_start.is_none()
+                || match_.end_y < visible_start.unwrap()
+                || match_.start_y > visible_end.unwrap()
+            {
                 continue;
             }
 
@@ -757,18 +729,16 @@ impl Editor {
                 .or(cursor_start)
                 .is_some_and(|start| start == (match_.start_x, match_.start_y));
             let bg = if is_current { &match_bg } else { &highlight_bg };
-            let start_y = match_.start_y.max(window.vtop);
-            let end_y = match_
-                .end_y
-                .min(window.vtop + window.inner_height().saturating_sub(1));
+            let start_y = match_.start_y.max(visible_start.unwrap());
+            let end_y = match_.end_y.min(visible_end.unwrap());
 
             for line_index in start_y..=end_y {
-                let local_y = line_index.saturating_sub(window.vtop);
                 let line = self
                     .buffers
                     .get(window.buffer_index)
                     .and_then(|buffer| buffer.get(line_index))
                     .unwrap_or_default();
+                let line = line.trim_end_matches('\n');
                 let line_len = line.chars().count();
                 let start_x = if line_index == match_.start_y {
                     match_.start_x
@@ -786,28 +756,56 @@ impl Editor {
 
                 let start_col = display_width(char_prefix(&line, start_x));
                 let end_col = display_width(char_prefix(&line, end_x));
-                let start = content_start.saturating_add(start_col).min(content_end);
-                let end = content_start
-                    .saturating_add(end_col)
-                    .saturating_sub(1)
-                    .min(content_end.saturating_sub(1));
-                if start > end {
-                    continue;
-                }
-
-                let term_y = self.window_to_terminal_y(window, local_y);
-                let term_start = self.window_to_terminal_x(window, start);
-                let term_end = self.window_to_terminal_x(window, end);
-                buffer.set_bg_for_range(
-                    Point::new(term_start, term_y),
-                    Point::new(term_end, term_y),
-                    bg,
-                    &self.theme,
-                );
+                let points =
+                    self.display_col_range_points_in_window(window, line_index, start_col, end_col);
+                buffer.set_bg_for_points(points, bg, &self.theme);
             }
         }
 
         Ok(())
+    }
+
+    fn display_col_range_points_in_window(
+        &self,
+        window: &crate::window::Window,
+        line_index: usize,
+        start_col: usize,
+        end_col: usize,
+    ) -> Vec<Point> {
+        if end_col <= start_col {
+            return Vec::new();
+        }
+
+        let layout = self.layout_for_window(window);
+        let gutter_width = self.gutter_width_for_window(window);
+        let content_start = gutter_width + 1;
+        let content_width = self.window_content_width(window);
+        let mut points = Vec::new();
+
+        for segment in layout
+            .rows
+            .iter()
+            .filter(|segment| segment.line == line_index)
+        {
+            let start = start_col.max(segment.start_col);
+            let end = end_col.min(segment.end_col);
+            if end <= start {
+                continue;
+            }
+
+            for col in start..end {
+                let local_x = col.saturating_sub(segment.start_col);
+                if local_x >= content_width {
+                    continue;
+                }
+                points.push(Point::new(
+                    self.window_to_terminal_x(window, content_start + local_x),
+                    self.window_to_terminal_y(window, segment.row),
+                ));
+            }
+        }
+
+        points
     }
 
     /// Renders a single diagnostic entry
@@ -860,15 +858,18 @@ impl Editor {
                 acc
             });
 
+        let layout = self.layout_for_window(window);
+
         // Render diagnostics for visible lines in this window
         for (line_num, diagnostics) in diagnostics_by_line {
-            // Skip if line is not in window's viewport
-            if line_num < window.vtop || line_num >= window.vtop + window.inner_height() {
+            let Some(segment) = layout
+                .rows
+                .iter()
+                .rev()
+                .find(|segment| segment.line == line_num)
+            else {
                 continue;
-            }
-
-            // Get the window-relative line number
-            let window_y = line_num - window.vtop;
+            };
 
             // Get the line content to determine where to place the diagnostic
             let Some(line) = window_buffer.get(line_num) else {
@@ -877,7 +878,11 @@ impl Editor {
 
             // Calculate diagnostic indicator position within window
             let gutter_width = self.gutter_width_for_window(window);
-            let content_end = gutter_width + display_width(line.trim_end_matches('\n'));
+            let line_width = display_width(line.trim_end_matches('\n'));
+            if line_width > segment.end_col {
+                continue;
+            }
+            let content_end = gutter_width + 1 + line_width.saturating_sub(segment.start_col);
             let indicator_x = content_end + 5; // Add some padding
 
             // Skip if diagnostic would be outside window
@@ -894,7 +899,7 @@ impl Editor {
 
             // Convert to terminal coordinates
             let term_x = self.window_to_terminal_x(window, indicator_x);
-            let term_y = self.window_to_terminal_y(window, window_y);
+            let term_y = self.window_to_terminal_y(window, segment.row);
 
             // Render diagnostic indicator and truncated message
             self.render_line_diagnostics(
@@ -923,13 +928,6 @@ impl Editor {
         let mut cells = Vec::new();
 
         for y in selection.y0..=selection.y1 {
-            // Skip lines outside window viewport
-            if y < window.vtop || y >= window.vtop + window.inner_height() {
-                continue;
-            }
-
-            let window_y = y - window.vtop;
-
             let (start_x, end_x) = match self.mode {
                 Mode::Visual => {
                     if y == selection.y0 && y == selection.y1 {
@@ -947,17 +945,15 @@ impl Editor {
                 _ => unreachable!(),
             };
 
-            // Convert to terminal coordinates
-            for x in start_x..=end_x {
-                // Skip if x is outside window bounds
-                let gutter_width = self.gutter_width_for_window(window);
-                if x + gutter_width + 1 >= window.inner_width() {
-                    continue;
-                }
-
-                let term_x = self.window_to_terminal_x(window, x + gutter_width + 1);
-                let term_y = self.window_to_terminal_y(window, window_y);
-                cells.push(Point::new(term_x, term_y));
+            let Some(line) = self.buffers[window.buffer_index].get(y) else {
+                continue;
+            };
+            let line = line.trim_end_matches('\n');
+            let start_col = grapheme_to_column(line, start_x);
+            let end_col = grapheme_to_column(line, end_x.saturating_add(1));
+            cells.extend(self.display_col_range_points_in_window(window, y, start_col, end_col));
+            if line.is_empty() && start_x == 0 && end_x == 0 {
+                cells.extend(self.display_col_range_points_in_window(window, y, 0, 1));
             }
         }
 
@@ -1245,20 +1241,22 @@ impl Editor {
         let width = self.gutter_width_for_window(window);
         let gutter_style = self.theme.gutter_style.fallback_bg(&self.theme.style);
 
-        // Get the buffer for this window
+        let layout = self.layout_for_window(window);
         let window_buffer = &self.buffers[window.buffer_index];
 
         for y in 0..window.inner_height() {
-            let line_number = y + 1 + window.vtop;
             let mut line_count = window_buffer.navigable_line_count();
             if self.window_manager.active_window_id() == window_id && self.is_insert() {
                 line_count = line_count.max(window.vtop + window.cy + 1);
             }
-            let text = if line_number <= line_count {
-                format!("{:>width$} ", line_number)
-            } else {
-                " ".repeat(width + 1)
-            };
+            let text = layout
+                .row(y)
+                .filter(|segment| segment.first_segment)
+                .and_then(|segment| {
+                    let line_number = segment.line + 1;
+                    (line_number <= line_count).then(|| format!("{line_number:>width$} "))
+                })
+                .unwrap_or_else(|| " ".repeat(width + 1));
 
             let term_x = window.position.x;
             let term_y = window.position.y + y;
@@ -1332,10 +1330,7 @@ impl Editor {
         } else {
             // Get the active window to calculate cursor position
             if let Some(window) = self.window_manager.active_window() {
-                // Use window's cursor position
-                let window_cy = window.cy;
-                let window_cx = window.cx;
-                let buffer_y = window.vtop + window_cy;
+                let buffer_y = window.vtop + window.cy;
 
                 // Calculate the actual display column for the cursor
                 let display_col =
@@ -1343,14 +1338,18 @@ impl Editor {
                         let line = line.trim_end_matches('\n');
                         self.display_col_for_cursor_goal(line, window.cursor_goal)
                     } else {
-                        window_cx
+                        window.cx
                     };
 
-                // Convert to terminal coordinates based on active window
+                let layout = self.layout_for_window(window);
+                let segment = layout.segment_for_cursor(buffer_y, display_col)?;
                 let gutter_width = self.gutter_width_for_window(window);
-                let term_x = window.position.x + gutter_width + 1 + display_col;
-                let term_y =
-                    window.position.y + window_cy.min(window.inner_height().saturating_sub(1));
+                let term_x = window.position.x
+                    + gutter_width
+                    + 1
+                    + segment
+                        .screen_col_for_display_col(display_col, self.window_content_width(window));
+                let term_y = window.position.y + segment.row;
                 Some((term_x, term_y))
             } else {
                 // Fallback to old behavior if no active window

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -405,13 +405,51 @@ pub fn normalized_extension(file: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::theme::parse_vscode_theme;
+    use crate::{
+        color::Color,
+        theme::{parse_vscode_theme, Style, Theme, TokenStyle},
+    };
 
     use super::*;
 
     fn highlighter() -> Highlighter {
         let theme = parse_vscode_theme("themes/mocha.json").unwrap();
         Highlighter::new(&theme).unwrap()
+    }
+
+    fn theme_with_markdown_textmate_scopes() -> Theme {
+        let markdown_heading = Style {
+            fg: Some(Color::Rgb {
+                r: 139,
+                g: 164,
+                b: 176,
+            }),
+            ..Default::default()
+        };
+        let markdown_plain = Style {
+            fg: Some(Color::Rgb {
+                r: 197,
+                g: 201,
+                b: 199,
+            }),
+            ..Default::default()
+        };
+
+        Theme {
+            token_styles: vec![
+                TokenStyle {
+                    name: None,
+                    scope: vec!["markup.heading.markdown".to_string()],
+                    style: markdown_heading,
+                },
+                TokenStyle {
+                    name: None,
+                    scope: vec!["punctuation.definition.list_item.markdown".to_string()],
+                    style: markdown_plain,
+                },
+            ],
+            ..Theme::default()
+        }
     }
 
     #[test]
@@ -499,6 +537,28 @@ mod tests {
         assert!(
             styles.iter().any(|style| style.start == 14),
             "markdown list marker should be highlighted"
+        );
+    }
+
+    #[test]
+    fn markdown_highlights_with_textmate_markdown_theme_scopes() {
+        let theme = theme_with_markdown_textmate_scopes();
+        let mut highlighter = Highlighter::new(&theme).unwrap();
+        let code = "## Determining the PR(s)\n- Use `gh`\n";
+        let styles = highlighter
+            .highlight_for_file(Some("SKILL.md"), code)
+            .unwrap();
+        let list_marker_start = code.find("- ").unwrap();
+
+        assert!(
+            styles
+                .iter()
+                .any(|style| style.start <= 3 && style.end >= 21),
+            "markdown heading should use TextMate-compatible theme scopes"
+        );
+        assert!(
+            styles.iter().any(|style| style.start == list_marker_start),
+            "markdown list marker should use TextMate-compatible theme scopes"
         );
     }
 

--- a/src/plugin/overlay.rs
+++ b/src/plugin/overlay.rs
@@ -209,6 +209,10 @@ impl OverlayManager {
         self.overlays.values().any(|o| o.is_dirty())
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.overlays.is_empty()
+    }
+
     pub fn mark_all_dirty(&mut self) {
         for overlay in self.overlays.values_mut() {
             overlay.content.dirty = true;

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -28,12 +28,14 @@ pub struct Theme {
 
 impl Theme {
     pub fn get_style(&self, scope: &str) -> Option<Style> {
-        self.token_styles.iter().find_map(|ts| {
-            if ts.scope.contains(&scope.to_string()) {
-                Some(ts.style.clone())
-            } else {
-                None
-            }
+        compatible_scopes(scope).into_iter().find_map(|candidate| {
+            self.token_styles.iter().find_map(|ts| {
+                if ts.scope.contains(&candidate) {
+                    Some(ts.style.clone())
+                } else {
+                    None
+                }
+            })
         })
     }
 
@@ -46,6 +48,67 @@ impl Theme {
                 g: 255,
                 b: 255,
             })
+    }
+}
+
+fn compatible_scopes(scope: &str) -> Vec<String> {
+    let mut scopes = Vec::new();
+    push_scope_with_parents(&mut scopes, scope);
+
+    for alias in markdown_scope_aliases(scope) {
+        push_scope_with_parents(&mut scopes, alias);
+    }
+
+    scopes
+}
+
+fn push_scope_with_parents(scopes: &mut Vec<String>, scope: &str) {
+    push_unique_scope(scopes, scope);
+
+    let mut boundary = scope.len();
+    while let Some(previous) = scope[..boundary].rfind('.') {
+        let parent = &scope[..previous];
+        if parent.is_empty() {
+            break;
+        }
+        push_unique_scope(scopes, parent);
+        boundary = previous;
+    }
+}
+
+fn push_unique_scope(scopes: &mut Vec<String>, scope: &str) {
+    if !scopes.iter().any(|candidate| candidate == scope) {
+        scopes.push(scope.to_string());
+    }
+}
+
+fn markdown_scope_aliases(scope: &str) -> &'static [&'static str] {
+    match scope {
+        "heading.1.markdown"
+        | "heading.2.markdown"
+        | "heading.3.markdown"
+        | "heading.4.markdown"
+        | "heading.5.markdown"
+        | "heading.6.markdown"
+        | "markup.heading.setext.1.markdown"
+        | "markup.heading.setext.2.markdown"
+        | "punctuation.definition.heading.markdown" => &[
+            "markup.heading.markdown",
+            "markdown.heading",
+            "markup.heading",
+        ],
+        "punctuation.definition.list.begin.markdown" => {
+            &["punctuation.definition.list_item.markdown", "markup.list"]
+        }
+        "markup.raw.block.markdown" => &["markup.raw.block.fenced.markdown", "markup.raw.block"],
+        "punctuation.definition.raw.markdown" => &["punctuation.definition.fenced.markdown"],
+        "punctuation.definition.quote.begin.markdown" => {
+            &["punctuation.definition.blockquote.markdown", "markup.quote"]
+        }
+        "markup.underline.link.markdown" => {
+            &["string.other.link.title.markdown", "markup.underline"]
+        }
+        _ => &[],
     }
 }
 
@@ -220,3 +283,72 @@ impl Style {
 //         }
 //     }
 // }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn style(r: u8, g: u8, b: u8) -> Style {
+        Style {
+            fg: Some(Color::Rgb { r, g, b }),
+            ..Default::default()
+        }
+    }
+
+    fn theme_with_token_styles(token_styles: Vec<TokenStyle>) -> Theme {
+        Theme {
+            token_styles,
+            ..Theme::default()
+        }
+    }
+
+    #[test]
+    fn get_style_matches_markdown_textmate_heading_aliases() {
+        let markdown_heading = style(139, 164, 176);
+        let generic_heading = style(138, 154, 123);
+        let theme = theme_with_token_styles(vec![
+            TokenStyle {
+                name: None,
+                scope: vec!["markup.heading".to_string()],
+                style: generic_heading,
+            },
+            TokenStyle {
+                name: None,
+                scope: vec!["markup.heading.markdown".to_string()],
+                style: markdown_heading.clone(),
+            },
+        ]);
+
+        assert_eq!(
+            theme.get_style("heading.1.markdown"),
+            Some(markdown_heading)
+        );
+    }
+
+    #[test]
+    fn get_style_matches_markdown_textmate_list_and_fence_aliases() {
+        let list_marker = style(197, 201, 199);
+        let fence = style(92, 96, 102);
+        let theme = theme_with_token_styles(vec![
+            TokenStyle {
+                name: None,
+                scope: vec!["punctuation.definition.list_item.markdown".to_string()],
+                style: list_marker.clone(),
+            },
+            TokenStyle {
+                name: None,
+                scope: vec!["punctuation.definition.fenced.markdown".to_string()],
+                style: fence.clone(),
+            },
+        ]);
+
+        assert_eq!(
+            theme.get_style("punctuation.definition.list.begin.markdown"),
+            Some(list_marker)
+        );
+        assert_eq!(
+            theme.get_style("punctuation.definition.raw.markdown"),
+            Some(fence)
+        );
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -28,6 +28,12 @@ pub struct Window {
     /// Left column of viewport (for horizontal scrolling)
     pub vleft: usize,
 
+    /// First skipped display column when wrap mode scrolls within a long line.
+    pub skipcol: usize,
+
+    /// Whether this window wraps long lines.
+    pub wrap: bool,
+
     /// Cursor x position (column) within the buffer
     pub cx: usize,
 
@@ -53,6 +59,8 @@ impl Window {
             size,
             vtop: 0,
             vleft: 0,
+            skipcol: 0,
+            wrap: true,
             cx: 0,
             cy: 0,
             cursor_goal: CursorGoal::default(),
@@ -234,6 +242,10 @@ pub enum SplitSnapshot {
         buffer_index: usize,
         vtop: usize,
         vleft: usize,
+        #[serde(default)]
+        skipcol: usize,
+        #[serde(default = "default_wrap")]
+        wrap: bool,
         cx: usize,
         cy: usize,
         vx: usize,
@@ -248,6 +260,10 @@ pub enum SplitSnapshot {
         left: Box<SplitSnapshot>,
         right: Box<SplitSnapshot>,
     },
+}
+
+fn default_wrap() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -336,6 +352,8 @@ impl Split {
                 buffer_index: window.buffer_index,
                 vtop: window.vtop,
                 vleft: window.vleft,
+                skipcol: window.skipcol,
+                wrap: window.wrap,
                 cx: window.cx,
                 cy: window.cy,
                 vx: window.vx,
@@ -359,6 +377,8 @@ impl Split {
                 buffer_index,
                 vtop,
                 vleft,
+                skipcol,
+                wrap,
                 cx,
                 cy,
                 vx,
@@ -367,6 +387,8 @@ impl Split {
                 let mut window = Window::new(mapped_buffer, Point::new(0, 0), (0, 0));
                 window.vtop = *vtop;
                 window.vleft = *vleft;
+                window.skipcol = *skipcol;
+                window.wrap = *wrap;
                 window.cx = *cx;
                 window.cy = *cy;
                 window.vx = *vx;
@@ -1235,6 +1257,7 @@ impl WindowManager {
                     let mut new_window =
                         Window::new(new_buffer_index, window.position, window.size);
                     new_window.active = false;
+                    new_window.wrap = window.wrap;
 
                     let mut old_window = window.clone();
                     old_window.active = false;

--- a/tests/common/editor_harness.rs
+++ b/tests/common/editor_harness.rs
@@ -45,9 +45,19 @@ impl EditorHarness {
 
     /// Create a new test harness with custom configuration
     pub fn with_config(buffer: Buffer, config: Config) -> Self {
+        Self::with_config_and_size(buffer, config, 80, 24)
+    }
+
+    pub fn with_config_and_size(
+        buffer: Buffer,
+        config: Config,
+        width: usize,
+        height: usize,
+    ) -> Self {
         let lsp = Box::new(MockLsp) as Box<dyn LspClient + Send>;
         let theme = Theme::default();
-        let mut editor = Editor::with_size(lsp, 80, 24, config, theme, vec![buffer]).unwrap();
+        let mut editor =
+            Editor::with_size(lsp, width, height, config, theme, vec![buffer]).unwrap();
         editor.test_disable_terminal_output();
 
         Self { editor }
@@ -179,6 +189,18 @@ impl EditorHarness {
 
     pub fn viewport_top(&self) -> usize {
         self.editor.test_vtop()
+    }
+
+    pub fn viewport_left(&self) -> usize {
+        self.editor.test_vleft()
+    }
+
+    pub fn skipcol(&self) -> usize {
+        self.editor.test_skipcol()
+    }
+
+    pub fn wrap(&self) -> bool {
+        self.editor.test_wrap()
     }
 
     pub fn set_viewport_cursor(&mut self, vtop: usize, cx: usize, cy: usize) {

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -172,6 +172,24 @@ async fn whitespace_only_commands_are_not_saved_to_history() {
 }
 
 #[tokio::test]
+async fn wrap_commands_toggle_line_wrapping() {
+    let mut harness = EditorHarness::with_content("short");
+    assert!(harness.wrap());
+
+    harness
+        .execute_action(Action::Command("nowrap".to_string()))
+        .await
+        .unwrap();
+    assert!(!harness.wrap());
+
+    harness
+        .execute_action(Action::Command("wrap".to_string()))
+        .await
+        .unwrap();
+    assert!(harness.wrap());
+}
+
+#[tokio::test]
 async fn submitted_commands_are_persisted_to_preferences() {
     let dir = std::env::temp_dir().join(format!("red-command-history-{}", uuid::Uuid::new_v4()));
     let path = dir.join("preferences.json");

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -186,6 +186,39 @@ async fn test_wrap_uses_skipcol_for_deep_wrapped_cursor() {
 }
 
 #[tokio::test]
+async fn test_screen_line_down_updates_rendered_cursor_without_lag() {
+    let content = format!(
+        "{}\n{}",
+        (1..=7)
+            .map(|line| format!("Line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        "When this skill is invoked, the PR(s) to update may be specified explicitly, but in the common case, the PR(s) to update will be inferred from the branch / commit that the user is currently working on. "
+            .repeat(3)
+    );
+    let buffer = Buffer::new(None, content);
+    let config = Config {
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 80, 20);
+
+    for _ in 0..7 {
+        harness.execute_action(Action::MoveDown).await.unwrap();
+    }
+
+    let before = harness.render_cursor_position().unwrap();
+    harness
+        .execute_action(Action::MoveScreenLineDown)
+        .await
+        .unwrap();
+    let after = harness.render_cursor_position().unwrap();
+
+    harness.assert_cursor_at(77, 7);
+    assert_eq!(after.1, before.1 + 1);
+}
+
+#[tokio::test]
 async fn test_next_word_keeps_cursor_visible_on_deep_wrapped_line() {
     let buffer = Buffer::new(
         None,

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -21,6 +21,27 @@ async fn type_normal_keys(harness: &mut EditorHarness, keys: &str) {
     }
 }
 
+fn wrapped_long_line_content(line_count: usize) -> String {
+    (1..=line_count)
+        .map(|line| {
+            format!(
+                "Line {line:02} {}",
+                "this is a long wrapped markdown-style paragraph ".repeat(8)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn wrapped_long_line_harness(line_count: usize) -> EditorHarness {
+    let buffer = Buffer::new(None, wrapped_long_line_content(line_count));
+    let config = Config {
+        wrap: Some(true),
+        ..Default::default()
+    };
+    EditorHarness::with_config_and_size(buffer, config, 48, 12)
+}
+
 #[tokio::test]
 async fn test_basic_cursor_movement() {
     let mut harness = EditorHarness::with_content("Hello, World!\nThis is a test\nThird line");
@@ -977,6 +998,66 @@ async fn test_scrolling_clamps_to_last_real_line() {
     }
     assert_eq!(harness.buffer_line(), 7);
     assert_eq!(harness.current_line(), Some("Line 8\n".to_string()));
+}
+
+#[tokio::test]
+async fn test_wrapped_move_to_bottom_reaches_visible_last_line() {
+    let mut harness = wrapped_long_line_harness(86);
+
+    harness.execute_action(Action::MoveToBottom).await.unwrap();
+
+    assert_eq!(harness.buffer_line(), 85);
+    assert!(harness
+        .current_line()
+        .as_deref()
+        .is_some_and(|line| line.starts_with("Line 86 ")));
+    assert!(
+        harness.render_cursor_position().is_some(),
+        "last logical line should also be visible after G"
+    );
+}
+
+#[tokio::test]
+async fn test_wrapped_go_to_last_line_reaches_visible_last_line() {
+    let mut harness = wrapped_long_line_harness(86);
+
+    harness.execute_action(Action::GoToLine(86)).await.unwrap();
+
+    assert_eq!(harness.buffer_line(), 85);
+    assert!(
+        harness.render_cursor_position().is_some(),
+        ":$ should leave the last line visible in wrapped files"
+    );
+}
+
+#[tokio::test]
+async fn test_wrapped_page_down_reaches_end_of_large_wrapped_file() {
+    let mut harness = wrapped_long_line_harness(86);
+
+    for _ in 0..20 {
+        harness.execute_action(Action::PageDown).await.unwrap();
+    }
+
+    assert_eq!(harness.buffer_line(), 85);
+    assert!(
+        harness.render_cursor_position().is_some(),
+        "Ctrl-f should not stop before the visible end of a wrapped file"
+    );
+}
+
+#[tokio::test]
+async fn test_wrapped_move_down_reaches_end_of_large_wrapped_file() {
+    let mut harness = wrapped_long_line_harness(86);
+
+    for _ in 0..160 {
+        harness.execute_action(Action::MoveDown).await.unwrap();
+    }
+
+    assert_eq!(harness.buffer_line(), 85);
+    assert!(
+        harness.render_cursor_position().is_some(),
+        "holding j should not loop before the end of a wrapped file"
+    );
 }
 
 #[tokio::test]

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -62,6 +62,133 @@ async fn test_line_movement() {
 }
 
 #[tokio::test]
+async fn test_wrap_renders_long_line_across_screen_rows() {
+    let buffer = Buffer::new(None, "abcdefghijklmnop".to_string());
+    let config = Config {
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 10, 6);
+
+    let first_row = harness.render_row(0).unwrap();
+    let second_row = harness.render_row(1).unwrap();
+
+    assert_eq!(
+        first_row.chars().skip(3).take(7).collect::<String>(),
+        "abcdefg"
+    );
+    assert_eq!(second_row.chars().take(3).collect::<String>(), "   ");
+    assert_eq!(
+        second_row.chars().skip(3).take(7).collect::<String>(),
+        "hijklmn"
+    );
+}
+
+#[tokio::test]
+async fn test_nowrap_scrolls_horizontally_as_cursor_moves() {
+    let buffer = Buffer::new(None, "abcdefghijklmnopqrstuvwxyz".to_string());
+    let config = Config {
+        wrap: Some(false),
+        sidescroll: Some(1),
+        sidescrolloff: Some(0),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 10, 6);
+
+    for _ in 0..12 {
+        harness.execute_action(Action::MoveRight).await.unwrap();
+    }
+
+    assert_eq!(harness.cursor_position(), (12, 0));
+    assert_eq!(harness.viewport_left(), 6);
+    let row = harness.render_row(0).unwrap();
+    assert_eq!(row.chars().skip(3).take(7).collect::<String>(), "ghijklm");
+
+    for _ in 0..10 {
+        harness.execute_action(Action::MoveLeft).await.unwrap();
+    }
+
+    assert_eq!(harness.cursor_position(), (2, 0));
+    assert_eq!(harness.viewport_left(), 2);
+}
+
+#[tokio::test]
+async fn test_screen_line_start_and_end_use_wrapped_segment() {
+    let buffer = Buffer::new(None, "abcdefghijklmnop".to_string());
+    let config = Config {
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 10, 6);
+
+    for _ in 0..10 {
+        harness.execute_action(Action::MoveRight).await.unwrap();
+    }
+
+    harness
+        .execute_action(Action::MoveToScreenLineStart)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(7, 0);
+
+    harness
+        .execute_action(Action::MoveToScreenLineEnd)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(13, 0);
+}
+
+#[tokio::test]
+async fn test_wrap_uses_skipcol_for_deep_wrapped_cursor() {
+    let buffer = Buffer::new(None, "abcdefghijklmnopqrstuvwxyz0123456789".to_string());
+    let config = Config {
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 10, 6);
+
+    for _ in 0..30 {
+        harness.execute_action(Action::MoveRight).await.unwrap();
+    }
+
+    assert!(harness.skipcol() > 0);
+    assert_eq!(harness.viewport_left(), 0);
+    assert!(harness.render_cursor_position().is_some());
+
+    harness
+        .execute_action(Action::MoveScreenLineDown)
+        .await
+        .unwrap();
+
+    harness.assert_cursor_at(35, 0);
+    assert!(harness.skipcol() > 0);
+}
+
+#[tokio::test]
+async fn test_next_word_keeps_cursor_visible_on_deep_wrapped_line() {
+    let buffer = Buffer::new(
+        None,
+        "alpha beta gamma delta epsilon zeta eta theta iota kappa".to_string(),
+    );
+    let config = Config {
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 10, 4);
+
+    for _ in 0..7 {
+        harness
+            .execute_action(Action::MoveToNextWord)
+            .await
+            .unwrap();
+    }
+
+    harness.assert_cursor_at(40, 0);
+    assert!(harness.skipcol() > 0);
+    assert!(harness.render_cursor_position().is_some());
+}
+
+#[tokio::test]
 async fn test_word_movement() {
     let mut harness = EditorHarness::with_content("Hello world this is test");
 


### PR DESCRIPTION
## Why

Long prose-heavy buffers need the same practical behavior users expect from Vim and Neovim: wrapped display lines should be navigable as screen rows, and unwrapped long lines should keep the cursor visible by scrolling horizontally. Without that, Markdown skill files and other long-line documents can leave the cursor past the visible edge. Holding repeated motions such as `w` also exposed a performance issue where Red rendered too many stale intermediate states and continued processing queued repeats after the key was released.

This PR also fixes a related Markdown visibility issue found while testing the wrapping work. Red was parsing Markdown, but many common VS Code themes use TextMate-style Markdown scopes that did not exactly match Red's tree-sitter capture names, so Markdown tokens could silently fall back to plain text.

## What Changed

Added Vim-like wrapping controls with `wrap`, `sidescroll`, and `sidescrolloff`, plus per-window wrapping and horizontal scroll state. The editor now builds display layouts for wrapped and unwrapped lines so screen-line motions and no-wrap horizontal scrolling share a consistent rendering model.

Repeated normal-mode motions now drain queued key repeats in batches, avoid per-step full renders where possible, and discard stale queued repeats after the drain budget so Red does not keep walking long after a held key is released. Rendering also gained row-scoped snapshots and diffs for cheaper motion redraws.

Markdown highlighting now maps Red's Markdown tree-sitter captures to compatible TextMate and VS Code Markdown scopes, so themes that define selectors such as `markup.heading.markdown` or `punctuation.definition.list_item.markdown` visibly style `.md` buffers.

## How to Test

1. Start Red with a Markdown file that contains long prose lines, headings, list markers, and fenced code blocks.
2. Move through long lines with `w`, `j`, `k`, `gk`, `gj`, `g0`, and `g$` while `wrap` is enabled and confirm the cursor remains visible on wrapped screen rows. Also verify `G`, `:$`, and repeated `Ctrl-f` reach the visible end of the file.
3. Disable wrapping and move through a long line, confirming horizontal scrolling follows the cursor instead of clipping it permanently off-screen.
4. Hold `w` briefly, release it, and confirm Red does not continue walking through a long backlog of stale repeated keypresses. Then hold `j` through the same wrapped Markdown file and confirm it reaches the final line instead of looping around an earlier logical line.
5. Confirm headings, list markers, and fenced code in the Markdown file are visibly styled with the active theme.

Targeted tests:

- `RUSTC_WRAPPER= cargo test markdown`
- `RUSTC_WRAPPER= cargo test --test movement wrapped_`
- `RUSTC_WRAPPER= cargo test --test movement`
- `RUSTC_WRAPPER= cargo test plugin::registry::tests::plugin_command_yields_while_awaiting_editor_response -- --exact --nocapture`
- `RUSTC_WRAPPER= cargo test`

