### PR TITLE
perf(tui): retain previous render frame

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -995,6 +995,10 @@ pub struct Editor {
     /// Incremented after full renders so event handling can avoid duplicate frames.
     render_generation: u64,
 
+    /// The last frame sent to the terminal. Keeping this separately lets the
+    /// renderer diff frames without cloning the entire render buffer.
+    previous_render_buffer: Option<RenderBuffer>,
+
     /// Last terminal cursor cell painted into the render buffer.
     last_rendered_cursor_position: Option<(usize, usize)>,
 
@@ -1591,6 +1595,7 @@ impl Editor {
             is_focused: true,
             suppress_reactivation_click: false,
             render_generation: 0,
+            previous_render_buffer: None,
             last_rendered_cursor_position: None,
             last_rendered_cursor_surface: None,
             defer_motion_render: false,
@@ -12632,6 +12637,41 @@ mod test {
     }
 
     #[test]
+    fn render_frames_keep_the_previous_frame_in_sync() {
+        let mut editor = test_editor(40, 10);
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+
+        editor.render(&mut render_buffer).unwrap();
+        assert_eq!(
+            editor.previous_render_buffer.as_ref().unwrap().cells,
+            render_buffer.cells
+        );
+
+        editor.cx = 1;
+        editor
+            .render_cursor_motion_delta(&mut render_buffer)
+            .unwrap();
+        assert_eq!(
+            editor.previous_render_buffer.as_ref().unwrap().cells,
+            render_buffer.cells
+        );
+
+        editor.render_motion_frame(&mut render_buffer).unwrap();
+        assert_eq!(
+            editor.previous_render_buffer.as_ref().unwrap().cells,
+            render_buffer.cells
+        );
+
+        let mut resized_render_buffer = RenderBuffer::new(50, 10, &Style::default());
+        editor.size = (50, 10);
+        editor.render(&mut resized_render_buffer).unwrap();
+        assert_eq!(
+            editor.previous_render_buffer.as_ref().unwrap().cells,
+            resized_render_buffer.cells
+        );
+    }
+
+    #[test]
     fn break_indent_aligns_wrapped_rows_on_screen() {
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
@@ -14142,7 +14182,7 @@ mod test {
         editor.cursor_goal = CursorGoal::LineEnd;
         editor.sync_to_window();
 
-        editor.render_diff(Vec::new()).unwrap();
+        editor.render_diff(&[]).unwrap();
         editor.cy = 2;
         editor.apply_cursor_goal_to_current_line();
 

--- a/src/editor/render_buffer.rs
+++ b/src/editor/render_buffer.rs
@@ -370,9 +370,10 @@ impl RenderBuffer {
         s
     }
 
-    #[allow(unused)]
-    fn apply(&mut self, diff: Vec<Change<'_>>) {
-        for change in diff {
+    /// Applies a frame diff while retaining the allocations owned by this
+    /// buffer. Only changed cells are cloned into the previous-frame buffer.
+    pub(crate) fn apply_changes(&mut self, changes: &[Change<'_>]) {
+        for change in changes {
             let pos = (change.y * self.width) + change.x;
             self.cells[pos] = change.cell.clone();
         }

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -154,6 +154,28 @@ impl Editor {
             .map(|cell| cell.style.clone());
     }
 
+    /// Returns the cells changed since the last rendered frame. The previous
+    /// frame is updated after its diff has been sent to the terminal, so later
+    /// partial renders can continue to draw into the caller-owned buffer.
+    fn render_buffer_changes<'a>(&mut self, buffer: &'a RenderBuffer) -> Vec<Change<'a>> {
+        let previous = self.previous_render_buffer.get_or_insert_with(|| {
+            RenderBuffer::new(buffer.width, buffer.height, &Style::default())
+        });
+
+        if previous.width != buffer.width || previous.height != buffer.height {
+            *previous = RenderBuffer::new(buffer.width, buffer.height, &Style::default());
+        }
+
+        buffer.diff(previous)
+    }
+
+    fn commit_render_buffer_changes(&mut self, changes: &[Change<'_>]) {
+        self.previous_render_buffer
+            .as_mut()
+            .expect("render buffer diff requires a previous frame")
+            .apply_changes(changes);
+    }
+
     /// Renders the entire editor state to the terminal
     /// This is the main entry point for all rendering operations
     pub fn render(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
@@ -163,10 +185,6 @@ impl Editor {
         self.fix_cursor_pos();
         self.check_bounds();
         self.sync_to_window();
-        let clone_span = super::perf::PerfSpan::start("render:clone");
-        let current_buffer = buffer.clone();
-        drop(clone_span);
-
         // Render all windows
         let windows_span = super::perf::PerfSpan::start("render:windows");
         let window_count = self.window_manager.windows().len();
@@ -201,8 +219,9 @@ impl Editor {
 
         // Flush changes to terminal
         let diff_span = super::perf::PerfSpan::start("render:diff+flush");
-        let diff = buffer.diff(&current_buffer);
-        self.render_diff(diff)?;
+        let changes = self.render_buffer_changes(buffer);
+        self.render_diff(&changes)?;
+        self.commit_render_buffer_changes(&changes);
         drop(diff_span);
         self.render_generation = self.render_generation.wrapping_add(1);
 
@@ -253,8 +272,6 @@ impl Editor {
         self.update_gutter_width();
         self.fix_cursor_pos();
         self.sync_to_window();
-        let current_buffer = buffer.clone();
-
         let active_window_id = self.window_manager.active_window_id();
         self.render_window(buffer, active_window_id)?;
         self.render_ui_chrome(buffer)?;
@@ -264,8 +281,9 @@ impl Editor {
         self.render_cursor_cell(buffer);
         self.last_rendered_cursor_position = self.render_cursor_position();
 
-        let diff = buffer.diff(&current_buffer);
-        self.render_diff(diff)?;
+        let changes = self.render_buffer_changes(buffer);
+        self.render_diff(&changes)?;
+        self.commit_render_buffer_changes(&changes);
         self.render_generation = self.render_generation.wrapping_add(1);
 
         Ok(())
@@ -334,8 +352,9 @@ impl Editor {
         self.update_terminal_cursor_surface(buffer);
         self.render_cursor_cell(buffer);
 
-        let diff = buffer.diff_row_snapshots(&snapshots);
-        self.render_diff(diff)?;
+        let changes = buffer.diff_row_snapshots(&snapshots);
+        self.render_diff(&changes)?;
+        self.commit_render_buffer_changes(&changes);
         self.last_rendered_cursor_position = new_cursor_position;
         self.render_generation = self.render_generation.wrapping_add(1);
 
@@ -1450,7 +1469,7 @@ impl Editor {
         Ok(())
     }
 
-    pub fn render_diff(&mut self, change_set: Vec<Change<'_>>) -> anyhow::Result<()> {
+    pub fn render_diff(&mut self, change_set: &[Change<'_>]) -> anyhow::Result<()> {
         if !self.terminal_output_enabled {
             self.draw_cursor_preserving_cursor_goal()?;
             return Ok(());


### PR DESCRIPTION
Rendering cloned every terminal cell before each full and motion-frame diff, creating avoidable allocation and copy work even when most of the frame was unchanged.

Keep a persistent previous frame in the editor and update it only with the cells emitted to the terminal. This retains the existing partial-render behavior, resets safely after a terminal resize, and covers full, motion, and cursor-delta synchronization with a regression test.

## How to Test

1. Run `cargo test --all-features render_frames_keep_the_previous_frame_in_sync --lib`; it should verify the retained frame after full, delta, motion, and resized renders.
2. Run `cargo test --all-features`; the complete suite should pass with the unchanged rendering behavior.
3. Run `RED_PERF=summary cargo run --release`, move through a representative file, and confirm the summary no longer reports a `render:clone` span.