### PR TITLE
fix: wrapped screen-line cursor rendering

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2148,6 +2148,7 @@ impl Editor {
                 }
                 self.cy = target_line.saturating_sub(self.vtop);
                 self.move_to_display_col_on_current_line(target_display_col);
+                self.refresh_cursor_goal();
                 self.ensure_wrapped_cursor_segment_visible(delta);
             }
             return;
@@ -2174,6 +2175,7 @@ impl Editor {
         self.vtop = target.line.saturating_sub(self.cy);
         self.cy = target.line.saturating_sub(self.vtop);
         self.move_to_display_col_on_current_line(target_display_col);
+        self.refresh_cursor_goal();
     }
 
     fn recompute_window_cursor_goals(&mut self) {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2100,18 +2100,39 @@ impl Editor {
     }
 
     fn move_to_screen_line_start(&mut self) {
+        if !self.wrap {
+            self.cx = 0;
+            return;
+        }
+
         if let Some((start_col, _)) = self.current_screen_segment_bounds() {
             self.move_to_display_col_on_current_line(start_col);
         }
     }
 
     fn move_to_screen_line_end(&mut self) {
+        if !self.wrap {
+            self.cx = self.line_length().saturating_sub(1);
+            return;
+        }
+
         if let Some((_, end_col)) = self.current_screen_segment_bounds() {
             self.move_to_display_col_on_current_line(end_col.saturating_sub(1));
         }
     }
 
     fn move_to_screen_line_first_non_blank(&mut self) {
+        if !self.wrap {
+            if let Some(line) = self.current_line_contents() {
+                self.cx = line
+                    .trim_end_matches('\n')
+                    .graphemes(true)
+                    .position(|grapheme| !grapheme.chars().all(char::is_whitespace))
+                    .unwrap_or(0);
+            }
+            return;
+        }
+
         let Some((start_col, end_col)) = self.current_screen_segment_bounds() else {
             return;
         };

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -407,24 +407,23 @@ impl Editor {
 
         let layout = self.layout_for_window(window);
         let buffer_y = window.vtop + window.cy;
-        let Some(segment) = layout
-            .rows
-            .iter()
-            .find(|segment| segment.line == buffer_y && local_rows.contains(&segment.row))
-        else {
-            return;
-        };
-
-        let term_y = self.window_to_terminal_y(window, segment.row);
         let gutter_width = self.gutter_width_for_window(window);
         let start_x = window.position.x + gutter_width + 1;
         let end_x = window.position.x + window.inner_width() - 1;
-        buffer.set_bg_for_range(
-            Point::new(start_x, term_y),
-            Point::new(end_x, term_y),
-            &bg,
-            &self.theme,
-        );
+
+        for segment in layout
+            .rows
+            .iter()
+            .filter(|segment| segment.line == buffer_y && local_rows.contains(&segment.row))
+        {
+            let term_y = self.window_to_terminal_y(window, segment.row);
+            buffer.set_bg_for_range(
+                Point::new(start_x, term_y),
+                Point::new(end_x, term_y),
+                &bg,
+                &self.theme,
+            );
+        }
     }
 
     /// Renders a single window
@@ -859,13 +858,14 @@ impl Editor {
         // Render current line highlight
         if !self.is_visual() && self.current_dialog.is_none() && window.active {
             if let Some(ref style) = self.theme.line_highlight_style {
+                let Some(bg) = style.bg else {
+                    return Ok(());
+                };
                 let layout = self.layout_for_window(window);
                 let buffer_y = window.vtop + window.cy;
-                if let Some(segment) = layout
-                    .rows
-                    .iter()
-                    .find(|segment| segment.line == buffer_y && segment.row < window.inner_height())
-                {
+                for segment in layout.rows.iter().filter(|segment| {
+                    segment.line == buffer_y && segment.row < window.inner_height()
+                }) {
                     let term_y = self.window_to_terminal_y(window, segment.row);
                     let gutter_width = self.gutter_width_for_window(window);
                     let start_x = window.position.x + gutter_width + 1;
@@ -874,7 +874,7 @@ impl Editor {
                     buffer.set_bg_for_range(
                         Point::new(start_x, term_y),
                         Point::new(end_x, term_y),
-                        &style.bg.unwrap(),
+                        &bg,
                         &self.theme,
                     );
                 }

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -4,8 +4,10 @@ use common::EditorHarness;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use red::{
     buffer::Buffer,
+    color::Color,
     config::{Config, KeyAction},
     editor::{Action, Mode, SearchDirection},
+    theme::Style,
 };
 use std::collections::HashMap;
 
@@ -266,6 +268,71 @@ async fn test_screen_line_up_returns_from_hidden_wrapped_segment() {
 
     harness.assert_cursor_at(0, 3);
     assert_eq!(harness.render_cursor_position(), Some((3, 2)));
+}
+
+#[tokio::test]
+async fn test_screen_line_up_from_blank_line_paints_wrapped_target_segment() {
+    let content = format!(
+        "{}\n\nshort",
+        "Make use of Markdown to format the pull request professionally. ".repeat(5)
+    );
+    let buffer = Buffer::new(None, content);
+    let config = Config {
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 30, 8);
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.assert_cursor_at(0, 1);
+
+    harness
+        .execute_action(Action::MoveScreenLineUp)
+        .await
+        .unwrap();
+
+    let (cx, cy) = harness.cursor_position();
+    let rendered = harness.render_cursor_position().unwrap();
+
+    assert_eq!(cy, 0);
+    assert!(
+        cx > 0,
+        "screen-line up should land in the last wrapped segment"
+    );
+    assert!(
+        rendered.1 > 0,
+        "rendered cursor should be on the wrapped target segment, not the first segment"
+    );
+}
+
+#[tokio::test]
+async fn test_current_line_highlight_covers_all_visible_wrapped_segments() {
+    let buffer = Buffer::new(
+        None,
+        "Make use of Markdown to format the pull request professionally. ".repeat(3),
+    );
+    let config = Config {
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 30, 8);
+    let highlight = Color::Rgb {
+        r: 12,
+        g: 34,
+        b: 56,
+    };
+    harness.editor.theme.line_highlight_style = Some(Style {
+        bg: Some(highlight),
+        ..Style::default()
+    });
+
+    for row in 0..3 {
+        assert_eq!(
+            harness.render_cell_bg(10, row).unwrap(),
+            Some(highlight),
+            "wrapped row {row} should use the current-line background"
+        );
+    }
 }
 
 #[tokio::test]

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -336,6 +336,41 @@ async fn test_current_line_highlight_covers_all_visible_wrapped_segments() {
 }
 
 #[tokio::test]
+async fn test_nowrap_screen_line_start_after_toggle_moves_to_physical_line_start() {
+    let buffer = Buffer::new(
+        None,
+        "When this skill is invoked, the PR(s) to update may be specified explicitly, but in the common case, the PR(s) to update will be inferred from the branch / commit that the user is currently working on. For ordinary Git usage, you may have to use a combination of `git branch` and `gh pr view <branch> --repo openai/codex --json number --jq '.number'` to determine the PR associated with the current branch / commit.".to_string(),
+    );
+    let config = Config {
+        wrap: Some(true),
+        sidescroll: Some(1),
+        sidescrolloff: Some(0),
+        ..Default::default()
+    };
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 40, 8);
+
+    for _ in 0..6 {
+        harness
+            .execute_action(Action::MoveScreenLineDown)
+            .await
+            .unwrap();
+    }
+    let wrapped_cursor = harness.cursor_position().0;
+    assert!(wrapped_cursor > 0);
+
+    harness.execute_action(Action::ToggleWrap).await.unwrap();
+    assert!(!harness.wrap());
+
+    harness
+        .execute_action(Action::MoveToScreenLineStart)
+        .await
+        .unwrap();
+
+    harness.assert_cursor_at(0, 0);
+    assert_eq!(harness.viewport_left(), 0);
+}
+
+#[tokio::test]
 async fn test_next_word_keeps_cursor_visible_on_deep_wrapped_line() {
     let buffer = Buffer::new(
         None,


### PR DESCRIPTION
Wrapped-line screen movement could leave the visible cursor paint behind the logical cursor position. This was especially noticeable when moving up from a blank line below a long wrapped line: the statusline reported the cursor at the final wrapped segment, while the synthetic block cursor still appeared at the first character of the physical line. The current-line background also only covered one visible segment of a wrapped logical line, which made the active line look broken. A related nowrap transition could also leave screen-line `0`-style bindings at the horizontal scroll offset after toggling `wrap` off, instead of returning to the physical start of the line.

This updates screen-line motion to refresh the cursor goal after landing on the target display column, keeping the renderer and logical cursor in sync. It also changes current-line highlighting to paint every visible wrapped segment for the active logical line, including the row-diff rendering path used by cursor movement. When wrapping is disabled, screen-line start, end, and first-nonblank motions now collapse to their physical-line equivalents so toggling from wrap to nowrap does not trap `0` at a scrolled viewport column.

## How to Test

1. Open a file with a long wrapped line followed by a blank line, such as `.agents/skills/good-pr/SKILL.md` or a small file containing one long paragraph, a blank line, and another short line.
2. Configure normal-mode `j` and `k` to `MoveScreenLineDown` and `MoveScreenLineUp`, or use the default `gj` and `gk` bindings.
3. Move from the first wrapped segment down one screen line and confirm the synthetic cursor appears on the next wrapped row immediately.
4. Move to the blank line below the wrapped paragraph, press screen-line up, and confirm the cursor appears on the final visible segment of the wrapped paragraph rather than the first character of the physical line.
5. Confirm the current-line background spans every visible segment of the wrapped logical line.
6. From a wrapped middle segment, press `W` to toggle wrapping off, then press screen-line start (`0` in the custom config or `g0` in the default config) and confirm the view returns to the physical start of the line.

Targeted tests:

- `env CARGO_BUILD_RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test --test movement`
- `env CARGO_BUILD_RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo clippy --all-targets --all-features -- -D warnings`
