### PR TITLE
fix(editor): render command feedback after execution

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7732,6 +7732,8 @@ impl Editor {
                         return Ok(true);
                     }
                 }
+
+                self.render(buffer)?;
             }
             Action::PluginCommand(cmd) => {
                 self.plugin_registry.execute(runtime, cmd).await?;
@@ -13772,6 +13774,40 @@ mod test {
             .unwrap();
 
         assert!(render_row(&render_buffer, 4).starts_with(':'));
+    }
+
+    #[tokio::test]
+    async fn command_feedback_renders_after_prompt_closes() {
+        for (command, dirty, expected) in [
+            (
+                "q",
+                true,
+                "The following buffers have unwritten changes: [No Name]",
+            ),
+            ("w", true, "No file name"),
+            ("xyz", false, "unknown command \"xyz\""),
+        ] {
+            let mut editor = test_editor(80, 5);
+            editor.current_buffer_mut().dirty = dirty;
+            editor.mode = Mode::Command;
+            editor.command = command.to_string();
+            let mut render_buffer = RenderBuffer::new(80, 5, &Style::default());
+            let mut runtime = Runtime::new();
+
+            let processed = editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+                    &mut render_buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+
+            assert!(!processed.quit, "command {command:?} unexpectedly quit");
+            assert_eq!(editor.last_error.as_deref(), Some(expected));
+            assert_eq!(render_row(&render_buffer, 4).trim_end(), expected);
+        }
     }
 
     #[tokio::test]

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -1631,7 +1631,7 @@ impl Component for Picker {
                     KeyCode::Char(c) => {
                         self.reset_history_navigation();
                         let previous = self.selected_item();
-                        let search = format!("{}{}", &self.search, &c);
+                        let search = format!("{}{}", self.search, c);
                         self.set_search(search);
                         self.changed_actions(previous)
                     }


### PR DESCRIPTION
## Why

Submitting an Ex command first leaves command mode and clears the command line. Commands that only update the feedback message, including a refused :q on a modified buffer, did not repaint afterward, so the editor stayed open with no explanation. Successful writes and other command errors could be hidden for the same reason.

## What Changed

Render once after command dispatch completes so quit warnings, write feedback, unknown commands, and file-open errors reach the command line. Add a regression that submits Enter through the production event path and verifies the rendered row for :q, :w with no file name, and an unknown command.

## How to Test

1. Open a file with red, insert text, press Escape, and run :q. Confirm the editor stays open and displays the unwritten-changes warning.
2. Run :w. Confirm the modified marker clears and the written message appears; run :xyz and confirm the unknown-command error appears.
3. Run cargo test --lib command_feedback_renders_after_prompt_closes and confirm it passes.

Validated with the full all-targets/all-features test suite and strict Clippy.