### PR TITLE
feat(core): add matchit percent motions

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -99,7 +99,7 @@ Esc = { EnterMode = "Normal" }
 "o" = [ { EnterMode = "Insert" }, "InsertLineBelowCursor" ]
 "O" = [ { EnterMode = "Insert" }, "InsertLineAtCursor" ]
 "G" = "MoveToBottom"
-"g" = { "g" = "MoveToTop", "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd" }
+"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd" }
 "u" = "Undo"
 "Ctrl-r" = "Redo"
 "Down" = "MoveDown"
@@ -123,6 +123,7 @@ Esc = { EnterMode = "Normal" }
 "x" = "DeleteCharAtCursorPos"
 "z" = { "z" = "MoveLineToViewportCenter", "h" = "ScrollViewLeft", "l" = "ScrollViewRight", "H" = "ScrollViewHalfPageLeft", "L" = "ScrollViewHalfPageRight", "s" = "ScrollCursorToViewStart", "e" = "ScrollCursorToViewEnd" }
 "*" = "SearchWordUnderCursor"
+"%" = "MatchitForward"
 "n" = "RepeatSearch"
 "N" = "RepeatSearchOpposite"
 "a" = [ { EnterMode = "Insert" }, "MoveRight" ]
@@ -154,6 +155,12 @@ Esc = { EnterMode = "Normal" }
 
 [keys.normal."<"]
 "<" = "UnindentLine"
+
+[keys.normal."["]
+"%" = "MatchitPreviousUnmatched"
+
+[keys.normal."]"]
+"%" = "MatchitNextUnmatched"
 
 [keys.normal."Ctrl-w"]
 "h" = "MoveWindowLeft"
@@ -215,6 +222,8 @@ Esc = { EnterMode = "Normal" }
 "p" = [ "Paste", { EnterMode = "Normal" } ]
 "w" = "MoveToNextWord"
 "b" = "MoveToPreviousWord"
+"%" = "MatchitForward"
+"g" = { "%" = "MatchitBackward" }
 "I" = "InsertBlock"
 
 # TODO: "i" = "SelectInside"

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,12 +23,48 @@ pub struct Config {
     pub search: SearchConfig,
     #[serde(default)]
     pub lsp: LspConfig,
+    #[serde(default)]
+    pub matchit: MatchitConfig,
     #[serde(default = "default_true")]
     pub show_diagnostics: bool,
     #[serde(default = "default_false")]
     pub window_borders_ascii: bool,
     #[serde(default, skip_serializing)]
     pub startup_file_count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct MatchitConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_matchit_pairs")]
+    pub pairs: Vec<[String; 2]>,
+    #[serde(default)]
+    pub languages: HashMap<String, MatchitLanguageConfig>,
+}
+
+impl Default for MatchitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            pairs: default_matchit_pairs(),
+            languages: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+pub struct MatchitLanguageConfig {
+    #[serde(default)]
+    pub groups: Vec<Vec<String>>,
+}
+
+fn default_matchit_pairs() -> Vec<[String; 2]> {
+    vec![
+        ["(".to_string(), ")".to_string()],
+        ["{".to_string(), "}".to_string()],
+        ["[".to_string(), "]".to_string()],
+    ]
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -718,6 +754,57 @@ theme = "mocha.json"
         assert_eq!(
             config.keys.normal.get("W"),
             Some(&KeyAction::Single(Action::ToggleWrap))
+        );
+    }
+
+    #[test]
+    fn default_config_maps_matchit_keys() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.keys.normal.get("%"),
+            Some(&KeyAction::Single(Action::MatchitForward))
+        );
+        let Some(KeyAction::Nested(g)) = config.keys.normal.get("g") else {
+            panic!("default config should map g to nested actions");
+        };
+        assert_eq!(
+            g.get("%"),
+            Some(&KeyAction::Single(Action::MatchitBackward))
+        );
+    }
+
+    #[test]
+    fn matchit_config_defaults_and_language_groups() {
+        let config = Config::from_toml_with_overrides(
+            r#"
+theme = "mocha.json"
+
+[keys]
+
+[matchit.languages.vim]
+groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
+"#,
+            &[],
+        )
+        .unwrap();
+
+        assert!(config.matchit.enabled);
+        assert_eq!(
+            config.matchit.pairs,
+            vec![
+                ["(".to_string(), ")".to_string()],
+                ["{".to_string(), "}".to_string()],
+                ["[".to_string(), "]".to_string()],
+            ]
+        );
+        assert_eq!(
+            config.matchit.languages["vim"].groups,
+            vec![vec![
+                "\\bif\\b".to_string(),
+                "\\belse\\b".to_string(),
+                "\\bendif\\b".to_string()
+            ]]
         );
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -60,6 +60,7 @@ use crate::{
         ProgressParams, ProgressToken, Range, ResponseMessage, ServerCapabilities,
         TextEdit as LspTextEdit,
     },
+    matchit::{self, MatchDirection, MatchMotion},
     plugin::{self, PluginRegistry, Runtime},
     preferences::PreferencesStore,
     theme::{parse_vscode_theme, Style, Theme},
@@ -311,6 +312,12 @@ pub enum Action {
     MoveToFilePos(String, usize, usize),
     MoveToNextWord,
     MoveToPreviousWord,
+    MoveToFilePercent(usize),
+    MatchitForward,
+    MatchitBackward,
+    MatchitPreviousUnmatched,
+    MatchitNextUnmatched,
+    MatchitSelectAround,
 
     PageDown,
     PageUp,
@@ -3314,6 +3321,10 @@ impl Editor {
                 | Action::MoveToScreenLineFirstNonBlank
                 | Action::MoveToNextWord
                 | Action::MoveToPreviousWord
+                | Action::MatchitForward
+                | Action::MatchitBackward
+                | Action::MatchitPreviousUnmatched
+                | Action::MatchitNextUnmatched
         )
     }
 
@@ -4539,6 +4550,17 @@ impl Editor {
 
             self.waiting_command = None;
             let Some(kind) = text_object_kind_for_key(*c) else {
+                if *c == '%' {
+                    let Some(range) = self.matchit_select_around_range() else {
+                        self.last_error = Some("text object not found".to_string());
+                        return Some(KeyAction::None);
+                    };
+                    if self.select_text_range(range) {
+                        return Some(KeyAction::Single(Action::Refresh));
+                    }
+                    self.last_error = Some("text object not found".to_string());
+                    return Some(KeyAction::None);
+                }
                 return self.pending_visual_text_object_invalid();
             };
 
@@ -4670,6 +4692,11 @@ impl Editor {
                     self.word_motion_range(),
                     "no word under cursor",
                 ),
+                '%' => self.operator_action_for_range(
+                    pending.operator,
+                    self.matchit_motion_range(MatchDirection::Forward),
+                    "match not found",
+                ),
                 'i' => {
                     self.waiting_command = Some(format!("{}i", pending.operator.as_char()));
                     self.pending_operator = Some(PendingOperator {
@@ -4743,6 +4770,48 @@ impl Editor {
             .find_next_word((start.character, start.line))?;
         let end = TextPosition::new(end_y, end_x);
         (start != end).then(|| TextRange::new(start, end))
+    }
+
+    fn matchit_motion_range(&self, direction: MatchDirection) -> Option<TextRange> {
+        let start = self.cursor_text_position();
+        let motion = self.matchit_motion(direction)?;
+        Some(motion.range_from(start))
+    }
+
+    fn matchit_motion(&self, direction: MatchDirection) -> Option<MatchMotion> {
+        matchit::find_motion(
+            &self.current_buffer().contents(),
+            self.cursor_text_position(),
+            self.current_language_id().as_deref(),
+            &self.config.matchit,
+            direction,
+        )
+    }
+
+    fn unmatched_matchit_motion(&self, direction: MatchDirection) -> Option<MatchMotion> {
+        matchit::find_unmatched_group(
+            &self.current_buffer().contents(),
+            self.cursor_text_position(),
+            self.current_language_id().as_deref(),
+            &self.config.matchit,
+            direction,
+        )
+    }
+
+    fn matchit_select_around_range(&self) -> Option<TextRange> {
+        matchit::select_around(
+            &self.current_buffer().contents(),
+            self.cursor_text_position(),
+            self.current_language_id().as_deref(),
+            &self.config.matchit,
+        )
+    }
+
+    fn current_language_id(&self) -> Option<String> {
+        self.highlighter
+            .language_id_for_file(self.current_buffer().file.as_deref())
+            .map(str::to_string)
+            .or_else(|| self.current_buffer().file_type())
     }
 
     fn text_object_range(&self, scope: TextObjectScope, kind: TextObjectKind) -> Option<TextRange> {
@@ -6009,6 +6078,36 @@ impl Editor {
                     self.finish_cursor_motion(buffer, false)?;
                 }
             }
+            Action::MoveToFilePercent(percent) => {
+                let percent = (*percent).clamp(1, 100);
+                let line_count = self.current_buffer().navigable_line_count();
+                let line = (percent * line_count).div_ceil(100);
+                self.go_to_line(line, buffer, runtime, GoToLinePosition::Center)
+                    .await?;
+                self.move_to_first_non_blank_on_current_line();
+                self.finish_cursor_motion(buffer, false)?;
+            }
+            Action::MatchitForward => {
+                self.move_to_matchit_motion(MatchDirection::Forward, buffer)?;
+            }
+            Action::MatchitBackward => {
+                self.move_to_matchit_motion(MatchDirection::Backward, buffer)?;
+            }
+            Action::MatchitPreviousUnmatched => {
+                self.move_to_unmatched_matchit_group(MatchDirection::Backward, buffer)?;
+            }
+            Action::MatchitNextUnmatched => {
+                self.move_to_unmatched_matchit_group(MatchDirection::Forward, buffer)?;
+            }
+            Action::MatchitSelectAround => {
+                if let Some(range) = self.matchit_select_around_range() {
+                    if self.select_text_range(range) {
+                        self.render(buffer)?;
+                    }
+                } else {
+                    self.last_error = Some("text object not found".to_string());
+                }
+            }
             Action::MoveLineToViewportBottom => {
                 let line = self.buffer_line();
                 if line > self.vtop + self.vheight() {
@@ -6741,6 +6840,11 @@ impl Editor {
                     | Action::MoveToBottom
                     | Action::GoToLine(_)
                     | Action::MoveTo(_, _)
+                    | Action::MoveToFilePercent(_)
+                    | Action::MatchitForward
+                    | Action::MatchitBackward
+                    | Action::MatchitPreviousUnmatched
+                    | Action::MatchitNextUnmatched
             )
         {
             self.update_selection();
@@ -6828,6 +6932,11 @@ impl Editor {
                 | Action::PageUp
                 | Action::MoveToBottom
                 | Action::MoveToTop
+                | Action::MoveToFilePercent(_)
+                | Action::MatchitForward
+                | Action::MatchitBackward
+                | Action::MatchitPreviousUnmatched
+                | Action::MatchitNextUnmatched
                 | Action::MoveTo(_, _)
                 | Action::MoveToFilePos(_, _, _)
                 | Action::OpenFile(_)
@@ -7585,6 +7694,19 @@ impl Editor {
         mappings: &HashMap<String, KeyAction>,
         ev: &Event,
     ) -> Option<KeyAction> {
+        if let Event::Key(KeyEvent {
+            code: KeyCode::Char('%'),
+            modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
+            ..
+        }) = ev
+        {
+            if let Some(percent) = self.repeater.take() {
+                return Some(KeyAction::Single(Action::MoveToFilePercent(
+                    percent as usize,
+                )));
+            }
+        }
+
         if self.handle_repeater(ev) {
             return None;
         }
@@ -7812,6 +7934,44 @@ impl Editor {
         self.cy = y.saturating_sub(self.vtop);
         let char_x = position.character.min(self.length_for_line(y));
         self.cx = self.char_to_grapheme_on_line(char_x, y);
+    }
+
+    fn move_to_matchit_motion(
+        &mut self,
+        direction: MatchDirection,
+        buffer: &mut RenderBuffer,
+    ) -> anyhow::Result<()> {
+        if let Some(motion) = self.matchit_motion(direction) {
+            self.move_to_text_position(motion.target);
+            self.finish_cursor_motion(buffer, false)?;
+        } else {
+            self.last_error = Some("match not found".to_string());
+        }
+        Ok(())
+    }
+
+    fn move_to_unmatched_matchit_group(
+        &mut self,
+        direction: MatchDirection,
+        buffer: &mut RenderBuffer,
+    ) -> anyhow::Result<()> {
+        if let Some(motion) = self.unmatched_matchit_motion(direction) {
+            self.move_to_text_position(motion.target);
+            self.finish_cursor_motion(buffer, false)?;
+        } else {
+            self.last_error = Some("match not found".to_string());
+        }
+        Ok(())
+    }
+
+    fn move_to_first_non_blank_on_current_line(&mut self) {
+        if let Some(line) = self.current_line_contents() {
+            self.cx = line
+                .trim_end_matches('\n')
+                .graphemes(true)
+                .position(|grapheme| !grapheme.chars().all(char::is_whitespace))
+                .unwrap_or(0);
+        }
     }
 
     fn select_text_range(&mut self, range: TextRange) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod editor;
 pub mod highlighter;
 pub mod logger;
 pub mod lsp;
+pub mod matchit;
 pub mod onboarding;
 pub mod plugin;
 pub mod preferences;

--- a/src/matchit.rs
+++ b/src/matchit.rs
@@ -1,0 +1,627 @@
+use regex::Regex;
+
+use crate::{
+    config::{MatchitConfig, MatchitLanguageConfig},
+    undo::{TextPosition, TextRange},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchDirection {
+    Forward,
+    Backward,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchKind {
+    Charwise,
+    Linewise,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MatchMotion {
+    pub target: TextPosition,
+    pub target_end: TextPosition,
+    pub kind: MatchKind,
+}
+
+impl MatchMotion {
+    pub fn range_from(self, start: TextPosition) -> TextRange {
+        if self.kind == MatchKind::Linewise {
+            let (start_line, end_line) = if start.line <= self.target.line {
+                (start.line, self.target.line + 1)
+            } else {
+                (self.target.line, start.line + 1)
+            };
+            return TextRange::new(
+                TextPosition::new(start_line, 0),
+                TextPosition::new(end_line, 0),
+            );
+        }
+
+        if position_le(start, self.target) {
+            TextRange::new(start, self.target_end)
+        } else {
+            TextRange::new(self.target, advance_position(start))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenRole {
+    Open,
+    Middle,
+    Close,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenKind {
+    Pair,
+    Comment,
+    Preprocessor,
+    Language,
+    Tag,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Token {
+    start: usize,
+    end: usize,
+    group: usize,
+    item: usize,
+    role: TokenRole,
+    kind: TokenKind,
+    linewise: bool,
+}
+
+#[derive(Debug, Clone)]
+struct Group {
+    kind: TokenKind,
+    patterns: Vec<Pattern>,
+    linewise: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Pattern {
+    Literal(String),
+    Regex(Regex),
+}
+
+impl Pattern {
+    fn literal(value: impl Into<String>) -> Self {
+        Self::Literal(value.into())
+    }
+
+    fn regex(value: &str) -> Option<Self> {
+        Regex::new(value).ok().map(Self::Regex)
+    }
+}
+
+#[derive(Debug)]
+struct Document {
+    text: String,
+    line_starts: Vec<usize>,
+}
+
+impl Document {
+    fn new(text: &str) -> Self {
+        let mut line_starts = vec![0];
+        for (idx, c) in text.chars().enumerate() {
+            if c == '\n' {
+                line_starts.push(idx + 1);
+            }
+        }
+        Self {
+            text: text.to_string(),
+            line_starts,
+        }
+    }
+
+    fn chars(&self) -> Vec<char> {
+        self.text.chars().collect()
+    }
+
+    fn char_len(&self) -> usize {
+        self.text.chars().count()
+    }
+
+    fn offset_for_position(&self, position: TextPosition) -> usize {
+        let line_start = self
+            .line_starts
+            .get(position.line)
+            .copied()
+            .unwrap_or_else(|| self.char_len());
+        let line_end = self
+            .line_starts
+            .get(position.line + 1)
+            .copied()
+            .map(|end| end.saturating_sub(1))
+            .unwrap_or_else(|| self.char_len());
+        line_start + position.character.min(line_end.saturating_sub(line_start))
+    }
+
+    fn position_for_offset(&self, offset: usize) -> TextPosition {
+        let offset = offset.min(self.char_len());
+        let line = match self.line_starts.binary_search(&offset) {
+            Ok(line) => line,
+            Err(next) => next.saturating_sub(1),
+        };
+        TextPosition::new(line, offset.saturating_sub(self.line_starts[line]))
+    }
+
+    fn line_bounds(&self, line: usize) -> (usize, usize) {
+        let start = self.line_starts.get(line).copied().unwrap_or(0);
+        let end = self
+            .line_starts
+            .get(line + 1)
+            .copied()
+            .map(|end| end.saturating_sub(1))
+            .unwrap_or_else(|| self.char_len());
+        (start, end)
+    }
+}
+
+pub fn find_motion(
+    text: &str,
+    cursor: TextPosition,
+    language_id: Option<&str>,
+    config: &MatchitConfig,
+    direction: MatchDirection,
+) -> Option<MatchMotion> {
+    let doc = Document::new(text);
+    let tokens = tokens_for_document(&doc, language_id, config);
+    let cursor_offset = doc.offset_for_position(cursor);
+    let token = choose_token_on_line(&doc, &tokens, cursor.line, cursor_offset)?;
+    let target = match direction {
+        MatchDirection::Forward => matching_token(&tokens, token, MatchDirection::Forward),
+        MatchDirection::Backward => matching_token(&tokens, token, MatchDirection::Backward),
+    }?;
+    Some(motion_for_token(&doc, target))
+}
+
+pub fn find_unmatched_group(
+    text: &str,
+    cursor: TextPosition,
+    language_id: Option<&str>,
+    config: &MatchitConfig,
+    direction: MatchDirection,
+) -> Option<MatchMotion> {
+    let doc = Document::new(text);
+    let tokens = tokens_for_document(&doc, language_id, config);
+    let cursor_offset = doc.offset_for_position(cursor);
+    let target = match direction {
+        MatchDirection::Backward => unmatched_before(&tokens, cursor_offset),
+        MatchDirection::Forward => unmatched_after(&tokens, cursor_offset),
+    }?;
+    Some(motion_for_token(&doc, target))
+}
+
+pub fn select_around(
+    text: &str,
+    cursor: TextPosition,
+    language_id: Option<&str>,
+    config: &MatchitConfig,
+) -> Option<TextRange> {
+    let doc = Document::new(text);
+    let tokens = tokens_for_document(&doc, language_id, config);
+    let cursor_offset = doc.offset_for_position(cursor);
+    let token = containing_pair(&tokens, cursor_offset)?;
+    let target = matching_token(&tokens, token, MatchDirection::Forward)
+        .or_else(|| matching_token(&tokens, token, MatchDirection::Backward))?;
+    let start = token.start.min(target.start);
+    let end = token.end.max(target.end);
+    Some(TextRange::new(
+        doc.position_for_offset(start),
+        doc.position_for_offset(end),
+    ))
+}
+
+fn tokens_for_document(
+    doc: &Document,
+    language_id: Option<&str>,
+    config: &MatchitConfig,
+) -> Vec<Token> {
+    let groups = groups_for_config(language_id, config);
+    let skip_ranges = skip_ranges(doc);
+    let mut tokens = Vec::new();
+    for (group_idx, group) in groups.iter().enumerate() {
+        collect_group_tokens(doc, group_idx, group, &skip_ranges, &mut tokens);
+    }
+    collect_tag_tokens(doc, groups.len(), &mut tokens);
+    tokens.sort_by_key(|token| (token.start, token.end));
+    tokens
+}
+
+fn groups_for_config(language_id: Option<&str>, config: &MatchitConfig) -> Vec<Group> {
+    let mut groups = Vec::new();
+    for pair in &config.pairs {
+        groups.push(Group {
+            kind: TokenKind::Pair,
+            patterns: vec![Pattern::literal(&pair[0]), Pattern::literal(&pair[1])],
+            linewise: false,
+        });
+    }
+
+    groups.push(Group {
+        kind: TokenKind::Comment,
+        patterns: vec![Pattern::literal("/*"), Pattern::literal("*/")],
+        linewise: false,
+    });
+    groups.push(Group {
+        kind: TokenKind::Preprocessor,
+        patterns: vec![
+            Pattern::regex(r"(?m)^\s*#\s*(?:if|ifdef|ifndef)\b").unwrap(),
+            Pattern::regex(r"(?m)^\s*#\s*(?:elif|else)\b").unwrap(),
+            Pattern::regex(r"(?m)^\s*#\s*endif\b").unwrap(),
+        ],
+        linewise: true,
+    });
+
+    if config.enabled {
+        if let Some(language_id) = language_id {
+            groups.extend(builtin_language_groups(language_id));
+            if let Some(language) = config.languages.get(language_id) {
+                groups.extend(config_language_groups(language));
+            }
+        }
+    }
+
+    groups
+}
+
+fn builtin_language_groups(language_id: &str) -> Vec<Group> {
+    match language_id {
+        "bash" => vec![Group {
+            kind: TokenKind::Language,
+            patterns: vec![
+                Pattern::regex(r"\bif\b").unwrap(),
+                Pattern::regex(r"\b(?:elif|else)\b").unwrap(),
+                Pattern::regex(r"\bfi\b").unwrap(),
+            ],
+            linewise: false,
+        }],
+        _ => Vec::new(),
+    }
+}
+
+fn config_language_groups(language: &MatchitLanguageConfig) -> Vec<Group> {
+    language
+        .groups
+        .iter()
+        .filter(|group| group.len() >= 2)
+        .filter_map(|group| {
+            let patterns = group
+                .iter()
+                .map(|pattern| Pattern::regex(pattern))
+                .collect::<Option<Vec<_>>>()?;
+            Some(Group {
+                kind: TokenKind::Language,
+                patterns,
+                linewise: false,
+            })
+        })
+        .collect()
+}
+
+fn collect_group_tokens(
+    doc: &Document,
+    group_idx: usize,
+    group: &Group,
+    skip_ranges: &[(usize, usize)],
+    tokens: &mut Vec<Token>,
+) {
+    for (item_idx, pattern) in group.patterns.iter().enumerate() {
+        match pattern {
+            Pattern::Literal(value) => {
+                collect_literal_tokens(doc, group_idx, group, item_idx, value, skip_ranges, tokens)
+            }
+            Pattern::Regex(regex) => {
+                collect_regex_tokens(doc, group_idx, group, item_idx, regex, skip_ranges, tokens)
+            }
+        }
+    }
+}
+
+fn collect_literal_tokens(
+    doc: &Document,
+    group_idx: usize,
+    group: &Group,
+    item_idx: usize,
+    value: &str,
+    skip_ranges: &[(usize, usize)],
+    tokens: &mut Vec<Token>,
+) {
+    let chars = doc.chars();
+    let pattern = value.chars().collect::<Vec<_>>();
+    if pattern.is_empty() || pattern.len() > chars.len() {
+        return;
+    }
+
+    for start in 0..=chars.len() - pattern.len() {
+        let end = start + pattern.len();
+        if chars[start..end] == pattern && should_keep_token(group.kind, start, end, skip_ranges) {
+            tokens.push(token(group_idx, item_idx, start, end, group));
+        }
+    }
+}
+
+fn collect_regex_tokens(
+    doc: &Document,
+    group_idx: usize,
+    group: &Group,
+    item_idx: usize,
+    regex: &Regex,
+    skip_ranges: &[(usize, usize)],
+    tokens: &mut Vec<Token>,
+) {
+    for match_ in regex.find_iter(&doc.text) {
+        let start = doc.text[..match_.start()].chars().count();
+        let end = start + match_.as_str().chars().count();
+        if should_keep_token(group.kind, start, end, skip_ranges) {
+            tokens.push(token(group_idx, item_idx, start, end, group));
+        }
+    }
+}
+
+fn token(group: usize, item: usize, start: usize, end: usize, meta: &Group) -> Token {
+    let role = if item == 0 {
+        TokenRole::Open
+    } else if item + 1 == meta.patterns.len() {
+        TokenRole::Close
+    } else {
+        TokenRole::Middle
+    };
+    Token {
+        start,
+        end,
+        group,
+        item,
+        role,
+        kind: meta.kind,
+        linewise: meta.linewise,
+    }
+}
+
+fn should_keep_token(
+    kind: TokenKind,
+    start: usize,
+    end: usize,
+    skip_ranges: &[(usize, usize)],
+) -> bool {
+    if matches!(kind, TokenKind::Comment | TokenKind::Preprocessor) {
+        return true;
+    }
+    !skip_ranges
+        .iter()
+        .any(|(range_start, range_end)| start >= *range_start && end <= *range_end)
+}
+
+fn skip_ranges(doc: &Document) -> Vec<(usize, usize)> {
+    let chars = doc.chars();
+    let mut ranges = Vec::new();
+    let mut idx = 0;
+    while idx < chars.len() {
+        match chars[idx] {
+            '"' | '\'' => {
+                let quote = chars[idx];
+                let start = idx;
+                idx += 1;
+                while idx < chars.len() {
+                    if chars[idx] == quote && !is_escaped(&chars, idx) {
+                        idx += 1;
+                        break;
+                    }
+                    idx += 1;
+                }
+                ranges.push((start, idx));
+            }
+            '/' if chars.get(idx + 1) == Some(&'/') => {
+                let start = idx;
+                idx += 2;
+                while idx < chars.len() && chars[idx] != '\n' {
+                    idx += 1;
+                }
+                ranges.push((start, idx));
+            }
+            _ => idx += 1,
+        }
+    }
+    ranges
+}
+
+fn is_escaped(chars: &[char], idx: usize) -> bool {
+    let mut slash_count = 0;
+    let mut cursor = idx;
+    while cursor > 0 {
+        cursor -= 1;
+        if chars[cursor] != '\\' {
+            break;
+        }
+        slash_count += 1;
+    }
+    slash_count % 2 == 1
+}
+
+fn collect_tag_tokens(doc: &Document, group_base: usize, tokens: &mut Vec<Token>) {
+    let Ok(regex) = Regex::new(r"</?([A-Za-z][A-Za-z0-9:_-]*)(?:\s[^<>]*)?>") else {
+        return;
+    };
+    let mut tag_groups = Vec::<String>::new();
+    for capture in regex.captures_iter(&doc.text) {
+        let Some(full) = capture.get(0) else {
+            continue;
+        };
+        let text = full.as_str();
+        if text.ends_with("/>") || text.starts_with("<!") || text.starts_with("<?") {
+            continue;
+        }
+        let Some(name) = capture.get(1).map(|name| name.as_str().to_string()) else {
+            continue;
+        };
+        let group_offset = tag_groups
+            .iter()
+            .position(|existing| existing == &name)
+            .unwrap_or_else(|| {
+                tag_groups.push(name);
+                tag_groups.len() - 1
+            });
+        let start = doc.text[..full.start()].chars().count();
+        let end = start + text.chars().count();
+        let is_close = text.starts_with("</");
+        tokens.push(Token {
+            start,
+            end,
+            group: group_base + group_offset,
+            item: usize::from(is_close),
+            role: if is_close {
+                TokenRole::Close
+            } else {
+                TokenRole::Open
+            },
+            kind: TokenKind::Tag,
+            linewise: false,
+        });
+    }
+}
+
+fn choose_token_on_line<'a>(
+    doc: &Document,
+    tokens: &'a [Token],
+    line: usize,
+    cursor_offset: usize,
+) -> Option<&'a Token> {
+    let (line_start, line_end) = doc.line_bounds(line);
+    tokens
+        .iter()
+        .filter(|token| {
+            token.start >= line_start && token.start <= line_end && token.end > cursor_offset
+        })
+        .min_by_key(|token| {
+            (
+                !(token.start <= cursor_offset && cursor_offset < token.end),
+                token.start.saturating_sub(cursor_offset),
+                token.group,
+                token.item,
+            )
+        })
+}
+
+fn containing_pair(tokens: &[Token], cursor_offset: usize) -> Option<&Token> {
+    tokens
+        .iter()
+        .filter(|token| token.role == TokenRole::Open)
+        .filter_map(|token| {
+            let target = matching_token(tokens, token, MatchDirection::Forward)?;
+            (token.start <= cursor_offset && cursor_offset < target.end)
+                .then_some((token, target.end.saturating_sub(token.start)))
+        })
+        .min_by_key(|(_, width)| *width)
+        .map(|(token, _)| token)
+}
+
+fn matching_token<'a>(
+    tokens: &'a [Token],
+    token: &Token,
+    direction: MatchDirection,
+) -> Option<&'a Token> {
+    let effective_direction = match direction {
+        MatchDirection::Forward if token.role == TokenRole::Close => MatchDirection::Backward,
+        MatchDirection::Backward if token.role == TokenRole::Open => MatchDirection::Forward,
+        direction => direction,
+    };
+
+    match effective_direction {
+        MatchDirection::Forward => matching_forward(tokens, token),
+        MatchDirection::Backward => matching_backward(tokens, token),
+    }
+}
+
+fn matching_forward<'a>(tokens: &'a [Token], token: &Token) -> Option<&'a Token> {
+    let mut depth = 0usize;
+    for candidate in tokens
+        .iter()
+        .filter(|candidate| candidate.group == token.group && candidate.start > token.start)
+    {
+        match candidate.role {
+            TokenRole::Open => depth += 1,
+            TokenRole::Middle if depth == 0 => return Some(candidate),
+            TokenRole::Middle => {}
+            TokenRole::Close if depth == 0 => return Some(candidate),
+            TokenRole::Close => depth = depth.saturating_sub(1),
+        }
+    }
+    None
+}
+
+fn matching_backward<'a>(tokens: &'a [Token], token: &Token) -> Option<&'a Token> {
+    let mut depth = 0usize;
+    for candidate in tokens
+        .iter()
+        .rev()
+        .filter(|candidate| candidate.group == token.group && candidate.start < token.start)
+    {
+        match candidate.role {
+            TokenRole::Close => depth += 1,
+            TokenRole::Middle if depth == 0 => return Some(candidate),
+            TokenRole::Middle => {}
+            TokenRole::Open if depth == 0 => return Some(candidate),
+            TokenRole::Open => depth = depth.saturating_sub(1),
+        }
+    }
+    None
+}
+
+fn unmatched_before(tokens: &[Token], cursor_offset: usize) -> Option<&Token> {
+    let mut stack = Vec::<&Token>::new();
+    for token in tokens.iter().filter(|token| token.start < cursor_offset) {
+        match token.role {
+            TokenRole::Open => stack.push(token),
+            TokenRole::Close => {
+                if let Some(pos) = stack.iter().rposition(|open| open.group == token.group) {
+                    stack.remove(pos);
+                }
+            }
+            TokenRole::Middle => {}
+        }
+    }
+    stack.pop()
+}
+
+fn unmatched_after(tokens: &[Token], cursor_offset: usize) -> Option<&Token> {
+    let mut stack = Vec::<&Token>::new();
+    for token in tokens
+        .iter()
+        .rev()
+        .filter(|token| token.start > cursor_offset)
+    {
+        match token.role {
+            TokenRole::Close => stack.push(token),
+            TokenRole::Open => {
+                if let Some(pos) = stack.iter().rposition(|close| close.group == token.group) {
+                    stack.remove(pos);
+                }
+            }
+            TokenRole::Middle => {}
+        }
+    }
+    stack.pop()
+}
+
+fn motion_for_token(doc: &Document, token: &Token) -> MatchMotion {
+    MatchMotion {
+        target: doc.position_for_offset(token.start),
+        target_end: doc.position_for_offset(token.end),
+        kind: if token.linewise {
+            MatchKind::Linewise
+        } else {
+            MatchKind::Charwise
+        },
+    }
+}
+
+fn advance_position(position: TextPosition) -> TextPosition {
+    TextPosition::new(position.line, position.character + 1)
+}
+
+fn position_le(left: TextPosition, right: TextPosition) -> bool {
+    (left.line, left.character) <= (right.line, right.character)
+}

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -1352,3 +1352,126 @@ async fn test_move_to_specific_position() {
     harness.execute_action(Action::MoveTo(0, 3)).await.unwrap();
     harness.assert_cursor_at(0, 2); // At 'T' in "Test" (line 2)
 }
+
+#[tokio::test]
+async fn test_percent_matches_next_bracket_on_line() {
+    let mut harness = EditorHarness::with_content("if (a == (b * c) / d)");
+
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(20, 0);
+
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(3, 0);
+}
+
+#[tokio::test]
+async fn test_percent_matches_nested_bracket_under_cursor() {
+    let mut harness = EditorHarness::with_content("if (a == (b * c) / d)");
+
+    harness.execute_action(Action::MoveTo(9, 1)).await.unwrap();
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(15, 0);
+}
+
+#[tokio::test]
+async fn test_counted_percent_jumps_to_file_percentage() {
+    let content = (1..=100)
+        .map(|line| format!("Line {line:03}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut harness = EditorHarness::with_content(&content);
+
+    type_normal_keys(&mut harness, "50%").await;
+    harness.assert_cursor_at(0, 49);
+}
+
+#[tokio::test]
+async fn test_percent_matches_c_comment_delimiters() {
+    let mut harness = EditorHarness::with_content("alpha /* beta */ gamma");
+
+    harness.execute_action(Action::MoveTo(6, 1)).await.unwrap();
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(14, 0);
+
+    harness
+        .execute_action(Action::MatchitBackward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(6, 0);
+}
+
+#[tokio::test]
+async fn test_percent_cycles_preprocessor_groups_linewise() {
+    let mut harness = EditorHarness::with_content("#if FOO\nbody\n#else\nother\n#endif");
+
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(0, 2);
+
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(0, 4);
+
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(0, 2);
+}
+
+#[tokio::test]
+async fn test_percent_cycles_bash_matchit_groups() {
+    let buffer = Buffer::new(
+        Some("script.sh".to_string()),
+        "if foo\nthen\n  echo yes\nelse\n  echo no\nfi".to_string(),
+    );
+    let mut harness = EditorHarness::with_config(buffer, Config::default());
+
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(0, 3);
+
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(0, 5);
+}
+
+#[tokio::test]
+async fn test_percent_matches_html_like_tags() {
+    let mut harness = EditorHarness::with_content("<section><div>hello</div></section>");
+
+    harness.execute_action(Action::MoveTo(9, 1)).await.unwrap();
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(19, 0);
+}
+
+#[tokio::test]
+async fn test_operator_delete_percent_deletes_through_match() {
+    let mut harness = EditorHarness::with_content("(alpha) beta");
+
+    type_normal_keys(&mut harness, "d%").await;
+    harness.assert_buffer_contents(" beta");
+}


### PR DESCRIPTION
## Why

Neovim users expect `%` to jump between matching syntax constructs, not just move around plain text. `red` already has several Vim-like motions, but it did not have the core `%` behavior for brackets, counted `N%` jumps, comments, or Matchit-style language groups.

## What Changed

- Added a Matchit-style matcher for bracket pairs, C comments, C preprocessor groups, Bash conditionals, and simple HTML/XML-like tag pairs.
- Added `matchit` config defaults and user-configurable language groups using Rust regex syntax.
- Wired `%`, `g%`, `[%`, `]%`, and visual `%` defaults through `default_config.toml`.
- Preserved Vim's counted `{N}%` behavior as a file-percentage jump instead of repeated match motion.
- Added movement/config regressions for plain matching, nested pairs, comments, preprocessor groups, Bash groups, tags, counted jumps, and `d%` operator behavior.

## How to Test

1. Open a Rust file in `red` and put the cursor on or before a brace in a line such as `if !config_file.exists() {`.
2. Press `%` and confirm the cursor jumps to the matching closing brace.
3. Press `g%` and confirm it jumps back.
4. Type `50%` in a file with many lines and confirm the cursor moves to the midpoint of the file instead of repeating `%` fifty times.
5. In a shell file, place the cursor on `if`, press `%`, and confirm it cycles through the matching `else` / `fi` group.

Targeted tests:

- `cargo test percent`
- `cargo test matchit_config`
- `cargo test default_config_maps_matchit_keys`

Full validation also passed with `cargo test -- --test-threads=1` and `cargo clippy --all-targets --all-features -- -D warnings`.
