### PR TITLE
fix(neotree): prevent instruction budget exhaustion

### DIFF
--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -79,6 +79,9 @@ fn panel_event(event: Json) {
     if row == red::null() {
         return;
     }
+    if row.path == red::null() {
+        return;
+    }
 
     if event.action == "activate" || event.action == "toggle" {
         if row.kind == "directory" {
@@ -120,9 +123,9 @@ fn request_git_status() {
 
 fn directory_loaded(listing: Json) {
     if listing.error != red::null() {
-        set_children(listing.path, []);
+        set_children(listing.path, [], false);
     } else {
-        set_children(listing.path, listing.entries);
+        set_children(listing.path, listing.entries, red::bool(listing.truncated, false));
         watch_directory(listing.path);
     }
 
@@ -292,7 +295,7 @@ fn find_child(entries: Json, name: String, kind: String) -> Json {
     return red::null();
 }
 
-fn set_children(path: String, entries: Json) {
+fn set_children(path: String, entries: Json, truncated: bool) {
     let children = [];
     for child in red::state("children") {
         if child.path != path {
@@ -302,6 +305,7 @@ fn set_children(path: String, entries: Json) {
     children = red::push(children, Children {
         path: path,
         entries: entries,
+        truncated: truncated,
     });
     red::state_set("children", children);
 }
@@ -322,6 +326,15 @@ fn children_for(path: String) -> Json {
         }
     }
     return [];
+}
+
+fn children_truncated(path: String) -> bool {
+    for child in red::state("children") {
+        if child.path == path {
+            return red::bool(child.truncated, false);
+        }
+    }
+    return false;
 }
 
 fn toggle_directory(path: String) {
@@ -400,6 +413,9 @@ fn build_rows() -> Json {
     if is_expanded(root) {
         rows = append_rows(root, [], rows);
     }
+    if red::len(rows) >= 200 {
+        rows = red::push(rows, truncation_row("tree-limit", "… tree limited to 200 rows"));
+    }
     return rows;
 }
 
@@ -411,7 +427,7 @@ fn append_rows(path: String, ancestors: Json, rows: Json) -> Json {
         }
     }
     let index = 0;
-    while index < red::len(entries) {
+    while index < red::len(entries) && red::len(rows) < 200 {
         let entry = entries[index];
         let is_last = index == red::len(entries) - 1;
         let is_directory = entry.kind == "directory";
@@ -438,7 +454,24 @@ fn append_rows(path: String, ancestors: Json, rows: Json) -> Json {
         }
         index = index + 1;
     }
+    if children_truncated(path) && red::len(rows) < 200 {
+        rows = red::push(rows, truncation_row("directory-limit:" + path, "… directory listing truncated"));
+    }
     return rows;
+}
+
+fn truncation_row(id: String, text: String) -> Json {
+    return PanelRow {
+        id: id,
+        path: red::null(),
+        expanded: false,
+        kind: "file",
+        segments: [
+            segment("  ", ["tree.indentGuidesStroke"], false),
+            segment(text, ["gitDecoration.ignoredResourceForeground"], false),
+        ],
+        right_segments: [],
+    };
 }
 
 fn branch_prefix(ancestors: Json, is_last: bool) -> Json {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -118,6 +118,7 @@ const AGENT_EVENTS_PER_TICK: usize = 64;
 const GUTTER_SIGN_COLUMN_WIDTH: usize = 2;
 const MAX_HIGHLIGHT_SLICE_BYTES: usize = 512 * 1024;
 const MAX_PLUGIN_VIEWPORT_LINE_CHARS: usize = 64 * 1024;
+const MAX_DIRECTORY_LISTING_ENTRIES: usize = 160;
 const AGENT_BRIDGE_CAPACITY: usize = 64;
 const MACRO_MAX_REPLAY_DEPTH: usize = 20;
 const MACRO_MAX_REPLAY_EVENTS: usize = 10_000;
@@ -18921,35 +18922,60 @@ impl From<&Buffer> for BufferInfo {
 }
 
 fn directory_listing(path: &str) -> Value {
-    let read_dir = match std::fs::read_dir(path) {
-        Ok(read_dir) => read_dir,
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {
+            return json!({
+                "path": path,
+                "entries": [],
+                "truncated": false,
+                "error": "path is not a directory",
+            });
+        }
         Err(err) => {
             return json!({
                 "path": path,
                 "entries": [],
+                "truncated": false,
                 "error": err.to_string(),
             });
         }
-    };
+    }
 
-    let mut entries = read_dir
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            let metadata = entry.metadata().ok()?;
-            let kind = if metadata.is_dir() {
-                "directory"
-            } else if metadata.is_file() {
-                "file"
-            } else {
-                "other"
-            };
-            Some(json!({
-                "name": entry.file_name().to_string_lossy(),
-                "path": entry.path().to_string_lossy(),
-                "kind": kind,
-            }))
-        })
-        .collect::<Vec<_>>();
+    let mut builder = ignore::WalkBuilder::new(path);
+    builder
+        .max_depth(Some(1))
+        .hidden(false)
+        .ignore(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .follow_links(false)
+        .filter_entry(|entry| {
+            entry.depth() == 0 || !matches!(entry.file_name().to_str(), Some(".git" | ".bare"))
+        });
+
+    let mut entries = Vec::new();
+    let mut truncated = false;
+    for entry in builder.build().filter_map(Result::ok).skip(1) {
+        let kind = match entry.file_type() {
+            Some(file_type) if file_type.is_dir() => "directory",
+            Some(file_type) if file_type.is_file() => "file",
+            _ => "other",
+        };
+        if kind == "other" {
+            continue;
+        }
+        if entries.len() == MAX_DIRECTORY_LISTING_ENTRIES {
+            truncated = true;
+            break;
+        }
+        entries.push(json!({
+            "name": entry.file_name().to_string_lossy(),
+            "path": entry.path().to_string_lossy(),
+            "kind": kind,
+        }));
+    }
 
     entries.sort_by(|a, b| {
         let kind_rank = |value: &Value| match value.get("kind").and_then(Value::as_str) {
@@ -18968,6 +18994,7 @@ fn directory_listing(path: &str) -> Value {
     json!({
         "path": path,
         "entries": entries,
+        "truncated": truncated,
         "error": null,
     })
 }
@@ -26010,6 +26037,53 @@ while True:
         assert_eq!(entries[0]["name"], "src");
         assert_eq!(entries[1]["kind"], "file");
         assert_eq!(entries[1]["name"], "README.md");
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn directory_listing_honors_ignores_and_hides_vcs_metadata() {
+        let root =
+            std::env::temp_dir().join(format!("red-dir-listing-ignore-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(root.join("target/debug")).unwrap();
+        std::fs::create_dir_all(root.join(".git/objects")).unwrap();
+        std::fs::create_dir_all(root.join(".github")).unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join(".gitignore"), "/target\n").unwrap();
+
+        let listing = directory_listing(&root.to_string_lossy());
+        let names = listing["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|entry| entry["name"].as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"src"));
+        assert!(names.contains(&".github"));
+        assert!(!names.contains(&"target"));
+        assert!(!names.contains(&".git"));
+        assert_eq!(listing["truncated"], false);
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn directory_listing_caps_pathological_directories() {
+        let root =
+            std::env::temp_dir().join(format!("red-dir-listing-cap-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        for index in 0..MAX_DIRECTORY_LISTING_ENTRIES + 10 {
+            std::fs::write(root.join(format!("file-{index:03}.txt")), "fixture").unwrap();
+        }
+
+        let listing = directory_listing(&root.to_string_lossy());
+
+        assert_eq!(
+            listing["entries"].as_array().unwrap().len(),
+            MAX_DIRECTORY_LISTING_ENTRIES
+        );
+        assert_eq!(listing["truncated"], true);
 
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -6976,6 +6976,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn neotree_caps_a_pathological_visible_listing_within_the_instruction_budget() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("neotree", include_str!("../../plugins/neotree.hk"))
+            .await
+            .unwrap();
+        runtime.execute_command("NeoTree").await.unwrap();
+
+        let mut directory_request = None;
+        for _ in 0..7 {
+            if let PluginRequest::ListDirectory { path, request_id } =
+                ACTION_DISPATCHER.recv_request()
+            {
+                assert_eq!(path, ".");
+                directory_request = Some(request_id);
+            }
+        }
+
+        let entries = (0..1_000)
+            .map(|index| {
+                serde_json::json!({
+                    "name": format!("file-{index:04}.rlib"),
+                    "path": format!("./file-{index:04}.rlib"),
+                    "kind": "file",
+                })
+            })
+            .collect::<Vec<_>>();
+        runtime
+            .resolve_request(
+                directory_request.expect("expected root directory request"),
+                serde_json::json!({
+                    "path": ".",
+                    "entries": entries,
+                    "truncated": true,
+                    "error": null,
+                }),
+            )
+            .await
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::WatchDirectory { path, .. } => assert_eq!(path, "."),
+            _ => panic!("expected neotree directory watch"),
+        }
+        let rows = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::UpdatePanel { id, rows } => {
+                assert_eq!(id, "neotree");
+                rows
+            }
+            _ => panic!("expected neotree panel update"),
+        };
+        assert_eq!(rows.len(), 201);
+        assert!(rows.last().unwrap().path.is_none());
+        assert_eq!(
+            rows.last().unwrap().segments[1].text,
+            "… tree limited to 200 rows"
+        );
+    }
+
+    #[tokio::test]
     async fn neotree_renders_git_status_for_a_filesystem_root_repository() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();


### PR DESCRIPTION
## Why

NeoTree rebuilt every visible row from unbounded raw directory listings. Expanding generated or VCS directories with hundreds of entries could exhaust Husk's 100,000-instruction callback budget and abort the plugin callback. Raising that budget would only permit longer editor stalls without addressing pathological panel payloads.

## What Changed

- honor project, global Git, and exclude-file ignore rules while keeping non-VCS hidden files visible
- exclude `.git` and `.bare` metadata directories from NeoTree
- cap each directory listing at 160 entries and report when it is truncated
- cap the complete visible tree at 200 rows and render a non-interactive truncation notice
- cover ignored directories, bounded host listings, and a 1,000-entry plugin response with regression tests

## How to Test

1. Run `cargo test directory_listing --all-features -- --test-threads=1`.
   - Ignored build directories and VCS metadata should be absent.
   - Ordinary hidden directories such as `.github` should remain visible.
   - Listings above 160 entries should report truncation.
2. Run `cargo test neotree_ --all-features -- --test-threads=1`.
   - Existing expansion, reveal, selection, and Git decoration behavior should pass.
   - A 1,000-entry listing should render a 200-row tree plus a truncation notice without exhausting Husk's instruction budget.
3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
   - The workspace should complete without warnings.
