### PR TITLE
feat(picker): add command and keymap discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
  "husk-ast",
  "husk-diagnostics",
  "husk-parser",
+ "serde",
  "serde_json",
  "thiserror 1.0.57",
 ]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Diagnostics from the language server are displayed inline, and emitted progress 
 
 ### Pickers and panels
 
+- `F1`, `Space ?`, `Alt-x`, or `Ctrl-Shift-p` - Command palette; search commands, their current keymaps, and available `:Command` invocations
+- `Ctrl-p` then `>` - Switch from the file picker to the command palette
 - `Ctrl-p` - File picker (`Ctrl-e` toggles hidden and ignored files while open)
 - `Ctrl-e` - File tree (neotree)
 - `Ctrl-j` or `Space b` - Buffer picker
@@ -174,6 +176,7 @@ Enter Command mode with `:` (or `;`).
 - `:noh` - Clear search highlights
 - `:wrap` / `:nowrap` - Enable/disable line wrapping
 - `:join [count]` / `:join! [count]` - Join lines with normalized/preserved whitespace (`:j` is accepted)
+- `:commands` / `:command-palette` - Open the command palette
 
 ## Configuration
 
@@ -208,7 +211,23 @@ Every mode has its own table (`[keys.normal]`, `[keys.insert]`, `[keys.visual]`,
 "a" = [ { EnterMode = "Insert" }, "MoveRight" ]  # sequence
 "g" = { "d" = "GoToDefinition" }               # chord: g then d
 "Ctrl-j" = { PluginCommand = "BufferPicker" }  # plugin command
+"Ctrl-Shift-p" = "CommandPalette"              # combined modifiers
 ```
+
+Pause briefly after a configured prefix such as `Space`, `Ctrl-w`, or `g` to see
+its available continuations. Fast key sequences complete normally. The guide can
+be disabled or delayed in user configuration:
+
+```toml
+[key_hints]
+enabled = true
+delay_ms = 250
+```
+
+Red preserves combined modifiers such as `Ctrl-Shift-p` and enables the terminal
+enhanced-keyboard protocol on supported Unix terminals while active. Some terminals
+reserve `Ctrl-Shift-p` for their own command palette, so `F1`, `Space ?`, `Alt-x`, and
+`Ctrl-p` then `>` remain portable alternatives.
 
 ### Language servers
 
@@ -343,7 +362,12 @@ Plugins are Husk files running in Red's embedded scripting runtime. A plugin exp
 
 ```rust
 pub fn activate() {
-    red::add_command("HelloWorld", hello_world);
+    red::add_command("HelloWorld", hello_world, Json {
+        title: "Say hello",
+        category: "Example",
+        description: "Print a greeting",
+        aliases: ["greeting"],
+    });
 }
 
 fn hello_world() {
@@ -354,6 +378,8 @@ fn hello_world() {
 Commands registered this way can be invoked directly with `:HelloWorld` or bound to keys
 with `{ PluginCommand = "HelloWorld" }`. Direct invocation uses an exact,
 case-sensitive command name; built-in commands and their abbreviations take precedence.
+The optional metadata makes plugin commands searchable in the command palette and
+shows their effective keymaps alongside the exact `:HelloWorld` invocation.
 
 The Husk host API covers commands, events, editor state and edits, pickers, panels,
 workspace views, overlays/gutter signs, timers, filesystem watches, permitted

--- a/crates/husk/Cargo.toml
+++ b/crates/husk/Cargo.toml
@@ -11,5 +11,6 @@ anyhow = "1.0.79"
 husk-ast.workspace = true
 husk-diagnostics.workspace = true
 husk-parser.workspace = true
+serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 thiserror = "1.0"

--- a/crates/husk/src/lib.rs
+++ b/crates/husk/src/lib.rs
@@ -14,6 +14,7 @@ use husk_ast::{
     StmtKind, UnaryOp,
 };
 use husk_diagnostics::{CallFrame, Diagnostic, Report, SourceFile};
+use serde::{Deserialize, Serialize};
 
 /// A dynamically typed value crossing the Husk/host boundary.
 #[derive(Debug, Clone)]
@@ -122,6 +123,20 @@ impl Value {
 pub struct Callback {
     plugin: String,
     function: String,
+}
+
+/// User-facing metadata attached to a registered Husk command.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct CommandMetadata {
+    /// Human-readable command title shown in discovery surfaces.
+    pub title: Option<String>,
+    /// Category used to group related commands.
+    pub category: Option<String>,
+    /// Longer explanation of what the command does.
+    pub description: Option<String>,
+    /// Additional terms users may search for.
+    pub aliases: Vec<String>,
 }
 
 impl Callback {
@@ -281,6 +296,7 @@ struct Function {
 pub struct Vm {
     programs: HashMap<String, Program>,
     commands: HashMap<String, Callback>,
+    command_metadata: HashMap<String, CommandMetadata>,
     event_listeners: HashMap<String, Vec<Callback>>,
     pending_requests: HashMap<RequestId, Callback>,
     plugin_states: HashMap<String, HashMap<String, Value>>,
@@ -419,6 +435,8 @@ impl Vm {
 
     fn remove_plugin_registrations(&mut self, name: &str) {
         self.commands.retain(|_, callback| callback.plugin != name);
+        self.command_metadata
+            .retain(|command, _| self.commands.contains_key(command));
         self.event_listeners.retain(|_, callbacks| {
             callbacks.retain(|callback| callback.plugin != name);
             !callbacks.is_empty()
@@ -579,6 +597,7 @@ impl Vm {
             self.call_function(&callback, Vec::new(), host)?;
         }
         self.commands.clear();
+        self.command_metadata.clear();
         self.event_listeners.clear();
         self.pending_requests.clear();
         self.plugin_states.clear();
@@ -588,6 +607,12 @@ impl Vm {
     #[must_use]
     pub fn commands(&self) -> &HashMap<String, Callback> {
         &self.commands
+    }
+
+    /// Returns the metadata registered for a command, when present.
+    #[must_use]
+    pub fn command_metadata(&self, command: &str) -> Option<&CommandMetadata> {
+        self.command_metadata.get(command)
     }
 
     fn has_function(&self, plugin: &str, function: &str) -> bool {
@@ -1317,6 +1342,15 @@ impl Vm {
             "red::add_command" => {
                 let command = required_string(&args, 0, name)?;
                 let callback = required_callback(&args, 1, name)?;
+                let metadata = args
+                    .get(2)
+                    .map(Value::to_json)
+                    .map(serde_json::from_value::<CommandMetadata>)
+                    .transpose()
+                    .map_err(|error| {
+                        anyhow::anyhow!("invalid metadata for command `{command}`: {error}")
+                    })?
+                    .unwrap_or_default();
                 if let Some(existing) = self.commands.get(command)
                     && existing.plugin != frame.plugin
                 {
@@ -1326,6 +1360,7 @@ impl Vm {
                     );
                 }
                 self.commands.insert(command.to_string(), callback.clone());
+                self.command_metadata.insert(command.to_string(), metadata);
                 Ok(Value::Unit)
             }
             "red::on" => {
@@ -2075,6 +2110,60 @@ mod tests {
                 "Print".to_string(),
                 vec![Value::String("hello from husk".to_string())]
             )]
+        );
+    }
+
+    #[test]
+    fn registered_command_preserves_optional_discovery_metadata() {
+        let source = r#"
+            pub fn activate() {
+                red::add_command("ProjectSearch", search, Json {
+                    title: "Search project",
+                    category: "Search",
+                    description: "Find text across the workspace",
+                    aliases: ["ripgrep", "find text"],
+                });
+            }
+
+            fn search() {}
+        "#;
+        let mut host = TestHost::default();
+        let mut vm = Vm::new();
+
+        vm.load_plugin("search", source, &mut host).unwrap();
+
+        assert_eq!(
+            vm.command_metadata("ProjectSearch"),
+            Some(&CommandMetadata {
+                title: Some("Search project".to_string()),
+                category: Some("Search".to_string()),
+                description: Some("Find text across the workspace".to_string()),
+                aliases: vec!["ripgrep".to_string(), "find text".to_string()],
+            })
+        );
+
+        vm.unload_plugin("search");
+        assert_eq!(vm.command_metadata("ProjectSearch"), None);
+    }
+
+    #[test]
+    fn registered_command_rejects_invalid_discovery_metadata() {
+        let source = r#"
+            pub fn activate() {
+                red::add_command("ProjectSearch", search, Json { unknown: true });
+            }
+
+            fn search() {}
+        "#;
+        let mut host = TestHost::default();
+        let mut vm = Vm::new();
+
+        let error = vm.load_plugin("search", source, &mut host).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid metadata for command `ProjectSearch`")
         );
     }
 

--- a/default_config.toml
+++ b/default_config.toml
@@ -64,6 +64,12 @@ smartcase = false
 # "top". Bottom matches the default command-line-oriented picker layout.
 input_position = "bottom"
 
+# Show available continuations after a keymap prefix such as Space or Ctrl-w.
+# Fast key sequences complete before the guide appears.
+[key_hints]
+enabled = true
+delay_ms = 250
+
 # Cursor shape per editor state. Supported values are "default",
 # "blinking_block", "steady_block", "blinking_underscore",
 # "steady_underscore", "blinking_bar", and "steady_bar".
@@ -180,6 +186,9 @@ Esc = { EnterMode = "Normal" }
 # "|" = "Split" 
 # "_" = "SplitVertical"
 "Ctrl-p" = "FilePicker"
+"Ctrl-Shift-p" = "CommandPalette"
+"Alt-x" = "CommandPalette"
+"F1" = "CommandPalette"
 "Ctrl-j" = { PluginCommand = "BufferPicker" }
 "Ctrl-z" = "Suspend"
 "Ctrl-e" = { PluginCommand = "NeoTree" }
@@ -245,6 +254,7 @@ Esc = { EnterMode = "Normal" }
 "." = "CodeAction"
 "r" = "StartRename"
 "G" = { PluginCommand = "GitDashboard" }
+"?" = "CommandPalette"
 "h" = { "s" = { PluginCommand = "GitHunkStage" }, "u" = { PluginCommand = "GitHunkUnstage" }, "r" = { PluginCommand = "GitHunkReset" } }
 "c" = { "c" = { PluginCommand = "GitSubmitMessage" }, "q" = { PluginCommand = "GitCancelMessage" } }
 
@@ -292,10 +302,6 @@ Esc = { EnterMode = "Normal" }
 [keys.visual_block]
 
 [keys.visual_line]
-
-[commands]
-"write" = "Save"
-"quit" = "Quit"
 
 [plugins]
 agent = "agent.hk"

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -23,6 +23,15 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 (`HUSK-A0003`) against the machine-readable signature. `--no-typecheck` is an unsupported
 development escape hatch; compatibility guarantees do not apply while it is enabled.
 
+## Command discovery metadata
+
+`red::add_command(name, callback[, metadata])` accepts an optional `Json` object
+with `title`, `category`, `description`, and `aliases: [String]`. Red uses these
+fields to populate the command palette; aliases are search terms and do not
+create alternate colon commands. The palette shows the exact, case-sensitive
+`:Name` invocation when it is available and resolves keymaps from the user's
+effective configuration. Existing two-argument registrations continue to work.
+
 ## Agent composer
 
 Plugins that collect an agent request should call `OpenAgentComposer(title: String, id: i32, query: String, history: [String])`. The host owns multiline editing, wrapping, cursor movement, and history navigation; it does not send a callback for each keystroke. On submit it emits `composer:submitted:<id>` with the complete prompt as a JSON string, and on cancellation it emits `composer:cancelled:<id>`. These callbacks are delivered only to the plugin that opened the composer. Input is limited to 128 KiB so an escaping-heavy prompt remains within the ACP frame limit; an oversized paste leaves the current draft intact and shows a validation message. Enter submits, `Ctrl-j` or Shift-Enter inserts a newline, Escape or `Ctrl-c` cancels, and `Ctrl-p` / `Ctrl-n` moves through the supplied history while preserving the current draft.

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -8,7 +8,12 @@ Every plugin may define these functions:
 
 ```rust
 pub fn activate() {
-    red::add_command("HelloWorld", hello_world);
+    red::add_command("HelloWorld", hello_world, Json {
+        title: "Say hello",
+        category: "Example",
+        description: "Print a greeting",
+        aliases: ["greeting"],
+    });
     red::on("editor:ready", ready);
 }
 
@@ -37,7 +42,7 @@ Husk plugins use the versioned native `red` host module:
 
 | Function | Purpose |
 |----------|---------|
-| `red::add_command(name, callback)` | Register a command callable with `:Name` or from `{ PluginCommand = "Name" }` keymaps |
+| `red::add_command(name, callback[, metadata])` | Register a command callable with `:Name`, from `{ PluginCommand = "Name" }` keymaps, or through the command palette |
 | `red::on(event, callback)` | Subscribe to editor events |
 | `red::execute(action, ...)` | Call a fire-and-forget Rust host action |
 | `red::request(action, callback, ...)` | Issue a one-shot request and invoke the callback with its payload |
@@ -48,6 +53,12 @@ Execute and request actions cover editor state and edits, dialogs, pickers and a
 Direct `:Name` invocation requires an exact, case-sensitive registered name and does not
 currently pass arguments to the callback. Built-in commands and their abbreviations take
 precedence over plugin commands with the same name.
+
+The optional command metadata object accepts `title`, `category`, `description`,
+and `aliases`. All fields are optional; `aliases` is an array of additional
+search terms, not alternate colon commands. When present, metadata is shown in
+the command palette with the command's effective keymaps and its exact `:Name`
+invocation. Existing two-argument registrations remain valid.
 
 Use `red::request` for actions that return a value:
 

--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -1,10 +1,40 @@
 pub fn activate() {
-    red::add_command("Agent", prompt);
-    red::add_command("AgentStart", start);
-    red::add_command("AgentPrompt", prompt);
-    red::add_command("AgentCancel", cancel);
-    red::add_command("AgentReview", review);
-    red::add_command("AgentHistory", history);
+    red::add_command("Agent", prompt, Json {
+        title: "Ask the agent",
+        category: "Agent",
+        description: "Open the agent prompt",
+        aliases: ["ask ai", "chat"],
+    });
+    red::add_command("AgentStart", start, Json {
+        title: "Start agent session",
+        category: "Agent",
+        description: "Start a new agent session",
+        aliases: ["new chat"],
+    });
+    red::add_command("AgentPrompt", prompt, Json {
+        title: "Open agent prompt",
+        category: "Agent",
+        description: "Ask a question in the active agent session",
+        aliases: ["ask ai", "chat"],
+    });
+    red::add_command("AgentCancel", cancel, Json {
+        title: "Cancel agent request",
+        category: "Agent",
+        description: "Cancel the active agent request",
+        aliases: ["stop agent"],
+    });
+    red::add_command("AgentReview", review, Json {
+        title: "Review agent changes",
+        category: "Agent",
+        description: "Review changes proposed by the agent",
+        aliases: ["proposals"],
+    });
+    red::add_command("AgentHistory", history, Json {
+        title: "Show agent history",
+        category: "Agent",
+        description: "Inspect previous agent transactions",
+        aliases: ["transactions"],
+    });
     red::on("agent:session_created", session_created);
     red::on("agent:update", update);
     red::on("agent:completed", completed);

--- a/plugins/buffer_picker.hk
+++ b/plugins/buffer_picker.hk
@@ -1,5 +1,10 @@
 pub fn activate() {
-    red::add_command("BufferPicker", buffer_picker);
+    red::add_command("BufferPicker", buffer_picker, Json {
+        title: "Open buffer picker",
+        category: "Buffer",
+        description: "Find and switch between open buffers",
+        aliases: ["buffers"],
+    });
     red::on("picker:selected:701", buffer_selected);
 }
 

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -1,13 +1,58 @@
 pub fn activate() {
-    red::add_command("GitDashboard", dashboard);
-    red::add_command("GitRefresh", refresh);
-    red::add_command("GitHunkPrevious", hunk_previous);
-    red::add_command("GitHunkNext", hunk_next);
-    red::add_command("GitHunkStage", hunk_stage);
-    red::add_command("GitHunkUnstage", hunk_unstage);
-    red::add_command("GitHunkReset", hunk_reset);
-    red::add_command("GitSubmitMessage", submit_message);
-    red::add_command("GitCancelMessage", cancel_message);
+    red::add_command("GitDashboard", dashboard, Json {
+        title: "Open Git dashboard",
+        category: "Git",
+        description: "Inspect and manage workspace changes",
+        aliases: ["source control", "status"],
+    });
+    red::add_command("GitRefresh", refresh, Json {
+        title: "Refresh Git status",
+        category: "Git",
+        description: "Refresh workspace Git information",
+        aliases: ["status"],
+    });
+    red::add_command("GitHunkPrevious", hunk_previous, Json {
+        title: "Previous Git hunk",
+        category: "Git",
+        description: "Move to the previous changed hunk",
+        aliases: ["previous change"],
+    });
+    red::add_command("GitHunkNext", hunk_next, Json {
+        title: "Next Git hunk",
+        category: "Git",
+        description: "Move to the next changed hunk",
+        aliases: ["next change"],
+    });
+    red::add_command("GitHunkStage", hunk_stage, Json {
+        title: "Stage Git hunk",
+        category: "Git",
+        description: "Stage the changed hunk under the cursor",
+        aliases: ["stage change"],
+    });
+    red::add_command("GitHunkUnstage", hunk_unstage, Json {
+        title: "Unstage Git hunk",
+        category: "Git",
+        description: "Unstage the changed hunk under the cursor",
+        aliases: ["unstage change"],
+    });
+    red::add_command("GitHunkReset", hunk_reset, Json {
+        title: "Reset Git hunk",
+        category: "Git",
+        description: "Discard the changed hunk under the cursor",
+        aliases: ["discard change"],
+    });
+    red::add_command("GitSubmitMessage", submit_message, Json {
+        title: "Submit Git message",
+        category: "Git",
+        description: "Submit the current Git commit message",
+        aliases: ["commit"],
+    });
+    red::add_command("GitCancelMessage", cancel_message, Json {
+        title: "Cancel Git message",
+        category: "Git",
+        description: "Cancel the current Git commit message",
+        aliases: ["abort commit"],
+    });
     red::on("workspace:event:git-dashboard", workspace_event);
     red::on("picker:selected:490", reset_confirmed);
     red::on("picker:selected:491", commit_choice);

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -1,7 +1,22 @@
 pub fn activate() {
-    red::add_command("LspDocumentSymbols", document_symbols);
-    red::add_command("LspWorkspaceSymbols", workspace_symbols);
-    red::add_command("LspReferences", references);
+    red::add_command("LspDocumentSymbols", document_symbols, Json {
+        title: "Show document symbols",
+        category: "LSP",
+        description: "Find symbols in the current document",
+        aliases: ["outline", "symbols"],
+    });
+    red::add_command("LspWorkspaceSymbols", workspace_symbols, Json {
+        title: "Search workspace symbols",
+        category: "LSP",
+        description: "Find symbols across the workspace",
+        aliases: ["symbols"],
+    });
+    red::add_command("LspReferences", references, Json {
+        title: "Find references",
+        category: "LSP",
+        description: "Find references to the symbol under the cursor",
+        aliases: ["usages", "references"],
+    });
 
     red::on("picker:selected:201", open_symbol_selection);
     red::on("picker:selected:202", open_symbol_selection);

--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -1,5 +1,10 @@
 pub fn activate() {
-    red::add_command("NeoTree", neotree);
+    red::add_command("NeoTree", neotree, Json {
+        title: "Toggle file tree",
+        category: "File",
+        description: "Show or hide the workspace file tree",
+        aliases: ["explorer", "neotree"],
+    });
     red::on("panel:event:neotree", panel_event);
 
     red::state_set("created", false);

--- a/plugins/project_search.hk
+++ b/plugins/project_search.hk
@@ -1,5 +1,10 @@
 pub fn activate() {
-    red::add_command("ProjectSearch", project_search);
+    red::add_command("ProjectSearch", project_search, Json {
+        title: "Search project",
+        category: "Search",
+        description: "Find text across the workspace",
+        aliases: ["ripgrep", "find text"],
+    });
     red::on("picker:query:301", search_query);
     red::on("picker:action:301", picker_action);
     red::on("picker:selected:301", open_current);

--- a/plugins/theme_browser.hk
+++ b/plugins/theme_browser.hk
@@ -1,5 +1,10 @@
 pub fn activate() {
-    red::add_command("ThemeBrowser", theme_browser);
+    red::add_command("ThemeBrowser", theme_browser, Json {
+        title: "Browse themes",
+        category: "View",
+        description: "Preview and select an editor theme",
+        aliases: ["colorscheme", "theme"],
+    });
     red::on("picker:changed:601", theme_changed);
     red::on("picker:cancelled:601", theme_cancelled);
     red::on("picker:selected:601", theme_selected);

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -1,0 +1,1177 @@
+//! Command and keymap metadata used by Red's discovery surfaces.
+
+use std::collections::HashMap;
+
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use serde_json::json;
+
+use crate::{
+    command,
+    config::{KeyAction, Keys},
+    editor::{Action, Mode, SearchDirection},
+    plugin::RegisteredPluginCommand,
+    ui::PickerItem,
+    unicode_utils::{display_width, truncate_display_width},
+};
+
+/// Colon commands handled by the built-in command parser.
+pub(crate) const BUILTIN_COLON_COMMANDS: &[&str] = &[
+    "$",
+    "quit",
+    "write",
+    "buffer-next",
+    "buffer-prev",
+    "bd",
+    "bdelete",
+    "buffer-delete",
+    "edit",
+    "split",
+    "sp",
+    "vsplit",
+    "vs",
+    "close",
+    "only",
+    "noh",
+    "nohlsearch",
+    "wrap",
+    "nowrap",
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CommandPaletteEntry {
+    pub(crate) id: String,
+    pub(crate) title: String,
+    pub(crate) category: String,
+    pub(crate) description: String,
+    pub(crate) colon: Option<String>,
+    pub(crate) aliases: Vec<String>,
+    pub(crate) shortcuts: Vec<String>,
+    pub(crate) action: Action,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct KeymapHint {
+    pub(crate) key: String,
+    pub(crate) label: String,
+    pub(crate) is_group: bool,
+}
+
+struct BuiltinCommand {
+    id: &'static str,
+    title: &'static str,
+    category: &'static str,
+    description: &'static str,
+    colon: Option<&'static str>,
+    aliases: &'static [&'static str],
+    action: Action,
+}
+
+/// Builds searchable palette rows using the effective configured keymaps.
+pub(crate) fn entries(
+    keys: &Keys,
+    plugin_commands: &[RegisteredPluginCommand],
+) -> Vec<CommandPaletteEntry> {
+    let mut entries = builtin_commands()
+        .into_iter()
+        .map(|command| {
+            let shortcuts = shortcuts_for_action(keys, &command.action);
+            CommandPaletteEntry {
+                id: command.id.to_string(),
+                title: command.title.to_string(),
+                category: command.category.to_string(),
+                description: command.description.to_string(),
+                colon: command.colon.map(str::to_string),
+                aliases: command.aliases.iter().map(ToString::to_string).collect(),
+                shortcuts,
+                action: command.action,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    entries.extend(plugin_commands.iter().map(|command| {
+        let action = Action::PluginCommand(command.name.clone());
+        let shortcuts = shortcuts_for_action(keys, &action);
+        let title = command
+            .metadata
+            .title
+            .clone()
+            .unwrap_or_else(|| humanize_identifier(&command.name));
+        let category = command
+            .metadata
+            .category
+            .as_deref()
+            .unwrap_or(command.plugin.as_str());
+        let description = command.metadata.description.as_deref().unwrap_or("");
+        let colon = (!colon_name_is_builtin(&command.name)).then(|| format!(":{}", command.name));
+
+        CommandPaletteEntry {
+            id: format!("plugin.{}.{}", command.plugin, command.name),
+            title,
+            category: category.to_string(),
+            description: description.to_string(),
+            colon,
+            aliases: command.metadata.aliases.clone(),
+            shortcuts,
+            action,
+        }
+    }));
+
+    entries.sort_unstable_by(|left, right| {
+        left.category
+            .cmp(&right.category)
+            .then_with(|| left.title.cmp(&right.title))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    entries
+}
+
+/// Converts command entries into aligned, structured picker rows.
+pub(crate) fn picker_items(entries: &[CommandPaletteEntry]) -> Vec<PickerItem> {
+    let category_width = entries
+        .iter()
+        .map(|entry| display_width(&entry.category))
+        .max()
+        .unwrap_or_default()
+        .clamp(4, 18);
+    let shortcut_width = entries
+        .iter()
+        .map(|entry| display_width(&primary_shortcut(&entry.shortcuts)))
+        .max()
+        .unwrap_or_default()
+        .min(26);
+
+    entries
+        .iter()
+        .map(|entry| {
+            let category = truncate_display_width(&entry.category, category_width);
+            let category_padding =
+                " ".repeat(category_width.saturating_sub(display_width(&category)));
+            let shortcut =
+                truncate_display_width(&primary_shortcut(&entry.shortcuts), shortcut_width);
+            let shortcut_padding =
+                " ".repeat(shortcut_width.saturating_sub(display_width(&shortcut)));
+            let detail = match entry.colon.as_deref() {
+                Some(colon) if shortcut_width > 0 => {
+                    format!("{shortcut}{shortcut_padding}  {colon}")
+                }
+                Some(colon) => colon.to_string(),
+                None => shortcut,
+            };
+
+            PickerItem {
+                id: entry.id.clone(),
+                label: entry.title.clone(),
+                kind: Some("Command".to_string()),
+                annotation: Some(format!("{category}{category_padding}")),
+                detail: (!detail.is_empty()).then_some(detail),
+                data: json!({
+                    "description": entry.description,
+                    "aliases": entry.aliases,
+                    "shortcuts": entry.shortcuts,
+                    "colon": entry.colon,
+                }),
+                matches: Vec::new(),
+                detail_matches: Vec::new(),
+                preview: None,
+            }
+        })
+        .collect()
+}
+
+/// Scores one command row against a tokenized query without searching descriptions.
+pub(crate) fn filter_score(item: &PickerItem, query: &str) -> Option<i64> {
+    let matcher = SkimMatcherV2::default();
+    let category = item.annotation.as_deref().unwrap_or_default().trim_end();
+    let colon = item
+        .data
+        .get("colon")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let aliases = item
+        .data
+        .get("aliases")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+    let shortcuts = item
+        .data
+        .get("shortcuts")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+
+    query.split_whitespace().try_fold(0, |total, token| {
+        let shortcut_query = token.eq_ignore_ascii_case("space")
+            || token.starts_with("Ctrl-")
+            || token.starts_with("Alt-")
+            || token.starts_with("Shift-");
+        let score = if token.starts_with(':') {
+            field_score(&matcher, colon, token, 5000)
+        } else if shortcut_query {
+            shortcuts
+                .iter()
+                .filter_map(|shortcut| field_score(&matcher, shortcut, token, 4500))
+                .max()
+        } else {
+            field_score(&matcher, &item.label, token, 5000)
+                .into_iter()
+                .chain(field_score(&matcher, category, token, 4500))
+                .chain(field_score(&matcher, colon, token, 4000))
+                .chain(
+                    aliases
+                        .iter()
+                        .filter_map(|alias| field_score(&matcher, alias, token, 3500)),
+                )
+                .chain(
+                    shortcuts
+                        .iter()
+                        .filter_map(|shortcut| field_score(&matcher, shortcut, token, 2500)),
+                )
+                .max()
+        }?;
+        Some(total + score)
+    })
+}
+
+fn field_score(matcher: &SkimMatcherV2, field: &str, token: &str, weight: i64) -> Option<i64> {
+    if field.is_empty() {
+        return None;
+    }
+    let field_lower = field.to_ascii_lowercase();
+    let token_lower = token.to_ascii_lowercase();
+    let contains = field_lower.contains(&token_lower);
+    if token.chars().count() <= 3 && token.chars().all(char::is_alphanumeric) && !contains {
+        return None;
+    }
+    let exact_bonus = if field.eq_ignore_ascii_case(token) {
+        3000
+    } else if field_lower.starts_with(&token_lower) {
+        1500
+    } else if contains {
+        750
+    } else {
+        0
+    };
+    matcher
+        .fuzzy_match(field, token)
+        .map(|score| weight + exact_bonus + score)
+}
+
+fn primary_shortcut(shortcuts: &[String]) -> String {
+    let Some(first) = shortcuts.first() else {
+        return String::new();
+    };
+    if shortcuts.len() == 1 {
+        first.clone()
+    } else {
+        format!("{first} +{}", shortcuts.len() - 1)
+    }
+}
+
+/// Returns the immediate continuations for an active keymap prefix.
+pub(crate) fn keymap_hints(
+    prefix: &[String],
+    mappings: &HashMap<String, KeyAction>,
+) -> Vec<KeymapHint> {
+    let mut hints = mappings
+        .iter()
+        .filter_map(|(key, action)| {
+            let is_group = matches!(action, KeyAction::Nested(_));
+            let label = if is_group {
+                group_label(prefix, key)
+            } else {
+                key_action_label(action)?
+            };
+            Some(KeymapHint {
+                key: display_key(key).to_string(),
+                label,
+                is_group,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    hints.sort_unstable_by(|left, right| {
+        left.is_group
+            .cmp(&right.is_group)
+            .then_with(|| left.key.to_lowercase().cmp(&right.key.to_lowercase()))
+            .then_with(|| left.key.cmp(&right.key))
+    });
+    hints
+}
+
+fn builtin_commands() -> Vec<BuiltinCommand> {
+    vec![
+        builtin(
+            "editor.command_palette",
+            "All commands",
+            "Editor",
+            "Search available commands and keymaps",
+            Some(":commands"),
+            &[":command-palette"],
+            Action::CommandPalette,
+        ),
+        builtin(
+            "file.save",
+            "Save file",
+            "File",
+            "Write the current buffer",
+            Some(":w"),
+            &[":write"],
+            Action::Save,
+        ),
+        builtin(
+            "file.save_and_quit",
+            "Save and quit",
+            "File",
+            "Write the current buffer and quit",
+            Some(":wq"),
+            &[],
+            Action::Command("wq".to_string()),
+        ),
+        builtin(
+            "file.quit",
+            "Quit",
+            "File",
+            "Quit when all buffers are saved",
+            Some(":q"),
+            &[":quit"],
+            Action::Quit(false),
+        ),
+        builtin(
+            "file.force_quit",
+            "Force quit",
+            "File",
+            "Quit and discard unsaved changes",
+            Some(":q!"),
+            &[":quit!"],
+            Action::Quit(true),
+        ),
+        builtin(
+            "file.reload",
+            "Reload file",
+            "File",
+            "Reload the current file from disk",
+            Some(":e!"),
+            &[":edit!"],
+            Action::ReloadFile(true),
+        ),
+        builtin(
+            "file.picker",
+            "Find file",
+            "File",
+            "Open the file picker",
+            None,
+            &["file picker", "open file"],
+            Action::FilePicker,
+        ),
+        builtin(
+            "buffer.next",
+            "Next buffer",
+            "Buffer",
+            "Switch to the next buffer",
+            Some(":bn"),
+            &[":buffer-next"],
+            Action::NextBuffer,
+        ),
+        builtin(
+            "buffer.previous",
+            "Previous buffer",
+            "Buffer",
+            "Switch to the previous buffer",
+            Some(":bp"),
+            &[":buffer-prev"],
+            Action::PreviousBuffer,
+        ),
+        builtin(
+            "buffer.delete",
+            "Delete buffer",
+            "Buffer",
+            "Close the current buffer",
+            Some(":bd"),
+            &[":bdelete", ":buffer-delete"],
+            Action::DeleteBuffer(false),
+        ),
+        builtin(
+            "edit.undo",
+            "Undo",
+            "Edit",
+            "Undo the last edit",
+            None,
+            &["revert"],
+            Action::Undo,
+        ),
+        builtin(
+            "edit.redo",
+            "Redo",
+            "Edit",
+            "Redo the last undone edit",
+            None,
+            &[],
+            Action::Redo,
+        ),
+        builtin(
+            "edit.repeat",
+            "Repeat last change",
+            "Edit",
+            "Repeat the last semantic edit",
+            None,
+            &["dot repeat"],
+            Action::RepeatLastChange,
+        ),
+        builtin(
+            "edit.join",
+            "Join lines",
+            "Edit",
+            "Join the current and next line",
+            Some(":join"),
+            &[":j"],
+            Action::JoinLines(2),
+        ),
+        builtin(
+            "edit.join_keep_spaces",
+            "Join lines without trimming",
+            "Edit",
+            "Join lines and preserve whitespace",
+            Some(":join!"),
+            &[":j!"],
+            Action::JoinLinesKeepSpaces(2),
+        ),
+        builtin(
+            "search.forward",
+            "Search forward",
+            "Search",
+            "Search toward the end of the buffer",
+            None,
+            &["find next"],
+            Action::EnterSearch(SearchDirection::Forward),
+        ),
+        builtin(
+            "search.backward",
+            "Search backward",
+            "Search",
+            "Search toward the start of the buffer",
+            None,
+            &["find previous"],
+            Action::EnterSearch(SearchDirection::Backward),
+        ),
+        builtin(
+            "search.clear",
+            "Clear search highlights",
+            "Search",
+            "Remove visible search highlights",
+            Some(":noh"),
+            &[":nohlsearch"],
+            Action::ClearSearchHighlight,
+        ),
+        builtin(
+            "view.toggle_wrap",
+            "Toggle line wrapping",
+            "View",
+            "Toggle wrapping for long lines",
+            None,
+            &["wrap", "nowrap"],
+            Action::ToggleWrap,
+        ),
+        builtin(
+            "view.enable_wrap",
+            "Enable line wrapping",
+            "View",
+            "Wrap long lines at the window edge",
+            Some(":wrap"),
+            &[],
+            Action::SetWrap(true),
+        ),
+        builtin(
+            "view.disable_wrap",
+            "Disable line wrapping",
+            "View",
+            "Scroll horizontally instead of wrapping",
+            Some(":nowrap"),
+            &[],
+            Action::SetWrap(false),
+        ),
+        builtin(
+            "window.split_horizontal",
+            "Split horizontally",
+            "Window",
+            "Create a horizontal split",
+            Some(":sp"),
+            &[":split"],
+            Action::SplitHorizontal,
+        ),
+        builtin(
+            "window.split_vertical",
+            "Split vertically",
+            "Window",
+            "Create a vertical split",
+            Some(":vs"),
+            &[":vsplit"],
+            Action::SplitVertical,
+        ),
+        builtin(
+            "window.close",
+            "Close window",
+            "Window",
+            "Close the active split",
+            Some(":close"),
+            &[],
+            Action::CloseWindow,
+        ),
+        builtin(
+            "window.only",
+            "Keep only current window",
+            "Window",
+            "Close every other split",
+            Some(":only"),
+            &[],
+            Action::OnlyWindow,
+        ),
+        builtin(
+            "window.next",
+            "Next window",
+            "Window",
+            "Focus the next split",
+            None,
+            &[],
+            Action::NextWindow,
+        ),
+        builtin(
+            "window.previous",
+            "Previous window",
+            "Window",
+            "Focus the previous split",
+            None,
+            &[],
+            Action::PreviousWindow,
+        ),
+        builtin(
+            "window.left",
+            "Focus window left",
+            "Window",
+            "Move focus to the split on the left",
+            None,
+            &[],
+            Action::MoveWindowLeft,
+        ),
+        builtin(
+            "window.down",
+            "Focus window below",
+            "Window",
+            "Move focus to the split below",
+            None,
+            &[],
+            Action::MoveWindowDown,
+        ),
+        builtin(
+            "window.up",
+            "Focus window above",
+            "Window",
+            "Move focus to the split above",
+            None,
+            &[],
+            Action::MoveWindowUp,
+        ),
+        builtin(
+            "window.right",
+            "Focus window right",
+            "Window",
+            "Move focus to the split on the right",
+            None,
+            &[],
+            Action::MoveWindowRight,
+        ),
+        builtin(
+            "window.balance",
+            "Balance windows",
+            "Window",
+            "Give all splits equal space",
+            None,
+            &[],
+            Action::BalanceWindows,
+        ),
+        builtin(
+            "window.maximize",
+            "Maximize window",
+            "Window",
+            "Maximize the active split",
+            None,
+            &[],
+            Action::MaximizeWindow,
+        ),
+        builtin(
+            "lsp.definition",
+            "Go to definition",
+            "LSP",
+            "Jump to the symbol definition",
+            None,
+            &["definition"],
+            Action::GoToDefinition,
+        ),
+        builtin(
+            "lsp.hover",
+            "Show hover documentation",
+            "LSP",
+            "Show documentation for the symbol under the cursor",
+            None,
+            &["hover"],
+            Action::Hover,
+        ),
+        builtin(
+            "lsp.format",
+            "Format document",
+            "LSP",
+            "Format the current document",
+            None,
+            &["formatter"],
+            Action::FormatDocument,
+        ),
+        builtin(
+            "lsp.code_action",
+            "Show code actions",
+            "LSP",
+            "Show applicable fixes and refactors",
+            None,
+            &["quick fix", "refactor"],
+            Action::CodeAction,
+        ),
+        builtin(
+            "lsp.rename",
+            "Rename symbol",
+            "LSP",
+            "Rename the symbol under the cursor",
+            None,
+            &["rename"],
+            Action::StartRename,
+        ),
+        builtin(
+            "lsp.signature",
+            "Show signature help",
+            "LSP",
+            "Show the active call signature",
+            None,
+            &["signature"],
+            Action::SignatureHelp,
+        ),
+        builtin(
+            "debug.buffer",
+            "Dump buffer",
+            "Debug",
+            "Show the current buffer state",
+            Some(":db"),
+            &[],
+            Action::DumpBuffer,
+        ),
+        builtin(
+            "debug.history",
+            "Dump history",
+            "Debug",
+            "Show editor action history",
+            Some(":dh"),
+            &[],
+            Action::DumpHistory,
+        ),
+        builtin(
+            "debug.diagnostics",
+            "Dump diagnostics",
+            "Debug",
+            "Show language-server diagnostics",
+            Some(":di"),
+            &[],
+            Action::DumpDiagnostics,
+        ),
+        builtin(
+            "debug.capabilities",
+            "Dump LSP capabilities",
+            "Debug",
+            "Show language-server capabilities",
+            Some(":dc"),
+            &[],
+            Action::DumpCapabilities,
+        ),
+        builtin(
+            "debug.timers",
+            "Dump plugin timers",
+            "Debug",
+            "Show plugin timer statistics",
+            Some(":dt"),
+            &[],
+            Action::DumpTimers,
+        ),
+        builtin(
+            "debug.logs",
+            "View logs",
+            "Debug",
+            "Open the editor log",
+            None,
+            &["log file"],
+            Action::ViewLogs,
+        ),
+        builtin(
+            "debug.plugins",
+            "List plugins",
+            "Debug",
+            "Show loaded plugin information",
+            None,
+            &["plugin list"],
+            Action::ListPlugins,
+        ),
+        builtin(
+            "debug.registers",
+            "Show registers",
+            "Debug",
+            "Show register contents",
+            Some(":registers"),
+            &[],
+            Action::PrintRegisters,
+        ),
+    ]
+}
+
+fn builtin(
+    id: &'static str,
+    title: &'static str,
+    category: &'static str,
+    description: &'static str,
+    colon: Option<&'static str>,
+    aliases: &'static [&'static str],
+    action: Action,
+) -> BuiltinCommand {
+    BuiltinCommand {
+        id,
+        title,
+        category,
+        description,
+        colon,
+        aliases,
+        action,
+    }
+}
+
+fn shortcuts_for_action(keys: &Keys, target: &Action) -> Vec<String> {
+    let tables = [
+        ("Normal", &keys.normal),
+        ("Insert", &keys.insert),
+        ("Visual", &keys.visual),
+        ("Visual line", &keys.visual_line),
+        ("Visual block", &keys.visual_block),
+        ("Command", &keys.command),
+    ];
+    let mut shortcuts = Vec::new();
+    for (mode, mappings) in tables {
+        let mut paths = Vec::new();
+        collect_shortcuts(mappings, target, &mut Vec::new(), &mut paths);
+        paths.sort_unstable_by_key(|path| (path.len(), path.join(" ")));
+        shortcuts.extend(paths.into_iter().map(|path| {
+            let sequence = path.join(" ");
+            if mode == "Normal" {
+                sequence
+            } else {
+                format!("{mode}: {sequence}")
+            }
+        }));
+    }
+    shortcuts
+}
+
+fn collect_shortcuts(
+    mappings: &HashMap<String, KeyAction>,
+    target: &Action,
+    prefix: &mut Vec<String>,
+    output: &mut Vec<Vec<String>>,
+) {
+    for (key, action) in mappings {
+        prefix.push(display_key(key).to_string());
+        match action {
+            KeyAction::Single(action) if action == target => output.push(prefix.clone()),
+            KeyAction::Multiple(actions)
+                if actions.len() == 1 && actions.first().is_some_and(|action| action == target) =>
+            {
+                output.push(prefix.clone());
+            }
+            KeyAction::Nested(mappings) => collect_shortcuts(mappings, target, prefix, output),
+            KeyAction::Repeating(_, action) if key_action_is(action, target) => {
+                output.push(prefix.clone());
+            }
+            KeyAction::None
+            | KeyAction::Single(_)
+            | KeyAction::Multiple(_)
+            | KeyAction::Repeating(_, _) => {}
+        }
+        prefix.pop();
+    }
+}
+
+fn key_action_is(action: &KeyAction, target: &Action) -> bool {
+    matches!(action, KeyAction::Single(action) if action == target)
+        || matches!(
+            action,
+            KeyAction::Multiple(actions)
+                if actions.len() == 1 && actions.first().is_some_and(|action| action == target)
+        )
+}
+
+fn key_action_label(action: &KeyAction) -> Option<String> {
+    match action {
+        KeyAction::None => None,
+        KeyAction::Single(action) => Some(action_label(action)),
+        KeyAction::Multiple(actions)
+            if matches!(
+                actions.as_slice(),
+                [
+                    Action::MoveToTop,
+                    Action::EnterMode(Mode::VisualLine),
+                    Action::MoveToBottom
+                ]
+            ) =>
+        {
+            Some("Select all".to_string())
+        }
+        KeyAction::Multiple(actions) => Some(
+            actions
+                .iter()
+                .map(action_label)
+                .collect::<Vec<_>>()
+                .join(" then "),
+        ),
+        KeyAction::Nested(_) => Some("More keymaps".to_string()),
+        KeyAction::Repeating(_, action) => key_action_label(action),
+    }
+}
+
+fn action_label(action: &Action) -> String {
+    match action {
+        Action::CommandPalette => "All commands".to_string(),
+        Action::PluginCommand(name) => humanize_identifier(name),
+        Action::Save => "Save file".to_string(),
+        Action::Quit(_) => "Quit".to_string(),
+        Action::Undo => "Undo".to_string(),
+        Action::Redo => "Redo".to_string(),
+        Action::RepeatLastChange => "Repeat last change".to_string(),
+        Action::NextBuffer => "Next buffer".to_string(),
+        Action::PreviousBuffer => "Previous buffer".to_string(),
+        Action::FilePicker => "Find file".to_string(),
+        Action::GoToDefinition => "Go to definition".to_string(),
+        Action::FormatDocument => "Format document".to_string(),
+        Action::CodeAction => "Show code actions".to_string(),
+        Action::StartRename => "Rename symbol".to_string(),
+        Action::Hover => "Show hover documentation".to_string(),
+        Action::SignatureHelp => "Show signature help".to_string(),
+        Action::ClearSearchHighlight => "Clear search highlights".to_string(),
+        Action::ToggleWrap => "Toggle line wrapping".to_string(),
+        Action::SplitHorizontal => "Split horizontally".to_string(),
+        Action::SplitVertical => "Split vertically".to_string(),
+        Action::CloseWindow => "Close window".to_string(),
+        Action::OnlyWindow => "Keep only current window".to_string(),
+        Action::BalanceWindows => "Balance windows".to_string(),
+        Action::MaximizeWindow => "Maximize window".to_string(),
+        Action::NextWindow => "Next window".to_string(),
+        Action::PreviousWindow => "Previous window".to_string(),
+        Action::MoveWindowLeft => "Focus window left".to_string(),
+        Action::MoveWindowDown => "Focus window below".to_string(),
+        Action::MoveWindowUp => "Focus window above".to_string(),
+        Action::MoveWindowRight => "Focus window right".to_string(),
+        Action::ViewLogs => "View logs".to_string(),
+        Action::ListPlugins => "List plugins".to_string(),
+        Action::DumpBuffer => "Dump buffer".to_string(),
+        Action::DumpDiagnostics => "Dump diagnostics".to_string(),
+        Action::DumpCapabilities => "Dump LSP capabilities".to_string(),
+        Action::DumpHistory => "Dump history".to_string(),
+        _ => humanize_identifier(&action_variant_name(action)),
+    }
+}
+
+fn action_variant_name(action: &Action) -> String {
+    match serde_json::to_value(action).ok() {
+        Some(serde_json::Value::String(name)) => name,
+        Some(serde_json::Value::Object(value)) => value
+            .into_iter()
+            .next()
+            .map(|(name, _)| name)
+            .unwrap_or_else(|| "Action".to_string()),
+        _ => "Action".to_string(),
+    }
+}
+
+fn group_label(prefix: &[String], key: &str) -> String {
+    let prefix = prefix.join(" ");
+    match (prefix.as_str(), display_key(key)) {
+        ("Space", "h") => "Git hunks".to_string(),
+        ("Space", "c") => "Commit message".to_string(),
+        ("Space", "d") => "Debug".to_string(),
+        (_, "Ctrl-w") => "Windows".to_string(),
+        (_, "g") => "Go to".to_string(),
+        (_, "z") => "View".to_string(),
+        (_, "[") => "Previous".to_string(),
+        (_, "]") => "Next".to_string(),
+        _ => "More keymaps".to_string(),
+    }
+}
+
+fn display_key(key: &str) -> &str {
+    if key == " " {
+        "Space"
+    } else {
+        key
+    }
+}
+
+fn colon_name_is_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "commands"
+            | "command-palette"
+            | "db"
+            | "dh"
+            | "di"
+            | "dc"
+            | "dt"
+            | "registers"
+            | "undotree"
+            | "j"
+            | "join"
+    ) || command::parse(BUILTIN_COLON_COMMANDS, name).is_some()
+}
+
+fn humanize_identifier(identifier: &str) -> String {
+    let characters = identifier.chars().collect::<Vec<_>>();
+    let mut words = Vec::new();
+    let mut start = 0;
+    for index in 1..characters.len() {
+        let previous = characters[index - 1];
+        let current = characters[index];
+        let next = characters.get(index + 1).copied();
+        let boundary = current.is_ascii_uppercase()
+            && (previous.is_ascii_lowercase()
+                || next.is_some_and(|character| character.is_ascii_lowercase()));
+        if boundary {
+            words.push(characters[start..index].iter().collect::<String>());
+            start = index;
+        }
+    }
+    words.push(characters[start..].iter().collect::<String>());
+
+    words
+        .into_iter()
+        .enumerate()
+        .map(|(index, word)| match word.as_str() {
+            "Lsp" | "LSP" => "LSP".to_string(),
+            "Acp" | "ACP" => "ACP".to_string(),
+            _ if index == 0 => word,
+            _ => word.to_lowercase(),
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use husk::CommandMetadata;
+
+    use super::*;
+
+    fn default_keys() -> Keys {
+        let config: crate::config::Config =
+            toml::from_str(include_str!("../default_config.toml")).unwrap();
+        config.keys
+    }
+
+    #[test]
+    fn palette_lists_builtin_shortcuts_and_colon_aliases() {
+        let entries = entries(&default_keys(), &[]);
+
+        let format = entries
+            .iter()
+            .find(|entry| entry.id == "lsp.format")
+            .unwrap();
+        assert_eq!(format.category, "LSP");
+        assert_eq!(format.title, "Format document");
+        assert!(format
+            .shortcuts
+            .iter()
+            .any(|shortcut| shortcut == "Space f"));
+
+        let save = entries
+            .iter()
+            .find(|entry| entry.id == "file.save")
+            .unwrap();
+        assert_eq!(save.colon.as_deref(), Some(":w"));
+        assert!(save.aliases.iter().any(|alias| alias == ":write"));
+    }
+
+    #[test]
+    fn palette_uses_effective_user_keymap() {
+        let mut keys = default_keys();
+        let Some(KeyAction::Nested(leader)) = keys.normal.get_mut(" ") else {
+            panic!("expected leader keymap");
+        };
+        leader.remove("f");
+        keys.normal.insert(
+            "Ctrl-s".to_string(),
+            KeyAction::Single(Action::FormatDocument),
+        );
+
+        let entries = entries(&keys, &[]);
+        let format = entries
+            .iter()
+            .find(|entry| entry.id == "lsp.format")
+            .unwrap();
+
+        assert!(format.shortcuts.iter().any(|shortcut| shortcut == "Ctrl-s"));
+        assert!(!format
+            .shortcuts
+            .iter()
+            .any(|shortcut| shortcut == "Space f"));
+    }
+
+    #[test]
+    fn palette_lists_plugin_metadata_shortcut_and_exact_colon_command() {
+        let plugin = RegisteredPluginCommand {
+            name: "ProjectSearch".to_string(),
+            plugin: "project_search".to_string(),
+            metadata: CommandMetadata {
+                title: Some("Search project".to_string()),
+                category: Some("Search".to_string()),
+                description: Some("Find text across the workspace".to_string()),
+                aliases: vec!["ripgrep".to_string()],
+            },
+        };
+
+        let entries = entries(&default_keys(), &[plugin]);
+        let project_search = entries
+            .iter()
+            .find(|entry| entry.id == "plugin.project_search.ProjectSearch")
+            .unwrap();
+
+        assert_eq!(project_search.category, "Search");
+        assert_eq!(project_search.title, "Search project");
+        assert!(project_search
+            .shortcuts
+            .iter()
+            .any(|shortcut| shortcut == "Space g"));
+        assert_eq!(project_search.colon.as_deref(), Some(":ProjectSearch"));
+        assert!(project_search
+            .aliases
+            .iter()
+            .any(|alias| alias == "ripgrep"));
+    }
+
+    #[test]
+    fn palette_does_not_advertise_shadowed_plugin_colon_command() {
+        let plugin = RegisteredPluginCommand {
+            name: "wrap".to_string(),
+            plugin: "custom".to_string(),
+            metadata: CommandMetadata {
+                title: Some("Custom wrap".to_string()),
+                ..CommandMetadata::default()
+            },
+        };
+
+        let entries = entries(&default_keys(), &[plugin]);
+        let custom = entries
+            .iter()
+            .find(|entry| entry.id == "plugin.custom.wrap")
+            .unwrap();
+
+        assert_eq!(custom.colon, None);
+    }
+
+    #[test]
+    fn palette_items_keep_category_shortcut_colon_and_description_separate() {
+        let entries = entries(&default_keys(), &[]);
+        let items = picker_items(&entries);
+        let format = items.iter().find(|item| item.id == "lsp.format").unwrap();
+        let save = items.iter().find(|item| item.id == "file.save").unwrap();
+
+        assert_eq!(format.kind.as_deref(), Some("Command"));
+        assert_eq!(format.label, "Format document");
+        assert_eq!(format.annotation.as_deref().map(str::trim), Some("LSP"));
+        assert!(format
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("Space f")));
+        assert_eq!(
+            format.data["description"].as_str(),
+            Some("Format the current document")
+        );
+        assert_eq!(save.data["colon"].as_str(), Some(":w"));
+        assert!(save
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains(":w")));
+    }
+
+    #[test]
+    fn palette_filter_matches_command_fields_without_matching_description_noise() {
+        let plugins = [
+            RegisteredPluginCommand {
+                name: "GitDashboard".to_string(),
+                plugin: "git".to_string(),
+                metadata: CommandMetadata {
+                    title: Some("Open Git dashboard".to_string()),
+                    category: Some("Git".to_string()),
+                    description: Some("Inspect and manage workspace changes".to_string()),
+                    aliases: vec!["source control".to_string()],
+                },
+            },
+            RegisteredPluginCommand {
+                name: "Unrelated".to_string(),
+                plugin: "other".to_string(),
+                metadata: CommandMetadata {
+                    title: Some("Go to definition".to_string()),
+                    category: Some("Other".to_string()),
+                    description: Some("Get information together".to_string()),
+                    aliases: vec![],
+                },
+            },
+        ];
+        let items = picker_items(&entries(&default_keys(), &plugins));
+        let git = items
+            .iter()
+            .find(|item| item.id == "plugin.git.GitDashboard")
+            .unwrap();
+        let unrelated = items
+            .iter()
+            .find(|item| item.id == "plugin.other.Unrelated")
+            .unwrap();
+
+        assert!(filter_score(git, "git").is_some());
+        assert_eq!(filter_score(unrelated, "git"), None);
+        assert!(filter_score(git, ":GitDash").is_some());
+        assert!(filter_score(git, "Space G").is_some());
+        assert!(filter_score(git, "source control").is_some());
+        assert!(filter_score(git, "git dashboard").is_some());
+    }
+
+    #[test]
+    fn keymap_hints_describe_leaf_commands_and_nested_groups() {
+        let keys = default_keys();
+        let Some(KeyAction::Nested(leader)) = keys.normal.get(" ") else {
+            panic!("expected leader keymap");
+        };
+
+        let hints = keymap_hints(&["Space".to_string()], leader);
+        assert!(hints
+            .iter()
+            .any(|hint| hint.key == "f" && hint.label == "Format document" && !hint.is_group));
+        assert!(hints
+            .iter()
+            .any(|hint| hint.key == "h" && hint.label == "Git hunks" && hint.is_group));
+        assert!(hints
+            .iter()
+            .any(|hint| hint.key == "a" && hint.label == "Select all"));
+    }
+
+    #[test]
+    fn humanizes_camel_case_plugin_names() {
+        assert_eq!(humanize_identifier("ProjectSearch"), "Project search");
+        assert_eq!(
+            humanize_identifier("LspWorkspaceSymbols"),
+            "LSP workspace symbols"
+        );
+        assert_eq!(humanize_identifier("GitHunkStage"), "Git hunk stage");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,8 @@ pub struct Config {
     #[serde(default)]
     pub picker: PickerConfig,
     #[serde(default)]
+    pub key_hints: KeyHintsConfig,
+    #[serde(default)]
     pub clipboard: ClipboardConfig,
     #[serde(default)]
     pub lsp: LspConfig,
@@ -74,6 +76,30 @@ pub struct AgentConfig {
 pub struct PickerConfig {
     #[serde(default)]
     pub input_position: PickerInputPosition,
+}
+
+/// Configuration for the delayed keymap-prefix guide.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub struct KeyHintsConfig {
+    /// Show available key continuations after entering a configured prefix.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Delay before the prefix guide is shown.
+    #[serde(default = "default_key_hint_delay_ms")]
+    pub delay_ms: u64,
+}
+
+impl Default for KeyHintsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            delay_ms: default_key_hint_delay_ms(),
+        }
+    }
+}
+
+fn default_key_hint_delay_ms() -> u64 {
+    250
 }
 
 impl Default for PickerConfig {
@@ -1191,6 +1217,46 @@ groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
             config.keys.insert.get("Ctrl-k"),
             Some(&KeyAction::Single(Action::SignatureHelp))
         );
+    }
+
+    #[test]
+    fn default_config_maps_command_palette_entrypoints_and_enables_key_hints() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.keys.normal.get("F1"),
+            Some(&KeyAction::Single(Action::CommandPalette))
+        );
+        assert_eq!(
+            config.keys.normal.get("Ctrl-Shift-p"),
+            Some(&KeyAction::Single(Action::CommandPalette))
+        );
+        assert_eq!(
+            config.keys.normal.get("Alt-x"),
+            Some(&KeyAction::Single(Action::CommandPalette))
+        );
+        let Some(KeyAction::Nested(leader)) = config.keys.normal.get(" ") else {
+            panic!("expected a Space leader mapping");
+        };
+        assert_eq!(
+            leader.get("?"),
+            Some(&KeyAction::Single(Action::CommandPalette))
+        );
+        assert_eq!(config.key_hints, KeyHintsConfig::default());
+        assert!(config.key_hints.enabled);
+        assert_eq!(config.key_hints.delay_ms, 250);
+    }
+
+    #[test]
+    fn user_config_can_disable_or_delay_key_hints() {
+        let config = Config::from_user_toml_with_overrides(
+            "[key_hints]\nenabled = false\ndelay_ms = 750\n",
+            &[],
+        )
+        .unwrap();
+
+        assert!(!config.key_hints.enabled);
+        assert_eq!(config.key_hints.delay_ms, 750);
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -61,7 +61,7 @@ use crate::{
     buffer::{Buffer, BufferId, SearchMatch},
     clipboard::{ClipboardProvider, DisabledClipboardProvider, NativeClipboardProvider},
     color::Color,
-    command,
+    command, command_palette,
     config::{Config, KeyAction},
     dispatcher::Dispatcher,
     highlighter::Highlighter,
@@ -1033,6 +1033,7 @@ pub enum Action {
     PreviousBuffer,
     DeleteBuffer(bool),
     FilePicker,
+    CommandPalette,
     ShowDialog,
     CloseDialog,
     SetAgentApiKey(String),
@@ -1513,6 +1514,15 @@ pub struct Editor {
     /// Next key action to process
     waiting_key_action: Option<KeyAction>,
 
+    /// Fully entered configured-keymap prefix, such as `Space h`.
+    keymap_hint_prefix: Vec<String>,
+
+    /// Time at which the delayed prefix guide becomes visible.
+    keymap_hint_deadline: Option<Instant>,
+
+    /// Whether the delayed prefix guide is currently visible.
+    keymap_hints_visible: bool,
+
     /// Actions that are pending while in visual mode
     pending_select_action: Option<ActionOnSelection>,
 
@@ -1964,6 +1974,7 @@ fn detached_input_to_crossterm(event: crate::headless::InputEvent) -> Event {
                 crate::headless::KeyCode::Escape => KeyCode::Esc,
                 crate::headless::KeyCode::Tab => KeyCode::Tab,
                 crate::headless::KeyCode::BackTab => KeyCode::BackTab,
+                crate::headless::KeyCode::Function(number) => KeyCode::F(number),
                 crate::headless::KeyCode::Delete => KeyCode::Delete,
                 crate::headless::KeyCode::Left => KeyCode::Left,
                 crate::headless::KeyCode::Right => KeyCode::Right,
@@ -2500,6 +2511,9 @@ impl Editor {
             insert_entry_cursor: None,
             waiting_command: None,
             waiting_key_action: None,
+            keymap_hint_prefix: Vec::new(),
+            keymap_hint_deadline: None,
+            keymap_hints_visible: false,
             pending_select_action: None,
             pending_visual_text_object_scope: None,
             pending_operator: None,
@@ -4679,7 +4693,12 @@ impl Editor {
             .execute(event::EnableMouseCapture)?
             .execute(event::EnableFocusChange)?
             .execute(event::EnableBracketedPaste)?
-            .execute(terminal::EnterAlternateScreen)?
+            .execute(terminal::EnterAlternateScreen)?;
+        #[cfg(unix)]
+        self.stdout.execute(event::PushKeyboardEnhancementFlags(
+            event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+        ))?;
+        self.stdout
             .execute(terminal::Clear(terminal::ClearType::All))?;
 
         let mut runtime;
@@ -4943,7 +4962,14 @@ impl Editor {
         } else {
             false
         };
-        if dialog_changed {
+        let keymap_hints_changed = self
+            .keymap_hint_deadline
+            .is_some_and(|deadline| Instant::now() >= deadline);
+        if keymap_hints_changed {
+            self.keymap_hint_deadline = None;
+            self.keymap_hints_visible = true;
+        }
+        if dialog_changed || keymap_hints_changed {
             self.render(buffer)?;
         }
 
@@ -6939,15 +6965,15 @@ impl Editor {
                     "Nested key action detected, actions count: {}",
                     actions.len()
                 );
-                if let Event::Key(KeyEvent {
-                    code: KeyCode::Char(c),
-                    ..
-                }) = ev
-                {
-                    self.waiting_command = Some(format!("{c}"));
-                    log!("Setting waiting command: {}", c);
+                if let Some(key) = Self::key_string_for_event(ev) {
+                    self.keymap_hint_prefix.push(key);
+                    self.waiting_command = Some(self.keymap_hint_prefix.join(" "));
                 }
                 self.waiting_key_action = Some(KeyAction::Nested(actions.clone()));
+                self.keymap_hints_visible = false;
+                self.keymap_hint_deadline = self.config.key_hints.enabled.then(|| {
+                    Instant::now() + Duration::from_millis(self.config.key_hints.delay_ms)
+                });
                 false
             }
             KeyAction::Repeating(times, action) => {
@@ -8109,6 +8135,7 @@ impl Editor {
         if matches!(ev, Event::Paste(_)) {
             self.waiting_key_action = None;
             self.waiting_command = None;
+            self.clear_keymap_hints();
             self.repeater = None;
             self.pending_operator = None;
             self.pending_character_motion = None;
@@ -8117,8 +8144,16 @@ impl Editor {
 
         if let Some(ka) = self.waiting_key_action.take() {
             self.waiting_command = None;
-            return Ok(self.handle_waiting_command(ka, ev));
+            self.keymap_hint_deadline = None;
+            self.keymap_hints_visible = false;
+            let action = self.handle_waiting_command(ka, ev);
+            if !matches!(action, Some(KeyAction::Nested(_))) {
+                self.keymap_hint_prefix.clear();
+            }
+            return Ok(action);
         }
+
+        self.clear_keymap_hints();
 
         if let Some(current_dialog) = &mut self.current_dialog {
             let action = current_dialog.handle_event(ev);
@@ -8354,13 +8389,16 @@ impl Editor {
             KeyAction::Single(
                 Action::EnterMode(Mode::Command | Mode::Search)
                 | Action::PluginCommand(_)
+                | Action::CommandPalette
                 | Action::NextWindow
                 | Action::PreviousWindow,
             ) => true,
             KeyAction::Multiple(actions) => actions.iter().any(|action| {
                 matches!(
                     action,
-                    Action::EnterMode(Mode::Command | Mode::Search) | Action::PluginCommand(_)
+                    Action::EnterMode(Mode::Command | Mode::Search)
+                        | Action::PluginCommand(_)
+                        | Action::CommandPalette
                 )
             }),
             _ => false,
@@ -8375,17 +8413,44 @@ impl Editor {
             return None;
         };
 
+        let has_modifier = modifiers.intersects(
+            KeyModifiers::CONTROL
+                | KeyModifiers::ALT
+                | KeyModifiers::SUPER
+                | KeyModifiers::HYPER
+                | KeyModifiers::META,
+        );
         let key = match code {
             KeyCode::Char(' ') => "Space".to_string(),
-            KeyCode::Char(c) => format!("{c}"),
+            KeyCode::Char(c) if has_modifier => c.to_ascii_lowercase().to_string(),
+            KeyCode::Char(c) => c.to_string(),
+            KeyCode::F(number) => format!("F{number}"),
             _ => format!("{code:?}"),
         };
 
-        Some(match *modifiers {
-            KeyModifiers::CONTROL => format!("Ctrl-{key}"),
-            KeyModifiers::ALT => format!("Alt-{key}"),
-            _ => key,
-        })
+        let mut parts = Vec::new();
+        if modifiers.contains(KeyModifiers::CONTROL) {
+            parts.push("Ctrl");
+        }
+        if modifiers.contains(KeyModifiers::ALT) {
+            parts.push("Alt");
+        }
+        if modifiers.contains(KeyModifiers::SUPER) {
+            parts.push("Super");
+        }
+        if modifiers.contains(KeyModifiers::HYPER) {
+            parts.push("Hyper");
+        }
+        if modifiers.contains(KeyModifiers::META) {
+            parts.push("Meta");
+        }
+        if modifiers.contains(KeyModifiers::SHIFT)
+            && (has_modifier || !matches!(code, KeyCode::Char(_)))
+        {
+            parts.push("Shift");
+        }
+        parts.push(&key);
+        Some(parts.join("-"))
     }
 
     fn poll_directory_watchers(&mut self) -> Vec<(i32, Value)> {
@@ -8528,6 +8593,10 @@ impl Editor {
             }
         }
 
+        if matches!(cmd, "commands" | "command-palette") {
+            return vec![Action::CommandPalette];
+        }
+
         // Handle debug commands first (these don't go through normal command parsing)
         match cmd {
             "db" => return vec![Action::DumpBuffer],
@@ -8602,28 +8671,7 @@ impl Editor {
             }];
         }
 
-        let commands = &[
-            "$",
-            "quit",
-            "write",
-            "buffer-next",
-            "buffer-prev",
-            "bd",
-            "bdelete",
-            "buffer-delete",
-            "edit",
-            "split",
-            "sp",
-            "vsplit",
-            "vs",
-            "close",
-            "only",
-            "noh",
-            "nohlsearch",
-            "wrap",
-            "nowrap",
-        ];
-        let parsed = command::parse(commands, cmd);
+        let parsed = command::parse(command_palette::BUILTIN_COLON_COMMANDS, cmd);
 
         let Some(parsed) = parsed else {
             if runtime.command_plugin(cmd).is_some() {
@@ -9551,6 +9599,12 @@ impl Editor {
         };
 
         self.event_to_key_action(&nested_mappings, ev)
+    }
+
+    fn clear_keymap_hints(&mut self) {
+        self.keymap_hint_prefix.clear();
+        self.keymap_hint_deadline = None;
+        self.keymap_hints_visible = false;
     }
 
     fn handle_insert_event(&mut self, ev: &event::Event) -> anyhow::Result<Option<KeyAction>> {
@@ -10823,6 +10877,8 @@ impl Editor {
 
     pub fn cleanup(&mut self) -> anyhow::Result<()> {
         write!(self.stdout, "\x1b]112\x1b\\")?;
+        #[cfg(unix)]
+        self.stdout.execute(event::PopKeyboardEnhancementFlags)?;
         self.stdout
             .execute(terminal::LeaveAlternateScreen)?
             .execute(event::DisableBracketedPaste)?
@@ -13163,6 +13219,29 @@ impl Editor {
                 self.current_dialog =
                     Some(Box::new(FilePicker::new(self, std::env::current_dir()?)?));
             }
+            Action::CommandPalette => {
+                let entries =
+                    command_palette::entries(&self.config.keys, &runtime.registered_commands());
+                let actions = entries
+                    .iter()
+                    .map(|entry| (entry.id.clone(), entry.action.clone()))
+                    .collect::<HashMap<_, _>>();
+                let items = command_palette::picker_items(&entries);
+                let picker = Picker::builder()
+                    .title("Commands")
+                    .structured_items(items)
+                    .filter_action(command_palette::filter_score)
+                    .placeholder("Type a command, keymap, or :command")
+                    .history_key("command-palette")
+                    .select_action(move |item| {
+                        actions.get(&item).cloned().unwrap_or_else(|| {
+                            Action::Print("command is no longer available".to_string())
+                        })
+                    })
+                    .build(self);
+                self.current_dialog = Some(Box::new(picker));
+                self.render(buffer)?;
+            }
             Action::ShowDialog => {
                 self.render(buffer)?;
             }
@@ -13281,6 +13360,9 @@ impl Editor {
                         .execute(event::EnableFocusChange)?
                         .execute(event::EnableBracketedPaste)?
                         .execute(terminal::EnterAlternateScreen)?
+                        .execute(event::PushKeyboardEnhancementFlags(
+                            event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+                        ))?
                         .execute(terminal::Clear(terminal::ClearType::All))?;
                     self.invalidate_terminal_render_state(buffer);
                     self.render(buffer)?;
@@ -15138,25 +15220,19 @@ impl Editor {
             event::Event::Key(KeyEvent {
                 code, modifiers, ..
             }) => {
-                let key = match code {
-                    KeyCode::Char(' ') if *modifiers == KeyModifiers::NONE => " ".to_string(),
-                    KeyCode::Char(' ') => "Space".to_string(),
-                    KeyCode::Char(c) => format!("{c}"),
-                    _ => format!("{code:?}"),
-                };
-
-                let key = match *modifiers {
-                    KeyModifiers::CONTROL => format!("Ctrl-{key}"),
-                    KeyModifiers::ALT => format!("Alt-{key}"),
-                    _ => key,
-                };
+                let key = Self::key_string_for_event(ev)?;
 
                 mappings
                     .get(&key)
                     .cloned()
                     .or_else(|| {
                         (matches!(code, KeyCode::Char(' ')) && *modifiers == KeyModifiers::NONE)
-                            .then(|| mappings.get("Space").cloned())
+                            .then(|| {
+                                mappings
+                                    .get(" ")
+                                    .cloned()
+                                    .or_else(|| mappings.get("Space").cloned())
+                            })
                             .flatten()
                     })
                     .or_else(|| {
@@ -19196,6 +19272,196 @@ mod test {
             editor.last_error.as_deref(),
             Some("plugin shadowed built-in")
         );
+    }
+
+    #[tokio::test]
+    async fn command_palette_searches_and_runs_a_registered_plugin_command() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let mut editor = test_editor(/*width*/ 140, /*height*/ 16);
+        editor.config.keys = toml::from_str::<Config>(include_str!("../default_config.toml"))
+            .unwrap()
+            .keys;
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 140, /*height*/ 16, &Style::default());
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin(
+                "project_search",
+                r#"
+                    pub fn activate() {
+                        red::add_command("ProjectSearch", search, Json {
+                            title: "Search project",
+                            category: "Search",
+                            description: "Find text across the workspace",
+                            aliases: ["ripgrep"],
+                        });
+                    }
+
+                    fn search() {
+                        red::execute("Print", "project search ran");
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert!(editor.current_dialog.is_some());
+
+        editor
+            .process_editor_event(
+                Event::Paste("ripgrep".to_string()),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        let frame = render_text_rows(&buffer).join("\n");
+        assert!(frame.contains("Commands"));
+        assert!(frame.contains("Search"));
+        assert!(frame.contains("Search project"));
+        assert!(frame.contains("Space g"));
+        assert!(frame.contains(":ProjectSearch"));
+        assert!(frame.contains("Find text across the workspace"));
+        assert!(frame.contains("1/"));
+        assert!(!frame.contains("ripgrep)"));
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        editor
+            .service_background(&mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(editor.current_dialog.is_none());
+        assert_eq!(editor.last_error.as_deref(), Some("project search ran"));
+    }
+
+    #[tokio::test]
+    async fn command_palette_opens_from_leader_and_colon_entrypoints() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 14);
+        editor.config.keys = toml::from_str::<Config>(include_str!("../default_config.toml"))
+            .unwrap()
+            .keys;
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 14, &Style::default());
+        let mut runtime = Runtime::new();
+
+        for key in [' ', '?'] {
+            editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)),
+                    &mut buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+        assert!(editor.current_dialog.is_some());
+        assert!(render_text_rows(&buffer).join("\n").contains("Commands"));
+        assert!(editor.keymap_hint_prefix.is_empty());
+        assert!(!editor.keymap_hints_visible);
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert!(editor.current_dialog.is_none());
+
+        enter_colon_command(&mut editor, &mut buffer, &mut runtime, "commands").await;
+
+        assert!(editor.current_dialog.is_some());
+        assert!(render_text_rows(&buffer).join("\n").contains("Commands"));
+    }
+
+    #[tokio::test]
+    async fn command_palette_opens_from_combined_modifier_alt_and_quick_open_entrypoints() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 14);
+        editor.config.keys = toml::from_str::<Config>(include_str!("../default_config.toml"))
+            .unwrap()
+            .keys;
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 14, &Style::default());
+        let mut runtime = Runtime::new();
+
+        for event in [
+            KeyEvent::new(
+                KeyCode::Char('P'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            ),
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::ALT),
+        ] {
+            editor
+                .process_editor_event(
+                    Event::Key(event),
+                    &mut buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+            assert!(editor.current_dialog.is_some());
+            assert!(render_text_rows(&buffer).join("\n").contains("Commands"));
+            editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+                    &mut buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert!(editor.current_dialog.is_some());
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('>'), KeyModifiers::SHIFT)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert!(editor.current_dialog.is_some());
+        assert!(render_text_rows(&buffer).join("\n").contains("Commands"));
     }
 
     #[tokio::test]
@@ -24820,6 +25086,161 @@ while True:
             .unwrap();
 
         assert!(!processed.drain_repeated_motion);
+    }
+
+    #[test]
+    fn editor_key_normalization_preserves_combined_modifiers_and_shifted_text() {
+        assert_eq!(
+            Editor::key_string_for_event(&Event::Key(KeyEvent::new(
+                KeyCode::Char('P'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            )))
+            .as_deref(),
+            Some("Ctrl-Shift-p")
+        );
+        assert_eq!(
+            Editor::key_string_for_event(&Event::Key(KeyEvent::new(
+                KeyCode::Char('X'),
+                KeyModifiers::ALT | KeyModifiers::SHIFT,
+            )))
+            .as_deref(),
+            Some("Alt-Shift-x")
+        );
+        assert_eq!(
+            Editor::key_string_for_event(&Event::Key(KeyEvent::new(
+                KeyCode::Char('G'),
+                KeyModifiers::SHIFT,
+            )))
+            .as_deref(),
+            Some("G")
+        );
+        assert_eq!(
+            Editor::key_string_for_event(&Event::Key(KeyEvent::new(
+                KeyCode::F(1),
+                KeyModifiers::SHIFT,
+            )))
+            .as_deref(),
+            Some("Shift-F1")
+        );
+    }
+
+    #[tokio::test]
+    async fn delayed_keymap_hints_render_and_clear_after_a_continuation() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let mut editor = test_editor(/*width*/ 80, /*height*/ 12);
+        editor.config.keys.normal.insert(
+            "g".to_string(),
+            KeyAction::Nested(HashMap::from([(
+                "j".to_string(),
+                KeyAction::Single(Action::MoveScreenLineDown),
+            )])),
+        );
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 80, /*height*/ 12, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(editor.keymap_hint_prefix, ["g"]);
+        assert_eq!(editor.waiting_command.as_deref(), Some("g"));
+        assert!(editor.keymap_hint_deadline.is_some());
+        assert!(!editor.keymap_hints_visible);
+        assert!(!render_text_rows(&buffer).join("\n").contains("keymaps"));
+
+        editor.keymap_hint_deadline = Some(Instant::now() - Duration::from_millis(1));
+        editor
+            .service_background(&mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        let frame = render_text_rows(&buffer).join("\n");
+        assert!(editor.keymap_hints_visible);
+        assert!(frame.contains("g · keymaps"));
+        assert!(frame.contains("Move screen line down"));
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert!(editor.waiting_key_action.is_none());
+        assert!(editor.keymap_hint_prefix.is_empty());
+        assert!(!editor.keymap_hints_visible);
+        assert!(!render_text_rows(&buffer).join("\n").contains("keymaps"));
+    }
+
+    #[tokio::test]
+    async fn nested_keymap_hints_keep_the_full_prefix_and_honor_disable() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let mut editor = test_editor(/*width*/ 80, /*height*/ 12);
+        editor.config.keys.normal.insert(
+            " ".to_string(),
+            KeyAction::Nested(HashMap::from([(
+                "h".to_string(),
+                KeyAction::Nested(HashMap::from([(
+                    "s".to_string(),
+                    KeyAction::Single(Action::PluginCommand("GitHunkStage".to_string())),
+                )])),
+            )])),
+        );
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 80, /*height*/ 12, &Style::default());
+        let mut runtime = Runtime::new();
+
+        for key in [' ', 'h'] {
+            editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)),
+                    &mut buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(editor.keymap_hint_prefix, ["Space", "h"]);
+        assert_eq!(editor.waiting_command.as_deref(), Some("Space h"));
+
+        editor.keymap_hint_deadline = Some(Instant::now() - Duration::from_millis(1));
+        editor
+            .service_background(&mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        let frame = render_text_rows(&buffer).join("\n");
+        assert!(frame.contains("Space h · keymaps"));
+        assert!(frame.contains("Git hunk stage"));
+
+        editor.config.key_hints.enabled = false;
+        editor.waiting_key_action = None;
+        editor.clear_keymap_hints();
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert!(editor.keymap_hint_deadline.is_none());
+        assert!(!editor.keymap_hints_visible);
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8142,6 +8142,10 @@ impl Editor {
             self.pending_visual_text_object_scope = None;
         }
 
+        if self.waiting_key_action.is_some() && matches!(ev, Event::Mouse(_)) {
+            return Ok(None);
+        }
+
         if let Some(ka) = self.waiting_key_action.take() {
             self.waiting_command = None;
             self.keymap_hint_deadline = None;
@@ -25181,6 +25185,118 @@ while True:
         assert!(editor.keymap_hint_prefix.is_empty());
         assert!(!editor.keymap_hints_visible);
         assert!(!render_text_rows(&buffer).join("\n").contains("keymaps"));
+    }
+
+    #[tokio::test]
+    async fn mouse_events_preserve_pending_and_visible_keymap_hints() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let mut editor = test_editor(/*width*/ 80, /*height*/ 12);
+        editor.config.keys.normal.insert(
+            "g".to_string(),
+            KeyAction::Nested(HashMap::from([(
+                "j".to_string(),
+                KeyAction::Single(Action::MoveScreenLineDown),
+            )])),
+        );
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 80, /*height*/ 12, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        let deadline = editor.keymap_hint_deadline;
+        let position = (editor.cx, editor.cy, editor.vtop);
+        for kind in [
+            MouseEventKind::Moved,
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::ScrollUp,
+            MouseEventKind::ScrollDown,
+        ] {
+            editor
+                .process_editor_event(
+                    Event::Mouse(MouseEvent {
+                        kind,
+                        column: 6,
+                        row: 2,
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    &mut buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+
+            assert!(matches!(
+                editor.waiting_key_action,
+                Some(KeyAction::Nested(_))
+            ));
+            assert_eq!(editor.waiting_command.as_deref(), Some("g"));
+            assert_eq!(editor.keymap_hint_prefix, ["g"]);
+            assert_eq!(editor.keymap_hint_deadline, deadline);
+            assert_eq!((editor.cx, editor.cy, editor.vtop), position);
+        }
+
+        editor.keymap_hint_deadline = Some(Instant::now() - Duration::from_millis(1));
+        editor
+            .service_background(&mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert!(editor.keymap_hints_visible);
+        assert!(render_text_rows(&buffer).join("\n").contains("g · keymaps"));
+
+        for kind in [
+            MouseEventKind::Moved,
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::ScrollUp,
+            MouseEventKind::ScrollDown,
+        ] {
+            editor
+                .process_editor_event(
+                    Event::Mouse(MouseEvent {
+                        kind,
+                        column: 6,
+                        row: 2,
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    &mut buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+
+            assert!(matches!(
+                editor.waiting_key_action,
+                Some(KeyAction::Nested(_))
+            ));
+            assert!(editor.keymap_hints_visible);
+            assert!(render_text_rows(&buffer).join("\n").contains("g · keymaps"));
+            assert_eq!((editor.cx, editor.cy, editor.vtop), position);
+        }
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert!(editor.waiting_key_action.is_none());
+        assert!(editor.keymap_hint_prefix.is_empty());
+        assert!(!editor.keymap_hints_visible);
     }
 
     #[tokio::test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -11,7 +11,7 @@ use unicode_segmentation::UnicodeSegmentation as _;
 
 use crate::{
     color::{blend_color, Color},
-    config::CursorShape,
+    config::{CursorShape, KeyAction},
     editor::RenderCommand,
     lsp::Diagnostic,
     plugin::DecorationAnchor,
@@ -1499,6 +1499,19 @@ impl Editor {
     fn render_dialog(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         if let Some(current_dialog) = &self.current_dialog {
             current_dialog.draw(buffer)?;
+        }
+
+        if self.keymap_hints_visible {
+            if let Some(KeyAction::Nested(mappings)) = &self.waiting_key_action {
+                let hints =
+                    crate::command_palette::keymap_hints(&self.keymap_hint_prefix, mappings);
+                crate::ui::draw_keymap_hints(
+                    buffer,
+                    &self.theme,
+                    &self.keymap_hint_prefix.join(" "),
+                    &hints,
+                )?;
+            }
         }
 
         Ok(())

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -62,6 +62,7 @@ pub enum KeyCode {
     Escape,
     Tab,
     BackTab,
+    Function(u8),
     Delete,
     Left,
     Right,
@@ -354,9 +355,11 @@ impl HeadlessOwner {
                 self.cursor.0 = self.lines[self.cursor.1].chars().count();
                 Ok(Vec::new())
             }
-            KeyCode::Escape | KeyCode::BackTab | KeyCode::PageUp | KeyCode::PageDown => {
-                Ok(Vec::new())
-            }
+            KeyCode::Escape
+            | KeyCode::BackTab
+            | KeyCode::Function(_)
+            | KeyCode::PageUp
+            | KeyCode::PageDown => Ok(Vec::new()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cli;
 pub mod clipboard;
 pub mod color;
 pub mod command;
+pub mod command_palette;
 pub mod config;
 pub mod dispatcher;
 pub mod editor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,9 @@ async fn attach_session(session: &str) -> anyhow::Result<()> {
             .execute(event::EnableFocusChange)?
             .execute(event::EnableMouseCapture)?
             .execute(terminal::EnterAlternateScreen)?
+            .execute(event::PushKeyboardEnhancementFlags(
+                event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+            ))?
             .execute(terminal::DisableLineWrap)?
             .execute(terminal::Clear(terminal::ClearType::All))?;
         let result = async {
@@ -361,6 +364,7 @@ impl Drop for DetachedTerminalGuard {
         _ = output.execute(event::DisableFocusChange);
         _ = output.execute(event::DisableMouseCapture);
         _ = output.execute(terminal::EnableLineWrap);
+        _ = output.execute(event::PopKeyboardEnhancementFlags);
         _ = output.execute(terminal::LeaveAlternateScreen);
         _ = terminal::disable_raw_mode();
     }
@@ -385,6 +389,7 @@ fn detached_key_input(key: event::KeyEvent) -> Option<DetachedInput> {
         event::KeyCode::Esc => DetachedKeyCode::Escape,
         event::KeyCode::Tab => DetachedKeyCode::Tab,
         event::KeyCode::BackTab => DetachedKeyCode::BackTab,
+        event::KeyCode::F(number) => DetachedKeyCode::Function(number),
         event::KeyCode::Delete => DetachedKeyCode::Delete,
         event::KeyCode::Left => DetachedKeyCode::Left,
         event::KeyCode::Right => DetachedKeyCode::Right,
@@ -572,6 +577,30 @@ mod tests {
             event::KeyCode::Char('4'),
             event::KeyModifiers::NONE
         )));
+    }
+
+    #[test]
+    fn detached_key_input_preserves_function_keys_and_combined_modifiers() {
+        assert_eq!(
+            detached_key_input(event::KeyEvent::new(
+                event::KeyCode::F(1),
+                event::KeyModifiers::NONE,
+            )),
+            Some(DetachedInput::Key {
+                code: DetachedKeyCode::Function(1),
+                modifiers: Vec::new(),
+            })
+        );
+        assert_eq!(
+            detached_key_input(event::KeyEvent::new(
+                event::KeyCode::Char('p'),
+                event::KeyModifiers::CONTROL | event::KeyModifiers::SHIFT,
+            )),
+            Some(DetachedInput::Key {
+                code: DetachedKeyCode::Character('p'),
+                modifiers: vec![KeyModifier::Control, KeyModifier::Shift],
+            })
+        );
     }
 
     #[test]

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -23,7 +23,7 @@ pub use panel::{
     TextPanelBlockFormat, TextPanelBlockKind,
 };
 pub use registry::{PluginRegistry, PluginStatus, RED_HOST_API_VERSION};
-pub use runtime::{poll_timer_callbacks, Runtime};
+pub use runtime::{poll_timer_callbacks, RegisteredPluginCommand, Runtime};
 pub use window_bar::{
     RenderedWindowBar, WindowBarConfig, WindowBarEdge, WindowBarHitRegion, WindowBarManager,
     WindowBarOverflow, WindowBarSegment, WindowBarSemanticStyle, WindowBarStyle,

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use husk::{Host, RequestId, Value};
+use husk::{CommandMetadata, Host, RequestId, Value};
 use husk_diagnostics::{Diagnostic as HuskDiagnostic, Report as HuskReport, SourceFile};
 use uuid::Uuid;
 
@@ -1127,6 +1127,17 @@ pub struct Runtime {
     inner: Arc<Mutex<RuntimeInner>>,
 }
 
+/// A command currently registered by an active Husk plugin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisteredPluginCommand {
+    /// Exact, case-sensitive command name.
+    pub name: String,
+    /// Plugin that owns the command.
+    pub plugin: String,
+    /// User-facing command information supplied during registration.
+    pub metadata: CommandMetadata,
+}
+
 struct RuntimeInner {
     vm: husk::Vm,
     host: RedHost,
@@ -1218,6 +1229,24 @@ impl Runtime {
             .commands()
             .get(command)
             .map(|callback| callback.plugin().to_string())
+    }
+
+    /// Returns the active plugin commands in a stable order for discovery UI.
+    #[must_use]
+    pub fn registered_commands(&self) -> Vec<RegisteredPluginCommand> {
+        let inner = self.inner.lock().unwrap();
+        let mut commands = inner
+            .vm
+            .commands()
+            .iter()
+            .map(|(name, callback)| RegisteredPluginCommand {
+                name: name.clone(),
+                plugin: callback.plugin().to_string(),
+                metadata: inner.vm.command_metadata(name).cloned().unwrap_or_default(),
+            })
+            .collect::<Vec<_>>();
+        commands.sort_unstable_by(|left, right| left.name.cmp(&right.name));
+        commands
     }
 
     pub async fn add_module(&mut self, code: &str) -> anyhow::Result<()> {
@@ -1534,6 +1563,43 @@ mod tests {
             }
             _ => panic!("unexpected plugin request"),
         }
+    }
+
+    #[tokio::test]
+    async fn registered_commands_include_owner_and_discovery_metadata() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        let source = r#"
+            pub fn activate() {
+                red::add_command("ProjectSearch", search, Json {
+                    title: "Search project",
+                    category: "Search",
+                    aliases: ["ripgrep"],
+                });
+                red::add_command("BufferPicker", buffers);
+            }
+
+            fn search() {}
+            fn buffers() {}
+        "#;
+        let mut runtime = Runtime::new();
+
+        runtime.load_plugin("navigation", source).await.unwrap();
+
+        let commands = runtime.registered_commands();
+        assert_eq!(
+            commands
+                .iter()
+                .map(|command| command.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["BufferPicker", "ProjectSearch"]
+        );
+        assert_eq!(commands[1].plugin, "navigation");
+        assert_eq!(
+            commands[1].metadata.title.as_deref(),
+            Some("Search project")
+        );
+        assert_eq!(commands[1].metadata.category.as_deref(), Some("Search"));
+        assert_eq!(commands[1].metadata.aliases, vec!["ripgrep"]);
     }
 
     #[tokio::test]

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -143,6 +143,21 @@ impl Component for FilePicker {
     }
 
     fn handle_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
+        if self.picker.query().is_empty()
+            && matches!(
+                ev,
+                event::Event::Key(key)
+                    if key.code == event::KeyCode::Char('>')
+                        && !key.modifiers.intersects(
+                            event::KeyModifiers::CONTROL | event::KeyModifiers::ALT
+                        )
+            )
+        {
+            return Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::CommandPalette,
+            ]));
+        }
         if matches!(
             ev,
             event::Event::Key(key)
@@ -501,6 +516,37 @@ mod tests {
                 Action::OpenFile("visible-match.txt".to_string()),
             ]))
         );
+    }
+
+    #[test]
+    fn leading_greater_than_switches_file_picker_to_command_palette() {
+        let editor = test_editor();
+        let mut picker = FilePicker::loading(&editor);
+
+        assert_eq!(
+            picker.handle_event(&Event::Key(KeyEvent::new(
+                KeyCode::Char('>'),
+                KeyModifiers::SHIFT,
+            ))),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::CommandPalette,
+            ]))
+        );
+    }
+
+    #[test]
+    fn greater_than_after_file_query_remains_part_of_the_query() {
+        let editor = test_editor();
+        let mut picker = FilePicker::loading(&editor);
+        picker.handle_event(&key(KeyCode::Char('s')));
+
+        picker.handle_event(&Event::Key(KeyEvent::new(
+            KeyCode::Char('>'),
+            KeyModifiers::SHIFT,
+        )));
+
+        assert_eq!(picker.picker.query(), "s>");
     }
 
     #[test]

--- a/src/ui/keymap_hints.rs
+++ b/src/ui/keymap_hints.rs
@@ -1,0 +1,116 @@
+use crate::{
+    command_palette::KeymapHint,
+    editor::RenderBuffer,
+    theme::Theme,
+    unicode_utils::{display_width, truncate_display_width},
+};
+
+use super::{dialog::BorderStyle, Component, Dialog};
+
+pub(crate) fn draw_keymap_hints(
+    buffer: &mut RenderBuffer,
+    theme: &Theme,
+    prefix: &str,
+    hints: &[KeymapHint],
+) -> anyhow::Result<()> {
+    let available_width = buffer.width.saturating_sub(2);
+    let available_height = buffer.height.saturating_sub(2);
+    if hints.is_empty() || available_width < 12 || available_height < 4 {
+        return Ok(());
+    }
+
+    let key_width = hints
+        .iter()
+        .map(|hint| display_width(&hint.key))
+        .max()
+        .unwrap_or(1);
+    let entry_width = hints
+        .iter()
+        .map(|hint| key_width + 2 + display_width(&hint.label) + usize::from(hint.is_group) * 2)
+        .max()
+        .unwrap_or(1)
+        .min(available_width.saturating_sub(2));
+    let column_width = entry_width.saturating_add(3);
+    let columns = (available_width.saturating_sub(2) / column_width)
+        .clamp(1, 3)
+        .min(hints.len());
+    let max_rows = available_height.saturating_sub(2).max(1);
+    let rows = hints.len().div_ceil(columns).min(max_rows);
+    let visible = rows * columns;
+    let title = if visible < hints.len() {
+        format!("{prefix} · keymaps ({}/{})", visible, hints.len())
+    } else {
+        format!("{prefix} · keymaps")
+    };
+    let inner_width = (columns * entry_width + columns.saturating_sub(1) * 3)
+        .max(display_width(&title).saturating_add(2))
+        .min(available_width.saturating_sub(2));
+    let outer_width = inner_width + 2;
+    let outer_height = rows + 2;
+    let x = buffer.width.saturating_sub(outer_width + 1);
+    let y = buffer.height.saturating_sub(2).saturating_sub(outer_height);
+    let title = truncate_display_width(&title, inner_width.saturating_sub(2));
+    let dialog = Dialog::new(
+        Some(title),
+        x,
+        y,
+        inner_width,
+        rows,
+        &theme.ui_style.popup,
+        BorderStyle::Single,
+        theme,
+    )
+    .with_border_draw_style(&theme.ui_style.popup_border)
+    .with_title_style(&theme.ui_style.popup_title);
+    dialog.draw(buffer)?;
+
+    for (index, hint) in hints.iter().take(visible).enumerate() {
+        let column = index / rows;
+        let row = index % rows;
+        let marker = if hint.is_group { "› " } else { "" };
+        let text = format!(
+            "{:width$}  {marker}{}",
+            hint.key,
+            hint.label,
+            width = key_width
+        );
+        let text = truncate_display_width(&text, entry_width);
+        let style = if hint.is_group {
+            &theme.ui_style.popup_title
+        } else {
+            &theme.ui_style.picker_item
+        };
+        buffer.set_text(
+            x + 1 + column * (entry_width + 3),
+            y + 1 + row,
+            &text,
+            style,
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::Style;
+
+    #[test]
+    fn keymap_hints_fit_a_small_terminal_without_overflow() {
+        let mut buffer = RenderBuffer::new(24, 8, &Style::default());
+        let hints = (0..24)
+            .map(|index| KeymapHint {
+                key: index.to_string(),
+                label: format!("Command {index}"),
+                is_group: index % 2 == 0,
+            })
+            .collect::<Vec<_>>();
+
+        draw_keymap_hints(&mut buffer, &Theme::default(), "Space", &hints).unwrap();
+
+        assert_eq!(buffer.cells.len(), 24 * 8);
+        assert!(buffer.cells.iter().any(|cell| cell.c == '┌'));
+        assert!(buffer.cells.iter().any(|cell| cell.c == '└'));
+    }
+}

--- a/src/ui/keymap_hints.rs
+++ b/src/ui/keymap_hints.rs
@@ -1,11 +1,27 @@
 use crate::{
     command_palette::KeymapHint,
     editor::RenderBuffer,
-    theme::Theme,
+    theme::{Style, Theme},
     unicode_utils::{display_width, truncate_display_width},
 };
 
 use super::{dialog::BorderStyle, Component, Dialog};
+
+const COLUMN_GAP: usize = 3;
+const KEY_GAP: usize = 1;
+const CONTINUATION_WIDTH: usize = 2;
+const MIN_LABEL_WIDTH: usize = 18;
+const MAX_COLUMNS: usize = 3;
+const MAX_KEY_WIDTH: usize = 20;
+
+fn foreground_style(base: &Style, semantic: &Style) -> Style {
+    Style {
+        fg: semantic.fg.or(base.fg),
+        bg: base.bg,
+        bold: base.bold || semantic.bold,
+        italic: base.italic || semantic.italic,
+    }
+}
 
 pub(crate) fn draw_keymap_hints(
     buffer: &mut RenderBuffer,
@@ -19,32 +35,55 @@ pub(crate) fn draw_keymap_hints(
         return Ok(());
     }
 
-    let key_width = hints
+    let max_inner_width = available_width.saturating_sub(2);
+    let max_key_width = hints
         .iter()
         .map(|hint| display_width(&hint.key))
         .max()
-        .unwrap_or(1);
-    let entry_width = hints
-        .iter()
-        .map(|hint| key_width + 2 + display_width(&hint.label) + usize::from(hint.is_group) * 2)
-        .max()
         .unwrap_or(1)
-        .min(available_width.saturating_sub(2));
-    let column_width = entry_width.saturating_add(3);
-    let columns = (available_width.saturating_sub(2) / column_width)
-        .clamp(1, 3)
+        .min(MAX_KEY_WIDTH)
+        .min(max_inner_width.saturating_sub(KEY_GAP + CONTINUATION_WIDTH + 1));
+    let min_entry_width = (max_key_width + KEY_GAP + CONTINUATION_WIDTH + MIN_LABEL_WIDTH)
+        .min(max_inner_width)
+        .max(1);
+    let columns = ((max_inner_width + COLUMN_GAP) / (min_entry_width + COLUMN_GAP))
+        .clamp(1, MAX_COLUMNS)
         .min(hints.len());
     let max_rows = available_height.saturating_sub(2).max(1);
     let rows = hints.len().div_ceil(columns).min(max_rows);
     let visible = rows * columns;
+    let key_widths = (0..columns)
+        .map(|column| {
+            hints
+                .iter()
+                .skip(column * rows)
+                .take(rows)
+                .map(|hint| display_width(&hint.key))
+                .max()
+                .unwrap_or(1)
+                .min(max_key_width)
+        })
+        .collect::<Vec<_>>();
+    let preferred_entry_width = hints
+        .iter()
+        .take(visible)
+        .enumerate()
+        .map(|(index, hint)| {
+            key_widths[index / rows] + KEY_GAP + CONTINUATION_WIDTH + display_width(&hint.label)
+        })
+        .max()
+        .unwrap_or(1);
+    let max_entry_width =
+        max_inner_width.saturating_sub(columns.saturating_sub(1) * COLUMN_GAP) / columns;
+    let entry_width = preferred_entry_width.min(max_entry_width);
     let title = if visible < hints.len() {
         format!("{prefix} · keymaps ({}/{})", visible, hints.len())
     } else {
         format!("{prefix} · keymaps")
     };
-    let inner_width = (columns * entry_width + columns.saturating_sub(1) * 3)
+    let inner_width = (columns * entry_width + columns.saturating_sub(1) * COLUMN_GAP)
         .max(display_width(&title).saturating_add(2))
-        .min(available_width.saturating_sub(2));
+        .min(max_inner_width);
     let outer_width = inner_width + 2;
     let outer_height = rows + 2;
     let x = buffer.width.saturating_sub(outer_width + 1);
@@ -64,28 +103,60 @@ pub(crate) fn draw_keymap_hints(
     .with_title_style(&theme.ui_style.popup_title);
     dialog.draw(buffer)?;
 
+    let item_style = &theme.ui_style.picker_item;
+    let key_semantic = theme
+        .colors
+        .get("peekViewResult.lineForeground")
+        .copied()
+        .map(|fg| Style {
+            fg: Some(fg),
+            ..Style::default()
+        })
+        .unwrap_or_else(|| theme.ui_style.muted.clone());
+    let label_semantic = theme
+        .get_style("markup.underline.link")
+        .or_else(|| {
+            theme
+                .colors
+                .get("peekViewResult.fileForeground")
+                .copied()
+                .map(|fg| Style {
+                    fg: Some(fg),
+                    ..Style::default()
+                })
+        })
+        .or_else(|| theme.get_style("string.other.link"))
+        .unwrap_or_else(|| theme.ui_style.picker_prompt.clone());
+    let key_style = foreground_style(item_style, &key_semantic);
+    let label_style = foreground_style(item_style, &label_semantic);
+    let mut group_style = label_style.clone();
+    group_style.bold |= theme.ui_style.popup_title.bold;
+    let blank_row = " ".repeat(inner_width);
+    for row in 0..rows {
+        buffer.set_text(x + 1, y + 1 + row, &blank_row, item_style);
+    }
+
     for (index, hint) in hints.iter().take(visible).enumerate() {
         let column = index / rows;
         let row = index % rows;
-        let marker = if hint.is_group { "› " } else { "" };
-        let text = format!(
-            "{:width$}  {marker}{}",
-            hint.key,
-            hint.label,
-            width = key_width
-        );
-        let text = truncate_display_width(&text, entry_width);
-        let style = if hint.is_group {
-            &theme.ui_style.popup_title
+        let entry_x = x + 1 + column * (entry_width + COLUMN_GAP);
+        let entry_y = y + 1 + row;
+        let key_width = key_widths[column];
+        let key = truncate_display_width(&hint.key, key_width);
+        buffer.set_text(entry_x, entry_y, &key, &key_style);
+
+        let label_x = entry_x + key_width + KEY_GAP;
+        let label_width = entry_width.saturating_sub(key_width + KEY_GAP + CONTINUATION_WIDTH);
+        let label = truncate_display_width(&hint.label, label_width);
+        let item_label_style = if hint.is_group {
+            &group_style
         } else {
-            &theme.ui_style.picker_item
+            &label_style
         };
-        buffer.set_text(
-            x + 1 + column * (entry_width + 3),
-            y + 1 + row,
-            &text,
-            style,
-        );
+        buffer.set_text(label_x, entry_y, &label, item_label_style);
+        if hint.is_group {
+            buffer.set_text(label_x + display_width(&label), entry_y, " …", &group_style);
+        }
     }
 
     Ok(())
@@ -94,7 +165,345 @@ pub(crate) fn draw_keymap_hints(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::theme::Style;
+    use crate::{color::Color, theme::Style};
+
+    fn row(buffer: &RenderBuffer, y: usize) -> String {
+        let cells = &buffer.cells[y * buffer.width..(y + 1) * buffer.width];
+        let mut text = String::new();
+        let mut column = 0;
+        while let Some(cell) = cells.get(column) {
+            text.push_str(&cell.text);
+            column += display_width(&cell.text).max(1);
+        }
+        text
+    }
+
+    fn column(row: &str, needle: &str) -> Option<usize> {
+        row.find(needle).map(|index| display_width(&row[..index]))
+    }
+
+    #[test]
+    fn keymap_hints_align_and_style_keys_groups_and_labels_independently() {
+        let item_background = Color::Rgb {
+            r: 20,
+            g: 22,
+            b: 24,
+        };
+        let label_color = Color::Rgb {
+            r: 60,
+            g: 210,
+            b: 140,
+        };
+        let key_color = Color::Rgb {
+            r: 110,
+            g: 120,
+            b: 150,
+        };
+        let mut theme = Theme::default();
+        theme
+            .colors
+            .insert("peekViewResult.fileForeground".to_string(), label_color);
+        theme
+            .colors
+            .insert("peekViewResult.lineForeground".to_string(), key_color);
+        theme.ui_style.picker_item = Style {
+            fg: Some(Color::Rgb { r: 0, g: 180, b: 0 }),
+            bg: Some(item_background),
+            ..Style::default()
+        };
+        theme.ui_style.picker_prompt = Style {
+            fg: Some(Color::Rgb {
+                r: 240,
+                g: 220,
+                b: 20,
+            }),
+            bg: Some(Color::Rgb { r: 0, g: 0, b: 200 }),
+            bold: true,
+            ..Style::default()
+        };
+        theme.ui_style.muted = Style {
+            fg: Some(Color::Rgb {
+                r: 100,
+                g: 100,
+                b: 100,
+            }),
+            bg: Some(Color::Rgb { r: 200, g: 0, b: 0 }),
+            ..Style::default()
+        };
+        theme.ui_style.popup_title = Style {
+            fg: Some(Color::Rgb {
+                r: 20,
+                g: 220,
+                b: 220,
+            }),
+            bg: Some(Color::Rgb {
+                r: 200,
+                g: 0,
+                b: 200,
+            }),
+            bold: true,
+            ..Style::default()
+        };
+        let hints = vec![
+            KeymapHint {
+                key: "?".to_string(),
+                label: "All commands".to_string(),
+                is_group: false,
+            },
+            KeymapHint {
+                key: "Ctrl-w".to_string(),
+                label: "Windows".to_string(),
+                is_group: true,
+            },
+            KeymapHint {
+                key: "漢".to_string(),
+                label: "Unicode action".to_string(),
+                is_group: false,
+            },
+        ];
+        let mut buffer = RenderBuffer::new(48, 10, &Style::default());
+
+        draw_keymap_hints(&mut buffer, &theme, "Space", &hints).unwrap();
+
+        let rows = (0..buffer.height)
+            .map(|index| row(&buffer, index))
+            .collect::<Vec<_>>();
+        let leaf_y = rows
+            .iter()
+            .position(|row| row.contains("All commands"))
+            .unwrap();
+        let group_y = rows.iter().position(|row| row.contains("Windows")).unwrap();
+        let unicode_y = rows
+            .iter()
+            .position(|row| row.contains("Unicode action"))
+            .unwrap();
+        let leaf = &rows[leaf_y];
+        let group = &rows[group_y];
+        let unicode = &rows[unicode_y];
+        let label_x = column(leaf, "All commands").unwrap();
+
+        assert_eq!(column(group, "Windows"), Some(label_x));
+        assert_eq!(column(unicode, "Unicode action"), Some(label_x));
+        assert!(group.contains("Windows …"));
+        assert!(!group.contains("… Windows"));
+
+        let key_x = column(leaf, "?").unwrap();
+        let group_key_x = column(group, "Ctrl-w").unwrap();
+        let marker_x = column(group, "…").unwrap();
+        assert_eq!(key_x, group_key_x);
+        assert_eq!(
+            buffer.cells[leaf_y * buffer.width + key_x].style.fg,
+            Some(key_color)
+        );
+        assert_eq!(
+            buffer.cells[leaf_y * buffer.width + key_x].style.bg,
+            Some(item_background)
+        );
+        assert_eq!(
+            buffer.cells[leaf_y * buffer.width + label_x].style.fg,
+            Some(label_color)
+        );
+        assert_eq!(
+            buffer.cells[leaf_y * buffer.width + label_x].style.bg,
+            Some(item_background)
+        );
+        assert_eq!(
+            buffer.cells[group_y * buffer.width + marker_x].style.fg,
+            Some(label_color)
+        );
+        assert_eq!(
+            buffer.cells[group_y * buffer.width + marker_x].style.bg,
+            Some(item_background)
+        );
+        assert_eq!(
+            buffer.cells[group_y * buffer.width + label_x].style.fg,
+            Some(label_color)
+        );
+        assert_eq!(
+            buffer.cells[group_y * buffer.width + label_x].style.bg,
+            Some(item_background)
+        );
+    }
+
+    #[test]
+    fn keymap_hints_size_keys_per_column_and_keep_action_spacing_compact() {
+        let hints = [
+            ("?", "All commands", false),
+            ("a", "Select all", false),
+            ("b", "Buffer picker", false),
+            ("Space", "Next buffer", false),
+            ("Ctrl-w", "Windows", true),
+            ("g", "Project search", false),
+        ]
+        .into_iter()
+        .map(|(key, label, is_group)| KeymapHint {
+            key: key.to_string(),
+            label: label.to_string(),
+            is_group,
+        })
+        .collect::<Vec<_>>();
+        let mut buffer = RenderBuffer::new(70, 10, &Style::default());
+
+        draw_keymap_hints(&mut buffer, &Theme::default(), "Space", &hints).unwrap();
+
+        let screen = (0..buffer.height)
+            .map(|index| row(&buffer, index))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(screen.contains("? All commands"), "{screen}");
+        assert!(screen.contains("a Select all"), "{screen}");
+        assert!(screen.contains("Space  Next buffer"), "{screen}");
+        assert!(screen.contains("Ctrl-w Windows …"), "{screen}");
+        assert!(!screen.contains("?      All commands"), "{screen}");
+    }
+
+    #[test]
+    fn keymap_hints_fall_back_to_picker_theme_roles() {
+        let item_background = Color::Rgb {
+            r: 18,
+            g: 20,
+            b: 24,
+        };
+        let key_color = Color::Rgb {
+            r: 90,
+            g: 100,
+            b: 110,
+        };
+        let label_color = Color::Rgb {
+            r: 100,
+            g: 210,
+            b: 160,
+        };
+        let mut theme = Theme::default();
+        theme.ui_style.picker_item.bg = Some(item_background);
+        theme.ui_style.muted.fg = Some(key_color);
+        theme.ui_style.picker_prompt.fg = Some(label_color);
+        theme.ui_style.popup_title.bold = true;
+        let hints = [
+            KeymapHint {
+                key: "a".to_string(),
+                label: "Select all".to_string(),
+                is_group: false,
+            },
+            KeymapHint {
+                key: "h".to_string(),
+                label: "Git hunks".to_string(),
+                is_group: true,
+            },
+        ];
+        let mut buffer = RenderBuffer::new(40, 8, &Style::default());
+
+        draw_keymap_hints(&mut buffer, &theme, "Space", &hints).unwrap();
+
+        let rows = (0..buffer.height)
+            .map(|index| row(&buffer, index))
+            .collect::<Vec<_>>();
+        let leaf_y = rows
+            .iter()
+            .position(|row| row.contains("Select all"))
+            .unwrap();
+        let group_y = rows
+            .iter()
+            .position(|row| row.contains("Git hunks …"))
+            .unwrap();
+        let key_x = column(&rows[leaf_y], "a").unwrap();
+        let label_x = column(&rows[leaf_y], "Select all").unwrap();
+        let marker_x = column(&rows[group_y], "…").unwrap();
+
+        assert_eq!(
+            buffer.cells[leaf_y * buffer.width + key_x].style.fg,
+            Some(key_color)
+        );
+        assert_eq!(
+            buffer.cells[leaf_y * buffer.width + label_x].style.fg,
+            Some(label_color)
+        );
+        assert_eq!(
+            buffer.cells[group_y * buffer.width + marker_x].style.fg,
+            Some(label_color)
+        );
+        assert!(buffer.cells[group_y * buffer.width + marker_x].style.bold);
+        assert_eq!(
+            buffer.cells[group_y * buffer.width + marker_x].style.bg,
+            Some(item_background)
+        );
+    }
+
+    #[test]
+    fn keymap_hints_keep_multiple_columns_when_one_label_is_long() {
+        let hints = (0..9)
+            .map(|index| KeymapHint {
+                key: index.to_string(),
+                label: if index == 0 {
+                    "One unusually long command label that must be truncated".to_string()
+                } else {
+                    format!("Command {index}")
+                },
+                is_group: index % 3 == 0,
+            })
+            .collect::<Vec<_>>();
+        let mut buffer = RenderBuffer::new(80, 10, &Style::default());
+
+        draw_keymap_hints(&mut buffer, &Theme::default(), "Space", &hints).unwrap();
+
+        let screen = (0..buffer.height)
+            .map(|index| row(&buffer, index))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(screen.contains("Command 8"), "{screen}");
+        assert!(!screen.contains("(6/9)"), "{screen}");
+        assert!(screen.contains('┌'));
+        assert!(screen.contains('┘'));
+    }
+
+    #[test]
+    fn keymap_hints_prefer_readable_labels_over_an_extra_column() {
+        let labels = [
+            "Show code actions",
+            "All commands",
+            "Agent",
+            "Select all",
+            "Buffer picker",
+            "Format document",
+            "Git dashboard",
+            "Project search",
+            "LSP references",
+            "Next buffer",
+            "Previous buffer",
+            "Rename symbol",
+            "Theme browser",
+            "LSP workspace symbols",
+            "Commit message",
+            "Debug",
+            "Git hunks",
+            "Next buffer",
+        ];
+        let hints = labels
+            .iter()
+            .enumerate()
+            .map(|(index, label)| KeymapHint {
+                key: if index == 17 {
+                    "Space".to_string()
+                } else {
+                    index.to_string()
+                },
+                label: (*label).to_string(),
+                is_group: index >= 14,
+            })
+            .collect::<Vec<_>>();
+        let mut buffer = RenderBuffer::new(80, 14, &Style::default());
+
+        draw_keymap_hints(&mut buffer, &Theme::default(), "Space", &hints).unwrap();
+
+        let screen = (0..buffer.height)
+            .map(|index| row(&buffer, index))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(screen.contains("Show code actions"), "{screen}");
+        assert!(screen.contains("Previous buffer"), "{screen}");
+        assert!(screen.contains("LSP workspace symbols"), "{screen}");
+        assert!(!screen.contains("(16/18)"), "{screen}");
+    }
 
     #[test]
     fn keymap_hints_fit_a_small_terminal_without_overflow() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ mod dialog;
 mod file_picker;
 mod info;
 mod input_prompt;
+mod keymap_hints;
 mod list;
 mod picker;
 
@@ -14,6 +15,7 @@ use dialog::Dialog;
 pub use file_picker::FilePicker;
 pub use info::Info;
 pub use input_prompt::InputPrompt;
+pub(crate) use keymap_hints::draw_keymap_hints;
 use list::List;
 pub use picker::{
     LegacyPickerOptions, Picker, PickerItem, PickerOptions, PickerPresentation, PickerPreview,

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -29,6 +29,7 @@ use crate::{
 use super::{dialog::BorderStyle, Component, Dialog, List};
 
 type SelectAction = Box<dyn Fn(String) -> Action + Send>;
+type FilterAction = Box<dyn Fn(&PickerItem, &str) -> Option<i64> + Send>;
 const MIN_HORIZONTAL_PREVIEW_PANE_WIDTH: usize = 40;
 const MAX_PREVIEW_HIGHLIGHT_BYTES: usize = 64 * 1024;
 const MAX_UNFOCUSED_PREVIEW_BYTES: u64 = 256 * 1024;
@@ -251,6 +252,7 @@ pub struct Picker {
     dialog: Dialog,
     matcher: SkimMatcherV2,
     select_action: Option<SelectAction>,
+    filter_action: Option<FilterAction>,
     search: String,
     empty_message: Option<String>,
     theme: Theme,
@@ -391,6 +393,7 @@ impl Picker {
             dialog,
             matcher: SkimMatcherV2::default(),
             select_action: None,
+            filter_action: None,
             search: String::new(),
             empty_message: None,
             theme: editor.theme.clone(),
@@ -545,8 +548,12 @@ impl Picker {
                     .iter()
                     .enumerate()
                     .filter_map(|(index, item)| {
-                        self.matcher
-                            .fuzzy_match(&item.label, term)
+                        self.filter_action
+                            .as_ref()
+                            .map_or_else(
+                                || self.matcher.fuzzy_match(&item.label, term),
+                                |filter| filter(item, term),
+                            )
                             .map(|score| (index, score))
                     })
                     .collect::<Vec<_>>();
@@ -651,6 +658,10 @@ impl Picker {
 
     pub fn set_status(&mut self, status: Option<String>) {
         self.status = status;
+    }
+
+    pub(crate) fn query(&self) -> &str {
+        &self.search
     }
 
     fn selected_item(&self) -> Option<String> {
@@ -1119,7 +1130,24 @@ impl Picker {
             );
         }
 
-        if let Some(status) = &self.status {
+        let command_status = self
+            .selected_dynamic_item()
+            .filter(|item| item.kind.as_deref() == Some("Command"))
+            .map(|item| {
+                let description = item
+                    .data
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let total = self.dynamic_items.as_ref().map_or(0, Vec::len);
+                let visible = self.visible_dynamic_items.len();
+                if description.is_empty() {
+                    format!("{visible}/{total} commands")
+                } else {
+                    format!("{description} · {visible}/{total} commands")
+                }
+            });
+        if let Some(status) = command_status.as_deref().or(self.status.as_deref()) {
             let status = truncate_display_width(status, self.width.saturating_sub(4));
             let status = format!(" {status} ");
             let status_x = self.x + self.width + 1 - display_width(&status);
@@ -1136,6 +1164,13 @@ impl Picker {
         let Some(items) = self.dynamic_items.as_ref() else {
             return;
         };
+        let command_detail_width = items
+            .iter()
+            .filter(|item| item.kind.as_deref() == Some("Command"))
+            .filter_map(|item| item.detail.as_deref())
+            .map(display_width)
+            .max()
+            .unwrap_or_default();
         let selected = self.list.selected_index();
         let top = self.list.top_index();
         for (offset, index) in self
@@ -1158,20 +1193,36 @@ impl Picker {
             let min_primary_width = content_width.min(8);
             let max_detail_width =
                 content_width.saturating_sub(min_primary_width + detail_separator_width);
-            let detail_width = item
-                .detail
-                .as_deref()
-                .filter(|detail| !detail.is_empty())
-                .map(|detail| display_width(detail).min(max_detail_width))
-                .unwrap_or_default();
+            let detail_width = if item.kind.as_deref() == Some("Command") {
+                command_detail_width.min(max_detail_width)
+            } else {
+                item.detail
+                    .as_deref()
+                    .filter(|detail| !detail.is_empty())
+                    .map(|detail| display_width(detail).min(max_detail_width))
+                    .unwrap_or_default()
+            };
             let separator_width = usize::from(detail_width > 0) * detail_separator_width;
             let primary_width = content_width.saturating_sub(detail_width + separator_width);
-            let label_width = display_width(&item.label).min(primary_width);
+            let command_category = item
+                .annotation
+                .as_deref()
+                .filter(|_| item.kind.as_deref() == Some("Command"));
+            let category_width = command_category.map_or(0, display_width);
+            let category_gap = usize::from(category_width > 0) * 2;
+            let label_x = x + category_width + category_gap;
+            let label_width = display_width(&item.label)
+                .min(primary_width.saturating_sub(category_width + category_gap));
+            if let Some(category) = command_category {
+                let annotation_style = self.result_annotation_style(&row_style, is_selected);
+                let visible = truncate_display_width(category, primary_width);
+                buffer.set_text(x, y, &visible, &annotation_style);
+            }
             let label_style = self.result_label_style(item, &row_style, is_selected);
             let match_style = self.result_match_style(&label_style);
             let used = self.draw_text_with_matches(
                 buffer,
-                x,
+                label_x,
                 y,
                 &item.label,
                 label_width,
@@ -1179,12 +1230,16 @@ impl Picker {
                 &match_style,
                 &item.matches,
             );
-            let annotation_remaining = primary_width.saturating_sub(used);
+            let annotation_remaining = primary_width
+                .saturating_sub(category_width + category_gap)
+                .saturating_sub(used);
 
-            if let Some(annotation) = item.annotation.as_deref().filter(|value| !value.is_empty()) {
-                if annotation_remaining > 1 {
+            if command_category.is_none() && annotation_remaining > 1 {
+                if let Some(annotation) =
+                    item.annotation.as_deref().filter(|value| !value.is_empty())
+                {
                     let annotation_style = self.result_annotation_style(&row_style, is_selected);
-                    let annotation_x = x + used + 1;
+                    let annotation_x = label_x + used + 1;
                     let visible =
                         truncate_display_width(annotation, annotation_remaining.saturating_sub(1));
                     buffer.set_text(annotation_x, y, &visible, &annotation_style);
@@ -2043,14 +2098,16 @@ impl Component for Picker {
                         if self.list.items().is_empty() {
                             return None;
                         }
-                        let action = if self.dynamic_items.is_some() {
+                        let action = if let Some(select_action) = &self.select_action {
+                            let item = self
+                                .selected_dynamic_item()
+                                .map_or_else(|| self.list.selected_item(), |item| item.id.clone());
+                            select_action(item)
+                        } else if self.dynamic_items.is_some() {
                             Action::NotifyPlugins(
                                 format!("picker:selected:{}", self.id.unwrap_or_default()),
                                 self.selected_value().unwrap_or(Value::Null),
                             )
-                        } else if let Some(select_action) = &self.select_action {
-                            let item = self.list.selected_item();
-                            select_action(item)
                         } else {
                             Action::Picked(self.list.selected_item(), self.id)
                         };
@@ -2195,8 +2252,11 @@ fn normalized_key(event: &event::KeyEvent) -> Option<String> {
 pub struct PickerBuilder {
     title: Option<String>,
     items: Vec<String>,
+    structured_items: Option<Vec<PickerItem>>,
     id: Option<i32>,
     select_action: Option<SelectAction>,
+    filter_action: Option<FilterAction>,
+    placeholder: Option<String>,
     history_key: Option<String>,
 }
 
@@ -2211,8 +2271,11 @@ impl PickerBuilder {
         PickerBuilder {
             title: None,
             items: vec![],
+            structured_items: None,
             id: None,
             select_action: None,
+            filter_action: None,
+            placeholder: None,
             history_key: None,
         }
     }
@@ -2227,6 +2290,12 @@ impl PickerBuilder {
         self
     }
 
+    /// Supplies precomputed picker rows with stable IDs and structured display fields.
+    pub fn structured_items(mut self, items: Vec<PickerItem>) -> Self {
+        self.structured_items = Some(items);
+        self
+    }
+
     #[allow(unused)]
     pub fn id(mut self, id: i32) -> Self {
         self.id = Some(id);
@@ -2238,6 +2307,21 @@ impl PickerBuilder {
         self
     }
 
+    /// Sets the scorer used to filter structured picker rows for the current query.
+    pub fn filter_action(
+        mut self,
+        filter: impl Fn(&PickerItem, &str) -> Option<i64> + Send + 'static,
+    ) -> Self {
+        self.filter_action = Some(Box::new(filter));
+        self
+    }
+
+    /// Sets the prompt hint shown while the picker query is empty.
+    pub fn placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = Some(placeholder.into());
+        self
+    }
+
     pub fn history_key(mut self, key: impl Into<String>) -> Self {
         self.history_key = Some(key.into());
         self
@@ -2245,15 +2329,26 @@ impl PickerBuilder {
 
     pub fn build(self, editor: &Editor) -> Picker {
         let title = self.title;
-        let items = self.items;
+        let structured_items = self.structured_items;
+        let items = structured_items.as_ref().map_or(self.items, |items| {
+            items.iter().map(PickerItem::display_text).collect()
+        });
         let id = self.id;
         let select_action = self.select_action;
+        let filter_action = self.filter_action;
+        let placeholder = self.placeholder;
         let history_key = self.history_key;
 
         let mut picker = Picker::new(title, editor, &items, id);
+        if let Some(structured_items) = structured_items {
+            picker.visible_dynamic_items = (0..structured_items.len()).collect();
+            picker.dynamic_items = Some(structured_items);
+        }
         if let Some(select_action) = select_action {
             picker.select_action = Some(select_action);
         }
+        picker.filter_action = filter_action;
+        picker.placeholder = placeholder;
         if let Some(history_key) = history_key {
             let history = editor.picker_history(&history_key).to_vec();
             picker.set_history(history_key, history);
@@ -2992,6 +3087,96 @@ mod tests {
         assert!(!row.contains("Catppuccin Macchiatocatppuccin"));
         assert!(!row.contains("catppuccin-macchiato.json"));
         assert!(row.contains("embedded"));
+    }
+
+    #[test]
+    fn structured_command_picker_aligns_fields_filters_noise_and_selects_by_id() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 120, 24);
+        let items = vec![
+            PickerItem {
+                id: "git.open".to_string(),
+                label: "Open Git dashboard".to_string(),
+                kind: Some("Command".to_string()),
+                annotation: Some("Git   ".to_string()),
+                detail: Some("Space G    :GitDashboard".to_string()),
+                data: json!({
+                    "description": "Inspect workspace changes",
+                    "aliases": ["source control"],
+                    "shortcuts": ["Space G"],
+                    "colon": ":GitDashboard",
+                }),
+                matches: Vec::new(),
+                detail_matches: Vec::new(),
+                preview: None,
+            },
+            PickerItem {
+                id: "other.open".to_string(),
+                label: "Open dashboard".to_string(),
+                kind: Some("Command".to_string()),
+                annotation: Some("Other ".to_string()),
+                detail: Some("           :Other".to_string()),
+                data: json!({
+                    "description": "Get information together",
+                    "aliases": [],
+                    "shortcuts": [],
+                    "colon": ":Other",
+                }),
+                matches: Vec::new(),
+                detail_matches: Vec::new(),
+                preview: None,
+            },
+            PickerItem {
+                id: "tree.toggle".to_string(),
+                label: "Toggle file tree".to_string(),
+                kind: Some("Command".to_string()),
+                annotation: Some("File  ".to_string()),
+                detail: Some("Ctrl-e".to_string()),
+                data: json!({
+                    "description": "Show or hide the workspace file tree",
+                    "aliases": [],
+                    "shortcuts": ["Ctrl-e"],
+                    "colon": null,
+                }),
+                matches: Vec::new(),
+                detail_matches: Vec::new(),
+                preview: None,
+            },
+        ];
+        let mut picker = Picker::builder()
+            .title("Commands")
+            .structured_items(items)
+            .filter_action(crate::command_palette::filter_score)
+            .select_action(Action::Print)
+            .placeholder("Type a command")
+            .build(&editor);
+        let mut buffer = RenderBuffer::new(120, 24, &Style::default());
+
+        picker.draw(&mut buffer).unwrap();
+        let first = render_row(&buffer, picker.y + 1);
+        let second = render_row(&buffer, picker.y + 2);
+        let third = render_row(&buffer, picker.y + 3);
+        assert!(first.contains("Git     Open Git dashboard"));
+        assert!(second.contains("Other   Open dashboard"));
+        assert!(third.contains("File    Toggle file tree"));
+        assert!(first.contains("Space G    :GitDashboard"));
+        assert_eq!(first.find(":GitDashboard"), second.find(":Other"));
+        assert_eq!(first.find("Space G"), third.find("Ctrl-e"));
+        assert!(render_row(&buffer, picker.layout().separator_y)
+            .contains("Inspect workspace changes · 3/3 commands"));
+
+        picker.handle_event(&Event::Paste("git".to_string()));
+        picker.draw(&mut buffer).unwrap();
+
+        assert_eq!(picker.visible_dynamic_items.len(), 1);
+        assert!(render_row(&buffer, picker.y + 1).contains("Open Git dashboard"));
+        assert!(!render_row(&buffer, picker.y + 2).contains("Open dashboard"));
+        assert_eq!(
+            select(&mut picker),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::Print("git.open".to_string()),
+            ]))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Commands and effective keymaps were difficult to discover: users had to remember modal bindings or exact colon commands, and the existing picker presentation mixed titles, shortcuts, and descriptions together. Prefix-key discovery also disappeared on incidental mouse input, making it unreliable in terminals that continuously report mouse movement.

## What changed

- Add a structured command palette that combines built-in and plugin commands, groups them by category, shows the effective primary keymap and additional-binding count, exposes the exact available `:Command`, and keeps the selected description in the footer. Search covers titles, categories, aliases, keymaps, and colon commands without matching unrelated description text.
- Add optional typed discovery metadata to `red::add_command`, populate the bundled plugins, preserve exact case-sensitive plugin dispatch and built-in precedence, and document the API and user-facing behavior.
- Add familiar palette entrypoints (`F1`, `Space ?`, `Alt-x`, `Ctrl-Shift-p`, `:commands`, and `Ctrl-p` then `>`), preserve combined modifiers through enhanced terminal keyboard handling, and keep portable alternatives for terminals that reserve `Ctrl-Shift-p`.
- Add the delayed prefix-key guide with configurable timing, compact responsive columns, picker-compatible colors, Unicode-safe alignment, and a trailing `…` for nested groups. Mouse movement, clicks, and scrolling no longer consume a pending key sequence or change the editor beneath the guide.
- Extend picker, editor, config, plugin-runtime, and rendering regressions for effective keymaps, colon precedence, noise-free filtering, stable selection IDs, column alignment, nested prefixes, mouse handling, theme fallbacks, and small terminals.

## How to Test

1. Run `cargo run --bin red -- README.md`, then press `F1` (or `Space ?`, `Alt-x`, or `Ctrl-Shift-p`). Confirm the command palette shows aligned category, command, keymap, and `:Command` columns with the selected description in the footer.
2. Search for `git`, a shortcut such as `Space G`, and a colon command such as `:GitDashboard`. Confirm relevant rows remain, unrelated description-only matches do not appear, and selecting a result runs the intended command. Press `Ctrl-p`, type `>`, and confirm the file picker switches directly to commands.
3. Press `Space` and pause briefly. Confirm the key guide appears with readable aligned actions and nested entries such as `Git hunks …`; move/click/scroll the mouse and confirm the guide and cursor stay put, then press `h` and confirm the nested `Space h` guide appears. Press `Esc` and confirm it closes.
4. For focused automated coverage, run `cargo test --lib keymap_hints -- --test-threads=1` and `cargo test --lib command_palette -- --test-threads=1`.

Validation completed locally: formatter and whitespace checks, `cargo clippy --all-targets --all-features -- -D warnings`, production `--self-check`, live terminal smoke, and the serial workspace suite with three unrelated ACP timeout cases excluded. The two detached-agent restart cases pass in isolation but exceed their one-second deadline in the full library run; `a_late_control_response_does_not_terminate_the_actor` also reaches its hard-coded one-second ACP timeout in this environment.
