### PR TITLE
fix(git): render hunk navigation immediately

### DIFF
--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -1640,7 +1640,11 @@ fn spawn_hunk_diff(action: String) {
         args = red::push(args, "--cached");
     }
     args = red::push(args, "--no-ext-diff");
-    args = red::push(args, "--unified=3");
+    if action == "next" || action == "previous" {
+        args = red::push(args, "--unified=0");
+    } else {
+        args = red::push(args, "--unified=3");
+    }
     args = red::push(args, "--");
     args = red::push(args, red::string(red::state("git_hunk_path"), ""));
     let process_id = red::execute("SpawnProcess", Process {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -5665,6 +5665,7 @@ impl Editor {
                         self.cy = y - self.vtop;
                     }
                     self.draw_cursor()?;
+                    needs_motion_render = true;
                 }
                 PluginRequest::SetCursorDisplayColumn { column, y } => {
                     // Convert display column to character index
@@ -5685,6 +5686,7 @@ impl Editor {
                         self.cy = y - self.vtop;
                     }
                     self.draw_cursor()?;
+                    needs_motion_render = true;
                 }
                 PluginRequest::GetBufferText {
                     request_id,
@@ -19555,6 +19557,28 @@ mod test {
         });
         let error = core.tick().await.unwrap_err();
         assert!(error.to_string().contains("injected render failure"));
+        drain_plugin_requests();
+    }
+
+    #[tokio::test]
+    async fn detached_plugin_cursor_requests_render_immediately() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "zero\none\ntwo\nthree".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        let mut core = DetachedEditorCore::new(editor).await.unwrap();
+
+        ACTION_DISPATCHER.send_request(PluginRequest::SetCursorPosition { x: 0, y: 2 });
+        let position = core.tick().await.unwrap().expect("cursor-position render");
+        assert_eq!(position.cursor.1, 2);
+
+        ACTION_DISPATCHER.send_request(PluginRequest::SetCursorDisplayColumn { column: 1, y: 3 });
+        let column = core.tick().await.unwrap().expect("cursor-column render");
+        assert_eq!(column.cursor.1, 3);
         drain_plugin_requests();
     }
 

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -5257,6 +5257,166 @@ mod tests {
         }
     }
 
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_hunk_navigation_targets_changed_lines_without_diff_context() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        let file = root.join("tracked.txt");
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        let original = (1..=30)
+            .map(|line| format!("line {line}\n"))
+            .collect::<String>();
+        fs::write(&file, &original).unwrap();
+        assert!(Command::new("git")
+            .args(["add", "tracked.txt"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "-c",
+                "user.name=Red Test",
+                "-c",
+                "user.email=red@example.test",
+                "commit",
+                "-qm",
+                "initial",
+            ])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(
+            &file,
+            original
+                .replace("line 14\n", "changed 14\n")
+                .replace("line 26\n", "changed 26\n"),
+        )
+        .unwrap();
+
+        let mut runtime = Runtime::new_with_permissions(HashMap::from([(
+            "git".to_string(),
+            PluginPermissions {
+                process: vec!["git".to_string()],
+            },
+        )]));
+        runtime
+            .load_plugin("git", include_str!("../../plugins/git.hk"))
+            .await
+            .unwrap();
+        let mut cwd_request_id = None;
+        let mut config_request_id = None;
+        let mut info_request_id = None;
+        for _ in 0..3 {
+            match ACTION_DISPATCHER.recv_request() {
+                PluginRequest::GetConfig { request_id, key } if key.as_deref() == Some("cwd") => {
+                    cwd_request_id = Some(request_id);
+                }
+                PluginRequest::GetConfig {
+                    request_id,
+                    key: None,
+                } => config_request_id = Some(request_id),
+                PluginRequest::EditorInfo(request_id) => info_request_id = Some(request_id),
+                _ => panic!("unexpected plugin request"),
+            }
+        }
+        runtime
+            .resolve_request(
+                cwd_request_id.unwrap(),
+                serde_json::json!({ "value": root.display().to_string() }),
+            )
+            .await
+            .unwrap();
+        runtime
+            .resolve_request(
+                config_request_id.unwrap(),
+                serde_json::json!({ "value": { "executable": "red", "plugin_config": {} } }),
+            )
+            .await
+            .unwrap();
+        runtime
+            .resolve_request(
+                info_request_id.unwrap(),
+                serde_json::json!({
+                    "theme": {
+                        "style": { "fg": null, "bg": null, "bold": false, "italic": false },
+                        "ui_style": {
+                            "muted": { "fg": null, "bg": null, "bold": false, "italic": false },
+                            "popup_title": { "fg": null, "bg": null, "bold": false, "italic": false }
+                        },
+                        "colors": {}
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+        for (command, cursor_line, expected_line) in
+            [("GitHunkNext", 0, 13), ("GitHunkPrevious", 29, 25)]
+        {
+            runtime.execute_command(command).await.unwrap();
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let target = loop {
+                pump_process_events(&mut runtime).await.unwrap();
+                let mut target = None;
+                while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                    match request {
+                        PluginRequest::GetWindows { request_id } => {
+                            runtime
+                                .resolve_request(
+                                    request_id,
+                                    serde_json::json!({
+                                        "windows": [{
+                                            "buffer_path": file.display().to_string(),
+                                            "buffer_index": 7,
+                                            "active": true
+                                        }]
+                                    }),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                        PluginRequest::GetSelection { request_id } => {
+                            runtime
+                                .resolve_request(request_id, serde_json::Value::Null)
+                                .await
+                                .unwrap();
+                        }
+                        PluginRequest::GetCursorPosition { request_id } => {
+                            runtime
+                                .resolve_request(
+                                    request_id,
+                                    serde_json::json!({ "x": 0, "y": cursor_line }),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                        PluginRequest::SetCursorPosition { x, y } => target = Some((x, y)),
+                        _ => {}
+                    }
+                }
+                if let Some(target) = target {
+                    break target;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "hunk navigation did not complete"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            };
+            assert_eq!(target, (0, expected_line));
+        }
+    }
+
     #[tokio::test]
     async fn project_search_streams_rg_matches_into_picker() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;


### PR DESCRIPTION
`]h`/`[h` hunk navigation could appear to do nothing until a later refresh, and then place the cursor several lines before the actual change. Plugin-driven cursor updates changed editor state without scheduling a frame, while the Git plugin navigated using hunk headers from a three-line-context diff.

This makes both plugin cursor setters request a motion render and uses zero-context diffs specifically for next/previous hunk navigation. Stage, unstage, and reset retain their existing three-line context. Focused regressions cover immediate detached rendering plus both navigation directions against two real Git hunks.

## How to Test

1. Open a tracked file with two separated unstaged changes, place the cursor above the first change, and press `]h`. The cursor should move immediately to the first changed line; press `]h` again to reach the second.
2. From below the changes, press `[h`. The cursor should move immediately to the last changed line, without landing three context lines early.
3. Run the focused regressions:

   ```bash
   cargo test --lib detached_plugin_cursor_requests_render_immediately
   cargo test --lib git_hunk_navigation_targets_changed_lines_without_diff_context
   cargo test --lib git_
   cargo test --test buffer_text_git
   cargo clippy --all-targets --all-features -- -D warnings
   ```
