### PR TITLE
fix(core): harden crash-prone editor paths

### DIFF
--- a/crates/husk/src/lib.rs
+++ b/crates/husk/src/lib.rs
@@ -276,6 +276,8 @@ pub struct Vm {
     instruction_budget: usize,
 }
 
+const MAX_CALL_DEPTH: usize = 512;
+
 impl Vm {
     #[must_use]
     pub fn new() -> Self {
@@ -456,6 +458,28 @@ impl Vm {
             plugin: callback.plugin.clone(),
             locals: HashMap::new(),
             remaining: self.instruction_budget,
+            call_depth: 0,
+        };
+
+        self.call_function_in_frame(callback, args, &mut frame, host)
+    }
+
+    fn call_function_in_frame<H: Host>(
+        &mut self,
+        callback: &Callback,
+        args: Vec<Value>,
+        parent_frame: &mut Frame,
+        host: &mut H,
+    ) -> anyhow::Result<Value> {
+        if parent_frame.call_depth >= MAX_CALL_DEPTH {
+            anyhow::bail!("Husk call depth exceeded");
+        }
+
+        let mut frame = Frame {
+            plugin: callback.plugin.clone(),
+            locals: HashMap::new(),
+            remaining: parent_frame.remaining,
+            call_depth: parent_frame.call_depth + 1,
         };
 
         let function = self
@@ -475,8 +499,11 @@ impl Vm {
             frame.locals.insert(name.clone(), value);
         }
 
-        self.eval_statements(&function.body, &mut frame, host)
-            .map_err(|error| with_call_frame(error, callback))
+        let result = self
+            .eval_statements(&function.body, &mut frame, host)
+            .map_err(|error| with_call_frame(error, callback));
+        parent_frame.remaining = frame.remaining;
+        result
     }
 
     fn eval_statements<H: Host>(
@@ -1121,12 +1148,12 @@ impl Vm {
         &mut self,
         callee: Value,
         args: Vec<Value>,
-        frame: &Frame,
+        frame: &mut Frame,
         host: &mut H,
     ) -> anyhow::Result<Value> {
         match callee {
             Value::String(name) => self.call_named(&name, args, frame, host),
-            Value::Callback(callback) => self.call_function(&callback, args, host),
+            Value::Callback(callback) => self.call_function_in_frame(&callback, args, frame, host),
             _ => anyhow::bail!("value is not callable: {callee:?}"),
         }
     }
@@ -1135,7 +1162,7 @@ impl Vm {
         &mut self,
         name: &str,
         args: Vec<Value>,
-        frame: &Frame,
+        frame: &mut Frame,
         host: &mut H,
     ) -> anyhow::Result<Value> {
         match name {
@@ -1427,9 +1454,10 @@ impl Vm {
                     .map(Value::Json)
                     .unwrap_or(Value::Unit))
             }
-            function if self.has_function(&frame.plugin, function) => self.call_function(
+            function if self.has_function(&frame.plugin, function) => self.call_function_in_frame(
                 &Callback::new(frame.plugin.clone(), function.to_string()),
                 args,
+                frame,
                 host,
             ),
             _ => anyhow::bail!("unknown Husk function `{name}`"),
@@ -1708,6 +1736,7 @@ struct Frame {
     plugin: String,
     locals: HashMap<String, Value>,
     remaining: usize,
+    call_depth: usize,
 }
 
 impl Frame {
@@ -2000,6 +2029,31 @@ mod tests {
             .unwrap();
 
         assert_eq!(host.logs, vec!["ready".to_string()]);
+    }
+
+    #[test]
+    fn recursive_calls_share_instruction_budget() {
+        let source = r#"
+            pub fn activate() {
+                red::add_command("Recurse", recurse);
+            }
+
+            fn recurse() {
+                recurse();
+            }
+        "#;
+        let mut host = TestHost::default();
+        let mut vm = Vm::new();
+        vm.set_instruction_budget(32);
+
+        vm.load_plugin("test", source, &mut host).unwrap();
+        let error = vm.execute_command("Recurse", &mut host).unwrap_err();
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("Husk instruction budget exhausted")
+                || rendered.contains("Husk call depth exceeded")
+        );
     }
 
     #[test]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -45,7 +45,7 @@ pub struct Buffer {
 impl Buffer {
     /// Creates a new Buffer instance with the given file path and contents
     pub fn new(file: Option<String>, contents: String) -> Self {
-        let contents = if contents.is_empty() {
+        let contents = if contents.is_empty() && file.is_none() {
             "\n".to_string()
         } else {
             contents
@@ -124,11 +124,6 @@ impl Buffer {
 
         let contents = std::fs::read_to_string(&path)?;
         let byte_count = contents.len();
-        let contents = if contents.is_empty() {
-            "\n".to_string()
-        } else {
-            contents
-        };
 
         self.content = Rope::from_str(&contents);
         self.file = Some(path.to_string_lossy().into_owned());
@@ -987,6 +982,26 @@ mod test {
             fs::read_to_string(real_dir.join("config.toml")).unwrap(),
             "theme = \"zen\"\n"
         );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn load_and_save_preserves_empty_file() {
+        let root = unique_temp_dir("empty-file");
+        fs::create_dir_all(&root).unwrap();
+        let file = root.join("empty.txt");
+        fs::write(&file, "").unwrap();
+
+        let mut buffer = Buffer::load_or_create(Some(file.to_string_lossy().into_owned()))
+            .await
+            .unwrap();
+
+        assert_eq!(buffer.contents(), "");
+
+        buffer.save().unwrap();
+
+        assert_eq!(fs::read(&file).unwrap(), b"");
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -33,16 +33,68 @@ impl fmt::Display for Color {
 }
 
 pub fn parse_rgb(s: &str) -> anyhow::Result<Color> {
+    if s.eq_ignore_ascii_case("transparent") {
+        return Ok(Color::Rgba {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        });
+    }
+
+    let named = match s.to_ascii_lowercase().as_str() {
+        "black" => Some(Color::Rgb { r: 0, g: 0, b: 0 }),
+        "white" => Some(Color::Rgb {
+            r: 255,
+            g: 255,
+            b: 255,
+        }),
+        "red" => Some(Color::Rgb { r: 255, g: 0, b: 0 }),
+        "green" => Some(Color::Rgb { r: 0, g: 128, b: 0 }),
+        "blue" => Some(Color::Rgb { r: 0, g: 0, b: 255 }),
+        "yellow" => Some(Color::Rgb {
+            r: 255,
+            g: 255,
+            b: 0,
+        }),
+        "cyan" => Some(Color::Rgb {
+            r: 0,
+            g: 255,
+            b: 255,
+        }),
+        "magenta" => Some(Color::Rgb {
+            r: 255,
+            g: 0,
+            b: 255,
+        }),
+        "gray" | "grey" => Some(Color::Rgb {
+            r: 128,
+            g: 128,
+            b: 128,
+        }),
+        _ => None,
+    };
+    if let Some(color) = named {
+        return Ok(color);
+    }
+
     if !s.starts_with('#') {
         anyhow::bail!("Invalid hex string: {}", s);
     }
 
     let hex = s.trim_start_matches('#');
+    let expanded;
+    let hex = if hex.len() == 3 || hex.len() == 4 {
+        expanded = hex.chars().flat_map(|c| [c, c]).collect::<String>();
+        expanded.as_str()
+    } else {
+        hex
+    };
     let len = hex.len();
 
     if len != 6 && len != 8 {
         anyhow::bail!(
-            "Hex string must be in the format #RRGGBB or #RRGGBBAA, got: {}",
+            "Hex string must be in the format #RGB, #RGBA, #RRGGBB or #RRGGBBAA, got: {}",
             s
         );
     }
@@ -249,6 +301,44 @@ mod test {
                 g: 222,
                 b: 233,
                 a: 255
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_short_hex_and_named_colors() {
+        assert_eq!(
+            parse_rgb("#fff").unwrap(),
+            Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255,
+            }
+        );
+        assert_eq!(
+            parse_rgb("#08af").unwrap(),
+            Color::Rgba {
+                r: 0,
+                g: 136,
+                b: 170,
+                a: 255,
+            }
+        );
+        assert_eq!(
+            parse_rgb("transparent").unwrap(),
+            Color::Rgba {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0,
+            }
+        );
+        assert_eq!(
+            parse_rgb("white").unwrap(),
+            Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255
             }
         );
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -5038,7 +5038,9 @@ impl Editor {
                     if method == "textDocument/hover" {
                         log!("hover response: {msg:?}");
                         let result = match msg.result {
-                            serde_json::Value::Array(ref arr) => arr[0].as_object().unwrap(),
+                            serde_json::Value::Array(ref arr) => {
+                                arr.first().and_then(|value| value.as_object())?
+                            }
                             serde_json::Value::Object(ref obj) => obj,
                             _ => return None,
                         };
@@ -5445,10 +5447,10 @@ impl Editor {
             }
 
             if let Some(repeater) = self.repeater {
-                let new_repeater = format!("{}{}", repeater, c).parse::<u16>().unwrap();
-                self.repeater = Some(new_repeater);
+                let digit = c.to_digit(10).unwrap_or(0) as u16;
+                self.repeater = Some(repeater.saturating_mul(10).saturating_add(digit));
             } else {
-                self.repeater = Some(c.to_string().parse::<u16>().unwrap());
+                self.repeater = c.to_digit(10).and_then(|digit| u16::try_from(digit).ok());
             }
 
             return true;
@@ -7740,16 +7742,20 @@ impl Editor {
             }
             Action::GoToDefinition => {
                 if let Some(file) = self.current_buffer().file.clone() {
+                    let position = self.cursor_lsp_position();
                     self.ensure_current_buffer_lsp_opened().await?;
                     self.lsp
-                        .goto_definition(&file, self.cx, self.cy + self.vtop)
+                        .goto_definition(&file, position.character, position.line)
                         .await?;
                 }
             }
             Action::Hover => {
                 if let Some(file) = self.current_buffer().file.clone() {
+                    let position = self.cursor_lsp_position();
                     self.ensure_current_buffer_lsp_opened().await?;
-                    self.lsp.hover(&file, self.cx, self.cy + self.vtop).await?;
+                    self.lsp
+                        .hover(&file, position.character, position.line)
+                        .await?;
                 }
             }
             Action::MoveTo(x, y) => {
@@ -13387,6 +13393,23 @@ mod test {
     }
 
     #[test]
+    fn empty_hover_array_is_ignored() {
+        let mut editor = test_editor(40, 10);
+        let message = InboundMessage::Message(ResponseMessage {
+            id: 42,
+            result: serde_json::json!([]),
+            request: Some(crate::lsp::Request::new(
+                "textDocument/hover",
+                serde_json::json!({}),
+            )),
+        });
+
+        let action = editor.handle_lsp_message(&message, Some("textDocument/hover".to_string()));
+
+        assert!(action.is_none());
+    }
+
+    #[test]
     fn retrigger_cancellation_keeps_pending_plugin_request() {
         let mut editor = test_editor(40, 10);
         editor
@@ -14050,6 +14073,18 @@ mod test {
 
         editor.repeater = Some(2);
         assert!(!editor.should_drain_repeated_motion(&event, &word_motion));
+    }
+
+    #[test]
+    fn oversized_repeat_count_saturates_without_panicking() {
+        let mut editor = test_editor(20, 5);
+
+        for digit in "99999999999999999999".chars() {
+            let event = Event::Key(KeyEvent::new(KeyCode::Char(digit), KeyModifiers::NONE));
+            assert!(editor.handle_repeater(&event));
+        }
+
+        assert_eq!(editor.repeater, Some(u16::MAX));
     }
 
     #[tokio::test]

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -361,7 +361,7 @@ impl RealLspClient {
         let before = &text[..byte_offset];
         let line = bytecount_newlines(before);
         let line_start = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
-        let character = before[line_start..].chars().count();
+        let character = before[line_start..].chars().map(char::len_utf16).sum();
 
         Position { line, character }
     }
@@ -1400,7 +1400,7 @@ mod test {
                 line += 1;
                 character = 0;
             } else {
-                character += 1;
+                character += c.len_utf16();
             }
             offset = i + c.len_utf8();
         }
@@ -1451,6 +1451,18 @@ mod test {
         assert_eq!(range.start.line, 1);
         assert_eq!(range.start.character, 3);
         assert_eq!(range.end.line, 1);
+        assert_eq!(change.text, "X");
+    }
+
+    #[test]
+    fn test_calculate_changes_positions_use_utf16_units() {
+        let change = single_change("😀 target", "😀 Xtarget");
+        let range = change.range.unwrap();
+
+        assert_eq!(range.start.line, 0);
+        assert_eq!(range.start.character, 3);
+        assert_eq!(range.end.line, 0);
+        assert_eq!(range.end.character, 3);
         assert_eq!(change.text, "X");
     }
 

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -108,7 +108,10 @@ impl PluginRegistry {
     }
 
     pub async fn execute(&mut self, runtime: &mut Runtime, command: &str) -> anyhow::Result<()> {
-        runtime.execute_command(command).await
+        if let Err(error) = runtime.execute_command(command).await {
+            crate::log!("Plugin command `{command}` failed: {error:?}");
+        }
+        Ok(())
     }
 
     pub async fn notify(
@@ -118,7 +121,10 @@ impl PluginRegistry {
         args: serde_json::Value,
     ) -> anyhow::Result<()> {
         let _span = crate::editor::perf::PerfSpan::with_detail("notify", event);
-        runtime.notify(event, args).await
+        if let Err(error) = runtime.notify(event, args).await {
+            crate::log!("Plugin event `{event}` failed: {error:?}");
+        }
+        Ok(())
     }
 
     pub async fn before_exit(
@@ -223,6 +229,61 @@ mod tests {
             }
             _ => panic!("unexpected plugin request"),
         }
+    }
+
+    #[tokio::test]
+    async fn plugin_command_errors_do_not_escape_registry() {
+        let dir = tempfile_dir("husk-command-error");
+        let plugin = dir.join("plugin.hk");
+        fs::write(
+            &plugin,
+            r#"
+                pub fn activate() {
+                    red::add_command("Fail", fail);
+                }
+
+                fn fail() {
+                    red::execute(1);
+                }
+            "#,
+        )
+        .unwrap();
+        let mut registry = PluginRegistry::new();
+        registry.add("test", plugin.to_str().unwrap());
+        let mut runtime = Runtime::new();
+
+        registry.initialize(&mut runtime).await.unwrap();
+
+        registry.execute(&mut runtime, "Fail").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn plugin_notify_errors_do_not_escape_registry() {
+        let dir = tempfile_dir("husk-notify-error");
+        let plugin = dir.join("plugin.hk");
+        fs::write(
+            &plugin,
+            r#"
+                pub fn activate() {
+                    red::on("editor:ready", fail);
+                }
+
+                fn fail(event: Json) {
+                    red::execute(1);
+                }
+            "#,
+        )
+        .unwrap();
+        let mut registry = PluginRegistry::new();
+        registry.add("test", plugin.to_str().unwrap());
+        let mut runtime = Runtime::new();
+
+        registry.initialize(&mut runtime).await.unwrap();
+
+        registry
+            .notify(&mut runtime, "editor:ready", serde_json::json!({}))
+            .await
+            .unwrap();
     }
 
     fn tempfile_dir(prefix: &str) -> std::path::PathBuf {

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -68,6 +68,7 @@ pub fn parse_vscode_theme(file: &str) -> anyhow::Result<Theme> {
 pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
     let contents = StripComments::new(contents.as_bytes());
     let vscode_theme: VsCodeTheme = serde_json::from_reader(contents)?;
+    let default_theme = Theme::default();
 
     let error_style = vscode_theme.style_from("editorError.foreground", "editorError.background");
     let cursor_style = vscode_theme
@@ -81,12 +82,12 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
             .colors
             .iter()
             .find(|(c, _)| **c == "editorLineNumber.foreground")
-            .map(|(_, hex)| parse_rgb(hex.as_str().expect("colors are an hex string")).unwrap()),
+            .and_then(|(_, hex)| parse_color_value(hex).ok()),
         bg: vscode_theme
             .colors
             .iter()
             .find(|(c, _)| **c == "editorLineNumber.background")
-            .map(|(_, hex)| parse_rgb(hex.as_str().expect("colors are an hex string")).unwrap()),
+            .and_then(|(_, hex)| parse_color_value(hex).ok()),
         ..Default::default()
     };
 
@@ -94,8 +95,9 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
         .colors
         .iter()
         .find(|(c, _)| **c == "editor.lineHighlightBackground")
-        .map(|(_, hex)| Style {
-            bg: Some(parse_rgb(hex.as_str().expect("colors are an hex string")).unwrap()),
+        .and_then(|(_, hex)| parse_color_value(hex).ok())
+        .map(|color| Style {
+            bg: Some(color),
             ..Default::default()
         });
 
@@ -106,8 +108,9 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
         .colors
         .iter()
         .find(|(c, _)| **c == "editor.findMatchBackground")
-        .map(|(_, hex)| Style {
-            bg: Some(parse_rgb(hex.as_str().expect("colors are an hex string")).unwrap()),
+        .and_then(|(_, hex)| parse_color_value(hex).ok())
+        .map(|color| Style {
+            bg: Some(color),
             ..Default::default()
         });
 
@@ -115,8 +118,9 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
         .colors
         .iter()
         .find(|(c, _)| **c == "editor.findMatchHighlightBackground")
-        .map(|(_, hex)| Style {
-            bg: Some(parse_rgb(hex.as_str().expect("colors are an hex string")).unwrap()),
+        .and_then(|(_, hex)| parse_color_value(hex).ok())
+        .map(|color| Style {
+            bg: Some(color),
             ..Default::default()
         });
 
@@ -143,12 +147,12 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
     };
 
     let editor_style = Style {
-        fg: Some(parse_rgb(
-            fg.expect("foreground color exists").as_str().expect(""),
-        )?),
-        bg: Some(parse_rgb(
-            bg.expect("background color exists").as_str().expect(""),
-        )?),
+        fg: fg
+            .and_then(|value| parse_color_value(value).ok())
+            .or(default_theme.style.fg),
+        bg: bg
+            .and_then(|value| parse_color_value(value).ok())
+            .or(default_theme.style.bg),
         bold: false,
         italic: false,
     };
@@ -171,8 +175,9 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
         .colors
         .iter()
         .filter_map(|(key, value)| {
-            let hex = value.as_str()?;
-            parse_rgb(hex).ok().map(|color| (key.to_string(), color))
+            parse_color_value(value)
+                .ok()
+                .map(|color| (key.to_string(), color))
         })
         .collect::<BTreeMap<_, _>>();
 
@@ -205,7 +210,7 @@ impl VsCodeTheme {
     fn color_from(&self, key: &str) -> Option<Color> {
         self.colors
             .get(key)
-            .map(|v| parse_rgb(v.as_str().expect("colors are an hex string")).unwrap())
+            .and_then(|value| parse_color_value(value).ok())
     }
 
     fn style_from(&self, fg_key: &str, bg_key: &str) -> Option<Style> {
@@ -491,24 +496,16 @@ impl TryFrom<VsCodeTokenColor> for TokenStyle {
         let mut style = Style::default();
 
         if let Some(fg) = tc.settings.get("foreground") {
-            style.fg =
-                Some(parse_rgb(fg.as_str().expect("fg is string")).expect("parsing rgb works"));
+            style.fg = Some(parse_color_value(fg)?);
         }
 
         if let Some(bg) = tc.settings.get("background") {
-            style.bg =
-                Some(parse_rgb(bg.as_str().expect("bg is string")).expect("parsing rgb works"));
+            style.bg = Some(parse_color_value(bg)?);
         }
 
-        if let Some(font_style) = tc.settings.get("fontStyle") {
-            style.bold = font_style
-                .as_str()
-                .expect("fontStyle is string")
-                .contains("bold");
-            style.italic = font_style
-                .as_str()
-                .expect("fontStyle is string")
-                .contains("italic");
+        if let Some(font_style) = tc.settings.get("fontStyle").and_then(Value::as_str) {
+            style.bold = font_style.contains("bold");
+            style.italic = font_style.contains("italic");
         }
 
         let Some(scope) = tc.scope else {
@@ -521,6 +518,13 @@ impl TryFrom<VsCodeTokenColor> for TokenStyle {
             style,
         })
     }
+}
+
+fn parse_color_value(value: &Value) -> anyhow::Result<Color> {
+    let Some(color) = value.as_str() else {
+        anyhow::bail!("theme color must be a string, got {value}");
+    };
+    parse_rgb(color)
 }
 
 fn translate_scope(vscode_scope: String) -> String {
@@ -813,6 +817,67 @@ mod test {
     #[test]
     fn test_theme_with_comments() {
         parse_vscode_theme("src/fixtures/nord.json").unwrap();
+    }
+
+    #[test]
+    fn test_theme_parsing_accepts_short_hex_and_missing_foreground() {
+        let theme = parse_vscode_theme_contents(
+            r##"
+            {
+                "name": "partial",
+                "colors": {
+                    "editor.background": "#123",
+                    "editorLineNumber.foreground": "transparent",
+                    "editor.findMatchBackground": 7
+                },
+                "tokenColors": [
+                    {
+                        "scope": "keyword",
+                        "settings": {
+                            "foreground": "#fff",
+                            "fontStyle": 4
+                        }
+                    }
+                ]
+            }
+            "##,
+        )
+        .unwrap();
+
+        assert_eq!(
+            theme.style.bg,
+            Some(Color::Rgb {
+                r: 17,
+                g: 34,
+                b: 51,
+            })
+        );
+        assert_eq!(
+            theme.style.fg,
+            Some(Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255,
+            })
+        );
+        assert_eq!(
+            theme.gutter_style.fg,
+            Some(Color::Rgba {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0,
+            })
+        );
+        assert!(theme.find_match_style.is_none());
+        assert_eq!(
+            theme.token_styles[0].style.fg,
+            Some(Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255,
+            })
+        );
     }
 
     #[test]

--- a/tests/common/editor_harness.rs
+++ b/tests/common/editor_harness.rs
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     fn test_harness_creation() {
         let harness = EditorHarness::new();
-        // Empty buffers have a single newline
+        // Unnamed scratch buffers have a single newline.
         assert_eq!(harness.buffer_contents(), "\n");
         assert_eq!(harness.cursor_position(), (0, 0));
         assert!(harness.is_normal());


### PR DESCRIPTION
Crash reports identified several user-controlled inputs and plugin/LSP paths that could panic or unwind the editor. This PR hardens those paths so malformed data, large repeat counts, recursive plugins, and empty files fail safely or preserve user data.

The change removes panic-prone parsing in repeat counts, hover responses, VS Code themes, and LSP UTF-16 position handling. It also preserves zero-byte file contents, shares Husk instruction budgets across recursive calls, and contains plugin callback errors at the registry boundary.

## How to Test

1. Open and save a zero-byte file. It should remain zero bytes after saving without edits.
2. Load a VS Code theme with shorthand colors such as `#fff`, `transparent`, or missing `editor.foreground`. The editor should fall back or ignore malformed optional colors without crashing.
3. Trigger hover with an empty LSP result array or use hover/goto after an astral Unicode character such as `😀`. The editor should ignore empty hover results and send UTF-16 positions.
4. Run `cargo test --all-features`; expected result: all workspace tests pass.
5. Run `cargo test -p husk`; expected result: recursive Husk callbacks exhaust budget/depth instead of overflowing the stack.
6. Run `cargo clippy --all-targets --all-features -- -D warnings`; expected result: no warnings.