### PR TITLE
chore(release): prepare v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Red are documented in this file.
 
+## [0.1.1](https://github.com/codersauce/red/compare/v0.1.0...v0.1.1)
+
+### Bug Fixes
+
+- **ci:** Normalize release checks across platforms ([571cf5c](https://github.com/codersauce/red/commit/571cf5c9b7cf02a48c97b0251b3b1f37af404f85))
+- **release:** Make packaged runtime self-contained ([3c2c5e3](https://github.com/codersauce/red/commit/3c2c5e38810ba98dc0de43e5e62df81892455ffa))
+
 ## [0.1.0](https://github.com/codersauce/red/releases/tag/v0.1.0)
 
 - Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,7 +2172,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "red"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Why

Prepare Red 0.1.1 with a reviewed version bump and a changelog generated from Git history.

## What changed

- Updated the package and lockfile versions.
- Prepended the generated release section to `CHANGELOG.md`.

## How to test

1. Confirm the package version is `0.1.1` and matches the requested release tag.
2. Review every generated changelog group and entry.
3. Confirm CI, including Clippy and the packaged runtime self-check, passes.

Merging this PR does not publish the release. After merge, create and push the annotated `v0.1.1` tag to start the release workflow.
