### PR TITLE
feat(vim): add editing and motion parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Limit Windows test concurrency
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "RUST_TEST_THREADS=1" >> "$GITHUB_ENV"
+
       - name: Run tests
         run: cargo test --all-targets --all-features --verbose
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ Red uses Vim-style modal editing. Everything below is the default; all of it can
 ### Moving around
 
 - `h/j/k/l` or arrow keys - Move left/down/up/right
-- `w/b` - Move forward/backward by word
-- `0/$` - Move to beginning/end of line
+- `w/b/e/ge` - Move by word start/end (`B/E/gE` for whitespace-delimited WORDs)
+- `f{char}/t{char}` and `F{char}/T{char}` - Find/till a character forward or backward; `,` repeats in the opposite direction
+- `0/^/$` - Move to beginning/first non-blank/end of line
 - `gg/G` - Go to first/last line
-- `Ctrl-b/Ctrl-f` - Page up/down
+- `Ctrl-b/Ctrl-f` - Page up/down; `Ctrl-u/Ctrl-d` - half-page up/down
 - `zz` - Center the current line in the view
 - `%` - Jump to the matching bracket (`g%` backward, `[%`/`]%` for unmatched brackets)
 - `Ctrl-o/Tab` - Jump back/forward through the jump list
@@ -101,8 +102,12 @@ Red uses Vim-style modal editing. Everything below is the default; all of it can
 
 - `i/a` - Insert before/after the cursor (`I/A` for start/end of line)
 - `o/O` - Open a new line below/above
-- `x` - Delete character; `dd` - delete line; `dw` - delete word
-- `u` / `Ctrl-r` - Undo/redo
+- `x/X` - Delete the character under/before the cursor; `dd` - delete line; `dw` - delete word
+- `D/C/Y` - Delete/change/yank from the cursor to the end of the line; counts include following lines
+- `s/S` - Substitute characters/the current line and enter Insert mode
+- `J/gJ` - Join lines with normalized/preserved whitespace (counts and Visual selections work too)
+- `~`, `gu{motion}`, `gU{motion}`, `g~{motion}` - Toggle/lowercase/uppercase text
+- `u` / `Ctrl-r` or `U` - Undo/redo
 - `p/P` - Paste after/before
 - `>>` / `<<` - Indent/unindent the current line
 - `Esc` - Back to Normal mode
@@ -113,7 +118,7 @@ Red uses Vim-style modal editing. Everything below is the default; all of it can
 - `V` - Visual Line mode
 - `Ctrl-v` - Visual Block mode (rectangular selections; `I` inserts on every selected line)
 - In Visual mode, `i`/`a` select inside/around a text object: `iw` for a word, `i(`, `i[`, `i{`, `i<`, `i"`, `i'`, or `` i` `` for delimited text, and `a%` for a matchit pair
-- In a selection: `y` copies, `x` deletes, `p` pastes over it
+- In a selection: `y` copies, `x` deletes, `p` pastes over it, `r{char}` replaces, and `u/U/~` changes case
 
 ### Searching
 
@@ -168,6 +173,7 @@ Enter Command mode with `:` (or `;`).
 - `:close` / `:only` - Close the current window / keep only the current window
 - `:noh` - Clear search highlights
 - `:wrap` / `:nowrap` - Enable/disable line wrapping
+- `:join [count]` / `:join! [count]` - Join lines with normalized/preserved whitespace (`:j` is accepted)
 
 ## Configuration
 

--- a/default_config.toml
+++ b/default_config.toml
@@ -122,11 +122,15 @@ Esc = { EnterMode = "Normal" }
 [keys.normal]
 "w" = [ "MoveToNextWord" ]
 "b" = [ "MoveToPreviousWord" ]
+"e" = "MoveToNextWordEnd"
+"E" = "MoveToNextBigWordEnd"
+"B" = "MoveToPreviousBigWord"
 "o" = [ { EnterMode = "Insert" }, "InsertLineBelowCursor" ]
 "O" = [ { EnterMode = "Insert" }, "InsertLineAtCursor" ]
 "G" = "MoveToBottom"
-"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd", "-" = "SelectPreviousUndoBranch", "+" = "SelectNextUndoBranch" }
+"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd", "e" = "MoveToPreviousWordEnd", "E" = "MoveToPreviousBigWordEnd", "J" = { JoinLinesKeepSpaces = 2 }, "u" = { StartLowercaseOperator = 1 }, "U" = { StartUppercaseOperator = 1 }, "~" = { StartToggleCaseOperator = 1 }, "-" = "SelectPreviousUndoBranch", "+" = "SelectNextUndoBranch" }
 "u" = "Undo"
+"U" = "Redo"
 "Ctrl-r" = "Redo"
 "Down" = "MoveDown"
 "Left" = "MoveLeft"
@@ -137,6 +141,7 @@ Esc = { EnterMode = "Normal" }
 "h" = "MoveLeft"
 "l" = "MoveRight"
 "0" = "MoveToLineStart"
+"^" = "MoveToFirstLineChar"
 "Home" = "MoveToLineStart"
 "$" = "MoveToLineEnd"
 "End" = "MoveToLineEnd"
@@ -144,9 +149,20 @@ Esc = { EnterMode = "Normal" }
 "L" = "MoveToLastLineChar"
 "Ctrl-b" = "PageUp"
 "Ctrl-f" = "PageDown"
+"Ctrl-u" = { HalfPageUp = 0 }
+"Ctrl-d" = { HalfPageDown = 0 }
 "Ctrl-o" = "JumpBack"
 "Tab" = "JumpForward"
 "x" = "DeleteCharAtCursorPos"
+"X" = { DeletePreviousChars = 1 }
+"s" = { ChangeCharsAtCursor = 1 }
+"S" = { ChangeCurrentLines = 1 }
+"D" = { DeleteToLineEnd = 1 }
+"C" = { ChangeToLineEnd = 1 }
+"Y" = { YankToLineEnd = 1 }
+"J" = { JoinLines = 2 }
+"~" = { ToggleCharCase = 1 }
+"," = { RepeatCharSearchOpposite = 1 }
 "." = "RepeatLastChange"
 "z" = { "z" = "MoveLineToViewportCenter", "h" = "ScrollViewLeft", "l" = "ScrollViewRight", "H" = "ScrollViewHalfPageLeft", "L" = "ScrollViewHalfPageRight", "s" = "ScrollCursorToViewStart", "e" = "ScrollCursorToViewEnd" }
 "*" = "SearchWordUnderCursor"
@@ -258,6 +274,11 @@ Esc = { EnterMode = "Normal" }
 "p" = [ "Paste", { EnterMode = "Normal" } ]
 "P" = [ "PasteBefore", { EnterMode = "Normal" } ]
 "I" = "InsertBlock"
+"J" = [ { JoinLines = 2 }, { EnterMode = "Normal" } ]
+"g" = { "J" = [ { JoinLinesKeepSpaces = 2 }, { EnterMode = "Normal" } ] }
+"u" = [ { TransformSelection = "Lower" }, { EnterMode = "Normal" } ]
+"U" = [ { TransformSelection = "Upper" }, { EnterMode = "Normal" } ]
+"~" = [ { TransformSelection = "Toggle" }, { EnterMode = "Normal" } ]
 
 [keys.visual." "."h"]
 "s" = { PluginCommand = "GitHunkStage" }

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Red Vim compatibility matrix
 
-**Matrix version:** 1.0  
+**Matrix version:** 1.1
 **Validated against:** Red 0.1.1, July 2026  
 **Status vocabulary:** **supported**, **intentional difference**, **not yet supported**
 
@@ -12,14 +12,16 @@ the corresponding integration tests.
 
 | Area | Status | Red behavior |
 |---|---|---|
-| Counts | **supported** | Decimal prefixes apply to motions, macro playback, dot-repeat, find/till, and `r`. Individual commands may document a narrower count surface. |
-| Basic motions | **supported** | `h j k l`, arrows, `0`, `$`, `w`, `b`, `gg`, `G`, screen-line motions, paging, and file percentages use grapheme-safe cursor positions. |
-| Character motions | **supported** | `f{char}`, `t{char}`, and counted forms; delete, change, and yank accept the same suffixes. |
-| Operators | **supported** | `d`, `c`, and `y` with line, word, find/till, match, and supported text-object targets. |
+| Counts | **supported** | Decimal prefixes apply to motions, joins, line-end edits, substitute/delete-character aliases, macro playback, dot-repeat, find/till, and `r`. Nested mappings preserve the prefix until their final key. |
+| Basic motions | **supported** | `h j k l`, arrows, `0`, `^`, `$`, `w`, `b`, `e`, `ge`, `B`, `E`, `gE`, `gg`, `G`, screen-line motions, full/half-page motions, and file percentages use grapheme-safe cursor positions. The typed `MoveToNextBigWord` action can be mapped when `W` semantics are preferred. |
+| Character motions | **supported** | `f{char}`, `t{char}`, `F{char}`, `T{char}`, counted forms, and `,` reverse-repeat; delete, change, and yank accept the same suffixes. Forward-repeat is available as the remappable `RepeatCharSearch` action. |
+| Operators | **supported** | `d`, `c`, and `y` with line, vertical, line-start/end, forward/backward word, find/till, match, and supported text-object targets. `cw` preserves trailing whitespace like Vim. |
 | Text objects | **supported** | Inner/around word, parentheses, brackets, braces, single quotes, double quotes, and backticks. |
 | `r{char}` | **supported** | Replaces one or a counted run of graphemes and is one undoable change. A count longer than the remaining line is rejected without editing. |
-| Join | **supported** | Line joining is available through the typed action surface. |
-| Ex commands | **intentional difference** | Red implements a documented subset and uses `;` as an additional command-line entry key. It does not implement Vimscript. |
+| Editing aliases | **supported** | `D`, `C`, and Neovim-style `Y` operate to line end; `S`, `s`, and `X` provide line/character substitute and backward-delete shortcuts. Counts, default-register kind, undo, and Insert transitions are preserved. `U` is an additional redo alias. |
+| Case changes | **supported** | `~`, `gu{motion}`, `gU{motion}`, `g~{motion}`, and the `guu`/`gUU`/`g~~` line forms transform Unicode text as one transaction. |
+| Join | **supported** | `J` joins at least two lines, removes following indentation, and inserts a space unless trailing whitespace or `)` makes it unnecessary; `gJ` preserves whitespace. Normal counts, Visual joins, `:j[oin][!] [count]`, undo, dot-repeat, and macros are covered. |
+| Ex commands and default-key differences | **intentional difference** | Red implements a documented Ex subset and uses `;` as an additional command-line entry key, `W` to toggle wrapping, and `Ctrl-e` for NeoTree; these defaults intentionally differ from Vim and can be remapped. Red does not implement Vimscript. |
 
 ## Registers, repeat, and macros
 
@@ -42,7 +44,7 @@ the corresponding integration tests.
 | Visual character | **supported** | Motions, supported text objects, yank/delete/change/paste, and Unicode selections. |
 | Visual line | **supported** | Linewise yank/delete/change/paste, including whole-document and interior replacements. |
 | Visual block | **supported** | Block delete/change/insert, one-transaction replay, undo/redo, and dot-repeat for block insert. |
-| Visual `r` replace | **not yet supported** | Normal-mode `r` is supported; visual replacement remains separate work. |
+| Visual `r` replace and case changes | **supported** | Visual `r{char}`, `u`, `U`, and `~` replace/change the selection in one transaction, including shifted terminal key events and Visual-line/block selections. |
 | Wrapped-line motions | **supported** | `gj`, `gk`, `g0`, `g^`, and `g$`; scroll and cursor state are window-local. |
 
 ## Search, substitution, history, and marks

--- a/src/bin/red_codex_acp.rs
+++ b/src/bin/red_codex_acp.rs
@@ -3363,7 +3363,7 @@ client-private-key = "./certs/client.key"
             #[cfg(windows)]
             let key = key.to_ascii_lowercase();
             assert_eq!(
-                projects[key.as_ref()]["trust_level"],
+                projects[&*key]["trust_level"],
                 "untrusted",
                 "missing trust override for {}",
                 path.display()

--- a/src/bin/red_codex_acp.rs
+++ b/src/bin/red_codex_acp.rs
@@ -2946,7 +2946,8 @@ client-private-key = "./certs/client.key"
             Some(
                 source
                     .path()
-                    .join("~literal/prompt.md")
+                    .join("~literal")
+                    .join("prompt.md")
                     .to_string_lossy()
                     .as_ref()
             )
@@ -3348,14 +3349,21 @@ client-private-key = "./certs/client.key"
     #[test]
     fn project_trust_overrides_cover_every_ancestor() {
         let source = tempfile::tempdir().unwrap();
-        let nested = source.path().join("worktree/nested/project");
+        let nested = source
+            .path()
+            .join("worktree")
+            .join("nested")
+            .join("project");
         fs::create_dir_all(&nested).unwrap();
 
         let projects = project_trust_overrides(&nested);
 
         for path in nested.ancestors() {
+            let key = path.to_string_lossy();
+            #[cfg(windows)]
+            let key = key.to_ascii_lowercase();
             assert_eq!(
-                projects[path.to_string_lossy().as_ref()]["trust_level"],
+                projects[key.as_ref()]["trust_level"],
                 "untrusted",
                 "missing trust override for {}",
                 path.display()

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -20250,6 +20250,9 @@ for line in sys.stdin:
         let first_turn = {
             let mut workspace = workspace.lock().unwrap();
             workspace
+                .sync_visible_file(&path, 0, "disk base\n".to_string())
+                .unwrap();
+            workspace
                 .write("session-1", &path, "first edit\n".to_string())
                 .unwrap();
             match workspace

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -835,6 +835,13 @@ pub enum SearchDirection {
     Backward,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum CaseTransform {
+    Lower,
+    Upper,
+    Toggle,
+}
+
 impl SearchDirection {
     fn opposite(self) -> Self {
         match self {
@@ -884,6 +891,16 @@ pub enum Action {
         target: char,
         count: u16,
     },
+    FindCharBackward {
+        target: char,
+        count: u16,
+    },
+    TillCharBackward {
+        target: char,
+        count: u16,
+    },
+    RepeatCharSearch(u16),
+    RepeatCharSearchOpposite(u16),
     RepeatSearch,
     RepeatSearchOpposite,
     CommitSearch,
@@ -913,6 +930,12 @@ pub enum Action {
     OpenLocation(plugin::PluginLocation, plugin::OpenLocationTarget),
     MoveToNextWord,
     MoveToPreviousWord,
+    MoveToNextBigWord,
+    MoveToNextWordEnd,
+    MoveToPreviousWordEnd,
+    MoveToNextBigWordEnd,
+    MoveToPreviousBigWord,
+    MoveToPreviousBigWordEnd,
     MoveToFilePercent(usize),
     MatchitForward,
     MatchitBackward,
@@ -922,6 +945,8 @@ pub enum Action {
 
     PageDown,
     PageUp,
+    HalfPageDown(u16),
+    HalfPageUp(u16),
     ScrollUp,
     ScrollDown,
     ScrollViewLeft,
@@ -943,9 +968,29 @@ pub enum Action {
     DeleteTextRange(TextRange),
     ChangeTextRange(TextRange),
     YankTextRange(TextRange),
+    DeleteLinewiseRange(TextRange),
+    ChangeLinewiseRange(TextRange),
+    YankLinewiseRange(TextRange),
     ChangeCurrentLine,
     ChangeCurrentLines(u16),
     DeleteWord,
+    DeleteToLineEnd(u16),
+    ChangeToLineEnd(u16),
+    YankToLineEnd(u16),
+    DeletePreviousChars(u16),
+    ChangeCharsAtCursor(u16),
+    JoinLines(u16),
+    JoinLinesKeepSpaces(u16),
+    ToggleCharCase(u16),
+    StartLowercaseOperator(u16),
+    StartUppercaseOperator(u16),
+    StartToggleCaseOperator(u16),
+    TransformTextRange {
+        range: TextRange,
+        transform: CaseTransform,
+    },
+    TransformSelection(CaseTransform),
+    ReplaceSelection(char),
 
     InsertNewLine,
     InsertCharAtCursorPos(char),
@@ -1477,8 +1522,11 @@ pub struct Editor {
     /// Partially entered normal-mode Vim operator, such as `d` in `diw`.
     pending_operator: Option<PendingOperator>,
 
-    /// Partially entered forward character motion, such as f followed by a target.
+    /// Partially entered character motion, such as f or F followed by a target.
     pending_character_motion: Option<PendingCharacterMotion>,
+
+    /// Last completed character search, used by the reverse-repeat binding.
+    last_character_motion: Option<(ForwardCharacterMotion, char)>,
 
     /// Whether Normal-mode `r` is waiting for its replacement character.
     pending_replace: bool,
@@ -2114,6 +2162,9 @@ enum EditOperator {
     Delete,
     Change,
     Yank,
+    Lowercase,
+    Uppercase,
+    ToggleCase,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2121,6 +2172,8 @@ enum PendingOperatorStep {
     Operator,
     FindForward,
     TillForward,
+    FindBackward,
+    TillBackward,
     TextObjectScope(TextObjectScope),
 }
 
@@ -2136,6 +2189,8 @@ struct PendingOperator {
 enum ForwardCharacterMotion {
     Find,
     Till,
+    FindBackward,
+    TillBackward,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2161,11 +2216,14 @@ impl PendingOperator {
 }
 
 impl EditOperator {
-    fn as_char(self) -> char {
+    fn as_str(self) -> &'static str {
         match self {
-            EditOperator::Delete => 'd',
-            EditOperator::Change => 'c',
-            EditOperator::Yank => 'y',
+            EditOperator::Delete => "d",
+            EditOperator::Change => "c",
+            EditOperator::Yank => "y",
+            EditOperator::Lowercase => "gu",
+            EditOperator::Uppercase => "gU",
+            EditOperator::ToggleCase => "g~",
         }
     }
 }
@@ -2446,6 +2504,7 @@ impl Editor {
             pending_visual_text_object_scope: None,
             pending_operator: None,
             pending_character_motion: None,
+            last_character_motion: None,
             pending_replace: false,
             actions: vec![],
             last_semantic_change: None,
@@ -6720,8 +6779,18 @@ impl Editor {
                 | Action::MoveToScreenLineFirstNonBlank
                 | Action::MoveToNextWord
                 | Action::MoveToPreviousWord
+                | Action::MoveToNextBigWord
+                | Action::MoveToNextWordEnd
+                | Action::MoveToPreviousWordEnd
+                | Action::MoveToNextBigWordEnd
+                | Action::MoveToPreviousBigWord
+                | Action::MoveToPreviousBigWordEnd
                 | Action::FindCharForward { .. }
                 | Action::TillCharForward { .. }
+                | Action::FindCharBackward { .. }
+                | Action::TillCharBackward { .. }
+                | Action::RepeatCharSearch(_)
+                | Action::RepeatCharSearchOpposite(_)
                 | Action::MatchitForward
                 | Action::MatchitBackward
                 | Action::MatchitPreviousUnmatched
@@ -6755,8 +6824,18 @@ impl Editor {
                 | Action::MoveTo(_, _)
                 | Action::MoveToNextWord
                 | Action::MoveToPreviousWord
+                | Action::MoveToNextBigWord
+                | Action::MoveToNextWordEnd
+                | Action::MoveToPreviousWordEnd
+                | Action::MoveToNextBigWordEnd
+                | Action::MoveToPreviousBigWord
+                | Action::MoveToPreviousBigWordEnd
                 | Action::FindCharForward { .. }
                 | Action::TillCharForward { .. }
+                | Action::FindCharBackward { .. }
+                | Action::TillCharBackward { .. }
+                | Action::RepeatCharSearch(_)
+                | Action::RepeatCharSearchOpposite(_)
                 | Action::MoveToFilePercent(_)
                 | Action::MatchitForward
                 | Action::MatchitBackward
@@ -6764,6 +6843,8 @@ impl Editor {
                 | Action::MatchitNextUnmatched
                 | Action::PageDown
                 | Action::PageUp
+                | Action::HalfPageDown(_)
+                | Action::HalfPageUp(_)
                 | Action::GoToLine(_)
         )
     }
@@ -8502,6 +8583,25 @@ impl Editor {
             }];
         }
 
+        let (name, arguments) = cmd.split_once(' ').unwrap_or((cmd, ""));
+        let keep_spaces = name.ends_with('!');
+        let name = name.strip_suffix('!').unwrap_or(name);
+        if matches!(name, "j" | "join") {
+            let count = if arguments.trim().is_empty() {
+                2
+            } else if let Ok(count) = arguments.trim().parse::<u16>() {
+                count.max(2)
+            } else {
+                self.last_error = Some("join count must be a positive integer".to_string());
+                return Vec::new();
+            };
+            return vec![if keep_spaces {
+                Action::JoinLinesKeepSpaces(count)
+            } else {
+                Action::JoinLines(count)
+            }];
+        }
+
         let commands = &[
             "$",
             "quit",
@@ -9363,6 +9463,10 @@ impl Editor {
             return Some(action);
         }
 
+        if let Some(action) = self.handle_replace_event(ev) {
+            return Some(action);
+        }
+
         if let Some(action) = self.handle_visual_text_object_event(ev) {
             return Some(action);
         }
@@ -9528,7 +9632,7 @@ impl Editor {
                 self.repeater = None;
                 return Some(KeyAction::None);
             }
-            if *modifiers != KeyModifiers::NONE {
+            if !matches!(*modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT) {
                 self.last_error = Some("replacement must be a character".to_string());
                 self.repeater = None;
                 return Some(KeyAction::None);
@@ -9538,9 +9642,14 @@ impl Editor {
                 self.repeater = None;
                 return Some(KeyAction::None);
             };
-            return Some(KeyAction::Single(Action::ReplaceCharsAtCursor {
-                character: *character,
-                count: self.repeater.take().unwrap_or(1),
+            return Some(KeyAction::Single(if self.is_visual() {
+                self.repeater = None;
+                Action::ReplaceSelection(*character)
+            } else {
+                Action::ReplaceCharsAtCursor {
+                    character: *character,
+                    count: self.repeater.take().unwrap_or(1),
+                }
             }));
         }
         if *code == KeyCode::Char('r') && *modifiers == KeyModifiers::NONE {
@@ -9757,6 +9866,7 @@ impl Editor {
             if !matches!(*modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT) {
                 return self.pending_character_motion_invalid();
             }
+            self.last_character_motion = Some((pending.kind, *target));
             let action = match pending.kind {
                 ForwardCharacterMotion::Find => Action::FindCharForward {
                     target: *target,
@@ -9766,20 +9876,30 @@ impl Editor {
                     target: *target,
                     count: pending.count,
                 },
+                ForwardCharacterMotion::FindBackward => Action::FindCharBackward {
+                    target: *target,
+                    count: pending.count,
+                },
+                ForwardCharacterMotion::TillBackward => Action::TillCharBackward {
+                    target: *target,
+                    count: pending.count,
+                },
             };
             return Some(KeyAction::Single(action));
         }
 
-        if *modifiers != KeyModifiers::NONE {
+        if !matches!(*modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT) {
             return None;
         }
-        let KeyCode::Char(c @ ('f' | 't')) = code else {
+        let KeyCode::Char(c @ ('f' | 't' | 'F' | 'T')) = code else {
             return None;
         };
-        let kind = if *c == 'f' {
-            ForwardCharacterMotion::Find
-        } else {
-            ForwardCharacterMotion::Till
+        let kind = match *c {
+            'f' => ForwardCharacterMotion::Find,
+            't' => ForwardCharacterMotion::Till,
+            'F' => ForwardCharacterMotion::FindBackward,
+            'T' => ForwardCharacterMotion::TillBackward,
+            _ => return None,
         };
         self.pending_character_motion = Some(PendingCharacterMotion {
             kind,
@@ -9798,7 +9918,10 @@ impl Editor {
     }
 
     fn handle_operator_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
-        let Event::Key(KeyEvent { code, .. }) = ev else {
+        let Event::Key(KeyEvent {
+            code, modifiers, ..
+        }) = ev
+        else {
             return None;
         };
 
@@ -9821,7 +9944,14 @@ impl Editor {
 
         if let Some(pending) = self.pending_operator.take() {
             self.waiting_command = None;
+            if !matches!(*modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT) {
+                return self.pending_operator_invalid();
+            }
             return self.handle_pending_operator(pending, *c);
+        }
+
+        if *modifiers != KeyModifiers::NONE {
+            return None;
         }
 
         let operator = match c {
@@ -9848,7 +9978,7 @@ impl Editor {
                         .saturating_mul(10)
                         .saturating_add(digit);
                     self.waiting_command =
-                        Some(format!("{}{}", pending.operator.as_char(), motion_count));
+                        Some(format!("{}{}", pending.operator.as_str(), motion_count));
                     self.pending_operator = Some(PendingOperator {
                         motion_count: Some(motion_count),
                         ..pending
@@ -9864,10 +9994,76 @@ impl Editor {
                 'y' if pending.operator == EditOperator::Yank => {
                     Some(KeyAction::Single(Action::YankCurrentLines(pending.count())))
                 }
+                'u' if pending.operator == EditOperator::Lowercase => self
+                    .operator_action_for_range(
+                        pending.operator,
+                        Some(self.current_line_range(pending.count(), false)),
+                        "no text under cursor",
+                    ),
+                'U' if pending.operator == EditOperator::Uppercase => self
+                    .operator_action_for_range(
+                        pending.operator,
+                        Some(self.current_line_range(pending.count(), false)),
+                        "no text under cursor",
+                    ),
+                '~' if pending.operator == EditOperator::ToggleCase => self
+                    .operator_action_for_range(
+                        pending.operator,
+                        Some(self.current_line_range(pending.count(), false)),
+                        "no text under cursor",
+                    ),
                 'w' => self.operator_action_for_range(
                     pending.operator,
-                    self.word_motion_range(pending.count()),
+                    self.word_motion_range(
+                        pending.count(),
+                        pending.operator == EditOperator::Change,
+                    ),
                     "no word under cursor",
+                ),
+                'b' => self.operator_action_for_range(
+                    pending.operator,
+                    self.previous_word_motion_range(pending.count(), false),
+                    "no word under cursor",
+                ),
+                'B' => self.operator_action_for_range(
+                    pending.operator,
+                    self.previous_word_motion_range(pending.count(), true),
+                    "no word under cursor",
+                ),
+                'e' => self.operator_action_for_range(
+                    pending.operator,
+                    self.end_word_motion_range(pending.count(), false),
+                    "no word under cursor",
+                ),
+                'E' => self.operator_action_for_range(
+                    pending.operator,
+                    self.end_word_motion_range(pending.count(), true),
+                    "no word under cursor",
+                ),
+                '$' => self.operator_action_for_range(
+                    pending.operator,
+                    Some(self.line_end_motion_range(pending.count())),
+                    "no text under cursor",
+                ),
+                '0' => self.operator_action_for_range(
+                    pending.operator,
+                    self.line_start_motion_range(false),
+                    "no text under cursor",
+                ),
+                '^' => self.operator_action_for_range(
+                    pending.operator,
+                    self.line_start_motion_range(true),
+                    "no text under cursor",
+                ),
+                'j' => self.operator_action_for_linewise_range(
+                    pending.operator,
+                    self.vertical_motion_range(pending.count(), false),
+                    "no line below cursor",
+                ),
+                'k' => self.operator_action_for_linewise_range(
+                    pending.operator,
+                    self.vertical_motion_range(pending.count(), true),
+                    "no line above cursor",
                 ),
                 '%' => self.operator_action_for_range(
                     pending.operator,
@@ -9875,7 +10071,7 @@ impl Editor {
                     "match not found",
                 ),
                 'f' => {
-                    self.waiting_command = Some(format!("{}f", pending.operator.as_char()));
+                    self.waiting_command = Some(format!("{}f", pending.operator.as_str()));
                     self.pending_operator = Some(PendingOperator {
                         step: PendingOperatorStep::FindForward,
                         ..pending
@@ -9883,15 +10079,31 @@ impl Editor {
                     Some(KeyAction::None)
                 }
                 't' => {
-                    self.waiting_command = Some(format!("{}t", pending.operator.as_char()));
+                    self.waiting_command = Some(format!("{}t", pending.operator.as_str()));
                     self.pending_operator = Some(PendingOperator {
                         step: PendingOperatorStep::TillForward,
                         ..pending
                     });
                     Some(KeyAction::None)
                 }
+                'F' => {
+                    self.waiting_command = Some(format!("{}F", pending.operator.as_str()));
+                    self.pending_operator = Some(PendingOperator {
+                        step: PendingOperatorStep::FindBackward,
+                        ..pending
+                    });
+                    Some(KeyAction::None)
+                }
+                'T' => {
+                    self.waiting_command = Some(format!("{}T", pending.operator.as_str()));
+                    self.pending_operator = Some(PendingOperator {
+                        step: PendingOperatorStep::TillBackward,
+                        ..pending
+                    });
+                    Some(KeyAction::None)
+                }
                 'i' => {
-                    self.waiting_command = Some(format!("{}i", pending.operator.as_char()));
+                    self.waiting_command = Some(format!("{}i", pending.operator.as_str()));
                     self.pending_operator = Some(PendingOperator {
                         step: PendingOperatorStep::TextObjectScope(TextObjectScope::Inner),
                         ..pending
@@ -9899,7 +10111,7 @@ impl Editor {
                     Some(KeyAction::None)
                 }
                 'a' => {
-                    self.waiting_command = Some(format!("{}a", pending.operator.as_char()));
+                    self.waiting_command = Some(format!("{}a", pending.operator.as_str()));
                     self.pending_operator = Some(PendingOperator {
                         step: PendingOperatorStep::TextObjectScope(TextObjectScope::Around),
                         ..pending
@@ -9908,16 +10120,38 @@ impl Editor {
                 }
                 _ => self.pending_operator_invalid(),
             },
-            PendingOperatorStep::FindForward => self.operator_action_for_range(
-                pending.operator,
-                self.find_forward_motion_range(c, pending.count()),
-                "character not found",
-            ),
-            PendingOperatorStep::TillForward => self.operator_action_for_range(
-                pending.operator,
-                self.till_forward_motion_range(c, pending.count()),
-                "character not found",
-            ),
+            PendingOperatorStep::FindForward => {
+                self.last_character_motion = Some((ForwardCharacterMotion::Find, c));
+                self.operator_action_for_range(
+                    pending.operator,
+                    self.find_forward_motion_range(c, pending.count()),
+                    "character not found",
+                )
+            }
+            PendingOperatorStep::TillForward => {
+                self.last_character_motion = Some((ForwardCharacterMotion::Till, c));
+                self.operator_action_for_range(
+                    pending.operator,
+                    self.till_forward_motion_range(c, pending.count()),
+                    "character not found",
+                )
+            }
+            PendingOperatorStep::FindBackward => {
+                self.last_character_motion = Some((ForwardCharacterMotion::FindBackward, c));
+                self.operator_action_for_range(
+                    pending.operator,
+                    self.find_backward_motion_range(c, pending.count()),
+                    "character not found",
+                )
+            }
+            PendingOperatorStep::TillBackward => {
+                self.last_character_motion = Some((ForwardCharacterMotion::TillBackward, c));
+                self.operator_action_for_range(
+                    pending.operator,
+                    self.till_backward_motion_range(c, pending.count()),
+                    "character not found",
+                )
+            }
             PendingOperatorStep::TextObjectScope(scope) => {
                 let Some(kind) = text_object_kind_for_key(c) else {
                     return self.pending_operator_invalid();
@@ -9956,6 +10190,52 @@ impl Editor {
             EditOperator::Delete => Action::DeleteTextRange(range),
             EditOperator::Change => Action::ChangeTextRange(range),
             EditOperator::Yank => Action::YankTextRange(range),
+            EditOperator::Lowercase => Action::TransformTextRange {
+                range,
+                transform: CaseTransform::Lower,
+            },
+            EditOperator::Uppercase => Action::TransformTextRange {
+                range,
+                transform: CaseTransform::Upper,
+            },
+            EditOperator::ToggleCase => Action::TransformTextRange {
+                range,
+                transform: CaseTransform::Toggle,
+            },
+        };
+        self.repeater = None;
+        Some(KeyAction::Single(action))
+    }
+
+    fn operator_action_for_linewise_range(
+        &mut self,
+        operator: EditOperator,
+        range: Option<TextRange>,
+        error: &str,
+    ) -> Option<KeyAction> {
+        self.pending_operator = None;
+        self.waiting_command = None;
+        let Some(range) = range else {
+            self.last_error = Some(error.to_string());
+            return Some(KeyAction::None);
+        };
+
+        let action = match operator {
+            EditOperator::Delete => Action::DeleteLinewiseRange(range),
+            EditOperator::Change => Action::ChangeLinewiseRange(range),
+            EditOperator::Yank => Action::YankLinewiseRange(range),
+            EditOperator::Lowercase => Action::TransformTextRange {
+                range,
+                transform: CaseTransform::Lower,
+            },
+            EditOperator::Uppercase => Action::TransformTextRange {
+                range,
+                transform: CaseTransform::Upper,
+            },
+            EditOperator::ToggleCase => Action::TransformTextRange {
+                range,
+                transform: CaseTransform::Toggle,
+            },
         };
         self.repeater = None;
         Some(KeyAction::Single(action))
@@ -10016,7 +10296,7 @@ impl Editor {
         characters[start..end].iter().collect()
     }
 
-    fn word_motion_range(&self, count: u16) -> Option<TextRange> {
+    fn word_motion_range(&self, count: u16, change_word: bool) -> Option<TextRange> {
         let start = self.cursor_text_position();
         let buffer = self.current_buffer();
         let characters = buffer.contents().chars().collect::<Vec<_>>();
@@ -10030,7 +10310,11 @@ impl Editor {
                 2
             }
         };
-        for _ in 0..count {
+        let preserve_trailing_whitespace = change_word
+            && characters
+                .get(end)
+                .is_some_and(|character| !character.is_whitespace());
+        for index in 0..count {
             let Some(&character) = characters.get(end) else {
                 break;
             };
@@ -10041,12 +10325,184 @@ impl Editor {
             {
                 end += 1;
             }
-            while characters.get(end).is_some_and(|next| next.is_whitespace()) {
-                end += 1;
+            if !preserve_trailing_whitespace || index + 1 < count {
+                while characters.get(end).is_some_and(|next| next.is_whitespace()) {
+                    end += 1;
+                }
             }
         }
         let end = buffer.char_idx_to_position(end);
         (start != end).then(|| TextRange::new(start, end))
+    }
+
+    fn word_motion_target(
+        &self,
+        count: u16,
+        backward: bool,
+        end: bool,
+        big_word: bool,
+    ) -> Option<TextPosition> {
+        let contents = self.current_buffer().contents();
+        let characters = contents.chars().collect::<Vec<_>>();
+        if characters.is_empty() {
+            return None;
+        }
+
+        let word_kind = |character: char| {
+            if character.is_whitespace() {
+                0
+            } else if big_word || character.is_alphanumeric() || character == '_' {
+                1
+            } else {
+                2
+            }
+        };
+        let mut cursor = self
+            .current_buffer()
+            .position_to_char_idx(self.cursor_text_position())
+            .min(characters.len().saturating_sub(1));
+        let mut target = None;
+
+        for _ in 0..count {
+            if backward {
+                if end && !characters[cursor].is_whitespace() {
+                    let kind = word_kind(characters[cursor]);
+                    while cursor > 0 && word_kind(characters[cursor - 1]) == kind {
+                        cursor -= 1;
+                    }
+                }
+                if cursor == 0 {
+                    break;
+                }
+                cursor -= 1;
+                while cursor > 0 && characters[cursor].is_whitespace() {
+                    cursor -= 1;
+                }
+                if characters[cursor].is_whitespace() {
+                    break;
+                }
+                let found_end = cursor;
+                let kind = word_kind(characters[cursor]);
+                while cursor > 0 && word_kind(characters[cursor - 1]) == kind {
+                    cursor -= 1;
+                }
+                target = Some(if end { found_end } else { cursor });
+            } else {
+                if characters[cursor].is_whitespace() {
+                    while cursor < characters.len() && characters[cursor].is_whitespace() {
+                        cursor += 1;
+                    }
+                } else {
+                    let kind = word_kind(characters[cursor]);
+                    let mut group_end = cursor;
+                    while group_end + 1 < characters.len()
+                        && word_kind(characters[group_end + 1]) == kind
+                    {
+                        group_end += 1;
+                    }
+                    if end && cursor < group_end {
+                        cursor = group_end;
+                        target = Some(cursor);
+                        continue;
+                    }
+                    cursor = group_end.saturating_add(1);
+                    while cursor < characters.len() && characters[cursor].is_whitespace() {
+                        cursor += 1;
+                    }
+                }
+
+                if cursor >= characters.len() {
+                    break;
+                }
+                if end {
+                    let kind = word_kind(characters[cursor]);
+                    while cursor + 1 < characters.len() && word_kind(characters[cursor + 1]) == kind
+                    {
+                        cursor += 1;
+                    }
+                }
+                target = Some(cursor);
+            }
+        }
+
+        target.map(|index| self.current_buffer().char_idx_to_position(index))
+    }
+
+    fn previous_word_motion_range(&self, count: u16, big_word: bool) -> Option<TextRange> {
+        let start = self.word_motion_target(count, true, false, big_word)?;
+        let end = self.cursor_text_position();
+        (start != end).then(|| TextRange::new(start, end))
+    }
+
+    fn end_word_motion_range(&self, count: u16, big_word: bool) -> Option<TextRange> {
+        let start = self.cursor_text_position();
+        let target = self.word_motion_target(count, false, true, big_word)?;
+        let end_index = self
+            .current_buffer()
+            .position_to_char_idx(target)
+            .saturating_add(1);
+        let end = self.current_buffer().char_idx_to_position(end_index);
+        (start != end).then(|| TextRange::new(start, end))
+    }
+
+    fn line_character_len(&self, line: usize) -> usize {
+        self.current_buffer()
+            .get(line)
+            .map(|contents| trim_line_ending(&contents).chars().count())
+            .unwrap_or(0)
+    }
+
+    fn line_end_motion_range(&self, count: u16) -> TextRange {
+        let start = self.cursor_text_position();
+        let end_line = start
+            .line
+            .saturating_add(usize::from(count.saturating_sub(1)))
+            .min(self.last_navigable_line());
+        TextRange::new(
+            start,
+            TextPosition::new(end_line, self.line_character_len(end_line)),
+        )
+    }
+
+    fn line_start_motion_range(&self, first_non_blank: bool) -> Option<TextRange> {
+        let end = self.cursor_text_position();
+        let start_character = if first_non_blank {
+            self.current_buffer()
+                .get(end.line)
+                .map(|line| {
+                    trim_line_ending(&line)
+                        .chars()
+                        .take_while(|character| character.is_whitespace())
+                        .count()
+                })
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        let start = TextPosition::new(end.line, start_character);
+        (start != end).then(|| TextRange::new(start, end))
+    }
+
+    fn vertical_motion_range(&self, count: u16, backward: bool) -> Option<TextRange> {
+        let current = self.buffer_line();
+        let target = if backward {
+            current.checked_sub(usize::from(count))?
+        } else {
+            current
+                .saturating_add(usize::from(count))
+                .min(self.last_navigable_line())
+        };
+        if target == current {
+            return None;
+        }
+        let start_line = current.min(target);
+        let last_line = current.max(target);
+        let end = if last_line < self.current_buffer().len() {
+            TextPosition::new(last_line + 1, 0)
+        } else {
+            TextPosition::new(last_line, self.line_character_len(last_line))
+        };
+        Some(TextRange::new(TextPosition::new(start_line, 0), end))
     }
 
     fn forward_character_match(&self, target: char, count: u16) -> Option<TextPosition> {
@@ -10062,6 +10518,20 @@ impl Editor {
         Some(TextPosition::new(start.line, search_start + target_offset))
     }
 
+    fn backward_character_match(&self, target: char, count: u16) -> Option<TextPosition> {
+        let start = self.cursor_text_position();
+        let line = self.current_buffer().get(start.line)?;
+        let line = trim_line_ending(&line);
+        let prefix = char_prefix(line, start.character);
+        let target_byte = prefix
+            .match_indices(target)
+            .rev()
+            .nth(usize::from(count.saturating_sub(1)))?
+            .0;
+        let target_index = prefix[..target_byte].chars().count();
+        Some(TextPosition::new(start.line, target_index))
+    }
+
     fn find_forward_motion_range(&self, target: char, count: u16) -> Option<TextRange> {
         let start = self.cursor_text_position();
         let target = self.forward_character_match(target, count)?;
@@ -10072,6 +10542,19 @@ impl Editor {
     fn till_forward_motion_range(&self, target: char, count: u16) -> Option<TextRange> {
         let start = self.cursor_text_position();
         let end = self.forward_character_match(target, count)?;
+        Some(TextRange::new(start, end))
+    }
+
+    fn find_backward_motion_range(&self, target: char, count: u16) -> Option<TextRange> {
+        let end = self.cursor_text_position();
+        let start = self.backward_character_match(target, count)?;
+        Some(TextRange::new(start, end))
+    }
+
+    fn till_backward_motion_range(&self, target: char, count: u16) -> Option<TextRange> {
+        let end = self.cursor_text_position();
+        let target = self.backward_character_match(target, count)?;
+        let start = TextPosition::new(target.line, target.character.saturating_add(1));
         Some(TextRange::new(start, end))
     }
 
@@ -10088,6 +10571,7 @@ impl Editor {
                 target.line,
                 target.character.saturating_sub(1),
             )),
+            ForwardCharacterMotion::FindBackward | ForwardCharacterMotion::TillBackward => None,
         }
     }
 
@@ -10540,6 +11024,42 @@ impl Editor {
                     buffer,
                 )?;
             }
+            Action::FindCharBackward { target, count } => {
+                self.move_to_forward_character(
+                    *target,
+                    *count,
+                    ForwardCharacterMotion::FindBackward,
+                    buffer,
+                )?;
+            }
+            Action::TillCharBackward { target, count } => {
+                self.move_to_forward_character(
+                    *target,
+                    *count,
+                    ForwardCharacterMotion::TillBackward,
+                    buffer,
+                )?;
+            }
+            Action::RepeatCharSearch(count) => {
+                let Some((kind, target)) = self.last_character_motion else {
+                    self.last_error = Some("no previous character search".to_string());
+                    return Ok(false);
+                };
+                self.move_to_forward_character(target, *count, kind, buffer)?;
+            }
+            Action::RepeatCharSearchOpposite(count) => {
+                let Some((kind, target)) = self.last_character_motion else {
+                    self.last_error = Some("no previous character search".to_string());
+                    return Ok(false);
+                };
+                let kind = match kind {
+                    ForwardCharacterMotion::Find => ForwardCharacterMotion::FindBackward,
+                    ForwardCharacterMotion::Till => ForwardCharacterMotion::TillBackward,
+                    ForwardCharacterMotion::FindBackward => ForwardCharacterMotion::Find,
+                    ForwardCharacterMotion::TillBackward => ForwardCharacterMotion::Till,
+                };
+                self.move_to_forward_character(target, *count, kind, buffer)?;
+            }
             Action::MoveToLineStart => {
                 self.cx = 0;
             }
@@ -10601,6 +11121,36 @@ impl Editor {
                 let target_line =
                     (self.buffer_line() + self.vheight()).min(self.last_navigable_line());
                 self.vtop = target_line.saturating_sub(self.vheight().saturating_sub(1));
+                self.cy = target_line.saturating_sub(self.vtop);
+                self.apply_cursor_goal_to_current_line();
+                self.render(buffer)?;
+            }
+            Action::HalfPageUp(count) => {
+                let distance = if *count == 0 {
+                    self.vheight().max(1) / 2
+                } else {
+                    usize::from(*count)
+                };
+                let target_line = self.buffer_line().saturating_sub(distance);
+                self.vtop = self.vtop.saturating_sub(distance);
+                self.cy = target_line.saturating_sub(self.vtop);
+                self.apply_cursor_goal_to_current_line();
+                self.render(buffer)?;
+            }
+            Action::HalfPageDown(count) => {
+                let distance = if *count == 0 {
+                    self.vheight().max(1) / 2
+                } else {
+                    usize::from(*count)
+                };
+                let target_line = self
+                    .buffer_line()
+                    .saturating_add(distance)
+                    .min(self.last_navigable_line());
+                let max_vtop = self
+                    .last_navigable_line()
+                    .saturating_sub(self.vheight().saturating_sub(1));
+                self.vtop = self.vtop.saturating_add(distance).min(max_vtop);
                 self.cy = target_line.saturating_sub(self.vtop);
                 self.apply_cursor_goal_to_current_line();
                 self.render(buffer)?;
@@ -10749,15 +11299,60 @@ impl Editor {
                 self.render(buffer)?;
             }
             Action::ChangeTextRange(range) => {
+                let start = range.start;
                 if self.begin_change_range(*range, "change text object", false) {
                     self.notify_change(runtime).await?;
                 }
-                self.render(buffer)?;
                 self.execute(&Action::EnterMode(Mode::Insert), buffer, runtime)
                     .await?;
+                self.move_to_insert_text_position(start);
+                self.render(buffer)?;
             }
             Action::YankTextRange(range) => {
                 if self.yank_text_range(*range) {
+                    self.draw_commandline(buffer);
+                }
+            }
+            Action::DeleteLinewiseRange(range) => {
+                if self.delete_linewise_range(*range, "delete lines") {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::ChangeLinewiseRange(range) => {
+                let line = range.start.line;
+                let range = if range.end.character == 0 && range.end.line > line {
+                    let last_line = range.end.line - 1;
+                    TextRange::new(
+                        range.start,
+                        TextPosition::new(last_line, self.line_character_len(last_line)),
+                    )
+                } else {
+                    *range
+                };
+                let indentation = self
+                    .current_buffer()
+                    .get(line)
+                    .map(|contents| Self::leading_indentation(&contents))
+                    .unwrap_or(0);
+                if self.begin_change_range(range, "change lines", true) {
+                    if indentation > 0 {
+                        self.replace_range(
+                            TextRange::insertion(TextPosition::new(line, 0)),
+                            &" ".repeat(indentation),
+                        );
+                    }
+                    self.notify_change(runtime).await?;
+                }
+                self.execute(&Action::EnterMode(Mode::Insert), buffer, runtime)
+                    .await?;
+                self.move_to_insert_text_position(TextPosition::new(line, indentation));
+                self.render(buffer)?;
+            }
+            Action::YankLinewiseRange(range) => {
+                let text = self.current_buffer().text_in_range(*range);
+                if !text.is_empty() {
+                    self.set_default_register(Content::linewise(text));
                     self.draw_commandline(buffer);
                 }
             }
@@ -10776,12 +11371,132 @@ impl Editor {
             }
             Action::ChangeCurrentLines(count) => {
                 let range = self.current_line_range(*count, false);
+                let indentation = self.current_line_indentation();
+                let line = range.start.line;
                 if self.begin_change_range(range, "change lines", true) {
+                    if indentation > 0 {
+                        self.replace_range(
+                            TextRange::insertion(TextPosition::new(line, 0)),
+                            &" ".repeat(indentation),
+                        );
+                        self.move_to_insert_text_position(TextPosition::new(line, indentation));
+                    }
+                    self.notify_change(runtime).await?;
+                }
+                self.execute(&Action::EnterMode(Mode::Insert), buffer, runtime)
+                    .await?;
+                self.move_to_insert_text_position(TextPosition::new(line, indentation));
+                self.render(buffer)?;
+            }
+            Action::DeleteToLineEnd(count) => {
+                let range = self.line_end_motion_range(*count);
+                if self.delete_text_range(range, "delete to line end") {
                     self.notify_change(runtime).await?;
                 }
                 self.render(buffer)?;
+            }
+            Action::ChangeToLineEnd(count) => {
+                let range = self.line_end_motion_range(*count);
+                let start = range.start;
+                if self.begin_change_range(range, "change to line end", false) {
+                    self.notify_change(runtime).await?;
+                }
                 self.execute(&Action::EnterMode(Mode::Insert), buffer, runtime)
                     .await?;
+                self.move_to_insert_text_position(start);
+                self.render(buffer)?;
+            }
+            Action::YankToLineEnd(count) => {
+                let range = self.line_end_motion_range(*count);
+                if self.yank_text_range(range) {
+                    self.draw_commandline(buffer);
+                }
+            }
+            Action::DeletePreviousChars(count) => {
+                let line = self.buffer_line();
+                let start_x = self.cx.saturating_sub(usize::from(*count));
+                let range = TextRange::new(
+                    TextPosition::new(line, self.grapheme_to_char_on_line(start_x, line)),
+                    self.cursor_text_position(),
+                );
+                if self.delete_text_range(range, "delete previous chars") {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::ChangeCharsAtCursor(count) => {
+                let line = self.buffer_line();
+                let end_x = self
+                    .cx
+                    .saturating_add(usize::from(*count))
+                    .min(self.length_for_line(line));
+                let range = TextRange::new(
+                    self.cursor_text_position(),
+                    TextPosition::new(line, self.grapheme_to_char_on_line(end_x, line)),
+                );
+                let start = range.start;
+                if self.begin_change_range(range, "substitute chars", false) {
+                    self.notify_change(runtime).await?;
+                }
+                self.execute(&Action::EnterMode(Mode::Insert), buffer, runtime)
+                    .await?;
+                self.move_to_insert_text_position(start);
+                self.render(buffer)?;
+            }
+            Action::JoinLines(count) | Action::JoinLinesKeepSpaces(count) => {
+                let keep_spaces = matches!(action, Action::JoinLinesKeepSpaces(_));
+                if self.join_lines(*count, keep_spaces) {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::ToggleCharCase(count) => {
+                let line = self.buffer_line();
+                let end_x = self
+                    .cx
+                    .saturating_add(usize::from(*count))
+                    .min(self.length_for_line(line));
+                let range = TextRange::new(
+                    self.cursor_text_position(),
+                    TextPosition::new(line, self.grapheme_to_char_on_line(end_x, line)),
+                );
+                if self.transform_text_range(range, CaseTransform::Toggle, "toggle case") {
+                    self.cx = end_x.min(self.last_cell_for_line(line));
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::StartLowercaseOperator(count)
+            | Action::StartUppercaseOperator(count)
+            | Action::StartToggleCaseOperator(count) => {
+                let operator = match action {
+                    Action::StartLowercaseOperator(_) => EditOperator::Lowercase,
+                    Action::StartUppercaseOperator(_) => EditOperator::Uppercase,
+                    Action::StartToggleCaseOperator(_) => EditOperator::ToggleCase,
+                    _ => unreachable!(),
+                };
+                self.pending_operator = Some(PendingOperator::new(operator, *count));
+                self.waiting_command = Some(operator.as_str().to_string());
+            }
+            Action::TransformTextRange { range, transform } => {
+                if self.transform_text_range(*range, *transform, "change case") {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::TransformSelection(transform) => {
+                if self.transform_selection(*transform, None) {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::ReplaceSelection(character) => {
+                if self.transform_selection(CaseTransform::Toggle, Some(*character)) {
+                    self.notify_change(runtime).await?;
+                }
+                self.execute(&Action::EnterMode(Mode::Normal), buffer, runtime)
+                    .await?;
+                self.render(buffer)?;
             }
             Action::DeleteCharAtCursorPos => {
                 let cx = self.cx;
@@ -10809,11 +11524,11 @@ impl Editor {
                         ),
                         "",
                     );
+                    self.set_default_register(Content::charwise(deleted));
                     self.notify_change(runtime).await?;
                     if started_transaction {
                         self.commit_transaction(self.cursor_snapshot());
                     }
-                    let _ = deleted;
                     self.draw_line(buffer);
                 }
             }
@@ -12004,6 +12719,26 @@ impl Editor {
                         self.go_to_line(y + 1, buffer, runtime, GoToLinePosition::Top)
                             .await?;
                     }
+                    self.finish_cursor_motion(buffer, false)?;
+                }
+            }
+            Action::MoveToNextBigWord
+            | Action::MoveToNextWordEnd
+            | Action::MoveToPreviousWordEnd
+            | Action::MoveToNextBigWordEnd
+            | Action::MoveToPreviousBigWord
+            | Action::MoveToPreviousBigWordEnd => {
+                let (backward, end, big_word) = match action {
+                    Action::MoveToNextBigWord => (false, false, true),
+                    Action::MoveToNextWordEnd => (false, true, false),
+                    Action::MoveToPreviousWordEnd => (true, true, false),
+                    Action::MoveToNextBigWordEnd => (false, true, true),
+                    Action::MoveToPreviousBigWord => (true, false, true),
+                    Action::MoveToPreviousBigWordEnd => (true, true, true),
+                    _ => unreachable!(),
+                };
+                if let Some(target) = self.word_motion_target(1, backward, end, big_word) {
+                    self.move_to_text_position(target);
                     self.finish_cursor_motion(buffer, false)?;
                 }
             }
@@ -14563,9 +15298,65 @@ impl Editor {
             _ => None,
         };
 
-        if let Some(ref ka) = key_action {
-            if let Some(ref repeater) = self.repeater {
-                return Some(KeyAction::Repeating(*repeater, Box::new(ka.clone())));
+        if let Some(ref action) = key_action {
+            if let Some(count) = self.repeater {
+                if matches!(action, KeyAction::Nested(_)) {
+                    return key_action;
+                }
+
+                let counted = match action {
+                    KeyAction::Single(Action::JoinLines(minimum)) => {
+                        KeyAction::Single(Action::JoinLines(count.max(*minimum)))
+                    }
+                    KeyAction::Single(Action::JoinLinesKeepSpaces(minimum)) => {
+                        KeyAction::Single(Action::JoinLinesKeepSpaces(count.max(*minimum)))
+                    }
+                    KeyAction::Single(Action::DeleteToLineEnd(_)) => {
+                        KeyAction::Single(Action::DeleteToLineEnd(count))
+                    }
+                    KeyAction::Single(Action::ChangeToLineEnd(_)) => {
+                        KeyAction::Single(Action::ChangeToLineEnd(count))
+                    }
+                    KeyAction::Single(Action::YankToLineEnd(_)) => {
+                        KeyAction::Single(Action::YankToLineEnd(count))
+                    }
+                    KeyAction::Single(Action::ChangeCurrentLines(_)) => {
+                        KeyAction::Single(Action::ChangeCurrentLines(count))
+                    }
+                    KeyAction::Single(Action::DeletePreviousChars(_)) => {
+                        KeyAction::Single(Action::DeletePreviousChars(count))
+                    }
+                    KeyAction::Single(Action::ChangeCharsAtCursor(_)) => {
+                        KeyAction::Single(Action::ChangeCharsAtCursor(count))
+                    }
+                    KeyAction::Single(Action::ToggleCharCase(_)) => {
+                        KeyAction::Single(Action::ToggleCharCase(count))
+                    }
+                    KeyAction::Single(Action::RepeatCharSearch(_)) => {
+                        KeyAction::Single(Action::RepeatCharSearch(count))
+                    }
+                    KeyAction::Single(Action::RepeatCharSearchOpposite(_)) => {
+                        KeyAction::Single(Action::RepeatCharSearchOpposite(count))
+                    }
+                    KeyAction::Single(Action::HalfPageDown(_)) => {
+                        KeyAction::Single(Action::HalfPageDown(count))
+                    }
+                    KeyAction::Single(Action::HalfPageUp(_)) => {
+                        KeyAction::Single(Action::HalfPageUp(count))
+                    }
+                    KeyAction::Single(Action::StartLowercaseOperator(_)) => {
+                        KeyAction::Single(Action::StartLowercaseOperator(count))
+                    }
+                    KeyAction::Single(Action::StartUppercaseOperator(_)) => {
+                        KeyAction::Single(Action::StartUppercaseOperator(count))
+                    }
+                    KeyAction::Single(Action::StartToggleCaseOperator(_)) => {
+                        KeyAction::Single(Action::StartToggleCaseOperator(count))
+                    }
+                    _ => KeyAction::Repeating(count, Box::new(action.clone())),
+                };
+                self.repeater = None;
+                return Some(counted);
             }
         }
 
@@ -14816,6 +15607,171 @@ impl Editor {
         true
     }
 
+    fn transformed_text(text: &str, transform: CaseTransform) -> String {
+        let mut transformed = String::with_capacity(text.len());
+        for character in text.chars() {
+            match transform {
+                CaseTransform::Lower => transformed.extend(character.to_lowercase()),
+                CaseTransform::Upper => transformed.extend(character.to_uppercase()),
+                CaseTransform::Toggle if character.is_lowercase() => {
+                    transformed.extend(character.to_uppercase());
+                }
+                CaseTransform::Toggle if character.is_uppercase() => {
+                    transformed.extend(character.to_lowercase());
+                }
+                CaseTransform::Toggle => transformed.push(character),
+            }
+        }
+        transformed
+    }
+
+    fn transform_text_range(
+        &mut self,
+        range: TextRange,
+        transform: CaseTransform,
+        label: &str,
+    ) -> bool {
+        let text = self.current_buffer().text_in_range(range);
+        let replacement = Self::transformed_text(&text, transform);
+        if text == replacement {
+            return false;
+        }
+
+        self.begin_transaction(label);
+        self.replace_range(range, &replacement);
+        self.move_to_text_position(range.start);
+        self.commit_transaction(self.cursor_snapshot());
+        true
+    }
+
+    fn transform_selection(&mut self, transform: CaseTransform, replacement: Option<char>) -> bool {
+        let Some(selection) = self.selection else {
+            return false;
+        };
+        let (x0, y0, x1, y1) = selection.into();
+        let ranges = match self.mode {
+            Mode::VisualLine => (y0..=y1)
+                .map(|line| {
+                    TextRange::new(
+                        TextPosition::new(line, 0),
+                        TextPosition::new(line, self.line_character_len(line)),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            Mode::VisualBlock => (y0..=y1)
+                .map(|line| {
+                    let line_len = self.length_for_line(line);
+                    let start = x0.min(x1).min(line_len);
+                    let end = x0.max(x1).saturating_add(1).min(line_len);
+                    TextRange::new(
+                        TextPosition::new(line, self.grapheme_to_char_on_line(start, line)),
+                        TextPosition::new(line, self.grapheme_to_char_on_line(end, line)),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            Mode::Visual => {
+                if replacement.is_some() {
+                    (y0..=y1)
+                        .map(|line| {
+                            let start = if line == y0 { x0 } else { 0 };
+                            let end = if line == y1 {
+                                x1.saturating_add(1)
+                            } else {
+                                self.length_for_line(line)
+                            };
+                            TextRange::new(
+                                TextPosition::new(line, self.grapheme_to_char_on_line(start, line)),
+                                TextPosition::new(line, self.grapheme_to_char_on_line(end, line)),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    let start = TextPosition::new(y0, self.grapheme_to_char_on_line(x0, y0));
+                    let end = TextPosition::new(y1, self.grapheme_to_char_on_line(x1 + 1, y1));
+                    vec![TextRange::new(start, end)]
+                }
+            }
+            Mode::Normal | Mode::Insert | Mode::Command | Mode::Search => return false,
+        };
+
+        let edits = ranges
+            .into_iter()
+            .filter_map(|range| {
+                let text = self.current_buffer().text_in_range(range);
+                let replacement = if let Some(character) = replacement {
+                    character.to_string().repeat(grapheme_len(&text))
+                } else {
+                    Self::transformed_text(&text, transform)
+                };
+                (text != replacement).then_some((range, replacement))
+            })
+            .collect::<Vec<_>>();
+        if edits.is_empty() {
+            return false;
+        }
+
+        self.begin_transaction("change selection");
+        for (range, replacement) in edits.into_iter().rev() {
+            self.replace_range(range, &replacement);
+        }
+        self.move_to_text_position(TextPosition::new(y0, self.grapheme_to_char_on_line(x0, y0)));
+        self.commit_transaction(self.cursor_snapshot());
+        true
+    }
+
+    fn join_lines(&mut self, count: u16, keep_spaces: bool) -> bool {
+        let (start_line, requested_last_line) = if self.is_visual() {
+            let Some(selection) = self.selection else {
+                return false;
+            };
+            let (_, y0, _, y1) = selection.into();
+            (y0, y1.max(y0.saturating_add(1)))
+        } else {
+            let start = self.buffer_line();
+            (
+                start,
+                start.saturating_add(usize::from(count.max(2).saturating_sub(1))),
+            )
+        };
+        let last_line = requested_last_line.min(self.last_navigable_line());
+        if last_line <= start_line {
+            return false;
+        }
+
+        let mut lines = (start_line..=last_line)
+            .filter_map(|line| self.current_buffer().get(line))
+            .map(|line| trim_line_ending(&line).to_string());
+        let Some(mut joined) = lines.next() else {
+            return false;
+        };
+        let mut cursor_character = joined.chars().count();
+        for line in lines {
+            cursor_character = joined.chars().count();
+            if keep_spaces {
+                joined.push_str(&line);
+                continue;
+            }
+
+            let line = line.trim_start_matches(char::is_whitespace);
+            if !joined.chars().last().is_some_and(char::is_whitespace) && !line.starts_with(')') {
+                joined.push(' ');
+            }
+            joined.push_str(line);
+        }
+
+        let range = TextRange::new(
+            TextPosition::new(start_line, 0),
+            TextPosition::new(last_line, self.line_character_len(last_line)),
+        );
+        self.begin_transaction("join lines");
+        self.replace_range(range, &joined);
+        self.move_to_text_position(TextPosition::new(start_line, cursor_character));
+        self.selection = None;
+        self.selection_start = None;
+        self.commit_transaction(self.cursor_snapshot());
+        true
+    }
+
     fn current_line_range(&self, count: u16, include_line_ending: bool) -> TextRange {
         let line = self.buffer_line();
         let last_line = line
@@ -14894,7 +15850,16 @@ impl Editor {
         kind: ForwardCharacterMotion,
         buffer: &mut RenderBuffer,
     ) -> anyhow::Result<()> {
-        if let Some(position) = self.forward_character_target(target, count, kind) {
+        let position = match kind {
+            ForwardCharacterMotion::Find | ForwardCharacterMotion::Till => {
+                self.forward_character_target(target, count, kind)
+            }
+            ForwardCharacterMotion::FindBackward => self.backward_character_match(target, count),
+            ForwardCharacterMotion::TillBackward => self
+                .backward_character_match(target, count)
+                .map(|target| TextPosition::new(target.line, target.character.saturating_add(1))),
+        };
+        if let Some(position) = position {
             self.move_to_text_position(position);
             self.finish_cursor_motion(buffer, false)?;
         } else {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1074,10 +1074,18 @@ fn validate_windows_session_handle(
     allow_reparse: bool,
     description: &(impl std::fmt::Display + ?Sized),
 ) -> io::Result<()> {
+    use std::os::windows::fs::MetadataExt as _;
+
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
+
     let metadata = file.metadata()?;
-    if !allow_reparse && portable_session_reparse_point(&metadata)
-        || is_directory.is_some_and(|expected| metadata.file_type().is_dir() != expected)
-        || is_directory == Some(false) && !metadata.file_type().is_file()
+    let reparse = portable_session_reparse_point(&metadata);
+    let directory = metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0;
+    if !allow_reparse && reparse
+        || is_directory.is_some_and(|expected| directory != expected)
+        || is_directory == Some(false)
+            && !metadata.file_type().is_file()
+            && !(allow_reparse && reparse)
     {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/src/session.rs
+++ b/src/session.rs
@@ -1224,13 +1224,11 @@ unsafe fn windows_sid_string(sid: windows_sys::Win32::Security::PSID) -> io::Res
 fn set_windows_session_dacl(file: &File, sddl: &str) -> io::Result<()> {
     use std::os::windows::io::AsRawHandle as _;
 
+    use windows_sys::Wdk::Storage::FileSystem::NtSetSecurityObject;
     use windows_sys::Win32::{
-        Foundation::LocalFree,
+        Foundation::{LocalFree, RtlNtStatusToDosError, STATUS_SUCCESS},
         Security::{
-            Authorization::{
-                ConvertStringSecurityDescriptorToSecurityDescriptorW, SetSecurityInfo,
-                SE_FILE_OBJECT,
-            },
+            Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW,
             GetSecurityDescriptorDacl, DACL_SECURITY_INFORMATION,
             PROTECTED_DACL_SECURITY_INFORMATION,
         },
@@ -1270,23 +1268,23 @@ fn set_windows_session_dacl(file: &File, sddl: &str) -> io::Result<()> {
             "session snapshot user-only security descriptor has no DACL",
         ))
     } else {
-        // SAFETY: the target is the retained session handle and `dacl` remains valid
-        // until `descriptor` is released below.
+        // SAFETY: the target is the retained session handle with `WRITE_DAC`, and the
+        // self-relative descriptor remains valid until it is released below. Unlike
+        // `SetSecurityInfo`, this updates only the pinned object and does not attempt
+        // to propagate inheritable ACEs through unrelated descendants.
         let status = unsafe {
-            SetSecurityInfo(
+            NtSetSecurityObject(
                 file.as_raw_handle().cast(),
-                SE_FILE_OBJECT,
                 DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                dacl,
-                std::ptr::null(),
+                descriptor,
             )
         };
-        if status == 0 {
+        if status == STATUS_SUCCESS {
             Ok(())
         } else {
-            Err(io::Error::from_raw_os_error(status as i32))
+            // SAFETY: `status` is the NTSTATUS returned by `NtSetSecurityObject`.
+            let error = unsafe { RtlNtStatusToDosError(status) };
+            Err(io::Error::from_raw_os_error(error as i32))
         }
     };
     // SAFETY: `descriptor` was allocated by `ConvertStringSecurityDescriptor...`.

--- a/tests/codex_acp.rs
+++ b/tests/codex_acp.rs
@@ -192,7 +192,7 @@ while True:
             runtime_home = pathlib.Path(os.environ['CODEX_HOME'])
             cwd = request['params']['cwd']
             projects = request['params']['config'].get('projects', {})
-            trust = projects.get(cwd, {}).get('trust_level')
+            trust = projects.get(os.path.normcase(cwd), {}).get('trust_level')
             snapshot = (runtime_home / 'config.toml').read_text()
             save('isolation', {
                 'sameHome': source_home == runtime_home,
@@ -203,7 +203,7 @@ while True:
                 'snapshotHasConfigLockfile': 'config_lockfile' in snapshot,
                 'sqliteHomeIsolated': pathlib.Path(os.environ.get('CODEX_SQLITE_HOME', '')) == runtime_home,
                 'projectTrust': trust,
-                'trustedAncestors': [str(path) for path in pathlib.Path(cwd).parents if projects.get(str(path), {}).get('trust_level') != 'untrusted'],
+                'trustedAncestors': [str(path) for path in pathlib.Path(cwd).parents if projects.get(os.path.normcase(str(path)), {}).get('trust_level') != 'untrusted'],
             })
         thread_count += 1
         thread_id = 'thread-red-codex' if thread_count == 1 else 'thread-red-codex-' + str(thread_count)
@@ -722,10 +722,10 @@ async fn codex_dynamic_tools_round_trip_the_real_proposal_host_without_touching_
     expected_config["projects"] = projects.clone();
     assert_eq!(thread["config"], expected_config);
     for ancestor in workspace.path().ancestors() {
-        assert_eq!(
-            projects[ancestor.to_string_lossy().as_ref()]["trust_level"],
-            "untrusted"
-        );
+        let key = ancestor.to_string_lossy();
+        #[cfg(windows)]
+        let key = key.to_ascii_lowercase();
+        assert_eq!(projects[&*key]["trust_level"], "untrusted");
     }
     let tools = thread["dynamicTools"].as_array().unwrap();
     assert_eq!(tools.len(), 4);
@@ -1303,7 +1303,7 @@ async fn codex_counts_pending_session_starts_toward_the_session_limit() {
         response["error"]["message"],
         "Codex session capacity reached"
     );
-    tokio::time::timeout(TEST_TIMEOUT, async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             let events = std::fs::read(&acp.record)
                 .ok()

--- a/tests/codex_acp.rs
+++ b/tests/codex_acp.rs
@@ -17,11 +17,14 @@ use tokio::{
 };
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(windows)]
+static CAPACITY_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 const MOCK_APP_SERVER: &str = r#"#!/usr/bin/env python3
 import json
 import os
 import pathlib
 import sys
+import time
 
 mode = os.environ['MOCK_MODE']
 record = pathlib.Path(os.environ['MOCK_RECORD'])
@@ -36,7 +39,14 @@ def save(event, value):
     seen.append({'event': event, 'value': value})
     temporary = record.with_suffix('.tmp')
     temporary.write_text(json.dumps(seen))
-    temporary.replace(record)
+    for attempt in range(100):
+        try:
+            temporary.replace(record)
+            return
+        except PermissionError:
+            if os.name != 'nt' or attempt == 99:
+                raise
+            time.sleep(0.01)
 
 def send(value):
     sys.stdout.write(json.dumps(value) + '\n')
@@ -1202,6 +1212,8 @@ async fn closing_a_codex_session_interrupts_a_late_turn_start() {
 
 #[tokio::test]
 async fn closing_a_codex_session_cancels_when_request_capacity_is_full() {
+    #[cfg(windows)]
+    let _capacity_test = CAPACITY_TEST_LOCK.lock().await;
     let workspace = tempfile::tempdir().unwrap();
     let mut acp = Harness::start("saturated-cancel");
     acp.initialize().await;
@@ -1283,6 +1295,8 @@ async fn closing_a_codex_session_cancels_when_request_capacity_is_full() {
 
 #[tokio::test]
 async fn codex_counts_pending_session_starts_toward_the_session_limit() {
+    #[cfg(windows)]
+    let _capacity_test = CAPACITY_TEST_LOCK.lock().await;
     let workspace = tempfile::tempdir().unwrap();
     let mut acp = Harness::start("hold-account");
     acp.initialize().await;

--- a/tests/codex_acp.rs
+++ b/tests/codex_acp.rs
@@ -1219,7 +1219,7 @@ async fn closing_a_codex_session_cancels_when_request_capacity_is_full() {
         acp.send(json!({"jsonrpc": "2.0", "id": id, "method": "authenticate", "params": {}}))
             .await;
     }
-    tokio::time::timeout(TEST_TIMEOUT, async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             if acp
                 .available_events()
@@ -1568,11 +1568,11 @@ async fn codex_accepts_many_mcp_servers_in_the_restricted_configuration() {
 #[tokio::test]
 async fn codex_ignores_mcp_servers_added_after_configuration_inspection() {
     let workspace = tempfile::tempdir().unwrap();
-    let nested = workspace.path().join("nested/project");
+    let nested = workspace.path().join("nested").join("project");
     std::fs::create_dir_all(&nested).unwrap();
     std::fs::create_dir(workspace.path().join(".codex")).unwrap();
     std::fs::write(
-        workspace.path().join(".codex/config.toml"),
+        workspace.path().join(".codex").join("config.toml"),
         "[mcp_servers.project]\ncommand = \"must-not-launch\"\nenabled = true\n",
     )
     .unwrap();

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1137,6 +1137,11 @@ async fn proposal_only_mutations_trigger_a_periodic_recovery_snapshot() {
     workspace
         .lock()
         .unwrap()
+        .sync_visible_file(&path, /*revision*/ 0, "base\n".to_string())
+        .unwrap();
+    workspace
+        .lock()
+        .unwrap()
         .write("session-1", &path, "proposed\n".to_string())
         .unwrap();
     harness

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1775,27 +1775,13 @@ async fn test_delete_line() {
 
 #[tokio::test]
 async fn test_delete_to_end_of_line() {
-    let mut harness = EditorHarness::with_content("Hello World Test");
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "Hello World Test".to_string()),
+        default_key_config(),
+    );
 
-    // Move to middle of line
-    harness
-        .execute_action(Action::MoveToNextWord)
-        .await
-        .unwrap();
+    type_normal_keys(&mut harness, "wD").await;
 
-    // Delete to end of line with 'D' - not a direct action, so delete from cursor to end
-    // This would typically be a composed action in vim
-    let (x, _) = harness.cursor_position();
-    let line_content = harness.current_line().unwrap();
-    let line_len = line_content.trim_end().len(); // Don't include newline
-
-    // Delete all characters from cursor to end of line
-    for _ in x..line_len {
-        harness
-            .execute_action(Action::DeleteCharAtCursorPos)
-            .await
-            .unwrap();
-    }
     harness.assert_buffer_contents("Hello ");
 }
 
@@ -2210,7 +2196,7 @@ async fn operator_and_motion_counts_multiply_for_words_and_character_motions() {
     let mut harness = EditorHarness::with_config(buffer, default_key_config());
     type_normal_keys(&mut harness, "c2wX").await;
     command_key(&mut harness, KeyCode::Esc).await;
-    harness.assert_buffer_contents("Xγ δ");
+    harness.assert_buffer_contents("X γ δ");
 
     for (contents, keys, expected) in [
         ("one two", "d2w", ""),
@@ -2922,10 +2908,100 @@ async fn test_delete_word() {
 
 #[tokio::test]
 async fn test_join_lines() {
-    let _harness = EditorHarness::with_content("Line 1\nLine 2\nLine 3");
+    for (contents, keys, expected, cursor) in [
+        ("alpha\n    beta", "J", "alpha beta", (5, 0)),
+        ("alpha\n    ) tail", "J", "alpha) tail", (5, 0)),
+        ("alpha \n    beta", "J", "alpha beta", (6, 0)),
+        ("α\u{0301}\r\n    β", "J", "α\u{0301} β", (1, 0)),
+        (
+            "one\n  two\n    three\nfour",
+            "3J",
+            "one two three\nfour",
+            (7, 0),
+        ),
+        ("alpha \n    beta", "gJ", "alpha     beta", (6, 0)),
+        (
+            "one\n  two\n    three\nfour",
+            "VjjJ",
+            "one two three\nfour",
+            (7, 0),
+        ),
+        (
+            "one \n  two\n    three\nfour",
+            "VjjgJ",
+            "one   two    three\nfour",
+            (9, 0),
+        ),
+        (
+            "one \n  two\n    three\nfour",
+            "3gJ",
+            "one   two    three\nfour",
+            (9, 0),
+        ),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
 
-    // Join lines is typically a complex operation - skip for now
-    // Would need to delete newline and add space
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn join_lines_is_one_undoable_repeatable_change() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "one\n  two\nthree\n  four".to_string()),
+        default_key_config(),
+    );
+
+    type_normal_keys(&mut harness, "Jj.").await;
+    harness.assert_buffer_contents("one two\nthree four");
+
+    type_normal_keys(&mut harness, "u").await;
+    harness.assert_buffer_contents("one two\nthree\n  four");
+    type_normal_keys(&mut harness, "u").await;
+    harness.assert_buffer_contents("one\n  two\nthree\n  four");
+}
+
+#[tokio::test]
+async fn join_lines_survives_macro_replay_and_eof() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "one\n  two\nthree\n  four".to_string()),
+        default_key_config(),
+    );
+
+    type_normal_keys(&mut harness, "qaJjq@a").await;
+    harness.assert_buffer_contents("one two\nthree four");
+
+    type_normal_keys(&mut harness, "GJ").await;
+    harness.assert_buffer_contents("one two\nthree four");
+}
+
+#[tokio::test]
+async fn join_ex_command_supports_count_and_bang() {
+    for (contents, command, expected) in [
+        ("one\n  two\nthree", "join", "one two\nthree"),
+        ("one\n  two\nthree\nfour", "j 3", "one two three\nfour"),
+        ("one \n  two\nthree", "join!", "one   two\nthree"),
+        ("one \n  two\nthree\nfour", "j! 3", "one   twothree\nfour"),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        harness
+            .execute_action(Action::Command(command.to_string()))
+            .await
+            .unwrap();
+
+        harness.assert_buffer_contents(expected);
+    }
 }
 
 #[tokio::test]
@@ -4510,31 +4586,275 @@ async fn test_delete_at_end_of_file() {
 
 #[tokio::test]
 async fn test_change_to_end_of_line() {
-    let mut harness = EditorHarness::with_content("Hello World Test");
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "Hello World Test".to_string()),
+        default_key_config(),
+    );
 
-    // Move to middle
-    harness
-        .execute_action(Action::MoveToNextWord)
-        .await
-        .unwrap();
-
-    // Change to end of line with 'C' - delete to end and enter insert
-    let (x, _) = harness.cursor_position();
-    let line_len = harness.current_line().unwrap().trim_end().len();
-    for _ in x..line_len {
-        harness
-            .execute_action(Action::DeleteCharAtCursorPos)
-            .await
-            .unwrap();
-    }
-    harness
-        .execute_action(Action::EnterMode(Mode::Insert))
-        .await
-        .unwrap();
-    harness.execute_action(Action::MoveRight).await.unwrap();
+    type_normal_keys(&mut harness, "wC").await;
     harness.assert_mode(Mode::Insert);
-
-    // Type replacement
     harness.type_text("Universe").await.unwrap();
     harness.assert_buffer_contents("Hello Universe");
+}
+
+#[tokio::test]
+async fn vim_editing_shortcuts_honor_counts_and_register_kinds() {
+    let cases = [
+        ("one two\nthree four\nfive", "w2D", "one \nfive"),
+        ("one two\nthree four\nfive", "w2CX", "one X\nfive"),
+        ("  one two\nnext", "SX", "  X\nnext"),
+        ("one two", "w2sX", "one Xo"),
+        ("one two", "wX", "onetwo"),
+        ("one two", "wY$p", "one twotwo"),
+        ("abc", "xp", "bac"),
+        ("abc", "xuU", "bc"),
+    ];
+
+    for (contents, keys, expected) in cases {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+
+        harness.assert_buffer_contents(expected);
+    }
+}
+
+#[tokio::test]
+async fn vim_operator_motions_cover_line_edges_backward_words_and_vertical_lines() {
+    for (contents, keys, expected) in [
+        ("one two three", "wd$", "one "),
+        ("one two three", "wdb", "two three"),
+        ("one\ntwo\nthree", "dj", "three"),
+        ("one\ntwo\nthree", "jdk", "three"),
+        ("one two three", "cwX", "X two three"),
+        ("one two three four", "c2wX", "X three four"),
+        ("one two", "wcwX", "one X"),
+        ("  one\n    two\nthree", "cjX", "  X\nthree"),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+
+        harness.assert_buffer_contents(expected);
+    }
+}
+
+#[tokio::test]
+async fn vim_line_end_changes_repeat_at_the_new_cursor() {
+    for (keys, expected) in [("wCX", "one X\nthree X"), ("wD", "one \nthree ")] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, "one two\nthree four".to_string()),
+            default_key_config(),
+        );
+        type_normal_keys(&mut harness, keys).await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+        type_normal_keys(&mut harness, "jw.").await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+        harness.assert_buffer_contents(expected);
+    }
+}
+
+#[tokio::test]
+async fn vim_backward_character_and_end_word_motions_work_in_normal_and_operator_modes() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "alpha.beta.gamma".to_string()),
+        default_key_config(),
+    );
+    type_normal_keys(&mut harness, "$F.").await;
+    harness.assert_cursor_at(10, 0);
+
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "alpha.beta.gamma".to_string()),
+        default_key_config(),
+    );
+    type_normal_keys(&mut harness, "$T.").await;
+    harness.assert_cursor_at(11, 0);
+
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "alpha.beta.gamma".to_string()),
+        default_key_config(),
+    );
+    type_normal_keys(&mut harness, "f.f.,").await;
+    harness.assert_cursor_at(5, 0);
+
+    for (contents, keys, expected) in [
+        ("alpha.beta.gamma", "$dF.", "alpha.betaa"),
+        ("alpha.beta.gamma", "$dT.", "alpha.beta.a"),
+        ("alpha beta gamma", "de", " beta gamma"),
+        ("alpha beta gamma", "wdb", "beta gamma"),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+        type_normal_keys(&mut harness, keys).await;
+        harness.assert_buffer_contents(expected);
+    }
+
+    for (keys, cursor) in [("e", 4), ("E", 9), ("$ge", 9), ("$gE", 9), ("$B", 11)] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, "alpha.beta gamma".to_string()),
+            default_key_config(),
+        );
+        type_normal_keys(&mut harness, keys).await;
+        harness.assert_cursor_at(cursor, 0);
+    }
+}
+
+#[tokio::test]
+async fn vim_case_changes_and_visual_replace_are_transactional() {
+    for (contents, keys, expected) in [
+        ("alpha beta", "~", "Alpha beta"),
+        ("alpha beta", "gUiw", "ALPHA beta"),
+        ("ALPHA beta", "guiw", "alpha beta"),
+        ("aLpHa beta", "g~iw", "AlPhA beta"),
+        ("alpha beta", "viwU", "ALPHA beta"),
+        ("ALPHA beta", "viwu", "alpha beta"),
+        ("aLpHa beta", "viw~", "AlPhA beta"),
+        ("alpha beta", "viwrX", "XXXXX beta"),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_mode(Mode::Normal);
+        type_normal_keys(&mut harness, "u").await;
+        harness.assert_buffer_contents(contents);
+    }
+}
+
+#[tokio::test]
+async fn vim_word_and_character_repeat_actions_remain_remappable() {
+    let mut config = default_key_config();
+    config.keys.normal.insert(
+        "W".to_string(),
+        KeyAction::Single(Action::MoveToNextBigWord),
+    );
+    config.keys.normal.insert(
+        ";".to_string(),
+        KeyAction::Single(Action::RepeatCharSearch(1)),
+    );
+
+    let mut harness =
+        EditorHarness::with_config(Buffer::new(None, "alpha.beta gamma".to_string()), config);
+    type_normal_keys(&mut harness, "W").await;
+    harness.assert_cursor_at(11, 0);
+
+    let mut config = default_key_config();
+    config.keys.normal.insert(
+        ";".to_string(),
+        KeyAction::Single(Action::RepeatCharSearch(1)),
+    );
+    let mut harness =
+        EditorHarness::with_config(Buffer::new(None, "alpha.beta.gamma".to_string()), config);
+    type_normal_keys(&mut harness, "f.;").await;
+    harness.assert_cursor_at(10, 0);
+}
+
+#[tokio::test]
+async fn visual_replace_accepts_a_shifted_terminal_key_event() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "alpha beta".to_string()),
+        default_key_config(),
+    );
+    type_normal_keys(&mut harness, "viwr").await;
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('X'),
+            KeyModifiers::SHIFT,
+        )))
+        .await
+        .unwrap();
+
+    harness.assert_buffer_contents("XXXXX beta");
+    harness.assert_mode(Mode::Normal);
+}
+
+#[tokio::test]
+async fn visual_multiline_and_block_replace_and_case_changes_preserve_line_breaks() {
+    let cases = [
+        ("vjrX", "XXXXX\nXeta\ngamma"),
+        ("VjrX", "XXXXX\nXXXX\ngamma"),
+        ("VjU", "ALPHA\nBETA\ngamma"),
+    ];
+    for (keys, expected) in cases {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, "alpha\nbeta\ngamma".to_string()),
+            default_key_config(),
+        );
+        type_normal_keys(&mut harness, keys).await;
+        harness.assert_buffer_contents(expected);
+    }
+
+    for (suffix, expected) in [
+        ("jlrX", "XXpha\nXXta\ngamma"),
+        ("jlU", "ALpha\nBEta\ngamma"),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, "alpha\nbeta\ngamma".to_string()),
+            default_key_config(),
+        );
+        harness
+            .execute_event(Event::Key(KeyEvent::new(
+                KeyCode::Char('v'),
+                KeyModifiers::CONTROL,
+            )))
+            .await
+            .unwrap();
+        type_normal_keys(&mut harness, suffix).await;
+        harness.assert_buffer_contents(expected);
+    }
+}
+
+#[tokio::test]
+async fn vim_half_page_keys_move_the_cursor_by_half_a_viewport() {
+    let contents = (0..40)
+        .map(|line| format!("line-{line:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut harness = EditorHarness::with_config_and_size(
+        Buffer::new(None, contents),
+        default_key_config(),
+        80,
+        12,
+    );
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('d'),
+            KeyModifiers::CONTROL,
+        )))
+        .await
+        .unwrap();
+    assert_eq!(harness.buffer_line(), 5);
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('u'),
+            KeyModifiers::CONTROL,
+        )))
+        .await
+        .unwrap();
+    assert_eq!(harness.buffer_line(), 0);
 }


### PR DESCRIPTION
Red's default Vim keymap was missing common editing commands such as `J`, `D`, `C`, and word-end/backward character motions. The compatibility matrix also claimed that line joining was supported while its integration test was still an empty placeholder. This makes everyday Neovim editing sequences fail or behave differently in Red. The merged foundation base also leaves both Windows test jobs red, so this includes the narrow recovery/test-state fix needed to exercise the new editing coverage cross-platform.

## What changed

- Add normalized and whitespace-preserving joins for `J`, `gJ`, Visual selections, and `:j[oin][!] [count]`, including counts, cursor placement, undo, dot-repeat, macros, CRLF, and Unicode coverage.
- Add the missing editing aliases and motion/operator paths: `D/C/Y`, `s/S/X`, `e/ge/B/E/gE`, `F/T`, reverse character-search repeat, vertical and line-edge operators, half-page movement, case transforms, and Visual `r`/case changes. Keep Red's intentional `W`, `;`, and `Ctrl-e` defaults remappable.
- Replace simulated/placeholder tests with production-key-path regressions, fix register and Insert-transition behavior exercised by those paths, and update the README and Vim compatibility matrix to describe the actual defaults and differences.
- Restore Windows session snapshots by applying the protected user-only DACL directly to the pinned handle, avoiding recursive ACE propagation that fails with `Access is denied`, and distinguish file symlinks from directory reparse points so safe replacement works without following links; republish the visible proposal source after the editor's background refresh so the existing fail-closed Windows filesystem contract remains intact.
- Make the inherited Codex-ACP configuration and integration tests portable by constructing paths component-wise, matching the intentional case-insensitive Windows trust-key representation, retrying transient Windows event-snapshot replacement locks, and serializing the Windows CI test matrix to avoid ACP subprocess starvation. Seed the proposal-recovery fixture with its open-file source so Windows keeps its fail-closed filesystem behavior.

## How to Test

1. Run the focused join and editing regressions:

   ```bash
   cargo test --locked --test editing test_join_lines
   cargo test --locked --test editing join_lines_
   cargo test --locked --test editing vim_
   ```

   Confirm joins normalize or preserve whitespace as documented, EOF joins are harmless, macro/dot/undo behavior works, `D/C/Y` and operator motions edit the expected ranges, and Visual replacement/case changes preserve line breaks.

2. Run the focused recovery regressions (these cover the inherited Windows failures):

   ```bash
   cargo test --locked --lib session::tests::
   cargo test --locked --lib concurrent_agent_prompt_preserves_the_active_proposal_turn_until_completion
   cargo test --locked --lib detached_agent_proposal_acceptance_survives_a_failed_review_refresh_render
   cargo test --locked --bin red_codex_acp
   cargo test --locked --test codex_acp
   cargo test --locked --test editing proposal_only_mutations_trigger_a_periodic_recovery_snapshot
   ```

   Confirm snapshot writes, rotation, recovery, and file-symlink replacement remain valid while directory reparse points stay rejected, visible ACP proposals and proposal-only recovery snapshots retain their open-file source without allowing unsafe disk reads, and Codex configuration/trust paths and capacity coverage remain stable on Windows.

3. Run the complete validation gates:

   ```bash
   cargo test --locked --all-targets --all-features
   cargo test --locked --all-targets --no-default-features
   cargo clippy --all-targets --all-features -- -D warnings
   cargo fmt --check
   python3 scripts/check_markdown_links.py
   ```

   Expected: all 1,403 tests pass (including 217 editing tests), Clippy and formatting are clean, and all relative Markdown links resolve.
