### PR TITLE
feat(themes): port nvim color schemes

### DIFF
--- a/themes/THIRD_PARTY.md
+++ b/themes/THIRD_PARTY.md
@@ -96,6 +96,45 @@ load them directly without following extension-local `include` paths.
 | `atom-one-light.json` | Atom One Light | `akamud.vscode-theme-onelight` | MIT |
 | `kanso.json` | Kanso Ink | `webhooked/kanso.nvim` | MIT |
 
+## Generated Neovim Theme Ports
+
+These Red theme JSON files were generated from the resolved highlight groups of the locally installed Neovim colorschemes listed in `~/code/config/nvim/lua/plugins/theme.lua`. They are not copied VS Code extension theme files; they preserve the resulting editor UI and token colors in Red's VS Code-compatible theme format.
+
+| Package | License | Source | Notice | Generated files |
+| --- | --- | --- | --- | --- |
+| `slugbyte/lackluster.nvim` | MIT | https://github.com/slugbyte/lackluster.nvim | licenses/slugbyte-lackluster-nvim.txt | `lackluster.json`, `lackluster-dark.json`, `lackluster-hack.json`, `lackluster-mint.json`, `lackluster-night.json` |
+| `datsfilipe/vesper.nvim` | MIT | https://github.com/datsfilipe/vesper.nvim | licenses/datsfilipe-vesper-nvim.txt | `vesper.json` |
+| `AlexvZyl/nordic.nvim` | MIT | https://github.com/AlexvZyl/nordic.nvim | licenses/alexvzyl-nordic-nvim.txt | `nordic.json` |
+| `fcancelinha/nordern.nvim` | MIT | https://github.com/fcancelinha/nordern.nvim | licenses/fcancelinha-nordern-nvim.txt | `nordern.json` |
+| `rmehri01/onenord.nvim` | MIT | https://github.com/rmehri01/onenord.nvim | licenses/rmehri01-onenord-nvim.txt | `onenord.json` |
+| `zenbones-theme/zenbones.nvim` | MIT | https://github.com/zenbones-theme/zenbones.nvim | licenses/zenbones-theme-zenbones-nvim.txt | `zenbones.json`, `zenwritten.json`, `neobones.json`, `rosebones.json`, `forestbones.json`, `nordbones.json`, `seoulbones.json`, `duckbones.json`, `zenburned.json`, `kanagawabones.json` |
+| `ribru17/bamboo.nvim` | MIT | https://github.com/ribru17/bamboo.nvim | licenses/ribru17-bamboo-nvim.txt | `bamboo.json` |
+| `uloco/bluloco.nvim` | LGPL-3.0 | https://github.com/uloco/bluloco.nvim | licenses/uloco-bluloco-nvim.txt | `bluloco-dark.json`, `bluloco-light.json` |
+| `baliestri/aura-theme` | MIT | https://github.com/baliestri/aura-theme | licenses/baliestri-aura-theme.txt | `aura-dark.json`, `aura-dark-soft-text.json`, `aura-soft-dark.json`, `aura-soft-dark-soft-text.json` |
+| `nyoom-engineering/oxocarbon.nvim` | MIT | https://github.com/nyoom-engineering/oxocarbon.nvim | licenses/nyoom-engineering-oxocarbon-nvim.txt | `oxocarbon.json` |
+| `bluz71/vim-moonfly-colors` | MIT | https://github.com/bluz71/vim-moonfly-colors | licenses/bluz71-vim-moonfly-colors.txt | `moonfly.json` |
+| `bluz71/vim-nightfly-colors` | MIT | https://github.com/bluz71/vim-nightfly-colors | licenses/bluz71-vim-nightfly-colors.txt | `nightfly.json` |
+| `cocopon/iceberg.vim` | MIT | https://github.com/cocopon/iceberg.vim | licenses/cocopon-iceberg-vim.txt | `iceberg.json` |
+| `sainnhe/everforest` | MIT | https://github.com/sainnhe/everforest | licenses/sainnhe-everforest.txt | `everforest.json` |
+| `rebelot/kanagawa.nvim` | MIT | https://github.com/rebelot/kanagawa.nvim | licenses/rebelot-kanagawa-nvim.txt | `kanagawa.json`, `kanagawa-dragon.json`, `kanagawa-wave.json`, `kanagawa-lotus.json` |
+| `EdenEast/nightfox.nvim` | MIT | https://github.com/EdenEast/nightfox.nvim | licenses/edeneast-nightfox-nvim.txt | `terafox.json` |
+| `folke/tokyonight.nvim` | MIT | https://github.com/folke/tokyonight.nvim | licenses/folke-tokyonight-nvim.txt | `tokyonight.json`, `tokyonight-night.json`, `tokyonight-storm.json`, `tokyonight-moon.json` |
+| `rose-pine/neovim` | MIT | https://github.com/rose-pine/neovim | licenses/rose-pine-neovim.txt | `rose-pine-main.json`, `rose-pine-dawn.json`, `rose-pine-moon.json` |
+| `morhetz/gruvbox` | MIT | https://github.com/morhetz/gruvbox | licenses/morhetz-gruvbox.txt | `gruvbox.json` |
+| `ramojus/mellifluous.nvim` | MIT | https://github.com/ramojus/mellifluous.nvim | licenses/ramojus-mellifluous-nvim.txt | `mellifluous.json` |
+| `wtfox/jellybeans.nvim` | Apache-2.0 | https://github.com/wtfox/jellybeans.nvim | licenses/wtfox-jellybeans-nvim.txt | `jellybeans.json`, `jellybeans-muted.json`, `jellybeans-mono.json` |
+| `tahayvr/matteblack.nvim` | MIT | https://github.com/tahayvr/matteblack.nvim | licenses/tahayvr-matteblack-nvim.txt | `matteblack.json` |
+| `oskarnurm/koda.nvim` | MIT | https://github.com/oskarnurm/koda.nvim | licenses/oskarnurm-koda-nvim.txt | `koda.json` |
+| `navarasu/onedark.nvim` | MIT | https://github.com/navarasu/onedark.nvim | licenses/navarasu-onedark-nvim.txt | `onedark.json` |
+| `craftzdog/solarized-osaka.nvim` | Apache-2.0 | https://github.com/craftzdog/solarized-osaka.nvim | licenses/craftzdog-solarized-osaka-nvim.txt | `solarized-osaka.json`, `solarized-osaka-day.json` |
+| `scottmckendry/cyberdream.nvim` | MIT | https://github.com/scottmckendry/cyberdream.nvim | licenses/scottmckendry-cyberdream-nvim.txt | `cyberdream.json` |
+| `maxmx03/fluoromachine.nvim` | MIT | https://github.com/maxmx03/fluoromachine.nvim | licenses/maxmx03-fluoromachine-nvim.txt | `fluoromachine.json` |
+| `Mofiqul/vscode.nvim` | MIT | https://github.com/Mofiqul/vscode.nvim | licenses/mofiqul-vscode-nvim.txt | `vscode.json` |
+| `sainnhe/sonokai` | MIT | https://github.com/sainnhe/sonokai | licenses/sainnhe-sonokai.txt | `sonokai.json` |
+| `sainnhe/edge` | MIT | https://github.com/sainnhe/edge | licenses/sainnhe-edge.txt | `edge.json` |
+| `Hiroya-W/sequoia-moonlight.nvim` | MIT | https://github.com/Hiroya-W/sequoia-moonlight.nvim | licenses/hiroya-w-sequoia-moonlight-nvim.txt | `sequoia.json` |
+| `fcoury/termy.nvim` | MIT | https://github.com/fcoury/termy.nvim | licenses/fcoury-termy-nvim.txt | `termy-dark.json` |
+
 ## Skipped
 
 | Package or Theme | Reason |
@@ -105,3 +144,7 @@ load them directly without following extension-local `include` paths.
 | `BeardedBear.beardedtheme` | Bundled license is GPL-3.0; keep out of the MIT theme bundle unless the project opts into GPL asset distribution. |
 | `dracula-theme.theme-dracula` / Dracula Theme | Already bundled as dracula.json or dracula-soft.json. |
 | `dracula-theme.theme-dracula` / Dracula Theme Soft | Already bundled as dracula.json or dracula-soft.json. |
+| `yorumicolors/yorumi.nvim` / `yorumi` | Upstream repository and local checkout expose no redistributable license. |
+| `sam4llis/nvim-tundra` / `tundra` | Upstream repository and local checkout expose no redistributable license. |
+| `olivercederborg/poimandres.nvim` / `poimandres` | Upstream repository and local checkout expose no redistributable license. |
+| `LucidMach/poimandres-ghostty` / `poimandres-ghostty` | Base theme repository exposes no redistributable license. |

--- a/themes/aura-dark-soft-text.json
+++ b/themes/aura-dark-soft-text.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6d6d6d",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ffca85"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ffca85"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#82e2ff"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#edecee"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#f694ff",
+        "fontStyle": "bold"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff6767",
+        "fontStyle": "bold underline"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#edecee",
+    "editorWidget.background": "#07080d",
+    "editorWidget.foreground": "#edecee",
+    "editorWidget.border": "#edecee",
+    "editorHoverWidget.background": "#07080d",
+    "editorHoverWidget.foreground": "#edecee",
+    "editorHoverWidget.border": "#edecee",
+    "list.activeSelectionBackground": "#3d375e",
+    "list.activeSelectionForeground": "#edecee",
+    "list.warningForeground": "#fce094",
+    "statusBar.foreground": "#e0e2ea",
+    "statusBar.background": "#4f5258",
+    "statusBarItem.prominentBackground": "#ffca85",
+    "statusBarItem.prominentForeground": "#15141b",
+    "focusBorder": "#edecee",
+    "descriptionForeground": "#6d6d6d",
+    "editor.foreground": "#edecee",
+    "editor.background": "#15141b",
+    "editor.lineHighlightBackground": "#15141b",
+    "editor.selectionForeground": "#edecee",
+    "editor.selectionBackground": "#3d375e",
+    "editor.findMatchBackground": "#15141b",
+    "editor.findMatchHighlightBackground": "#15141b",
+    "editorCursor.foreground": "#edecee",
+    "editorLineNumber.foreground": "#6d6d6d",
+    "editorLineNumber.background": "#15141b",
+    "editorError.foreground": "#ffc0b9",
+    "editorWarning.foreground": "#fce094",
+    "quickInput.background": "#07080d",
+    "quickInput.foreground": "#edecee",
+    "quickInputTitle.background": "#07080d",
+    "quickInputList.focusBackground": "#3d375e",
+    "quickInputList.focusForeground": "#edecee",
+    "input.background": "#07080d",
+    "input.foreground": "#edecee",
+    "input.placeholderForeground": "#6d6d6d"
+  },
+  "type": "dark",
+  "name": "aura-dark-soft-text"
+}

--- a/themes/aura-dark.json
+++ b/themes/aura-dark.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6d6d6d",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ffca85"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ffca85"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#82e2ff"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#edecee"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#f694ff",
+        "fontStyle": "bold"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff6767",
+        "fontStyle": "bold underline"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#edecee",
+    "editorWidget.background": "#07080d",
+    "editorWidget.foreground": "#edecee",
+    "editorWidget.border": "#edecee",
+    "editorHoverWidget.background": "#07080d",
+    "editorHoverWidget.foreground": "#edecee",
+    "editorHoverWidget.border": "#edecee",
+    "list.activeSelectionBackground": "#3d375e",
+    "list.activeSelectionForeground": "#edecee",
+    "list.warningForeground": "#fce094",
+    "statusBar.foreground": "#e0e2ea",
+    "statusBar.background": "#4f5258",
+    "statusBarItem.prominentBackground": "#ffca85",
+    "statusBarItem.prominentForeground": "#15141b",
+    "focusBorder": "#edecee",
+    "descriptionForeground": "#6d6d6d",
+    "editor.foreground": "#edecee",
+    "editor.background": "#15141b",
+    "editor.lineHighlightBackground": "#15141b",
+    "editor.selectionForeground": "#edecee",
+    "editor.selectionBackground": "#3d375e",
+    "editor.findMatchBackground": "#15141b",
+    "editor.findMatchHighlightBackground": "#15141b",
+    "editorCursor.foreground": "#edecee",
+    "editorLineNumber.foreground": "#6d6d6d",
+    "editorLineNumber.background": "#15141b",
+    "editorError.foreground": "#ffc0b9",
+    "editorWarning.foreground": "#fce094",
+    "quickInput.background": "#07080d",
+    "quickInput.foreground": "#edecee",
+    "quickInputTitle.background": "#07080d",
+    "quickInputList.focusBackground": "#3d375e",
+    "quickInputList.focusForeground": "#edecee",
+    "input.background": "#07080d",
+    "input.foreground": "#edecee",
+    "input.placeholderForeground": "#6d6d6d"
+  },
+  "type": "dark",
+  "name": "aura-dark"
+}

--- a/themes/aura-soft-dark-soft-text.json
+++ b/themes/aura-soft-dark-soft-text.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6d6d6d",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#54c59f"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#54c59f"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#54c59f"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#c7a06f"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#c7a06f"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#6cb2c7"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#bdbdbd"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#8464c6"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#c17ac8",
+        "fontStyle": "bold"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#c55858",
+        "fontStyle": "bold underline"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#bdbdbd",
+    "editorWidget.background": "#07080d",
+    "editorWidget.foreground": "#bdbdbd",
+    "editorWidget.border": "#bdbdbd",
+    "editorHoverWidget.background": "#07080d",
+    "editorHoverWidget.foreground": "#bdbdbd",
+    "editorHoverWidget.border": "#bdbdbd",
+    "list.activeSelectionBackground": "#3d375e",
+    "list.activeSelectionForeground": "#bdbdbd",
+    "list.warningForeground": "#fce094",
+    "statusBar.foreground": "#e0e2ea",
+    "statusBar.background": "#4f5258",
+    "statusBarItem.prominentBackground": "#c7a06f",
+    "statusBarItem.prominentForeground": "#21202e",
+    "focusBorder": "#bdbdbd",
+    "descriptionForeground": "#6d6d6d",
+    "editor.foreground": "#bdbdbd",
+    "editor.background": "#21202e",
+    "editor.lineHighlightBackground": "#21202e",
+    "editor.selectionForeground": "#bdbdbd",
+    "editor.selectionBackground": "#3d375e",
+    "editor.findMatchBackground": "#21202e",
+    "editor.findMatchHighlightBackground": "#21202e",
+    "editorCursor.foreground": "#bdbdbd",
+    "editorLineNumber.foreground": "#6d6d6d",
+    "editorLineNumber.background": "#21202e",
+    "editorError.foreground": "#ffc0b9",
+    "editorWarning.foreground": "#fce094",
+    "quickInput.background": "#07080d",
+    "quickInput.foreground": "#bdbdbd",
+    "quickInputTitle.background": "#07080d",
+    "quickInputList.focusBackground": "#3d375e",
+    "quickInputList.focusForeground": "#bdbdbd",
+    "input.background": "#07080d",
+    "input.foreground": "#bdbdbd",
+    "input.placeholderForeground": "#6d6d6d"
+  },
+  "type": "dark",
+  "name": "aura-soft-dark-soft-text"
+}

--- a/themes/aura-soft-dark.json
+++ b/themes/aura-soft-dark.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6d6d6d",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#61ffca"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ffca85"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ffca85"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#82e2ff"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#edecee"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#a277ff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#f694ff",
+        "fontStyle": "bold"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff6767",
+        "fontStyle": "bold underline"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#edecee",
+    "editorWidget.background": "#07080d",
+    "editorWidget.foreground": "#edecee",
+    "editorWidget.border": "#edecee",
+    "editorHoverWidget.background": "#07080d",
+    "editorHoverWidget.foreground": "#edecee",
+    "editorHoverWidget.border": "#edecee",
+    "list.activeSelectionBackground": "#3d375e",
+    "list.activeSelectionForeground": "#edecee",
+    "list.warningForeground": "#fce094",
+    "statusBar.foreground": "#e0e2ea",
+    "statusBar.background": "#4f5258",
+    "statusBarItem.prominentBackground": "#ffca85",
+    "statusBarItem.prominentForeground": "#21202e",
+    "focusBorder": "#edecee",
+    "descriptionForeground": "#6d6d6d",
+    "editor.foreground": "#edecee",
+    "editor.background": "#21202e",
+    "editor.lineHighlightBackground": "#21202e",
+    "editor.selectionForeground": "#edecee",
+    "editor.selectionBackground": "#3d375e",
+    "editor.findMatchBackground": "#21202e",
+    "editor.findMatchHighlightBackground": "#21202e",
+    "editorCursor.foreground": "#edecee",
+    "editorLineNumber.foreground": "#6d6d6d",
+    "editorLineNumber.background": "#21202e",
+    "editorError.foreground": "#ffc0b9",
+    "editorWarning.foreground": "#fce094",
+    "quickInput.background": "#07080d",
+    "quickInput.foreground": "#edecee",
+    "quickInputTitle.background": "#07080d",
+    "quickInputList.focusBackground": "#3d375e",
+    "quickInputList.focusForeground": "#edecee",
+    "input.background": "#07080d",
+    "input.foreground": "#edecee",
+    "input.placeholderForeground": "#6d6d6d"
+  },
+  "type": "dark",
+  "name": "aura-soft-dark"
+}

--- a/themes/bamboo.json
+++ b/themes/bamboo.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#838781",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#8fb573"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9966"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9966"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9966"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#e75a7c"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e75a7c"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#f08080",
+        "fontStyle": "italic"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#57a5e5"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#57a5e5"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#dbb651"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#dbb651"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaff"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaff",
+        "fontStyle": "italic"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#c5c2ee"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#dbb651",
+        "fontStyle": "italic"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#57a5e5"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#70c2be"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#838781"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e75a7c"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#aaaaff",
+    "editorWidget.background": "#252623",
+    "editorWidget.foreground": "#f1e9d2",
+    "editorWidget.border": "#aaaaff",
+    "editorHoverWidget.background": "#252623",
+    "editorHoverWidget.foreground": "#f1e9d2",
+    "editorHoverWidget.border": "#aaaaff",
+    "list.activeSelectionBackground": "#3a3d37",
+    "list.activeSelectionForeground": "#f1e9d2",
+    "list.warningForeground": "#dbb651",
+    "statusBar.foreground": "#f1e9d2",
+    "statusBar.background": "#383b35",
+    "statusBarItem.prominentBackground": "#57a5e5",
+    "statusBarItem.prominentForeground": "#252623",
+    "focusBorder": "#aaaaff",
+    "descriptionForeground": "#838781",
+    "editor.foreground": "#f1e9d2",
+    "editor.background": "#252623",
+    "editor.lineHighlightBackground": "#2f312c",
+    "editor.selectionForeground": "#f1e9d2",
+    "editor.selectionBackground": "#3a3d37",
+    "editor.findMatchBackground": "#ff9966",
+    "editor.findMatchHighlightBackground": "#e2c792",
+    "editorCursor.foreground": "#57a5e5",
+    "editorLineNumber.foreground": "#838781",
+    "editorLineNumber.background": "#252623",
+    "editorError.foreground": "#e75a7c",
+    "editorWarning.foreground": "#dbb651",
+    "quickInput.background": "#252623",
+    "quickInput.foreground": "#f1e9d2",
+    "quickInputTitle.background": "#252623",
+    "quickInputList.focusBackground": "#3a3d37",
+    "quickInputList.focusForeground": "#f1e9d2",
+    "input.background": "#252623",
+    "input.foreground": "#f1e9d2",
+    "input.placeholderForeground": "#838781"
+  },
+  "type": "dark",
+  "name": "bamboo"
+}

--- a/themes/bluloco-dark.json
+++ b/themes/bluloco-dark.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#636d83"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#f9c958"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#a081fe"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ff7af8"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#10b3fe"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#ff956b"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#abb2bf"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#8acdef"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#3fc66c"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#3fc66c"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#ff6682"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#10b3fe"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#10b3fe"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#10b3fe"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#7c84da"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#ff6682"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#3892ff"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#50adaf"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff2e3f"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#7c84da",
+    "editorWidget.background": "#21232c",
+    "editorWidget.foreground": "#abb2bf",
+    "editorWidget.border": "#7c84da",
+    "editorHoverWidget.background": "#21232c",
+    "editorHoverWidget.foreground": "#abb2bf",
+    "editorHoverWidget.border": "#7c84da",
+    "list.activeSelectionBackground": "#284671",
+    "list.activeSelectionForeground": "#abb2bf",
+    "list.warningForeground": "#da7b44",
+    "statusBar.foreground": "#abb2bf",
+    "statusBar.background": "#3c495d",
+    "statusBarItem.prominentBackground": "#3fc66c",
+    "statusBarItem.prominentForeground": "#282c34",
+    "focusBorder": "#7c84da",
+    "descriptionForeground": "#636d83",
+    "editor.foreground": "#abb2bf",
+    "editor.background": "#282c34",
+    "editor.lineHighlightBackground": "#384252",
+    "editor.selectionForeground": "#abb2bf",
+    "editor.selectionBackground": "#284671",
+    "editor.findMatchBackground": "#e3b80d",
+    "editor.findMatchHighlightBackground": "#197046",
+    "editorCursor.foreground": "#282c34",
+    "editorLineNumber.foreground": "#636d83",
+    "editorLineNumber.background": "#282c34",
+    "editorError.foreground": "#ff2e3f",
+    "editorWarning.foreground": "#da7b44",
+    "quickInput.background": "#21232c",
+    "quickInput.foreground": "#abb2bf",
+    "quickInputTitle.background": "#21232c",
+    "quickInputList.focusBackground": "#284671",
+    "quickInputList.focusForeground": "#abb2bf",
+    "input.background": "#21232c",
+    "input.foreground": "#abb2bf",
+    "input.placeholderForeground": "#636d83"
+  },
+  "type": "dark",
+  "name": "bluloco-dark"
+}

--- a/themes/bluloco-light.json
+++ b/themes/bluloco-light.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#a0a1a7"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#c4a231"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#8541f1"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#cd32c0"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#0096db"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#de631b"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#383a42"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#40b7c4"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#239549"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#239549"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#d32752"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#0096db"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#0096db"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#0096db"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#7c84da"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#d32752"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#255ee4"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#047486"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#14161b"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff0000"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#7c84da",
+    "editorWidget.background": "#ecedee",
+    "editorWidget.foreground": "#383a42",
+    "editorWidget.border": "#7c84da",
+    "editorHoverWidget.background": "#ecedee",
+    "editorHoverWidget.foreground": "#383a42",
+    "editorHoverWidget.border": "#7c84da",
+    "list.activeSelectionBackground": "#d1ecff",
+    "list.activeSelectionForeground": "#383a42",
+    "list.warningForeground": "#ff8e38",
+    "statusBar.foreground": "#383a42",
+    "statusBar.background": "#d2d8da",
+    "statusBarItem.prominentBackground": "#239549",
+    "statusBarItem.prominentForeground": "#fafafa",
+    "focusBorder": "#7c84da",
+    "descriptionForeground": "#a0a1a7",
+    "editor.foreground": "#383a42",
+    "editor.background": "#fafafa",
+    "editor.lineHighlightBackground": "#dee1e3",
+    "editor.selectionForeground": "#383a42",
+    "editor.selectionBackground": "#d1ecff",
+    "editor.findMatchBackground": "#ea3971",
+    "editor.findMatchHighlightBackground": "#b2ebd0",
+    "editorCursor.foreground": "#fafafa",
+    "editorLineNumber.foreground": "#a0a1a7",
+    "editorLineNumber.background": "#fafafa",
+    "editorError.foreground": "#ff0000",
+    "editorWarning.foreground": "#ff8e38",
+    "quickInput.background": "#ecedee",
+    "quickInput.foreground": "#383a42",
+    "quickInputTitle.background": "#ecedee",
+    "quickInputList.focusBackground": "#d1ecff",
+    "quickInputList.focusForeground": "#383a42",
+    "input.background": "#ecedee",
+    "input.foreground": "#383a42",
+    "input.placeholderForeground": "#a0a1a7"
+  },
+  "type": "dark",
+  "name": "bluloco-light"
+}

--- a/themes/cyberdream.json
+++ b/themes/cyberdream.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#7b8496"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#5eff6c"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5ea0"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ffbd5e"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#5ef1ff"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5ea0"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#5ea1ff"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#5ea1ff"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#bd5eff"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#d45edd"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ffbd5e"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5ef1"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#bd5eff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#bd5eff"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5ea0"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#5ef1ff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff6e5e"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#3c4048",
+    "editorWidget.background": "#16181a",
+    "editorWidget.foreground": "#ffffff",
+    "editorWidget.border": "#3c4048",
+    "editorHoverWidget.background": "#16181a",
+    "editorHoverWidget.foreground": "#ffffff",
+    "editorHoverWidget.border": "#3c4048",
+    "list.activeSelectionBackground": "#3c4048",
+    "list.activeSelectionForeground": "#ffffff",
+    "list.warningForeground": "#f1ff5e",
+    "statusBar.foreground": "#ffffff",
+    "statusBar.background": "#16181a",
+    "statusBarItem.prominentBackground": "#5ea1ff",
+    "statusBarItem.prominentForeground": "#16181a",
+    "focusBorder": "#3c4048",
+    "descriptionForeground": "#7b8496",
+    "editor.foreground": "#ffffff",
+    "editor.background": "#16181a",
+    "editor.lineHighlightBackground": "#3c4048",
+    "editor.selectionForeground": "#ffffff",
+    "editor.selectionBackground": "#3c4048",
+    "editor.findMatchBackground": "#5ef1ff",
+    "editor.findMatchHighlightBackground": "#ffffff",
+    "editorCursor.foreground": "#16181a",
+    "editorLineNumber.foreground": "#7b8496",
+    "editorLineNumber.background": "#16181a",
+    "editorError.foreground": "#ff6e5e",
+    "editorWarning.foreground": "#f1ff5e",
+    "quickInput.background": "#16181a",
+    "quickInput.foreground": "#ffffff",
+    "quickInputTitle.background": "#16181a",
+    "quickInputList.focusBackground": "#3c4048",
+    "quickInputList.focusForeground": "#ffffff",
+    "input.background": "#16181a",
+    "input.foreground": "#ffffff",
+    "input.placeholderForeground": "#7b8496"
+  },
+  "type": "dark",
+  "name": "cyberdream"
+}

--- a/themes/duckbones.json
+++ b/themes/duckbones.json
@@ -1,0 +1,190 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#5a5f7b",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#aeb18d",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#aeb18d",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#aeb18d"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ebefc0",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#5dcd97"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#c6caa1"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c6caa1"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ebefc0"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ebefc0"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#898fb1"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#898fb1"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#795ccc",
+        "fontStyle": "bold"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#795ccc",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#898fb1"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#5dcd97"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#00a3cb"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#6d759d"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e03600"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#6b729b",
+    "editorWidget.background": "#222536",
+    "editorWidget.foreground": "#ebefc0",
+    "editorWidget.border": "#6b729b",
+    "editorHoverWidget.background": "#222536",
+    "editorHoverWidget.foreground": "#ebefc0",
+    "editorHoverWidget.border": "#6b729b",
+    "list.activeSelectionBackground": "#37382d",
+    "list.activeSelectionForeground": "#ebefc0",
+    "list.warningForeground": "#e39500",
+    "statusBar.foreground": "#ebefc0",
+    "statusBar.background": "#232738",
+    "statusBarItem.prominentBackground": "#ebefc0",
+    "statusBarItem.prominentForeground": "#0e101a",
+    "focusBorder": "#6b729b",
+    "descriptionForeground": "#5a5f7b",
+    "editor.foreground": "#ebefc0",
+    "editor.background": "#0e101a",
+    "editor.lineHighlightBackground": "#161926",
+    "editor.selectionForeground": "#ebefc0",
+    "editor.selectionBackground": "#37382d",
+    "editor.findMatchBackground": "#9a87dc",
+    "editor.findMatchHighlightBackground": "#4d3191",
+    "editorCursor.foreground": "#0e101a",
+    "editorLineNumber.foreground": "#5a5f7b",
+    "editorLineNumber.background": "#0e101a",
+    "editorError.foreground": "#e03600",
+    "editorWarning.foreground": "#e39500",
+    "quickInput.background": "#222536",
+    "quickInput.foreground": "#ebefc0",
+    "quickInputTitle.background": "#222536",
+    "quickInputList.focusBackground": "#37382d",
+    "quickInputList.focusForeground": "#ebefc0",
+    "input.background": "#222536",
+    "input.foreground": "#ebefc0",
+    "input.placeholderForeground": "#5a5f7b"
+  },
+  "type": "dark",
+  "name": "duckbones"
+}

--- a/themes/edge.json
+++ b/themes/edge.json
@@ -1,0 +1,185 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#758094",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#a0c980"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#a0c980"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#a0c980"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#5dbbc1"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ec7279"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#6cb6eb"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#6cb6eb"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#ec7279"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#d38aea"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#d38aea"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#d38aea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#ec7279"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#c5cdd9"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ec7279"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#758094",
+    "editorWidget.background": "#363944",
+    "editorWidget.foreground": "#c5cdd9",
+    "editorWidget.border": "#758094",
+    "editorHoverWidget.background": "#363944",
+    "editorHoverWidget.foreground": "#c5cdd9",
+    "editorHoverWidget.border": "#758094",
+    "list.activeSelectionBackground": "#3b3e48",
+    "list.activeSelectionForeground": "#c5cdd9",
+    "list.warningForeground": "#deb974",
+    "statusBar.foreground": "#c5cdd9",
+    "statusBar.background": "#363944",
+    "statusBarItem.prominentBackground": "#6cb6eb",
+    "statusBarItem.prominentForeground": "#2c2e34",
+    "focusBorder": "#758094",
+    "descriptionForeground": "#758094",
+    "editor.foreground": "#c5cdd9",
+    "editor.background": "#2c2e34",
+    "editor.lineHighlightBackground": "#33353f",
+    "editor.selectionForeground": "#c5cdd9",
+    "editor.selectionBackground": "#3b3e48",
+    "editor.findMatchBackground": "#6cb6eb",
+    "editor.findMatchHighlightBackground": "#a0c980",
+    "editorCursor.foreground": "#2c2e34",
+    "editorLineNumber.foreground": "#758094",
+    "editorLineNumber.background": "#2c2e34",
+    "editorError.foreground": "#ec7279",
+    "editorWarning.foreground": "#deb974",
+    "quickInput.background": "#363944",
+    "quickInput.foreground": "#c5cdd9",
+    "quickInputTitle.background": "#363944",
+    "quickInputList.focusBackground": "#3b3e48",
+    "quickInputList.focusForeground": "#c5cdd9",
+    "input.background": "#363944",
+    "input.foreground": "#c5cdd9",
+    "input.placeholderForeground": "#758094"
+  },
+  "type": "dark",
+  "name": "edge"
+}

--- a/themes/everforest.json
+++ b/themes/everforest.json
@@ -1,0 +1,185 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#859289",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#a7c080"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#83c092"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#d699b6"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#d699b6"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#dbbc7f"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#7fbbb3"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#d3c6aa"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#a7c080"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#a7c080"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#dbbc7f"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#dbbc7f"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#e67e80"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#e67e80"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e69875"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#e69875"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#e69875"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#d699b6"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#d3c6aa"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e67e80"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#859289",
+    "editorWidget.background": "#3d484d",
+    "editorWidget.foreground": "#d3c6aa",
+    "editorWidget.border": "#859289",
+    "editorHoverWidget.background": "#3d484d",
+    "editorHoverWidget.foreground": "#d3c6aa",
+    "editorHoverWidget.border": "#859289",
+    "list.activeSelectionBackground": "#543a48",
+    "list.activeSelectionForeground": "#d3c6aa",
+    "list.warningForeground": "#dbbc7f",
+    "statusBar.foreground": "#859289",
+    "statusBar.background": "#3d484d",
+    "statusBarItem.prominentBackground": "#a7c080",
+    "statusBarItem.prominentForeground": "#2d353b",
+    "focusBorder": "#859289",
+    "descriptionForeground": "#859289",
+    "editor.foreground": "#d3c6aa",
+    "editor.background": "#2d353b",
+    "editor.lineHighlightBackground": "#343f44",
+    "editor.selectionForeground": "#d3c6aa",
+    "editor.selectionBackground": "#543a48",
+    "editor.findMatchBackground": "#e67e80",
+    "editor.findMatchHighlightBackground": "#a7c080",
+    "editorCursor.foreground": "#2d353b",
+    "editorLineNumber.foreground": "#859289",
+    "editorLineNumber.background": "#2d353b",
+    "editorError.foreground": "#e67e80",
+    "editorWarning.foreground": "#dbbc7f",
+    "quickInput.background": "#3d484d",
+    "quickInput.foreground": "#d3c6aa",
+    "quickInputTitle.background": "#3d484d",
+    "quickInputList.focusBackground": "#543a48",
+    "quickInputList.focusForeground": "#d3c6aa",
+    "input.background": "#3d484d",
+    "input.foreground": "#d3c6aa",
+    "input.placeholderForeground": "#859289"
+  },
+  "type": "dark",
+  "name": "everforest"
+}

--- a/themes/fluoromachine.json
+++ b/themes/fluoromachine.json
@@ -1,0 +1,206 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#495495"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#af6df9"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#af6df9",
+        "background": "#2d273f"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#af6df9",
+        "background": "#2d273f"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#af6df9",
+        "background": "#2d273f"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#ffcc00"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#61e2ff"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ff8b39"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#ffcc00",
+        "background": "#312b32"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#ffcc00",
+        "background": "#312b32"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#af6df9"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fc199a",
+        "background": "#31233a"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fc199a",
+        "background": "#31233a"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fc199a",
+        "background": "#31233a"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fc199a",
+        "background": "#31233a"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fc199a",
+        "background": "#31233a"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ffcc00"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fc199a",
+        "background": "#31233a"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#fc199a"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#fe4450"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#8c57c7",
+    "editorWidget.background": "#241b2f",
+    "editorWidget.foreground": "#8ba7a7",
+    "editorWidget.border": "#8c57c7",
+    "editorHoverWidget.background": "#241b2f",
+    "editorHoverWidget.foreground": "#8ba7a7",
+    "editorHoverWidget.border": "#8c57c7",
+    "list.activeSelectionBackground": "#463465",
+    "list.activeSelectionForeground": "#8ba7a7",
+    "list.warningForeground": "#ff8b39",
+    "statusBar.foreground": "#8ba7a7",
+    "statusBar.background": "#241b2f",
+    "statusBarItem.prominentBackground": "#ffcc00",
+    "statusBarItem.prominentForeground": "#262335",
+    "focusBorder": "#8c57c7",
+    "descriptionForeground": "#495495",
+    "editor.foreground": "#8ba7a7",
+    "editor.background": "#262335",
+    "editor.lineHighlightBackground": "#463465",
+    "editor.selectionForeground": "#8ba7a7",
+    "editor.selectionBackground": "#463465",
+    "editor.findMatchBackground": "#463465",
+    "editor.findMatchHighlightBackground": "#463465",
+    "editorCursor.foreground": "#282a36",
+    "editorLineNumber.foreground": "#495495",
+    "editorLineNumber.background": "#262335",
+    "editorError.foreground": "#fe4450",
+    "editorWarning.foreground": "#ff8b39",
+    "quickInput.background": "#241b2f",
+    "quickInput.foreground": "#8ba7a7",
+    "quickInputTitle.background": "#241b2f",
+    "quickInputList.focusBackground": "#463465",
+    "quickInputList.focusForeground": "#8ba7a7",
+    "input.background": "#241b2f",
+    "input.foreground": "#8ba7a7",
+    "input.placeholderForeground": "#495495"
+  },
+  "type": "dark",
+  "name": "fluoromachine"
+}

--- a/themes/forestbones.json
+++ b/themes/forestbones.json
@@ -1,0 +1,192 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6e7b85",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#ada28b",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ada28b",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ada28b"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#e7dcc4",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#b5aa92",
+        "fontStyle": "bold"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#c6baa0"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c6baa0"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#e7dcc4"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#e7dcc4"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#7fbcb4"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#7fbcb4"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a9c181",
+        "fontStyle": "bold"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#a9c181",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#7fbcb4"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b5aa92",
+        "fontStyle": "bold"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#83c193"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7b8e9d"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e67c7f"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#798b9a",
+    "editorWidget.background": "#3b464e",
+    "editorWidget.foreground": "#e7dcc4",
+    "editorWidget.border": "#798b9a",
+    "editorHoverWidget.background": "#3b464e",
+    "editorHoverWidget.foreground": "#e7dcc4",
+    "editorHoverWidget.border": "#798b9a",
+    "list.activeSelectionBackground": "#615b51",
+    "list.activeSelectionForeground": "#e7dcc4",
+    "list.warningForeground": "#ddbd7f",
+    "statusBar.foreground": "#e7dcc4",
+    "statusBar.background": "#3e4850",
+    "statusBarItem.prominentBackground": "#e7dcc4",
+    "statusBarItem.prominentForeground": "#2c343a",
+    "focusBorder": "#798b9a",
+    "descriptionForeground": "#6e7b85",
+    "editor.foreground": "#e7dcc4",
+    "editor.background": "#2c343a",
+    "editor.lineHighlightBackground": "#313a41",
+    "editor.selectionForeground": "#e7dcc4",
+    "editor.selectionBackground": "#615b51",
+    "editor.findMatchBackground": "#dfb2c7",
+    "editor.findMatchHighlightBackground": "#9e5179",
+    "editorCursor.foreground": "#2c343a",
+    "editorLineNumber.foreground": "#6e7b85",
+    "editorLineNumber.background": "#2c343a",
+    "editorError.foreground": "#e67c7f",
+    "editorWarning.foreground": "#ddbd7f",
+    "quickInput.background": "#3b464e",
+    "quickInput.foreground": "#e7dcc4",
+    "quickInputTitle.background": "#3b464e",
+    "quickInputList.focusBackground": "#615b51",
+    "quickInputList.focusForeground": "#e7dcc4",
+    "input.background": "#3b464e",
+    "input.foreground": "#e7dcc4",
+    "input.placeholderForeground": "#6e7b85"
+  },
+  "type": "dark",
+  "name": "forestbones"
+}

--- a/themes/gruvbox.json
+++ b/themes/gruvbox.json
@@ -1,0 +1,189 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#928374"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#b8bb26"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#d3869b"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#d3869b"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#d3869b"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#fe8019"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#83a598"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#b8bb26",
+        "fontStyle": "bold"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#b8bb26",
+        "fontStyle": "bold"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#fabd2f"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#fe8019"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#fb4934"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#fb4934"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#ebdbb2",
+        "background": "#282828"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#fe8019"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#fe8019"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#8ec07c"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fb4934",
+        "background": "#282828"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#ebdbb2",
+    "editorWidget.background": "#07080d",
+    "editorWidget.foreground": "#ebdbb2",
+    "editorWidget.border": "#ebdbb2",
+    "editorHoverWidget.background": "#07080d",
+    "editorHoverWidget.foreground": "#ebdbb2",
+    "editorHoverWidget.border": "#ebdbb2",
+    "list.activeSelectionBackground": "#665c54",
+    "list.activeSelectionForeground": "#ebdbb2",
+    "list.warningForeground": "#fce094",
+    "statusBar.foreground": "#504945",
+    "statusBar.background": "#ebdbb2",
+    "statusBarItem.prominentBackground": "#b8bb26",
+    "statusBarItem.prominentForeground": "#282828",
+    "focusBorder": "#ebdbb2",
+    "descriptionForeground": "#928374",
+    "editor.foreground": "#ebdbb2",
+    "editor.background": "#282828",
+    "editor.lineHighlightBackground": "#3c3836",
+    "editor.selectionForeground": "#ebdbb2",
+    "editor.selectionBackground": "#665c54",
+    "editor.findMatchBackground": "#282828",
+    "editor.findMatchHighlightBackground": "#282828",
+    "editorCursor.foreground": "#b8bb26",
+    "editorLineNumber.foreground": "#928374",
+    "editorLineNumber.background": "#282828",
+    "editorError.foreground": "#ffc0b9",
+    "editorWarning.foreground": "#fce094",
+    "quickInput.background": "#07080d",
+    "quickInput.foreground": "#ebdbb2",
+    "quickInputTitle.background": "#07080d",
+    "quickInputList.focusBackground": "#665c54",
+    "quickInputList.focusForeground": "#ebdbb2",
+    "input.background": "#07080d",
+    "input.foreground": "#ebdbb2",
+    "input.placeholderForeground": "#928374"
+  },
+  "type": "dark",
+  "name": "gruvbox"
+}

--- a/themes/iceberg.json
+++ b/themes/iceberg.json
@@ -1,0 +1,185 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6b7089"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#89b8c2"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#a093c7"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#a093c7"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#a093c7"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#b4be82"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#89b8c2"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c6c8d1"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#84a0c6"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#a3adcb"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#84a0c6"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#84a0c6"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#84a0c6"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#84a0c6"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#84a0c6"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#84a0c6"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b4be82"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#b4be82"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#c6c8d1"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e27878",
+        "background": "#161821"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#c6c8d1",
+    "editorWidget.background": "#07080d",
+    "editorWidget.foreground": "#c6c8d1",
+    "editorWidget.border": "#c6c8d1",
+    "editorHoverWidget.background": "#07080d",
+    "editorHoverWidget.foreground": "#c6c8d1",
+    "editorHoverWidget.border": "#c6c8d1",
+    "list.activeSelectionBackground": "#272c42",
+    "list.activeSelectionForeground": "#c6c8d1",
+    "list.warningForeground": "#e2a478",
+    "statusBar.foreground": "#818596",
+    "statusBar.background": "#17171b",
+    "statusBarItem.prominentBackground": "#84a0c6",
+    "statusBarItem.prominentForeground": "#161821",
+    "focusBorder": "#c6c8d1",
+    "descriptionForeground": "#6b7089",
+    "editor.foreground": "#c6c8d1",
+    "editor.background": "#161821",
+    "editor.lineHighlightBackground": "#1e2132",
+    "editor.selectionForeground": "#c6c8d1",
+    "editor.selectionBackground": "#272c42",
+    "editor.findMatchBackground": "#e4aa80",
+    "editor.findMatchHighlightBackground": "#e4aa80",
+    "editorCursor.foreground": "#161821",
+    "editorLineNumber.foreground": "#6b7089",
+    "editorLineNumber.background": "#161821",
+    "editorError.foreground": "#e27878",
+    "editorWarning.foreground": "#e2a478",
+    "quickInput.background": "#07080d",
+    "quickInput.foreground": "#c6c8d1",
+    "quickInputTitle.background": "#07080d",
+    "quickInputList.focusBackground": "#272c42",
+    "quickInputList.focusForeground": "#c6c8d1",
+    "input.background": "#07080d",
+    "input.foreground": "#c6c8d1",
+    "input.placeholderForeground": "#6b7089"
+  },
+  "type": "dark",
+  "name": "iceberg"
+}

--- a/themes/jellybeans-mono.json
+++ b/themes/jellybeans-mono.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#606060",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#a08070"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#b39066"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#b39066"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#b39066"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#a0a8b0"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e8e8d3"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ccc5c4",
+        "fontStyle": "italic"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7a8aa6",
+        "fontStyle": "bold"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#7a8aa6",
+        "fontStyle": "bold"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#b39066",
+        "fontStyle": "bold"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b39066",
+        "fontStyle": "bold"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#888888"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#888888"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#b39066",
+        "fontStyle": "bold"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a0a8b0"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "background": "#c95c5c"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#403c41",
+    "editorWidget.background": "#403c41",
+    "editorWidget.foreground": "#e8e8d3",
+    "editorWidget.border": "#403c41",
+    "editorHoverWidget.background": "#403c41",
+    "editorHoverWidget.foreground": "#e8e8d3",
+    "editorHoverWidget.border": "#403c41",
+    "list.activeSelectionBackground": "#404040",
+    "list.activeSelectionForeground": "#e8e8d3",
+    "list.warningForeground": "#ffaf00",
+    "statusBar.foreground": "#ffffff",
+    "statusBar.background": "#1c1c1c",
+    "statusBarItem.prominentBackground": "#7a8aa6",
+    "statusBarItem.prominentForeground": "#151515",
+    "focusBorder": "#403c41",
+    "descriptionForeground": "#606060",
+    "editor.foreground": "#e8e8d3",
+    "editor.background": "#151515",
+    "editor.lineHighlightBackground": "#212121",
+    "editor.selectionForeground": "#e8e8d3",
+    "editor.selectionBackground": "#404040",
+    "editor.findMatchBackground": "#888888",
+    "editor.findMatchHighlightBackground": "#302028",
+    "editorCursor.foreground": "#151515",
+    "editorLineNumber.foreground": "#606060",
+    "editorLineNumber.background": "#151515",
+    "editorError.foreground": "#c95c5c",
+    "editorWarning.foreground": "#ffaf00",
+    "quickInput.background": "#403c41",
+    "quickInput.foreground": "#e8e8d3",
+    "quickInputTitle.background": "#403c41",
+    "quickInputList.focusBackground": "#404040",
+    "quickInputList.focusForeground": "#e8e8d3",
+    "input.background": "#403c41",
+    "input.foreground": "#e8e8d3",
+    "input.placeholderForeground": "#606060"
+  },
+  "type": "dark",
+  "name": "jellybeans-mono"
+}

--- a/themes/jellybeans-muted.json
+++ b/themes/jellybeans-muted.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#7a7a7a",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#909c6e"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#c88a77"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#c88a77"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#c88a77"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#c88a77"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#dad6c8"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c2bdb8",
+        "fontStyle": "italic"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#eace98"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#eace98"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#d8a16c",
+        "fontStyle": "italic"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#698a9c"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#83adc3"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#83adc3"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#a6c3d9"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#d8a16c",
+        "fontStyle": "italic"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b8aed3"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#7a8aa6"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#617b87"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "background": "#cc4d4d"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#3c3936",
+    "editorWidget.background": "#3c3936",
+    "editorWidget.foreground": "#dad6c8",
+    "editorWidget.border": "#3c3936",
+    "editorHoverWidget.background": "#3c3936",
+    "editorHoverWidget.foreground": "#dad6c8",
+    "editorHoverWidget.border": "#3c3936",
+    "list.activeSelectionBackground": "#3c3b38",
+    "list.activeSelectionForeground": "#dad6c8",
+    "list.warningForeground": "#d9a45a",
+    "statusBar.foreground": "#f9f5ec",
+    "statusBar.background": "#1e1e1c",
+    "statusBarItem.prominentBackground": "#eace98",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#3c3936",
+    "descriptionForeground": "#7a7a7a",
+    "editor.foreground": "#dad6c8",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#1c1c1c",
+    "editor.selectionForeground": "#dad6c8",
+    "editor.selectionBackground": "#3c3b38",
+    "editor.findMatchBackground": "#d8a16c",
+    "editor.findMatchHighlightBackground": "#2c2824",
+    "editorCursor.foreground": "#101010",
+    "editorLineNumber.foreground": "#7a7a7a",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#cc4d4d",
+    "editorWarning.foreground": "#d9a45a",
+    "quickInput.background": "#3c3936",
+    "quickInput.foreground": "#dad6c8",
+    "quickInputTitle.background": "#3c3936",
+    "quickInputList.focusBackground": "#3c3b38",
+    "quickInputList.focusForeground": "#dad6c8",
+    "input.background": "#3c3936",
+    "input.foreground": "#dad6c8",
+    "input.placeholderForeground": "#7a7a7a"
+  },
+  "type": "dark",
+  "name": "jellybeans-muted"
+}

--- a/themes/jellybeans.json
+++ b/themes/jellybeans.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#888888",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#99ad6a"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#d98870"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#d98870"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#d98870"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#d98870"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e8e8d3"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ccc5c4",
+        "fontStyle": "italic"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#fbd587"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#fbd587"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#e6a75a",
+        "fontStyle": "italic"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#7299b0"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#8fbfdc"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#8fbfdc"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#b0d0f0"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#e6a75a",
+        "fontStyle": "italic"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#c6b6ee"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#8197bf"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#668799"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "background": "#d74545"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#403c41",
+    "editorWidget.background": "#403c41",
+    "editorWidget.foreground": "#e8e8d3",
+    "editorWidget.border": "#403c41",
+    "editorHoverWidget.background": "#403c41",
+    "editorHoverWidget.foreground": "#e8e8d3",
+    "editorHoverWidget.border": "#403c41",
+    "list.activeSelectionBackground": "#404040",
+    "list.activeSelectionForeground": "#e8e8d3",
+    "list.warningForeground": "#ffaf00",
+    "statusBar.foreground": "#ffffff",
+    "statusBar.background": "#1c1c1c",
+    "statusBarItem.prominentBackground": "#fbd587",
+    "statusBarItem.prominentForeground": "#151515",
+    "focusBorder": "#403c41",
+    "descriptionForeground": "#888888",
+    "editor.foreground": "#e8e8d3",
+    "editor.background": "#151515",
+    "editor.lineHighlightBackground": "#212121",
+    "editor.selectionForeground": "#e8e8d3",
+    "editor.selectionBackground": "#404040",
+    "editor.findMatchBackground": "#e6a75a",
+    "editor.findMatchHighlightBackground": "#302028",
+    "editorCursor.foreground": "#151515",
+    "editorLineNumber.foreground": "#888888",
+    "editorLineNumber.background": "#151515",
+    "editorError.foreground": "#d74545",
+    "editorWarning.foreground": "#ffaf00",
+    "quickInput.background": "#403c41",
+    "quickInput.foreground": "#e8e8d3",
+    "quickInputTitle.background": "#403c41",
+    "quickInputList.focusBackground": "#404040",
+    "quickInputList.focusForeground": "#e8e8d3",
+    "input.background": "#403c41",
+    "input.foreground": "#e8e8d3",
+    "input.placeholderForeground": "#888888"
+  },
+  "type": "dark",
+  "name": "jellybeans"
+}

--- a/themes/kanagawa-dragon.json
+++ b/themes/kanagawa-dragon.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#737c73",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#8a9a7b"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#b6927b"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#a292a3"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#b6927b",
+        "fontStyle": "bold"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#949fb5"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#c4b28a"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#a6a69c"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#8ba4b0"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#8ba4b0"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#8ea4a2"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#949fb5"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#8992a7",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#8992a7",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#c4746e"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#8ea4a2"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#949fb5"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#b6927b"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#9e9b93"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e82424"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#54546d",
+    "editorWidget.background": "#0d0c0c",
+    "editorWidget.foreground": "#c8c093",
+    "editorWidget.border": "#54546d",
+    "editorHoverWidget.background": "#0d0c0c",
+    "editorHoverWidget.foreground": "#c8c093",
+    "editorHoverWidget.border": "#54546d",
+    "list.activeSelectionBackground": "#223249",
+    "list.activeSelectionForeground": "#c5c9c5",
+    "list.warningForeground": "#ff9e3b",
+    "statusBar.foreground": "#c8c093",
+    "statusBar.background": "#0d0c0c",
+    "statusBarItem.prominentBackground": "#8ba4b0",
+    "statusBarItem.prominentForeground": "#181616",
+    "focusBorder": "#54546d",
+    "descriptionForeground": "#737c73",
+    "editor.foreground": "#c5c9c5",
+    "editor.background": "#181616",
+    "editor.lineHighlightBackground": "#393836",
+    "editor.selectionForeground": "#c5c9c5",
+    "editor.selectionBackground": "#223249",
+    "editor.findMatchBackground": "#ff9e3b",
+    "editor.findMatchHighlightBackground": "#2d4f67",
+    "editorCursor.foreground": "#181616",
+    "editorLineNumber.foreground": "#737c73",
+    "editorLineNumber.background": "#181616",
+    "editorError.foreground": "#e82424",
+    "editorWarning.foreground": "#ff9e3b",
+    "quickInput.background": "#0d0c0c",
+    "quickInput.foreground": "#c8c093",
+    "quickInputTitle.background": "#0d0c0c",
+    "quickInputList.focusBackground": "#223249",
+    "quickInputList.focusForeground": "#c5c9c5",
+    "input.background": "#0d0c0c",
+    "input.foreground": "#c8c093",
+    "input.placeholderForeground": "#737c73"
+  },
+  "type": "dark",
+  "name": "kanagawa-dragon"
+}

--- a/themes/kanagawa-lotus.json
+++ b/themes/kanagawa-lotus.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#8a8980",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#6f894e"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#cc6d00"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#b35b79"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#cc6d00",
+        "fontStyle": "bold"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#6693bf"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#77713f"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#5d57a3"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#4d699b"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#4d699b"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#597b75"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#6693bf"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#624c83",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#624c83",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#836f4a"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#597b75"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#6693bf"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#cc6d00"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#4e8ca2"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e82424"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#716e61",
+    "editorWidget.background": "#d5cea3",
+    "editorWidget.foreground": "#43436c",
+    "editorWidget.border": "#716e61",
+    "editorHoverWidget.background": "#d5cea3",
+    "editorHoverWidget.foreground": "#43436c",
+    "editorHoverWidget.border": "#716e61",
+    "list.activeSelectionBackground": "#c9cbd1",
+    "list.activeSelectionForeground": "#545464",
+    "list.warningForeground": "#e98a00",
+    "statusBar.foreground": "#43436c",
+    "statusBar.background": "#d5cea3",
+    "statusBarItem.prominentBackground": "#4d699b",
+    "statusBarItem.prominentForeground": "#f2ecbc",
+    "focusBorder": "#716e61",
+    "descriptionForeground": "#8a8980",
+    "editor.foreground": "#545464",
+    "editor.background": "#f2ecbc",
+    "editor.lineHighlightBackground": "#e4d794",
+    "editor.selectionForeground": "#545464",
+    "editor.selectionBackground": "#c9cbd1",
+    "editor.findMatchBackground": "#e98a00",
+    "editor.findMatchHighlightBackground": "#b5cbd2",
+    "editorCursor.foreground": "#f2ecbc",
+    "editorLineNumber.foreground": "#8a8980",
+    "editorLineNumber.background": "#f2ecbc",
+    "editorError.foreground": "#e82424",
+    "editorWarning.foreground": "#e98a00",
+    "quickInput.background": "#d5cea3",
+    "quickInput.foreground": "#43436c",
+    "quickInputTitle.background": "#d5cea3",
+    "quickInputList.focusBackground": "#c9cbd1",
+    "quickInputList.focusForeground": "#545464",
+    "input.background": "#d5cea3",
+    "input.foreground": "#43436c",
+    "input.placeholderForeground": "#8a8980"
+  },
+  "type": "dark",
+  "name": "kanagawa-lotus"
+}

--- a/themes/kanagawa-wave.json
+++ b/themes/kanagawa-wave.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#727169",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#98bb6c"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ffa066"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#d27e99"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ffa066",
+        "fontStyle": "bold"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#7fb4ca"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e6c384"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#b8b4d0"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7e9cd8"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#7e9cd8"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa89f"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#7fb4ca"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#957fb8",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#957fb8",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#c0a36e"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa89f"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#7fb4ca"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#ffa066"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#9cabca"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e82424"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#54546d",
+    "editorWidget.background": "#16161d",
+    "editorWidget.foreground": "#c8c093",
+    "editorWidget.border": "#54546d",
+    "editorHoverWidget.background": "#16161d",
+    "editorHoverWidget.foreground": "#c8c093",
+    "editorHoverWidget.border": "#54546d",
+    "list.activeSelectionBackground": "#223249",
+    "list.activeSelectionForeground": "#dcd7ba",
+    "list.warningForeground": "#ff9e3b",
+    "statusBar.foreground": "#c8c093",
+    "statusBar.background": "#16161d",
+    "statusBarItem.prominentBackground": "#7e9cd8",
+    "statusBarItem.prominentForeground": "#1f1f28",
+    "focusBorder": "#54546d",
+    "descriptionForeground": "#727169",
+    "editor.foreground": "#dcd7ba",
+    "editor.background": "#1f1f28",
+    "editor.lineHighlightBackground": "#363646",
+    "editor.selectionForeground": "#dcd7ba",
+    "editor.selectionBackground": "#223249",
+    "editor.findMatchBackground": "#ff9e3b",
+    "editor.findMatchHighlightBackground": "#2d4f67",
+    "editorCursor.foreground": "#1f1f28",
+    "editorLineNumber.foreground": "#727169",
+    "editorLineNumber.background": "#1f1f28",
+    "editorError.foreground": "#e82424",
+    "editorWarning.foreground": "#ff9e3b",
+    "quickInput.background": "#16161d",
+    "quickInput.foreground": "#c8c093",
+    "quickInputTitle.background": "#16161d",
+    "quickInputList.focusBackground": "#223249",
+    "quickInputList.focusForeground": "#dcd7ba",
+    "input.background": "#16161d",
+    "input.foreground": "#c8c093",
+    "input.placeholderForeground": "#727169"
+  },
+  "type": "dark",
+  "name": "kanagawa-wave"
+}

--- a/themes/kanagawa.json
+++ b/themes/kanagawa.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#727169",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#98bb6c"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ffa066"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#d27e99"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ffa066",
+        "fontStyle": "bold"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#7fb4ca"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e6c384"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#b8b4d0"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7e9cd8"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#7e9cd8"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa89f"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#7fb4ca"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#957fb8",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#957fb8",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#c0a36e"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa89f"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#7fb4ca"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#ffa066"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#9cabca"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e82424"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#54546d",
+    "editorWidget.background": "#16161d",
+    "editorWidget.foreground": "#c8c093",
+    "editorWidget.border": "#54546d",
+    "editorHoverWidget.background": "#16161d",
+    "editorHoverWidget.foreground": "#c8c093",
+    "editorHoverWidget.border": "#54546d",
+    "list.activeSelectionBackground": "#223249",
+    "list.activeSelectionForeground": "#dcd7ba",
+    "list.warningForeground": "#ff9e3b",
+    "statusBar.foreground": "#c8c093",
+    "statusBar.background": "#16161d",
+    "statusBarItem.prominentBackground": "#7e9cd8",
+    "statusBarItem.prominentForeground": "#1f1f28",
+    "focusBorder": "#54546d",
+    "descriptionForeground": "#727169",
+    "editor.foreground": "#dcd7ba",
+    "editor.background": "#1f1f28",
+    "editor.lineHighlightBackground": "#363646",
+    "editor.selectionForeground": "#dcd7ba",
+    "editor.selectionBackground": "#223249",
+    "editor.findMatchBackground": "#ff9e3b",
+    "editor.findMatchHighlightBackground": "#2d4f67",
+    "editorCursor.foreground": "#1f1f28",
+    "editorLineNumber.foreground": "#727169",
+    "editorLineNumber.background": "#1f1f28",
+    "editorError.foreground": "#e82424",
+    "editorWarning.foreground": "#ff9e3b",
+    "quickInput.background": "#16161d",
+    "quickInput.foreground": "#c8c093",
+    "quickInputTitle.background": "#16161d",
+    "quickInputList.focusBackground": "#223249",
+    "quickInputList.focusForeground": "#dcd7ba",
+    "input.background": "#16161d",
+    "input.foreground": "#c8c093",
+    "input.placeholderForeground": "#727169"
+  },
+  "type": "dark",
+  "name": "kanagawa"
+}

--- a/themes/kanagawabones.json
+++ b/themes/kanagawabones.json
@@ -1,0 +1,193 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#696977",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#a29e89",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#a29e89",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#a29e89"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ddd8bb",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#ada992",
+        "fontStyle": "bold"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#bbb79e"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#bbb79e"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ddd8bb"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ddd8bb"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#9797a5"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#9797a5"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ddd8bb",
+        "fontStyle": "bold"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#ddd8bb",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#9797a5"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ada992",
+        "fontStyle": "bold"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#ddd8bb",
+        "fontStyle": "bold"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7d7d8d"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e46a78"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#7b7b8b",
+    "editorWidget.background": "#31313f",
+    "editorWidget.foreground": "#ddd8bb",
+    "editorWidget.border": "#7b7b8b",
+    "editorHoverWidget.background": "#31313f",
+    "editorHoverWidget.foreground": "#ddd8bb",
+    "editorHoverWidget.border": "#7b7b8b",
+    "list.activeSelectionBackground": "#49473e",
+    "list.activeSelectionForeground": "#ddd8bb",
+    "list.warningForeground": "#e5c283",
+    "statusBar.foreground": "#ddd8bb",
+    "statusBar.background": "#363644",
+    "statusBarItem.prominentBackground": "#ddd8bb",
+    "statusBarItem.prominentForeground": "#1f1f28",
+    "focusBorder": "#7b7b8b",
+    "descriptionForeground": "#696977",
+    "editor.foreground": "#ddd8bb",
+    "editor.background": "#1f1f28",
+    "editor.lineHighlightBackground": "#272732",
+    "editor.selectionForeground": "#ddd8bb",
+    "editor.selectionBackground": "#49473e",
+    "editor.findMatchBackground": "#ae9fca",
+    "editor.findMatchHighlightBackground": "#614a82",
+    "editorCursor.foreground": "#1f1f28",
+    "editorLineNumber.foreground": "#696977",
+    "editorLineNumber.background": "#1f1f28",
+    "editorError.foreground": "#e46a78",
+    "editorWarning.foreground": "#e5c283",
+    "quickInput.background": "#31313f",
+    "quickInput.foreground": "#ddd8bb",
+    "quickInputTitle.background": "#31313f",
+    "quickInputList.focusBackground": "#49473e",
+    "quickInputList.focusForeground": "#ddd8bb",
+    "input.background": "#31313f",
+    "input.foreground": "#ddd8bb",
+    "input.placeholderForeground": "#696977"
+  },
+  "type": "dark",
+  "name": "kanagawabones"
+}

--- a/themes/koda.json
+++ b/themes/koda.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#50585d"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#d9ba73"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#d9ba73"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#d9ba73"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#b0b0b0"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#b0b0b0"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#b0b0b0"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff",
+        "fontStyle": "bold"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff",
+        "fontStyle": "bold"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b0b0b0"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#777777"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff7676"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#ffffff",
+    "editorWidget.background": "#101010",
+    "editorWidget.foreground": "#b0b0b0",
+    "editorWidget.border": "#ffffff",
+    "editorHoverWidget.background": "#101010",
+    "editorHoverWidget.foreground": "#b0b0b0",
+    "editorHoverWidget.border": "#ffffff",
+    "list.activeSelectionBackground": "#272727",
+    "list.activeSelectionForeground": "#b0b0b0",
+    "list.warningForeground": "#d9ba73",
+    "statusBar.foreground": "#b0b0b0",
+    "statusBar.background": "#272727",
+    "statusBarItem.prominentBackground": "#ffffff",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#ffffff",
+    "descriptionForeground": "#50585d",
+    "editor.foreground": "#b0b0b0",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#272727",
+    "editor.selectionForeground": "#b0b0b0",
+    "editor.selectionBackground": "#272727",
+    "editor.findMatchBackground": "#383224",
+    "editor.findMatchHighlightBackground": "#272727",
+    "editorCursor.foreground": "#b0b0b0",
+    "editorLineNumber.foreground": "#50585d",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#ff7676",
+    "editorWarning.foreground": "#d9ba73",
+    "quickInput.background": "#101010",
+    "quickInput.foreground": "#b0b0b0",
+    "quickInputTitle.background": "#101010",
+    "quickInputList.focusBackground": "#272727",
+    "quickInputList.focusForeground": "#b0b0b0",
+    "input.background": "#101010",
+    "input.foreground": "#b0b0b0",
+    "input.placeholderForeground": "#50585d"
+  },
+  "type": "dark",
+  "name": "koda"
+}

--- a/themes/lackluster-dark.json
+++ b/themes/lackluster-dark.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#3a3a3a"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#aa6666"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#555555"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#d70000"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#444444",
+    "editorWidget.background": "#1a1a1a",
+    "editorWidget.foreground": "#cccccc",
+    "editorWidget.border": "#444444",
+    "editorHoverWidget.background": "#1a1a1a",
+    "editorHoverWidget.foreground": "#cccccc",
+    "editorHoverWidget.border": "#444444",
+    "list.activeSelectionBackground": "#cccccc",
+    "list.activeSelectionForeground": "#000000",
+    "list.warningForeground": "#444444",
+    "statusBar.foreground": "#aaaaaa",
+    "statusBar.background": "#242424",
+    "statusBarItem.prominentBackground": "#555555",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#444444",
+    "descriptionForeground": "#3a3a3a",
+    "editor.foreground": "#cccccc",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#191919",
+    "editor.selectionForeground": "#000000",
+    "editor.selectionBackground": "#cccccc",
+    "editor.findMatchBackground": "#cccccc",
+    "editor.findMatchHighlightBackground": "#708090",
+    "editorCursor.foreground": "#101010",
+    "editorLineNumber.foreground": "#3a3a3a",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#d70000",
+    "editorWarning.foreground": "#444444",
+    "quickInput.background": "#1a1a1a",
+    "quickInput.foreground": "#cccccc",
+    "quickInputTitle.background": "#1a1a1a",
+    "quickInputList.focusBackground": "#cccccc",
+    "quickInputList.focusForeground": "#000000",
+    "input.background": "#1a1a1a",
+    "input.foreground": "#cccccc",
+    "input.placeholderForeground": "#3a3a3a"
+  },
+  "type": "dark",
+  "name": "lackluster-dark"
+}

--- a/themes/lackluster-hack.json
+++ b/themes/lackluster-hack.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#3a3a3a"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#8e8e8e"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#deeeed"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#d70000"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#444444",
+    "editorWidget.background": "#1a1a1a",
+    "editorWidget.foreground": "#cccccc",
+    "editorWidget.border": "#444444",
+    "editorHoverWidget.background": "#1a1a1a",
+    "editorHoverWidget.foreground": "#cccccc",
+    "editorHoverWidget.border": "#444444",
+    "list.activeSelectionBackground": "#cccccc",
+    "list.activeSelectionForeground": "#000000",
+    "list.warningForeground": "#444444",
+    "statusBar.foreground": "#aaaaaa",
+    "statusBar.background": "#242424",
+    "statusBarItem.prominentBackground": "#7a7a7a",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#444444",
+    "descriptionForeground": "#3a3a3a",
+    "editor.foreground": "#cccccc",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#191919",
+    "editor.selectionForeground": "#000000",
+    "editor.selectionBackground": "#cccccc",
+    "editor.findMatchBackground": "#cccccc",
+    "editor.findMatchHighlightBackground": "#708090",
+    "editorCursor.foreground": "#101010",
+    "editorLineNumber.foreground": "#3a3a3a",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#d70000",
+    "editorWarning.foreground": "#444444",
+    "quickInput.background": "#1a1a1a",
+    "quickInput.foreground": "#cccccc",
+    "quickInputTitle.background": "#1a1a1a",
+    "quickInputList.focusBackground": "#cccccc",
+    "quickInputList.focusForeground": "#000000",
+    "input.background": "#1a1a1a",
+    "input.foreground": "#cccccc",
+    "input.placeholderForeground": "#3a3a3a"
+  },
+  "type": "dark",
+  "name": "lackluster-hack"
+}

--- a/themes/lackluster-mint.json
+++ b/themes/lackluster-mint.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#3a3a3a"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#789978"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#deeeed"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#789978"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#789978"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#789978"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#d70000"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#444444",
+    "editorWidget.background": "#1a1a1a",
+    "editorWidget.foreground": "#cccccc",
+    "editorWidget.border": "#444444",
+    "editorHoverWidget.background": "#1a1a1a",
+    "editorHoverWidget.foreground": "#cccccc",
+    "editorHoverWidget.border": "#444444",
+    "list.activeSelectionBackground": "#cccccc",
+    "list.activeSelectionForeground": "#000000",
+    "list.warningForeground": "#444444",
+    "statusBar.foreground": "#aaaaaa",
+    "statusBar.background": "#242424",
+    "statusBarItem.prominentBackground": "#7a7a7a",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#444444",
+    "descriptionForeground": "#3a3a3a",
+    "editor.foreground": "#cccccc",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#191919",
+    "editor.selectionForeground": "#000000",
+    "editor.selectionBackground": "#cccccc",
+    "editor.findMatchBackground": "#cccccc",
+    "editor.findMatchHighlightBackground": "#708090",
+    "editorCursor.foreground": "#101010",
+    "editorLineNumber.foreground": "#3a3a3a",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#d70000",
+    "editorWarning.foreground": "#444444",
+    "quickInput.background": "#1a1a1a",
+    "quickInput.foreground": "#cccccc",
+    "quickInputTitle.background": "#1a1a1a",
+    "quickInputList.focusBackground": "#cccccc",
+    "quickInputList.focusForeground": "#000000",
+    "input.background": "#1a1a1a",
+    "input.foreground": "#cccccc",
+    "input.placeholderForeground": "#3a3a3a"
+  },
+  "type": "dark",
+  "name": "lackluster-mint"
+}

--- a/themes/lackluster-night.json
+++ b/themes/lackluster-night.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#3a3a3a"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#abab77"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#8e8e8e"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#deeeed"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#d70000"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#444444",
+    "editorWidget.background": "#1a1a1a",
+    "editorWidget.foreground": "#cccccc",
+    "editorWidget.border": "#444444",
+    "editorHoverWidget.background": "#1a1a1a",
+    "editorHoverWidget.foreground": "#cccccc",
+    "editorHoverWidget.border": "#444444",
+    "list.activeSelectionBackground": "#cccccc",
+    "list.activeSelectionForeground": "#000000",
+    "list.warningForeground": "#444444",
+    "statusBar.foreground": "#aaaaaa",
+    "statusBar.background": "#242424",
+    "statusBarItem.prominentBackground": "#7a7a7a",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#444444",
+    "descriptionForeground": "#3a3a3a",
+    "editor.foreground": "#cccccc",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#191919",
+    "editor.selectionForeground": "#000000",
+    "editor.selectionBackground": "#cccccc",
+    "editor.findMatchBackground": "#cccccc",
+    "editor.findMatchHighlightBackground": "#708090",
+    "editorCursor.foreground": "#101010",
+    "editorLineNumber.foreground": "#3a3a3a",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#d70000",
+    "editorWarning.foreground": "#444444",
+    "quickInput.background": "#1a1a1a",
+    "quickInput.foreground": "#cccccc",
+    "quickInputTitle.background": "#1a1a1a",
+    "quickInputList.focusBackground": "#cccccc",
+    "quickInputList.focusForeground": "#000000",
+    "input.background": "#1a1a1a",
+    "input.foreground": "#cccccc",
+    "input.placeholderForeground": "#3a3a3a"
+  },
+  "type": "dark",
+  "name": "lackluster-night"
+}

--- a/themes/lackluster.json
+++ b/themes/lackluster.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#3a3a3a"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#8e8e8e"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#deeeed"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#aaaaaa"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#708090"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#666666"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7a7a7a"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#d70000"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#444444",
+    "editorWidget.background": "#1a1a1a",
+    "editorWidget.foreground": "#cccccc",
+    "editorWidget.border": "#444444",
+    "editorHoverWidget.background": "#1a1a1a",
+    "editorHoverWidget.foreground": "#cccccc",
+    "editorHoverWidget.border": "#444444",
+    "list.activeSelectionBackground": "#cccccc",
+    "list.activeSelectionForeground": "#000000",
+    "list.warningForeground": "#444444",
+    "statusBar.foreground": "#aaaaaa",
+    "statusBar.background": "#242424",
+    "statusBarItem.prominentBackground": "#7a7a7a",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#444444",
+    "descriptionForeground": "#3a3a3a",
+    "editor.foreground": "#cccccc",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#191919",
+    "editor.selectionForeground": "#000000",
+    "editor.selectionBackground": "#cccccc",
+    "editor.findMatchBackground": "#cccccc",
+    "editor.findMatchHighlightBackground": "#708090",
+    "editorCursor.foreground": "#101010",
+    "editorLineNumber.foreground": "#3a3a3a",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#d70000",
+    "editorWarning.foreground": "#444444",
+    "quickInput.background": "#1a1a1a",
+    "quickInput.foreground": "#cccccc",
+    "quickInputTitle.background": "#1a1a1a",
+    "quickInputList.focusBackground": "#cccccc",
+    "quickInputList.focusForeground": "#000000",
+    "input.background": "#1a1a1a",
+    "input.foreground": "#cccccc",
+    "input.placeholderForeground": "#3a3a3a"
+  },
+  "type": "dark",
+  "name": "lackluster"
+}

--- a/themes/licenses/alexvzyl-nordic-nvim.txt
+++ b/themes/licenses/alexvzyl-nordic-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Alexander van Zyl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/baliestri-aura-theme.txt
+++ b/themes/licenses/baliestri-aura-theme.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 - * Dalton Menezes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/bluz71-vim-moonfly-colors.txt
+++ b/themes/licenses/bluz71-vim-moonfly-colors.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-present vim-moonfly-colors authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/bluz71-vim-nightfly-colors.txt
+++ b/themes/licenses/bluz71-vim-nightfly-colors.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present vim-nightfly-colors authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/cocopon-iceberg-vim.txt
+++ b/themes/licenses/cocopon-iceberg-vim.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2014 cocopon <cocopon@me.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/craftzdog-solarized-osaka-nvim.txt
+++ b/themes/licenses/craftzdog-solarized-osaka-nvim.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Takuya Matsuyama
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/themes/licenses/datsfilipe-vesper-nvim.txt
+++ b/themes/licenses/datsfilipe-vesper-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 datsfilipe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/edeneast-nightfox-nvim.txt
+++ b/themes/licenses/edeneast-nightfox-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 James Simpson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/fcancelinha-nordern-nvim.txt
+++ b/themes/licenses/fcancelinha-nordern-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Filipe Cancelinha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/fcoury-termy-nvim.txt
+++ b/themes/licenses/fcoury-termy-nvim.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2026 Felipe Coury
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/folke-tokyonight-nvim.txt
+++ b/themes/licenses/folke-tokyonight-nvim.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/themes/licenses/hiroya-w-sequoia-moonlight-nvim.txt
+++ b/themes/licenses/hiroya-w-sequoia-moonlight-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Hiroya-W
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/maxmx03-fluoromachine-nvim.txt
+++ b/themes/licenses/maxmx03-fluoromachine-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Dracula Theme
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/mofiqul-vscode-nvim.txt
+++ b/themes/licenses/mofiqul-vscode-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Mofiqul Islam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/morhetz-gruvbox.txt
+++ b/themes/licenses/morhetz-gruvbox.txt
@@ -1,0 +1,6 @@
+morhetz/gruvbox
+
+License: MIT
+Source: https://github.com/morhetz/gruvbox
+
+The local checkout did not include a standalone license text file. Its package metadata or README declares this license.

--- a/themes/licenses/navarasu-onedark-nvim.txt
+++ b/themes/licenses/navarasu-onedark-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Navarasu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/nyoom-engineering-oxocarbon-nvim.txt
+++ b/themes/licenses/nyoom-engineering-oxocarbon-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Riccardo Mazzarini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/oskarnurm-koda-nvim.txt
+++ b/themes/licenses/oskarnurm-koda-nvim.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2026 Karl Oskar Joosep Nurm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/ramojus-mellifluous-nvim.txt
+++ b/themes/licenses/ramojus-mellifluous-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Ramojus Lapinskas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/rebelot-kanagawa-nvim.txt
+++ b/themes/licenses/rebelot-kanagawa-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Tommaso Laurenzi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/ribru17-bamboo-nvim.txt
+++ b/themes/licenses/ribru17-bamboo-nvim.txt
@@ -1,0 +1,23 @@
+MIT License
+
+Original Copyright (c) 2021 Navarasu
+
+Copyright (c) 2023 Riley Bruins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/rmehri01-onenord-nvim.txt
+++ b/themes/licenses/rmehri01-onenord-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Ryan Mehri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/rose-pine-neovim.txt
+++ b/themes/licenses/rose-pine-neovim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Rosé Pine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/sainnhe-edge.txt
+++ b/themes/licenses/sainnhe-edge.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Sainnhepark
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/sainnhe-everforest.txt
+++ b/themes/licenses/sainnhe-everforest.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 sainnhe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/sainnhe-sonokai.txt
+++ b/themes/licenses/sainnhe-sonokai.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 sainnhe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/scottmckendry-cyberdream-nvim.txt
+++ b/themes/licenses/scottmckendry-cyberdream-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Scott McKendry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/slugbyte-lackluster-nvim.txt
+++ b/themes/licenses/slugbyte-lackluster-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Duncan Marsh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/tahayvr-matteblack-nvim.txt
+++ b/themes/licenses/tahayvr-matteblack-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Taha Nejad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/licenses/uloco-bluloco-nvim.txt
+++ b/themes/licenses/uloco-bluloco-nvim.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/themes/licenses/wtfox-jellybeans-nvim.txt
+++ b/themes/licenses/wtfox-jellybeans-nvim.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/themes/licenses/zenbones-theme-zenbones-nvim.txt
+++ b/themes/licenses/zenbones-theme-zenbones-nvim.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Michael Chris Lopez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/matteblack.json
+++ b/themes/matteblack.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#8a8a8d",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#eaeaea"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#d97706"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#efbf04"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#10b981"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#efbf04"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#d97706"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#bebebe"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#dc2626"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#f59e0b"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#fbbf24"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#f59e0b",
+        "fontStyle": "italic"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#059669"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#059669"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#bebebe"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#fbbf24"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#059669"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#d97706",
+        "fontStyle": "italic"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#8a8a8d"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#eef1f8",
+        "background": "#590008"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#333333",
+    "editorWidget.background": "#212121",
+    "editorWidget.foreground": "#eaeaea",
+    "editorWidget.border": "#333333",
+    "editorHoverWidget.background": "#212121",
+    "editorHoverWidget.foreground": "#eaeaea",
+    "editorHoverWidget.border": "#333333",
+    "list.activeSelectionBackground": "#333333",
+    "list.activeSelectionForeground": "#ffffff",
+    "list.warningForeground": "#d97706",
+    "statusBar.foreground": "#eaeaea",
+    "statusBar.background": "#212121",
+    "statusBarItem.prominentBackground": "#dc2626",
+    "statusBarItem.prominentForeground": "#121212",
+    "focusBorder": "#333333",
+    "descriptionForeground": "#8a8a8d",
+    "editor.foreground": "#eaeaea",
+    "editor.background": "#121212",
+    "editor.lineHighlightBackground": "#212121",
+    "editor.selectionForeground": "#ffffff",
+    "editor.selectionBackground": "#333333",
+    "editor.findMatchBackground": "#efbf04",
+    "editor.findMatchHighlightBackground": "#f59e0b",
+    "editorCursor.foreground": "#121212",
+    "editorLineNumber.foreground": "#8a8a8d",
+    "editorLineNumber.background": "#121212",
+    "editorError.foreground": "#dc2626",
+    "editorWarning.foreground": "#d97706",
+    "quickInput.background": "#212121",
+    "quickInput.foreground": "#eaeaea",
+    "quickInputTitle.background": "#212121",
+    "quickInputList.focusBackground": "#333333",
+    "quickInputList.focusForeground": "#ffffff",
+    "input.background": "#212121",
+    "input.foreground": "#eaeaea",
+    "input.placeholderForeground": "#8a8a8d"
+  },
+  "type": "dark",
+  "name": "matteblack"
+}

--- a/themes/mellifluous.json
+++ b/themes/mellifluous.json
@@ -1,0 +1,185 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#737246",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#bfaf8e"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#b99bb5"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#b99bb5"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#b99bb5"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#cbaa88"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#dadada"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#dadada"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#a8a1be"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#a8a1be"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#bfad9d"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#bfad9d"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#cbaa88"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#d59192"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#bfad9d"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#bfad9d"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#cbaa88"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#cbaa88"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#bfad9d"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#d59192"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#282828",
+    "editorWidget.background": "#282828",
+    "editorWidget.foreground": "#848484",
+    "editorWidget.border": "#282828",
+    "editorHoverWidget.background": "#282828",
+    "editorHoverWidget.foreground": "#848484",
+    "editorHoverWidget.border": "#282828",
+    "list.activeSelectionBackground": "#2d2d2d",
+    "list.activeSelectionForeground": "#dadada",
+    "list.warningForeground": "#aa8a69",
+    "statusBar.foreground": "#aeaeae",
+    "statusBar.background": "#2d2d2d",
+    "statusBarItem.prominentBackground": "#a8a1be",
+    "statusBarItem.prominentForeground": "#1a1a1a",
+    "focusBorder": "#282828",
+    "descriptionForeground": "#737246",
+    "editor.foreground": "#dadada",
+    "editor.background": "#1a1a1a",
+    "editor.lineHighlightBackground": "#242424",
+    "editor.selectionForeground": "#dadada",
+    "editor.selectionBackground": "#2d2d2d",
+    "editor.findMatchBackground": "#9f8f6f",
+    "editor.findMatchHighlightBackground": "#3b372f",
+    "editorCursor.foreground": "#1a1a1a",
+    "editorLineNumber.foreground": "#737246",
+    "editorLineNumber.background": "#1a1a1a",
+    "editorError.foreground": "#be7c7d",
+    "editorWarning.foreground": "#aa8a69",
+    "quickInput.background": "#282828",
+    "quickInput.foreground": "#848484",
+    "quickInputTitle.background": "#282828",
+    "quickInputList.focusBackground": "#2d2d2d",
+    "quickInputList.focusForeground": "#dadada",
+    "input.background": "#282828",
+    "input.foreground": "#848484",
+    "input.placeholderForeground": "#737246"
+  },
+  "type": "dark",
+  "name": "mellifluous"
+}

--- a/themes/moonfly.json
+++ b/themes/moonfly.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#949494",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#c6c684"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#de935f"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#de935f"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#e65e72"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#e65e72"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#79dac8"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e196a2"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#74b2ff"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#74b2ff"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#36c692"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#36c692"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#cf87e8"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#cf87e8"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e65e72"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#cf87e8"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#e65e72"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#74b2ff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#c6c6c6"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5d5d",
+        "background": "#080808"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#444444",
+    "editorWidget.background": "#212121",
+    "editorWidget.foreground": "#c6c6c6",
+    "editorWidget.border": "#444444",
+    "editorHoverWidget.background": "#212121",
+    "editorHoverWidget.foreground": "#c6c6c6",
+    "editorHoverWidget.border": "#444444",
+    "list.activeSelectionBackground": "#323437",
+    "list.activeSelectionForeground": "#c6c6c6",
+    "list.warningForeground": "#e3c78a",
+    "statusBar.foreground": "#c6c6c6",
+    "statusBar.background": "#292929",
+    "statusBarItem.prominentBackground": "#74b2ff",
+    "statusBarItem.prominentForeground": "#080808",
+    "focusBorder": "#444444",
+    "descriptionForeground": "#949494",
+    "editor.foreground": "#c6c6c6",
+    "editor.background": "#080808",
+    "editor.lineHighlightBackground": "#1c1c1c",
+    "editor.selectionForeground": "#c6c6c6",
+    "editor.selectionBackground": "#323437",
+    "editor.findMatchBackground": "#e3c78a",
+    "editor.findMatchHighlightBackground": "#373c4d",
+    "editorCursor.foreground": "#080808",
+    "editorLineNumber.foreground": "#949494",
+    "editorLineNumber.background": "#080808",
+    "editorError.foreground": "#ff5d5d",
+    "editorWarning.foreground": "#e3c78a",
+    "quickInput.background": "#212121",
+    "quickInput.foreground": "#c6c6c6",
+    "quickInputTitle.background": "#212121",
+    "quickInputList.focusBackground": "#323437",
+    "quickInputList.focusForeground": "#c6c6c6",
+    "input.background": "#212121",
+    "input.foreground": "#c6c6c6",
+    "input.placeholderForeground": "#949494"
+  },
+  "type": "dark",
+  "name": "moonfly"
+}

--- a/themes/neobones.json
+++ b/themes/neobones.json
@@ -1,0 +1,193 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#536977",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#939e99",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#939e99",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#939e99"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#c6d5cf",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#9aa6a1",
+        "fontStyle": "bold"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#a7b3ae"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#a7b3ae"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#c6d5cf"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#c6d5cf"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#6e99b2"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#6e99b2"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#c6d5cf",
+        "fontStyle": "bold"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#c6d5cf",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#6e99b2"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#9aa6a1",
+        "fontStyle": "bold"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#c6d5cf",
+        "fontStyle": "bold"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#5b7e94"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#de6e7c"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#1f3e56",
+    "editorWidget.background": "#1d2c35",
+    "editorWidget.foreground": "#c6d5cf",
+    "editorWidget.border": "#1f3e56",
+    "editorHoverWidget.background": "#1d2c35",
+    "editorHoverWidget.foreground": "#c6d5cf",
+    "editorHoverWidget.border": "#1f3e56",
+    "list.activeSelectionBackground": "#3a3e3d",
+    "list.activeSelectionForeground": "#c6d5cf",
+    "list.warningForeground": "#b77e64",
+    "statusBar.foreground": "#c6d5cf",
+    "statusBar.background": "#20303a",
+    "statusBarItem.prominentBackground": "#c6d5cf",
+    "statusBarItem.prominentForeground": "#0f191f",
+    "focusBorder": "#1f3e56",
+    "descriptionForeground": "#536977",
+    "editor.foreground": "#c6d5cf",
+    "editor.background": "#0f191f",
+    "editor.lineHighlightBackground": "#152128",
+    "editor.selectionForeground": "#c6d5cf",
+    "editor.selectionBackground": "#3a3e3d",
+    "editor.findMatchBackground": "#be8cb3",
+    "editor.findMatchHighlightBackground": "#62415b",
+    "editorCursor.foreground": "#0f191f",
+    "editorLineNumber.foreground": "#536977",
+    "editorLineNumber.background": "#0f191f",
+    "editorError.foreground": "#de6e7c",
+    "editorWarning.foreground": "#b77e64",
+    "quickInput.background": "#1d2c35",
+    "quickInput.foreground": "#c6d5cf",
+    "quickInputTitle.background": "#1d2c35",
+    "quickInputList.focusBackground": "#3a3e3d",
+    "quickInputList.focusForeground": "#c6d5cf",
+    "input.background": "#1d2c35",
+    "input.foreground": "#c6d5cf",
+    "input.placeholderForeground": "#536977"
+  },
+  "type": "dark",
+  "name": "neobones"
+}

--- a/themes/nightfly.json
+++ b/themes/nightfly.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#7c8f8f",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#ecc48d"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#f78c6c"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#f78c6c"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5874"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5874"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#7fdbca"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e39aa6"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#82aaff"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#82aaff"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#21c7a8"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#21c7a8"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#c792ea"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#c792ea"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5874"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#c792ea"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ff5874"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#82aaff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#c3ccdc"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#fc514e",
+        "background": "#011627"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#334e65",
+    "editorWidget.background": "#09243a",
+    "editorWidget.foreground": "#c3ccdc",
+    "editorWidget.border": "#334e65",
+    "editorHoverWidget.background": "#09243a",
+    "editorHoverWidget.foreground": "#c3ccdc",
+    "editorHoverWidget.border": "#334e65",
+    "list.activeSelectionBackground": "#1d3b53",
+    "list.activeSelectionForeground": "#c3ccdc",
+    "list.warningForeground": "#e3d18a",
+    "statusBar.foreground": "#c3ccdc",
+    "statusBar.background": "#252c3f",
+    "statusBarItem.prominentBackground": "#82aaff",
+    "statusBarItem.prominentForeground": "#011627",
+    "focusBorder": "#334e65",
+    "descriptionForeground": "#7c8f8f",
+    "editor.foreground": "#c3ccdc",
+    "editor.background": "#011627",
+    "editor.lineHighlightBackground": "#092236",
+    "editor.selectionForeground": "#c3ccdc",
+    "editor.selectionBackground": "#1d3b53",
+    "editor.findMatchBackground": "#ffcb8b",
+    "editor.findMatchHighlightBackground": "#38507a",
+    "editorCursor.foreground": "#011627",
+    "editorLineNumber.foreground": "#7c8f8f",
+    "editorLineNumber.background": "#011627",
+    "editorError.foreground": "#fc514e",
+    "editorWarning.foreground": "#e3d18a",
+    "quickInput.background": "#09243a",
+    "quickInput.foreground": "#c3ccdc",
+    "quickInputTitle.background": "#09243a",
+    "quickInputList.focusBackground": "#1d3b53",
+    "quickInputList.focusForeground": "#c3ccdc",
+    "input.background": "#09243a",
+    "input.foreground": "#c3ccdc",
+    "input.placeholderForeground": "#7c8f8f"
+  },
+  "type": "dark",
+  "name": "nightfly"
+}

--- a/themes/nordbones.json
+++ b/themes/nordbones.json
@@ -1,0 +1,191 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#737c90",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#9eafc9",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#9eafc9",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#8fbcba",
+        "fontStyle": "italic"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ebeef3",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#abbad0",
+        "fontStyle": "bold"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#ebeef3"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ebeef3"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#87bfce"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#87bfce"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#5e81ab"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#5e81ab"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#5e81ab"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#abbad0",
+        "fontStyle": "bold"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#818eab"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#c1616a"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#7e8ca8",
+    "editorWidget.background": "#3f4756",
+    "editorWidget.foreground": "#ebeef3",
+    "editorWidget.border": "#7e8ca8",
+    "editorHoverWidget.background": "#3f4756",
+    "editorHoverWidget.foreground": "#ebeef3",
+    "editorHoverWidget.border": "#7e8ca8",
+    "list.activeSelectionBackground": "#545f70",
+    "list.activeSelectionForeground": "#ebeef3",
+    "list.warningForeground": "#cf866f",
+    "statusBar.foreground": "#ebeef3",
+    "statusBar.background": "#414959",
+    "statusBarItem.prominentBackground": "#87bfce",
+    "statusBarItem.prominentForeground": "#2f3541",
+    "focusBorder": "#7e8ca8",
+    "descriptionForeground": "#737c90",
+    "editor.foreground": "#ebeef3",
+    "editor.background": "#2f3541",
+    "editor.lineHighlightBackground": "#353c49",
+    "editor.selectionForeground": "#ebeef3",
+    "editor.selectionBackground": "#545f70",
+    "editor.findMatchBackground": "#d1bacd",
+    "editor.findMatchHighlightBackground": "#84637e",
+    "editorCursor.foreground": "#2f3541",
+    "editorLineNumber.foreground": "#737c90",
+    "editorLineNumber.background": "#2f3541",
+    "editorError.foreground": "#c1616a",
+    "editorWarning.foreground": "#cf866f",
+    "quickInput.background": "#3f4756",
+    "quickInput.foreground": "#ebeef3",
+    "quickInputTitle.background": "#3f4756",
+    "quickInputList.focusBackground": "#545f70",
+    "quickInputList.focusForeground": "#ebeef3",
+    "input.background": "#3f4756",
+    "input.foreground": "#ebeef3",
+    "input.placeholderForeground": "#737c90"
+  },
+  "type": "dark",
+  "name": "nordbones"
+}

--- a/themes/nordern.json
+++ b/themes/nordern.json
@@ -1,0 +1,177 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#5c6881"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#a3be8c"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#8fbcbb"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#b48ead"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#b48ead"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#ebcb8b"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#eceff4"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c0c8d8"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#88c0d0"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#88c0d0"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#88c0d0"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#88c0d0"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#ebcb8b"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#bf616a"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#eceff4"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#bf616a"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#88c0d0",
+    "editorWidget.background": "#2e3440",
+    "editorWidget.foreground": "#eceff4",
+    "editorWidget.border": "#88c0d0",
+    "editorHoverWidget.background": "#2e3440",
+    "editorHoverWidget.foreground": "#eceff4",
+    "editorHoverWidget.border": "#88c0d0",
+    "list.activeSelectionBackground": "#384356",
+    "list.activeSelectionForeground": "#eceff4",
+    "list.warningForeground": "#ebcb8b",
+    "statusBar.foreground": "#eceff4",
+    "statusBar.background": "#2e3440",
+    "statusBarItem.prominentBackground": "#88c0d0",
+    "statusBarItem.prominentForeground": "#2e3440",
+    "focusBorder": "#88c0d0",
+    "descriptionForeground": "#5c6881",
+    "editor.foreground": "#eceff4",
+    "editor.background": "#2e3440",
+    "editor.lineHighlightBackground": "#384356",
+    "editor.selectionForeground": "#eceff4",
+    "editor.selectionBackground": "#384356",
+    "editor.findMatchBackground": "#88c0d0",
+    "editor.findMatchHighlightBackground": "#88c0d0",
+    "editorCursor.foreground": "#2e3440",
+    "editorLineNumber.foreground": "#5c6881",
+    "editorLineNumber.background": "#2e3440",
+    "editorError.foreground": "#bf616a",
+    "editorWarning.foreground": "#ebcb8b",
+    "quickInput.background": "#2e3440",
+    "quickInput.foreground": "#eceff4",
+    "quickInputTitle.background": "#2e3440",
+    "quickInputList.focusBackground": "#384356",
+    "quickInputList.focusForeground": "#eceff4",
+    "input.background": "#2e3440",
+    "input.foreground": "#eceff4",
+    "input.placeholderForeground": "#5c6881"
+  },
+  "type": "dark",
+  "name": "nordern"
+}

--- a/themes/nordic.json
+++ b/themes/nordic.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#4c566a",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#a3be8c"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#be9db8"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#be9db8"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#be9db8"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#c0c8d8"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c0c8d8"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#88c0d0"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#88c0d0"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#ebcb8b"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ebcb8b"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#d08770"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#d08770"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#c0c8d8"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#d08770"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#bf616a"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#60728a",
+        "fontStyle": "italic"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#c5727a"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#191d24",
+    "editorWidget.background": "#1e222a",
+    "editorWidget.foreground": "#c0c8d8",
+    "editorWidget.border": "#191d24",
+    "editorHoverWidget.background": "#1e222a",
+    "editorHoverWidget.foreground": "#c0c8d8",
+    "editorHoverWidget.border": "#191d24",
+    "list.activeSelectionBackground": "#1b1f26",
+    "list.activeSelectionForeground": "#c0c8d8",
+    "list.warningForeground": "#ebcb8b",
+    "statusBar.foreground": "#3b4252",
+    "statusBar.background": "#191d24",
+    "statusBarItem.prominentBackground": "#88c0d0",
+    "statusBarItem.prominentForeground": "#242933",
+    "focusBorder": "#191d24",
+    "descriptionForeground": "#4c566a",
+    "editor.foreground": "#c0c8d8",
+    "editor.background": "#242933",
+    "editor.lineHighlightBackground": "#1b1f26",
+    "editor.selectionForeground": "#c0c8d8",
+    "editor.selectionBackground": "#1b1f26",
+    "editor.findMatchBackground": "#ebcb8b",
+    "editor.findMatchHighlightBackground": "#1b1f26",
+    "editorCursor.foreground": "#191d24",
+    "editorLineNumber.foreground": "#4c566a",
+    "editorLineNumber.background": "#242933",
+    "editorError.foreground": "#c5727a",
+    "editorWarning.foreground": "#ebcb8b",
+    "quickInput.background": "#1e222a",
+    "quickInput.foreground": "#c0c8d8",
+    "quickInputTitle.background": "#1e222a",
+    "quickInputList.focusBackground": "#1b1f26",
+    "quickInputList.focusForeground": "#c0c8d8",
+    "input.background": "#1e222a",
+    "input.foreground": "#c0c8d8",
+    "input.placeholderForeground": "#4c566a"
+  },
+  "type": "dark",
+  "name": "nordic"
+}

--- a/themes/onedark.json
+++ b/themes/onedark.json
@@ -1,0 +1,185 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#5c6370",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#98c379"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#56b6c2"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#d19a66"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#d19a66"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#e86671"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e86671"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e86671"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#61afef"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#61afef"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#e5c07b"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#d19a66"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#c678dd"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#c678dd"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#c678dd"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#e5c07b"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#98c379"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#56b6c2"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#848b98"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#c678dd"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#5c6370",
+    "editorWidget.background": "#31353f",
+    "editorWidget.foreground": "#abb2bf",
+    "editorWidget.border": "#5c6370",
+    "editorHoverWidget.background": "#31353f",
+    "editorHoverWidget.foreground": "#abb2bf",
+    "editorHoverWidget.border": "#5c6370",
+    "list.activeSelectionBackground": "#3b3f4c",
+    "list.activeSelectionForeground": "#abb2bf",
+    "list.warningForeground": "#e5c07b",
+    "statusBar.foreground": "#abb2bf",
+    "statusBar.background": "#393f4a",
+    "statusBarItem.prominentBackground": "#61afef",
+    "statusBarItem.prominentForeground": "#282c34",
+    "focusBorder": "#5c6370",
+    "descriptionForeground": "#5c6370",
+    "editor.foreground": "#abb2bf",
+    "editor.background": "#282c34",
+    "editor.lineHighlightBackground": "#31353f",
+    "editor.selectionForeground": "#abb2bf",
+    "editor.selectionBackground": "#3b3f4c",
+    "editor.findMatchBackground": "#d19a66",
+    "editor.findMatchHighlightBackground": "#ebd09c",
+    "editorCursor.foreground": "#61afef",
+    "editorLineNumber.foreground": "#5c6370",
+    "editorLineNumber.background": "#282c34",
+    "editorError.foreground": "#e86671",
+    "editorWarning.foreground": "#e5c07b",
+    "quickInput.background": "#31353f",
+    "quickInput.foreground": "#abb2bf",
+    "quickInputTitle.background": "#31353f",
+    "quickInputList.focusBackground": "#3b3f4c",
+    "quickInputList.focusForeground": "#abb2bf",
+    "input.background": "#31353f",
+    "input.foreground": "#abb2bf",
+    "input.placeholderForeground": "#5c6370"
+  },
+  "type": "dark",
+  "name": "onedark"
+}

--- a/themes/onenord.json
+++ b/themes/onenord.json
@@ -1,0 +1,185 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6c7a96"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#a3be8c"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#d08f70"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#d08f70"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#de878f"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#c8d0e0"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#d57780"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#81a1c1"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#ebcb8b"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#d08f70"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b988b0"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#b988b0"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#b988b0"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#b988b0"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a3be8c"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#b988b0"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#5e81ac"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#bf616a",
+        "fontStyle": "bold underline"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#81a1c1",
+    "editorWidget.background": "#353b49",
+    "editorWidget.foreground": "#c8d0e0",
+    "editorWidget.border": "#81a1c1",
+    "editorHoverWidget.background": "#353b49",
+    "editorHoverWidget.foreground": "#c8d0e0",
+    "editorHoverWidget.border": "#81a1c1",
+    "list.activeSelectionBackground": "#3f4758",
+    "list.activeSelectionForeground": "#c8d0e0",
+    "list.warningForeground": "#d08f70",
+    "statusBar.foreground": "#c8d0e0",
+    "statusBar.background": "#353b49",
+    "statusBarItem.prominentBackground": "#81a1c1",
+    "statusBarItem.prominentForeground": "#2e3440",
+    "focusBorder": "#81a1c1",
+    "descriptionForeground": "#6c7a96",
+    "editor.foreground": "#c8d0e0",
+    "editor.background": "#2e3440",
+    "editor.lineHighlightBackground": "#353b49",
+    "editor.selectionForeground": "#c8d0e0",
+    "editor.selectionBackground": "#3f4758",
+    "editor.findMatchBackground": "#4c566a",
+    "editor.findMatchHighlightBackground": "#4c566a",
+    "editorCursor.foreground": "#c8d0e0",
+    "editorLineNumber.foreground": "#6c7a96",
+    "editorLineNumber.background": "#2e3440",
+    "editorError.foreground": "#bf616a",
+    "editorWarning.foreground": "#d08f70",
+    "quickInput.background": "#353b49",
+    "quickInput.foreground": "#c8d0e0",
+    "quickInputTitle.background": "#353b49",
+    "quickInputList.focusBackground": "#3f4758",
+    "quickInputList.focusForeground": "#c8d0e0",
+    "input.background": "#353b49",
+    "input.foreground": "#c8d0e0",
+    "input.placeholderForeground": "#6c7a96"
+  },
+  "type": "dark",
+  "name": "onenord"
+}

--- a/themes/oxocarbon.json
+++ b/themes/oxocarbon.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#525252",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#be95ff"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#d0d0d0"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#82cfff"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#78a9ff"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#d0d0d0"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#d0d0d0"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#d0d0d0"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#3ddbd9"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ff7eb6",
+        "fontStyle": "bold"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#78a9ff"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#78a9ff"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#78a9ff"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#78a9ff"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#78a9ff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#78a9ff"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#d0d0d0"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#82cfff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#c17ac8",
+        "fontStyle": "bold"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ee5396",
+        "background": "#262626"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#131313",
+    "editorWidget.background": "#131313",
+    "editorWidget.foreground": "#f2f2f2",
+    "editorWidget.border": "#131313",
+    "editorHoverWidget.background": "#131313",
+    "editorHoverWidget.foreground": "#f2f2f2",
+    "editorHoverWidget.border": "#131313",
+    "list.activeSelectionBackground": "#393939",
+    "list.activeSelectionForeground": "#d0d0d0",
+    "list.warningForeground": "#be95ff",
+    "statusBar.foreground": "#d0d0d0",
+    "statusBar.background": "#161616",
+    "statusBarItem.prominentBackground": "#3ddbd9",
+    "statusBarItem.prominentForeground": "#161616",
+    "focusBorder": "#131313",
+    "descriptionForeground": "#525252",
+    "editor.foreground": "#d0d0d0",
+    "editor.background": "#161616",
+    "editor.lineHighlightBackground": "#262626",
+    "editor.selectionForeground": "#d0d0d0",
+    "editor.selectionBackground": "#393939",
+    "editor.findMatchBackground": "#ee5396",
+    "editor.findMatchHighlightBackground": "#3ddbd9",
+    "editorCursor.foreground": "#161616",
+    "editorLineNumber.foreground": "#525252",
+    "editorLineNumber.background": "#161616",
+    "editorError.foreground": "#ee5396",
+    "editorWarning.foreground": "#be95ff",
+    "quickInput.background": "#131313",
+    "quickInput.foreground": "#f2f2f2",
+    "quickInputTitle.background": "#131313",
+    "quickInputList.focusBackground": "#393939",
+    "quickInputList.focusForeground": "#d0d0d0",
+    "input.background": "#131313",
+    "input.foreground": "#f2f2f2",
+    "input.placeholderForeground": "#525252"
+  },
+  "type": "dark",
+  "name": "oxocarbon"
+}

--- a/themes/rose-pine-dawn.json
+++ b/themes/rose-pine-dawn.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#797593",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#ea9d34"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ea9d34"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ea9d34"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#d7827e"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#56949f"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#464261"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#907aa9",
+        "fontStyle": "italic"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#d7827e"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#d7827e"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#56949f"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#56949f",
+        "fontStyle": "bold"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#286983"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#286983"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#797593"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#56949f"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#56949f"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#907aa9"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#797593"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#b4637a"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#9893a5",
+    "editorWidget.background": "#fffaf3",
+    "editorWidget.foreground": "#797593",
+    "editorWidget.border": "#9893a5",
+    "editorHoverWidget.background": "#fffaf3",
+    "editorHoverWidget.foreground": "#797593",
+    "editorHoverWidget.border": "#9893a5",
+    "list.activeSelectionBackground": "#eae2e3",
+    "list.activeSelectionForeground": "#464261",
+    "list.warningForeground": "#ea9d34",
+    "statusBar.foreground": "#797593",
+    "statusBar.background": "#fffaf3",
+    "statusBarItem.prominentBackground": "#d7827e",
+    "statusBarItem.prominentForeground": "#faf4ed",
+    "focusBorder": "#9893a5",
+    "descriptionForeground": "#797593",
+    "editor.foreground": "#464261",
+    "editor.background": "#faf4ed",
+    "editor.lineHighlightBackground": "#f2e9e1",
+    "editor.selectionForeground": "#464261",
+    "editor.selectionBackground": "#eae2e3",
+    "editor.findMatchBackground": "#ea9d34",
+    "editor.findMatchHighlightBackground": "#f7e3c8",
+    "editorCursor.foreground": "#464261",
+    "editorLineNumber.foreground": "#797593",
+    "editorLineNumber.background": "#faf4ed",
+    "editorError.foreground": "#b4637a",
+    "editorWarning.foreground": "#ea9d34",
+    "quickInput.background": "#fffaf3",
+    "quickInput.foreground": "#797593",
+    "quickInputTitle.background": "#fffaf3",
+    "quickInputList.focusBackground": "#eae2e3",
+    "quickInputList.focusForeground": "#464261",
+    "input.background": "#fffaf3",
+    "input.foreground": "#797593",
+    "input.placeholderForeground": "#797593"
+  },
+  "type": "dark",
+  "name": "rose-pine-dawn"
+}

--- a/themes/rose-pine-main.json
+++ b/themes/rose-pine-main.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#908caa",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#f6c177"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#f6c177"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#f6c177"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ebbcba"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e0def4"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c4a7e7",
+        "fontStyle": "italic"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ebbcba"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ebbcba"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8",
+        "fontStyle": "bold"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#31748f"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#31748f"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#908caa"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#c4a7e7"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#908caa"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#eb6f92"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#6e6a86",
+    "editorWidget.background": "#1f1d2e",
+    "editorWidget.foreground": "#908caa",
+    "editorWidget.border": "#6e6a86",
+    "editorHoverWidget.background": "#1f1d2e",
+    "editorHoverWidget.foreground": "#908caa",
+    "editorHoverWidget.border": "#6e6a86",
+    "list.activeSelectionBackground": "#332d41",
+    "list.activeSelectionForeground": "#e0def4",
+    "list.warningForeground": "#f6c177",
+    "statusBar.foreground": "#908caa",
+    "statusBar.background": "#1f1d2e",
+    "statusBarItem.prominentBackground": "#ebbcba",
+    "statusBarItem.prominentForeground": "#191724",
+    "focusBorder": "#6e6a86",
+    "descriptionForeground": "#908caa",
+    "editor.foreground": "#e0def4",
+    "editor.background": "#191724",
+    "editor.lineHighlightBackground": "#26233a",
+    "editor.selectionForeground": "#e0def4",
+    "editor.selectionBackground": "#332d41",
+    "editor.findMatchBackground": "#f6c177",
+    "editor.findMatchHighlightBackground": "#453935",
+    "editorCursor.foreground": "#e0def4",
+    "editorLineNumber.foreground": "#908caa",
+    "editorLineNumber.background": "#191724",
+    "editorError.foreground": "#eb6f92",
+    "editorWarning.foreground": "#f6c177",
+    "quickInput.background": "#1f1d2e",
+    "quickInput.foreground": "#908caa",
+    "quickInputTitle.background": "#1f1d2e",
+    "quickInputList.focusBackground": "#332d41",
+    "quickInputList.focusForeground": "#e0def4",
+    "input.background": "#1f1d2e",
+    "input.foreground": "#908caa",
+    "input.placeholderForeground": "#908caa"
+  },
+  "type": "dark",
+  "name": "rose-pine-main"
+}

--- a/themes/rose-pine-moon.json
+++ b/themes/rose-pine-moon.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#908caa",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#f6c177"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#f6c177"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#f6c177"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ea9a97"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e0def4"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c4a7e7",
+        "fontStyle": "italic"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ea9a97"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ea9a97"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8",
+        "fontStyle": "bold"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#3e8fb0"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#3e8fb0"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#908caa"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#c4a7e7"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#908caa"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#eb6f92"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#6e6a86",
+    "editorWidget.background": "#2a273f",
+    "editorWidget.foreground": "#908caa",
+    "editorWidget.border": "#6e6a86",
+    "editorHoverWidget.background": "#2a273f",
+    "editorHoverWidget.foreground": "#908caa",
+    "editorHoverWidget.border": "#6e6a86",
+    "list.activeSelectionBackground": "#3b3551",
+    "list.activeSelectionForeground": "#e0def4",
+    "list.warningForeground": "#f6c177",
+    "statusBar.foreground": "#908caa",
+    "statusBar.background": "#2a273f",
+    "statusBarItem.prominentBackground": "#ea9a97",
+    "statusBarItem.prominentForeground": "#232136",
+    "focusBorder": "#6e6a86",
+    "descriptionForeground": "#908caa",
+    "editor.foreground": "#e0def4",
+    "editor.background": "#232136",
+    "editor.lineHighlightBackground": "#393552",
+    "editor.selectionForeground": "#e0def4",
+    "editor.selectionBackground": "#3b3551",
+    "editor.findMatchBackground": "#f6c177",
+    "editor.findMatchHighlightBackground": "#4d4143",
+    "editorCursor.foreground": "#e0def4",
+    "editorLineNumber.foreground": "#908caa",
+    "editorLineNumber.background": "#232136",
+    "editorError.foreground": "#eb6f92",
+    "editorWarning.foreground": "#f6c177",
+    "quickInput.background": "#2a273f",
+    "quickInput.foreground": "#908caa",
+    "quickInputTitle.background": "#2a273f",
+    "quickInputList.focusBackground": "#3b3551",
+    "quickInputList.focusForeground": "#e0def4",
+    "input.background": "#2a273f",
+    "input.foreground": "#908caa",
+    "input.placeholderForeground": "#908caa"
+  },
+  "type": "dark",
+  "name": "rose-pine-moon"
+}

--- a/themes/rosebones.json
+++ b/themes/rosebones.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#69657e",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#bc9493",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#bc9493",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#bc9493"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#e1d4d4",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#cab0af"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#cab0af"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#e1d4d4"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#e1d4d4"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#dfdef1"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#dfdef1"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#317490"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#317490"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#dfdef1"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#9ccfd8"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#317490"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7d7997"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#eb7193"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#7a7695",
+    "editorWidget.background": "#2d2a3d",
+    "editorWidget.foreground": "#e1d4d4",
+    "editorWidget.border": "#7a7695",
+    "editorHoverWidget.background": "#2d2a3d",
+    "editorHoverWidget.foreground": "#e1d4d4",
+    "editorHoverWidget.border": "#7a7695",
+    "list.activeSelectionBackground": "#523a39",
+    "list.activeSelectionForeground": "#e1d4d4",
+    "list.warningForeground": "#f6c074",
+    "statusBar.foreground": "#e1d4d4",
+    "statusBar.background": "#312e43",
+    "statusBarItem.prominentBackground": "#e1d4d4",
+    "statusBarItem.prominentForeground": "#1a1825",
+    "focusBorder": "#7a7695",
+    "descriptionForeground": "#69657e",
+    "editor.foreground": "#e1d4d4",
+    "editor.background": "#1a1825",
+    "editor.lineHighlightBackground": "#222030",
+    "editor.selectionForeground": "#e1d4d4",
+    "editor.selectionBackground": "#523a39",
+    "editor.findMatchBackground": "#b48de0",
+    "editor.findMatchHighlightBackground": "#673592",
+    "editorCursor.foreground": "#1a1825",
+    "editorLineNumber.foreground": "#69657e",
+    "editorLineNumber.background": "#1a1825",
+    "editorError.foreground": "#eb7193",
+    "editorWarning.foreground": "#f6c074",
+    "quickInput.background": "#2d2a3d",
+    "quickInput.foreground": "#e1d4d4",
+    "quickInputTitle.background": "#2d2a3d",
+    "quickInputList.focusBackground": "#523a39",
+    "quickInputList.focusForeground": "#e1d4d4",
+    "input.background": "#2d2a3d",
+    "input.foreground": "#e1d4d4",
+    "input.placeholderForeground": "#69657e"
+  },
+  "type": "dark",
+  "name": "rosebones"
+}

--- a/themes/seoulbones.json
+++ b/themes/seoulbones.json
@@ -1,0 +1,190 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#719871",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#abc4db",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#a3a3a3",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#f7e0b3"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#dddddd",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#bcbcd3"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#dddddd"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#dddddd"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#dfdfc1"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#dfdfc1"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#aeaeae"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#aeaeae"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#dc8ca3",
+        "fontStyle": "bold"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#97bdde",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#aeaeae"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#bcbcd3"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#d590a3"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#9b9b9b"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e388a3"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#989898",
+    "editorWidget.background": "#5c5c5c",
+    "editorWidget.foreground": "#dddddd",
+    "editorWidget.border": "#989898",
+    "editorHoverWidget.background": "#5c5c5c",
+    "editorHoverWidget.foreground": "#dddddd",
+    "editorHoverWidget.border": "#989898",
+    "list.activeSelectionBackground": "#777777",
+    "list.activeSelectionForeground": "#dddddd",
+    "list.warningForeground": "#ffdf9b",
+    "statusBar.foreground": "#dddddd",
+    "statusBar.background": "#5e5e5e",
+    "statusBarItem.prominentBackground": "#dfdfc1",
+    "statusBarItem.prominentForeground": "#4b4b4b",
+    "focusBorder": "#989898",
+    "descriptionForeground": "#719871",
+    "editor.foreground": "#dddddd",
+    "editor.background": "#4b4b4b",
+    "editor.lineHighlightBackground": "#525252",
+    "editor.selectionForeground": "#dddddd",
+    "editor.selectionBackground": "#777777",
+    "editor.findMatchBackground": "#dcdce8",
+    "editor.findMatchHighlightBackground": "#8283ad",
+    "editorCursor.foreground": "#4b4b4b",
+    "editorLineNumber.foreground": "#719871",
+    "editorLineNumber.background": "#4b4b4b",
+    "editorError.foreground": "#e388a3",
+    "editorWarning.foreground": "#ffdf9b",
+    "quickInput.background": "#5c5c5c",
+    "quickInput.foreground": "#dddddd",
+    "quickInputTitle.background": "#5c5c5c",
+    "quickInputList.focusBackground": "#777777",
+    "quickInputList.focusForeground": "#dddddd",
+    "input.background": "#5c5c5c",
+    "input.foreground": "#dddddd",
+    "input.placeholderForeground": "#719871"
+  },
+  "type": "dark",
+  "name": "seoulbones"
+}

--- a/themes/sequoia.json
+++ b/themes/sequoia.json
@@ -1,0 +1,192 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#43444d",
+        "background": "#0f1014"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#9898a6",
+        "background": "#0f1014"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#fdfdfe",
+        "background": "#0f1014"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ffbb88",
+        "background": "#0f1014"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ffbb88",
+        "background": "#0f1014"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#ffbb88",
+        "background": "#0f1014"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ec7279"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ffbb88",
+        "background": "#0f1014"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#6cb6eb"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#8eb6f5",
+        "background": "#0f1014"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#d38aea"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#d38aea"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#d38aea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#ec7279"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#deb974"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#c5cdd9"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#f58ee0"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#758094",
+    "editorWidget.background": "#363944",
+    "editorWidget.foreground": "#c5cdd9",
+    "editorWidget.border": "#758094",
+    "editorHoverWidget.background": "#363944",
+    "editorHoverWidget.foreground": "#c5cdd9",
+    "editorHoverWidget.border": "#758094",
+    "list.activeSelectionBackground": "#26262f",
+    "list.activeSelectionForeground": "#868690",
+    "list.warningForeground": "#deb974",
+    "statusBar.foreground": "#868690",
+    "statusBar.background": "#0f1014",
+    "statusBarItem.prominentBackground": "#ffbb88",
+    "statusBarItem.prominentForeground": "#0f1014",
+    "focusBorder": "#758094",
+    "descriptionForeground": "#43444d",
+    "editor.foreground": "#868690",
+    "editor.background": "#0f1014",
+    "editor.lineHighlightBackground": "#18191e",
+    "editor.selectionForeground": "#868690",
+    "editor.selectionBackground": "#26262f",
+    "editor.findMatchBackground": "#373643",
+    "editor.findMatchHighlightBackground": "#373643",
+    "editorCursor.foreground": "#c58fff",
+    "editorLineNumber.foreground": "#43444d",
+    "editorLineNumber.background": "#0f1014",
+    "editorError.foreground": "#ec7279",
+    "editorWarning.foreground": "#deb974",
+    "quickInput.background": "#363944",
+    "quickInput.foreground": "#c5cdd9",
+    "quickInputTitle.background": "#363944",
+    "quickInputList.focusBackground": "#26262f",
+    "quickInputList.focusForeground": "#868690",
+    "input.background": "#363944",
+    "input.foreground": "#c5cdd9",
+    "input.placeholderForeground": "#43444d"
+  },
+  "type": "dark",
+  "name": "sequoia"
+}

--- a/themes/solarized-osaka-day.json
+++ b/themes/solarized-osaka-day.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#adb7b7",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#29a298"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#29a298"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#29a298"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#29a298"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#c94c16"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#268bd3"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c94c16"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#268bd3"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#268bd3"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#b28500"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b28500"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#849900",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#849900"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#849900"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#b28500"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#c94c16"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#db302d"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#eef1f8",
+        "background": "#590008"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#ffbf00",
+    "editorWidget.background": "#ffffff",
+    "editorWidget.foreground": "#637981",
+    "editorWidget.border": "#ffbf00",
+    "editorHoverWidget.background": "#ffffff",
+    "editorHoverWidget.foreground": "#637981",
+    "editorHoverWidget.border": "#ffbf00",
+    "list.activeSelectionBackground": "#ede7d3",
+    "list.activeSelectionForeground": "#637981",
+    "list.warningForeground": "#b28500",
+    "statusBar.foreground": "#576d74",
+    "statusBar.background": "#fdf5e2",
+    "statusBarItem.prominentBackground": "#268bd3",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#ffbf00",
+    "descriptionForeground": "#adb7b7",
+    "editor.foreground": "#637981",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#fdf5e2",
+    "editor.selectionForeground": "#637981",
+    "editor.selectionBackground": "#ede7d3",
+    "editor.findMatchBackground": "#c94c16",
+    "editor.findMatchHighlightBackground": "#ede7d3",
+    "editorCursor.foreground": "#fdf5e2",
+    "editorLineNumber.foreground": "#adb7b7",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#db302d",
+    "editorWarning.foreground": "#b28500",
+    "quickInput.background": "#ffffff",
+    "quickInput.foreground": "#637981",
+    "quickInputTitle.background": "#ffffff",
+    "quickInputList.focusBackground": "#ede7d3",
+    "quickInputList.focusForeground": "#637981",
+    "input.background": "#ffffff",
+    "input.foreground": "#637981",
+    "input.placeholderForeground": "#adb7b7"
+  },
+  "type": "dark",
+  "name": "solarized-osaka-day"
+}

--- a/themes/solarized-osaka.json
+++ b/themes/solarized-osaka.json
@@ -1,0 +1,187 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#576d74",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#29a298"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#29a298"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#29a298"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#29a298"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#c94c16"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#268bd3"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#c94c16"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#268bd3"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#268bd3"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#b28500"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b28500"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#849900",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#849900"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#849900"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#b28500"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#c94c16"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#db302d"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#eef1f8",
+        "background": "#590008"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#664c00",
+    "editorWidget.background": "#001419",
+    "editorWidget.foreground": "#9eabac",
+    "editorWidget.border": "#664c00",
+    "editorHoverWidget.background": "#001419",
+    "editorHoverWidget.foreground": "#9eabac",
+    "editorHoverWidget.border": "#664c00",
+    "list.activeSelectionBackground": "#063540",
+    "list.activeSelectionForeground": "#9eabac",
+    "list.warningForeground": "#b28500",
+    "statusBar.foreground": "#adb7b7",
+    "statusBar.background": "#002c38",
+    "statusBarItem.prominentBackground": "#268bd3",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#664c00",
+    "descriptionForeground": "#576d74",
+    "editor.foreground": "#9eabac",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#002c38",
+    "editor.selectionForeground": "#9eabac",
+    "editor.selectionBackground": "#063540",
+    "editor.findMatchBackground": "#c94c16",
+    "editor.findMatchHighlightBackground": "#063540",
+    "editorCursor.foreground": "#002c38",
+    "editorLineNumber.foreground": "#576d74",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#db302d",
+    "editorWarning.foreground": "#b28500",
+    "quickInput.background": "#001419",
+    "quickInput.foreground": "#9eabac",
+    "quickInputTitle.background": "#001419",
+    "quickInputList.focusBackground": "#063540",
+    "quickInputList.focusForeground": "#9eabac",
+    "input.background": "#001419",
+    "input.foreground": "#9eabac",
+    "input.placeholderForeground": "#576d74"
+  },
+  "type": "dark",
+  "name": "solarized-osaka"
+}

--- a/themes/sonokai.json
+++ b/themes/sonokai.json
@@ -1,0 +1,185 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#7f8490",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#e7c664"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#f39660"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#b39df3"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#b39df3"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#b39df3"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#f39660"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e2e2e3"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#9ed072"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#9ed072"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#76cce0"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#76cce0"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#fc5d7c"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#fc5d7c"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#fc5d7c"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#76cce0"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#f39660"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#76cce0"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#e2e2e3"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#fc5d7c"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#7f8490",
+    "editorWidget.background": "#363944",
+    "editorWidget.foreground": "#e2e2e3",
+    "editorWidget.border": "#7f8490",
+    "editorHoverWidget.background": "#363944",
+    "editorHoverWidget.foreground": "#e2e2e3",
+    "editorHoverWidget.border": "#7f8490",
+    "list.activeSelectionBackground": "#414550",
+    "list.activeSelectionForeground": "#e2e2e3",
+    "list.warningForeground": "#e7c664",
+    "statusBar.foreground": "#e2e2e3",
+    "statusBar.background": "#3b3e48",
+    "statusBarItem.prominentBackground": "#9ed072",
+    "statusBarItem.prominentForeground": "#2c2e34",
+    "focusBorder": "#7f8490",
+    "descriptionForeground": "#7f8490",
+    "editor.foreground": "#e2e2e3",
+    "editor.background": "#2c2e34",
+    "editor.lineHighlightBackground": "#33353f",
+    "editor.selectionForeground": "#e2e2e3",
+    "editor.selectionBackground": "#414550",
+    "editor.findMatchBackground": "#ff6077",
+    "editor.findMatchHighlightBackground": "#a7df78",
+    "editorCursor.foreground": "#2c2e34",
+    "editorLineNumber.foreground": "#7f8490",
+    "editorLineNumber.background": "#2c2e34",
+    "editorError.foreground": "#fc5d7c",
+    "editorWarning.foreground": "#e7c664",
+    "quickInput.background": "#363944",
+    "quickInput.foreground": "#e2e2e3",
+    "quickInputTitle.background": "#363944",
+    "quickInputList.focusBackground": "#414550",
+    "quickInputList.focusForeground": "#e2e2e3",
+    "input.background": "#363944",
+    "input.foreground": "#e2e2e3",
+    "input.placeholderForeground": "#7f8490"
+  },
+  "type": "dark",
+  "name": "sonokai"
+}

--- a/themes/terafox.json
+++ b/themes/terafox.json
@@ -1,0 +1,184 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6d7f8b"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa4a1"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9664"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ff8349"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ff8349"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#73a3b7"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#a1cdd8"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#afd4de"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#73a3b7"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#73a3b7"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#fda47f"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#afd4de"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ad5c7c"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#b97490"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#cbd9d8"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#fda47f"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#73a3b7"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9664"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#73a3b7"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e85c51"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#587b7b",
+    "editorWidget.background": "#0f1c1e",
+    "editorWidget.foreground": "#e6eaea",
+    "editorWidget.border": "#587b7b",
+    "editorHoverWidget.background": "#0f1c1e",
+    "editorHoverWidget.foreground": "#e6eaea",
+    "editorHoverWidget.border": "#587b7b",
+    "list.activeSelectionBackground": "#293e40",
+    "list.activeSelectionForeground": "#e6eaea",
+    "list.warningForeground": "#fda47f",
+    "statusBar.foreground": "#cbd9d8",
+    "statusBar.background": "#0f1c1e",
+    "statusBarItem.prominentBackground": "#73a3b7",
+    "statusBarItem.prominentForeground": "#152528",
+    "focusBorder": "#587b7b",
+    "descriptionForeground": "#6d7f8b",
+    "editor.foreground": "#e6eaea",
+    "editor.background": "#152528",
+    "editor.lineHighlightBackground": "#254147",
+    "editor.selectionForeground": "#e6eaea",
+    "editor.selectionBackground": "#293e40",
+    "editor.findMatchBackground": "#7aa4a1",
+    "editor.findMatchHighlightBackground": "#425e5e",
+    "editorCursor.foreground": "#152528",
+    "editorLineNumber.foreground": "#6d7f8b",
+    "editorLineNumber.background": "#152528",
+    "editorError.foreground": "#e85c51",
+    "editorWarning.foreground": "#fda47f",
+    "quickInput.background": "#0f1c1e",
+    "quickInput.foreground": "#e6eaea",
+    "quickInputTitle.background": "#0f1c1e",
+    "quickInputList.focusBackground": "#293e40",
+    "quickInputList.focusForeground": "#e6eaea",
+    "input.background": "#0f1c1e",
+    "input.foreground": "#e6eaea",
+    "input.placeholderForeground": "#6d7f8b"
+  },
+  "type": "dark",
+  "name": "terafox"
+}

--- a/themes/termy-dark.json
+++ b/themes/termy-dark.json
@@ -1,0 +1,185 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#69749b",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#9df0a7"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9cb1"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9cb1"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9cb1"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#8ac5ff"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#e8ecf8"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e8ecf8"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#8ac5ff"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#96e4ff"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#ffe28a"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ffe28a"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9cb1"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9cb1"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#b8bff0"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9cb1"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ff8fa3"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#8ac5ff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#84bbf3"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff6f8d"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#232a3b",
+    "editorWidget.background": "#0b1020",
+    "editorWidget.foreground": "#e8ecf8",
+    "editorWidget.border": "#232a3b",
+    "editorHoverWidget.background": "#0b1020",
+    "editorHoverWidget.foreground": "#e8ecf8",
+    "editorHoverWidget.border": "#232a3b",
+    "list.activeSelectionBackground": "#3d59a1",
+    "list.activeSelectionForeground": "#e8ecf8",
+    "list.warningForeground": "#ffe28a",
+    "statusBar.foreground": "#e8ecf8",
+    "statusBar.background": "#0b1020",
+    "statusBarItem.prominentBackground": "#8ac5ff",
+    "statusBarItem.prominentForeground": "#070a14",
+    "focusBorder": "#232a3b",
+    "descriptionForeground": "#69749b",
+    "editor.foreground": "#e8ecf8",
+    "editor.background": "#070a14",
+    "editor.lineHighlightBackground": "#111830",
+    "editor.selectionForeground": "#e8ecf8",
+    "editor.selectionBackground": "#3d59a1",
+    "editor.findMatchBackground": "#7aa2f7",
+    "editor.findMatchHighlightBackground": "#3d59a1",
+    "editorCursor.foreground": "#070a14",
+    "editorLineNumber.foreground": "#69749b",
+    "editorLineNumber.background": "#070a14",
+    "editorError.foreground": "#ff6f8d",
+    "editorWarning.foreground": "#ffe28a",
+    "quickInput.background": "#0b1020",
+    "quickInput.foreground": "#e8ecf8",
+    "quickInputTitle.background": "#0b1020",
+    "quickInputList.focusBackground": "#3d59a1",
+    "quickInputList.focusForeground": "#e8ecf8",
+    "input.background": "#0b1020",
+    "input.foreground": "#e8ecf8",
+    "input.placeholderForeground": "#69749b"
+  },
+  "type": "dark",
+  "name": "termy-dark"
+}

--- a/themes/tokyonight-moon.json
+++ b/themes/tokyonight-moon.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#636da6",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#c3e88d"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ff966c"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ff966c"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ff966c"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#c099ff"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ffc777"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#82aaff"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#82aaff"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#589ed7"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#86e1fc",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#c099ff"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#89ddff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#86e1fc"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#c53b53"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#589ed7",
+    "editorWidget.background": "#1e2030",
+    "editorWidget.foreground": "#c8d3f5",
+    "editorWidget.border": "#589ed7",
+    "editorHoverWidget.background": "#1e2030",
+    "editorHoverWidget.foreground": "#c8d3f5",
+    "editorHoverWidget.border": "#589ed7",
+    "list.activeSelectionBackground": "#2d3f76",
+    "list.activeSelectionForeground": "#c8d3f5",
+    "list.warningForeground": "#ffc777",
+    "statusBar.foreground": "#828bb8",
+    "statusBar.background": "#1e2030",
+    "statusBarItem.prominentBackground": "#82aaff",
+    "statusBarItem.prominentForeground": "#222436",
+    "focusBorder": "#589ed7",
+    "descriptionForeground": "#636da6",
+    "editor.foreground": "#c8d3f5",
+    "editor.background": "#222436",
+    "editor.lineHighlightBackground": "#2f334d",
+    "editor.selectionForeground": "#c8d3f5",
+    "editor.selectionBackground": "#2d3f76",
+    "editor.findMatchBackground": "#ff966c",
+    "editor.findMatchHighlightBackground": "#3e68d7",
+    "editorCursor.foreground": "#222436",
+    "editorLineNumber.foreground": "#636da6",
+    "editorLineNumber.background": "#222436",
+    "editorError.foreground": "#c53b53",
+    "editorWarning.foreground": "#ffc777",
+    "quickInput.background": "#1e2030",
+    "quickInput.foreground": "#c8d3f5",
+    "quickInputTitle.background": "#1e2030",
+    "quickInputList.focusBackground": "#2d3f76",
+    "quickInputList.focusForeground": "#c8d3f5",
+    "input.background": "#1e2030",
+    "input.foreground": "#c8d3f5",
+    "input.placeholderForeground": "#636da6"
+  },
+  "type": "dark",
+  "name": "tokyonight-moon"
+}

--- a/themes/tokyonight-night.json
+++ b/themes/tokyonight-night.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#565f89",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#9ece6a"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9e64"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9e64"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9e64"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#bb9af7"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e0af68"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa2f7"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa2f7"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#27a1b9"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#7dcfff",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#bb9af7"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#89ddff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#7dcfff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#db4b4b"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#27a1b9",
+    "editorWidget.background": "#16161e",
+    "editorWidget.foreground": "#c0caf5",
+    "editorWidget.border": "#27a1b9",
+    "editorHoverWidget.background": "#16161e",
+    "editorHoverWidget.foreground": "#c0caf5",
+    "editorHoverWidget.border": "#27a1b9",
+    "list.activeSelectionBackground": "#283457",
+    "list.activeSelectionForeground": "#c0caf5",
+    "list.warningForeground": "#e0af68",
+    "statusBar.foreground": "#a9b1d6",
+    "statusBar.background": "#16161e",
+    "statusBarItem.prominentBackground": "#7aa2f7",
+    "statusBarItem.prominentForeground": "#1a1b26",
+    "focusBorder": "#27a1b9",
+    "descriptionForeground": "#565f89",
+    "editor.foreground": "#c0caf5",
+    "editor.background": "#1a1b26",
+    "editor.lineHighlightBackground": "#292e42",
+    "editor.selectionForeground": "#c0caf5",
+    "editor.selectionBackground": "#283457",
+    "editor.findMatchBackground": "#ff9e64",
+    "editor.findMatchHighlightBackground": "#3d59a1",
+    "editorCursor.foreground": "#1a1b26",
+    "editorLineNumber.foreground": "#565f89",
+    "editorLineNumber.background": "#1a1b26",
+    "editorError.foreground": "#db4b4b",
+    "editorWarning.foreground": "#e0af68",
+    "quickInput.background": "#16161e",
+    "quickInput.foreground": "#c0caf5",
+    "quickInputTitle.background": "#16161e",
+    "quickInputList.focusBackground": "#283457",
+    "quickInputList.focusForeground": "#c0caf5",
+    "input.background": "#16161e",
+    "input.foreground": "#c0caf5",
+    "input.placeholderForeground": "#565f89"
+  },
+  "type": "dark",
+  "name": "tokyonight-night"
+}

--- a/themes/tokyonight-storm.json
+++ b/themes/tokyonight-storm.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#565f89",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#9ece6a"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9e64"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9e64"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ff9e64"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#bb9af7"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#e0af68"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa2f7"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#7aa2f7"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#29a4bd"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#7dcfff",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#bb9af7"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#89ddff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#7dcfff"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#2ac3de"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#db4b4b"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#29a4bd",
+    "editorWidget.background": "#1f2335",
+    "editorWidget.foreground": "#c0caf5",
+    "editorWidget.border": "#29a4bd",
+    "editorHoverWidget.background": "#1f2335",
+    "editorHoverWidget.foreground": "#c0caf5",
+    "editorHoverWidget.border": "#29a4bd",
+    "list.activeSelectionBackground": "#2e3c64",
+    "list.activeSelectionForeground": "#c0caf5",
+    "list.warningForeground": "#e0af68",
+    "statusBar.foreground": "#a9b1d6",
+    "statusBar.background": "#1f2335",
+    "statusBarItem.prominentBackground": "#7aa2f7",
+    "statusBarItem.prominentForeground": "#24283b",
+    "focusBorder": "#29a4bd",
+    "descriptionForeground": "#565f89",
+    "editor.foreground": "#c0caf5",
+    "editor.background": "#24283b",
+    "editor.lineHighlightBackground": "#292e42",
+    "editor.selectionForeground": "#c0caf5",
+    "editor.selectionBackground": "#2e3c64",
+    "editor.findMatchBackground": "#ff9e64",
+    "editor.findMatchHighlightBackground": "#3d59a1",
+    "editorCursor.foreground": "#24283b",
+    "editorLineNumber.foreground": "#565f89",
+    "editorLineNumber.background": "#24283b",
+    "editorError.foreground": "#db4b4b",
+    "editorWarning.foreground": "#e0af68",
+    "quickInput.background": "#1f2335",
+    "quickInput.foreground": "#c0caf5",
+    "quickInputTitle.background": "#1f2335",
+    "quickInputList.focusBackground": "#2e3c64",
+    "quickInputList.focusForeground": "#c0caf5",
+    "input.background": "#1f2335",
+    "input.foreground": "#c0caf5",
+    "input.placeholderForeground": "#565f89"
+  },
+  "type": "dark",
+  "name": "tokyonight-storm"
+}

--- a/themes/tokyonight.json
+++ b/themes/tokyonight.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#636da6",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#c3e88d"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ff966c"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ff966c"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#ff966c"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#c099ff"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ffc777"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#82aaff"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#82aaff"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#589ed7"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#86e1fc",
+        "fontStyle": "italic"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#c099ff"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#89ddff"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#86e1fc"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#65bcff"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#c53b53"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#589ed7",
+    "editorWidget.background": "#1e2030",
+    "editorWidget.foreground": "#c8d3f5",
+    "editorWidget.border": "#589ed7",
+    "editorHoverWidget.background": "#1e2030",
+    "editorHoverWidget.foreground": "#c8d3f5",
+    "editorHoverWidget.border": "#589ed7",
+    "list.activeSelectionBackground": "#2d3f76",
+    "list.activeSelectionForeground": "#c8d3f5",
+    "list.warningForeground": "#ffc777",
+    "statusBar.foreground": "#828bb8",
+    "statusBar.background": "#1e2030",
+    "statusBarItem.prominentBackground": "#82aaff",
+    "statusBarItem.prominentForeground": "#222436",
+    "focusBorder": "#589ed7",
+    "descriptionForeground": "#636da6",
+    "editor.foreground": "#c8d3f5",
+    "editor.background": "#222436",
+    "editor.lineHighlightBackground": "#2f334d",
+    "editor.selectionForeground": "#c8d3f5",
+    "editor.selectionBackground": "#2d3f76",
+    "editor.findMatchBackground": "#ff966c",
+    "editor.findMatchHighlightBackground": "#3e68d7",
+    "editorCursor.foreground": "#222436",
+    "editorLineNumber.foreground": "#636da6",
+    "editorLineNumber.background": "#222436",
+    "editorError.foreground": "#c53b53",
+    "editorWarning.foreground": "#ffc777",
+    "quickInput.background": "#1e2030",
+    "quickInput.foreground": "#c8d3f5",
+    "quickInputTitle.background": "#1e2030",
+    "quickInputList.focusBackground": "#2d3f76",
+    "quickInputList.focusForeground": "#c8d3f5",
+    "input.background": "#1e2030",
+    "input.foreground": "#c8d3f5",
+    "input.placeholderForeground": "#636da6"
+  },
+  "type": "dark",
+  "name": "tokyonight"
+}

--- a/themes/vesper.json
+++ b/themes/vesper.json
@@ -1,0 +1,188 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#7d7d7d",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#82d9c2",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff",
+        "fontStyle": "bold"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#82d9c2"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#ffcfa8"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#cccccc"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#ffffff",
+        "fontStyle": "italic"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#ffcfa8"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#ffcfa8"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#cccccc"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ffcfa8"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a0a0a0"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#a0a0a0"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#a0a0a0"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#cccccc"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#ffcfa8"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#a0a0a0"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#65737e"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#ff8080"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#505050",
+    "editorWidget.background": "#282828",
+    "editorWidget.foreground": "#cccccc",
+    "editorWidget.border": "#505050",
+    "editorHoverWidget.background": "#282828",
+    "editorHoverWidget.foreground": "#cccccc",
+    "editorHoverWidget.border": "#505050",
+    "list.activeSelectionBackground": "#656565",
+    "list.activeSelectionForeground": "#cccccc",
+    "list.warningForeground": "#ffc799",
+    "statusBar.foreground": "#cccccc",
+    "statusBar.background": "#101010",
+    "statusBarItem.prominentBackground": "#ffcfa8",
+    "statusBarItem.prominentForeground": "#101010",
+    "focusBorder": "#505050",
+    "descriptionForeground": "#7d7d7d",
+    "editor.foreground": "#cccccc",
+    "editor.background": "#101010",
+    "editor.lineHighlightBackground": "#343434",
+    "editor.selectionForeground": "#cccccc",
+    "editor.selectionBackground": "#656565",
+    "editor.findMatchBackground": "#e7bc99",
+    "editor.findMatchHighlightBackground": "#e7bc99",
+    "editorCursor.foreground": "#101010",
+    "editorLineNumber.foreground": "#7d7d7d",
+    "editorLineNumber.background": "#101010",
+    "editorError.foreground": "#ff8080",
+    "editorWarning.foreground": "#ffc799",
+    "quickInput.background": "#282828",
+    "quickInput.foreground": "#cccccc",
+    "quickInputTitle.background": "#282828",
+    "quickInputList.focusBackground": "#656565",
+    "quickInputList.focusForeground": "#cccccc",
+    "input.background": "#282828",
+    "input.foreground": "#cccccc",
+    "input.placeholderForeground": "#7d7d7d"
+  },
+  "type": "dark",
+  "name": "vesper"
+}

--- a/themes/vscode.json
+++ b/themes/vscode.json
@@ -1,0 +1,186 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6a9955"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#ce9178"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#569cd6"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#b5cea8"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#569cd6"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#d4d4d4"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#9cdcfe"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#9cdcfe"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#dcdcaa"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#dcdcaa"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#569cd6"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#569cd6"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#c586c0"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#c586c0"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#d4d4d4"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#569cd6"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#d4d4d4"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#dcdcaa"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#d4d4d4"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#f44747",
+        "background": "#1f1f1f"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#444444",
+    "editorWidget.background": "#202020",
+    "editorWidget.foreground": "#bbbbbb",
+    "editorWidget.border": "#444444",
+    "editorHoverWidget.background": "#202020",
+    "editorHoverWidget.foreground": "#bbbbbb",
+    "editorHoverWidget.border": "#444444",
+    "list.activeSelectionBackground": "#264f78",
+    "list.activeSelectionForeground": "#d4d4d4",
+    "list.warningForeground": "#dcdcaa",
+    "statusBar.foreground": "#d4d4d4",
+    "statusBar.background": "#373737",
+    "statusBarItem.prominentBackground": "#dcdcaa",
+    "statusBarItem.prominentForeground": "#1f1f1f",
+    "focusBorder": "#444444",
+    "descriptionForeground": "#6a9955",
+    "editor.foreground": "#d4d4d4",
+    "editor.background": "#1f1f1f",
+    "editor.lineHighlightBackground": "#222222",
+    "editor.selectionForeground": "#d4d4d4",
+    "editor.selectionBackground": "#264f78",
+    "editor.findMatchBackground": "#515c6a",
+    "editor.findMatchHighlightBackground": "#613315",
+    "editorCursor.foreground": "#51504f",
+    "editorLineNumber.foreground": "#6a9955",
+    "editorLineNumber.background": "#1f1f1f",
+    "editorError.foreground": "#f44747",
+    "editorWarning.foreground": "#dcdcaa",
+    "quickInput.background": "#202020",
+    "quickInput.foreground": "#bbbbbb",
+    "quickInputTitle.background": "#202020",
+    "quickInputList.focusBackground": "#264f78",
+    "quickInputList.focusForeground": "#d4d4d4",
+    "input.background": "#202020",
+    "input.foreground": "#bbbbbb",
+    "input.placeholderForeground": "#6a9955"
+  },
+  "type": "dark",
+  "name": "vscode"
+}

--- a/themes/zenbones.json
+++ b/themes/zenbones.json
@@ -1,0 +1,193 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#6e6763",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#868c91",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#868c91",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#868c91"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#b4bdc3",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#8d9499",
+        "fontStyle": "bold"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#979fa4"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#979fa4"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#b4bdc3"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#b4bdc3"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#a1938c"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a1938c"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#b4bdc3",
+        "fontStyle": "bold"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#b4bdc3",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#a1938c"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#8d9499",
+        "fontStyle": "bold"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#b4bdc3",
+        "fontStyle": "bold"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#867a74"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#de6e7c"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#837771",
+    "editorWidget.background": "#302b29",
+    "editorWidget.foreground": "#b4bdc3",
+    "editorWidget.border": "#837771",
+    "editorHoverWidget.background": "#302b29",
+    "editorHoverWidget.foreground": "#b4bdc3",
+    "editorHoverWidget.border": "#837771",
+    "list.activeSelectionBackground": "#3d4042",
+    "list.activeSelectionForeground": "#b4bdc3",
+    "list.warningForeground": "#b77e64",
+    "statusBar.foreground": "#b4bdc3",
+    "statusBar.background": "#352f2d",
+    "statusBarItem.prominentBackground": "#b4bdc3",
+    "statusBarItem.prominentForeground": "#1c1917",
+    "focusBorder": "#837771",
+    "descriptionForeground": "#6e6763",
+    "editor.foreground": "#b4bdc3",
+    "editor.background": "#1c1917",
+    "editor.lineHighlightBackground": "#25211f",
+    "editor.selectionForeground": "#b4bdc3",
+    "editor.selectionBackground": "#3d4042",
+    "editor.findMatchBackground": "#bf8fb5",
+    "editor.findMatchHighlightBackground": "#65435e",
+    "editorCursor.foreground": "#1c1917",
+    "editorLineNumber.foreground": "#6e6763",
+    "editorLineNumber.background": "#1c1917",
+    "editorError.foreground": "#de6e7c",
+    "editorWarning.foreground": "#b77e64",
+    "quickInput.background": "#302b29",
+    "quickInput.foreground": "#b4bdc3",
+    "quickInputTitle.background": "#302b29",
+    "quickInputList.focusBackground": "#3d4042",
+    "quickInputList.focusForeground": "#b4bdc3",
+    "input.background": "#302b29",
+    "input.foreground": "#b4bdc3",
+    "input.placeholderForeground": "#6e6763"
+  },
+  "type": "dark",
+  "name": "zenbones"
+}

--- a/themes/zenburned.json
+++ b/themes/zenburned.json
@@ -1,0 +1,190 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#848484",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#baa681",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#baa681",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#baa681"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#f0e4cf",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#f0f08f"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#d5be95"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#d5be95"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#f0e4cf"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#f0e4cf"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#a8a8a8"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#a8a8a8"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#dca2a2",
+        "fontStyle": "bold"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#dca2a2",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#a8a8a8"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#f0f08f"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#ffcdab"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#939393"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#e3716e"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#939393",
+    "editorWidget.background": "#505050",
+    "editorWidget.foreground": "#f0e4cf",
+    "editorWidget.border": "#939393",
+    "editorHoverWidget.background": "#505050",
+    "editorHoverWidget.foreground": "#f0e4cf",
+    "editorHoverWidget.border": "#939393",
+    "list.activeSelectionBackground": "#746956",
+    "list.activeSelectionForeground": "#f0e4cf",
+    "list.warningForeground": "#b77e64",
+    "statusBar.foreground": "#f0e4cf",
+    "statusBar.background": "#555555",
+    "statusBarItem.prominentBackground": "#f0e4cf",
+    "statusBarItem.prominentForeground": "#404040",
+    "focusBorder": "#939393",
+    "descriptionForeground": "#848484",
+    "editor.foreground": "#f0e4cf",
+    "editor.background": "#404040",
+    "editor.lineHighlightBackground": "#474747",
+    "editor.selectionForeground": "#f0e4cf",
+    "editor.selectionBackground": "#746956",
+    "editor.findMatchBackground": "#dfc8da",
+    "editor.findMatchHighlightBackground": "#9c6992",
+    "editorCursor.foreground": "#404040",
+    "editorLineNumber.foreground": "#848484",
+    "editorLineNumber.background": "#404040",
+    "editorError.foreground": "#e3716e",
+    "editorWarning.foreground": "#b77e64",
+    "quickInput.background": "#505050",
+    "quickInput.foreground": "#f0e4cf",
+    "quickInputTitle.background": "#505050",
+    "quickInputList.focusBackground": "#746956",
+    "quickInputList.focusForeground": "#f0e4cf",
+    "input.background": "#505050",
+    "input.foreground": "#f0e4cf",
+    "input.placeholderForeground": "#848484"
+  },
+  "type": "dark",
+  "name": "zenburned"
+}

--- a/themes/zenwritten.json
+++ b/themes/zenwritten.json
@@ -1,0 +1,193 @@
+{
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#686868",
+        "fontStyle": "italic"
+      },
+      "name": "Comment",
+      "scope": "comment"
+    },
+    {
+      "settings": {
+        "foreground": "#8b8b8b",
+        "fontStyle": "italic"
+      },
+      "name": "String",
+      "scope": "string"
+    },
+    {
+      "settings": {
+        "foreground": "#8b8b8b",
+        "fontStyle": "italic"
+      },
+      "name": "Constant",
+      "scope": "constant"
+    },
+    {
+      "settings": {
+        "foreground": "#8b8b8b"
+      },
+      "name": "Number",
+      "scope": "constant.numeric"
+    },
+    {
+      "settings": {
+        "foreground": "#bbbbbb",
+        "fontStyle": "italic"
+      },
+      "name": "Boolean",
+      "scope": "constant.language"
+    },
+    {
+      "settings": {
+        "foreground": "#939393",
+        "fontStyle": "bold"
+      },
+      "name": "SpecialChar",
+      "scope": "constant.character.escape"
+    },
+    {
+      "settings": {
+        "foreground": "#9e9e9e"
+      },
+      "name": "Identifier",
+      "scope": "variable"
+    },
+    {
+      "settings": {
+        "foreground": "#9e9e9e"
+      },
+      "name": "@variable.parameter",
+      "scope": "variable.parameter"
+    },
+    {
+      "settings": {
+        "foreground": "#bbbbbb"
+      },
+      "name": "Function",
+      "scope": "entity.name.function"
+    },
+    {
+      "settings": {
+        "foreground": "#bbbbbb"
+      },
+      "name": "@function.method",
+      "scope": "entity.name.function.member"
+    },
+    {
+      "settings": {
+        "foreground": "#969696"
+      },
+      "name": "Type",
+      "scope": "entity.name.type"
+    },
+    {
+      "settings": {
+        "foreground": "#969696"
+      },
+      "name": "@type.builtin",
+      "scope": "support.type"
+    },
+    {
+      "settings": {
+        "foreground": "#bbbbbb",
+        "fontStyle": "bold"
+      },
+      "name": "Keyword",
+      "scope": "keyword"
+    },
+    {
+      "settings": {
+        "foreground": "#bbbbbb",
+        "fontStyle": "bold"
+      },
+      "name": "Conditional",
+      "scope": "keyword.control"
+    },
+    {
+      "settings": {
+        "foreground": "#e0e2ea"
+      },
+      "name": "Operator",
+      "scope": "keyword.operator"
+    },
+    {
+      "settings": {
+        "foreground": "#969696"
+      },
+      "name": "StorageClass",
+      "scope": "storage.type"
+    },
+    {
+      "settings": {
+        "foreground": "#939393",
+        "fontStyle": "bold"
+      },
+      "name": "Tag",
+      "scope": "entity.name.tag"
+    },
+    {
+      "settings": {
+        "foreground": "#bbbbbb",
+        "fontStyle": "bold"
+      },
+      "name": "@attribute",
+      "scope": "entity.other.attribute-name"
+    },
+    {
+      "settings": {
+        "foreground": "#7c7c7c"
+      },
+      "name": "Delimiter",
+      "scope": "punctuation.delimiter"
+    },
+    {
+      "settings": {
+        "foreground": "#de6e7c"
+      },
+      "name": "Error",
+      "scope": "invalid"
+    }
+  ],
+  "colors": {
+    "input.border": "#797979",
+    "editorWidget.background": "#2c2c2c",
+    "editorWidget.foreground": "#bbbbbb",
+    "editorWidget.border": "#797979",
+    "editorHoverWidget.background": "#2c2c2c",
+    "editorHoverWidget.foreground": "#bbbbbb",
+    "editorHoverWidget.border": "#797979",
+    "list.activeSelectionBackground": "#404040",
+    "list.activeSelectionForeground": "#bbbbbb",
+    "list.warningForeground": "#b77e64",
+    "statusBar.foreground": "#bbbbbb",
+    "statusBar.background": "#303030",
+    "statusBarItem.prominentBackground": "#bbbbbb",
+    "statusBarItem.prominentForeground": "#191919",
+    "focusBorder": "#797979",
+    "descriptionForeground": "#686868",
+    "editor.foreground": "#bbbbbb",
+    "editor.background": "#191919",
+    "editor.lineHighlightBackground": "#222222",
+    "editor.selectionForeground": "#bbbbbb",
+    "editor.selectionBackground": "#404040",
+    "editor.findMatchBackground": "#bf8fb5",
+    "editor.findMatchHighlightBackground": "#65435e",
+    "editorCursor.foreground": "#191919",
+    "editorLineNumber.foreground": "#686868",
+    "editorLineNumber.background": "#191919",
+    "editorError.foreground": "#de6e7c",
+    "editorWarning.foreground": "#b77e64",
+    "quickInput.background": "#2c2c2c",
+    "quickInput.foreground": "#bbbbbb",
+    "quickInputTitle.background": "#2c2c2c",
+    "quickInputList.focusBackground": "#404040",
+    "quickInputList.focusForeground": "#bbbbbb",
+    "input.background": "#2c2c2c",
+    "input.foreground": "#bbbbbb",
+    "input.placeholderForeground": "#686868"
+  },
+  "type": "dark",
+  "name": "zenwritten"
+}


### PR DESCRIPTION
## Summary

Red already bundles several VS Code-derived themes, but it was missing many of the color schemes configured in our Neovim theme picker. This adds Red-compatible theme JSON generated from the resolved highlight groups of the locally installed Neovim colorschemes so those schemes are available directly in Red.

The new bundle includes lackluster variants, Aura, Kanagawa variants, Zenbones variants, Rose Pine variants, tokyonight.nvim variants, Solarized Osaka, Cyberdream, Bamboo, Bluloco, Jellybeans, Nordic/Nordern/Onenord, and other configured Neovim schemes. `themes/THIRD_PARTY.md` now documents the generated Neovim theme ports, license notices, and the schemes skipped because no redistributable upstream license was discoverable.

## How to Test

1. Run `git diff --name-only origin/master...HEAD -- "themes/*.json" | xargs -n1 jq empty`.
   Expected: all newly added theme JSON files parse as strict JSON with no output.

2. Run `cargo test test_bundled_themes_parse`.
   Expected: the bundled theme parser test passes, confirming all bundled themes parse and meet the picker selection contrast checks.

3. Run `rg "yorumi|nvim-tundra|poimandres" themes/THIRD_PARTY.md`.
   Expected: the unlicensed Neovim schemes are listed only in the skipped section, not bundled as theme JSON files.