### PR TITLE
Bundle runtime assets for self-contained distribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +1947,7 @@ dependencies = [
  "deno_error",
  "futures",
  "fuzzy-matcher",
+ "include_dir",
  "json_comments",
  "lazy_static",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ deno_core = { version = "=0.403.0", features = ["include_icu_data"] }
 deno_error = "=0.7.1"
 futures = "0.3.30"
 fuzzy-matcher = "0.3.7"
+include_dir = "0.7.4"
 json_comments = "0.2.2"
 lazy_static = "1.5.0"
 nix = { version = "0.28.0", features = ["signal"] }

--- a/README.md
+++ b/README.md
@@ -3,31 +3,25 @@
 [![CI](https://github.com/codersauce/red/actions/workflows/ci.yml/badge.svg)](https://github.com/codersauce/red/actions/workflows/ci.yml)
 [![Plugin System Check](https://github.com/codersauce/red/actions/workflows/plugin-check.yml/badge.svg)](https://github.com/codersauce/red/actions/workflows/plugin-check.yml)
 [![Release](https://github.com/codersauce/red/actions/workflows/release.yml/badge.svg)](https://github.com/codersauce/red/actions/workflows/release.yml)
-[![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Discord](https://img.shields.io/badge/Discord-Join%20us-7289DA?logo=discord&logoColor=white)](https://discord.gg/5PWvAUNRHU)
 
-A modern, modal text editor built in Rust with minimal dependencies. Red combines the power of modal editing with modern features like Language Server Protocol support, async operations, and a JavaScript plugin system.
+A modern, modal text editor built in Rust. Red combines Vim-inspired editing with modern features - Language Server Protocol support, tree-sitter syntax highlighting, and a sandboxed JavaScript/TypeScript plugin system - in a single self-contained binary that works with zero setup.
 
 ![red screenshot](docs/screenshot.png)
 
 ## Features
 
-- **Modal Editing**: Vim-inspired modal interface with Normal, Insert, Visual, and Command modes
-- **Language Server Protocol**: Full LSP support for intelligent code completion, diagnostics, and more
-- **Async Architecture**: Built on Tokio for responsive, non-blocking operations
-- **Plugin System**: Extend functionality with JavaScript plugins running in a sandboxed Deno runtime
-- **Syntax Highlighting**: Tree-sitter based syntax highlighting for accurate code coloring
-- **Theme Support**: VSCode theme compatibility - use your favorite themes
+- **Modal Editing**: Vim-inspired Normal, Insert, Visual, Visual Line, Visual Block, and Command modes
+- **Language Server Protocol**: Code completion, diagnostics, hover documentation, goto definition, find references, document and workspace symbols, and inlay hints, with sensible defaults for seven common language servers
+- **Syntax Highlighting**: Tree-sitter based highlighting for Rust, Markdown, JavaScript, TypeScript/TSX, JSON, TOML, YAML, Python, and Bash
+- **Windows and Buffers**: Horizontal/vertical splits with independent viewports, multiple buffers, and a jump list
+- **Plugin System**: JavaScript and TypeScript plugins in a sandboxed Deno runtime, with a typed API - the file tree, project search, and theme browser are all plugins
+- **Theme Support**: VSCode theme compatibility, with a large collection of themes built in
 - **Self-Contained**: Default config, themes, and plugins are bundled into the binary - no setup required
-- **Minimal Dependencies**: Built from scratch with a focus on simplicity and performance
+- **Async Architecture**: Built on Tokio for responsive, non-blocking operations
 - **Cross-Platform**: Works on Linux, macOS, and Windows
-
-## Requirements
-
-- Rust 1.70 or newer
-- Cargo (comes with Rust)
-- Git
 
 ## Current Status
 
@@ -42,6 +36,11 @@ If you want to collaborate or discuss red's features, usage or anything, join ou
 https://discord.gg/5PWvAUNRHU
 
 ## Installation
+
+### Requirements
+
+- A recent stable Rust toolchain (install via [rustup](https://rustup.rs))
+- Git
 
 ### From Source (Recommended)
 
@@ -68,68 +67,158 @@ red <file-to-edit>
 
 On the first interactive run, Red offers to create a starter config at `~/.config/red/config.toml`. You can decline (or run non-interactively) and Red launches with its embedded defaults - a config file is entirely optional.
 
+## A Tour of the Basics
+
+Red uses Vim-style modal editing. Everything below is the default; all of it can be remapped (see [Configuration](#configuration)).
+
+### Moving around
+
+- `h/j/k/l` or arrow keys - Move left/down/up/right
+- `w/b` - Move forward/backward by word
+- `0/$` - Move to beginning/end of line
+- `gg/G` - Go to first/last line
+- `Ctrl-b/Ctrl-f` - Page up/down
+- `zz` - Center the current line in the view
+- `%` - Jump to the matching bracket (`g%` backward, `[%`/`]%` for unmatched brackets)
+- `Ctrl-o/Tab` - Jump back/forward through the jump list
+- `gj/gk` - Move by screen line when long lines wrap
+
+### Editing
+
+- `i/a` - Insert before/after the cursor (`I/A` for start/end of line)
+- `o/O` - Open a new line below/above
+- `x` - Delete character; `dd` - delete line; `dw` - delete word
+- `u` / `Ctrl-r` - Undo/redo
+- `p/P` - Paste after/before
+- `>>` / `<<` - Indent/unindent the current line
+- `Esc` - Back to Normal mode
+
+### Selecting
+
+- `v` - Visual mode (character-wise)
+- `V` - Visual Line mode
+- `Ctrl-v` - Visual Block mode (rectangular selections; `I` inserts on every selected line)
+- In Visual mode, `i`/`a` select inside/around a text object: `iw` for a word, `i(`, `i[`, `i{`, `i<`, `i"`, `i'`, or `` i` `` for delimited text, and `a%` for a matchit pair
+- In a selection: `y` copies, `x` deletes, `p` pastes over it
+
+### Searching
+
+- `/` and `?` - Forward/backward search with live preview and highlighted matches
+- `n/N` - Repeat search in the same/opposite direction
+- `*` - Search for the word under the cursor
+- `:noh` - Clear search highlights
+
+Search patterns use Rust regex syntax. Behavior (`incsearch`, `hlsearch`, `wrapscan`, `ignorecase`, `smartcase`) is configurable. The bundled `cool_search` plugin clears highlights automatically once you move away from a committed match or enter Insert mode.
+
+### Code intelligence (LSP)
+
+- `K` - Hover documentation
+- `gd` - Go to definition
+- `Ctrl-Space` - Trigger completion (in Insert mode; completion also triggers as you type)
+- `Ctrl-t` - Document symbols picker
+- `Space w` - Workspace symbols picker
+- `Space k` - Find references
+
+Diagnostics from the language server are displayed inline, and LSP progress is shown by the bundled `fidget` plugin.
+
+### Pickers and panels
+
+- `Ctrl-p` - File picker
+- `Ctrl-e` - File tree (neotree)
+- `Ctrl-j` or `Space b` - Buffer picker
+- `Space g` - Project-wide search (requires `rg` on your PATH)
+- `Space t` - Theme browser with live preview
+
+### Windows and buffers
+
+- `Ctrl-w s` / `Ctrl-w v` - Split horizontally/vertically
+- `Ctrl-w h/j/k/l` - Move between windows
+- `Ctrl-w w` - Next window; `Ctrl-w c` - close window
+- `Ctrl-w =` / `Ctrl-w _` / `Ctrl-w o` - Balance/maximize/keep only the current window
+- `Space Space` or `Space n` / `Space p` - Next/previous buffer
+
+### Command mode
+
+Enter Command mode with `:` (or `;`).
+
+- `:w [file]` - Save (optionally to a new name); `:wq` - save and quit
+- `:q` / `:q!` - Quit / quit discarding changes
+- `:e <file>` - Open a file; `:e!` - reload the current file
+- `:<number>` / `:$` - Jump to a line / the last line
+- `:bn` / `:bd` - Next/delete buffer (`Space p` goes to the previous buffer)
+- `:sp [file]` / `:vs [file]` - Split horizontally/vertically
+- `:close` / `:only` - Close the current window / keep only the current window
+- `:noh` - Clear search highlights
+- `:wrap` / `:nowrap` - Enable/disable line wrapping
+
 ## Configuration
 
 Red works out of the box with sensible embedded defaults. To customize it, use a TOML configuration file at `~/.config/red/config.toml`.
 
 Your config is layered **on top of** the embedded defaults: you only need to write the settings you want to change, and everything else keeps its default value. The starter config that Red offers to create on first run is a commented template to get you going - it is not the source of truth for defaults, so deleting it (or any setting in it) simply falls back to the built-in behavior.
 
-Here are some key configuration options:
+```toml
+# ~/.config/red/config.toml — only what you want to change
+theme = "atom-one-dark.json"
+
+scrolloff = 8
+
+[search]
+ignorecase = true
+smartcase = true
+
+# Remap or add keybindings; everything not listed keeps its default
+[keys.normal]
+"Ctrl-s" = "Save"
+```
+
+For the full set of options - cursor shapes per mode, wrapping and scrolling behavior, plugin settings, logging, and more - see the commented [`default_config.toml`](default_config.toml), which documents every default exactly as the binary ships it.
+
+### Keybindings
+
+Every mode has its own table (`[keys.normal]`, `[keys.insert]`, `[keys.visual]`, …). Bindings map a key to an editor action, a sequence of actions, a nested table for chords, or a plugin command:
 
 ```toml
-# Theme selection (theme filename, including the .json extension)
-theme = "mocha.json"
+[keys.normal]
+"u" = "Undo"                                   # single action
+"a" = [ { EnterMode = "Insert" }, "MoveRight" ]  # sequence
+"g" = { "d" = "GoToDefinition" }               # chord: g then d
+"Ctrl-j" = { PluginCommand = "BufferPicker" }  # plugin command
+```
 
-# Editor settings
-[editor]
-line_numbers = true
-indent_style = "spaces"
-indent_size = 4
-cursor_line = true
+### Language servers
 
-# LSP configuration
-[lsp]
-enabled = true
+Built-in LSP defaults cover Rust (`rust-analyzer`), TypeScript/JavaScript (`typescript-language-server`), Python (`pyright`), Markdown (`marksman`), JSON, TOML, and YAML. Servers start only when a matching file is opened, and each one must be installed and on your PATH. Add or override servers in your config:
 
-# Built-in syntax highlighting covers Rust, Markdown, JavaScript,
-# TypeScript/TSX, JSON, TOML, YAML, Python, and Bash. LSP defaults are
-# provided for common language-server-backed file types and start only when a
-# matching file is opened.
+```toml
+[lsp.servers.go]
+command = "gopls"
+language_id = "go"
+file_extensions = ["go"]
+root_markers = ["go.mod", ".git"]
+```
 
-[lsp.servers.typescript]
-command = "typescript-language-server"
-args = ["--stdio"]
-root_markers = ["package.json", "tsconfig.json", "jsconfig.json", ".git"]
+### Plugin settings
 
-[[lsp.servers.typescript.documents]]
-language_id = "typescript"
-file_extensions = ["ts"]
+Bundled plugins are enabled by default. Disable any of them by name, and configure the ones that take options:
 
-[[lsp.servers.typescript.documents]]
-language_id = "typescriptreact"
-file_extensions = ["tsx"]
+```toml
+disabled_plugins = ["barbecue"]
 
-[[lsp.servers.typescript.documents]]
-language_id = "javascript"
-file_extensions = ["js", "mjs", "cjs"]
+[plugin_config.lsp_symbols.icons]
+enabled = false
+```
 
-# Search settings
-[search]
-incsearch = true
-hlsearch = true
-wrapscan = true
-ignorecase = false
-smartcase = false
+Plugins that spawn external processes need an explicit allowlist, e.g. `project_search` ships with `[plugin_permissions.project_search] process = ["rg"]`.
 
-# Plugin settings
-[plugins]
-enabled = true
-directory = "~/.config/red/plugins"
+### Command-line options
 
-# Logging
-[debug]
-log_file = "/tmp/red.log"
-log_level = "info"
+```
+red [files...]              # open one or more files
+red -r <path>               # set the working directory root
+red -c 'wrap = false'       # inline TOML config override (repeatable)
+red --runtime-files         # list visible plugins/themes and their sources
+red --eject <asset>         # copy a bundled plugin/theme into your config dir
 ```
 
 ### Themes
@@ -140,11 +229,29 @@ Red ships with a collection of VSCode-compatible themes bundled into the binary 
 theme = "your_theme_name.json"  # the theme's filename
 ```
 
-To add your own theme, place a `.json` theme file in `~/.config/red/themes/`. Run `red --runtime-files` to see every theme Red can currently load.
+To add your own theme, place a `.json` theme file in `~/.config/red/themes/`. Run `red --runtime-files` to see every theme Red can currently load, or browse them interactively with `Space t`.
 
 ## Bundled Plugins and Themes
 
 Red's default plugins and themes are embedded in the binary, so a fresh install has everything it needs and upgrades automatically pick up newer bundled versions. Nothing is copied to your config directory unless you ask for it.
+
+The bundled plugins:
+
+| Plugin ID | File | What it does |
+|-----------|------|--------------|
+| `barbecue` | `barbecue.js` | Breadcrumb bar showing your current location in the code |
+| `buffer_picker` | `buffer_picker.js` | Quick switcher for open buffers |
+| `cool_search` | `cool_search.js` | Clears search highlights automatically when you move on |
+| `fidget` | `fidget.js` | LSP progress indicator |
+| `indent_guides` | `indent_guides.js` | Vertical indentation guides |
+| `inlay_hints` | `inlay_hints.js` | Inline LSP type and parameter hints |
+| `lsp_symbols` | `lsp_symbols.ts` | Document and workspace symbol pickers |
+| `neotree` | `neotree.js` | File tree with git status and file icons |
+| `project_search` | `project_search.js` | Project-wide text search powered by ripgrep |
+| `session_restore` | `session_restore.js` | Reopens your files and layout from the last session |
+| `theme_browser` | `theme_browser.js` | Theme picker with live preview |
+
+To turn one off, add its plugin ID to `disabled_plugins` in your config, e.g. `disabled_plugins = ["fidget"]`.
 
 ### Seeing what's available
 
@@ -180,48 +287,24 @@ Packagers and developers working from a source checkout can point `$RED_RUNTIME`
 
 Normal users don't need to set this - the embedded assets cover everyday use.
 
-## Key Bindings
+## Writing Plugins
 
-Red uses Vim-style modal editing. Here are the essential key bindings:
+Plugins are JavaScript or TypeScript files running in a sandboxed Deno runtime. A plugin exports an `activate` function and gets a typed `red` API object:
 
-### Normal Mode
-- `i` - Enter Insert mode
-- `v` - Enter Visual mode
-- `:` - Enter Command mode
-- `h/j/k/l` - Move left/down/up/right
-- `w/b` - Move forward/backward by word
-- `0/$` - Move to beginning/end of line
-- `gg/G` - Go to first/last line
-- `dd` - Delete line
-- `yy` - Copy line
-- `p` - Paste
-- `u` - Undo
-- `Ctrl+r` - Redo
-- `/` - Forward search with live preview and highlighted matches
-- `?` - Backward search with live preview and highlighted matches
-- `n/N` - Repeat search in the same/opposite direction
+```javascript
+export async function activate(red) {
+    red.addCommand("HelloWorld", async () => {
+        const { x, y } = await red.getCursorPosition();
+        red.insertText(x, y, "Hello from a plugin!");
+    });
+}
+```
 
-Search patterns use Rust regex syntax. The bundled `cool_search` plugin clears
-search highlights automatically after you move away from a committed match or
-enter Insert mode. `:noh` or `:nohlsearch` still clears the current search
-highlights manually until the next search.
+Commands registered this way can be bound to keys with `{ PluginCommand = "HelloWorld" }`.
 
-### Insert Mode
-- `Esc` - Return to Normal mode
-- All regular typing works as expected
+The API covers buffer access, cursor control, pickers and dialogs, per-window bars, virtual text decorations, events, LSP queries, timers, persistent storage, and permission-gated process spawning. TypeScript definitions are available in [`types/red.d.ts`](types/red.d.ts) (published as `@red-editor/types`).
 
-### Visual Mode
-- `Esc` - Return to Normal mode
-- `d` - Delete selection
-- `y` - Copy selection
-- `>/<` - Indent/unindent selection
-
-### Command Mode
-- `:w` - Save file
-- `:q` - Quit
-- `:wq` - Save and quit
-- `:e <file>` - Open file
-- `:set <option>` - Set editor option
+See [`docs/PLUGIN_SYSTEM.md`](docs/PLUGIN_SYSTEM.md) for the full plugin development guide, and the [bundled plugins](plugins/) for real-world examples.
 
 ## Development
 
@@ -245,6 +328,12 @@ cargo test
 RUST_LOG=debug cargo run -- test.txt
 ```
 
+When iterating on bundled plugins or themes, point `$RED_RUNTIME` at your checkout to use the working-tree files without rebuilding:
+
+```shell
+RED_RUNTIME=. cargo run -- test.txt
+```
+
 ### Project Structure
 
 ```
@@ -255,9 +344,11 @@ red/
 │   ├── buffer.rs         # Text buffer management
 │   ├── lsp/              # Language Server Protocol implementation
 │   ├── ui/               # Terminal UI components
-│   └── plugins/          # Plugin system
+│   └── plugin/           # Plugin runtime
 ├── plugins/              # Built-in plugins (bundled into the binary)
 ├── themes/               # Default themes (bundled into the binary)
+├── types/                # TypeScript definitions for the plugin API
+├── docs/                 # Plugin system and internals documentation
 └── tests/                # Integration tests
 ```
 
@@ -275,12 +366,10 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 
 ### Debug Mode
 
-Enable debug logging to troubleshoot issues:
+Red logs to `/tmp/red.log` by default. Override `log_file` in your config to change the path:
 
 ```toml
-[debug]
-log_file = "/tmp/red.log"
-log_level = "debug"
+log_file = "~/red.log"
 ```
 
 Then check the log file:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A modern, modal text editor built in Rust with minimal dependencies. Red combine
 - **Plugin System**: Extend functionality with JavaScript plugins running in a sandboxed Deno runtime
 - **Syntax Highlighting**: Tree-sitter based syntax highlighting for accurate code coloring
 - **Theme Support**: VSCode theme compatibility - use your favorite themes
+- **Self-Contained**: Default config, themes, and plugins are bundled into the binary - no setup required
 - **Minimal Dependencies**: Built from scratch with a focus on simplicity and performance
 - **Cross-Platform**: Works on Linux, macOS, and Windows
 
@@ -55,12 +56,7 @@ cd red
 cargo install --path .
 ```
 
-3. Set up configuration:
-```shell
-mkdir -p ~/.config/red
-cp default_config.toml ~/.config/red/config.toml
-cp -R themes ~/.config/red
-```
+That's it. No configuration step is needed - the default config, themes, and plugins are bundled into the binary.
 
 ### Quick Start
 
@@ -70,13 +66,19 @@ Once installed, you can start editing files immediately:
 red <file-to-edit>
 ```
 
+On the first interactive run, Red offers to create a starter config at `~/.config/red/config.toml`. You can decline (or run non-interactively) and Red launches with its embedded defaults - a config file is entirely optional.
+
 ## Configuration
 
-Red uses a TOML configuration file located at `~/.config/red/config.toml`. Here are some key configuration options:
+Red works out of the box with sensible embedded defaults. To customize it, use a TOML configuration file at `~/.config/red/config.toml`.
+
+Your config is layered **on top of** the embedded defaults: you only need to write the settings you want to change, and everything else keeps its default value. The starter config that Red offers to create on first run is a commented template to get you going - it is not the source of truth for defaults, so deleting it (or any setting in it) simply falls back to the built-in behavior.
+
+Here are some key configuration options:
 
 ```toml
-# Theme selection
-theme = "github_dark"
+# Theme selection (theme filename, including the .json extension)
+theme = "mocha.json"
 
 # Editor settings
 [editor]
@@ -132,11 +134,51 @@ log_level = "info"
 
 ### Themes
 
-Red supports VSCode themes. Place `.json` theme files in `~/.config/red/themes/` and reference them in your config:
+Red ships with a collection of VSCode-compatible themes bundled into the binary - they work without any files on disk. Reference a theme in your config:
 
 ```toml
-theme = "your_theme_name"  # without .json extension
+theme = "your_theme_name.json"  # the theme's filename
 ```
+
+To add your own theme, place a `.json` theme file in `~/.config/red/themes/`. Run `red --runtime-files` to see every theme Red can currently load.
+
+## Bundled Plugins and Themes
+
+Red's default plugins and themes are embedded in the binary, so a fresh install has everything it needs and upgrades automatically pick up newer bundled versions. Nothing is copied to your config directory unless you ask for it.
+
+### Seeing what's available
+
+```shell
+red --runtime-files
+```
+
+This lists every plugin and theme Red can see and where each one comes from (your config directory, `$RED_RUNTIME`, or the embedded assets). When the same filename exists in more than one place, the listing shows which source wins.
+
+### Overriding a bundled asset
+
+Files in your config directory take precedence over bundled ones with the same filename. For example, `~/.config/red/plugins/fidget.js` replaces the bundled `fidget.js`.
+
+To start from the bundled version, *eject* a copy into your config directory:
+
+```shell
+red --eject plugins/fidget.js   # copy a bundled plugin for editing
+red --eject themes/mocha.json   # copy a bundled theme for editing
+red --eject fidget.js           # the plugins/ or themes/ prefix is optional
+```
+
+Eject refuses to overwrite an existing file; use `red --eject-force <asset>` to replace your copy with the bundled version.
+
+Keep in mind that an ejected file shadows the bundled one permanently - if a later Red release improves that plugin or theme, your copy still wins. Delete the file from your config directory to go back to the bundled version.
+
+### Advanced: `$RED_RUNTIME`
+
+Packagers and developers working from a source checkout can point `$RED_RUNTIME` at a directory containing `plugins/` and `themes/` subdirectories. Assets are resolved in this order:
+
+1. Your config directory (e.g. `~/.config/red/plugins/foo.js`)
+2. `$RED_RUNTIME/plugins/foo.js` or `$RED_RUNTIME/themes/foo.json`
+3. The assets embedded in the binary
+
+Normal users don't need to set this - the embedded assets cover everyday use.
 
 ## Key Bindings
 
@@ -214,8 +256,8 @@ red/
 │   ├── lsp/              # Language Server Protocol implementation
 │   ├── ui/               # Terminal UI components
 │   └── plugins/          # Plugin system
-├── plugins/              # Built-in plugins
-├── themes/               # Default themes
+├── plugins/              # Built-in plugins (bundled into the binary)
+├── themes/               # Default themes (bundled into the binary)
 └── tests/                # Integration tests
 ```
 
@@ -249,8 +291,9 @@ tail -f /tmp/red.log
 ### Common Issues
 
 - **LSP not working**: Ensure the language server for your file type is installed and in your PATH
-- **Plugins not loading**: Check that the plugin directory exists and plugins have correct permissions
-- **Theme not found**: Verify the theme file exists in `~/.config/red/themes/` and is valid JSON
+- **Plugins not loading**: Run `red --runtime-files` to check that the plugin is visible and which source (config directory, `$RED_RUNTIME`, or embedded) is being used
+- **Theme not found**: Run `red --runtime-files` to confirm the theme name; custom themes in `~/.config/red/themes/` must be valid JSON
+- **A bundled plugin/theme behaves like an old version**: An ejected copy in your config directory shadows the bundled one - delete it or re-eject with `red --eject-force`
 
 ## Reporting Issues
 

--- a/default_config.toml
+++ b/default_config.toml
@@ -36,6 +36,10 @@ sidescrolloff = 0
 # This setting is optional, if not present, red will not log anything.
 log_file = "/tmp/red.log"
 
+# Built-in plugins are enabled through the [plugins] table below. Add plugin
+# names here to disable defaults without copying or editing bundled plugin files.
+disabled_plugins = []
+
 [search]
 # Preview the next match while typing / or ?.
 incsearch = true

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,6 +1,9 @@
 use std::{
-    collections::HashSet,
-    path::{Component, Path},
+    collections::{BTreeMap, BTreeSet, HashSet},
+    env,
+    fmt::{self, Display},
+    fs,
+    path::{Component, Path, PathBuf},
 };
 
 use include_dir::{include_dir, Dir};
@@ -11,18 +14,152 @@ static THEMES: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/themes");
 static PLUGINS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/plugins");
 
 const BUNDLED_PLUGIN_SCHEME: &str = "red-bundled";
+const STARTER_CONFIG_HEADER: &str = "# Red user config.\n# Defaults are built into this version of red.\n# Uncomment settings below to override them.\n# Uncomment the matching table header, such as [keys.normal], with any setting inside it.\n\n";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RuntimeAssetKind {
+    Plugin,
+    Theme,
+}
+
+impl RuntimeAssetKind {
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            Self::Plugin => "plugins",
+            Self::Theme => "themes",
+        }
+    }
+
+    fn embedded_dir(self) -> &'static Dir<'static> {
+        match self {
+            Self::Plugin => &PLUGINS,
+            Self::Theme => &THEMES,
+        }
+    }
+
+    fn accepts_file(self, path: &Path) -> bool {
+        path.is_file()
+            && path
+                .file_name()
+                .is_some_and(|file| self.accepts_file_name(Path::new(file)))
+    }
+
+    fn accepts_file_name(self, path: &Path) -> bool {
+        if path.parent().is_some_and(|parent| parent != Path::new("")) {
+            return false;
+        }
+
+        match self {
+            Self::Plugin => matches!(
+                path.extension().and_then(|ext| ext.to_str()),
+                Some("js" | "ts")
+            ),
+            Self::Theme => path.extension().and_then(|ext| ext.to_str()) == Some("json"),
+        }
+    }
+
+    fn accepts_public_embedded_file_name(self, path: &Path) -> bool {
+        if !self.accepts_file_name(path) {
+            return false;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|file| file.to_str()) else {
+            return false;
+        };
+
+        match self {
+            Self::Plugin => {
+                !matches!(file_name, "test.js" | "unicode_demo.js")
+                    && !file_name.ends_with(".test.js")
+                    && !file_name.ends_with(".test.ts")
+            }
+            Self::Theme => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RuntimeAssetSource {
+    User,
+    Runtime,
+    Embedded,
+}
+
+impl RuntimeAssetSource {
+    fn precedence(self) -> usize {
+        match self {
+            Self::User => 0,
+            Self::Runtime => 1,
+            Self::Embedded => 2,
+        }
+    }
+}
+
+impl Display for RuntimeAssetSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::User => "user",
+            Self::Runtime => "runtime",
+            Self::Embedded => "embedded",
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedRuntimeAsset {
+    pub kind: RuntimeAssetKind,
+    pub file: String,
+    pub source: RuntimeAssetSource,
+    path: Option<PathBuf>,
+    embedded_contents: Option<&'static str>,
+}
+
+impl ResolvedRuntimeAsset {
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    pub fn read_to_string(&self) -> anyhow::Result<String> {
+        if let Some(contents) = self.embedded_contents {
+            return Ok(contents.to_string());
+        }
+
+        let path = self
+            .path
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("runtime asset has no readable source"))?;
+        Ok(fs::read_to_string(path)?)
+    }
+
+    pub fn plugin_specifier(&self) -> anyhow::Result<String> {
+        anyhow::ensure!(
+            self.kind == RuntimeAssetKind::Plugin,
+            "runtime asset is not a plugin: {}",
+            self.file
+        );
+
+        if let Some(path) = &self.path {
+            return Ok(path.to_string_lossy().into_owned());
+        }
+
+        bundled_plugin_specifier(&self.file)
+            .ok_or_else(|| anyhow::anyhow!("bundled plugin `{}` was not found", self.file))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeAssetListEntry {
+    pub kind: RuntimeAssetKind,
+    pub file: String,
+    pub source: RuntimeAssetSource,
+    pub shadows: Vec<RuntimeAssetSource>,
+}
 
 pub fn starter_config() -> String {
-    let mut out = String::new();
-    out.push_str("# Red user config.\n");
-    out.push_str("# Defaults are built into this version of red.\n");
-    out.push_str("# Uncomment settings below to override them.\n\n");
+    let mut out = String::from(STARTER_CONFIG_HEADER);
 
     for line in DEFAULT_CONFIG.lines() {
         if line.trim().is_empty() {
-            out.push('\n');
-        } else if line.trim_start().starts_with('#') {
-            out.push_str(line);
             out.push('\n');
         } else {
             out.push_str("# ");
@@ -34,26 +171,39 @@ pub fn starter_config() -> String {
     out
 }
 
+pub fn resolve_theme(name: &str, config_dir: &Path) -> Option<ResolvedRuntimeAsset> {
+    resolve_runtime_asset(RuntimeAssetKind::Theme, name, config_dir)
+}
+
+pub fn resolve_plugin(name: &str, config_dir: &Path) -> Option<ResolvedRuntimeAsset> {
+    resolve_runtime_asset(RuntimeAssetKind::Plugin, name, config_dir)
+}
+
+pub fn resolve_runtime_asset(
+    kind: RuntimeAssetKind,
+    name: &str,
+    config_dir: &Path,
+) -> Option<ResolvedRuntimeAsset> {
+    resolve_runtime_asset_with_user(kind, name, config_dir, true)
+}
+
+pub fn resolve_non_user_runtime_asset(
+    kind: RuntimeAssetKind,
+    name: &str,
+    config_dir: &Path,
+) -> Option<ResolvedRuntimeAsset> {
+    resolve_runtime_asset_with_user(kind, name, config_dir, false)
+}
+
 pub fn bundled_theme(name: &str) -> Option<&'static str> {
-    safe_relative_path(name)
-        .and_then(|path| THEMES.get_file(path))
-        .and_then(|file| file.contents_utf8())
+    embedded_contents(RuntimeAssetKind::Theme, name)
 }
 
 pub fn bundled_theme_files() -> Vec<(&'static str, &'static str)> {
-    THEMES
-        .files()
+    embedded_files(RuntimeAssetKind::Theme)
+        .into_iter()
         .filter_map(|file| {
-            let path = file.path();
-            if path.parent().is_some_and(|parent| parent != Path::new(""))
-                || path.extension().and_then(|ext| ext.to_str()) != Some("json")
-            {
-                return None;
-            }
-
-            let name = path.file_name()?.to_str()?;
-            let contents = file.contents_utf8()?;
-            Some((name, contents))
+            embedded_contents(RuntimeAssetKind::Theme, file).map(|contents| (file, contents))
         })
         .collect()
 }
@@ -62,18 +212,138 @@ pub fn bundled_plugin_specifier(name: &str) -> Option<String> {
     let path = safe_relative_path(name)?;
     PLUGINS
         .get_file(path)
-        .map(|_| format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/{name}"))
+        .map(|_| format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/{path}"))
 }
 
 pub fn bundled_plugin_contents(specifier: &str) -> Option<&'static str> {
     let path = specifier.strip_prefix(&format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/"))?;
-    safe_relative_path(path)
-        .and_then(|path| PLUGINS.get_file(path))
-        .and_then(|file| file.contents_utf8())
+    embedded_contents(RuntimeAssetKind::Plugin, path)
 }
 
 pub fn is_bundled_plugin_specifier(specifier: &str) -> bool {
     specifier.starts_with(&format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/"))
+}
+
+pub fn list_runtime_assets(
+    kind: RuntimeAssetKind,
+    config_dir: &Path,
+) -> anyhow::Result<Vec<RuntimeAssetListEntry>> {
+    let mut by_file: BTreeMap<String, BTreeSet<RuntimeAssetSource>> = BTreeMap::new();
+
+    for file in list_files_in_dir(&config_dir.join(kind.dir_name()), kind)? {
+        by_file
+            .entry(file)
+            .or_default()
+            .insert(RuntimeAssetSource::User);
+    }
+
+    if let Some(runtime_dir) = runtime_dir() {
+        for file in list_files_in_dir(&runtime_dir.join(kind.dir_name()), kind)? {
+            by_file
+                .entry(file)
+                .or_default()
+                .insert(RuntimeAssetSource::Runtime);
+        }
+    }
+
+    for file in embedded_files(kind) {
+        by_file
+            .entry(file.to_string())
+            .or_default()
+            .insert(RuntimeAssetSource::Embedded);
+    }
+
+    let mut entries = Vec::new();
+    for (file, sources) in by_file {
+        let source = sources
+            .iter()
+            .copied()
+            .min_by_key(|source| source.precedence())
+            .expect("source set should not be empty");
+        let shadows = sources
+            .iter()
+            .copied()
+            .filter(|candidate| candidate.precedence() > source.precedence())
+            .collect();
+        entries.push(RuntimeAssetListEntry {
+            kind,
+            file,
+            source,
+            shadows,
+        });
+    }
+
+    Ok(entries)
+}
+
+pub fn format_runtime_files(config_dir: &Path) -> anyhow::Result<String> {
+    let mut out = String::new();
+
+    for (heading, kind) in [
+        ("Runtime plugins", RuntimeAssetKind::Plugin),
+        ("Runtime themes", RuntimeAssetKind::Theme),
+    ] {
+        out.push_str(heading);
+        out.push_str(":\n");
+
+        let entries = list_runtime_assets(kind, config_dir)?;
+        if entries.is_empty() {
+            out.push_str("  (none)\n");
+        }
+
+        for entry in entries {
+            out.push_str("  ");
+            out.push_str(&entry.file);
+            out.push_str("  ");
+            out.push_str(&entry.source.to_string());
+            if !entry.shadows.is_empty() {
+                out.push_str(" (shadows ");
+                out.push_str(
+                    &entry
+                        .shadows
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+                out.push(')');
+            }
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+
+    out.push_str("Resolution order: user config, $RED_RUNTIME, embedded.\n");
+    out.push_str(
+        "Use `red --eject plugins/<file>` or `red --eject themes/<file>` to copy an asset into your config directory.\n",
+    );
+    Ok(out)
+}
+
+pub fn eject_runtime_asset(asset: &str, config_dir: &Path, force: bool) -> anyhow::Result<PathBuf> {
+    let (kind, file) = parse_asset_path(asset)?;
+    let target = config_dir.join(kind.dir_name()).join(&file);
+    if target.exists() && !force {
+        anyhow::bail!(
+            "{} already exists; use --eject-force to overwrite it",
+            target.display()
+        );
+    }
+
+    let source = resolve_non_user_runtime_asset(kind, &file, config_dir).ok_or_else(|| {
+        anyhow::anyhow!(
+            "runtime asset `{}/{}` was not found in $RED_RUNTIME or embedded assets",
+            kind.dir_name(),
+            file
+        )
+    })?;
+    let contents = source.read_to_string()?;
+
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&target, contents)?;
+    Ok(target)
 }
 
 pub fn dedupe_theme_entries(
@@ -96,6 +366,142 @@ pub fn dedupe_theme_entries(
     }
 
     entries
+}
+
+fn resolve_runtime_asset_with_user(
+    kind: RuntimeAssetKind,
+    name: &str,
+    config_dir: &Path,
+    include_user: bool,
+) -> Option<ResolvedRuntimeAsset> {
+    let name = safe_relative_path(name)?.to_string();
+
+    if include_user {
+        let user_path = config_dir.join(kind.dir_name()).join(&name);
+        if user_path.is_file() {
+            return Some(ResolvedRuntimeAsset {
+                kind,
+                file: name,
+                source: RuntimeAssetSource::User,
+                path: Some(user_path),
+                embedded_contents: None,
+            });
+        }
+    }
+
+    if let Some(runtime_dir) = runtime_dir() {
+        let runtime_path = runtime_dir.join(kind.dir_name()).join(&name);
+        if runtime_path.is_file() {
+            return Some(ResolvedRuntimeAsset {
+                kind,
+                file: name,
+                source: RuntimeAssetSource::Runtime,
+                path: Some(runtime_path),
+                embedded_contents: None,
+            });
+        }
+    }
+
+    embedded_contents(kind, &name).map(|contents| ResolvedRuntimeAsset {
+        kind,
+        file: name,
+        source: RuntimeAssetSource::Embedded,
+        path: None,
+        embedded_contents: Some(contents),
+    })
+}
+
+fn parse_asset_path(asset: &str) -> anyhow::Result<(RuntimeAssetKind, String)> {
+    if let Some((dir, file)) = asset.split_once('/') {
+        anyhow::ensure!(
+            safe_relative_path(file).is_some(),
+            "invalid runtime asset path: {asset}"
+        );
+        anyhow::ensure!(
+            !file.contains('/'),
+            "runtime asset must be directly inside `plugins/` or `themes/`: {asset}"
+        );
+
+        let kind = match dir {
+            "plugins" => RuntimeAssetKind::Plugin,
+            "themes" => RuntimeAssetKind::Theme,
+            _ => anyhow::bail!("asset must start with `plugins/` or `themes/`: {asset}"),
+        };
+
+        let path = Path::new(file);
+        anyhow::ensure!(
+            kind.accepts_file_name(path),
+            "unsupported runtime asset file: {asset}"
+        );
+        return Ok((kind, file.to_string()));
+    }
+
+    anyhow::ensure!(
+        safe_relative_path(asset).is_some(),
+        "invalid runtime asset path: {asset}"
+    );
+
+    let path = Path::new(asset);
+    if RuntimeAssetKind::Plugin.accepts_file_name(path) {
+        return Ok((RuntimeAssetKind::Plugin, asset.to_string()));
+    }
+    if RuntimeAssetKind::Theme.accepts_file_name(path) {
+        return Ok((RuntimeAssetKind::Theme, asset.to_string()));
+    }
+
+    anyhow::bail!(
+        "asset must look like `plugins/name.js`, `themes/name.json`, or a bare plugin/theme file name"
+    )
+}
+
+fn runtime_dir() -> Option<PathBuf> {
+    env::var_os("RED_RUNTIME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn list_files_in_dir(dir: &Path, kind: RuntimeAssetKind) -> anyhow::Result<Vec<String>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !kind.accepts_file(&path) {
+            continue;
+        }
+        if let Some(file) = path.file_name().and_then(|file| file.to_str()) {
+            files.push(file.to_string());
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn embedded_files(kind: RuntimeAssetKind) -> Vec<&'static str> {
+    let mut files = kind
+        .embedded_dir()
+        .files()
+        .filter_map(|file| {
+            let path = file.path();
+            if path.parent().is_some_and(|parent| parent != Path::new(""))
+                || !kind.accepts_public_embedded_file_name(path)
+            {
+                return None;
+            }
+            path.file_name()?.to_str()
+        })
+        .collect::<Vec<_>>();
+    files.sort();
+    files
+}
+
+fn embedded_contents(kind: RuntimeAssetKind, name: &str) -> Option<&'static str> {
+    safe_relative_path(name)
+        .and_then(|path| kind.embedded_dir().get_file(path))
+        .and_then(|file| file.contents_utf8())
 }
 
 fn theme_name_from_json(contents: &str) -> Option<String> {
@@ -130,9 +536,54 @@ fn safe_relative_path(path: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Mutex, MutexGuard};
+
     use crate::config::Config;
 
     use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("red-assets-{name}-{}", uuid::Uuid::new_v4()))
+    }
+
+    struct RedRuntimeGuard<'a> {
+        _guard: MutexGuard<'a, ()>,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl RedRuntimeGuard<'_> {
+        fn set(path: &Path) -> Self {
+            let guard = ENV_LOCK.lock().unwrap();
+            let previous = env::var_os("RED_RUNTIME");
+            env::set_var("RED_RUNTIME", path);
+            Self {
+                _guard: guard,
+                previous,
+            }
+        }
+
+        fn unset() -> Self {
+            let guard = ENV_LOCK.lock().unwrap();
+            let previous = env::var_os("RED_RUNTIME");
+            env::remove_var("RED_RUNTIME");
+            Self {
+                _guard: guard,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for RedRuntimeGuard<'_> {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                env::set_var("RED_RUNTIME", previous);
+            } else {
+                env::remove_var("RED_RUNTIME");
+            }
+        }
+    }
 
     #[test]
     fn starter_config_is_loadable_as_user_overrides() {
@@ -141,6 +592,27 @@ mod tests {
         assert_eq!(config.theme, "mocha.json");
         assert!(config.plugins.contains_key("theme_browser"));
         assert!(config.keys.normal.contains_key("Ctrl-t"));
+    }
+
+    #[test]
+    fn starter_config_uncomments_to_default_config() {
+        let starter = starter_config();
+        let body = starter
+            .strip_prefix(STARTER_CONFIG_HEADER)
+            .expect("starter should begin with its header");
+        let mut uncommented = String::new();
+        for line in body.split_inclusive('\n') {
+            if line == "\n" {
+                uncommented.push('\n');
+            } else {
+                uncommented.push_str(
+                    line.strip_prefix("# ")
+                        .expect("non-blank starter lines should be commented"),
+                );
+            }
+        }
+
+        assert_eq!(uncommented, DEFAULT_CONFIG);
     }
 
     #[test]
@@ -156,5 +628,136 @@ mod tests {
     fn bundled_asset_lookup_rejects_parent_paths() {
         assert!(bundled_theme("../default_config.toml").is_none());
         assert!(bundled_plugin_specifier("../plugins/theme_browser.js").is_none());
+    }
+
+    #[test]
+    fn resolver_prefers_user_then_runtime_then_embedded() {
+        let config_dir = unique_temp_dir("resolver-config");
+        let runtime_dir = unique_temp_dir("resolver-runtime");
+        fs::create_dir_all(config_dir.join("themes")).unwrap();
+        fs::create_dir_all(runtime_dir.join("themes")).unwrap();
+        fs::write(
+            runtime_dir.join("themes/mocha.json"),
+            r#"{ "runtime": true }"#,
+        )
+        .unwrap();
+        let _runtime = RedRuntimeGuard::set(&runtime_dir);
+
+        let runtime_asset = resolve_theme("mocha.json", &config_dir).unwrap();
+        assert_eq!(runtime_asset.source, RuntimeAssetSource::Runtime);
+
+        fs::write(config_dir.join("themes/mocha.json"), r#"{ "user": true }"#).unwrap();
+        let user_asset = resolve_theme("mocha.json", &config_dir).unwrap();
+        assert_eq!(user_asset.source, RuntimeAssetSource::User);
+
+        fs::remove_dir_all(config_dir).ok();
+        fs::remove_dir_all(runtime_dir).ok();
+    }
+
+    #[test]
+    fn resolver_uses_embedded_when_user_and_runtime_are_missing() {
+        let _runtime = RedRuntimeGuard::unset();
+        let config_dir = unique_temp_dir("resolver-embedded");
+
+        let asset = resolve_theme("mocha.json", &config_dir).unwrap();
+
+        assert_eq!(asset.source, RuntimeAssetSource::Embedded);
+        fs::remove_dir_all(config_dir).ok();
+    }
+
+    #[test]
+    fn runtime_files_marks_shadowed_sources() {
+        let config_dir = unique_temp_dir("runtime-files-config");
+        let runtime_dir = unique_temp_dir("runtime-files-runtime");
+        fs::create_dir_all(config_dir.join("plugins")).unwrap();
+        fs::create_dir_all(runtime_dir.join("plugins")).unwrap();
+        fs::write(config_dir.join("plugins/theme_browser.js"), "export {};").unwrap();
+        fs::write(runtime_dir.join("plugins/theme_browser.js"), "export {};").unwrap();
+        let _runtime = RedRuntimeGuard::set(&runtime_dir);
+
+        let files = format_runtime_files(&config_dir).unwrap();
+
+        assert!(files.contains("Runtime plugins:"));
+        assert!(files.contains("Runtime themes:"));
+        assert!(files.contains("Resolution order: user config, $RED_RUNTIME, embedded."));
+        let line = files
+            .lines()
+            .find(|line| line.contains("theme_browser.js") && line.contains("user"))
+            .unwrap_or_else(|| panic!("missing shadowed theme_browser.js entry: {files}"));
+        assert!(
+            line.contains("runtime"),
+            "expected runtime shadow in {line}"
+        );
+        assert!(
+            line.contains("embedded"),
+            "expected embedded shadow in {line}"
+        );
+        fs::remove_dir_all(config_dir).ok();
+        fs::remove_dir_all(runtime_dir).ok();
+    }
+
+    #[test]
+    fn runtime_files_hides_bundled_dev_plugin_files() {
+        let _runtime = RedRuntimeGuard::unset();
+        let config_dir = unique_temp_dir("runtime-files-public-list");
+
+        let files = format_runtime_files(&config_dir).unwrap();
+
+        assert!(files.contains("theme_browser.js"));
+        assert!(!files.contains("barbecue.test.js"));
+        assert!(!files.contains("test.js"));
+        assert!(!files.contains("unicode_demo.js"));
+        fs::remove_dir_all(config_dir).ok();
+    }
+
+    #[test]
+    fn eject_copies_non_user_asset_and_refuses_overwrite() {
+        let _runtime = RedRuntimeGuard::unset();
+        let config_dir = unique_temp_dir("eject");
+
+        let target = eject_runtime_asset("plugins/theme_browser.js", &config_dir, false).unwrap();
+        assert_eq!(target, config_dir.join("plugins/theme_browser.js"));
+        assert!(target.exists());
+        assert!(eject_runtime_asset("plugins/theme_browser.js", &config_dir, false).is_err());
+        eject_runtime_asset("plugins/theme_browser.js", &config_dir, true).unwrap();
+
+        fs::remove_dir_all(config_dir).ok();
+    }
+
+    #[test]
+    fn eject_accepts_bare_plugin_and_theme_names() {
+        let _runtime = RedRuntimeGuard::unset();
+        let config_dir = unique_temp_dir("eject-bare");
+
+        let plugin = eject_runtime_asset("theme_browser.js", &config_dir, false).unwrap();
+        let theme = eject_runtime_asset("mocha.json", &config_dir, false).unwrap();
+
+        assert_eq!(plugin, config_dir.join("plugins/theme_browser.js"));
+        assert_eq!(theme, config_dir.join("themes/mocha.json"));
+        assert!(plugin.exists());
+        assert!(theme.exists());
+        fs::remove_dir_all(config_dir).ok();
+    }
+
+    #[test]
+    fn eject_uses_runtime_before_embedded() {
+        let config_dir = unique_temp_dir("eject-config");
+        let runtime_dir = unique_temp_dir("eject-runtime");
+        fs::create_dir_all(runtime_dir.join("plugins")).unwrap();
+        fs::write(
+            runtime_dir.join("plugins/theme_browser.js"),
+            "export const runtime = true;",
+        )
+        .unwrap();
+        let _runtime = RedRuntimeGuard::set(&runtime_dir);
+
+        let target = eject_runtime_asset("plugins/theme_browser.js", &config_dir, false).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(target).unwrap(),
+            "export const runtime = true;"
+        );
+        fs::remove_dir_all(config_dir).ok();
+        fs::remove_dir_all(runtime_dir).ok();
     }
 }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,0 +1,160 @@
+use std::{
+    collections::HashSet,
+    path::{Component, Path},
+};
+
+use include_dir::{include_dir, Dir};
+
+pub const DEFAULT_CONFIG: &str = include_str!("../default_config.toml");
+
+static THEMES: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/themes");
+static PLUGINS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/plugins");
+
+const BUNDLED_PLUGIN_SCHEME: &str = "red-bundled";
+
+pub fn starter_config() -> String {
+    let mut out = String::new();
+    out.push_str("# Red user config.\n");
+    out.push_str("# Defaults are built into this version of red.\n");
+    out.push_str("# Uncomment settings below to override them.\n\n");
+
+    for line in DEFAULT_CONFIG.lines() {
+        if line.trim().is_empty() {
+            out.push('\n');
+        } else if line.trim_start().starts_with('#') {
+            out.push_str(line);
+            out.push('\n');
+        } else {
+            out.push_str("# ");
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+pub fn bundled_theme(name: &str) -> Option<&'static str> {
+    safe_relative_path(name)
+        .and_then(|path| THEMES.get_file(path))
+        .and_then(|file| file.contents_utf8())
+}
+
+pub fn bundled_theme_files() -> Vec<(&'static str, &'static str)> {
+    THEMES
+        .files()
+        .filter_map(|file| {
+            let path = file.path();
+            if path.parent().is_some_and(|parent| parent != Path::new(""))
+                || path.extension().and_then(|ext| ext.to_str()) != Some("json")
+            {
+                return None;
+            }
+
+            let name = path.file_name()?.to_str()?;
+            let contents = file.contents_utf8()?;
+            Some((name, contents))
+        })
+        .collect()
+}
+
+pub fn bundled_plugin_specifier(name: &str) -> Option<String> {
+    let path = safe_relative_path(name)?;
+    PLUGINS
+        .get_file(path)
+        .map(|_| format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/{name}"))
+}
+
+pub fn bundled_plugin_contents(specifier: &str) -> Option<&'static str> {
+    let path = specifier.strip_prefix(&format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/"))?;
+    safe_relative_path(path)
+        .and_then(|path| PLUGINS.get_file(path))
+        .and_then(|file| file.contents_utf8())
+}
+
+pub fn is_bundled_plugin_specifier(specifier: &str) -> bool {
+    specifier.starts_with(&format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/"))
+}
+
+pub fn dedupe_theme_entries(
+    user_entries: impl IntoIterator<Item = (String, String)>,
+) -> Vec<(String, String)> {
+    let mut seen = HashSet::new();
+    let mut entries = Vec::new();
+
+    for (name, file) in user_entries {
+        seen.insert(file.clone());
+        entries.push((name, file));
+    }
+
+    for (file, contents) in bundled_theme_files() {
+        if seen.contains(file) {
+            continue;
+        }
+        let name = theme_name_from_json(contents).unwrap_or_else(|| file.to_string());
+        entries.push((name, file.to_string()));
+    }
+
+    entries
+}
+
+fn theme_name_from_json(contents: &str) -> Option<String> {
+    let metadata: serde_json::Value =
+        serde_json::from_reader(json_comments::StripComments::new(contents.as_bytes())).ok()?;
+    metadata
+        .get("name")
+        .and_then(|name| name.as_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+fn safe_relative_path(path: &str) -> Option<&str> {
+    let path = path.trim_start_matches('/');
+    if path.is_empty() {
+        return None;
+    }
+
+    let path_ref = Path::new(path);
+    if path_ref.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return None;
+    }
+
+    Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::Config;
+
+    use super::*;
+
+    #[test]
+    fn starter_config_is_loadable_as_user_overrides() {
+        let config = Config::from_user_toml_with_overrides(&starter_config(), &[]).unwrap();
+
+        assert_eq!(config.theme, "mocha.json");
+        assert!(config.plugins.contains_key("theme_browser"));
+        assert!(config.keys.normal.contains_key("Ctrl-t"));
+    }
+
+    #[test]
+    fn bundled_assets_include_default_theme_and_plugins() {
+        assert!(bundled_theme("mocha.json").is_some());
+        assert!(bundled_plugin_specifier("theme_browser.js")
+            .as_deref()
+            .is_some_and(|specifier| specifier == "red-bundled:///plugins/theme_browser.js"));
+        assert!(bundled_plugin_contents("red-bundled:///plugins/theme_browser.js").is_some());
+    }
+
+    #[test]
+    fn bundled_asset_lookup_rejects_parent_paths() {
+        assert!(bundled_theme("../default_config.toml").is_none());
+        assert!(bundled_plugin_specifier("../plugins/theme_browser.js").is_none());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,8 +10,35 @@ pub struct Args {
     #[clap(short = 'c', long = "config-override", value_name = "TOML")]
     pub config_overrides: Vec<String>,
 
+    /// List runtime files from user config, $RED_RUNTIME, and embedded assets.
+    #[clap(long = "runtime-files")]
+    pub runtime_files: bool,
+
+    /// Copy a bundled/runtime asset into the user config directory for editing.
+    /// Accepts `plugins/name.js`, `themes/name.json`, or a bare plugin/theme file name.
+    #[clap(long = "eject", value_name = "ASSET", conflicts_with = "eject_force")]
+    pub eject: Option<String>,
+
+    /// Copy a bundled/runtime asset into the user config directory, overwriting an existing user file.
+    /// Accepts `plugins/name.js`, `themes/name.json`, or a bare plugin/theme file name.
+    #[clap(long = "eject-force", value_name = "ASSET")]
+    pub eject_force: Option<String>,
+
     /// Files to edit
     pub files: Vec<String>,
+}
+
+impl Args {
+    pub fn utility_requested(&self) -> bool {
+        self.runtime_files || self.eject.is_some() || self.eject_force.is_some()
+    }
+
+    pub fn validate_utility_args(&self) -> anyhow::Result<()> {
+        if self.utility_requested() && !self.files.is_empty() {
+            anyhow::bail!("runtime utility flags cannot be used with files to edit");
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -32,5 +59,24 @@ mod tests {
 
         assert_eq!(args.config_overrides.len(), 2);
         assert_eq!(args.files, vec!["src/editor.rs"]);
+    }
+
+    #[test]
+    fn parses_runtime_utility_flags() {
+        let args = Args::try_parse_from(["red", "--runtime-files"]).unwrap();
+        assert!(args.runtime_files);
+        assert!(args.utility_requested());
+
+        let args = Args::try_parse_from(["red", "--eject", "plugins/fidget.js"]).unwrap();
+        assert_eq!(args.eject.as_deref(), Some("plugins/fidget.js"));
+
+        let args = Args::try_parse_from(["red", "--eject-force", "themes/mocha.json"]).unwrap();
+        assert_eq!(args.eject_force.as_deref(), Some("themes/mocha.json"));
+    }
+
+    #[test]
+    fn utility_flags_reject_files_to_edit() {
+        let args = Args::try_parse_from(["red", "--runtime-files", "src/main.rs"]).unwrap();
+        assert!(args.validate_utility_args().is_err());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, fs, path::PathBuf};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Value};
 
+use crate::assets;
 use crate::editor::Action;
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -13,6 +14,8 @@ pub struct Config {
     pub cursor: CursorConfig,
     #[serde(default)]
     pub plugins: HashMap<String, String>,
+    #[serde(default)]
+    pub disabled_plugins: Vec<String>,
     #[serde(default)]
     pub plugin_permissions: HashMap<String, PluginPermissions>,
     #[serde(default)]
@@ -423,13 +426,26 @@ pub fn rust_analyzer_initialization_options() -> Value {
 }
 
 impl Config {
+    pub fn config_dir() -> PathBuf {
+        if let Some(config_home) =
+            std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty())
+        {
+            return PathBuf::from(config_home).join("red");
+        }
+
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .or_else(|| {
+                #[allow(deprecated)]
+                std::env::home_dir()
+            })
+            .expect("home directory must be available to locate red config");
+
+        home.join(".config").join("red")
+    }
+
     pub fn path(p: &str) -> PathBuf {
-        #[allow(deprecated)]
-        std::env::home_dir()
-            .unwrap()
-            .join(".config")
-            .join("red")
-            .join(p)
+        Self::config_dir().join(p)
     }
 
     pub fn from_toml_with_overrides(contents: &str, overrides: &[String]) -> anyhow::Result<Self> {
@@ -443,19 +459,75 @@ impl Config {
             merge_toml_values(&mut value, override_value);
         }
 
-        value
+        let mut config: Self = value
             .try_into()
-            .map_err(|err| anyhow::anyhow!("failed to deserialize merged config: {err}"))
+            .map_err(|err| anyhow::anyhow!("failed to deserialize merged config: {err}"))?;
+        config.apply_disabled_plugins();
+        Ok(config)
+    }
+
+    pub fn from_user_toml_with_overrides(
+        contents: &str,
+        overrides: &[String],
+    ) -> anyhow::Result<Self> {
+        let mut value: toml::Value = toml::from_str(assets::DEFAULT_CONFIG)
+            .map_err(|err| anyhow::anyhow!("failed to parse bundled default_config.toml: {err}"))?;
+
+        if !contents.trim().is_empty() {
+            let user_value: toml::Value = toml::from_str(contents)
+                .map_err(|err| anyhow::anyhow!("failed to parse config.toml: {err}"))?;
+            merge_toml_values(&mut value, user_value);
+        }
+
+        for (index, override_toml) in overrides.iter().enumerate() {
+            let override_value: toml::Value = toml::from_str(override_toml).map_err(|err| {
+                anyhow::anyhow!("failed to parse config override #{}: {err}", index + 1)
+            })?;
+            merge_toml_values(&mut value, override_value);
+        }
+
+        let mut config: Self = value
+            .try_into()
+            .map_err(|err| anyhow::anyhow!("failed to deserialize merged config: {err}"))?;
+        config.apply_disabled_plugins();
+        Ok(config)
     }
 
     pub fn persist_theme(theme_name: &str) -> anyhow::Result<()> {
         let config_path = Self::path("config.toml");
-        let contents = fs::read_to_string(&config_path)?;
+        let contents = fs::read_to_string(&config_path).unwrap_or_default();
         fs::write(
             config_path,
             update_theme_config_contents(&contents, theme_name)?,
         )?;
         Ok(())
+    }
+
+    pub fn resolve_plugin_path(configured_path: &str) -> String {
+        let configured = PathBuf::from(configured_path);
+        let user_path = if configured.is_absolute() {
+            configured
+        } else {
+            Self::path("plugins").join(configured_path)
+        };
+
+        if user_path.is_file() {
+            return user_path.to_string_lossy().into_owned();
+        }
+
+        if !PathBuf::from(configured_path).is_absolute() {
+            if let Some(specifier) = assets::bundled_plugin_specifier(configured_path) {
+                return specifier;
+            }
+        }
+
+        user_path.to_string_lossy().into_owned()
+    }
+
+    fn apply_disabled_plugins(&mut self) {
+        for plugin in &self.disabled_plugins {
+            self.plugins.remove(plugin);
+        }
     }
 }
 
@@ -725,6 +797,35 @@ theme = "mocha.json"
         .unwrap_err();
 
         assert!(err.to_string().contains("config override #2"));
+    }
+
+    #[test]
+    fn user_config_is_layered_over_bundled_defaults() {
+        let config = Config::from_user_toml_with_overrides(
+            r#"
+theme = "latte.json"
+disabled_plugins = ["fidget"]
+
+[keys.normal]
+"Ctrl-x" = "FilePicker"
+"#,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(config.theme, "latte.json");
+        assert_eq!(
+            config.keys.normal.get("Ctrl-t"),
+            Some(&KeyAction::Single(Action::PluginCommand(
+                "LspDocumentSymbols".to_string()
+            )))
+        );
+        assert_eq!(
+            config.keys.normal.get("Ctrl-x"),
+            Some(&KeyAction::Single(Action::FilePicker))
+        );
+        assert!(!config.plugins.contains_key("fidget"));
+        assert!(config.plugins.contains_key("theme_browser"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -505,23 +505,23 @@ impl Config {
 
     pub fn resolve_plugin_path(configured_path: &str) -> String {
         let configured = PathBuf::from(configured_path);
-        let user_path = if configured.is_absolute() {
-            configured
-        } else {
-            Self::path("plugins").join(configured_path)
-        };
-
-        if user_path.is_file() {
-            return user_path.to_string_lossy().into_owned();
+        if configured.is_absolute() {
+            return configured.to_string_lossy().into_owned();
         }
 
-        if !PathBuf::from(configured_path).is_absolute() {
-            if let Some(specifier) = assets::bundled_plugin_specifier(configured_path) {
-                return specifier;
-            }
+        if let Some(asset) = assets::resolve_plugin(configured_path, &Self::config_dir()) {
+            return asset.plugin_specifier().unwrap_or_else(|_| {
+                Self::path("plugins")
+                    .join(configured_path)
+                    .to_string_lossy()
+                    .into_owned()
+            });
         }
 
-        user_path.to_string_lossy().into_owned()
+        Self::path("plugins")
+            .join(configured_path)
+            .to_string_lossy()
+            .into_owned()
     }
 
     fn apply_disabled_plugins(&mut self) {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -65,7 +65,7 @@ use crate::{
     matchit::{self, MatchDirection, MatchMotion},
     plugin::{self, PluginRegistry, Runtime},
     preferences::PreferencesStore,
-    theme::{parse_vscode_theme, Style, Theme},
+    theme::{parse_vscode_theme, parse_vscode_theme_contents, Style, Theme},
     ui::{
         CompletionUI, Component, FilePicker, Info, Picker, PickerItem, PickerOptions,
         PickerPreview, PickerUpdate,
@@ -3045,9 +3045,8 @@ impl Editor {
 
         let mut runtime = Runtime::new_with_permissions(self.config.plugin_permissions.clone());
         for (name, path) in &self.config.plugins {
-            let path = Config::path("plugins").join(path);
-            self.plugin_registry
-                .add(name, path.to_string_lossy().as_ref());
+            let path = Config::resolve_plugin_path(path);
+            self.plugin_registry.add(name, path.as_str());
         }
         self.plugin_registry.initialize(&mut runtime).await?;
         self.plugin_registry
@@ -8605,11 +8604,13 @@ impl Editor {
 
     fn apply_theme(&mut self, theme_name: &str, update_config: bool) -> anyhow::Result<()> {
         let theme_path = Config::path("themes").join(theme_name);
-        if !theme_path.exists() {
+        let theme = if theme_path.exists() {
+            parse_vscode_theme(&theme_path.to_string_lossy())?
+        } else if let Some(contents) = crate::assets::bundled_theme(theme_name) {
+            parse_vscode_theme_contents(contents)?
+        } else {
             anyhow::bail!("Theme file {} not found", theme_name);
-        }
-
-        let theme = parse_vscode_theme(&theme_path.to_string_lossy())?;
+        };
         let highlighter = Highlighter::new(&theme)?;
         self.theme = theme;
         self.highlighter = highlighter;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3939,9 +3939,8 @@ impl Editor {
         runtime: &mut Runtime,
         render_mode: EventRenderMode,
     ) -> anyhow::Result<ProcessedEvent> {
-        let _span = perf::enabled().then(|| {
-            perf::PerfSpan::with_detail("event", format!("{:?} {render_mode:?}", ev))
-        });
+        let _span = perf::enabled()
+            .then(|| perf::PerfSpan::with_detail("event", format!("{:?} {render_mode:?}", ev)));
         self.check_bounds();
 
         if let event::Event::Resize(width, height) = ev {
@@ -8603,13 +8602,14 @@ impl Editor {
     }
 
     fn apply_theme(&mut self, theme_name: &str, update_config: bool) -> anyhow::Result<()> {
-        let theme_path = Config::path("themes").join(theme_name);
-        let theme = if theme_path.exists() {
-            parse_vscode_theme(&theme_path.to_string_lossy())?
-        } else if let Some(contents) = crate::assets::bundled_theme(theme_name) {
-            parse_vscode_theme_contents(contents)?
-        } else {
+        let Some(theme_asset) = crate::assets::resolve_theme(theme_name, &Config::config_dir())
+        else {
             anyhow::bail!("Theme file {} not found", theme_name);
+        };
+        let theme = if let Some(path) = theme_asset.path() {
+            parse_vscode_theme(&path.to_string_lossy())?
+        } else {
+            parse_vscode_theme_contents(&theme_asset.read_to_string()?)?
         };
         let highlighter = Highlighter::new(&theme)?;
         self.theme = theme;
@@ -10825,7 +10825,9 @@ mod test {
         // must match what a cold parse at the same viewport produces.
         let (vtop, height) = (30, 20);
         let mut scrolled = rust_test_editor(200, 120, height + 2);
-        scrolled.viewport_highlight_spans(0, vtop - 5, height).unwrap();
+        scrolled
+            .viewport_highlight_spans(0, vtop - 5, height)
+            .unwrap();
         let sliced = scrolled.viewport_highlight_spans(0, vtop, height).unwrap();
 
         let mut fresh = rust_test_editor(200, 120, height + 2);
@@ -10849,15 +10851,22 @@ mod test {
     #[test]
     fn viewport_highlight_handles_view_past_end_of_buffer() {
         let mut editor = rust_test_editor(5, 120, 22);
-        assert!(editor.viewport_highlight_spans(0, 10, 20).unwrap().is_empty());
-        assert!(!editor.viewport_highlight_spans(0, 0, 20).unwrap().is_empty());
+        assert!(editor
+            .viewport_highlight_spans(0, 10, 20)
+            .unwrap()
+            .is_empty());
+        assert!(!editor
+            .viewport_highlight_spans(0, 0, 20)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
     fn wrapped_line_continuation_renders() {
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
-        let long_line = "let dialog = Some(Box::new(Picker::new(title.clone(), other, items, id)));";
+        let long_line =
+            "let dialog = Some(Box::new(Picker::new(title.clone(), other, items, id)));";
         let contents = format!("short one\n{long_line}\nshort two\n");
         let buffer = Buffer::new(None, contents);
         // wrap defaults to on; 40 columns forces the long line to wrap.
@@ -11032,10 +11041,11 @@ mod test {
         // delta row list and must keep its styles.
         editor.last_rendered_cursor_position = Some((content_start, 5));
         editor.cx = 3;
-        editor.render_cursor_motion_delta(&mut render_buffer).unwrap();
+        editor
+            .render_cursor_motion_delta(&mut render_buffer)
+            .unwrap();
         assert_eq!(
-            render_buffer.cells[row5].style.fg,
-            styled,
+            render_buffer.cells[row5].style.fg, styled,
             "same-row delta render must keep highlighting"
         );
 
@@ -11044,10 +11054,11 @@ mod test {
         editor.last_rendered_cursor_position = Some((content_start, 10));
         editor.cy = 5;
         editor.cx = 0;
-        editor.render_cursor_motion_delta(&mut render_buffer).unwrap();
+        editor
+            .render_cursor_motion_delta(&mut render_buffer)
+            .unwrap();
         assert_eq!(
-            render_buffer.cells[row5].style.fg,
-            styled,
+            render_buffer.cells[row5].style.fg, styled,
             "upward delta render must keep highlighting"
         );
     }
@@ -11194,7 +11205,9 @@ mod test {
         }
         // ...but the wrapped text right after it is, end to end.
         assert_eq!(
-            editor.test_render_cell_bg(content_start + offset, 2).unwrap(),
+            editor
+                .test_render_cell_bg(content_start + offset, 2)
+                .unwrap(),
             Some(selection_bg)
         );
         assert_eq!(

--- a/src/editor/display_layout.rs
+++ b/src/editor/display_layout.rs
@@ -82,8 +82,7 @@ impl LineSegment {
     }
 
     pub fn screen_col_for_display_col(&self, col: usize, width: usize) -> usize {
-        (self.visual_offset + col.saturating_sub(self.start_col))
-            .min(width.saturating_sub(1))
+        (self.visual_offset + col.saturating_sub(self.start_col)).min(width.saturating_sub(1))
     }
 }
 
@@ -371,7 +370,13 @@ mod tests {
 
     #[test]
     fn skipcol_starts_at_later_wrapped_segment() {
-        let segments = wrap_line_segments("abcdefghijklmnopqrstuvwxyz", 0, 10, 10, BreakIndentOptions::disabled());
+        let segments = wrap_line_segments(
+            "abcdefghijklmnopqrstuvwxyz",
+            0,
+            10,
+            10,
+            BreakIndentOptions::disabled(),
+        );
 
         assert_eq!(segments[0].start_col, 10);
         assert_eq!(segments[0].end_col, 20);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+pub mod assets;
 pub mod buffer;
 pub mod cli;
 pub mod color;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1374,7 +1374,11 @@ mod test {
 
     fn single_change(old: &str, new: &str) -> TextDocumentContentChangeEvent {
         let mut changes = RealLspClient::calculate_changes(old, new);
-        assert_eq!(changes.len(), 1, "expected one change for {old:?} -> {new:?}");
+        assert_eq!(
+            changes.len(),
+            1,
+            "expected one change for {old:?} -> {new:?}"
+        );
         changes.pop().unwrap()
     }
 
@@ -1408,16 +1412,19 @@ mod test {
     #[test]
     fn test_calculate_changes_roundtrip() {
         let cases = [
-            ("hello world", "hello brave world"),       // insert
-            ("hello brave world", "hello world"),       // delete
-            ("hello world", "hello earth"),             // replace
-            ("line one\nline two\nline three", "line one\nline 2\nline three"), // mid-line
-            ("fn main() {}", "fn main() {}\n"),         // append
-            ("", "new content"),                        // from empty
-            ("ab", "aXb"),                              // insert between equal chars
-            ("aa", "aaa"),                              // ambiguous repeat
-            ("héllo wörld", "héllo wørld"),             // multi-byte
-            ("a👋b", "a👋👋b"),                          // emoji insert
+            ("hello world", "hello brave world"), // insert
+            ("hello brave world", "hello world"), // delete
+            ("hello world", "hello earth"),       // replace
+            (
+                "line one\nline two\nline three",
+                "line one\nline 2\nline three",
+            ), // mid-line
+            ("fn main() {}", "fn main() {}\n"),   // append
+            ("", "new content"),                  // from empty
+            ("ab", "aXb"),                        // insert between equal chars
+            ("aa", "aaa"),                        // ambiguous repeat
+            ("héllo wörld", "héllo wørld"),       // multi-byte
+            ("a👋b", "a👋👋b"),                   // emoji insert
         ];
         for (old, new) in cases {
             let change = single_change(old, new);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 use clap::Parser as _;
 use crossterm::{event, terminal, ExecutableCommand};
 
+use red::assets;
 use red::buffer::Buffer;
 use red::cli::Args;
 use red::config::Config;
@@ -15,24 +16,35 @@ use red::logger::Logger;
 use red::lsp::{LspClient, LspManager};
 use red::onboarding;
 use red::preferences::PreferencesStore;
-use red::theme::{parse_vscode_theme, parse_vscode_theme_contents};
+use red::theme::{parse_vscode_theme, parse_vscode_theme_contents, Theme};
 use red::{log, LOGGER};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    args.validate_utility_args()?;
+
+    if args.runtime_files {
+        print!("{}", assets::format_runtime_files(&Config::config_dir())?);
+        return Ok(());
+    }
+
+    if let Some(asset) = args.eject.as_deref().or(args.eject_force.as_deref()) {
+        let target =
+            assets::eject_runtime_asset(asset, &Config::config_dir(), args.eject_force.is_some())?;
+        println!("Ejected {}", target.display());
+        return Ok(());
+    }
+
     let config_file = Config::path("config.toml");
     if !config_file.exists() {
         let config_dir = config_file
             .parent()
             .expect("config path always has a parent directory");
-        match onboarding::run(config_dir)? {
-            onboarding::Outcome::Initialized => {}
-            onboarding::Outcome::Declined => return Ok(()),
-        }
+        onboarding::run(config_dir)?;
     }
 
-    let toml = fs::read_to_string(config_file)?;
+    let toml = fs::read_to_string(&config_file).unwrap_or_default();
     let mut config = Config::from_user_toml_with_overrides(&toml, &args.config_overrides)?;
 
     if let Some(log_file) = &config.log_file {
@@ -62,15 +74,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    let theme_file = Config::path("themes").join(&config.theme);
-    let theme = if theme_file.exists() {
-        parse_vscode_theme(&theme_file.to_string_lossy())?
-    } else if let Some(contents) = red::assets::bundled_theme(&config.theme) {
-        parse_vscode_theme_contents(contents)?
-    } else {
-        eprintln!("Theme file {} not found", config.theme);
-        std::process::exit(1);
-    };
+    let theme = load_theme(&config.theme)?;
     let mut editor = Editor::new_with_preferences(lsp, config, theme, buffers, preferences)?;
 
     panic::set_hook(Box::new(|info| {
@@ -94,4 +98,16 @@ async fn main() -> anyhow::Result<()> {
     result?;
 
     Ok(())
+}
+
+fn load_theme(theme_name: &str) -> anyhow::Result<Theme> {
+    let Some(theme_asset) = assets::resolve_theme(theme_name, &Config::config_dir()) else {
+        anyhow::bail!("Theme file {} not found", theme_name);
+    };
+
+    if let Some(path) = theme_asset.path() {
+        parse_vscode_theme(&path.to_string_lossy())
+    } else {
+        parse_vscode_theme_contents(&theme_asset.read_to_string()?)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use red::logger::Logger;
 use red::lsp::{LspClient, LspManager};
 use red::onboarding;
 use red::preferences::PreferencesStore;
-use red::theme::parse_vscode_theme;
+use red::theme::{parse_vscode_theme, parse_vscode_theme_contents};
 use red::{log, LOGGER};
 
 #[tokio::main(flavor = "multi_thread")]
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let toml = fs::read_to_string(config_file)?;
-    let mut config = Config::from_toml_with_overrides(&toml, &args.config_overrides)?;
+    let mut config = Config::from_user_toml_with_overrides(&toml, &args.config_overrides)?;
 
     if let Some(log_file) = &config.log_file {
         LOGGER.get_or_init(|| Some(Logger::new(log_file)));
@@ -62,12 +62,15 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    let theme_file = &Config::path("themes").join(&config.theme);
-    if !theme_file.exists() {
+    let theme_file = Config::path("themes").join(&config.theme);
+    let theme = if theme_file.exists() {
+        parse_vscode_theme(&theme_file.to_string_lossy())?
+    } else if let Some(contents) = red::assets::bundled_theme(&config.theme) {
+        parse_vscode_theme_contents(contents)?
+    } else {
         eprintln!("Theme file {} not found", config.theme);
         std::process::exit(1);
-    }
-    let theme = parse_vscode_theme(&theme_file.to_string_lossy())?;
+    };
     let mut editor = Editor::new_with_preferences(lsp, config, theme, buffers, preferences)?;
 
     panic::set_hook(Box::new(|info| {

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1,26 +1,15 @@
 //! First-run onboarding.
 //!
 //! When `~/.config/red/config.toml` is missing, [`run`] welcomes the user on
-//! the plain terminal and offers to create a starter config plus the default
-//! theme. The bundled `default_config.toml` and `themes/mocha.json` are
-//! embedded in the binary so a fresh install can bootstrap itself with no
-//! external files.
+//! the plain terminal and offers to create a starter config. Defaults, themes,
+//! and plugins are embedded in the binary so a fresh install can bootstrap
+//! itself with no external files.
 
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::Path;
 
-/// The starter config written on initialization. Single source of truth: the
-/// same file that ships in the repository root.
-const DEFAULT_CONFIG: &str = include_str!("../default_config.toml");
-
-/// The theme referenced by [`DEFAULT_CONFIG`]. Without it, the editor exits on
-/// startup because the theme file is required.
-const DEFAULT_THEME: &str = include_str!("../themes/mocha.json");
-
-/// File name of the bundled theme, matching the `theme = ` line in
-/// [`DEFAULT_CONFIG`].
-const DEFAULT_THEME_FILE: &str = "mocha.json";
+use crate::assets;
 
 /// Result of the onboarding flow.
 pub enum Outcome {
@@ -54,7 +43,7 @@ pub fn run(config_dir: &Path) -> anyhow::Result<Outcome> {
         println!();
         println!(
             "  {}",
-            paint(GREEN, "✓ Created your starter config and theme.", use_color)
+            paint(GREEN, "✓ Created your starter config.", use_color)
         );
         println!("  {}", paint(DIM, "Launching red…", use_color));
         println!();
@@ -74,13 +63,12 @@ pub fn run(config_dir: &Path) -> anyhow::Result<Outcome> {
     }
 }
 
-/// Write the embedded starter config and default theme under `config_dir`,
-/// creating the directory (and `themes/`) if needed.
+/// Write the starter config under `config_dir`, creating the directory if
+/// needed. Themes and plugins stay embedded until the user chooses to override
+/// them in their config directory.
 fn write_default_assets(config_dir: &Path) -> anyhow::Result<()> {
-    let themes_dir = config_dir.join("themes");
-    fs::create_dir_all(&themes_dir)?;
-    fs::write(config_dir.join("config.toml"), DEFAULT_CONFIG)?;
-    fs::write(themes_dir.join(DEFAULT_THEME_FILE), DEFAULT_THEME)?;
+    fs::create_dir_all(config_dir)?;
+    fs::write(config_dir.join("config.toml"), assets::starter_config())?;
     Ok(())
 }
 
@@ -105,7 +93,6 @@ fn parse_yes_no(input: &str, default_yes: bool) -> bool {
 /// ANSI styling is included only when `use_color` is true.
 fn render_welcome(config_dir: &Path, use_color: bool) -> String {
     let config_path = config_dir.join("config.toml");
-    let theme_path = config_dir.join("themes").join(DEFAULT_THEME_FILE);
     let bar = paint(DIM, "│", use_color);
 
     let mut out = String::new();
@@ -117,18 +104,13 @@ fn render_welcome(config_dir: &Path, use_color: bool) -> String {
     out.push_str(&format!("  {bar}\n"));
     out.push_str(&format!("  {bar} No configuration file was found.\n"));
     out.push_str(&format!(
-        "  {bar} red can create a starter config and theme for you:\n"
+        "  {bar} red can create a starter config for your overrides:\n"
     ));
     out.push_str(&format!("  {bar}\n"));
     out.push_str(&format!(
         "  {bar}   {}  {}\n",
         paint(DIM, "config", use_color),
         paint(CYAN, &config_path.display().to_string(), use_color),
-    ));
-    out.push_str(&format!(
-        "  {bar}   {}   {}\n",
-        paint(DIM, "theme", use_color),
-        paint(CYAN, &theme_path.display().to_string(), use_color),
     ));
     out.push_str(&format!("  {bar}\n"));
     out.push_str(&format!(
@@ -199,15 +181,14 @@ mod tests {
     }
 
     #[test]
-    fn write_default_assets_creates_config_and_theme() {
+    fn write_default_assets_creates_config_only() {
         let dir = unique_temp_dir("onboarding-write");
 
         write_default_assets(&dir).unwrap();
 
         let config = fs::read_to_string(dir.join("config.toml")).unwrap();
-        let theme = fs::read_to_string(dir.join("themes").join(DEFAULT_THEME_FILE)).unwrap();
-        assert_eq!(config, DEFAULT_CONFIG);
-        assert_eq!(theme, DEFAULT_THEME);
+        assert_eq!(config, assets::starter_config());
+        assert!(!dir.join("themes").exists());
 
         fs::remove_dir_all(&dir).ok();
     }
@@ -221,7 +202,7 @@ mod tests {
         write_default_assets(&dir).unwrap();
 
         assert!(dir.join("config.toml").exists());
-        assert!(dir.join("themes").join(DEFAULT_THEME_FILE).exists());
+        assert!(!dir.join("themes").exists());
 
         fs::remove_dir_all(dir.parent().unwrap()).ok();
     }
@@ -234,7 +215,7 @@ mod tests {
         write_default_assets(&dir).unwrap();
 
         let contents = fs::read_to_string(dir.join("config.toml")).unwrap();
-        let parsed: Result<crate::config::Config, _> = toml::from_str(&contents);
+        let parsed = crate::config::Config::from_user_toml_with_overrides(&contents, &[]);
         assert!(parsed.is_ok(), "starter config should parse: {parsed:?}");
 
         fs::remove_dir_all(&dir).ok();
@@ -247,7 +228,6 @@ mod tests {
 
         assert!(banner.to_lowercase().contains("red"));
         assert!(banner.contains("config.toml"));
-        assert!(banner.contains(DEFAULT_THEME_FILE));
         assert!(banner.contains("[Y/n]"));
     }
 

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -13,21 +13,18 @@ use crate::assets;
 
 /// Result of the onboarding flow.
 pub enum Outcome {
-    /// Config + theme were written; the caller should continue to load them.
+    /// The optional starter config was written; the caller should continue to launch.
     Initialized,
-    /// The user declined; the caller should exit cleanly without launching.
-    Declined,
+    /// No config was written; the caller should continue to launch with embedded defaults.
+    Skipped,
 }
 
 /// Run the first-run onboarding flow. Called only when `config.toml` is
-/// absent. On a non-interactive terminal it initializes silently; otherwise it
-/// welcomes the user and offers to create the starter files.
+/// absent. Non-interactive sessions launch from embedded defaults without
+/// writing files. Interactive sessions may write a starter override template.
 pub fn run(config_dir: &Path) -> anyhow::Result<Outcome> {
-    // Without an interactive stdin (piped input, CI) we can't prompt, so we
-    // initialize silently and let the editor start.
     if !io::stdin().is_terminal() {
-        write_default_assets(config_dir)?;
-        return Ok(Outcome::Initialized);
+        return Ok(Outcome::Skipped);
     }
 
     let use_color = color_enabled(
@@ -55,11 +52,11 @@ pub fn run(config_dir: &Path) -> anyhow::Result<Outcome> {
             "  {}",
             paint(
                 DIM,
-                "Run `red` again to set it up, or create the file manually.",
+                "Launching red with embedded defaults. Run `red` again to create the template.",
                 use_color,
             )
         );
-        Ok(Outcome::Declined)
+        Ok(Outcome::Skipped)
     }
 }
 
@@ -104,7 +101,7 @@ fn render_welcome(config_dir: &Path, use_color: bool) -> String {
     out.push_str(&format!("  {bar}\n"));
     out.push_str(&format!("  {bar} No configuration file was found.\n"));
     out.push_str(&format!(
-        "  {bar} red can create a starter config for your overrides:\n"
+        "  {bar} red can launch now and optionally create a starter config:\n"
     ));
     out.push_str(&format!("  {bar}\n"));
     out.push_str(&format!(

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -5,6 +5,8 @@ use deno_core::{
     ModuleSpecifier, ResolutionKind,
 };
 
+use crate::assets;
+
 pub struct TsModuleLoader;
 
 impl ModuleLoader for TsModuleLoader {
@@ -27,50 +29,64 @@ impl ModuleLoader for TsModuleLoader {
 
         ModuleLoadResponse::Async(
             async move {
-                let (extension, code, media_type) = if module_specifier.scheme() == "http"
-                    || module_specifier.scheme() == "https"
-                {
-                    let code = reqwest::get(module_specifier.as_str())
-                        .await
-                        .map_err(|err| ModuleLoaderError::generic(err.to_string()))?
-                        .text()
-                        .await
-                        .map_err(|err| ModuleLoaderError::generic(err.to_string()))?;
+                let (extension, code, media_type) =
+                    if assets::is_bundled_plugin_specifier(module_specifier.as_str()) {
+                        let code = assets::bundled_plugin_contents(module_specifier.as_str())
+                            .ok_or_else(|| {
+                                ModuleLoaderError::generic(format!(
+                                    "Bundled plugin module `{}` was not found",
+                                    module_specifier
+                                ))
+                            })?
+                            .to_string();
+                        let media_type = MediaType::from_specifier(&module_specifier);
+                        let extension = media_type.as_ts_extension();
 
-                    let media_type = MediaType::from_specifier(&module_specifier);
-                    let extension = media_type.as_ts_extension();
+                        (Some(extension.to_string()), code, media_type)
+                    } else if module_specifier.scheme() == "http"
+                        || module_specifier.scheme() == "https"
+                    {
+                        let code = reqwest::get(module_specifier.as_str())
+                            .await
+                            .map_err(|err| ModuleLoaderError::generic(err.to_string()))?
+                            .text()
+                            .await
+                            .map_err(|err| ModuleLoaderError::generic(err.to_string()))?;
 
-                    (Some(extension.to_string()), code, media_type)
-                } else {
-                    let path = match module_specifier.to_file_path() {
-                        Ok(path) => path,
-                        Err(e) => {
-                            return Err(ModuleLoaderError::generic(format!(
-                                "Cannot convert module specifier to file path: {:?}",
-                                e
-                            )));
-                        }
+                        let media_type = MediaType::from_specifier(&module_specifier);
+                        let extension = media_type.as_ts_extension();
+
+                        (Some(extension.to_string()), code, media_type)
+                    } else {
+                        let path = match module_specifier.to_file_path() {
+                            Ok(path) => path,
+                            Err(e) => {
+                                return Err(ModuleLoaderError::generic(format!(
+                                    "Cannot convert module specifier to file path: {:?}",
+                                    e
+                                )));
+                            }
+                        };
+
+                        // Determine what the MediaType is (this is done based on the file
+                        // extension) and whether transpiling is required.
+                        let media_type = MediaType::from_path(&path);
+
+                        // Read the file, transpile if necessary.
+                        let code = std::fs::read_to_string(&path).map_err(|err| {
+                            ModuleLoaderError::generic(format!(
+                                "Could not read plugin module `{}`: {}",
+                                path.display(),
+                                err
+                            ))
+                        })?;
+
+                        (
+                            path.extension().map(|e| e.to_str().unwrap().to_string()),
+                            code,
+                            media_type,
+                        )
                     };
-
-                    // Determine what the MediaType is (this is done based on the file
-                    // extension) and whether transpiling is required.
-                    let media_type = MediaType::from_path(&path);
-
-                    // Read the file, transpile if necessary.
-                    let code = std::fs::read_to_string(&path).map_err(|err| {
-                        ModuleLoaderError::generic(format!(
-                            "Could not read plugin module `{}`: {}",
-                            path.display(),
-                            err
-                        ))
-                    })?;
-
-                    (
-                        path.extension().map(|e| e.to_str().unwrap().to_string()),
-                        code,
-                        media_type,
-                    )
-                };
 
                 let (module_type, should_transpile) = match media_type {
                     MediaType::JavaScript | MediaType::Mjs | MediaType::Cjs => {

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -111,6 +111,10 @@ impl PluginRegistry {
 
     fn ensure_plugin_files_exist(&self) -> anyhow::Result<()> {
         for (name, plugin) in &self.plugins {
+            if crate::assets::is_bundled_plugin_specifier(plugin) {
+                continue;
+            }
+
             let path = Path::new(plugin);
             if path.is_file() {
                 continue;

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -19,6 +19,7 @@ use tokio::sync::oneshot;
 use uuid::Uuid;
 
 use crate::{
+    assets,
     config::{Config, PluginPermissions},
     editor::{PluginRequest, ACTION_DISPATCHER},
     log,
@@ -504,7 +505,7 @@ fn op_lsp_inlay_hints(
 #[op2]
 #[serde]
 fn op_list_themes() -> Result<serde_json::Value, PluginOpError> {
-    Ok(json!(list_themes_in_dir(&Config::path("themes"))?))
+    Ok(json!(list_themes()?))
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
@@ -538,13 +539,29 @@ fn list_themes_in_dir(themes_dir: &Path) -> anyhow::Result<Vec<ThemeListEntry>> 
             Some(ThemeListEntry { name, file })
         })
         .collect::<Vec<_>>();
+    sort_theme_entries(&mut themes);
+    Ok(themes)
+}
+
+fn list_themes() -> anyhow::Result<Vec<ThemeListEntry>> {
+    let user_entries = list_themes_in_dir(&Config::path("themes"))?
+        .into_iter()
+        .map(|entry| (entry.name, entry.file));
+    let mut themes = assets::dedupe_theme_entries(user_entries)
+        .into_iter()
+        .map(|(name, file)| ThemeListEntry { name, file })
+        .collect::<Vec<_>>();
+    sort_theme_entries(&mut themes);
+    Ok(themes)
+}
+
+fn sort_theme_entries(themes: &mut [ThemeListEntry]) {
     themes.sort_by(|a, b| {
         a.name
             .to_lowercase()
             .cmp(&b.name.to_lowercase())
             .then_with(|| a.file.cmp(&b.file))
     });
-    Ok(themes)
 }
 
 fn theme_name_from_file(path: &Path) -> anyhow::Result<Option<String>> {
@@ -1294,6 +1311,28 @@ mod tests {
                     }}
                     if (model.labelsByFile.get("latte.json") !== "Catppuccin Latte") {{
                         throw new Error("theme file did not map back to display name");
+                    }}
+                "#
+            ))
+            .await
+    }
+
+    #[tokio::test]
+    async fn runtime_imports_bundled_plugin_modules() -> anyhow::Result<()> {
+        let module_specifier = crate::assets::bundled_plugin_specifier("theme_browser.js")
+            .expect("theme browser should be bundled");
+
+        let mut runtime = Runtime::new();
+        runtime
+            .add_module(&format!(
+                r#"
+                    import {{ buildThemePickerModel }} from "{module_specifier}";
+
+                    const model = buildThemePickerModel([
+                        {{ name: "Catppuccin Mocha", file: "mocha.json" }},
+                    ]);
+                    if (model.filesByLabel.get("Catppuccin Mocha") !== "mocha.json") {{
+                        throw new Error("bundled plugin import returned wrong model");
                     }}
                 "#
             ))

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     env, fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
     rc::Rc,
     sync::{mpsc, Mutex},
     thread,
@@ -15,6 +15,8 @@ use deno_error::JsError;
 use json_comments::StripComments;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+#[cfg(test)]
+use std::path::Path;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
@@ -519,6 +521,7 @@ struct ThemeMetadata {
     name: Option<String>,
 }
 
+#[cfg(test)]
 fn list_themes_in_dir(themes_dir: &Path) -> anyhow::Result<Vec<ThemeListEntry>> {
     if !themes_dir.exists() {
         return Ok(vec![]);
@@ -544,15 +547,31 @@ fn list_themes_in_dir(themes_dir: &Path) -> anyhow::Result<Vec<ThemeListEntry>> 
 }
 
 fn list_themes() -> anyhow::Result<Vec<ThemeListEntry>> {
-    let user_entries = list_themes_in_dir(&Config::path("themes"))?
-        .into_iter()
-        .map(|entry| (entry.name, entry.file));
-    let mut themes = assets::dedupe_theme_entries(user_entries)
-        .into_iter()
-        .map(|(name, file)| ThemeListEntry { name, file })
-        .collect::<Vec<_>>();
+    let mut themes = Vec::new();
+    for entry in
+        assets::list_runtime_assets(assets::RuntimeAssetKind::Theme, &Config::config_dir())?
+    {
+        let Some(asset) = assets::resolve_theme(&entry.file, &Config::config_dir()) else {
+            continue;
+        };
+        let name = theme_name_from_asset(&asset)?.unwrap_or_else(|| entry.file.clone());
+        themes.push(ThemeListEntry {
+            name,
+            file: entry.file,
+        });
+    }
     sort_theme_entries(&mut themes);
     Ok(themes)
+}
+
+fn theme_name_from_asset(asset: &assets::ResolvedRuntimeAsset) -> anyhow::Result<Option<String>> {
+    let contents = asset.read_to_string()?;
+    let contents = StripComments::new(contents.as_bytes());
+    let metadata: ThemeMetadata = serde_json::from_reader(contents)?;
+    Ok(metadata
+        .name
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty()))
 }
 
 fn sort_theme_entries(themes: &mut [ThemeListEntry]) {
@@ -564,6 +583,7 @@ fn sort_theme_entries(themes: &mut [ThemeListEntry]) {
     });
 }
 
+#[cfg(test)]
 fn theme_name_from_file(path: &Path) -> anyhow::Result<Option<String>> {
     let contents = fs::read_to_string(path)?;
     let contents = StripComments::new(contents.as_bytes());

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 pub use vscode::parse_vscode_theme;
+pub use vscode::parse_vscode_theme_contents;
 
 use crate::color::Color;
 

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -57,6 +57,10 @@ static SYNTAX_HIGHLIGHTING_MAP: Lazy<HashMap<&'static str, &'static str>> = Lazy
 
 pub fn parse_vscode_theme(file: &str) -> anyhow::Result<Theme> {
     let contents = &fs::read_to_string(file)?;
+    parse_vscode_theme_contents(contents)
+}
+
+pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
     let contents = StripComments::new(contents.as_bytes());
     let vscode_theme: VsCodeTheme = serde_json::from_reader(contents)?;
 


### PR DESCRIPTION
Red is moving toward self-contained binary distribution, so first-run behavior should not depend on copying `default_config.toml`, themes, or plugins into the user's config directory. Copying those files also creates a stale-shadow problem after upgrades: old on-disk plugin/theme copies can mask the bundled versions that match the current binary. This PR makes embedded defaults and bundled runtime assets the source of truth, while keeping user overrides explicit and inspectable.

The config loader now layers user config over the bundled `default_config.toml`, so missing config is valid and existing users inherit new defaults unless they override them. Runtime plugin and theme resolution now checks the user config directory, then `$RED_RUNTIME`, then embedded assets. Built-in plugins and themes are embedded by default, user files with matching names shadow them, and `red --eject` / `red --eject-force` provide an intentional way to copy a bundled or runtime asset into the config directory for editing. `red --runtime-files` lists the visible runtime assets and shows which source wins.

The onboarding path now only writes the commented starter config template, and the editor can continue with embedded defaults when that template is declined or when no interactive config setup is possible. The README was rewritten around the same model: zero-setup startup, incremental config layering, bundled plugin/theme behavior, the current command/keybinding surface, plugin IDs, and runtime asset override workflows.

## How to Test

1. Build and run `red --runtime-files`.
2. Confirm the output is grouped into runtime plugins and runtime themes, hides bundled dev/test plugin files, and marks each listed asset as `user`, `runtime`, or `embedded` with shadowing information when relevant.
3. Run with a clean config home, for example `XDG_CONFIG_HOME=/tmp/red-eject-smoke red --eject mocha.json`.
4. Confirm `mocha.json` is copied to the Red config theme directory, and rerunning the same command refuses to overwrite it unless `--eject-force` is used.
5. Start Red without an existing `config.toml` and confirm it launches with embedded defaults rather than requiring copied config, plugin, or theme files.

Targeted tests:

- `cargo test --locked assets::tests -- --nocapture`
- `cargo test --locked`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`