### PR TITLE
feat(core): add plugin decorations and indent guides

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -238,6 +238,7 @@ Esc = { EnterMode = "Normal" }
 buffer_picker = "buffer_picker.js"
 cool_search = "cool_search.js"
 fidget = "fidget.js"
+indent_guides = "indent_guides.js"
 lsp_symbols = "lsp_symbols.ts"
 neotree = "neotree.js"
 session_restore = "session_restore.js"

--- a/plugins/indent_guides.js
+++ b/plugins/indent_guides.js
@@ -1,0 +1,293 @@
+const DEFAULT_NAMESPACE = "indent-guides";
+const DEFAULT_CHAR = "│";
+const DEFAULT_DEBOUNCE_MS = 50;
+const DEFAULT_MAX_LINES = 500;
+
+const rgb = (r, g, b) => ({ Rgb: { r, g, b } });
+
+const EMPTY_STYLE = {
+  fg: null,
+  bg: null,
+  bold: false,
+  italic: false,
+};
+
+function style(base = {}, overrides = {}) {
+  return {
+    fg: base.fg ?? null,
+    bg: base.bg ?? null,
+    bold: base.bold ?? false,
+    italic: base.italic ?? false,
+    ...overrides,
+  };
+}
+
+export function stylesFor(info) {
+  const theme = info?.theme ?? {};
+  const base = style(theme.style ?? EMPTY_STYLE);
+  const ui = theme.ui_style ?? theme.uiStyle ?? {};
+  const guide =
+    ui["editorIndentGuide.background1"] ??
+    ui["editorIndentGuide.background"] ??
+    rgb(88, 91, 112);
+  const activeGuide =
+    ui["editorIndentGuide.activeBackground1"] ??
+    ui["editorIndentGuide.activeBackground"] ??
+    theme.line_highlight_style?.fg ??
+    rgb(186, 194, 222);
+
+  return {
+    indent: style(base, { fg: guide }),
+    scope: style(base, { fg: activeGuide, bold: true }),
+  };
+}
+
+export function leadingIndentWidth(line, tabWidth = 4) {
+  const width = Math.max(1, Number(tabWidth) || 4);
+  let col = 0;
+  for (const ch of line ?? "") {
+    if (ch === " ") {
+      col += 1;
+    } else if (ch === "\t") {
+      col += width - (col % width);
+    } else if (/\s/u.test(ch)) {
+      col += 1;
+    } else {
+      break;
+    }
+  }
+  return col;
+}
+
+function uniqueFirstSegmentRows(rows = []) {
+  const lines = new Map();
+  for (const row of rows) {
+    const first = row.firstSegment ?? row.first_segment ?? true;
+    if (!first || lines.has(row.line)) {
+      continue;
+    }
+    lines.set(row.line, row);
+  }
+  return [...lines.values()];
+}
+
+export function activeScope(layout, widths) {
+  if (!layout || !Array.isArray(layout.rows) || widths.size === 0) {
+    return null;
+  }
+
+  const cursorLine = layout.cursor?.y ?? 0;
+  const currentIndent = widths.get(cursorLine) ?? 0;
+  const shiftWidth =
+    layout.indentation?.shiftWidth ??
+    layout.indentation?.shift_width ??
+    layout.indentation?.tabWidth ??
+    layout.indentation?.tab_width ??
+    4;
+
+  if (currentIndent < shiftWidth) {
+    return null;
+  }
+
+  const level = Math.floor(currentIndent / shiftWidth) * shiftWidth;
+  let start = cursorLine;
+  let end = cursorLine;
+
+  for (let line = cursorLine - 1; widths.has(line); line -= 1) {
+    const width = widths.get(line);
+    if (width === 0) {
+      continue;
+    }
+    if (width < level) {
+      break;
+    }
+    start = line;
+  }
+
+  const visibleLines = [...widths.keys()].sort((a, b) => a - b);
+  const maxLine = visibleLines[visibleLines.length - 1];
+  for (let line = cursorLine + 1; line <= maxLine && widths.has(line); line += 1) {
+    const width = widths.get(line);
+    if (width === 0) {
+      continue;
+    }
+    if (width < level) {
+      break;
+    }
+    end = line;
+  }
+
+  return { column: level - shiftWidth, start, end };
+}
+
+function guideText(indentWidth, shiftWidth, guideChar) {
+  let text = "";
+  for (let col = 0; col < indentWidth; col += 1) {
+    if (col % shiftWidth === 0) {
+      text += guideChar;
+    } else {
+      text += " ";
+    }
+  }
+
+  return text;
+}
+
+export function buildDecorations(layout, options = {}) {
+  const shiftWidth = Math.max(
+    1,
+    Number(
+      layout?.indentation?.shiftWidth ??
+        layout?.indentation?.shift_width ??
+        layout?.indentation?.tabWidth ??
+        layout?.indentation?.tab_width ??
+        options.shiftWidth ??
+        4,
+    ) || 4,
+  );
+  const tabWidth = Math.max(
+    1,
+    Number(layout?.indentation?.tabWidth ?? layout?.indentation?.tab_width ?? shiftWidth) || shiftWidth,
+  );
+  const guideChar = options.char ?? DEFAULT_CHAR;
+  const styles = options.styles ?? stylesFor(options.info);
+  const maxLines = Math.max(1, Number(options.maxLines ?? DEFAULT_MAX_LINES));
+  const rows = uniqueFirstSegmentRows(layout?.rows).slice(0, maxLines);
+  const widths = new Map();
+
+  for (const row of rows) {
+    widths.set(row.line, leadingIndentWidth(row.text ?? "", tabWidth));
+  }
+
+  const scope = options.scope === false ? null : activeScope(layout, widths);
+  const decorations = [];
+  const bufferIndex = layout?.bufferIndex ?? layout?.buffer_index ?? 0;
+
+  for (const row of rows) {
+    const indentWidth = widths.get(row.line) ?? 0;
+    if (indentWidth < shiftWidth) {
+      continue;
+    }
+
+    const inScope =
+      scope &&
+      row.line >= scope.start &&
+      row.line <= scope.end &&
+      indentWidth > scope.column;
+    decorations.push({
+      buffer_index: bufferIndex,
+      line: row.line,
+      column: 0,
+      text: guideText(indentWidth, shiftWidth, guideChar),
+      style: styles.indent,
+      priority: 1,
+      repeat_linebreak: true,
+      only_whitespace: true,
+    });
+
+    if (inScope) {
+      decorations.push({
+        buffer_index: bufferIndex,
+        line: row.line,
+        column: scope.column,
+        text: guideChar,
+        style: styles.scope,
+        priority: 1024,
+        repeat_linebreak: true,
+        only_whitespace: true,
+      });
+    }
+  }
+
+  return decorations;
+}
+
+function createController(red, options = {}) {
+  let timer = null;
+  let refreshInFlight = false;
+  let pendingRefresh = false;
+  let lastPayload = "";
+  let currentStyles = stylesFor(null);
+  const namespace = options.namespace ?? DEFAULT_NAMESPACE;
+  const debounceMs = Math.max(0, Number(options.debounceMs ?? DEFAULT_DEBOUNCE_MS));
+
+  async function refresh() {
+    if (refreshInFlight) {
+      pendingRefresh = true;
+      return;
+    }
+
+    refreshInFlight = true;
+    try {
+      const [info, layout] = await Promise.all([
+        red.getEditorInfo ? red.getEditorInfo() : Promise.resolve(null),
+        red.getViewportLayout(),
+      ]);
+      currentStyles = stylesFor(info);
+      const decorations = buildDecorations(layout, {
+        ...options,
+        styles: currentStyles,
+      });
+      const payload = JSON.stringify(decorations);
+      if (payload !== lastPayload) {
+        lastPayload = payload;
+        red.setDecorations(namespace, decorations);
+      }
+    } finally {
+      refreshInFlight = false;
+      if (pendingRefresh) {
+        pendingRefresh = false;
+        scheduleRefresh();
+      }
+    }
+  }
+
+  async function scheduleRefresh() {
+    if (timer != null) {
+      await red.clearTimeout(timer);
+    }
+    timer = await red.setTimeout(async () => {
+      timer = null;
+      await refresh();
+    }, debounceMs);
+  }
+
+  async function stop() {
+    if (timer != null) {
+      await red.clearTimeout(timer);
+      timer = null;
+    }
+    red.clearDecorations(namespace);
+  }
+
+  return { refresh, scheduleRefresh, stop };
+}
+
+export async function activate(red) {
+  const controller = createController(red);
+  red.on("buffer:changed", () => controller.scheduleRefresh());
+  red.on("cursor:moved", () => controller.scheduleRefresh());
+  red.on("viewport:changed", () => controller.scheduleRefresh());
+  red.on("mode:changed", () => controller.scheduleRefresh());
+  red.on("theme:changed", () => controller.scheduleRefresh());
+  red.__indentGuidesController = controller;
+  await controller.refresh();
+}
+
+export async function deactivate(red) {
+  await red.__indentGuidesController?.stop();
+  red.__indentGuidesController = null;
+}
+
+export function indentGuidesDefaults() {
+  return {
+    namespace: DEFAULT_NAMESPACE,
+    char: DEFAULT_CHAR,
+    debounceMs: DEFAULT_DEBOUNCE_MS,
+    maxLines: DEFAULT_MAX_LINES,
+  };
+}
+
+export function createIndentGuidesController(red, options = {}) {
+  return createController(red, options);
+}

--- a/plugins/indent_guides.js
+++ b/plugins/indent_guides.js
@@ -71,6 +71,42 @@ function uniqueFirstSegmentRows(rows = []) {
   return [...lines.values()];
 }
 
+function isBlankLine(row) {
+  return (row?.text ?? "").trim().length === 0;
+}
+
+export function inferBlankIndentWidths(rows, rawWidths) {
+  const widths = new Map(rawWidths);
+  const previous = [];
+  let previousIndent = null;
+
+  for (let index = 0; index < rows.length; index += 1) {
+    previous[index] = previousIndent;
+    if (!isBlankLine(rows[index])) {
+      previousIndent = rawWidths.get(rows[index].line) ?? 0;
+    }
+  }
+
+  let nextIndent = null;
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (isBlankLine(row)) {
+      const before = previous[index];
+      let inferred = 0;
+      if (before != null && nextIndent != null) {
+        inferred = Math.min(before, nextIndent);
+      } else {
+        inferred = before ?? nextIndent ?? 0;
+      }
+      widths.set(row.line, inferred);
+    } else {
+      nextIndent = rawWidths.get(row.line) ?? 0;
+    }
+  }
+
+  return widths;
+}
+
 export function activeScope(layout, widths) {
   if (!layout || !Array.isArray(layout.rows) || widths.size === 0) {
     return null;
@@ -153,12 +189,13 @@ export function buildDecorations(layout, options = {}) {
   const styles = options.styles ?? stylesFor(options.info);
   const maxLines = Math.max(1, Number(options.maxLines ?? DEFAULT_MAX_LINES));
   const rows = uniqueFirstSegmentRows(layout?.rows).slice(0, maxLines);
-  const widths = new Map();
+  const rawWidths = new Map();
 
   for (const row of rows) {
-    widths.set(row.line, leadingIndentWidth(row.text ?? "", tabWidth));
+    rawWidths.set(row.line, leadingIndentWidth(row.text ?? "", tabWidth));
   }
 
+  const widths = inferBlankIndentWidths(rows, rawWidths);
   const scope = options.scope === false ? null : activeScope(layout, widths);
   const decorations = [];
   const bufferIndex = layout?.bufferIndex ?? layout?.buffer_index ?? 0;

--- a/plugins/indent_guides.test.js
+++ b/plugins/indent_guides.test.js
@@ -1,0 +1,87 @@
+const testStyle = {
+  fg: { Rgb: { r: 120, g: 120, b: 120 } },
+  bg: null,
+  bold: false,
+  italic: false,
+};
+
+function layout(rows, cursorLine = 0) {
+  return {
+    bufferIndex: 0,
+    buffer_index: 0,
+    cursor: { x: 0, y: cursorLine, screenRow: cursorLine, screen_row: cursorLine },
+    indentation: { shiftWidth: 4, shift_width: 4, tabWidth: 4, tab_width: 4 },
+    rows: rows.map((text, line) => ({
+      line,
+      text,
+      screenRow: line,
+      screen_row: line,
+      startCol: 0,
+      start_col: 0,
+      endCol: text.length,
+      end_col: text.length,
+      firstSegment: true,
+      first_segment: true,
+    })),
+  };
+}
+
+describe("IndentGuides", () => {
+  test("measures spaces and tabs as display columns", async () => {
+    expect(plugin.leadingIndentWidth("    let x = 1", 4)).toBe(4);
+    expect(plugin.leadingIndentWidth("\tlet x = 1", 4)).toBe(4);
+    expect(plugin.leadingIndentWidth("  \tlet x = 1", 4)).toBe(4);
+    expect(plugin.leadingIndentWidth("  \t  let x = 1", 4)).toBe(6);
+  });
+
+  test("builds one decoration per visible indented line", async () => {
+    const decorations = plugin.buildDecorations(layout(["fn main() {", "    let x = 1;", "}"]), {
+      styles: { indent: testStyle, scope: { ...testStyle, bold: true } },
+      scope: false,
+    });
+
+    expect(decorations.length).toBe(1);
+    expect(decorations[0].line).toBe(1);
+    expect(decorations[0].column).toBe(0);
+    expect(decorations[0].text).toBe("│   ");
+    expect(decorations[0].repeat_linebreak).toBe(true);
+    expect(decorations[0].only_whitespace).toBe(true);
+  });
+
+  test("highlights the indentation-based active scope", async () => {
+    const decorations = plugin.buildDecorations(
+      layout(["fn main() {", "    if ready {", "        run();", "    }", "}"], 2),
+      {
+        styles: { indent: testStyle, scope: { ...testStyle, bold: true } },
+      },
+    );
+
+    const scoped = decorations.filter((decoration) => decoration.priority === 1024);
+    expect(scoped.map((decoration) => decoration.line)).toEqual([2]);
+    expect(scoped[0].column).toBe(4);
+    expect(scoped[0].style.bold).toBe(true);
+  });
+
+  test("caps the number of lines it processes", async () => {
+    const decorations = plugin.buildDecorations(layout(["    a", "    b", "    c"]), {
+      styles: { indent: testStyle, scope: testStyle },
+      scope: false,
+      maxLines: 2,
+    });
+
+    expect(decorations.map((decoration) => decoration.line)).toEqual([0, 1]);
+  });
+
+  test("activation sets an indent guide decoration namespace", async (red) => {
+    red.setMockState({
+      bufferContent: ["fn main() {", "    let x = 1;", "}"],
+      viewportLayout: layout(["fn main() {", "    let x = 1;", "}"], 1),
+    });
+
+    await plugin.activate(red);
+
+    const decorations = red.getDecorations("indent-guides");
+    const base = decorations.find((decoration) => decoration.priority === 1);
+    expect(base.text).toBe("│   ");
+  });
+});

--- a/plugins/indent_guides.test.js
+++ b/plugins/indent_guides.test.js
@@ -48,6 +48,26 @@ describe("IndentGuides", () => {
     expect(decorations[0].only_whitespace).toBe(true);
   });
 
+  test("continues guides through blank lines inside the same block", async () => {
+    const decorations = plugin.buildDecorations(layout(["fn main() {", "    let x = 1;", "", "    let y = 2;", "}"]), {
+      styles: { indent: testStyle, scope: { ...testStyle, bold: true } },
+      scope: false,
+    });
+
+    const blankLine = decorations.find((decoration) => decoration.line === 2);
+    expect(blankLine.text).toBe("│   ");
+  });
+
+  test("does not bridge blank lines between top-level blocks", async () => {
+    const decorations = plugin.buildDecorations(layout(["fn main() {", "}", "", "    let x = 1;"]), {
+      styles: { indent: testStyle, scope: { ...testStyle, bold: true } },
+      scope: false,
+    });
+
+    const blankLine = decorations.find((decoration) => decoration.line === 2);
+    expect(blankLine).toBe(undefined);
+  });
+
   test("highlights the indentation-based active scope", async () => {
     const decorations = plugin.buildDecorations(
       layout(["fn main() {", "    if ready {", "        run();", "    }", "}"], 2),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9433,6 +9433,45 @@ mod test {
     }
 
     #[test]
+    fn plugin_decorations_render_on_blank_lines() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "fn main() {\n\n    let x = 1;\n}".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 30, 8, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        let layout = editor.plugin_viewport_layout_payload();
+        let content_start = layout["contentStart"].as_u64().unwrap() as usize;
+        let style = Style {
+            fg: Some(Color::Rgb {
+                r: 120,
+                g: 120,
+                b: 120,
+            }),
+            ..Style::default()
+        };
+
+        editor.decoration_manager.set(
+            "guides".to_string(),
+            vec![crate::plugin::Decoration {
+                buffer_index: Some(0),
+                line: 1,
+                column: 0,
+                text: "x   ".to_string(),
+                style,
+                priority: 1,
+                repeat_linebreak: true,
+                only_whitespace: true,
+            }],
+        );
+
+        let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+        editor.render(&mut render_buffer).unwrap();
+
+        assert_eq!(render_buffer.cells[30 + content_start].c, 'x');
+    }
+
+    #[test]
     fn parse_git_status_records_normalizes_statuses() {
         let output = b" M src/editor.rs\0?? plugins/neotree.js\0!! target/\0";
         let statuses = parse_git_status_records(output, "/repo");

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -152,6 +152,16 @@ pub enum PluginRequest {
         start_line: Option<usize>,
         end_line: Option<usize>,
     },
+    GetViewportLayout {
+        request_id: i32,
+    },
+    SetDecorations {
+        namespace: String,
+        decorations: Vec<plugin::Decoration>,
+    },
+    ClearDecorations {
+        namespace: String,
+    },
     GetConfig {
         key: Option<String>,
     },
@@ -793,6 +803,9 @@ pub struct Editor {
     /// Plugin overlay manager
     overlay_manager: plugin::OverlayManager,
 
+    /// Persistent virtual text decorations owned by plugins.
+    decoration_manager: plugin::DecorationManager,
+
     panel_manager: plugin::PanelManager,
 
     directory_watchers: HashMap<i32, DirectoryWatcher>,
@@ -864,6 +877,11 @@ struct EditorEventSnapshot {
     cx: usize,
     y: usize,
     vtop: usize,
+    vleft: usize,
+    skipcol: usize,
+    wrap: bool,
+    width: usize,
+    height: usize,
     buffer_index: usize,
 }
 
@@ -1177,6 +1195,7 @@ impl Editor {
             jump_index: 0,
             render_commands: VecDeque::new(),
             overlay_manager: plugin::OverlayManager::new(),
+            decoration_manager: plugin::DecorationManager::default(),
             panel_manager: plugin::PanelManager::default(),
             directory_watchers: HashMap::new(),
             pending_plugin_document_symbols: HashMap::new(),
@@ -1467,6 +1486,83 @@ impl Editor {
                 skipcol: window.skipcol,
             },
         )
+    }
+
+    fn plugin_viewport_layout_payload(&self) -> Value {
+        let Some(window) = self.active_window_with_editor_view() else {
+            return json!({
+                "bufferIndex": self.current_buffer_index,
+                "buffer_index": self.current_buffer_index,
+                "windowId": self.window_manager.active_window_id(),
+                "window_id": self.window_manager.active_window_id(),
+                "rows": [],
+            });
+        };
+        let layout = self.layout_for_window(&window);
+        let buffer = &self.buffers[window.buffer_index];
+        let gutter_width = self.gutter_width_for_window(&window);
+        let content_start = gutter_width + 1;
+        let content_width = self.window_content_width(&window);
+        let indentation = self.indentation();
+        let rows = layout
+            .rows
+            .iter()
+            .map(|segment| {
+                let text = buffer
+                    .get(segment.line)
+                    .unwrap_or_default()
+                    .trim_end_matches('\n')
+                    .to_string();
+                json!({
+                    "screenRow": segment.row,
+                    "screen_row": segment.row,
+                    "line": segment.line,
+                    "startCol": segment.start_col,
+                    "start_col": segment.start_col,
+                    "endCol": segment.end_col,
+                    "end_col": segment.end_col,
+                    "startGrapheme": segment.start_grapheme,
+                    "start_grapheme": segment.start_grapheme,
+                    "endGrapheme": segment.end_grapheme,
+                    "end_grapheme": segment.end_grapheme,
+                    "firstSegment": segment.first_segment,
+                    "first_segment": segment.first_segment,
+                    "text": text,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        json!({
+            "bufferIndex": window.buffer_index,
+            "buffer_index": window.buffer_index,
+            "windowId": self.window_manager.active_window_id(),
+            "window_id": self.window_manager.active_window_id(),
+            "width": window.inner_width(),
+            "height": window.inner_height(),
+            "contentStart": content_start,
+            "content_start": content_start,
+            "contentWidth": content_width,
+            "content_width": content_width,
+            "vtop": window.vtop,
+            "vleft": window.vleft,
+            "skipcol": window.skipcol,
+            "wrap": window.wrap,
+            "cursor": {
+                "x": window.cx,
+                "y": window.vtop + window.cy,
+                "screenRow": window.cy,
+                "screen_row": window.cy,
+            },
+            "indentation": {
+                "shiftWidth": indentation.shift_width,
+                "shift_width": indentation.shift_width,
+                "tabWidth": indentation.shift_width,
+                "tab_width": indentation.shift_width,
+            },
+            "lineCount": buffer.navigable_line_count(),
+            "line_count": buffer.navigable_line_count(),
+            "rows": rows,
+        })
     }
 
     fn active_content_width(&self) -> usize {
@@ -2244,11 +2340,22 @@ impl Editor {
     }
 
     fn event_snapshot(&self) -> EditorEventSnapshot {
+        let (width, height) = self
+            .window_manager
+            .active_window()
+            .map(|window| (window.inner_width(), window.inner_height()))
+            .unwrap_or((self.vwidth(), self.vheight()));
+
         EditorEventSnapshot {
             mode: self.mode,
             cx: self.cx,
             y: self.cy + self.vtop,
             vtop: self.vtop,
+            vleft: self.vleft,
+            skipcol: self.skipcol,
+            wrap: self.wrap,
+            width,
+            height,
             buffer_index: self.current_buffer_index,
         }
     }
@@ -2310,6 +2417,30 @@ impl Editor {
             });
             self.plugin_registry
                 .notify(runtime, "cursor:moved", cursor_info)
+                .await?;
+        }
+
+        if before.vtop != after.vtop
+            || before.vleft != after.vleft
+            || before.skipcol != after.skipcol
+            || before.wrap != after.wrap
+            || before.width != after.width
+            || before.height != after.height
+            || before.buffer_index != after.buffer_index
+        {
+            let viewport_info = serde_json::json!({
+                "vtop": after.vtop,
+                "vleft": after.vleft,
+                "skipcol": after.skipcol,
+                "wrap": after.wrap,
+                "width": after.width,
+                "height": after.height,
+                "bufferIndex": after.buffer_index,
+                "buffer_index": after.buffer_index,
+                "cause": cause,
+            });
+            self.plugin_registry
+                .notify(runtime, "viewport:changed", viewport_info)
                 .await?;
         }
 
@@ -2677,6 +2808,37 @@ impl Editor {
                                 serde_json::json!({ "text": text }),
                             )
                             .await?;
+                    }
+                    PluginRequest::GetViewportLayout { request_id } => {
+                        let payload = self.plugin_viewport_layout_payload();
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                &format!("viewport:layout:{request_id}"),
+                                payload,
+                            )
+                            .await?;
+                    }
+                    PluginRequest::SetDecorations {
+                        namespace,
+                        decorations,
+                    } => {
+                        let current_buffer_index = self.current_buffer_index;
+                        let decorations = decorations
+                            .into_iter()
+                            .map(|mut decoration| {
+                                decoration.buffer_index.get_or_insert(current_buffer_index);
+                                decoration
+                            })
+                            .collect();
+                        if self.decoration_manager.set(namespace, decorations) {
+                            self.render(&mut buffer)?;
+                        }
+                    }
+                    PluginRequest::ClearDecorations { namespace } => {
+                        if self.decoration_manager.clear(&namespace) {
+                            self.render(&mut buffer)?;
+                        }
                     }
                     PluginRequest::GetConfig { key } => {
                         let config_value = if let Some(key) = key {
@@ -9227,6 +9389,47 @@ mod test {
             .iter()
             .map(|cell| cell.c)
             .collect()
+    }
+
+    #[test]
+    fn plugin_decorations_render_in_leading_whitespace() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "fn main() {\n    let x = 1;\n}".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 30, 8, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        let layout = editor.plugin_viewport_layout_payload();
+        let content_start = layout["contentStart"].as_u64().unwrap() as usize;
+        let style = Style {
+            fg: Some(Color::Rgb {
+                r: 120,
+                g: 120,
+                b: 120,
+            }),
+            ..Style::default()
+        };
+
+        editor.decoration_manager.set(
+            "guides".to_string(),
+            vec![crate::plugin::Decoration {
+                buffer_index: Some(0),
+                line: 1,
+                column: 0,
+                text: "xxxxxx".to_string(),
+                style: style.clone(),
+                priority: 1,
+                repeat_linebreak: true,
+                only_whitespace: true,
+            }],
+        );
+
+        let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+        editor.render(&mut render_buffer).unwrap();
+
+        assert_eq!(render_buffer.cells[30 + content_start].c, 'x');
+        assert_eq!(render_buffer.cells[30 + content_start + 3].c, 'x');
+        assert_eq!(render_buffer.cells[30 + content_start + 4].c, 'l');
     }
 
     #[test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -53,6 +53,20 @@ fn diagnostic_row(diagnostics: &[&Diagnostic], available_width: usize) -> Option
     Some(fit_display_width(&row, available_width))
 }
 
+fn leading_whitespace_display_width(line: &str, tab_width: usize) -> usize {
+    let tab_width = tab_width.max(1);
+    let mut width = 0;
+    for ch in line.chars() {
+        match ch {
+            ' ' => width += 1,
+            '\t' => width += tab_width - (width % tab_width),
+            ch if ch.is_whitespace() => width += display_width(&ch.to_string()).max(1),
+            _ => break,
+        }
+    }
+    width
+}
+
 fn queue_cell_attributes(output: &mut impl io::Write, cell_style: &Style) -> anyhow::Result<()> {
     if cell_style.bold {
         output.queue(style::SetAttribute(style::Attribute::Bold))?;
@@ -384,6 +398,14 @@ impl Editor {
                 let term_x = self.window_to_terminal_x(window, content_start + local_x);
                 buffer.set_text(term_x, term_y, grapheme, style);
             }
+            self.render_decorations_for_segment(
+                buffer,
+                window,
+                segment,
+                line,
+                content_start,
+                content_width,
+            );
         }
 
         Ok(())
@@ -816,6 +838,14 @@ impl Editor {
                 let term_y = self.window_to_terminal_y(window, segment.row);
                 buffer.set_text(term_x, term_y, grapheme, style);
             }
+            self.render_decorations_for_segment(
+                buffer,
+                window,
+                segment,
+                line,
+                content_start,
+                content_width,
+            );
         }
 
         for y in layout.rows.len()..window.inner_height() {
@@ -825,6 +855,57 @@ impl Editor {
         }
 
         Ok(())
+    }
+
+    fn render_decorations_for_segment(
+        &self,
+        buffer: &mut RenderBuffer,
+        window: &crate::window::Window,
+        segment: &super::display_layout::LineSegment,
+        line: &str,
+        content_start: usize,
+        content_width: usize,
+    ) {
+        let tab_width = self.indentation().shift_width.max(1);
+        let leading_width = leading_whitespace_display_width(line, tab_width);
+
+        for decoration in self
+            .decoration_manager
+            .decorations_for_line(window.buffer_index, segment.line)
+        {
+            if !segment.first_segment && !decoration.repeat_linebreak {
+                continue;
+            }
+
+            let mut local_x = if !segment.first_segment && decoration.repeat_linebreak {
+                decoration.column
+            } else if segment.contains_display_col(decoration.column) {
+                decoration.column.saturating_sub(segment.start_col)
+            } else {
+                continue;
+            };
+
+            if local_x >= content_width {
+                continue;
+            }
+
+            let term_y = self.window_to_terminal_y(window, segment.row);
+            let mut decoration_col = decoration.column;
+            for grapheme in decoration.text.graphemes(true) {
+                if local_x >= content_width {
+                    break;
+                }
+
+                let grapheme_width = display_width(grapheme).max(1);
+                if !decoration.only_whitespace || decoration_col < leading_width {
+                    let term_x = self.window_to_terminal_x(window, content_start + local_x);
+                    buffer.set_text(term_x, term_y, grapheme, &decoration.style);
+                }
+
+                local_x += grapheme_width;
+                decoration_col += grapheme_width;
+            }
+        }
     }
 
     /// Fill a line with the given style within window bounds

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -868,6 +868,7 @@ impl Editor {
     ) {
         let tab_width = self.indentation().shift_width.max(1);
         let leading_width = leading_whitespace_display_width(line, tab_width);
+        let line_is_blank = line.trim().is_empty();
 
         for decoration in self
             .decoration_manager
@@ -897,7 +898,7 @@ impl Editor {
                 }
 
                 let grapheme_width = display_width(grapheme).max(1);
-                if !decoration.only_whitespace || decoration_col < leading_width {
+                if !decoration.only_whitespace || line_is_blank || decoration_col < leading_width {
                     let term_x = self.window_to_terminal_x(window, content_start + local_x);
                     buffer.set_text(term_x, term_y, grapheme, &decoration.style);
                 }

--- a/src/plugin/decoration.rs
+++ b/src/plugin/decoration.rs
@@ -1,0 +1,160 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::theme::Style;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Decoration {
+    #[serde(default)]
+    pub buffer_index: Option<usize>,
+    pub line: usize,
+    pub column: usize,
+    pub text: String,
+    #[serde(default)]
+    pub style: Style,
+    #[serde(default)]
+    pub priority: i32,
+    #[serde(default)]
+    pub repeat_linebreak: bool,
+    #[serde(default)]
+    pub only_whitespace: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct DecorationManager {
+    namespaces: HashMap<String, Vec<Decoration>>,
+    line_index: HashMap<(usize, usize), Vec<Decoration>>,
+}
+
+impl DecorationManager {
+    pub fn set(&mut self, namespace: String, decorations: Vec<Decoration>) -> bool {
+        if self.namespaces.get(&namespace) == Some(&decorations) {
+            return false;
+        }
+
+        self.namespaces.insert(namespace, decorations);
+        self.rebuild_index();
+        true
+    }
+
+    pub fn clear(&mut self, namespace: &str) -> bool {
+        if self.namespaces.remove(namespace).is_none() {
+            return false;
+        }
+
+        self.rebuild_index();
+        true
+    }
+
+    pub fn decorations_for_line(
+        &self,
+        buffer_index: usize,
+        line: usize,
+    ) -> impl Iterator<Item = &Decoration> {
+        self.line_index
+            .get(&(buffer_index, line))
+            .into_iter()
+            .flatten()
+    }
+
+    pub fn buffers_for_namespace(&self, namespace: &str) -> HashSet<usize> {
+        self.namespaces
+            .get(namespace)
+            .into_iter()
+            .flatten()
+            .filter_map(|decoration| decoration.buffer_index)
+            .collect()
+    }
+
+    fn rebuild_index(&mut self) {
+        self.line_index.clear();
+
+        for decorations in self.namespaces.values() {
+            for decoration in decorations {
+                let Some(buffer_index) = decoration.buffer_index else {
+                    continue;
+                };
+                self.line_index
+                    .entry((buffer_index, decoration.line))
+                    .or_default()
+                    .push(decoration.clone());
+            }
+        }
+
+        for decorations in self.line_index.values_mut() {
+            decorations.sort_by_key(|decoration| decoration.priority);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decoration(buffer_index: usize, line: usize, column: usize, priority: i32) -> Decoration {
+        Decoration {
+            buffer_index: Some(buffer_index),
+            line,
+            column,
+            text: "|".to_string(),
+            style: Style::default(),
+            priority,
+            repeat_linebreak: false,
+            only_whitespace: false,
+        }
+    }
+
+    #[test]
+    fn replaces_namespace_and_indexes_by_buffer_line() {
+        let mut manager = DecorationManager::default();
+
+        assert!(manager.set(
+            "guides".to_string(),
+            vec![decoration(0, 1, 4, 10), decoration(1, 1, 2, 5)]
+        ));
+
+        let current = manager.decorations_for_line(0, 1).collect::<Vec<_>>();
+        assert_eq!(current.len(), 1);
+        assert_eq!(current[0].column, 4);
+
+        assert!(manager.set("guides".to_string(), vec![decoration(0, 2, 8, 10)]));
+        assert_eq!(manager.decorations_for_line(0, 1).count(), 0);
+        assert_eq!(manager.decorations_for_line(0, 2).count(), 1);
+    }
+
+    #[test]
+    fn reports_unchanged_payload_as_noop() {
+        let mut manager = DecorationManager::default();
+        let payload = vec![decoration(0, 1, 4, 10)];
+
+        assert!(manager.set("guides".to_string(), payload.clone()));
+        assert!(!manager.set("guides".to_string(), payload));
+    }
+
+    #[test]
+    fn returns_decorations_in_priority_order() {
+        let mut manager = DecorationManager::default();
+
+        manager.set(
+            "guides".to_string(),
+            vec![decoration(0, 1, 8, 20), decoration(0, 1, 4, 1)],
+        );
+
+        let columns = manager
+            .decorations_for_line(0, 1)
+            .map(|decoration| decoration.column)
+            .collect::<Vec<_>>();
+        assert_eq!(columns, vec![4, 8]);
+    }
+
+    #[test]
+    fn clears_namespace() {
+        let mut manager = DecorationManager::default();
+        manager.set("guides".to_string(), vec![decoration(0, 1, 4, 10)]);
+
+        assert!(manager.clear("guides"));
+        assert!(!manager.clear("guides"));
+        assert_eq!(manager.decorations_for_line(0, 1).count(), 0);
+    }
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,3 +1,4 @@
+pub mod decoration;
 mod loader;
 mod metadata;
 pub mod overlay;
@@ -6,6 +7,7 @@ mod registry;
 mod runtime;
 pub mod timer_stats;
 
+pub use decoration::{Decoration, DecorationManager};
 pub use metadata::PluginMetadata;
 pub use overlay::{OverlayAlignment, OverlayConfig, OverlayManager};
 pub use panel::{PanelConfig, PanelManager, PanelRow, PanelRowKind, PanelSegment, PanelSide};

--- a/src/plugin/runtime.js
+++ b/src/plugin/runtime.js
@@ -266,6 +266,24 @@ class RedContext {
     });
   }
 
+  getViewportLayout() {
+    return new Promise((resolve, _reject) => {
+      const reqId = nextReqId++;
+      this.once(`viewport:layout:${reqId}`, (layout) => {
+        resolve(layout);
+      });
+      ops.op_get_viewport_layout(reqId);
+    });
+  }
+
+  setDecorations(namespace, decorations) {
+    ops.op_set_decorations(namespace, decorations || []);
+  }
+
+  clearDecorations(namespace) {
+    ops.op_clear_decorations(namespace);
+  }
+
   documentSymbols() {
     return new Promise((resolve, _reject) => {
       const reqId = nextReqId++;

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -620,6 +620,31 @@ fn op_get_buffer_text(start_line: Option<u32>, end_line: Option<u32>) -> Result<
     Ok(())
 }
 
+#[op2(fast)]
+fn op_get_viewport_layout(request_id: i32) -> Result<(), PluginOpError> {
+    ACTION_DISPATCHER.send_request(PluginRequest::GetViewportLayout { request_id });
+    Ok(())
+}
+
+#[op2]
+fn op_set_decorations(
+    #[string] namespace: String,
+    #[serde] decorations: serde_json::Value,
+) -> Result<(), PluginOpError> {
+    let decorations = serde_json::from_value(decorations)?;
+    ACTION_DISPATCHER.send_request(PluginRequest::SetDecorations {
+        namespace,
+        decorations,
+    });
+    Ok(())
+}
+
+#[op2(fast)]
+fn op_clear_decorations(#[string] namespace: String) -> Result<(), PluginOpError> {
+    ACTION_DISPATCHER.send_request(PluginRequest::ClearDecorations { namespace });
+    Ok(())
+}
+
 #[op2]
 fn op_get_config(#[string] key: Option<String>) -> Result<(), PluginOpError> {
     ACTION_DISPATCHER.send_request(PluginRequest::GetConfig { key });
@@ -892,6 +917,9 @@ extension!(
         op_get_cursor_position,
         op_set_cursor_position,
         op_get_buffer_text,
+        op_get_viewport_layout,
+        op_set_decorations,
+        op_clear_decorations,
         op_get_config,
         op_get_editor_state,
         op_restore_editor_state,

--- a/test-harness/mock-red.js
+++ b/test-harness/mock-red.js
@@ -8,6 +8,7 @@ class MockRedAPI {
     this.eventListeners = new Map();
     this.logs = [];
     this.overlays = new Map();
+    this.decorations = new Map();
     this.panels = new Map();
     this.directoryListings = new Map();
     this.directoryWatches = new Map();
@@ -33,6 +34,7 @@ class MockRedAPI {
       },
       cursor: { x: 0, y: 0 },
       bufferContent: ["// Test file", "console.log('hello');", ""],
+      viewportLayout: null,
       config: {
         theme: "test-theme",
         plugins: { "test-plugin": "test-plugin.js" },
@@ -175,6 +177,65 @@ class MockRedAPI {
     return this.mockState.bufferContent.slice(start, end).join("\n");
   }
 
+  async getViewportLayout() {
+    if (this.mockState.viewportLayout) {
+      return this.mockState.viewportLayout;
+    }
+
+    return {
+      bufferIndex: this.mockState.current_buffer_index,
+      buffer_index: this.mockState.current_buffer_index,
+      windowId: 0,
+      window_id: 0,
+      width: this.mockState.size.cols,
+      height: this.mockState.size.rows,
+      contentStart: 4,
+      content_start: 4,
+      contentWidth: this.mockState.size.cols - 4,
+      content_width: this.mockState.size.cols - 4,
+      vtop: 0,
+      vleft: 0,
+      skipcol: 0,
+      wrap: true,
+      cursor: {
+        x: this.mockState.cursor.x,
+        y: this.mockState.cursor.y,
+        screenRow: this.mockState.cursor.y,
+        screen_row: this.mockState.cursor.y
+      },
+      indentation: {
+        shiftWidth: 4,
+        shift_width: 4,
+        tabWidth: 4,
+        tab_width: 4
+      },
+      lineCount: this.mockState.bufferContent.length,
+      line_count: this.mockState.bufferContent.length,
+      rows: this.mockState.bufferContent.map((text, line) => ({
+        screenRow: line,
+        screen_row: line,
+        line,
+        startCol: 0,
+        start_col: 0,
+        endCol: text.length,
+        end_col: text.length,
+        firstSegment: true,
+        first_segment: true,
+        text
+      }))
+    };
+  }
+
+  setDecorations(namespace, decorations = []) {
+    this.logs.push(`setDecorations: ${namespace} ${JSON.stringify(decorations)}`);
+    this.decorations.set(namespace, decorations);
+  }
+
+  clearDecorations(namespace) {
+    this.logs.push(`clearDecorations: ${namespace}`);
+    this.decorations.delete(namespace);
+  }
+
   execute(command, args) {
     this.logs.push(`execute: ${command} ${JSON.stringify(args || {})}`);
   }
@@ -268,6 +329,10 @@ class MockRedAPI {
 
   getOverlay(id) {
     return this.overlays.get(id);
+  }
+
+  getDecorations(namespace) {
+    return this.decorations.get(namespace);
   }
 
   createPanel(id, config = {}) {


### PR DESCRIPTION
## Summary

- add a namespaced plugin decoration API for persistent viewport-aware virtual text
- expose `red.getViewportLayout()`, `red.setDecorations()`, and `red.clearDecorations()` to plugins
- add a default `indent_guides` plugin that renders indent guides and active indent scope

## Notes

The decoration renderer only visits visible rows and indexes decorations by buffer and line. The indent guide plugin refreshes from one viewport-layout request, caps visible-line processing, and skips redundant namespace updates when the payload is unchanged.

## Validation

- `node test-harness/test-runner.js plugins/indent_guides.js plugins/indent_guides.test.js`
- `RUSTC_WRAPPER= cargo check`
- `RUSTC_WRAPPER= cargo test plugin_decorations_render_in_leading_whitespace`
- `RUSTC_WRAPPER= cargo test decoration`
- `RUSTC_WRAPPER= cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTC_WRAPPER= cargo test`
- `git diff --check`
