### PR TITLE
fix(core): use production snapshots in self-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,37 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  self-check:
+    name: Bundled Runtime Self-Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-self-check-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Initialize bundled runtime
+        run: cargo run --locked -- --self-check
+
   changelog:
     name: Changelog
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,18 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
+      - name: Install ripgrep (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes ripgrep
+
+      - name: Install ripgrep (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ripgrep
+
+      - name: Install ripgrep (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ripgrep --yes --no-progress
+
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arboard"
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2174,7 +2174,7 @@ impl Editor {
         })
     }
 
-    fn refresh_plugin_snapshots(
+    pub(crate) fn refresh_plugin_snapshots(
         &self,
         runtime: &mut Runtime,
         viewport: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod matchit;
 pub mod onboarding;
 pub mod plugin;
 pub mod preferences;
+mod self_check;
 pub mod sync;
 pub mod theme;
 pub mod ui;
@@ -32,6 +33,8 @@ use once_cell::sync::OnceCell;
 
 pub use logger::Logger;
 pub use lsp::{LspManager, RealLspClient};
+#[doc(hidden)]
+pub use self_check::run as run_self_check;
 
 #[allow(unused)]
 pub static LOGGER: OnceCell<Option<Logger>> = OnceCell::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,9 @@ use red::editor::Editor;
 use red::logger::Logger;
 use red::lsp::{LspClient, LspManager};
 use red::onboarding;
-use red::plugin::{PluginRegistry, Runtime};
 use red::preferences::PreferencesStore;
 use red::theme::{parse_vscode_theme, parse_vscode_theme_contents, Theme};
-use red::{log, LOGGER};
+use red::{log, run_self_check, LOGGER};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
@@ -132,46 +131,6 @@ fn format_error(error: &anyhow::Error) -> String {
     } else {
         format!("Error: {error:#}")
     }
-}
-
-async fn run_self_check() -> anyhow::Result<()> {
-    let config = Config::from_user_toml_with_overrides("", &[])?;
-
-    let themes = assets::bundled_theme_files();
-    anyhow::ensure!(!themes.is_empty(), "no bundled themes were found");
-    for (file, contents) in themes {
-        parse_vscode_theme_contents(contents)
-            .map_err(|error| anyhow::anyhow!("failed to parse bundled theme {file}: {error}"))?;
-    }
-
-    let mut registry = PluginRegistry::new();
-    for (name, file) in &config.plugins {
-        let specifier = assets::bundled_plugin_specifier(file)
-            .ok_or_else(|| anyhow::anyhow!("default plugin {name} is not bundled: {file}"))?;
-        registry.add(name, &specifier);
-    }
-
-    let mut runtime = Runtime::try_new_with_permissions(config.plugin_permissions)?;
-    runtime.set_snapshot(
-        "viewport_layout",
-        serde_json::json!({
-            "buffer_index": 0,
-            "revision": 0,
-            "vtop": 0,
-            "width": 0,
-            "height": 0,
-            "cursor": { "x": 0, "y": 0 },
-            "indentation": {
-                "shift_width": 4,
-                "tab_width": 4,
-            },
-            "rows": [],
-        }),
-    );
-    runtime.set_snapshot("windows", serde_json::json!({ "windows": [] }));
-    runtime.set_snapshot("editor_info", serde_json::json!({}));
-    registry.initialize(&mut runtime).await?;
-    Ok(())
 }
 
 fn load_theme(theme_name: &str) -> anyhow::Result<Theme> {

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -918,7 +918,7 @@ fn _keep_config_used(_: &Config) {}
 #[cfg(test)]
 mod tests {
     use std::{
-        path::Path,
+        path::{Path, PathBuf},
         time::{Duration, Instant},
     };
 
@@ -2122,7 +2122,10 @@ mod tests {
         }
         match ACTION_DISPATCHER.recv_request() {
             PluginRequest::OpenLocation { location, target } => {
-                assert_eq!(location.path, "plugins/project_search.hk");
+                assert_eq!(
+                    PathBuf::from(location.path),
+                    Path::new("plugins").join("project_search.hk")
+                );
                 assert_eq!(target, crate::plugin::OpenLocationTarget::Current);
             }
             _ => panic!("unexpected plugin request"),

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -917,7 +917,10 @@ fn _keep_config_used(_: &Config) {}
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
+    use std::{
+        path::Path,
+        time::{Duration, Instant},
+    };
 
     use super::*;
     use crate::{
@@ -2090,10 +2093,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         };
 
-        assert!(
-            item.label.ends_with("plugins/project_search.hk")
-                || item.label == "plugins/project_search.hk"
-        );
+        assert!(Path::new(&item.label).ends_with(Path::new("plugins").join("project_search.hk")));
         assert_eq!(item.kind.as_deref(), Some("Match"));
         assert!(item
             .detail

--- a/src/self_check.rs
+++ b/src/self_check.rs
@@ -1,0 +1,62 @@
+use crate::{
+    assets,
+    buffer::Buffer,
+    config::Config,
+    editor::Editor,
+    lsp::LspManager,
+    plugin::{PluginRegistry, Runtime},
+    theme::parse_vscode_theme_contents,
+};
+
+pub async fn run() -> anyhow::Result<()> {
+    let mut config = Config::from_user_toml_with_overrides("", &[])?;
+
+    let themes = assets::bundled_theme_files();
+    anyhow::ensure!(!themes.is_empty(), "no bundled themes were found");
+    for (file, contents) in themes {
+        parse_vscode_theme_contents(contents)
+            .map_err(|error| anyhow::anyhow!("failed to parse bundled theme {file}: {error}"))?;
+    }
+
+    let mut registry = PluginRegistry::new();
+    for (name, file) in &config.plugins {
+        let specifier = assets::bundled_plugin_specifier(file)
+            .ok_or_else(|| anyhow::anyhow!("default plugin {name} is not bundled: {file}"))?;
+        registry.add(name, &specifier);
+    }
+
+    let theme_contents = assets::bundled_theme(&config.theme)
+        .ok_or_else(|| anyhow::anyhow!("default theme is not bundled: {}", config.theme))?;
+    let theme = parse_vscode_theme_contents(theme_contents)?;
+    let permissions = std::mem::take(&mut config.plugin_permissions);
+    let lsp = Box::new(LspManager::new(config.lsp.clone()));
+    let editor = Editor::with_size(
+        lsp,
+        80,
+        24,
+        config,
+        theme,
+        vec![Buffer::new(None, String::new())],
+    )?;
+
+    let mut runtime = Runtime::try_new_with_permissions(permissions)?;
+    editor.refresh_plugin_snapshots(&mut runtime, true, true, true)?;
+    registry.initialize(&mut runtime).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::editor::{ACTION_DISPATCHER, PLUGIN_DISPATCHER_TEST_LOCK};
+
+    #[tokio::test]
+    async fn bundled_runtime_initializes_with_production_snapshots() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        while ACTION_DISPATCHER.try_recv_request().is_some() {}
+
+        let result = super::run().await;
+        while ACTION_DISPATCHER.try_recv_request().is_some() {}
+
+        result.unwrap();
+    }
+}

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -424,11 +424,11 @@ mod tests {
         let files = load_file_picker_items(root.path(), FilePickerVisibility::default()).unwrap();
 
         assert_eq!(
-            files,
+            files.into_iter().map(PathBuf::from).collect::<Vec<_>>(),
             vec![
-                "nested/important.tmp".to_string(),
-                "nested/root-only.txt".to_string(),
-                "visible.txt".to_string(),
+                PathBuf::from("nested").join("important.tmp"),
+                PathBuf::from("nested").join("root-only.txt"),
+                PathBuf::from("visible.txt"),
             ]
         );
     }


### PR DESCRIPTION
The release smoke test depends on the hidden `--self-check` command to prove that bundled themes and plugins can initialize, but the command constructed an empty `editor_info` snapshot instead of using the editor's real snapshot contract. As a result, `indent_guides.hk` failed on its required `theme` field even while the regular Rust suite remained green, leaving the release path as the first place this regression appeared.

This change moves bundled runtime validation into the library and constructs a minimal editor so self-check initialization uses the same viewport, window, and editor-info snapshots as an interactive session. It adds a regression test around bundled runtime initialization and a dedicated CI job that runs the release-facing command on ordinary pull requests.

The cross-platform test matrix also assumed `rg` was preinstalled even though the project-search integration test launches it directly. The workflow now installs ripgrep with each runner's native package manager so that test no longer depends on runner image contents.

Running the expanded matrix exposed existing Windows-only path assertion failures, so those tests now compare platform-native paths. The locked `crossbeam-epoch` and `anyhow` releases are also updated to the patched versions required by the current security audit database.

## What Changed

- Reuse `Editor::refresh_plugin_snapshots` during bundled runtime validation.
- Keep theme parsing, embedded plugin resolution, and Husk activation in one testable library path.
- Cover production-snapshot initialization with a focused async regression test.
- Run `cargo run --locked -- --self-check` in the existing CI workflow.
- Install ripgrep before the cross-platform test matrix runs plugin integration tests.
- Compare project-search and file-picker paths portably on Windows.
- Update vulnerable locked dependencies to patched releases.

## How to Test

1. Run `cargo run --locked -- --self-check` from the repository root.
2. Confirm the command initializes every bundled theme and Husk plugin, prints `red self-check ok`, and exits successfully.
3. Run `cargo test self_check::tests::bundled_runtime_initializes_with_production_snapshots -- --exact`.
4. Confirm the regression test passes without leaving plugin-dispatch requests behind for other runtime tests.

Targeted test:

- `cargo test self_check::tests::bundled_runtime_initializes_with_production_snapshots -- --exact`
