### PR TITLE
feat(agent): show waiting status in conversation pane

### DIFF
--- a/docs/AGENT_PANE_UX_PLAN.md
+++ b/docs/AGENT_PANE_UX_PLAN.md
@@ -1,0 +1,39 @@
+# Agent pane look-and-feel plan
+
+The agent pane should make three things obvious at a glance: who said what, what
+the agent is doing now, and what the user can do next. Improvements should stay
+useful in narrow terminals and should not turn transient UI state into durable
+conversation history.
+
+## 1. Make turn state visible
+
+- Show an agent-side waiting row immediately after prompt submission.
+- Replace the generic waiting label with concrete tool activity when available.
+- Mirror active, stopping, and ready states in the footer with distinct markers.
+- Replace it with a stopping state on cancellation, then remove it on response,
+  completion, or failure.
+
+This phase is implemented. The waiting row is semantic, muted, excluded from
+copy-all, and never written to transcript storage.
+
+## 2. Strengthen conversation hierarchy
+
+- Keep role labels visually distinct while reducing repeated chrome in long turns.
+- Give errors, interruptions, and proposal-ready notices consistent semantic styles.
+- Group tool activity under the turn that caused it instead of mixing it with
+  durable assistant prose.
+
+## 3. Clarify actions and outcomes
+
+- Surface proposal counts as a compact action near the relevant answer.
+- Make queued follow-ups and cancellation state visible without relying on print
+  messages outside the pane.
+- Keep the primary next action first in narrow footer layouts.
+
+## 4. Polish responsive behavior
+
+- Test the pane at narrow, default, and wide terminal sizes.
+- Preserve readable wrapping and stable scroll position as status rows appear.
+- Use text and shape, not color alone, for every state.
+- Add render-level coverage for each state and interaction-level coverage for
+  submission, activity, streaming, clearing, cancellation, and recovery.

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -40,6 +40,18 @@ Install or update Codex, run `codex login`, then retry without retyping.
 The app-server process is owned by the detachable editor core, so disconnecting
 and reattaching does not intentionally replace a healthy process.
 
+## Conversation pane
+
+Immediately after submission, a muted `◌ Waiting for agent…` row appears
+beneath the user turn. Tool activity replaces its label, cancellation changes
+it to a stopping state, and the row disappears when response text, completion,
+or an error arrives. The footer mirrors active and ready states with `◌` and
+`✓` markers.
+
+The waiting row is transient: it is never persisted or included by copy-all.
+Clearing the visible conversation during an active turn restores the current
+waiting state while preserving session context and the composer draft.
+
 ## Reviewable editing
 
 Every Codex thread is started with:

--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -100,6 +100,7 @@ pub fn activate() {
     red::state_set("agent_stream_timer", "");
     red::state_set("agent_stream_delta", "");
     red::state_set("agent_stream_trimmed", false);
+    red::state_set("agent_waiting_label", "Waiting for agent…");
     red::state_set("agent_history_open", false);
     red::state_set("agent_history_detail", [[PanelSegment { text: "Select a transaction", style: muted_style() }]]);
 }
@@ -221,7 +222,7 @@ fn submit_prompt(text: String) {
         }
         queue = red::push(queue, text);
         red::state_set("agent_prompt_queue", queue);
-        red::execute("SetTextPanelComposerState", "agent-conversation", true, "Working · " + red::len(queue) + " queued · Enter queues · ^C stops");
+        red::execute("SetTextPanelComposerState", "agent-conversation", true, "◌ Working · " + red::len(queue) + " queued · Enter queues · ^C stops");
         red::execute("Print", "Agent turn is still running; follow-up queued (" + red::len(queue) + ")");
         return;
     }
@@ -248,6 +249,7 @@ fn dispatch_prompt(text: String) {
     }
     red::state_set("agent_turn_active", true);
     append_transcript("You", text);
+    set_waiting_indicator("Waiting for agent…");
     red::execute("AgentPrompt", red::state("agent_session_id"), wire_text);
 }
 
@@ -256,9 +258,9 @@ fn turn_started(event: Json) {
         return;
     }
     let queued = red::len(red::state("agent_prompt_queue"));
-    let status = "Working · Enter queues · ^C stops";
+    let status = "◌ Working · Enter queues · ^C stops";
     if queued > 0 {
-        status = "Working · " + queued + " queued · Enter queues · ^C stops";
+        status = "◌ Working · " + queued + " queued · Enter queues · ^C stops";
     }
     red::execute("SetTextPanelComposerState", "agent-conversation", true, status);
 }
@@ -275,7 +277,8 @@ fn activity(event: Json) {
     if label == "" {
         label = red::string(update.session_update, "Working");
     }
-    red::execute("SetTextPanelComposerState", "agent-conversation", true, label + " · Enter queues · ^C stops");
+    set_waiting_indicator(label);
+    red::execute("SetTextPanelComposerState", "agent-conversation", true, "◌ " + label + " · Enter queues · ^C stops");
 }
 
 fn panel_event(event: Json) {
@@ -302,8 +305,13 @@ fn panel_event(event: Json) {
 fn clear_conversation() {
     reset_stream_render();
     red::state_set("agent_transcript_blocks", []);
-    red::execute("UpdateTextPanel", "agent-conversation", []);
-    red::execute("SetTextPanelComposerState", "agent-conversation", true, "Conversation view cleared · context preserved");
+    if red::state_bool("agent_turn_active") {
+        set_waiting_indicator(red::string(red::state("agent_waiting_label"), "Waiting for agent…"));
+        red::execute("SetTextPanelComposerState", "agent-conversation", true, "◌ Working · conversation cleared · ^C stops");
+    } else {
+        red::execute("UpdateTextPanel", "agent-conversation", []);
+        red::execute("SetTextPanelComposerState", "agent-conversation", true, "Conversation view cleared · context preserved");
+    }
 }
 
 fn reset_stream_render() {
@@ -363,6 +371,7 @@ fn update(event: Json) {
     if delta == "" {
         return;
     }
+    clear_waiting_indicator(false);
 
     let transcript = red::state("agent_transcript");
     let block_id = red::string(red::state("agent_stream_block_id"), "");
@@ -422,6 +431,7 @@ fn completed(event: Json) {
         return;
     }
     red::state_set("agent_turn_active", false);
+    clear_waiting_indicator(true);
     let session_id = red::string(event.session_id, "");
     let stop_reason = red::string(event.stop_reason, "end_turn");
     if stop_reason == "end_turn" {
@@ -434,7 +444,7 @@ fn completed(event: Json) {
         red::state_set("agent_recap_pending", true);
     }
     if stop_reason == "end_turn" {
-        red::execute("SetTextPanelComposerState", "agent-conversation", true, "Ready · Enter sends · ^J adds a line");
+        red::execute("SetTextPanelComposerState", "agent-conversation", true, "✓ Ready · Enter sends · ^J adds a line");
         submit_next_queued();
         return;
     }
@@ -472,6 +482,7 @@ fn cancelled(event: Json) {
     if !is_current_session_event(event) {
         return;
     }
+    let turn_active = red::state_bool("agent_turn_active");
     let session_id = red::string(event.session_id, "");
     if session_id != "" {
         red::state_set("agent_cancelled_session_id", session_id);
@@ -483,7 +494,12 @@ fn cancelled(event: Json) {
         red::state_set("agent_recap_pending", true);
     }
     red::execute("Print", "Agent cancellation requested");
-    red::execute("SetTextPanelComposerState", "agent-conversation", true, "Stopping · follow-ups remain queued");
+    if turn_active {
+        set_waiting_indicator("Stopping agent…");
+    } else {
+        clear_waiting_indicator(true);
+    }
+    red::execute("SetTextPanelComposerState", "agent-conversation", true, "◌ Stopping · follow-ups remain queued");
 }
 
 fn failed(event: Json) {
@@ -495,6 +511,7 @@ fn failed(event: Json) {
         return;
     }
     red::state_set("agent_turn_active", false);
+    clear_waiting_indicator(false);
     let session_id = red::string(event.session_id, "");
     if session_id != "" && session_id == red::string(red::state("agent_cancelled_session_id"), "") {
         red::execute("AgentCloseSession", session_id);
@@ -535,6 +552,7 @@ fn session_lost(event: Json) {
     red::state_set("agent_session_id", "");
     red::state_set("agent_cancelled_session_id", "");
     if attempted != "" {
+        set_waiting_indicator("Restarting agent…");
         red::state_set("agent_pending_prompt", attempted);
         red::state_set("agent_pending_prompt_is_replay", true);
         red::execute("Print", "Codex app-server stopped; retrying the saved prompt");
@@ -542,6 +560,7 @@ fn session_lost(event: Json) {
     } else if red::string(red::state("agent_pending_prompt"), "") != "" {
         failed(Json { message: "Codex app-server stopped" });
     } else {
+        clear_waiting_indicator(true);
         red::execute("Print", "Codex app-server stopped. Press Space A to start a new session");
     }
 }
@@ -627,6 +646,52 @@ fn append_transcript(role: String, text: String) {
     let bounded = bounded_transcript_blocks(blocks, "");
     red::state_set("agent_transcript_blocks", bounded.blocks);
     render_conversation();
+}
+
+fn set_waiting_indicator(label: String) {
+    red::state_set("agent_waiting_label", label);
+    let blocks = red::state("agent_transcript_blocks");
+    let updated = [];
+    let found = false;
+    for block in blocks {
+        if block.id == "agent-waiting" {
+            block.kind = "status";
+            block.format = "plain";
+            block.text = "◌ " + label;
+            found = true;
+        }
+        updated = red::push(updated, block);
+    }
+    if !found {
+        updated = red::push(updated, TextPanelBlock {
+            id: "agent-waiting",
+            kind: "status",
+            format: "plain",
+            text: "◌ " + label,
+        });
+    }
+    red::state_set("agent_transcript_blocks", updated);
+    render_conversation();
+}
+
+fn clear_waiting_indicator(render: bool) {
+    let blocks = red::state("agent_transcript_blocks");
+    let updated = [];
+    let removed = false;
+    for block in blocks {
+        if block.id == "agent-waiting" {
+            removed = true;
+        } else {
+            updated = red::push(updated, block);
+        }
+    }
+    red::state_set("agent_waiting_label", "Waiting for agent…");
+    if removed {
+        red::state_set("agent_transcript_blocks", updated);
+        if render {
+            render_conversation();
+        }
+    }
 }
 
 fn stream_timeout(event: Json) {

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -134,6 +134,7 @@ pub enum TextPanelBlockKind {
     User,
     Agent,
     Error,
+    Status,
     #[default]
     Text,
 }
@@ -402,7 +403,7 @@ impl TextPanel {
     fn copy_all(&self) -> String {
         self.blocks
             .iter()
-            .filter(|block| !block.text.is_empty())
+            .filter(|block| block.kind != TextPanelBlockKind::Status && !block.text.is_empty())
             .map(|block| block.text.as_str())
             .collect::<Vec<_>>()
             .join("\n\n")
@@ -1477,7 +1478,7 @@ fn block_label(kind: &TextPanelBlockKind) -> Option<(&'static str, TextPanelSpan
         TextPanelBlockKind::User => Some(("❯ You", TextPanelSpanStyle::User)),
         TextPanelBlockKind::Agent => Some(("◆ Agent", TextPanelSpanStyle::Agent)),
         TextPanelBlockKind::Error => Some(("⚠ Error", TextPanelSpanStyle::Error)),
-        TextPanelBlockKind::Text => None,
+        TextPanelBlockKind::Status | TextPanelBlockKind::Text => None,
     }
 }
 
@@ -1486,6 +1487,7 @@ fn block_style(kind: &TextPanelBlockKind) -> TextPanelSpanStyle {
         TextPanelBlockKind::User => TextPanelSpanStyle::User,
         TextPanelBlockKind::Agent => TextPanelSpanStyle::Agent,
         TextPanelBlockKind::Error => TextPanelSpanStyle::Error,
+        TextPanelBlockKind::Status => TextPanelSpanStyle::Muted,
         TextPanelBlockKind::Text => TextPanelSpanStyle::Text,
     }
 }
@@ -1717,6 +1719,45 @@ mod tests {
         assert_eq!(block.kind, TextPanelBlockKind::Agent);
         assert_eq!(block.format, TextPanelBlockFormat::Markdown);
         assert_eq!(block.text, "# Heading");
+    }
+
+    #[test]
+    fn text_panel_status_blocks_are_muted_and_excluded_from_copy() {
+        let mut panel = TextPanel::new(
+            "agent".to_string(),
+            PanelConfig {
+                width: 32,
+                ..PanelConfig::default()
+            },
+        );
+        panel.blocks = vec![
+            TextPanelBlock {
+                id: "user:1".to_string(),
+                kind: TextPanelBlockKind::User,
+                format: TextPanelBlockFormat::Plain,
+                text: "Inspect this".to_string(),
+            },
+            TextPanelBlock {
+                id: "agent-waiting".to_string(),
+                kind: TextPanelBlockKind::Status,
+                format: TextPanelBlockFormat::Plain,
+                text: "◌ Waiting for agent…".to_string(),
+            },
+        ];
+        assert_eq!(panel.copy_all(), "Inspect this");
+
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(32, 10, &theme.style);
+        render_text_panel(
+            &mut buffer,
+            &panel,
+            Point::new(0, 0),
+            panel.config.width,
+            &theme,
+        );
+
+        assert!(row_text(&buffer, 3).contains("◌ Waiting for agent…"));
+        assert_eq!(buffer.cells[3 * buffer.width].style, theme.ui_style.muted);
     }
 
     #[test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1809,6 +1809,14 @@ mod tests {
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdateTextPanel { id, blocks }
+                if id == "agent-conversation"
+                    && blocks.len() == 2
+                    && blocks[1].kind == crate::plugin::TextPanelBlockKind::Status
+                    && blocks[1].text == "◌ Waiting for agent…"
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
             PluginRequest::AgentPrompt { session_id, text }
                 if session_id == "session-lazy" && text == "explain the workspace"
         ));
@@ -1936,6 +1944,17 @@ mod tests {
                     && blocks[0].kind == crate::plugin::TextPanelBlockKind::User
                     && blocks[0].format == crate::plugin::TextPanelBlockFormat::Plain
                     && blocks[0].text == "  inspect the workspace\ninclude all unsaved changes  "
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdateTextPanel { id, blocks }
+                if id == "agent-conversation"
+                    && blocks.len() == 2
+                    && blocks[0].id == "user:1"
+                    && blocks[1].id == "agent-waiting"
+                    && blocks[1].kind == crate::plugin::TextPanelBlockKind::Status
+                    && blocks[1].format == crate::plugin::TextPanelBlockFormat::Plain
+                    && blocks[1].text == "◌ Waiting for agent…"
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
@@ -2099,7 +2118,7 @@ mod tests {
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::SetTextPanelComposerState { id, enabled: true, status }
                 if id == "agent-conversation"
-                    && status.as_deref() == Some("Ready · Enter sends · ^J adds a line")
+                    && status.as_deref() == Some("✓ Ready · Enter sends · ^J adds a line")
         ));
 
         runtime.execute_command("AgentCancel").await.unwrap();
@@ -2436,6 +2455,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bundled_agent_waiting_status_tracks_activity_and_empty_completion() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        runtime
+            .notify(
+                "agent:session_created",
+                serde_json::json!({ "session_id": "session-1" }),
+            )
+            .await
+            .unwrap();
+        drain_requests();
+
+        runtime
+            .notify(
+                "panel:event:agent-conversation",
+                serde_json::json!({ "action": "submit", "text": "inspect this" }),
+            )
+            .await
+            .unwrap();
+        let mut waiting = false;
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            if let PluginRequest::UpdateTextPanel { id, blocks } = request {
+                waiting |= id == "agent-conversation"
+                    && blocks.last().is_some_and(|block| {
+                        block.kind == crate::plugin::TextPanelBlockKind::Status
+                            && block.text == "◌ Waiting for agent…"
+                    });
+            }
+        }
+        assert!(waiting);
+
+        runtime
+            .notify(
+                "agent:activity",
+                serde_json::json!({
+                    "session_id": "session-1",
+                    "update": { "title": "Reading src/main.rs" }
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdateTextPanel { id, blocks }
+                if id == "agent-conversation"
+                    && blocks.last().is_some_and(|block| {
+                        block.kind == crate::plugin::TextPanelBlockKind::Status
+                            && block.text == "◌ Reading src/main.rs"
+                    })
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::SetTextPanelComposerState { id, enabled: true, status }
+                if id == "agent-conversation"
+                    && status.as_deref()
+                        == Some("◌ Reading src/main.rs · Enter queues · ^C stops")
+        ));
+
+        runtime
+            .notify(
+                "agent:completed",
+                serde_json::json!({
+                    "session_id": "session-1",
+                    "stop_reason": "end_turn",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdateTextPanel { id, blocks }
+                if id == "agent-conversation"
+                    && blocks.iter().all(|block| {
+                        block.kind != crate::plugin::TextPanelBlockKind::Status
+                    })
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::SetTextPanelComposerState { id, enabled: true, status }
+                if id == "agent-conversation"
+                    && status.as_deref() == Some("✓ Ready · Enter sends · ^J adds a line")
+        ));
+    }
+
+    #[tokio::test]
     async fn bundled_agent_clear_only_resets_the_visible_view_and_stream_timer() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
@@ -2471,12 +2580,15 @@ mod tests {
 
         runtime.execute_command("AgentClear").await.unwrap();
 
-        let mut cleared = false;
+        let mut waiting_restored = false;
         let mut status = false;
         while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
             match request {
                 PluginRequest::UpdateTextPanel { id, blocks } => {
-                    cleared |= id == "agent-conversation" && blocks.is_empty();
+                    waiting_restored |= id == "agent-conversation"
+                        && blocks.len() == 1
+                        && blocks[0].kind == crate::plugin::TextPanelBlockKind::Status
+                        && blocks[0].text == "◌ Waiting for agent…";
                 }
                 PluginRequest::SetTextPanelComposerState {
                     id,
@@ -2487,7 +2599,7 @@ mod tests {
                         && enabled
                         && value
                             .as_deref()
-                            .is_some_and(|value| value.contains("context preserved"));
+                            .is_some_and(|value| value.contains("conversation cleared"));
                 }
                 PluginRequest::SetPluginStorage { plugin, key, value }
                     if plugin == "agent"
@@ -2505,7 +2617,7 @@ mod tests {
                 _ => {}
             }
         }
-        assert!(cleared);
+        assert!(waiting_restored);
         assert!(status);
         tokio::time::sleep(Duration::from_millis(70)).await;
         assert!(poll_timer_callbacks().is_empty());
@@ -3141,6 +3253,15 @@ mod tests {
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::AgentArchiveSession { session_id } if session_id == "session-1"
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdateTextPanel { id, blocks }
+                if id == "agent-conversation"
+                    && blocks.last().is_some_and(|block| {
+                        block.kind == crate::plugin::TextPanelBlockKind::Status
+                            && block.text == "◌ Restarting agent…"
+                    })
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
@@ -3882,6 +4003,15 @@ mod tests {
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::UpdateTextPanel { id, .. } if id == "agent-conversation"
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdateTextPanel { id, blocks }
+                if id == "agent-conversation"
+                    && blocks.last().is_some_and(|block| {
+                        block.kind == crate::plugin::TextPanelBlockKind::Status
+                            && block.text == "◌ Waiting for agent…"
+                    })
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),


### PR DESCRIPTION
The agent pane can appear idle after a prompt is submitted because it has no agent-side presence until the first streamed response arrives. This makes slow starts, tool activity, cancellation, and adapter recovery difficult to distinguish from a stalled turn.

This change:

- adds a muted, transient `◌ Waiting for agent…` row immediately after submission and updates it with activity, stopping, and restart states;
- removes transient status when response text, completion, or failure arrives, while restoring it if the visible conversation is cleared during an active turn;
- adds semantic status-block rendering that stays out of transcript persistence and copy-all output;
- mirrors working and ready state in the composer footer and documents the broader agent-pane UX plan;
- covers submission, activity, empty completion, clearing, streaming, and recovery paths with focused tests.

## How to Test

1. Open the agent pane with `Space A`, submit a prompt, and verify `◌ Waiting for agent…` appears directly beneath the user message before the first response chunk.
2. Run a prompt that triggers editor/tool activity and verify the waiting row changes to the reported activity, then disappears when response text arrives; the footer should show `✓ Ready` after completion.
3. While a turn is active, clear the visible conversation and verify the waiting state remains visible. Cancel the turn and verify it changes to `◌ Stopping` without leaking the transient row into copied conversation text.

Automated coverage: `cargo test --all-targets --all-features` and `cargo clippy --all-targets --all-features -- -D warnings`.