### PR TITLE
feat(plugin): add window breadcrumb bars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Run plugin tests
         run: |
           cd test-harness
-          for test in ../examples/*.test.js; do
+          for test in ../examples/*.test.js ../plugins/*.test.js; do
             if [ -f "$test" ]; then
               plugin="${test%.test.js}.js"
               if [ -f "$plugin" ]; then
@@ -245,4 +245,3 @@ jobs:
       - name: Check MSRV
         run: cargo check --all-features
         if: steps.msrv.outputs.version != ''
-

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run plugin tests
         run: |
           cd test-harness
-          for test in ../examples/*.test.js; do
+          for test in ../examples/*.test.js ../plugins/*.test.js; do
             if [ -f "$test" ]; then
               plugin="${test%.test.js}.js"
               if [ -f "$plugin" ]; then

--- a/default_config.toml
+++ b/default_config.toml
@@ -247,6 +247,7 @@ Esc = { EnterMode = "Normal" }
 "quit" = "Quit"
 
 [plugins]
+barbecue = "barbecue.js"
 buffer_picker = "buffer_picker.js"
 cool_search = "cool_search.js"
 fidget = "fidget.js"
@@ -257,6 +258,22 @@ neotree = "neotree.js"
 project_search = "project_search.js"
 session_restore = "session_restore.js"
 theme_browser = "theme_browser.js"
+
+# Breadcrumbs use theme workbench colors and Nerd Font glyphs by default.
+# Set nerd_font to false for a plain Unicode presentation.
+[plugin_config.barbecue]
+enabled = true
+separator = ""
+truncate_marker = "…"
+show_directory = true
+show_file = true
+show_symbols = true
+nerd_font = true
+
+[plugin_config.barbecue.icons.overrides]
+# class = "C"
+# function = "fn"
+# struct = ""
 
 [plugin_permissions.project_search]
 process = ["rg"]

--- a/default_config.toml
+++ b/default_config.toml
@@ -259,13 +259,15 @@ project_search = "project_search.js"
 session_restore = "session_restore.js"
 theme_browser = "theme_browser.js"
 
-# Breadcrumbs use theme workbench colors and Nerd Font glyphs by default.
+# Breadcrumb text uses theme colors; file icons use nvim-web-devicons' light/dark palette.
 # Set nerd_font to false for a plain Unicode presentation.
 [plugin_config.barbecue]
 enabled = true
 separator = ""
 truncate_marker = "…"
 show_directory = true
+# Directory names are plain text by default, matching barbecue.nvim.
+show_folder_icon = false
 show_file = true
 show_symbols = true
 nerd_font = true

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -146,6 +146,7 @@ Subscribes to editor events. Available events include:
   payload includes the window, segment, and action IDs
 - `theme:changed` - The active theme changed
 - `editor:ready` - Plugins have loaded and startup work can begin
+- `editor:stateRestored` - Session state replaced the active buffers and windows
 
 #### Editor Information
 ```javascript

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -138,6 +138,13 @@ Subscribes to editor events. Available events include:
 - `search:cleared` - Search highlights were cleared. Payload includes `term`.
 - `file:opened` - File opened in a buffer
 - `file:saved` - File saved from a buffer
+- `window:focused` - The active editor window changed
+- `window:layoutChanged` - Window bounds or split layout changed
+- `window:bufferChanged` - A window switched to another buffer
+- `window:closed` - A window was closed
+- `windowBar:action:${id}` - An actionable window-bar segment was clicked;
+  payload includes the window, segment, and action IDs
+- `theme:changed` - The active theme changed
 - `editor:ready` - Plugins have loaded and startup work can begin
 
 #### Editor Information
@@ -182,6 +189,28 @@ red.openBuffer(name: string)
 
 // Draw text at specific coordinates
 red.drawText(x: number, y: number, text: string, style?: object)
+
+// Add one persistent row of window-local UI above buffer content
+red.ui.createWindowBar("breadcrumbs", {
+  edge: "top",
+  priority: 100,
+  overflow: "truncate_left",
+  truncateMarker: "…",
+})
+red.ui.updateWindowBar("breadcrumbs", windowId, [
+  {
+    id: "file",
+    text: " main.rs",
+    style: {
+      semantic: {
+        foreground: ["symbolIcon.fileForeground", "breadcrumb.foreground"],
+        background: ["breadcrumb.background", "editor.background"],
+      },
+    },
+    action: "open-file",
+  },
+])
+red.ui.closeWindowBar("breadcrumbs")
 
 // Create and update a persistent side panel
 red.createPanel("tree", { side: "left", width: 32 })
@@ -300,6 +329,39 @@ red.setCursorPosition(x: number, y: number)
 // Get buffer text
 const text = await red.getBufferText(startLine?: number, endLine?: number)
 ```
+
+#### Windows, Window Bars, and Theme Styles
+
+`red.getWindows()` returns session-stable window IDs together with each
+window's bounds, content bounds, buffer path and revision, cursor, UTF-16
+`lspPosition`, and viewport. Window bars reserve one row inside each window;
+the host adjusts buffer rendering, cursor placement, overlays, and mouse hit
+testing for that inset. Only the highest-priority bar is visible in a window.
+
+Window-bar text is a list of independently styled segments. Long content is
+clipped on a grapheme boundary according to the configured overflow direction.
+An actionable segment emits `windowBar:action:${id}` when clicked.
+
+Resolve concrete colors from the active theme when a component needs ordered
+fallbacks:
+
+```javascript
+const style = await red.theme.resolveStyle({
+  foreground: [
+    "symbolIcon.functionForeground",
+    "scope:entity.name.function",
+    "breadcrumb.foreground",
+    "editor.foreground",
+  ],
+  background: ["breadcrumb.background", "editor.background"],
+  bold: true,
+})
+```
+
+Workbench color keys are tried from left to right. TextMate scopes use a
+`scope:` prefix. The top-level `red.createWindowBar`, `red.updateWindowBar`,
+`red.closeWindowBar`, and `red.resolveThemeStyle` names remain available for
+compatibility.
 
 #### Action Execution
 ```javascript

--- a/plugins/barbecue.js
+++ b/plugins/barbecue.js
@@ -31,23 +31,24 @@ const DEFAULT_ICONS = {
   Unknown: "",
 };
 
+// Common nvim-web-devicons basename glyphs and colors, which barbecue.nvim delegates to.
 const FILE_ICONS = {
-  cjs: "",
-  fish: "",
-  js: "",
-  json: "",
-  jsx: "",
-  lock: "",
-  lua: "",
-  markdown: "",
-  md: "",
-  mjs: "",
-  rs: "",
-  sh: "",
-  toml: "",
-  ts: "",
-  tsx: "",
-  zsh: "",
+  cjs: { icon: "", dark: "#CBCB41", light: "#666620" },
+  fish: { icon: "", dark: "#4D5A5E", light: "#3A4446" },
+  js: { icon: "", dark: "#CBCB41", light: "#666620" },
+  json: { icon: "", dark: "#CBCB41", light: "#666620" },
+  jsx: { icon: "", dark: "#20C2E3", light: "#158197" },
+  lock: { icon: "", dark: "#BBBBBB", light: "#5E5E5E" },
+  lua: { icon: "", dark: "#51A0CF", light: "#366B8A" },
+  markdown: { icon: "", dark: "#DDDDDD", light: "#4A4A4A" },
+  md: { icon: "", dark: "#DDDDDD", light: "#4A4A4A" },
+  mjs: { icon: "", dark: "#F1E05A", light: "#504B1E" },
+  rs: { icon: "", dark: "#DEA584", light: "#6F5242" },
+  sh: { icon: "", dark: "#4D5A5E", light: "#3A4446" },
+  toml: { icon: "", dark: "#9C4221", light: "#753219" },
+  ts: { icon: "", dark: "#519ABA", light: "#36677C" },
+  tsx: { icon: "", dark: "#1354BF", light: "#1354BF" },
+  zsh: { icon: "", dark: "#89E051", light: "#447028" },
 };
 
 const KIND_THEME_KEYS = {
@@ -82,6 +83,45 @@ const BAR_BACKGROUND = ["breadcrumb.background", "editor.background"];
 
 function semantic(foreground, bold = false) {
   return { semantic: { foreground, background: BAR_BACKGROUND, ...(bold ? { bold } : {}) } };
+}
+
+function rgbFromHex(color) {
+  const hex = color.slice(1);
+  return {
+    Rgb: {
+      r: Number.parseInt(hex.slice(0, 2), 16),
+      g: Number.parseInt(hex.slice(2, 4), 16),
+      b: Number.parseInt(hex.slice(4, 6), 16),
+    },
+  };
+}
+
+function colorChannels(color) {
+  if (typeof color === "string" && /^#[0-9a-f]{6}$/i.test(color)) {
+    const rgb = rgbFromHex(color).Rgb;
+    return [rgb.r, rgb.g, rgb.b];
+  }
+  const rgb = color?.Rgb ?? color?.Rgba;
+  return rgb ? [rgb.r, rgb.g, rgb.b] : null;
+}
+
+function lightTheme(info) {
+  const channels = colorChannels(info?.theme?.style?.bg);
+  if (!channels) return false;
+  const linear = channels.map((channel) => {
+    const value = channel / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2] > 0.5;
+}
+
+function fileIconStyle(fileIcon, info, fallback) {
+  if (!fileIcon) return fallback;
+  const color = lightTheme(info) ? fileIcon.light : fileIcon.dark;
+  return {
+    semantic: { background: BAR_BACKGROUND },
+    style: { fg: rgbFromHex(color), bg: null, bold: false, italic: false },
+  };
 }
 
 export function stylesFor(_info) {
@@ -139,7 +179,7 @@ function relativeParts(path, cwd) {
   if (normalizedCwd && normalizedPath.startsWith(`${normalizedCwd}/`)) {
     relative = normalizedPath.slice(normalizedCwd.length + 1);
   }
-  const parts = relative.split("/").filter(Boolean);
+  const parts = relative.split("/").filter((part) => part && part !== ".");
   return { directories: parts.slice(0, -1), file: parts.at(-1) || "[No Name]" };
 }
 
@@ -250,7 +290,9 @@ export function buildSegments(window, symbols, options = {}, info = null, cwd = 
   if (options.showDirectory !== false) {
     path.directories.forEach((directory, index) => {
       addSeparator();
-      const icon = options.nerdFont === false ? "" : DEFAULT_ICONS.Folder;
+      const icon = options.nerdFont === false || options.showFolderIcon !== true
+        ? ""
+        : DEFAULT_ICONS.Folder;
       const label = index === path.directories.length - 1 && icon ? `${icon} ${directory}` : directory;
       segments.push(segment(`directory:${index}:${directory}`, label, styles.directory));
     });
@@ -258,10 +300,15 @@ export function buildSegments(window, symbols, options = {}, info = null, cwd = 
 
   if (options.showFile !== false) {
     addSeparator();
-    const icon = options.nerdFont === false
-      ? ""
-      : FILE_ICONS[extension(path.file)] ?? DEFAULT_ICONS.File;
-    segments.push(segment("file", icon ? `${icon} ${path.file}` : path.file, styles.file));
+    const fileIcon = FILE_ICONS[extension(path.file)];
+    if (options.nerdFont !== false) {
+      segments.push(segment(
+        "file-icon",
+        `${fileIcon?.icon ?? DEFAULT_ICONS.File} `,
+        fileIconStyle(fileIcon, info, styles.file),
+      ));
+    }
+    segments.push(segment("file", path.file, styles.file));
   }
 
   if (options.showSymbols !== false) {
@@ -315,6 +362,7 @@ function optionsFromConfig(config) {
     nerdFont: options.nerd_font ?? options.nerdFont ?? true,
     separator: options.separator ?? "",
     showDirectory: options.show_directory ?? options.showDirectory ?? true,
+    showFolderIcon: options.show_folder_icon ?? options.showFolderIcon ?? false,
     showFile: options.show_file ?? options.showFile ?? true,
     showSymbols: options.show_symbols ?? options.showSymbols ?? true,
     truncateMarker: options.truncate_marker ?? options.truncateMarker ?? "…",
@@ -333,7 +381,10 @@ export function createController(red) {
   let barOpen = false;
   let barMarker = null;
   let cwd = "";
+  let editorInfo = null;
+  let editorInfoPromise = null;
   let contextPromise = null;
+  let visibleWindows = [];
 
   function configureBar() {
     api.create(BAR_ID, {
@@ -355,6 +406,16 @@ export function createController(red) {
       });
     }
     return contextPromise;
+  }
+
+  function loadEditorInfo() {
+    if (!editorInfoPromise) {
+      editorInfoPromise = red.getEditorInfo().then((info) => {
+        editorInfo = info;
+        return info;
+      });
+    }
+    return editorInfoPromise;
   }
 
   function symbolCacheKey(window) {
@@ -385,6 +446,14 @@ export function createController(red) {
     return symbols;
   }
 
+  function renderCachedWindows() {
+    if (stopped || !barOpen) return;
+    for (const window of visibleWindows) {
+      const symbols = symbolsByBuffer.get(symbolCacheKey(window)) ?? [];
+      api.update(BAR_ID, windowId(window), buildSegments(window, symbols, options, editorInfo, cwd));
+    }
+  }
+
   async function refresh() {
     const requestGeneration = ++generation;
     const [, windows] = await Promise.all([
@@ -399,17 +468,29 @@ export function createController(red) {
     }
     if (!barOpen || barMarker !== options.truncateMarker) configureBar();
 
-    for (const window of windows ?? []) {
+    visibleWindows = windows ?? [];
+    for (const window of visibleWindows) {
       const key = symbolCacheKey(window);
       const cachedSymbols = symbolsByBuffer.get(key) ?? [];
-      api.update(BAR_ID, windowId(window), buildSegments(window, cachedSymbols, options, null, cwd));
+      api.update(
+        BAR_ID,
+        windowId(window),
+        buildSegments(window, cachedSymbols, options, editorInfo, cwd),
+      );
 
       if (!options.showSymbols || symbolsByBuffer.has(key)) continue;
       void symbolsFor(window).then((symbols) => {
         if (stopped || requestGeneration !== generation) return;
-        api.update(BAR_ID, windowId(window), buildSegments(window, symbols, options, null, cwd));
+        api.update(BAR_ID, windowId(window), buildSegments(window, symbols, options, editorInfo, cwd));
       }).catch((error) => {
         red.logWarn?.("Barbecue document symbols failed", error?.message ?? error);
+      });
+    }
+
+    if (!editorInfo && !editorInfoPromise) {
+      void loadEditorInfo().then(renderCachedWindows).catch((error) => {
+        editorInfoPromise = null;
+        red.logWarn?.("Barbecue editor info failed", error?.message ?? error);
       });
     }
   }
@@ -423,6 +504,12 @@ export function createController(red) {
   }
 
   function refreshFromCache() {
+    return refresh();
+  }
+
+  async function refreshTheme() {
+    editorInfoPromise = null;
+    await loadEditorInfo();
     return refresh();
   }
 
@@ -448,11 +535,13 @@ export function createController(red) {
 
   configureBar();
 
-  return { handleAction, refresh, refreshFromCache, scheduleRefresh, stop };
+  return { handleAction, refresh, refreshFromCache, refreshTheme, scheduleRefresh, stop };
 }
 
 export async function activate(red) {
   const controller = createController(red);
+  red.on("editor:ready", controller.refresh);
+  red.on("editor:stateRestored", controller.refresh);
   red.on("cursor:moved", controller.refreshFromCache);
   red.on("viewport:changed", controller.refreshFromCache);
   red.on("window:focused", controller.refreshFromCache);
@@ -461,7 +550,7 @@ export async function activate(red) {
   red.on("window:closed", controller.refresh);
   red.on("buffer:changed", controller.scheduleRefresh);
   red.on("file:opened", controller.refresh);
-  red.on("theme:changed", controller.refreshFromCache);
+  red.on("theme:changed", controller.refreshTheme);
   red.on(`windowBar:action:${BAR_ID}`, controller.handleAction);
   red.__barbecueController = controller;
   await controller.refresh();

--- a/plugins/barbecue.js
+++ b/plugins/barbecue.js
@@ -1,0 +1,473 @@
+const BAR_ID = "barbecue";
+const DEFAULT_DEBOUNCE_MS = 120;
+
+const DEFAULT_ICONS = {
+  Array: "",
+  Boolean: "󰨙",
+  Class: "",
+  Constant: "󰏿",
+  Constructor: "",
+  Enum: "",
+  EnumMember: "",
+  Event: "",
+  Field: "",
+  File: "",
+  Folder: "",
+  Function: "󰊕",
+  Interface: "",
+  Key: "",
+  Method: "󰊕",
+  Module: "",
+  Namespace: "󰦮",
+  Number: "󰎠",
+  Object: "",
+  Operator: "",
+  Package: "",
+  Property: "",
+  String: "",
+  Struct: "󰆼",
+  TypeParameter: "",
+  Variable: "󰀫",
+  Unknown: "",
+};
+
+const FILE_ICONS = {
+  cjs: "",
+  fish: "",
+  js: "",
+  json: "",
+  jsx: "",
+  lock: "",
+  lua: "",
+  markdown: "",
+  md: "",
+  mjs: "",
+  rs: "",
+  sh: "",
+  toml: "",
+  ts: "",
+  tsx: "",
+  zsh: "",
+};
+
+const KIND_THEME_KEYS = {
+  Array: "symbolIcon.arrayForeground",
+  Boolean: "symbolIcon.booleanForeground",
+  Class: "symbolIcon.classForeground",
+  Constant: "symbolIcon.constantForeground",
+  Constructor: "symbolIcon.constructorForeground",
+  Enum: "symbolIcon.enumeratorForeground",
+  EnumMember: "symbolIcon.enumeratorMemberForeground",
+  Event: "symbolIcon.eventForeground",
+  Field: "symbolIcon.fieldForeground",
+  File: "symbolIcon.fileForeground",
+  Function: "symbolIcon.functionForeground",
+  Interface: "symbolIcon.interfaceForeground",
+  Key: "symbolIcon.keyForeground",
+  Method: "symbolIcon.methodForeground",
+  Module: "symbolIcon.moduleForeground",
+  Namespace: "symbolIcon.namespaceForeground",
+  Number: "symbolIcon.numberForeground",
+  Object: "symbolIcon.objectForeground",
+  Operator: "symbolIcon.operatorForeground",
+  Package: "symbolIcon.packageForeground",
+  Property: "symbolIcon.propertyForeground",
+  String: "symbolIcon.stringForeground",
+  Struct: "symbolIcon.structForeground",
+  TypeParameter: "symbolIcon.typeParameterForeground",
+  Variable: "symbolIcon.variableForeground",
+};
+
+const BAR_BACKGROUND = ["breadcrumb.background", "editor.background"];
+
+function semantic(foreground, bold = false) {
+  return { semantic: { foreground, background: BAR_BACKGROUND, ...(bold ? { bold } : {}) } };
+}
+
+export function stylesFor(_info) {
+  const normal = semantic(["breadcrumb.foreground", "editor.foreground"]);
+  const separator = semantic([
+    "breadcrumb.foreground",
+    "descriptionForeground",
+    "editor.foreground",
+  ]);
+  const directory = semantic([
+    "symbolIcon.folderForeground",
+    "breadcrumb.foreground",
+    "editor.foreground",
+  ]);
+  const file = semantic([
+    "symbolIcon.fileForeground",
+    "breadcrumb.foreground",
+    "editor.foreground",
+  ]);
+  const current = semantic([
+    "breadcrumb.focusForeground",
+    "breadcrumb.activeSelectionForeground",
+    "list.activeSelectionForeground",
+    "editor.foreground",
+  ], true);
+
+  return {
+    current,
+    directory,
+    file,
+    normal,
+    separator,
+    symbol(kind, isCurrent = false) {
+      if (isCurrent) return current;
+      return semantic(
+        [KIND_THEME_KEYS[kind], "breadcrumb.foreground", "editor.foreground"].filter(Boolean),
+      );
+    },
+  };
+}
+
+function normalizePath(path) {
+  return String(path ?? "").replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function basename(path) {
+  const parts = normalizePath(path).split("/");
+  return parts.at(-1) || "[No Name]";
+}
+
+function relativeParts(path, cwd) {
+  const normalizedPath = normalizePath(path);
+  const normalizedCwd = normalizePath(cwd);
+  let relative = normalizedPath;
+  if (normalizedCwd && normalizedPath.startsWith(`${normalizedCwd}/`)) {
+    relative = normalizedPath.slice(normalizedCwd.length + 1);
+  }
+  const parts = relative.split("/").filter(Boolean);
+  return { directories: parts.slice(0, -1), file: parts.at(-1) || "[No Name]" };
+}
+
+function extension(path) {
+  const name = basename(path);
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(dot + 1).toLowerCase() : "";
+}
+
+function positionFromWindow(window) {
+  if (window.lspPosition) return window.lspPosition;
+  const cursor = window.cursor ?? {};
+  return {
+    line: cursor.line ?? cursor.y ?? window.cursorLine ?? window.cursor_line ?? 0,
+    character:
+      cursor.character ??
+      cursor.lspCharacter ??
+      cursor.lsp_character ??
+      cursor.utf16Character ??
+      cursor.utf16_character ??
+      cursor.x ??
+      window.cursorCharacter ??
+      window.cursor_character ??
+      0,
+  };
+}
+
+function comparePosition(left, right) {
+  return left.line - right.line || left.character - right.character;
+}
+
+export function rangeContains(range, position) {
+  if (!range?.start || !range?.end) return false;
+  return comparePosition(range.start, position) <= 0 && comparePosition(position, range.end) < 0;
+}
+
+function flattenSymbols(symbols, parentId = null, depth = 0, output = []) {
+  for (const [index, symbol] of (symbols ?? []).entries()) {
+    const id = symbol.id ?? `${parentId ?? "root"}:${index}:${symbol.name ?? "symbol"}`;
+    const flat = { ...symbol, id, parentId: symbol.parentId ?? parentId, depth: symbol.depth ?? depth };
+    delete flat.children;
+    output.push(flat);
+    flattenSymbols(symbol.children, id, flat.depth + 1, output);
+  }
+  return output;
+}
+
+export function enclosingSymbols(symbols, position) {
+  const flat = flattenSymbols(symbols);
+  if (flat.length === 0) return [];
+  const byId = new Map(flat.map((symbol) => [symbol.id, symbol]));
+  const containing = flat.filter((symbol) => rangeContains(symbol.range, position));
+  if (containing.length === 0) return [];
+  const leaf = containing.reduce((best, symbol) =>
+    (symbol.depth ?? 0) >= (best.depth ?? 0) ? symbol : best,
+  );
+
+  if (leaf.parentId != null && byId.has(leaf.parentId)) {
+    const chain = [];
+    const visited = new Set();
+    let current = leaf;
+    while (current && !visited.has(current.id)) {
+      visited.add(current.id);
+      chain.unshift(current);
+      current = byId.get(current.parentId);
+    }
+    return chain.filter((symbol) => rangeContains(symbol.range, position));
+  }
+
+  const leafIndex = flat.indexOf(leaf);
+  const chain = [leaf];
+  let wantedDepth = (leaf.depth ?? 0) - 1;
+  for (let index = leafIndex - 1; index >= 0 && wantedDepth >= 0; index -= 1) {
+    const candidate = flat[index];
+    if ((candidate.depth ?? 0) === wantedDepth && rangeContains(candidate.range, position)) {
+      chain.unshift(candidate);
+      wantedDepth -= 1;
+    }
+  }
+  return chain;
+}
+
+function configuredIcon(kind, options) {
+  if (options.nerdFont === false) return "";
+  const overrides = options.icons?.overrides ?? {};
+  const override = overrides[kind.toLowerCase()];
+  return override == null ? DEFAULT_ICONS[kind] ?? DEFAULT_ICONS.Unknown : String(override);
+}
+
+function segment(id, text, segmentStyle, action = null) {
+  return { id, text, style: segmentStyle, ...(action ? { action } : {}) };
+}
+
+export function buildSegments(window, symbols, options = {}, info = null, cwd = "") {
+  const windowPath =
+    window.bufferPath ?? window.buffer_path ?? window.path ?? window.file ?? window.filePath ??
+    window.file_path ?? "";
+  const path = relativeParts(windowPath, cwd);
+  const styles = stylesFor(info);
+  const separatorText = options.separator ?? "";
+  const segments = [];
+  const addSeparator = () => {
+    if (segments.length > 0) {
+      segments.push(segment(`separator:${segments.length}`, ` ${separatorText} `, styles.separator));
+    }
+  };
+
+  if (options.showDirectory !== false) {
+    path.directories.forEach((directory, index) => {
+      addSeparator();
+      const icon = options.nerdFont === false ? "" : DEFAULT_ICONS.Folder;
+      const label = index === path.directories.length - 1 && icon ? `${icon} ${directory}` : directory;
+      segments.push(segment(`directory:${index}:${directory}`, label, styles.directory));
+    });
+  }
+
+  if (options.showFile !== false) {
+    addSeparator();
+    const icon = options.nerdFont === false
+      ? ""
+      : FILE_ICONS[extension(path.file)] ?? DEFAULT_ICONS.File;
+    segments.push(segment("file", icon ? `${icon} ${path.file}` : path.file, styles.file));
+  }
+
+  if (options.showSymbols !== false) {
+    const chain = enclosingSymbols(symbols, positionFromWindow(window));
+    chain.forEach((symbol, index) => {
+      addSeparator();
+      const kind = symbol.kindName ?? symbol.kind_name ?? "Unknown";
+      const icon = configuredIcon(kind, options);
+      const current = index === chain.length - 1;
+      segments.push(
+        segment(
+          `symbol:${symbol.id}`,
+          icon ? `${icon} ${symbol.name}` : symbol.name,
+          styles.symbol(kind, current),
+          `jump:${bufferIndex(window)}:${symbol.id}`,
+        ),
+      );
+    });
+  }
+
+  return segments;
+}
+
+function windowId(window) {
+  return window.windowId ?? window.window_id ?? window.id;
+}
+
+function bufferIndex(window) {
+  return window.bufferIndex ?? window.buffer_index ?? window.bufferId ?? window.buffer_id ?? 0;
+}
+
+function bufferRevision(window) {
+  return window.revision ?? window.bufferRevision ?? window.buffer_revision ?? 0;
+}
+
+function barApi(red) {
+  const ui = red.ui ?? red;
+  return {
+    create: (id, config) => ui.createWindowBar(id, config),
+    update: (id, idOrWindow, segments) => ui.updateWindowBar(id, idOrWindow, segments),
+    close: (id) => ui.closeWindowBar(id),
+  };
+}
+
+function optionsFromConfig(config) {
+  const options = config?.barbecue ?? {};
+  return {
+    debounceMs: options.debounce_ms ?? options.debounceMs ?? DEFAULT_DEBOUNCE_MS,
+    enabled: options.enabled !== false,
+    icons: options.icons ?? {},
+    nerdFont: options.nerd_font ?? options.nerdFont ?? true,
+    separator: options.separator ?? "",
+    showDirectory: options.show_directory ?? options.showDirectory ?? true,
+    showFile: options.show_file ?? options.showFile ?? true,
+    showSymbols: options.show_symbols ?? options.showSymbols ?? true,
+    truncateMarker: options.truncate_marker ?? options.truncateMarker ?? "…",
+  };
+}
+
+export function createController(red) {
+  const api = barApi(red);
+  const symbolsByBuffer = new Map();
+  const pendingByBuffer = new Map();
+  const symbolsById = new Map();
+  let generation = 0;
+  let timer = null;
+  let options = optionsFromConfig(null);
+  let stopped = false;
+  let barOpen = false;
+  let barMarker = null;
+  let cwd = "";
+  let contextPromise = null;
+
+  function configureBar() {
+    api.create(BAR_ID, {
+      edge: "top",
+      overflow: "truncate_left",
+      priority: 100,
+      style: semantic(["breadcrumb.foreground", "editor.foreground"]),
+      truncateMarker: options.truncateMarker,
+    });
+    barOpen = true;
+    barMarker = options.truncateMarker;
+  }
+
+  async function loadContext() {
+    if (!contextPromise) {
+      contextPromise = red.getConfig().then((config) => {
+        options = optionsFromConfig(config?.plugin_config);
+        cwd = config?.cwd ?? "";
+      });
+    }
+    return contextPromise;
+  }
+
+  function symbolCacheKey(window) {
+    return `${bufferIndex(window)}:${bufferRevision(window)}`;
+  }
+
+  async function symbolsFor(window) {
+    if (!options.showSymbols) return [];
+    const index = bufferIndex(window);
+    const revision = bufferRevision(window);
+    const key = symbolCacheKey(window);
+    if (symbolsByBuffer.has(key)) return symbolsByBuffer.get(key);
+    let pending = pendingByBuffer.get(key);
+    if (!pending) {
+      pending = red.lsp.documentSymbols({ bufferIndex: index });
+      pendingByBuffer.set(key, pending);
+    }
+    const result = await pending;
+    pendingByBuffer.delete(key);
+    if (stopped || !result?.ok) return [];
+    if (result.revision != null && result.revision !== revision) return [];
+    const symbols = flattenSymbols(result.symbols ?? []);
+    for (const cachedKey of symbolsByBuffer.keys()) {
+      if (cachedKey.startsWith(`${index}:`) && cachedKey !== key) symbolsByBuffer.delete(cachedKey);
+    }
+    symbolsByBuffer.set(key, symbols);
+    for (const symbol of symbols) symbolsById.set(`${index}:${symbol.id}`, symbol);
+    return symbols;
+  }
+
+  async function refresh() {
+    const requestGeneration = ++generation;
+    const [, windows] = await Promise.all([
+      loadContext(),
+      red.getWindows(),
+    ]);
+    if (stopped || requestGeneration !== generation) return;
+    if (!options.enabled) {
+      if (barOpen) api.close(BAR_ID);
+      barOpen = false;
+      return;
+    }
+    if (!barOpen || barMarker !== options.truncateMarker) configureBar();
+
+    for (const window of windows ?? []) {
+      const key = symbolCacheKey(window);
+      const cachedSymbols = symbolsByBuffer.get(key) ?? [];
+      api.update(BAR_ID, windowId(window), buildSegments(window, cachedSymbols, options, null, cwd));
+
+      if (!options.showSymbols || symbolsByBuffer.has(key)) continue;
+      void symbolsFor(window).then((symbols) => {
+        if (stopped || requestGeneration !== generation) return;
+        api.update(BAR_ID, windowId(window), buildSegments(window, symbols, options, null, cwd));
+      }).catch((error) => {
+        red.logWarn?.("Barbecue document symbols failed", error?.message ?? error);
+      });
+    }
+  }
+
+  async function scheduleRefresh() {
+    if (timer != null) await red.clearTimeout(timer);
+    timer = await red.setTimeout(async () => {
+      timer = null;
+      await refresh();
+    }, Number(options.debounceMs));
+  }
+
+  function refreshFromCache() {
+    return refresh();
+  }
+
+  async function handleAction(event) {
+    const action = event?.action ?? event?.actionId ?? event?.action_id;
+    if (!String(action).startsWith("jump:")) return;
+    const symbol = symbolsById.get(String(action).slice(5));
+    if (!symbol?.selectionRange) return;
+    await red.openLocation({
+      path: symbol.file,
+      line: symbol.selectionRange.start.line,
+      column: symbol.selectionRange.start.character,
+      columnEncoding: "utf-16",
+    });
+  }
+
+  async function stop() {
+    stopped = true;
+    generation += 1;
+    if (timer != null) await red.clearTimeout(timer);
+    api.close(BAR_ID);
+  }
+
+  configureBar();
+
+  return { handleAction, refresh, refreshFromCache, scheduleRefresh, stop };
+}
+
+export async function activate(red) {
+  const controller = createController(red);
+  red.on("cursor:moved", controller.refreshFromCache);
+  red.on("viewport:changed", controller.refreshFromCache);
+  red.on("window:focused", controller.refreshFromCache);
+  red.on("window:layoutChanged", controller.refreshFromCache);
+  red.on("window:bufferChanged", controller.refresh);
+  red.on("window:closed", controller.refresh);
+  red.on("buffer:changed", controller.scheduleRefresh);
+  red.on("file:opened", controller.refresh);
+  red.on("theme:changed", controller.refreshFromCache);
+  red.on(`windowBar:action:${BAR_ID}`, controller.handleAction);
+  red.__barbecueController = controller;
+  await controller.refresh();
+}
+
+export async function deactivate(red) {
+  await red.__barbecueController?.stop();
+  red.__barbecueController = null;
+}

--- a/plugins/barbecue.test.js
+++ b/plugins/barbecue.test.js
@@ -62,7 +62,14 @@ describe("Barbecue", () => {
     );
 
     expect(segments.map((item) => item.text).join(""))
-      .toBe(" plugins   example.js  󰊕 outer  󰊕 inner");
+      .toBe("plugins   example.js  󰊕 outer  󰊕 inner");
+    expect(segments.find((item) => item.id === "file-icon").style.style.fg)
+      .toEqual({ Rgb: { r: 203, g: 203, b: 65 } });
+    expect(segments.find((item) => item.id === "file").style.semantic.foreground).toEqual([
+      "symbolIcon.fileForeground",
+      "breadcrumb.foreground",
+      "editor.foreground",
+    ]);
     expect(segments.at(-1).style.semantic.foreground).toEqual([
       "breadcrumb.focusForeground",
       "breadcrumb.activeSelectionForeground",
@@ -87,13 +94,62 @@ describe("Barbecue", () => {
     expect(segments.map((item) => item.text).join("")).toBe("plugins › example.js");
   });
 
+  test("omits explicit current-directory components and makes the folder icon opt-in", async () => {
+    const window = { ...windowAt(0), bufferPath: "./plugins/example.js" };
+    const plain = plugin.buildSegments(window, [], { separator: "›", nerdFont: true });
+    const withFolderIcon = plugin.buildSegments(
+      window,
+      [],
+      { separator: "›", nerdFont: true, showFolderIcon: true },
+    );
+
+    expect(plain.map((item) => item.text).join("")).toBe("plugins ›  example.js");
+    expect(withFolderIcon.map((item) => item.text).join(""))
+      .toBe(" plugins ›  example.js");
+  });
+
+  test("uses nvim-web-devicons accents for each file type", async () => {
+    const typescript = plugin.buildSegments(
+      { ...windowAt(0), bufferPath: "/repo/plugins/example.ts" },
+      [],
+      { nerdFont: true },
+      { theme },
+      "/repo",
+    );
+    const rust = plugin.buildSegments(
+      { ...windowAt(0), bufferPath: "/repo/src/main.rs" },
+      [],
+      { nerdFont: true },
+      { theme },
+      "/repo",
+    );
+
+    expect(typescript.find((item) => item.id === "file-icon").style.style.fg)
+      .toEqual({ Rgb: { r: 81, g: 154, b: 186 } });
+    expect(rust.find((item) => item.id === "file-icon").style.style.fg)
+      .toEqual({ Rgb: { r: 222, g: 165, b: 132 } });
+  });
+
+  test("uses the nvim-web-devicons light palette with a light theme", async () => {
+    const segments = plugin.buildSegments(
+      windowAt(0),
+      [],
+      { nerdFont: true },
+      { theme: { ...theme, style: { fg: "#222222", bg: "#ffffff" } } },
+      "/repo",
+    );
+
+    expect(segments.find((item) => item.id === "file-icon").style.style.fg)
+      .toEqual({ Rgb: { r: 102, g: 102, b: 32 } });
+  });
+
   test("renders every window and targets symbol requests by buffer revision", async (red) => {
     await plugin.deactivate(red);
     red.setMockState({
       config: {
         ...red.getMockState().config,
         cwd: "/repo",
-        plugin_config: { barbecue: { separator: "" } },
+        plugin_config: { barbecue: { separator: "", show_folder_icon: true } },
       },
       theme,
       windows: [windowAt(6, 1), { ...windowAt(0), windowId: 8, bufferIndex: 3 }],
@@ -104,7 +160,7 @@ describe("Barbecue", () => {
 
     expect(red.getWindowBar("barbecue", 7).at(-1).text).toBe("󰊕 inner");
     expect(red.getWindowBar("barbecue", 8).map((item) => item.text).join(""))
-      .toBe(" plugins   example.js");
+      .toBe(" plugins   example.js");
     expect(red.getLogs()).toContain('lsp.documentSymbols: {"bufferIndex":2}');
     expect(red.getLogs()).toContain('lsp.documentSymbols: {"bufferIndex":3}');
   });
@@ -129,7 +185,7 @@ describe("Barbecue", () => {
     try {
       await plugin.activate(red);
       expect(red.getWindowBar("barbecue", 7).map((item) => item.text).join(""))
-        .toBe(" plugins   example.js");
+        .toBe("plugins   example.js");
 
       resolveSymbols({ ok: true, revision: 4, symbols });
       await Promise.resolve();
@@ -142,15 +198,42 @@ describe("Barbecue", () => {
     }
   });
 
+  test("repaints after session restore without cursor input", async (red) => {
+    await plugin.deactivate(red);
+    red.setMockState({
+      config: {
+        ...red.getMockState().config,
+        cwd: "/repo",
+        plugin_config: { barbecue: { separator: "" } },
+      },
+      windows: [],
+    });
+
+    await plugin.activate(red);
+    expect(red.getWindowBar("barbecue", 7)).toBe(undefined);
+
+    red.setMockState({ windows: [windowAt(0)] });
+    await red.emitAsync("editor:stateRestored", { windows: [windowAt(0)] });
+
+    expect(red.getWindowBar("barbecue", 7).map((item) => item.text).join(""))
+      .toBe("plugins   example.js");
+  });
+
   test("caches static context and symbols across cursor refreshes", async (red) => {
     await plugin.deactivate(red);
     const originalGetConfig = red.getConfig.bind(red);
+    const originalGetEditorInfo = red.getEditorInfo.bind(red);
     const originalDocumentSymbols = red.lsp.documentSymbols;
     let configRequests = 0;
+    let editorInfoRequests = 0;
     let symbolRequests = 0;
     red.getConfig = async (...args) => {
       configRequests += 1;
       return originalGetConfig(...args);
+    };
+    red.getEditorInfo = async (...args) => {
+      editorInfoRequests += 1;
+      return originalGetEditorInfo(...args);
     };
     red.lsp.documentSymbols = async (...args) => {
       symbolRequests += 1;
@@ -164,9 +247,23 @@ describe("Barbecue", () => {
       await red.__barbecueController.refreshFromCache();
 
       expect(configRequests).toBe(1);
+      expect(editorInfoRequests).toBe(1);
       expect(symbolRequests).toBe(1);
+
+      red.setMockState({
+        theme: {
+          ...red.getMockState().theme,
+          style: { fg: "#222222", bg: "#ffffff" },
+        },
+      });
+      await red.__barbecueController.refreshTheme();
+
+      expect(editorInfoRequests).toBe(2);
+      expect(red.getWindowBar("barbecue", 7).find((item) => item.id === "file-icon").style.style.fg)
+        .toEqual({ Rgb: { r: 102, g: 102, b: 32 } });
     } finally {
       red.getConfig = originalGetConfig;
+      red.getEditorInfo = originalGetEditorInfo;
       red.lsp.documentSymbols = originalDocumentSymbols;
     }
   });

--- a/plugins/barbecue.test.js
+++ b/plugins/barbecue.test.js
@@ -157,6 +157,9 @@ describe("Barbecue", () => {
     });
 
     await plugin.activate(red);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(red.getWindowBar("barbecue", 7).at(-1).text).toBe("󰊕 inner");
     expect(red.getWindowBar("barbecue", 8).map((item) => item.text).join(""))

--- a/plugins/barbecue.test.js
+++ b/plugins/barbecue.test.js
@@ -1,0 +1,188 @@
+const theme = {
+  name: "night",
+  style: { fg: "#dddddd", bg: "#111111" },
+  colors: {
+    "breadcrumb.background": "#101010",
+    "breadcrumb.foreground": "#aaaaaa",
+    "breadcrumb.focusForeground": "#ffffff",
+    "symbolIcon.folderForeground": "#89b4fa",
+    "symbolIcon.functionForeground": "#a6e3a1",
+  },
+};
+
+const symbols = [
+  {
+    id: "outer",
+    parentId: null,
+    name: "outer",
+    kindName: "Function",
+    file: "/repo/plugins/example.js",
+    depth: 0,
+    range: { start: { line: 2, character: 0 }, end: { line: 12, character: 1 } },
+    selectionRange: { start: { line: 2, character: 9 }, end: { line: 2, character: 14 } },
+  },
+  {
+    id: "inner",
+    parentId: "outer",
+    name: "inner",
+    kindName: "Function",
+    file: "/repo/plugins/example.js",
+    depth: 1,
+    range: { start: { line: 5, character: 2 }, end: { line: 8, character: 3 } },
+    selectionRange: { start: { line: 5, character: 11 }, end: { line: 5, character: 16 } },
+  },
+];
+
+function windowAt(line, character = 0) {
+  return {
+    windowId: 7,
+    active: true,
+    bufferIndex: 2,
+    bufferPath: "/repo/plugins/example.js",
+    revision: 4,
+    cursor: { x: character, y: line },
+    lspPosition: { line, character },
+  };
+}
+
+describe("Barbecue", () => {
+  test("finds the nested symbol chain", async () => {
+    expect(plugin.enclosingSymbols(symbols, { line: 6, character: 1 }).map((item) => item.name))
+      .toEqual(["outer", "inner"]);
+    expect(plugin.enclosingSymbols(symbols, { line: 12, character: 1 })).toEqual([]);
+  });
+
+  test("builds path, file, and symbol segments with semantic theme fallbacks", async () => {
+    const segments = plugin.buildSegments(
+      windowAt(6, 1),
+      symbols,
+      { separator: "", nerdFont: true },
+      { theme },
+      "/repo",
+    );
+
+    expect(segments.map((item) => item.text).join(""))
+      .toBe(" plugins   example.js  󰊕 outer  󰊕 inner");
+    expect(segments.at(-1).style.semantic.foreground).toEqual([
+      "breadcrumb.focusForeground",
+      "breadcrumb.activeSelectionForeground",
+      "list.activeSelectionForeground",
+      "editor.foreground",
+    ]);
+    expect(segments.at(-1).style.semantic.background).toEqual([
+      "breadcrumb.background",
+      "editor.background",
+    ]);
+    expect(segments.at(-1).action).toBe("jump:2:inner");
+  });
+
+  test("supports plain Unicode mode and path fallback without LSP", async () => {
+    const segments = plugin.buildSegments(
+      windowAt(0),
+      [],
+      { separator: "›", nerdFont: false },
+      { theme },
+      "/repo",
+    );
+    expect(segments.map((item) => item.text).join("")).toBe("plugins › example.js");
+  });
+
+  test("renders every window and targets symbol requests by buffer revision", async (red) => {
+    await plugin.deactivate(red);
+    red.setMockState({
+      config: {
+        ...red.getMockState().config,
+        cwd: "/repo",
+        plugin_config: { barbecue: { separator: "" } },
+      },
+      theme,
+      windows: [windowAt(6, 1), { ...windowAt(0), windowId: 8, bufferIndex: 3 }],
+      documentSymbols: { ok: true, file: "/repo/plugins/example.js", symbols },
+    });
+
+    await plugin.activate(red);
+
+    expect(red.getWindowBar("barbecue", 7).at(-1).text).toBe("󰊕 inner");
+    expect(red.getWindowBar("barbecue", 8).map((item) => item.text).join(""))
+      .toBe(" plugins   example.js");
+    expect(red.getLogs()).toContain('lsp.documentSymbols: {"bufferIndex":2}');
+    expect(red.getLogs()).toContain('lsp.documentSymbols: {"bufferIndex":3}');
+  });
+
+  test("renders path segments before document symbols resolve and then enriches them", async (red) => {
+    await plugin.deactivate(red);
+    red.setMockState({
+      config: {
+        ...red.getMockState().config,
+        cwd: "/repo",
+        plugin_config: { barbecue: { separator: "" } },
+      },
+      windows: [windowAt(6, 1)],
+    });
+
+    const originalDocumentSymbols = red.lsp.documentSymbols;
+    let resolveSymbols;
+    red.lsp.documentSymbols = () => new Promise((resolve) => {
+      resolveSymbols = resolve;
+    });
+
+    try {
+      await plugin.activate(red);
+      expect(red.getWindowBar("barbecue", 7).map((item) => item.text).join(""))
+        .toBe(" plugins   example.js");
+
+      resolveSymbols({ ok: true, revision: 4, symbols });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(red.getWindowBar("barbecue", 7).at(-1).text).toBe("󰊕 inner");
+    } finally {
+      red.lsp.documentSymbols = originalDocumentSymbols;
+    }
+  });
+
+  test("caches static context and symbols across cursor refreshes", async (red) => {
+    await plugin.deactivate(red);
+    const originalGetConfig = red.getConfig.bind(red);
+    const originalDocumentSymbols = red.lsp.documentSymbols;
+    let configRequests = 0;
+    let symbolRequests = 0;
+    red.getConfig = async (...args) => {
+      configRequests += 1;
+      return originalGetConfig(...args);
+    };
+    red.lsp.documentSymbols = async (...args) => {
+      symbolRequests += 1;
+      return originalDocumentSymbols(...args);
+    };
+
+    try {
+      await plugin.activate(red);
+      await Promise.resolve();
+      await Promise.resolve();
+      await red.__barbecueController.refreshFromCache();
+
+      expect(configRequests).toBe(1);
+      expect(symbolRequests).toBe(1);
+    } finally {
+      red.getConfig = originalGetConfig;
+      red.lsp.documentSymbols = originalDocumentSymbols;
+    }
+  });
+
+  test("jumps to a clicked symbol using UTF-16 coordinates", async (red) => {
+    await red.emitWindowBarAction("barbecue", { action: "jump:2:inner" });
+    expect(red.openedLocations.at(-1).location).toEqual({
+      path: "/repo/plugins/example.js",
+      line: 5,
+      column: 11,
+      columnEncoding: "utf-16",
+    });
+  });
+
+  test("closes its bar on deactivation", async (red) => {
+    await plugin.deactivate(red);
+    expect(red.getWindowBar("barbecue")).toBe(undefined);
+  });
+});

--- a/plugins/indent_guides.js
+++ b/plugins/indent_guides.js
@@ -297,6 +297,8 @@ function createController(red, options = {}) {
 
 export async function activate(red) {
   const controller = createController(red);
+  red.on("editor:ready", () => controller.refresh());
+  red.on("editor:stateRestored", () => controller.refresh());
   red.on("buffer:changed", () => controller.scheduleRefresh());
   red.on("cursor:moved", () => controller.scheduleRefresh());
   red.on("viewport:changed", () => controller.scheduleRefresh());

--- a/plugins/indent_guides.test.js
+++ b/plugins/indent_guides.test.js
@@ -175,4 +175,19 @@ describe("IndentGuides", () => {
     const base = decorations.find((decoration) => decoration.priority === 1);
     expect(base.text).toBe("│   ");
   });
+
+  test("repaints after session restore without cursor input", async (red) => {
+    await plugin.deactivate(red);
+    red.setMockState({ viewportLayout: layout([]) });
+    await plugin.activate(red);
+    expect(red.getDecorations("indent-guides")).toEqual([]);
+
+    red.setMockState({
+      viewportLayout: layout(["fn main() {", "    let x = 1;", "}"], 1),
+    });
+    await red.emitAsync("editor:stateRestored", {});
+
+    const decorations = red.getDecorations("indent-guides");
+    expect(decorations.find((decoration) => decoration.priority === 1).text).toBe("│   ");
+  });
 });

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -71,7 +71,7 @@ use crate::{
     },
     undo::{CursorSnapshot, TextPosition, TextRange},
     utils::{expand_user_path, get_workspace_uri},
-    window::{WindowManager, WindowManagerSnapshot},
+    window::{WindowId, WindowManager, WindowManagerSnapshot},
 };
 
 use self::display_layout::{layout_lines, wrap_line_segments, DisplayLayout, LayoutConfig};
@@ -192,6 +192,9 @@ pub enum PluginRequest {
     GetViewportLayout {
         request_id: i32,
     },
+    GetWindows {
+        request_id: i32,
+    },
     InlayHints {
         request_id: i32,
         range: Option<Range>,
@@ -204,6 +207,7 @@ pub enum PluginRequest {
         namespace: String,
     },
     GetConfig {
+        request_id: i32,
         key: Option<String>,
     },
     GetEditorState {
@@ -215,6 +219,11 @@ pub enum PluginRequest {
     },
     DocumentSymbols {
         request_id: i32,
+        buffer_index: Option<usize>,
+    },
+    ResolveThemeStyle {
+        request_id: i32,
+        spec: crate::theme::ThemeStyleSpec,
     },
     WorkspaceSymbols {
         request_id: i32,
@@ -266,6 +275,19 @@ pub enum PluginRequest {
     FocusEditor,
     ClosePanel {
         id: String,
+    },
+    CreateWindowBar {
+        id: String,
+        config: plugin::WindowBarConfig,
+    },
+    UpdateWindowBar {
+        id: String,
+        window_id: u64,
+        segments: Vec<plugin::WindowBarSegment>,
+    },
+    CloseWindowBar {
+        id: String,
+        window_id: Option<u64>,
     },
     ListDirectory {
         path: String,
@@ -865,9 +887,11 @@ pub struct Editor {
 
     panel_manager: plugin::PanelManager,
 
+    window_bar_manager: plugin::WindowBarManager,
+
     directory_watchers: HashMap<i32, DirectoryWatcher>,
 
-    pending_plugin_document_symbols: HashMap<i64, i32>,
+    pending_plugin_document_symbols: HashMap<i64, PendingDocumentSymbols>,
     pending_plugin_workspace_symbols: HashMap<i64, i32>,
     pending_plugin_references: HashMap<i64, i32>,
     pending_plugin_inlay_hints: HashMap<i64, i32>,
@@ -931,7 +955,7 @@ struct SearchSession {
     preview: Option<SearchMatch>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct EditorEventSnapshot {
     mode: Mode,
     cx: usize,
@@ -943,6 +967,15 @@ struct EditorEventSnapshot {
     width: usize,
     height: usize,
     buffer_index: usize,
+    window_id: Option<WindowId>,
+    window_ids: Vec<WindowId>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingDocumentSymbols {
+    plugin_request_id: i32,
+    buffer_index: usize,
+    revision: u64,
 }
 
 impl HistoryEntry {
@@ -1272,6 +1305,7 @@ impl Editor {
             overlay_manager: plugin::OverlayManager::new(),
             decoration_manager: plugin::DecorationManager::default(),
             panel_manager: plugin::PanelManager::default(),
+            window_bar_manager: plugin::WindowBarManager::default(),
             directory_watchers: HashMap::new(),
             pending_plugin_document_symbols: HashMap::new(),
             pending_plugin_workspace_symbols: HashMap::new(),
@@ -1484,7 +1518,10 @@ impl Editor {
     }
 
     pub fn vheight(&self) -> usize {
-        (self.size.1 as usize).saturating_sub(2)
+        self.window_manager
+            .active_window()
+            .map(|window| self.window_content_height(window))
+            .unwrap_or_else(|| (self.size.1 as usize).saturating_sub(2))
     }
 
     /// Window-aware coordinate transformation methods
@@ -1495,7 +1532,7 @@ impl Editor {
 
     /// Convert window-local Y coordinate to terminal Y coordinate
     pub fn window_to_terminal_y(&self, window: &crate::window::Window, y: usize) -> usize {
-        window.position.y + y
+        window.position.y + self.window_content_top(window) + y
     }
 
     /// Convert buffer coordinates to window-local coordinates, accounting for viewport
@@ -1525,7 +1562,17 @@ impl Editor {
 
     /// Get the effective viewport height for a window
     pub fn window_vheight(&self, window: &crate::window::Window) -> usize {
-        window.inner_height()
+        self.window_content_height(window)
+    }
+
+    fn window_content_top(&self, window: &crate::window::Window) -> usize {
+        self.window_bar_manager.reserved_top_height(window.id)
+    }
+
+    fn window_content_height(&self, window: &crate::window::Window) -> usize {
+        window
+            .inner_height()
+            .saturating_sub(self.window_content_top(window))
     }
 
     fn window_content_width(&self, window: &crate::window::Window) -> usize {
@@ -1546,7 +1593,7 @@ impl Editor {
         }
         let end = window
             .vtop
-            .saturating_add(window.inner_height())
+            .saturating_add(self.window_content_height(window))
             .min(line_count);
         let lines = (window.vtop..end)
             .filter_map(|line| buffer.get(line))
@@ -1557,7 +1604,7 @@ impl Editor {
             line_count,
             LayoutConfig {
                 content_width: self.window_content_width(window),
-                height: window.inner_height(),
+                height: self.window_content_height(window),
                 wrap: window.wrap,
                 vtop: window.vtop,
                 vleft: window.vleft,
@@ -1571,8 +1618,8 @@ impl Editor {
             return json!({
                 "bufferIndex": self.current_buffer_index,
                 "buffer_index": self.current_buffer_index,
-                "windowId": self.window_manager.active_window_id(),
-                "window_id": self.window_manager.active_window_id(),
+                "windowId": self.window_manager.active_stable_window_id().map(|id| id.0),
+                "window_id": self.window_manager.active_stable_window_id().map(|id| id.0),
                 "rows": [],
             });
         };
@@ -1613,10 +1660,12 @@ impl Editor {
         json!({
             "bufferIndex": window.buffer_index,
             "buffer_index": window.buffer_index,
-            "windowId": self.window_manager.active_window_id(),
-            "window_id": self.window_manager.active_window_id(),
+            "windowId": window.id.0,
+            "window_id": window.id.0,
             "width": window.inner_width(),
-            "height": window.inner_height(),
+            "height": self.window_content_height(&window),
+            "contentTop": self.window_content_top(&window),
+            "content_top": self.window_content_top(&window),
             "contentStart": content_start,
             "content_start": content_start,
             "contentWidth": content_width,
@@ -1628,6 +1677,8 @@ impl Editor {
             "cursor": {
                 "x": window.cx,
                 "y": window.vtop + window.cy,
+                "lspCharacter": self.lsp_character_for_cursor(window.buffer_index, window.vtop + window.cy, window.cx),
+                "lsp_character": self.lsp_character_for_cursor(window.buffer_index, window.vtop + window.cy, window.cx),
                 "screenRow": window.cy,
                 "screen_row": window.cy,
             },
@@ -1639,8 +1690,99 @@ impl Editor {
             },
             "lineCount": buffer.navigable_line_count(),
             "line_count": buffer.navigable_line_count(),
+            "revision": buffer.revision(),
+            "file": buffer.file,
             "rows": rows,
         })
+    }
+
+    fn plugin_windows_payload(&self) -> Value {
+        let active_id = self.window_manager.active_stable_window_id();
+        let windows = self
+            .window_manager
+            .windows()
+            .into_iter()
+            .filter_map(|window| {
+                let buffer = self.buffers.get(window.buffer_index)?;
+                let cursor_y = window.vtop + window.cy;
+                let lsp_character =
+                    self.lsp_character_for_cursor(window.buffer_index, cursor_y, window.cx);
+                let content_top = self.window_content_top(window);
+                let content_width = self.window_content_width(window);
+                let content_height = self.window_content_height(window);
+                Some(json!({
+                    "id": window.id.0,
+                    "windowId": window.id.0,
+                    "window_id": window.id.0,
+                    "active": Some(window.id) == active_id,
+                    "bufferIndex": window.buffer_index,
+                    "buffer_index": window.buffer_index,
+                    "bufferPath": buffer.file,
+                    "buffer_path": buffer.file,
+                    "file": buffer.file,
+                    "name": buffer.name(),
+                    "revision": buffer.revision(),
+                    "bounds": {
+                        "x": window.position.x,
+                        "y": window.position.y,
+                        "width": window.inner_width(),
+                        "height": window.inner_height(),
+                    },
+                    "contentBounds": {
+                        "x": window.position.x,
+                        "y": window.position.y + content_top,
+                        "width": content_width,
+                        "height": content_height,
+                    },
+                    "x": window.position.x,
+                    "y": window.position.y,
+                    "width": window.inner_width(),
+                    "height": window.inner_height(),
+                    "contentTop": content_top,
+                    "content_top": content_top,
+                    "contentWidth": content_width,
+                    "content_width": content_width,
+                    "contentHeight": content_height,
+                    "content_height": content_height,
+                    "vtop": window.vtop,
+                    "vleft": window.vleft,
+                    "viewport": {
+                        "top": window.vtop,
+                        "left": window.vleft,
+                    },
+                    "cursor": {
+                        "x": window.cx,
+                        "y": cursor_y,
+                        "lspCharacter": lsp_character,
+                        "lsp_character": lsp_character,
+                    },
+                    "lspPosition": {
+                        "line": cursor_y,
+                        "character": lsp_character,
+                    },
+                }))
+            })
+            .collect::<Vec<_>>();
+        json!({ "windows": windows })
+    }
+
+    fn lsp_character_for_cursor(
+        &self,
+        buffer_index: usize,
+        line: usize,
+        grapheme_index: usize,
+    ) -> usize {
+        self.buffers
+            .get(buffer_index)
+            .and_then(|buffer| buffer.get(line))
+            .map(|text| {
+                text.graphemes(true)
+                    .take(grapheme_index)
+                    .flat_map(str::chars)
+                    .map(char::len_utf16)
+                    .sum()
+            })
+            .unwrap_or(grapheme_index)
     }
 
     fn active_content_width(&self) -> usize {
@@ -2421,7 +2563,7 @@ impl Editor {
         let (width, height) = self
             .window_manager
             .active_window()
-            .map(|window| (window.inner_width(), window.inner_height()))
+            .map(|window| (window.inner_width(), self.window_content_height(window)))
             .unwrap_or((self.vwidth(), self.vheight()));
 
         EditorEventSnapshot {
@@ -2435,6 +2577,13 @@ impl Editor {
             width,
             height,
             buffer_index: self.current_buffer_index,
+            window_id: self.window_manager.active_stable_window_id(),
+            window_ids: self
+                .window_manager
+                .windows()
+                .into_iter()
+                .map(|window| window.id)
+                .collect(),
         }
     }
 
@@ -2454,6 +2603,73 @@ impl Editor {
         cause: &str,
     ) -> anyhow::Result<()> {
         let after = self.event_snapshot();
+
+        let current_window_ids = after.window_ids.iter().copied().collect::<HashSet<_>>();
+        for window_id in before
+            .window_ids
+            .iter()
+            .copied()
+            .filter(|window_id| !current_window_ids.contains(window_id))
+        {
+            self.window_bar_manager.close_window(window_id);
+            self.plugin_registry
+                .notify(
+                    runtime,
+                    "window:closed",
+                    json!({
+                        "windowId": window_id.0,
+                        "window_id": window_id.0,
+                        "cause": cause,
+                    }),
+                )
+                .await?;
+        }
+
+        if before.window_id != after.window_id {
+            self.plugin_registry
+                .notify(
+                    runtime,
+                    "window:focused",
+                    json!({
+                        "windowId": after.window_id.map(|id| id.0),
+                        "window_id": after.window_id.map(|id| id.0),
+                        "bufferIndex": after.buffer_index,
+                        "buffer_index": after.buffer_index,
+                        "cause": cause,
+                    }),
+                )
+                .await?;
+        }
+
+        if before.window_ids != after.window_ids
+            || before.window_id != after.window_id
+            || before.width != after.width
+            || before.height != after.height
+        {
+            let mut payload = self.plugin_windows_payload();
+            if let Some(object) = payload.as_object_mut() {
+                object.insert("cause".to_string(), json!(cause));
+            }
+            self.plugin_registry
+                .notify(runtime, "window:layoutChanged", payload)
+                .await?;
+        }
+
+        if before.window_id == after.window_id && before.buffer_index != after.buffer_index {
+            self.plugin_registry
+                .notify(
+                    runtime,
+                    "window:bufferChanged",
+                    json!({
+                        "windowId": after.window_id.map(|id| id.0),
+                        "window_id": after.window_id.map(|id| id.0),
+                        "bufferIndex": after.buffer_index,
+                        "buffer_index": after.buffer_index,
+                        "cause": cause,
+                    }),
+                )
+                .await?;
+        }
 
         if before.mode != after.mode {
             let from = format!("{:?}", before.mode);
@@ -2492,6 +2708,10 @@ impl Editor {
                 "viewport_top": after.vtop,
                 "bufferIndex": after.buffer_index,
                 "buffer_index": after.buffer_index,
+                "windowId": after.window_id.map(|id| id.0),
+                "window_id": after.window_id.map(|id| id.0),
+                "lspCharacter": self.cursor_lsp_position().character,
+                "lsp_character": self.cursor_lsp_position().character,
             });
             self.plugin_registry
                 .notify(runtime, "cursor:moved", cursor_info)
@@ -2515,6 +2735,8 @@ impl Editor {
                 "height": after.height,
                 "bufferIndex": after.buffer_index,
                 "buffer_index": after.buffer_index,
+                "windowId": after.window_id.map(|id| id.0),
+                "window_id": after.window_id.map(|id| id.0),
                 "cause": cause,
             });
             self.plugin_registry
@@ -2950,6 +3172,15 @@ impl Editor {
                             )
                             .await?;
                     }
+                    PluginRequest::GetWindows { request_id } => {
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                &format!("windows:{request_id}"),
+                                self.plugin_windows_payload(),
+                            )
+                            .await?;
+                    }
                     PluginRequest::SetDecorations {
                         namespace,
                         decorations,
@@ -2971,7 +3202,7 @@ impl Editor {
                             self.render(&mut buffer)?;
                         }
                     }
-                    PluginRequest::GetConfig { key } => {
+                    PluginRequest::GetConfig { request_id, key } => {
                         let config_value = if let Some(key) = key {
                             // Return specific config value
                             match key.as_str() {
@@ -3007,7 +3238,7 @@ impl Editor {
                         self.plugin_registry
                             .notify(
                                 &mut runtime,
-                                "config:value",
+                                &format!("config:value:{request_id}"),
                                 json!({ "value": config_value }),
                             )
                             .await?;
@@ -3045,29 +3276,50 @@ impl Editor {
                             .await?;
                         self.render(&mut buffer)?;
                     }
-                    PluginRequest::DocumentSymbols { request_id } => {
+                    PluginRequest::DocumentSymbols {
+                        request_id,
+                        buffer_index,
+                    } => {
                         let event = format!("lsp:document_symbols:{request_id}");
-                        let Some(file) = self.current_buffer().file.clone() else {
+                        let buffer_index = buffer_index.unwrap_or(self.current_buffer_index);
+                        let Some(target_buffer) = self.buffers.get(buffer_index) else {
                             self.plugin_registry
                                 .notify(
                                     &mut runtime,
                                     &event,
-                                    plugin_lsp_error("current buffer is not file-backed"),
+                                    plugin_lsp_error("requested buffer does not exist"),
                                 )
                                 .await?;
                             continue;
                         };
+                        let Some(file) = target_buffer.file.clone() else {
+                            self.plugin_registry
+                                .notify(
+                                    &mut runtime,
+                                    &event,
+                                    plugin_lsp_error("requested buffer is not file-backed"),
+                                )
+                                .await?;
+                            continue;
+                        };
+                        let revision = target_buffer.revision();
 
                         let request_result: anyhow::Result<i64> = async {
-                            self.ensure_current_buffer_lsp_opened().await?;
+                            self.ensure_buffer_lsp_opened(buffer_index).await?;
                             Ok(self.lsp.document_symbols(&file).await?)
                         }
                         .await;
 
                         match request_result {
                             Ok(lsp_request_id) if lsp_request_id > 0 => {
-                                self.pending_plugin_document_symbols
-                                    .insert(lsp_request_id, request_id);
+                                self.pending_plugin_document_symbols.insert(
+                                    lsp_request_id,
+                                    PendingDocumentSymbols {
+                                        plugin_request_id: request_id,
+                                        buffer_index,
+                                        revision,
+                                    },
+                                );
                             }
                             Ok(_) => {
                                 self.plugin_registry
@@ -3090,6 +3342,15 @@ impl Editor {
                                     .await?;
                             }
                         }
+                    }
+                    PluginRequest::ResolveThemeStyle { request_id, spec } => {
+                        self.plugin_registry
+                            .notify(
+                                &mut runtime,
+                                &format!("theme:style:{request_id}"),
+                                serde_json::to_value(self.theme.resolve_style(&spec))?,
+                            )
+                            .await?;
                     }
                     PluginRequest::WorkspaceSymbols { request_id, query } => {
                         let event = format!("lsp:workspace_symbols:{request_id}");
@@ -3349,6 +3610,34 @@ impl Editor {
                         self.panel_manager.close_panel(&id);
                         self.apply_panel_layout();
                         self.render(&mut buffer)?;
+                    }
+                    PluginRequest::CreateWindowBar { id, config } => {
+                        if self.window_bar_manager.create(id, config) {
+                            self.render(&mut buffer)?;
+                        }
+                    }
+                    PluginRequest::UpdateWindowBar {
+                        id,
+                        window_id,
+                        segments,
+                    } => {
+                        if self
+                            .window_bar_manager
+                            .update(&id, WindowId(window_id), segments)
+                        {
+                            self.render(&mut buffer)?;
+                        }
+                    }
+                    PluginRequest::CloseWindowBar { id, window_id } => {
+                        let changed = match window_id {
+                            Some(window_id) => self
+                                .window_bar_manager
+                                .clear_window(&id, WindowId(window_id)),
+                            None => self.window_bar_manager.close(&id),
+                        };
+                        if changed {
+                            self.render(&mut buffer)?;
+                        }
                     }
                     PluginRequest::ListDirectory { path, request_id } => {
                         let payload = directory_listing(&path);
@@ -3714,7 +4003,9 @@ impl Editor {
         let (event, request_id) = match method {
             "textDocument/documentSymbol" => (
                 "lsp:document_symbols",
-                self.pending_plugin_document_symbols.remove(&id)?,
+                self.pending_plugin_document_symbols
+                    .remove(&id)?
+                    .plugin_request_id,
             ),
             "workspace/symbol" => (
                 "lsp:workspace_symbols",
@@ -3769,15 +4060,15 @@ impl Editor {
                     }
 
                     if method == "textDocument/documentSymbol" {
-                        if let Some(request_id) =
-                            self.pending_plugin_document_symbols.remove(&msg.id)
+                        if let Some(pending) = self.pending_plugin_document_symbols.remove(&msg.id)
                         {
-                            let payload = match self.plugin_document_symbols_payload(msg) {
+                            let payload = match self.plugin_document_symbols_payload(msg, &pending)
+                            {
                                 Ok(payload) => payload,
                                 Err(err) => plugin_lsp_error(&err.to_string()),
                             };
                             return Some(Action::NotifyPlugins(
-                                format!("lsp:document_symbols:{request_id}"),
+                                format!("lsp:document_symbols:{}", pending.plugin_request_id),
                                 payload,
                             ));
                         }
@@ -6938,14 +7229,32 @@ impl Editor {
                 }
             }
             Action::PreviewTheme(theme_name) => {
-                if let Err(err) = self.apply_theme(theme_name, false) {
-                    self.last_error = Some(err.to_string());
+                match self.apply_theme(theme_name, false) {
+                    Ok(()) => {
+                        self.plugin_registry
+                            .notify(
+                                runtime,
+                                "theme:changed",
+                                json!({ "name": theme_name, "persisted": false }),
+                            )
+                            .await?;
+                    }
+                    Err(err) => self.last_error = Some(err.to_string()),
                 }
                 self.render(buffer)?;
             }
             Action::SetTheme(theme_name) => {
-                if let Err(err) = self.apply_theme(theme_name, true) {
-                    self.last_error = Some(err.to_string());
+                match self.apply_theme(theme_name, true) {
+                    Ok(()) => {
+                        self.plugin_registry
+                            .notify(
+                                runtime,
+                                "theme:changed",
+                                json!({ "name": theme_name, "persisted": true }),
+                            )
+                            .await?;
+                    }
+                    Err(err) => self.last_error = Some(err.to_string()),
                 }
                 self.render(buffer)?;
             }
@@ -8013,16 +8322,24 @@ impl Editor {
     }
 
     async fn ensure_current_buffer_lsp_opened(&mut self) -> anyhow::Result<()> {
-        let Some(file) = self.current_buffer().file.clone() else {
+        self.ensure_buffer_lsp_opened(self.current_buffer_index)
+            .await
+    }
+
+    async fn ensure_buffer_lsp_opened(&mut self, buffer_index: usize) -> anyhow::Result<()> {
+        let Some(buffer) = self.buffers.get(buffer_index) else {
             return Ok(());
         };
-        let Some(uri) = self.current_buffer().uri()? else {
+        let Some(file) = buffer.file.clone() else {
+            return Ok(());
+        };
+        let Some(uri) = buffer.uri()? else {
             return Ok(());
         };
         if self.lsp_opened_documents.contains(&uri) {
             return Ok(());
         }
-        let contents = self.current_buffer().contents();
+        let contents = buffer.contents();
         self.lsp.did_open(&file, &contents).await?;
         self.lsp_opened_documents.insert(uri);
         Ok(())
@@ -8092,7 +8409,11 @@ impl Editor {
         Some(Action::MoveToFilePos(file, character, line + 1))
     }
 
-    fn plugin_document_symbols_payload(&self, response: &ResponseMessage) -> anyhow::Result<Value> {
+    fn plugin_document_symbols_payload(
+        &self,
+        response: &ResponseMessage,
+        pending: &PendingDocumentSymbols,
+    ) -> anyhow::Result<Value> {
         let file = response_text_document_uri(response)
             .map(|uri| self.uri_to_file(uri))
             .or_else(|| self.current_file_name())
@@ -8102,6 +8423,9 @@ impl Editor {
         Ok(json!({
             "ok": true,
             "file": file,
+            "bufferIndex": pending.buffer_index,
+            "buffer_index": pending.buffer_index,
+            "revision": pending.revision,
             "symbols": symbols,
         }))
     }
@@ -8361,10 +8685,39 @@ impl Editor {
                             // Switch to the clicked window if it's not already active
                             self.set_active_window(window_id);
 
+                            let local_y = click_y.saturating_sub(window.position.y);
+                            if local_y < self.window_content_top(&window) {
+                                let local_x = click_x.saturating_sub(window.position.x);
+                                if let Some(rendered) = self
+                                    .window_bar_manager
+                                    .render(window.id, window.inner_width())
+                                {
+                                    if let Some(region) =
+                                        rendered.hit_regions.iter().find(|region| {
+                                            local_x >= region.start_column
+                                                && local_x < region.end_column
+                                        })
+                                    {
+                                        return Some(KeyAction::Single(Action::NotifyPlugins(
+                                            format!("windowBar:action:{}", rendered.bar_id),
+                                            json!({
+                                                "windowId": window.id.0,
+                                                "window_id": window.id.0,
+                                                "segmentId": region.segment_id,
+                                                "segment_id": region.segment_id,
+                                                "action": region.action,
+                                            }),
+                                        )));
+                                    }
+                                }
+                                return Some(KeyAction::None);
+                            }
+
                             // Convert terminal coordinates to window-local coordinates
                             if let Some((local_x, local_y)) =
                                 window.terminal_to_local(click_x, click_y)
                             {
+                                let local_y = local_y - self.window_content_top(&window);
                                 // Adjust for the clicked window's gutter, not the active buffer's.
                                 let gutter_width =
                                     self.gutter_width_for_buffer_index(window_buffer_index);
@@ -10083,6 +10436,7 @@ impl Editor {
     #[doc(hidden)]
     pub fn test_set_size(&mut self, width: u16, height: u16) {
         self.size = (width, height);
+        self.resize_window_layout((width as usize, height as usize));
     }
 
     #[doc(hidden)]
@@ -10187,6 +10541,27 @@ mod test {
             .iter()
             .map(|cell| cell.c)
             .collect()
+    }
+
+    fn install_test_window_bar(editor: &mut Editor) {
+        let window_id = editor
+            .window_manager
+            .active_stable_window_id()
+            .expect("test editor should have an active window");
+        editor
+            .window_bar_manager
+            .create("test-bar".to_string(), plugin::WindowBarConfig::default());
+        editor.window_bar_manager.update(
+            "test-bar",
+            window_id,
+            vec![plugin::WindowBarSegment {
+                id: Some("chrome".to_string()),
+                text: "chrome".to_string(),
+                style: plugin::WindowBarStyle::default(),
+                tooltip: None,
+                action: None,
+            }],
+        );
     }
 
     #[test]
@@ -10600,7 +10975,16 @@ mod test {
             )),
         };
 
-        let payload = editor.plugin_document_symbols_payload(&response).unwrap();
+        let payload = editor
+            .plugin_document_symbols_payload(
+                &response,
+                &PendingDocumentSymbols {
+                    plugin_request_id: 1,
+                    buffer_index: 0,
+                    revision: 0,
+                },
+            )
+            .unwrap();
         let symbols = payload["symbols"].as_array().unwrap();
 
         assert_eq!(payload["ok"], true);
@@ -10644,7 +11028,16 @@ mod test {
             )),
         };
 
-        let payload = editor.plugin_document_symbols_payload(&response).unwrap();
+        let payload = editor
+            .plugin_document_symbols_payload(
+                &response,
+                &PendingDocumentSymbols {
+                    plugin_request_id: 1,
+                    buffer_index: 0,
+                    revision: 0,
+                },
+            )
+            .unwrap();
         let symbols = payload["symbols"].as_array().unwrap();
 
         assert_eq!(payload["file"], "/tmp/project/src/index.ts");
@@ -11206,6 +11599,41 @@ mod test {
             editor.render_cursor_position(),
             Some((start.0 + 1, start.1))
         );
+    }
+
+    #[test]
+    fn window_bar_reserves_the_first_row_from_gutter_content_and_cursor() {
+        let mut editor = test_editor(20, 5);
+        install_test_window_bar(&mut editor);
+        let mut render_buffer = RenderBuffer::new(20, 5, &Style::default());
+
+        editor.render(&mut render_buffer).unwrap();
+
+        assert!(render_row(&render_buffer, 0).starts_with("chrome"));
+        let content_row = render_row(&render_buffer, 1);
+        assert!(content_row.contains("1 hello"), "{content_row:?}");
+        assert_eq!(editor.render_cursor_position().map(|(_, y)| y), Some(1));
+    }
+
+    #[tokio::test]
+    async fn line_end_delta_render_does_not_paint_the_cursor_on_window_bar() {
+        let mut editor = test_editor(20, 5);
+        install_test_window_bar(&mut editor);
+        let mut render_buffer = RenderBuffer::new(20, 5, &Style::default());
+        let mut runtime = Runtime::new();
+        editor.render(&mut render_buffer).unwrap();
+        let chrome_before = render_buffer.cells[..render_buffer.width].to_vec();
+
+        editor
+            .execute(&Action::MoveToLineEnd, &mut render_buffer, &mut runtime)
+            .await
+            .unwrap();
+        editor
+            .render_cursor_motion_delta(&mut render_buffer)
+            .unwrap();
+
+        assert_eq!(editor.render_cursor_position().map(|(_, y)| y), Some(1));
+        assert_eq!(render_buffer.cells[..render_buffer.width], chrome_before);
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -85,6 +85,7 @@ pub(crate) static PLUGIN_DISPATCHER_TEST_LOCK: Lazy<tokio::sync::Mutex<()>> =
 pub const DEFAULT_REGISTER: char = '"';
 const JUMPLIST_SIZE: usize = 100;
 const REPEATED_MOTION_DRAIN_BUDGET_MS: u64 = 50;
+const PLUGIN_REQUESTS_PER_TICK: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EditorViewState {
@@ -2947,7 +2948,12 @@ impl Editor {
                 }
             }
 
-            if let Some(req) = ACTION_DISPATCHER.try_recv_request() {
+            // Startup refreshes form short request chains. Drain a bounded batch so each
+            // operation does not wait for a separate 10 ms editor tick.
+            for _ in 0..PLUGIN_REQUESTS_PER_TICK {
+                let Some(req) = ACTION_DISPATCHER.try_recv_request() else {
+                    break;
+                };
                 match req {
                     PluginRequest::Action(action) => {
                         // let current_buffer = buffer.clone();
@@ -3257,7 +3263,24 @@ impl Editor {
                         request_id,
                         snapshot,
                     } => {
+                        let before = self.event_snapshot();
                         let result = self.restore_editor_state(snapshot, &mut buffer).await;
+                        let restored = result.as_ref().is_ok_and(|result| result.restored);
+                        if restored {
+                            self.notify_editor_event_changes(
+                                before,
+                                &mut runtime,
+                                "RestoreEditorState",
+                            )
+                            .await?;
+                            let mut restored_payload = self.plugin_windows_payload();
+                            if let Some(object) = restored_payload.as_object_mut() {
+                                object.insert("cause".to_string(), json!("RestoreEditorState"));
+                            }
+                            self.plugin_registry
+                                .notify(&mut runtime, "editor:stateRestored", restored_payload)
+                                .await?;
+                        }
                         let payload = match result {
                             Ok(result) => serde_json::to_value(result)?,
                             Err(err) => json!({

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -334,7 +334,8 @@ impl Editor {
         let local_rows = terminal_rows
             .iter()
             .filter_map(|row| row.checked_sub(window.position.y))
-            .filter(|row| *row < window.inner_height())
+            .filter_map(|row| row.checked_sub(self.window_content_top(&window)))
+            .filter(|row| *row < self.window_content_height(&window))
             .collect::<Vec<_>>();
         if local_rows.is_empty() {
             return Ok(());
@@ -374,7 +375,7 @@ impl Editor {
                 .unwrap_or_else(|| " ".repeat(width + 1));
 
             let term_x = window.position.x;
-            let term_y = window.position.y + row;
+            let term_y = self.window_to_terminal_y(window, row);
             buffer.set_text(term_x, term_y, &text, &gutter_style);
         }
     }
@@ -395,7 +396,7 @@ impl Editor {
             revision,
             file: file.clone(),
             vtop: window.vtop,
-            height: window.inner_height(),
+            height: self.window_content_height(window),
         };
         let style_info =
             self.cached_viewport_highlight_spans(cache_key, file.as_deref(), &layout.text)?;
@@ -504,6 +505,8 @@ impl Editor {
         };
 
         if let Some((window, window_count)) = window_data {
+            self.render_window_bar(buffer, &window);
+
             // Render the gutter for this window
             self.render_gutter_in_window(buffer, &window, window_id)?;
 
@@ -521,6 +524,34 @@ impl Editor {
         }
 
         Ok(())
+    }
+
+    fn render_window_bar(&self, buffer: &mut RenderBuffer, window: &crate::window::Window) {
+        let Some(rendered) = self
+            .window_bar_manager
+            .render(window.id, window.inner_width())
+        else {
+            return;
+        };
+
+        let mut base_style = rendered.style.resolve(&self.theme);
+        base_style.fg = base_style.fg.or(self.theme.style.fg);
+        base_style.bg = base_style.bg.or(self.theme.style.bg);
+        let blank = " ".repeat(window.inner_width());
+        buffer.set_text(window.position.x, window.position.y, &blank, &base_style);
+
+        let mut x = window.position.x;
+        let end = window.position.x + window.inner_width();
+        for segment in rendered.segments {
+            if x >= end {
+                break;
+            }
+            let mut style = segment.style.resolve(&self.theme);
+            style.fg = style.fg.or(base_style.fg);
+            style.bg = style.bg.or(base_style.bg);
+            buffer.set_text(x, window.position.y, &segment.text, &style);
+            x += display_width(&segment.text);
+        }
     }
 
     /// Render window separator (placeholder for now)
@@ -836,7 +867,7 @@ impl Editor {
             revision,
             file: file.clone(),
             vtop: window.vtop,
-            height: window.inner_height(),
+            height: self.window_content_height(window),
         };
         let style_info =
             self.cached_viewport_highlight_spans(cache_key, file.as_deref(), &layout.text)?;
@@ -891,7 +922,7 @@ impl Editor {
             );
         }
 
-        for y in layout.rows.len()..window.inner_height() {
+        for y in layout.rows.len()..self.window_content_height(window) {
             let term_y = self.window_to_terminal_y(window, y);
             let term_x = self.window_to_terminal_x(window, gutter_width + 1);
             self.fill_line_in_window(buffer, term_x, term_y, content_width, &theme_style);
@@ -988,7 +1019,7 @@ impl Editor {
                 let layout = self.layout_for_window(window);
                 let buffer_y = window.vtop + window.cy;
                 for segment in layout.rows.iter().filter(|segment| {
-                    segment.line == buffer_y && segment.row < window.inner_height()
+                    segment.line == buffer_y && segment.row < self.window_content_height(window)
                 }) {
                     let term_y = self.window_to_terminal_y(window, segment.row);
                     let gutter_width = self.gutter_width_for_window(window);
@@ -1598,7 +1629,7 @@ impl Editor {
         let layout = self.layout_for_window(window);
         let window_buffer = &self.buffers[window.buffer_index];
 
-        for y in 0..window.inner_height() {
+        for y in 0..self.window_content_height(window) {
             let mut line_count = window_buffer.navigable_line_count();
             if self.window_manager.active_window_id() == window_id && self.is_insert() {
                 line_count = line_count.max(window.vtop + window.cy + 1);
@@ -1613,7 +1644,7 @@ impl Editor {
                 .unwrap_or_else(|| " ".repeat(width + 1));
 
             let term_x = window.position.x;
-            let term_y = window.position.y + y;
+            let term_y = self.window_to_terminal_y(window, y);
             buffer.set_text(term_x, term_y, &text, &gutter_style);
         }
 
@@ -1703,7 +1734,7 @@ impl Editor {
                     + 1
                     + segment
                         .screen_col_for_display_col(display_col, self.window_content_width(window));
-                let term_y = window.position.y + segment.row;
+                let term_y = self.window_to_terminal_y(window, segment.row);
                 Some((term_x, term_y))
             } else {
                 // Fallback to old behavior if no active window

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -8,6 +8,7 @@ pub mod process;
 mod registry;
 mod runtime;
 pub mod timer_stats;
+pub mod window_bar;
 
 pub use decoration::{Decoration, DecorationAnchor, DecorationManager};
 pub use location::{LocationColumnEncoding, OpenLocationTarget, PluginLocation};
@@ -16,3 +17,7 @@ pub use overlay::{OverlayAlignment, OverlayConfig, OverlayManager};
 pub use panel::{PanelConfig, PanelManager, PanelRow, PanelRowKind, PanelSegment, PanelSide};
 pub use registry::PluginRegistry;
 pub use runtime::{poll_timer_callbacks, Runtime};
+pub use window_bar::{
+    RenderedWindowBar, WindowBarConfig, WindowBarEdge, WindowBarHitRegion, WindowBarManager,
+    WindowBarOverflow, WindowBarSegment, WindowBarSemanticStyle, WindowBarStyle,
+};

--- a/src/plugin/process.rs
+++ b/src/plugin/process.rs
@@ -383,6 +383,61 @@ mod tests {
         panic!("process did not exit before timeout");
     }
 
+    #[cfg(not(windows))]
+    fn stdout_stderr_exit_options() -> ProcessSpawnOptions {
+        ProcessSpawnOptions {
+            command: "/bin/sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "printf 'first\\nsecond\\n'; printf 'problem\\n' >&2; exit 7".to_string(),
+            ],
+            cwd: None,
+        }
+    }
+
+    #[cfg(windows)]
+    fn stdout_stderr_exit_options() -> ProcessSpawnOptions {
+        ProcessSpawnOptions {
+            command: "powershell".to_string(),
+            args: vec![
+                "-NoLogo".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                concat!(
+                    "Write-Output 'first'; ",
+                    "Write-Output 'second'; ",
+                    "[Console]::Error.WriteLine('problem'); ",
+                    "exit 7"
+                )
+                .to_string(),
+            ],
+            cwd: None,
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn long_running_options() -> ProcessSpawnOptions {
+        ProcessSpawnOptions {
+            command: "/bin/sleep".to_string(),
+            args: vec!["30".to_string()],
+            cwd: None,
+        }
+    }
+
+    #[cfg(windows)]
+    fn long_running_options() -> ProcessSpawnOptions {
+        ProcessSpawnOptions {
+            command: "powershell".to_string(),
+            args: vec![
+                "-NoLogo".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Start-Sleep -Seconds 30".to_string(),
+            ],
+            cwd: None,
+        }
+    }
+
     #[test]
     fn denies_commands_without_an_exact_permission() {
         let mut manager = manager_with_commands(&["printf"]);
@@ -402,20 +457,9 @@ mod tests {
 
     #[test]
     fn streams_stdout_stderr_and_exit() {
-        let mut manager = manager_with_commands(&["/bin/sh"]);
-        let process_id = manager
-            .spawn(
-                "test",
-                ProcessSpawnOptions {
-                    command: "/bin/sh".to_string(),
-                    args: vec![
-                        "-c".to_string(),
-                        "printf 'first\\nsecond\\n'; printf 'problem\\n' >&2; exit 7".to_string(),
-                    ],
-                    cwd: None,
-                },
-            )
-            .unwrap();
+        let options = stdout_stderr_exit_options();
+        let mut manager = manager_with_commands(&[options.command.as_str()]);
+        let process_id = manager.spawn("test", options).unwrap();
 
         let events = collect_until_exit(&mut manager);
         assert!(events.contains(&ProcessEvent::Stdout {
@@ -443,33 +487,14 @@ mod tests {
 
     #[test]
     fn enforces_per_plugin_process_limit_and_kill_is_idempotent() {
-        let mut manager = manager_with_commands(&["/bin/sleep"]);
+        let options = long_running_options();
+        let mut manager = manager_with_commands(&[options.command.as_str()]);
         let mut process_ids = Vec::new();
         for _ in 0..MAX_PROCESSES_PER_PLUGIN {
-            process_ids.push(
-                manager
-                    .spawn(
-                        "test",
-                        ProcessSpawnOptions {
-                            command: "/bin/sleep".to_string(),
-                            args: vec!["30".to_string()],
-                            cwd: None,
-                        },
-                    )
-                    .unwrap(),
-            );
+            process_ids.push(manager.spawn("test", options.clone()).unwrap());
         }
 
-        let error = manager
-            .spawn(
-                "test",
-                ProcessSpawnOptions {
-                    command: "/bin/sleep".to_string(),
-                    args: vec!["30".to_string()],
-                    cwd: None,
-                },
-            )
-            .unwrap_err();
+        let error = manager.spawn("test", options).unwrap_err();
         assert!(error.to_string().contains("maximum of 4 active processes"));
 
         for process_id in process_ids {

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -330,15 +330,17 @@ mod tests {
             ACTION_DISPATCHER.try_recv_request(),
             Some(PluginRequest::CreatePanel { id, .. }) if id == "tree"
         ));
-        assert!(matches!(
-            ACTION_DISPATCHER.try_recv_request(),
-            Some(PluginRequest::GetConfig { key }) if key.as_deref() == Some("cwd")
-        ));
+        let config_request_id = match ACTION_DISPATCHER.try_recv_request() {
+            Some(PluginRequest::GetConfig { request_id, key }) if key.as_deref() == Some("cwd") => {
+                request_id
+            }
+            _ => panic!("expected cwd config request"),
+        };
 
         registry
             .notify(
                 &mut runtime,
-                "config:value",
+                &format!("config:value:{config_request_id}"),
                 json!({ "value": "/tmp/red-workspace" }),
             )
             .await
@@ -350,6 +352,84 @@ mod tests {
                 if id == "tree"
                     && rows.len() == 1
                     && rows[0].segments[0].text == "/tmp/red-workspace"
+        ));
+
+        let _ = std::fs::remove_file(plugin_path);
+    }
+
+    #[tokio::test]
+    async fn concurrent_config_requests_resolve_their_matching_values() {
+        let _guard = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+
+        let plugin_path =
+            std::env::temp_dir().join(format!("red-concurrent-config-{}.js", uuid::Uuid::new_v4()));
+        std::fs::write(
+            &plugin_path,
+            r#"
+                export function activate(red) {
+                    red.addCommand("ConcurrentConfig", async () => {
+                        const [theme, cwd] = await Promise.all([
+                            red.getConfig("theme"),
+                            red.getConfig("cwd"),
+                        ]);
+                        red.updatePanel("result", [{
+                            id: "config",
+                            path: "/tmp/config",
+                            kind: "file",
+                            segments: [{ text: `${theme}|${cwd}` }],
+                        }]);
+                    });
+                }
+            "#,
+        )
+        .unwrap();
+
+        let mut registry = PluginRegistry::new();
+        registry.add("concurrent_config", plugin_path.to_string_lossy().as_ref());
+        let mut runtime = Runtime::new();
+        registry.initialize(&mut runtime).await.unwrap();
+        registry
+            .execute(&mut runtime, "ConcurrentConfig")
+            .await
+            .unwrap();
+
+        let first = ACTION_DISPATCHER.try_recv_request().unwrap();
+        let second = ACTION_DISPATCHER.try_recv_request().unwrap();
+        let requests = [first, second]
+            .into_iter()
+            .map(|request| match request {
+                PluginRequest::GetConfig { request_id, key } => {
+                    (key.expect("config key"), request_id)
+                }
+                _ => panic!("expected config request"),
+            })
+            .collect::<std::collections::HashMap<_, _>>();
+
+        let cwd_request_id = requests["cwd"];
+        registry
+            .notify(
+                &mut runtime,
+                &format!("config:value:{cwd_request_id}"),
+                json!({ "value": "/tmp/project" }),
+            )
+            .await
+            .unwrap();
+        let theme_request_id = requests["theme"];
+        registry
+            .notify(
+                &mut runtime,
+                &format!("config:value:{theme_request_id}"),
+                json!({ "value": "mocha.json" }),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.try_recv_request(),
+            Some(PluginRequest::UpdatePanel { id, rows })
+                if id == "result"
+                    && rows[0].segments[0].text == "mocha.json|/tmp/project"
         ));
 
         let _ = std::fs::remove_file(plugin_path);
@@ -372,14 +452,17 @@ mod tests {
             .execute(&mut runtime, "LspWorkspaceSymbols")
             .await
             .unwrap();
-        assert!(matches!(
-            ACTION_DISPATCHER.try_recv_request(),
-            Some(PluginRequest::GetConfig { key: Some(key) }) if key == "plugin_config"
-        ));
+        let config_request_id = match ACTION_DISPATCHER.try_recv_request() {
+            Some(PluginRequest::GetConfig {
+                request_id,
+                key: Some(key),
+            }) if key == "plugin_config" => request_id,
+            _ => panic!("expected plugin config request"),
+        };
         registry
             .notify(
                 &mut runtime,
-                "config:value",
+                &format!("config:value:{config_request_id}"),
                 json!({
                     "value": {
                         "lsp_symbols": {
@@ -476,12 +559,19 @@ mod tests {
             }
             _ => panic!("expected a references request"),
         };
-        assert!(matches!(
-            ACTION_DISPATCHER.try_recv_request(),
-            Some(PluginRequest::GetConfig { key: Some(key) }) if key == "plugin_config"
-        ));
+        let config_request_id = match ACTION_DISPATCHER.try_recv_request() {
+            Some(PluginRequest::GetConfig {
+                request_id,
+                key: Some(key),
+            }) if key == "plugin_config" => request_id,
+            _ => panic!("expected plugin config request"),
+        };
         registry
-            .notify(&mut runtime, "config:value", json!({ "value": {} }))
+            .notify(
+                &mut runtime,
+                &format!("config:value:{config_request_id}"),
+                json!({ "value": {} }),
+            )
             .await
             .unwrap();
         registry

--- a/src/plugin/runtime.js
+++ b/src/plugin/runtime.js
@@ -80,10 +80,19 @@ class RedContext {
       delete: async (key) => ops.op_plugin_storage_delete(this.requirePluginName(), key),
     };
     this.lsp = {
-      documentSymbols: () => this.documentSymbols(),
+      documentSymbols: (options = {}) => this.documentSymbols(options),
       workspaceSymbols: (query = "") => this.workspaceSymbols(query),
       references: (options = {}) => this.references(options),
       inlayHints: (options = {}) => this.inlayHints(options),
+    };
+    this.theme = {
+      resolveStyle: (spec) => this.resolveThemeStyle(spec),
+    };
+    this.ui = {
+      createWindowBar: (id, config = {}) => this.createWindowBar(id, config),
+      updateWindowBar: (id, windowId, segments) =>
+        this.updateWindowBar(id, windowId, segments),
+      closeWindowBar: (id, windowId = null) => this.closeWindowBar(id, windowId),
     };
   }
 
@@ -144,6 +153,14 @@ class RedContext {
         resolve(info, null);
       });
       this.requestEditorInfo(reqId);
+    });
+  }
+
+  getWindows() {
+    return new Promise((resolve, _reject) => {
+      const reqId = nextReqId++;
+      this.once(`windows:${reqId}`, (payload) => resolve(payload?.windows ?? payload ?? []));
+      ops.op_get_windows(reqId);
     });
   }
 
@@ -333,6 +350,14 @@ class RedContext {
     this.execute("SetTheme", name);
   }
 
+  resolveThemeStyle(spec) {
+    return new Promise((resolve, _reject) => {
+      const reqId = nextReqId++;
+      this.once(`theme:style:${reqId}`, resolve);
+      ops.op_resolve_theme_style(reqId, spec || {});
+    });
+  }
+
   openBuffer(name) {
     this.execute("OpenBuffer", name);
   }
@@ -440,13 +465,13 @@ class RedContext {
     ops.op_clear_decorations(namespace);
   }
 
-  documentSymbols() {
+  documentSymbols(options = {}) {
     return new Promise((resolve, _reject) => {
       const reqId = nextReqId++;
       this.once(`lsp:document_symbols:${reqId}`, (result) => {
         resolve(result);
       });
-      ops.op_lsp_document_symbols(reqId);
+      ops.op_lsp_document_symbols(reqId, options || {});
     });
   }
 
@@ -528,11 +553,12 @@ class RedContext {
   // Get configuration values
   getConfig(key) {
     return new Promise((resolve, _reject) => {
+      const reqId = nextReqId++;
       const handler = (data) => {
         resolve(data.value);
       };
-      this.once("config:value", handler);
-      ops.op_get_config(key);
+      this.once(`config:value:${reqId}`, handler);
+      ops.op_get_config(reqId, key);
     });
   }
 
@@ -635,6 +661,18 @@ class RedContext {
 
   onPanelEvent(id, callback) {
     this.on(`panel:event:${id}`, callback);
+  }
+
+  createWindowBar(id, config = {}) {
+    ops.op_create_window_bar(id, config);
+  }
+
+  updateWindowBar(id, windowId, segments) {
+    ops.op_update_window_bar(id, windowId, segments || []);
+  }
+
+  closeWindowBar(id, windowId = null) {
+    ops.op_close_window_bar(id, windowId);
   }
 
   listDirectory(path) {

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -23,6 +23,7 @@ use crate::{
     editor::{PluginRequest, ACTION_DISPATCHER},
     log,
     lsp::Range,
+    theme::ThemeStyleSpec,
     ui::{PickerItem, PickerOptions, PickerPreview},
 };
 
@@ -48,6 +49,13 @@ impl From<serde_json::Error> for PluginOpError {
 struct InlayHintsOptions {
     #[serde(default)]
     range: Option<Range>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DocumentSymbolsOptions {
+    #[serde(default)]
+    buffer_index: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -421,9 +429,35 @@ fn op_close_picker(id: i32) -> Result<(), PluginOpError> {
     Ok(())
 }
 
+#[op2]
+fn op_lsp_document_symbols(
+    request_id: i32,
+    #[serde] options: serde_json::Value,
+) -> Result<(), PluginOpError> {
+    let options = if options.is_null() {
+        DocumentSymbolsOptions::default()
+    } else {
+        serde_json::from_value(options)?
+    };
+    ACTION_DISPATCHER.send_request(PluginRequest::DocumentSymbols {
+        request_id,
+        buffer_index: options.buffer_index,
+    });
+    Ok(())
+}
+
 #[op2(fast)]
-fn op_lsp_document_symbols(request_id: i32) -> Result<(), PluginOpError> {
-    ACTION_DISPATCHER.send_request(PluginRequest::DocumentSymbols { request_id });
+fn op_get_windows(request_id: i32) -> Result<(), PluginOpError> {
+    ACTION_DISPATCHER.send_request(PluginRequest::GetWindows { request_id });
+    Ok(())
+}
+
+#[op2]
+fn op_resolve_theme_style(
+    request_id: i32,
+    #[serde] spec: ThemeStyleSpec,
+) -> Result<(), PluginOpError> {
+    ACTION_DISPATCHER.send_request(PluginRequest::ResolveThemeStyle { request_id, spec });
     Ok(())
 }
 
@@ -815,8 +849,8 @@ fn op_clear_decorations(#[string] namespace: String) -> Result<(), PluginOpError
 }
 
 #[op2]
-fn op_get_config(#[string] key: Option<String>) -> Result<(), PluginOpError> {
-    ACTION_DISPATCHER.send_request(PluginRequest::GetConfig { key });
+fn op_get_config(request_id: i32, #[string] key: Option<String>) -> Result<(), PluginOpError> {
+    ACTION_DISPATCHER.send_request(PluginRequest::GetConfig { request_id, key });
     Ok(())
 }
 
@@ -997,6 +1031,40 @@ fn op_close_panel(#[string] id: String) -> Result<(), PluginOpError> {
     Ok(())
 }
 
+#[op2]
+fn op_create_window_bar(
+    #[string] id: String,
+    #[serde] config: serde_json::Value,
+) -> Result<(), PluginOpError> {
+    let config = serde_json::from_value(config)?;
+    ACTION_DISPATCHER.send_request(PluginRequest::CreateWindowBar { id, config });
+    Ok(())
+}
+
+#[op2]
+fn op_update_window_bar(
+    #[string] id: String,
+    window_id: u32,
+    #[serde] segments: serde_json::Value,
+) -> Result<(), PluginOpError> {
+    let segments = serde_json::from_value(segments)?;
+    ACTION_DISPATCHER.send_request(PluginRequest::UpdateWindowBar {
+        id,
+        window_id: u64::from(window_id),
+        segments,
+    });
+    Ok(())
+}
+
+#[op2]
+fn op_close_window_bar(#[string] id: String, window_id: Option<u32>) -> Result<(), PluginOpError> {
+    ACTION_DISPATCHER.send_request(PluginRequest::CloseWindowBar {
+        id,
+        window_id: window_id.map(u64::from),
+    });
+    Ok(())
+}
+
 #[op2(fast)]
 fn op_list_directory(#[string] path: String, request_id: i32) -> Result<(), PluginOpError> {
     ACTION_DISPATCHER.send_request(PluginRequest::ListDirectory { path, request_id });
@@ -1082,6 +1150,8 @@ extension!(
         op_update_picker_preview,
         op_close_picker,
         op_lsp_document_symbols,
+        op_get_windows,
+        op_resolve_theme_style,
         op_lsp_workspace_symbols,
         op_lsp_references,
         op_lsp_inlay_hints,
@@ -1116,6 +1186,9 @@ extension!(
         op_focus_panel,
         op_focus_editor,
         op_close_panel,
+        op_create_window_bar,
+        op_update_window_bar,
+        op_close_window_bar,
         op_list_directory,
         op_get_git_status,
         op_watch_directory,

--- a/src/plugin/window_bar.rs
+++ b/src/plugin/window_bar.rs
@@ -1,0 +1,530 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::{
+    theme::{Style, Theme, ThemeStyleSpec},
+    unicode_utils::display_width,
+    window::WindowId,
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowBarEdge {
+    #[default]
+    Top,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowBarOverflow {
+    TruncateRight,
+    #[default]
+    TruncateLeft,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowBarConfig {
+    #[serde(default)]
+    pub edge: WindowBarEdge,
+    #[serde(default)]
+    pub priority: i32,
+    #[serde(default)]
+    pub overflow: WindowBarOverflow,
+    #[serde(default = "default_truncate_marker")]
+    pub truncate_marker: String,
+    #[serde(default)]
+    pub style: WindowBarStyle,
+}
+
+impl Default for WindowBarConfig {
+    fn default() -> Self {
+        Self {
+            edge: WindowBarEdge::Top,
+            priority: 0,
+            overflow: WindowBarOverflow::TruncateLeft,
+            truncate_marker: default_truncate_marker(),
+            style: WindowBarStyle::default(),
+        }
+    }
+}
+
+fn default_truncate_marker() -> String {
+    "…".to_string()
+}
+
+/// A style can use concrete colors, a semantic theme key, or both.
+///
+/// When both are supplied, callers should resolve the semantic key first and
+/// overlay the concrete style on the result.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowBarStyle {
+    #[serde(default)]
+    pub semantic: Option<WindowBarSemanticStyle>,
+    #[serde(default)]
+    pub style: Option<Style>,
+}
+
+impl WindowBarStyle {
+    pub fn resolve(&self, theme: &Theme) -> Style {
+        let mut resolved = match &self.semantic {
+            Some(WindowBarSemanticStyle::Key(key)) => theme.resolve_style(&ThemeStyleSpec {
+                foreground: vec![key.clone()],
+                ..ThemeStyleSpec::default()
+            }),
+            Some(WindowBarSemanticStyle::Spec(spec)) => theme.resolve_style(spec),
+            None => Style::default(),
+        };
+        if let Some(concrete) = &self.style {
+            if concrete.fg.is_some() {
+                resolved.fg = concrete.fg;
+            }
+            if concrete.bg.is_some() {
+                resolved.bg = concrete.bg;
+            }
+            resolved.bold = concrete.bold;
+            resolved.italic = concrete.italic;
+        }
+        resolved
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WindowBarSemanticStyle {
+    Key(String),
+    Spec(ThemeStyleSpec),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowBarSegment {
+    #[serde(default)]
+    pub id: Option<String>,
+    pub text: String,
+    #[serde(default)]
+    pub style: WindowBarStyle,
+    #[serde(default)]
+    pub tooltip: Option<String>,
+    #[serde(default)]
+    pub action: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowBarHitRegion {
+    pub start_column: usize,
+    pub end_column: usize,
+    pub segment_id: Option<String>,
+    pub action: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedWindowBar {
+    pub bar_id: String,
+    pub style: WindowBarStyle,
+    pub segments: Vec<WindowBarSegment>,
+    pub hit_regions: Vec<WindowBarHitRegion>,
+    pub width: usize,
+}
+
+#[derive(Debug, Clone)]
+struct WindowBar {
+    id: String,
+    config: WindowBarConfig,
+    sequence: u64,
+    content: HashMap<WindowId, Vec<WindowBarSegment>>,
+}
+
+/// Owns plugin-defined chrome displayed above editor windows.
+///
+/// Only one bar occupies the top row of a window. Higher priority wins; ties
+/// are resolved in favor of the most recently created bar.
+#[derive(Debug, Default)]
+pub struct WindowBarManager {
+    bars: HashMap<String, WindowBar>,
+    next_sequence: u64,
+}
+
+impl WindowBarManager {
+    pub fn create_bar(&mut self, id: String, config: WindowBarConfig) -> bool {
+        self.create(id, config)
+    }
+
+    pub fn create(&mut self, id: String, config: WindowBarConfig) -> bool {
+        let sequence = self.next_sequence;
+        self.next_sequence += 1;
+
+        match self.bars.get_mut(&id) {
+            Some(bar) => {
+                bar.config = config;
+                bar.sequence = sequence;
+                true
+            }
+            None => {
+                self.bars.insert(
+                    id.clone(),
+                    WindowBar {
+                        id,
+                        config,
+                        sequence,
+                        content: HashMap::new(),
+                    },
+                );
+                true
+            }
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        id: &str,
+        window_id: WindowId,
+        segments: Vec<WindowBarSegment>,
+    ) -> bool {
+        let Some(bar) = self.bars.get_mut(id) else {
+            return false;
+        };
+        if bar.content.get(&window_id) == Some(&segments) {
+            return false;
+        }
+        bar.content.insert(window_id, segments);
+        true
+    }
+
+    pub fn update_bar(
+        &mut self,
+        id: &str,
+        window_id: WindowId,
+        segments: Vec<WindowBarSegment>,
+    ) -> bool {
+        self.update(id, window_id, segments)
+    }
+
+    pub fn clear_window(&mut self, id: &str, window_id: WindowId) -> bool {
+        self.bars
+            .get_mut(id)
+            .is_some_and(|bar| bar.content.remove(&window_id).is_some())
+    }
+
+    pub fn close_window(&mut self, window_id: WindowId) -> bool {
+        let mut changed = false;
+        for bar in self.bars.values_mut() {
+            changed |= bar.content.remove(&window_id).is_some();
+        }
+        changed
+    }
+
+    pub fn close(&mut self, id: &str) -> bool {
+        self.bars.remove(id).is_some()
+    }
+
+    pub fn close_bar(&mut self, id: &str) -> bool {
+        self.close(id)
+    }
+
+    pub fn has_bar_for_window(&self, window_id: WindowId) -> bool {
+        self.selected_bar(window_id).is_some()
+    }
+
+    pub fn reserved_top_height(&self, window_id: WindowId) -> usize {
+        usize::from(self.has_bar_for_window(window_id))
+    }
+
+    pub fn render(&self, window_id: WindowId, width: usize) -> Option<RenderedWindowBar> {
+        let bar = self.selected_bar(window_id)?;
+        let source = bar.content.get(&window_id)?;
+        let segments = clip_segments(
+            source,
+            width,
+            bar.config.overflow,
+            &bar.config.truncate_marker,
+        );
+        let hit_regions = hit_regions(&segments);
+        let rendered_width = segments
+            .iter()
+            .map(|segment| display_width(&segment.text))
+            .sum();
+
+        Some(RenderedWindowBar {
+            bar_id: bar.id.clone(),
+            style: bar.config.style.clone(),
+            segments,
+            hit_regions,
+            width: rendered_width,
+        })
+    }
+
+    pub fn render_resolved(
+        &self,
+        window_id: WindowId,
+        width: usize,
+        theme: &Theme,
+    ) -> Option<RenderedWindowBar> {
+        let mut rendered = self.render(window_id, width)?;
+        rendered.style = WindowBarStyle {
+            semantic: None,
+            style: Some(rendered.style.resolve(theme)),
+        };
+        for segment in &mut rendered.segments {
+            segment.style = WindowBarStyle {
+                semantic: None,
+                style: Some(segment.style.resolve(theme)),
+            };
+        }
+        Some(rendered)
+    }
+
+    fn selected_bar(&self, window_id: WindowId) -> Option<&WindowBar> {
+        self.bars
+            .values()
+            .filter(|bar| bar.content.contains_key(&window_id))
+            .max_by_key(|bar| (bar.config.priority, bar.sequence))
+    }
+}
+
+fn clip_segments(
+    segments: &[WindowBarSegment],
+    width: usize,
+    overflow: WindowBarOverflow,
+    marker: &str,
+) -> Vec<WindowBarSegment> {
+    let source_width: usize = segments
+        .iter()
+        .map(|segment| display_width(&segment.text))
+        .sum();
+    if source_width <= width {
+        return segments.to_vec();
+    }
+
+    let marker = truncate_right(marker, width);
+    let marker_width = display_width(&marker);
+    let content_width = width.saturating_sub(marker_width);
+    match overflow {
+        WindowBarOverflow::TruncateRight => {
+            let mut clipped = take_prefix(segments, content_width);
+            push_marker(&mut clipped, marker);
+            clipped
+        }
+        WindowBarOverflow::TruncateLeft => {
+            let mut clipped = take_suffix(segments, content_width);
+            insert_marker(&mut clipped, marker);
+            clipped
+        }
+    }
+}
+
+fn take_prefix(segments: &[WindowBarSegment], width: usize) -> Vec<WindowBarSegment> {
+    let mut remaining = width;
+    let mut result = Vec::new();
+    for segment in segments {
+        if remaining == 0 {
+            break;
+        }
+        let text = truncate_right(&segment.text, remaining);
+        remaining = remaining.saturating_sub(display_width(&text));
+        if !text.is_empty() {
+            result.push(WindowBarSegment {
+                text,
+                ..segment.clone()
+            });
+        }
+    }
+    result
+}
+
+fn take_suffix(segments: &[WindowBarSegment], width: usize) -> Vec<WindowBarSegment> {
+    let mut remaining = width;
+    let mut result = Vec::new();
+    for segment in segments.iter().rev() {
+        if remaining == 0 {
+            break;
+        }
+        let text = truncate_left(&segment.text, remaining);
+        remaining = remaining.saturating_sub(display_width(&text));
+        if !text.is_empty() {
+            result.push(WindowBarSegment {
+                text,
+                ..segment.clone()
+            });
+        }
+    }
+    result.reverse();
+    result
+}
+
+fn truncate_right(text: &str, width: usize) -> String {
+    let mut used = 0;
+    text.graphemes(true)
+        .take_while(|grapheme| {
+            let next = used + display_width(grapheme);
+            if next <= width {
+                used = next;
+                true
+            } else {
+                false
+            }
+        })
+        .collect()
+}
+
+fn truncate_left(text: &str, width: usize) -> String {
+    let mut used = 0;
+    let mut graphemes = text
+        .graphemes(true)
+        .rev()
+        .take_while(|grapheme| {
+            let next = used + display_width(grapheme);
+            if next <= width {
+                used = next;
+                true
+            } else {
+                false
+            }
+        })
+        .collect::<Vec<_>>();
+    graphemes.reverse();
+    graphemes.concat()
+}
+
+fn push_marker(segments: &mut Vec<WindowBarSegment>, text: String) {
+    if text.is_empty() {
+        return;
+    }
+    let style = segments
+        .last()
+        .map(|segment| segment.style.clone())
+        .unwrap_or_default();
+    segments.push(WindowBarSegment {
+        id: None,
+        text,
+        style,
+        tooltip: None,
+        action: None,
+    });
+}
+
+fn insert_marker(segments: &mut Vec<WindowBarSegment>, text: String) {
+    if text.is_empty() {
+        return;
+    }
+    let style = segments
+        .first()
+        .map(|segment| segment.style.clone())
+        .unwrap_or_default();
+    segments.insert(
+        0,
+        WindowBarSegment {
+            id: None,
+            text,
+            style,
+            tooltip: None,
+            action: None,
+        },
+    );
+}
+
+fn hit_regions(segments: &[WindowBarSegment]) -> Vec<WindowBarHitRegion> {
+    let mut column = 0;
+    let mut regions = Vec::new();
+    for segment in segments {
+        let end_column = column + display_width(&segment.text);
+        if let Some(action) = &segment.action {
+            regions.push(WindowBarHitRegion {
+                start_column: column,
+                end_column,
+                segment_id: segment.id.clone(),
+                action: action.clone(),
+            });
+        }
+        column = end_column;
+    }
+    regions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segment(id: &str, text: &str) -> WindowBarSegment {
+        WindowBarSegment {
+            id: Some(id.to_string()),
+            text: text.to_string(),
+            style: WindowBarStyle::default(),
+            tooltip: None,
+            action: Some(format!("open:{id}")),
+        }
+    }
+
+    #[test]
+    fn higher_priority_bar_owns_the_window_row() {
+        let window_id = WindowId(4);
+        let mut manager = WindowBarManager::default();
+        manager.create("low".to_string(), WindowBarConfig::default());
+        manager.create(
+            "high".to_string(),
+            WindowBarConfig {
+                priority: 10,
+                ..WindowBarConfig::default()
+            },
+        );
+        manager.update("low", window_id, vec![segment("low", "low")]);
+        manager.update("high", window_id, vec![segment("high", "high")]);
+
+        assert_eq!(manager.render(window_id, 20).unwrap().bar_id, "high");
+    }
+
+    #[test]
+    fn left_truncation_preserves_unicode_graphemes_and_current_symbol() {
+        let window_id = WindowId(1);
+        let mut manager = WindowBarManager::default();
+        manager.create("crumbs".to_string(), WindowBarConfig::default());
+        manager.update(
+            "crumbs",
+            window_id,
+            vec![segment("path", "src/👨‍👩‍👧‍👦/"), segment("symbol", "function")],
+        );
+
+        let rendered = manager.render(window_id, 10).unwrap();
+        let text = rendered
+            .segments
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect::<String>();
+        assert_eq!(text, "…/function");
+        assert_eq!(display_width(&text), 10);
+    }
+
+    #[test]
+    fn hit_regions_follow_clipped_segment_columns() {
+        let window_id = WindowId(2);
+        let mut manager = WindowBarManager::default();
+        manager.create("crumbs".to_string(), WindowBarConfig::default());
+        manager.update(
+            "crumbs",
+            window_id,
+            vec![segment("file", "main.rs"), segment("symbol", " › run")],
+        );
+
+        let rendered = manager.render(window_id, 20).unwrap();
+        assert_eq!(rendered.hit_regions.len(), 2);
+        assert_eq!(rendered.hit_regions[0].start_column, 0);
+        assert_eq!(rendered.hit_regions[0].end_column, 7);
+        assert_eq!(rendered.hit_regions[1].start_column, 7);
+        assert_eq!(rendered.hit_regions[1].end_column, 13);
+    }
+
+    #[test]
+    fn closing_a_window_removes_only_its_content() {
+        let mut manager = WindowBarManager::default();
+        manager.create("crumbs".to_string(), WindowBarConfig::default());
+        manager.update("crumbs", WindowId(1), vec![segment("one", "one")]);
+        manager.update("crumbs", WindowId(2), vec![segment("two", "two")]);
+
+        assert!(manager.close_window(WindowId(1)));
+        assert!(manager.render(WindowId(1), 10).is_none());
+        assert!(manager.render(WindowId(2), 10).is_some());
+    }
+}

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -26,6 +26,24 @@ pub struct Theme {
     pub error_style: Option<Style>,
 }
 
+/// A theme-derived style requested by a plugin.
+///
+/// Color references are tried in order. Workbench color keys such as
+/// `symbolIcon.functionForeground` resolve from [`Theme::colors`], while
+/// `scope:entity.name.function` resolves from TextMate token styles.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThemeStyleSpec {
+    #[serde(default)]
+    pub foreground: Vec<String>,
+    #[serde(default)]
+    pub background: Vec<String>,
+    #[serde(default)]
+    pub bold: Option<bool>,
+    #[serde(default)]
+    pub italic: Option<bool>,
+}
+
 impl Theme {
     pub fn get_style(&self, scope: &str) -> Option<Style> {
         compatible_scopes(scope).into_iter().find_map(|candidate| {
@@ -48,6 +66,58 @@ impl Theme {
                 g: 255,
                 b: 255,
             })
+    }
+
+    pub fn resolve_style(&self, spec: &ThemeStyleSpec) -> Style {
+        Style {
+            fg: self.resolve_color_references(&spec.foreground, StyleColorComponent::Foreground),
+            bg: self.resolve_color_references(&spec.background, StyleColorComponent::Background),
+            bold: spec.bold.unwrap_or(false),
+            italic: spec.italic.unwrap_or(false),
+        }
+    }
+
+    fn resolve_color_references(
+        &self,
+        references: &[String],
+        component: StyleColorComponent,
+    ) -> Option<Color> {
+        references
+            .iter()
+            .find_map(|reference| self.resolve_color_reference(reference, component))
+    }
+
+    fn resolve_color_reference(
+        &self,
+        reference: &str,
+        component: StyleColorComponent,
+    ) -> Option<Color> {
+        if let Some(scope) = reference.strip_prefix("scope:") {
+            return self
+                .get_style(scope)
+                .and_then(|style| component.get(&style));
+        }
+
+        match reference {
+            "editor.foreground" => self.style.fg,
+            "editor.background" => self.style.bg,
+            _ => self.colors.get(reference).copied(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StyleColorComponent {
+    Foreground,
+    Background,
+}
+
+impl StyleColorComponent {
+    fn get(self, style: &Style) -> Option<Color> {
+        match self {
+            Self::Foreground => style.fg,
+            Self::Background => style.bg,
+        }
     }
 }
 
@@ -300,6 +370,84 @@ mod tests {
             token_styles,
             ..Theme::default()
         }
+    }
+
+    #[test]
+    fn resolve_style_uses_the_first_available_workbench_color() {
+        let breadcrumb = Color::Rgb {
+            r: 139,
+            g: 164,
+            b: 176,
+        };
+        let mut theme = Theme::default();
+        theme
+            .colors
+            .insert("breadcrumb.foreground".to_string(), breadcrumb);
+
+        let resolved = theme.resolve_style(&ThemeStyleSpec {
+            foreground: vec![
+                "missing.foreground".to_string(),
+                "breadcrumb.foreground".to_string(),
+                "editor.foreground".to_string(),
+            ],
+            background: vec![
+                "breadcrumb.background".to_string(),
+                "editor.background".to_string(),
+            ],
+            ..Default::default()
+        });
+
+        assert_eq!(resolved.fg, Some(breadcrumb));
+        assert_eq!(resolved.bg, theme.style.bg);
+    }
+
+    #[test]
+    fn resolve_style_interleaves_token_scopes_with_workbench_fallbacks() {
+        let function = style(203, 166, 247);
+        let theme = theme_with_token_styles(vec![TokenStyle {
+            name: None,
+            scope: vec!["entity.name.function".to_string()],
+            style: function.clone(),
+        }]);
+
+        let resolved = theme.resolve_style(&ThemeStyleSpec {
+            foreground: vec![
+                "symbolIcon.functionForeground".to_string(),
+                "scope:entity.name.function".to_string(),
+                "editor.foreground".to_string(),
+            ],
+            bold: Some(true),
+            ..Default::default()
+        });
+
+        assert_eq!(resolved.fg, function.fg);
+        assert!(resolved.bold);
+    }
+
+    #[test]
+    fn resolve_style_can_use_a_token_background() {
+        let token_style = Style {
+            bg: Some(Color::Rgb {
+                r: 24,
+                g: 24,
+                b: 37,
+            }),
+            ..Default::default()
+        };
+        let theme = theme_with_token_styles(vec![TokenStyle {
+            name: None,
+            scope: vec!["meta.function".to_string()],
+            style: token_style.clone(),
+        }]);
+
+        let resolved = theme.resolve_style(&ThemeStyleSpec {
+            background: vec!["scope:meta.function".to_string()],
+            italic: Some(true),
+            ..Default::default()
+        });
+
+        assert_eq!(resolved.bg, token_style.bg);
+        assert!(resolved.italic);
     }
 
     #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,6 +1,23 @@
 use crate::editor::{CursorGoal, Point};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_WINDOW_ID: AtomicU64 = AtomicU64::new(0);
+
+/// Session-stable identity for a window.
+///
+/// Unlike the tree-order indexes accepted by the existing `WindowManager` API,
+/// this value does not change when another window is split or closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WindowId(pub u64);
+
+impl WindowId {
+    fn next() -> Self {
+        Self(NEXT_WINDOW_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub enum Direction {
@@ -13,6 +30,9 @@ pub enum Direction {
 /// Represents a single window displaying a buffer
 #[derive(Debug, Clone)]
 pub struct Window {
+    /// Stable identity for this window within the current editor session.
+    pub id: WindowId,
+
     /// Index of the buffer being displayed
     pub buffer_index: usize,
 
@@ -53,7 +73,17 @@ pub struct Window {
 impl Window {
     /// Creates a new window with the given buffer index and dimensions
     pub fn new(buffer_index: usize, position: Point, size: (usize, usize)) -> Self {
+        Self::new_with_id(WindowId::next(), buffer_index, position, size)
+    }
+
+    fn new_with_id(
+        id: WindowId,
+        buffer_index: usize,
+        position: Point,
+        size: (usize, usize),
+    ) -> Self {
         Self {
+            id,
             buffer_index,
             position,
             size,
@@ -133,6 +163,34 @@ mod tests {
     }
 
     #[test]
+    fn stable_window_ids_survive_tree_reordering() {
+        let mut manager = WindowManager::new(0, (80, 26));
+        let original_id = manager.active_stable_window_id().unwrap();
+        manager.split_vertical(1).unwrap();
+        let new_id = manager.active_stable_window_id().unwrap();
+
+        manager.set_active(0);
+        manager.close_window().unwrap();
+
+        assert_ne!(original_id, new_id);
+        assert_eq!(manager.active_window_id(), 0);
+        assert_eq!(manager.active_stable_window_id(), Some(new_id));
+        assert_eq!(manager.window_index(new_id), Some(0));
+        assert!(manager.window(original_id).is_none());
+    }
+
+    #[test]
+    fn split_ids_are_never_reused_after_close() {
+        let mut manager = WindowManager::new(0, (80, 26));
+        manager.split_vertical(1).unwrap();
+        let closed_id = manager.active_stable_window_id().unwrap();
+        manager.close_window().unwrap();
+        manager.split_vertical(2).unwrap();
+
+        assert!(manager.active_stable_window_id().unwrap() > closed_id);
+    }
+
+    #[test]
     fn close_first_window_in_split_keeps_sibling() {
         let mut manager = WindowManager::new(0, (80, 26));
         manager.split_vertical(0).unwrap();
@@ -202,6 +260,11 @@ mod tests {
         manager.active_window_mut().unwrap().vtop = 12;
 
         let snapshot = manager.snapshot();
+        let original_ids = manager
+            .windows()
+            .into_iter()
+            .map(|window| window.id)
+            .collect::<Vec<_>>();
         let buffer_map = HashMap::from([(0, 3), (1, 4)]);
         let restored = WindowManager::from_snapshot(&snapshot, (100, 30), &buffer_map).unwrap();
 
@@ -209,6 +272,10 @@ mod tests {
         assert_eq!(restored.active_window_id(), manager.active_window_id());
         assert_eq!(restored.active_window().unwrap().buffer_index, 4);
         assert_eq!(restored.active_window().unwrap().vtop, 12);
+        assert!(restored
+            .windows()
+            .into_iter()
+            .all(|window| !original_ids.contains(&window.id)));
     }
 }
 
@@ -420,11 +487,12 @@ pub struct WindowManager {
 impl WindowManager {
     /// Creates a new WindowManager with a single window
     pub fn new(buffer_index: usize, terminal_size: (usize, usize)) -> Self {
-        let mut root = Split::new_window(
+        let mut root = Split::Window(Window::new_with_id(
+            WindowId::next(),
             buffer_index,
             Point::new(0, 0),
             (terminal_size.0, terminal_size.1.saturating_sub(2)), // Leave room for status/command line
-        );
+        ));
 
         // Set the first window as active
         if let Split::Window(w) = &mut root {
@@ -463,6 +531,9 @@ impl WindowManager {
         if window_count == 0 {
             return None;
         }
+        for window in manager.root.windows_mut() {
+            window.id = WindowId::next();
+        }
         manager.set_active(snapshot.active_window_id.min(window_count - 1));
         Some(manager)
     }
@@ -476,6 +547,27 @@ impl WindowManager {
     pub fn active_window_mut(&mut self) -> Option<&mut Window> {
         let mut current_id = 0;
         Self::get_window_mut_recursive(&mut self.root, &mut current_id, self.active_window_id)
+    }
+
+    /// Returns the stable identity of the active window.
+    pub fn active_stable_window_id(&self) -> Option<WindowId> {
+        self.active_window().map(|window| window.id)
+    }
+
+    /// Finds a window by its stable identity.
+    pub fn window(&self, id: WindowId) -> Option<&Window> {
+        self.root
+            .windows()
+            .into_iter()
+            .find(|window| window.id == id)
+    }
+
+    /// Returns the current tree-order index for a stable window identity.
+    pub fn window_index(&self, id: WindowId) -> Option<usize> {
+        self.root
+            .windows()
+            .into_iter()
+            .position(|window| window.id == id)
     }
 
     fn get_window_mut_recursive<'a>(
@@ -566,8 +658,14 @@ impl WindowManager {
         log!("Terminal bounds: {}x{}", width, height);
         log!("Active window id before split: {}", self.active_window_id);
 
-        let new_root =
-            self.split_node(&self.root, self.active_window_id, new_buffer_index, true)?;
+        let new_window_id = WindowId::next();
+        let new_root = self.split_node(
+            &self.root,
+            self.active_window_id,
+            new_window_id,
+            new_buffer_index,
+            true,
+        )?;
         self.root = new_root;
         self.root.layout(Point::new(0, 0), (width, height));
 
@@ -596,8 +694,14 @@ impl WindowManager {
         let (width, height) = self.get_terminal_bounds();
         log!("Active window id before split: {}", self.active_window_id);
 
-        let new_root =
-            self.split_node(&self.root, self.active_window_id, new_buffer_index, false)?;
+        let new_window_id = WindowId::next();
+        let new_root = self.split_node(
+            &self.root,
+            self.active_window_id,
+            new_window_id,
+            new_buffer_index,
+            false,
+        )?;
         self.root = new_root;
         self.root.layout(Point::new(0, 0), (width, height));
 
@@ -1220,6 +1324,7 @@ impl WindowManager {
         &self,
         node: &Split,
         target_window_id: usize,
+        new_window_id: WindowId,
         new_buffer_index: usize,
         horizontal: bool,
     ) -> Option<Split> {
@@ -1228,6 +1333,7 @@ impl WindowManager {
             node,
             &mut current_id,
             target_window_id,
+            new_window_id,
             new_buffer_index,
             horizontal,
         )
@@ -1238,6 +1344,7 @@ impl WindowManager {
         node: &Split,
         current_id: &mut usize,
         target_window_id: usize,
+        new_window_id: WindowId,
         new_buffer_index: usize,
         horizontal: bool,
     ) -> Option<Split> {
@@ -1254,8 +1361,12 @@ impl WindowManager {
                 if *current_id == target_window_id {
                     log!("  Found target window to split!");
                     // This is the window to split
-                    let mut new_window =
-                        Window::new(new_buffer_index, window.position, window.size);
+                    let mut new_window = Window::new_with_id(
+                        new_window_id,
+                        new_buffer_index,
+                        window.position,
+                        window.size,
+                    );
                     new_window.active = false;
                     new_window.wrap = window.wrap;
 
@@ -1285,6 +1396,7 @@ impl WindowManager {
                     top,
                     current_id,
                     target_window_id,
+                    new_window_id,
                     new_buffer_index,
                     horizontal,
                 )?;
@@ -1292,6 +1404,7 @@ impl WindowManager {
                     bottom,
                     current_id,
                     target_window_id,
+                    new_window_id,
                     new_buffer_index,
                     horizontal,
                 )?;
@@ -1306,6 +1419,7 @@ impl WindowManager {
                     left,
                     current_id,
                     target_window_id,
+                    new_window_id,
                     new_buffer_index,
                     horizontal,
                 )?;
@@ -1313,6 +1427,7 @@ impl WindowManager {
                     right,
                     current_id,
                     target_window_id,
+                    new_window_id,
                     new_buffer_index,
                     horizontal,
                 )?;

--- a/test-harness/mock-red.js
+++ b/test-harness/mock-red.js
@@ -10,6 +10,7 @@ class MockRedAPI {
     this.overlays = new Map();
     this.decorations = new Map();
     this.panels = new Map();
+    this.windowBars = new Map();
     this.storageValues = new Map();
     this.spawnedProcesses = [];
     this.openedLocations = [];
@@ -37,7 +38,19 @@ class MockRedAPI {
         style: { fg: "#ffffff", bg: "#000000" }
       },
       cursor: { x: 0, y: 0 },
+      windows: [
+        {
+          id: 0,
+          active: true,
+          bufferIndex: 0,
+          bufferPath: "/tmp/test.js",
+          revision: 0,
+          cursor: { x: 0, y: 0 },
+          lspPosition: { line: 0, character: 0 }
+        }
+      ],
       bufferContent: ["// Test file", "console.log('hello');", ""],
+      documentSymbols: { ok: true, file: "/tmp/test.js", symbols: [] },
       inlayHints: { ok: true, file: "/tmp/test.js", hints: [] },
       viewportLayout: null,
       config: {
@@ -51,7 +64,10 @@ class MockRedAPI {
     };
 
     this.lsp = {
-      documentSymbols: async () => ({ ok: true, file: "/tmp/test.js", symbols: [] }),
+      documentSymbols: async (options = {}) => {
+        this.logs.push(`lsp.documentSymbols: ${JSON.stringify(options)}`);
+        return this.mockState.documentSymbols;
+      },
       inlayHints: async (options = {}) => {
         this.logs.push(`lsp.inlayHints: ${JSON.stringify(options)}`);
         return this.mockState.inlayHints;
@@ -61,6 +77,14 @@ class MockRedAPI {
       get: async (key) => this.storageValues.get(key) ?? null,
       set: async (key, value) => this.storageValues.set(key, value),
       delete: async (key) => this.storageValues.delete(key),
+    };
+    this.ui = {
+      createWindowBar: (id, config) => this.createWindowBar(id, config),
+      updateWindowBar: (id, windowId, segments) => this.updateWindowBar(id, windowId, segments),
+      closeWindowBar: (id, windowId = null) => this.closeWindowBar(id, windowId),
+    };
+    this.theme = {
+      resolveStyle: (spec) => this.resolveThemeStyle(spec),
     };
   }
 
@@ -105,6 +129,23 @@ class MockRedAPI {
       current_buffer_index: this.mockState.current_buffer_index,
       size: this.mockState.size,
       theme: this.mockState.theme
+    };
+  }
+
+  async getWindows() {
+    return this.mockState.windows;
+  }
+
+  async resolveThemeStyle(spec = {}) {
+    const theme = this.mockState.theme || {};
+    const colors = theme.colors || {};
+    const firstColor = (references, fallback) =>
+      (references || []).map((key) => colors[key]).find(Boolean) ?? fallback ?? null;
+    return {
+      fg: firstColor(spec.foreground, theme.style?.fg),
+      bg: firstColor(spec.background, theme.style?.bg),
+      bold: spec.bold === true,
+      italic: spec.italic === true,
     };
   }
 
@@ -459,6 +500,37 @@ class MockRedAPI {
 
   getPanel(id) {
     return this.panels.get(id);
+  }
+
+  createWindowBar(id, config = {}) {
+    this.logs.push(`createWindowBar: ${id} ${JSON.stringify(config)}`);
+    this.windowBars.set(id, { config, windows: new Map() });
+  }
+
+  updateWindowBar(id, windowId, segments = []) {
+    this.logs.push(`updateWindowBar: ${id} ${windowId} ${JSON.stringify(segments)}`);
+    const bar = this.windowBars.get(id) || { config: {}, windows: new Map() };
+    bar.windows.set(windowId, segments);
+    this.windowBars.set(id, bar);
+  }
+
+  closeWindowBar(id, windowId = null) {
+    this.logs.push(`closeWindowBar: ${id} ${windowId ?? "all"}`);
+    if (windowId == null) {
+      this.windowBars.delete(id);
+    } else {
+      this.windowBars.get(id)?.windows.delete(windowId);
+    }
+  }
+
+  getWindowBar(id, windowId = null) {
+    const bar = this.windowBars.get(id);
+    return windowId == null ? bar : bar?.windows.get(windowId);
+  }
+
+  async emitWindowBarAction(id, event) {
+    const listeners = this.eventListeners.get(`windowBar:action:${id}`) || [];
+    await Promise.all(listeners.map((callback) => callback(event)));
   }
 
   // Test helper methods

--- a/test-harness/mock-red.js
+++ b/test-harness/mock-red.js
@@ -122,6 +122,11 @@ class MockRedAPI {
     listeners.forEach(callback => callback(data));
   }
 
+  async emitAsync(event, data) {
+    const listeners = this.eventListeners.get(event) || [];
+    await Promise.all(listeners.map(callback => callback(data)));
+  }
+
   // API methods
   async getEditorInfo() {
     return {

--- a/types/red.d.ts
+++ b/types/red.d.ts
@@ -618,6 +618,11 @@ namespace Red {
      * @param event Event name
      * @param callback Event handler
      */
+    on(event: "editor:ready", callback: (data: Record<string, never>) => void): void;
+    on(
+      event: "editor:stateRestored",
+      callback: (data: { windows: WindowContext[]; cause: "RestoreEditorState" }) => void,
+    ): void;
     on(event: "buffer:changed", callback: (data: BufferChangeEvent) => void): void;
     on(event: "mode:changed", callback: (data: ModeChangeEvent) => void): void;
     on(event: "cursor:moved", callback: (data: CursorMoveEvent) => void): void;

--- a/types/red.d.ts
+++ b/types/red.d.ts
@@ -29,6 +29,84 @@ namespace Red {
   }
 
   /**
+   * A style resolved from the active theme. Entries are tried from left to
+   * right. Prefix a TextMate scope with `scope:`, for example
+   * `scope:entity.name.function`.
+   */
+  interface ThemeStyleSpec {
+    foreground?: string[];
+    background?: string[];
+    bold?: boolean;
+    italic?: boolean;
+  }
+
+  interface ThemeAPI {
+    resolveStyle(spec: ThemeStyleSpec): Promise<Style>;
+  }
+
+  interface WindowBounds {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+
+  interface WindowViewport {
+    top: number;
+    left?: number;
+  }
+
+  interface WindowContext {
+    id: number;
+    active: boolean;
+    bounds: WindowBounds;
+    contentBounds: WindowBounds;
+    bufferIndex: number;
+    bufferPath?: string;
+    revision: number;
+    cursor: CursorPosition;
+    /** Cursor position using the UTF-16 column encoding expected by LSP. */
+    lspPosition: Position;
+    viewport: WindowViewport;
+  }
+
+  interface WindowChangeEvent {
+    windowId: number | null;
+    bufferIndex: number;
+    cause: string;
+  }
+
+  type WindowBarEdge = "top";
+  type WindowBarOverflow = "truncate_left" | "truncate_right";
+
+  interface WindowBarConfig {
+    edge?: WindowBarEdge;
+    priority?: number;
+    overflow?: WindowBarOverflow;
+    truncateMarker?: string;
+    style?: WindowBarSegmentStyle;
+  }
+
+  interface WindowBarSegmentStyle {
+    semantic?: string | ThemeStyleSpec;
+    style?: Style;
+  }
+
+  interface WindowBarSegment {
+    id?: string;
+    text: string;
+    style?: WindowBarSegmentStyle;
+    tooltip?: string;
+    action?: string;
+  }
+
+  interface WindowBarAPI {
+    createWindowBar(id: string, config?: WindowBarConfig): void;
+    updateWindowBar(id: string, windowId: number, segments: WindowBarSegment[]): void;
+    closeWindowBar(id: string, windowId?: number | null): void;
+  }
+
+  /**
    * Information about a buffer
    */
   interface BufferInfo {
@@ -341,6 +419,8 @@ namespace Red {
   }
 
   interface DocumentSymbol {
+    id?: string;
+    parentId?: string;
     name: string;
     detail?: string;
     kind: number;
@@ -355,6 +435,8 @@ namespace Red {
     | {
         ok: true;
         file: string;
+        bufferIndex?: number;
+        revision?: number;
         symbols: DocumentSymbol[];
       }
     | {
@@ -436,8 +518,12 @@ namespace Red {
     visible?: boolean;
   }
 
+  interface DocumentSymbolsOptions {
+    bufferIndex?: number;
+  }
+
   interface LspAPI {
-    documentSymbols(): Promise<DocumentSymbolsResult>;
+    documentSymbols(options?: DocumentSymbolsOptions): Promise<DocumentSymbolsResult>;
     workspaceSymbols(query?: string): Promise<WorkspaceSymbolsResult>;
     references(options?: ReferencesOptions): Promise<ReferencesResult>;
     inlayHints(options?: InlayHintsOptions): Promise<InlayHintsResult>;
@@ -518,6 +604,8 @@ namespace Red {
   interface RedAPI {
     storage: PluginStorage;
     lsp: LspAPI;
+    theme: ThemeAPI;
+    ui: WindowBarAPI;
     /**
      * Register a new command
      * @param name Command name
@@ -539,6 +627,15 @@ namespace Red {
     on(event: "file:saved", callback: (data: FileEvent) => void): void;
     on(event: "lsp:progress", callback: (data: LspProgressEvent) => void): void;
     on(event: "editor:resize", callback: (data: ResizeEvent) => void): void;
+    on(event: "window:focused", callback: (data: WindowChangeEvent) => void): void;
+    on(event: "window:layoutChanged", callback: (data: { windows: WindowContext[] }) => void): void;
+    on(event: "window:bufferChanged", callback: (data: WindowChangeEvent) => void): void;
+    on(event: "window:closed", callback: (data: { windowId: number }) => void): void;
+    on(event: "theme:changed", callback: (data: { name: string }) => void): void;
+    on(
+      event: `windowBar:action:${string}`,
+      callback: (data: { windowId: number; segmentId?: string; action: string }) => void,
+    ): void;
     on(event: string, callback: (data: any) => void): void;
 
     /**
@@ -565,6 +662,17 @@ namespace Red {
      * @returns Promise resolving to editor info
      */
     getEditorInfo(): Promise<EditorInfo>;
+
+    /** Return session-stable identities and render context for open windows. */
+    getWindows(): Promise<WindowContext[]>;
+
+    /** Resolve an ordered semantic style against the active theme. */
+    resolveThemeStyle(spec: ThemeStyleSpec): Promise<Style>;
+
+    createWindowBar(id: string, config?: WindowBarConfig): void;
+    updateWindowBar(id: string, windowId: number, segments: WindowBarSegment[]): void;
+    /** Omit windowId to remove the bar from every window. */
+    closeWindowBar(id: string, windowId?: number | null): void;
 
     /**
      * Show a picker dialog


### PR DESCRIPTION
## Why

Red plugins can render overlays, panels, and virtual text, but they do not have a first-class way to reserve window-local UI space inside editor splits. That makes breadcrumb-style navigation difficult to implement correctly because plugin-drawn text has to compete with buffer content, window layout, cursor placement, and mouse hit testing.

This adds a window bar API and ships a built-in `barbecue` plugin so Red can show per-window breadcrumbs for the current file and enclosing LSP symbols, similar to `barbecue.nvim`.

## What Changed

- Adds stable window IDs and a window-bar manager that can reserve a top row per editor window.
- Exposes plugin APIs for `red.getWindows()`, `red.ui.createWindowBar()`, `red.ui.updateWindowBar()`, `red.ui.closeWindowBar()`, and semantic theme style resolution.
- Updates rendering, cursor placement, overlays, mouse hit testing, and window layout calculations to account for reserved window-bar rows.
- Adds `plugins/barbecue.js` with configurable path/file/symbol breadcrumb rendering, Nerd Font icons, nvim-web-devicons-inspired file colors, and clickable symbol segments.
- Lets plugins request document symbols for a specific buffer index and revision, so breadcrumb rendering works across splits.
- Documents the window-bar APIs and extends TypeScript definitions and the test harness.
- Runs plugin tests for `plugins/*.test.js` in CI in addition to example plugin tests.
- Updates `indent_guides` to repaint after session restore and to use buffer shift width for scope rendering.

## How to Test

1. Enable the default `barbecue` plugin and open Red in a repository with an LSP-backed source file.
2. Split the editor window and move between files or symbols.
3. Confirm each window shows a top breadcrumb row with directory, file, and enclosing symbols.
4. Move the cursor into nested symbols and confirm the active symbol updates.
5. Click a clickable symbol segment and confirm Red jumps to that symbol location.
6. Modify the active theme or restore a saved session and confirm the breadcrumb row repaints without needing cursor input.
7. Also verify a narrow window truncates breadcrumbs from the left while keeping the current file/symbol visible.

Targeted tests:

- `node test-harness/test-runner.js ../plugins/barbecue.js ../plugins/barbecue.test.js`
- `node test-harness/test-runner.js ../plugins/indent_guides.js ../plugins/indent_guides.test.js`
- `cargo test window_bar`
- `cargo test stable_window_ids_survive_tree_reordering`
