### PR TITLE
feat(editor): add branded startup splash and red theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ To start from the bundled version, *eject* a copy into your config directory:
 
 ```shell
 red --eject plugins/fidget.hk   # copy a bundled plugin for editing
-red --eject themes/mocha.json   # copy a bundled theme for editing
+red --eject themes/red.json     # copy the default theme for editing
 red --eject fidget.hk           # the plugins/ or themes/ prefix is optional
 ```
 

--- a/default_config.toml
+++ b/default_config.toml
@@ -9,7 +9,7 @@
 
 # Name of the VSCode theme to use. The theme file should be present in the
 # themes directory: $XDG_CONFIG_HOME/red/themes or $HOME/.config/red/themes
-theme = "mocha.json"
+theme = "red.json"
 
 # The number of lines to scroll when using the mouse wheel
 mouse_scroll_lines = 3

--- a/default_config.toml
+++ b/default_config.toml
@@ -31,6 +31,10 @@ breakindent = true
 sidescroll = 1
 sidescrolloff = 0
 
+# Show the startup splash when red opens without file arguments. It
+# disappears on the first edit, file open, or window split.
+splash = true
+
 # The full path to the log file. If the log file is not present, red will
 # create it. If the log file is present, red will append to it.
 # This setting is optional, if not present, red will not log anything.

--- a/docs/SPLASH.md
+++ b/docs/SPLASH.md
@@ -1,0 +1,101 @@
+# Splash screen
+
+Status: implemented (`src/splash.rs`, `render_splash` in
+`src/editor/rendering.rs`); companion theme at `themes/red.json`
+Date: 2026-07-19
+
+The intro screen shown when red starts with no file arguments — the same slot
+Neovim's `:intro` occupies, carrying red's own identity: a rounded lowercase
+wordmark, a single point of color (the dot, always the theme's red), six
+verified keystrokes, and the trust-model epigraph.
+
+## Layout
+
+A 60-column block, centered horizontally and vertically in the focused
+window's viewport. Render-only overlay: the buffer stays empty, the cursor
+stays at 1:1, line number 1 renders normally.
+
+```
+                                    ╷
+                   ╭──╮   ╭──╮   ╭──┤
+                   │      ├──╯   │  │
+                   ╵      ╰──╴   ╰──╯  ●
+
+                         red v0.1.1
+              the modal editor for the agent era
+                 github.com/codersauce/red
+
+────────────────────────────────────────────────────────────
+press  Space ?               to discover every command
+press  Ctrl-p                to find a file
+press  Space A               to ask the agent
+type   :AgentReview<Enter>   to review the agent's proposals
+press  Space t               to change the theme
+type   :q<Enter>             to exit
+────────────────────────────────────────────────────────────
+
+              every agent edit is a proposal —
+       nothing touches your files until you accept it
+```
+
+The version string comes from `CARGO_PKG_VERSION`. Every keystroke above is
+verified against `default_config.toml` (`Space ?` → CommandPalette, `Ctrl-p` →
+FilePicker, `Space A` → Agent, `Space t` → ThemeBrowser). red has no `:help`;
+the command palette is the discovery surface, so it leads the list.
+
+## Identity notes
+
+- **Rounded where Neovim is angular.** The wordmark is single-stroke box
+  drawing with rounded corners (`╭ ╮ ╰ ╯`), lowercase and small — the opposite
+  temperament of nvim's thin, doubled, angular N.
+- **The dot is the brand.** The wordmark reads "red●"; the dot is the only
+  saturated element on screen.
+- **The epigraph is the differentiator** (see `docs/DIFFERENTIATION.md`): the
+  proposal-based agent trust model, stated in one sentence, in the slot where
+  nvim puts its sponsor line.
+
+## Colors — theme tokens only, never hardcoded
+
+| Element                 | Token                       | Fallback                        |
+| ----------------------- | --------------------------- | ------------------------------- |
+| Wordmark strokes        | `editor.foreground`         | terminal default fg             |
+| The dot `●`             | `terminal.ansiBrightRed`    | `errorForeground`, then ANSI red|
+| Key column              | `terminal.ansiRed`          | same chain as the dot           |
+| Version, tagline, verbs | `descriptionForeground`     | dimmed fg                       |
+| Rules                   | `editorGroup.border`        | dim fg                          |
+| Epigraph                | `editor.foreground` dimmed  | between fg and muted            |
+
+Because everything maps to tokens red already reads from the active VSCode
+theme, the splash re-skins live with the theme browser (`Space t`) like every
+other surface.
+
+## Behavior
+
+- **Show when:** launched with no file arguments, a single unnamed blank
+  buffer, and a window content area of at least 60×20 cells.
+- **Dismiss when:** the buffer is first modified, a file is opened (picker,
+  `:e`, session restore), or the window is split. Pure motions do not
+  dismiss. Once its conditions fail after it has been shown, the splash is
+  latched off for the rest of the session.
+- **Config:** `splash = false` in `config.toml` (flat key, matching `wrap` /
+  `scrolloff` style; default `true`).
+- **Degrade:** below 60×20 content cells, a compact variant — wordmark,
+  `red v0.1.1`, and `press Space ? for commands`. Below 26×7, nothing.
+
+```
+                 ╷
+╭──╮   ╭──╮   ╭──┤
+│      ├──╯   │  │
+╵      ╰──╴   ╰──╯  ●
+
+     red v0.1.1
+press Space ? for commands
+```
+
+## Implementation
+
+Belongs in the core empty-buffer render path (like Neovim's intro), not a Husk
+plugin: it must appear on the very first frame, before plugin activation
+completes, and it needs the theme-token fallback chain that core rendering
+already owns. It is a paint-time overlay in the window's viewport, composed
+after the buffer/line-number pass and skipped entirely once dismissed.

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -594,7 +594,7 @@ mod tests {
     fn starter_config_is_loadable_as_user_overrides() {
         let config = Config::from_user_toml_with_overrides(&starter_config(), &[]).unwrap();
 
-        assert_eq!(config.theme, "mocha.json");
+        assert_eq!(config.theme, "red.json");
         assert!(config.plugins.contains_key("theme_browser"));
         assert!(config.keys.normal.contains_key("Ctrl-t"));
     }
@@ -625,7 +625,7 @@ mod tests {
 
     #[test]
     fn bundled_assets_include_default_theme_and_plugins() {
-        assert!(bundled_theme("mocha.json").is_some());
+        assert!(bundled_theme("red.json").is_some());
         assert!(bundled_plugin_specifier("theme_browser.hk")
             .as_deref()
             .is_some_and(|specifier| specifier == "red-bundled:///plugins/theme_browser.hk"));

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -392,6 +392,18 @@ impl Buffer {
         self.file.as_deref().unwrap_or("[No Name]")
     }
 
+    /// True when the buffer has never been associated with a file.
+    pub fn is_unnamed(&self) -> bool {
+        self.file.is_none()
+    }
+
+    /// True when the buffer holds no text. Unlike [`Buffer::is_empty`], this
+    /// treats the single newline that `Buffer::new` normalizes empty scratch
+    /// buffers to as blank.
+    pub fn is_blank(&self) -> bool {
+        self.content.len_bytes() <= 1 && self.content.chars().all(|c| c == '\n')
+    }
+
     pub fn uri(&self) -> anyhow::Result<Option<String>> {
         let Some(file) = &self.file else {
             return Ok(None);

--- a/src/config.rs
+++ b/src/config.rs
@@ -907,7 +907,7 @@ fn deserialize_config(value: toml::Value) -> anyhow::Result<Config> {
 
 fn safe_loaded_config(path: &Path, code: &str, message: String) -> anyhow::Result<LoadedConfig> {
     let mut config = deserialize_config(embedded_config_value()?)?;
-    config.theme = "mocha.json".to_string();
+    config.theme = "red.json".to_string();
     config.log_file = None;
     config.plugins.clear();
     config.disabled_plugins.clear();
@@ -1765,6 +1765,7 @@ wrap = "yes"
         assert!(!loaded.config.lsp.enabled);
         assert!(loaded.config.lsp.servers.is_empty());
         assert!(loaded.config.log_file.is_none());
+        assert_eq!(loaded.config.theme, "red.json");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,9 @@ pub struct Config {
     pub breakindent: Option<bool>,
     pub sidescroll: Option<usize>,
     pub sidescrolloff: Option<usize>,
+    /// Show the startup splash when red opens without file arguments.
+    /// Defaults to on.
+    pub splash: Option<bool>,
     #[serde(default)]
     pub search: SearchConfig,
     #[serde(default)]
@@ -949,6 +952,7 @@ fn known_top_level_field(field: &str) -> bool {
             | "breakindent"
             | "sidescroll"
             | "sidescrolloff"
+            | "splash"
             | "search"
             | "picker"
             | "key_hints"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1568,6 +1568,13 @@ pub struct Editor {
     /// Incremented after full renders so event handling can avoid duplicate frames.
     render_generation: u64,
 
+    /// True once the startup splash has been drawn at least once.
+    splash_shown: bool,
+
+    /// Latched when the splash's visibility conditions first fail after it was
+    /// shown, so it never reappears within the session.
+    splash_dismissed: bool,
+
     /// The last frame sent to the terminal. Keeping this separately lets the
     /// renderer diff frames without cloning the entire render buffer.
     previous_render_buffer: Option<RenderBuffer>,
@@ -2716,6 +2723,8 @@ impl Editor {
             is_focused: true,
             suppress_reactivation_click: false,
             render_generation: 0,
+            splash_shown: false,
+            splash_dismissed: false,
             previous_render_buffer: None,
             last_rendered_cursor_position: None,
             last_rendered_cursor_surface: None,
@@ -21494,6 +21503,71 @@ mod test {
             Editor::with_size(lsp, width, height, config, Theme::default(), vec![buffer]).unwrap();
         editor.test_disable_terminal_output();
         editor
+    }
+
+    fn splash_test_editor(width: usize, height: usize, config: Config) -> Editor {
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, String::new());
+        let mut editor =
+            Editor::with_size(lsp, width, height, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        editor
+    }
+
+    fn rendered_dump(editor: &mut Editor, width: usize, height: usize) -> String {
+        let mut buffer = RenderBuffer::new(width, height, &Style::default());
+        editor.render(&mut buffer).unwrap();
+        // The dump renders spaces as '·'; normalize so assertions can use
+        // the on-screen text verbatim.
+        buffer.dump(false).replace('·', " ")
+    }
+
+    #[test]
+    fn splash_renders_on_pristine_startup() {
+        let mut editor = splash_test_editor(100, 30, Config::default());
+        let dump = rendered_dump(&mut editor, 100, 30);
+        assert!(dump.contains("red v"));
+        assert!(dump.contains("╭──╮   ╭──╮   ╭──┤"));
+        assert!(dump.contains(":AgentReview<Enter>"));
+        assert!(dump.contains("every agent edit is a proposal"));
+    }
+
+    #[test]
+    fn splash_dismisses_on_edit_and_never_returns() {
+        let mut editor = splash_test_editor(100, 30, Config::default());
+        assert!(rendered_dump(&mut editor, 100, 30).contains("red v"));
+
+        editor.buffers[0].insert_str(0, 0, "x");
+        assert!(!rendered_dump(&mut editor, 100, 30).contains("red v"));
+        assert!(editor.splash_dismissed);
+
+        // Returning to a pristine-looking buffer must not resurrect it.
+        editor.buffers[0] = Buffer::new(None, String::new());
+        assert!(!rendered_dump(&mut editor, 100, 30).contains("red v"));
+    }
+
+    #[test]
+    fn splash_respects_config_and_startup_files() {
+        let mut disabled = Config::default();
+        disabled.splash = Some(false);
+        let mut editor = splash_test_editor(100, 30, disabled);
+        assert!(!rendered_dump(&mut editor, 100, 30).contains("red v"));
+
+        let mut with_files = Config::default();
+        with_files.startup_file_count = 1;
+        let mut editor = splash_test_editor(100, 30, with_files);
+        assert!(!rendered_dump(&mut editor, 100, 30).contains("red v"));
+    }
+
+    #[test]
+    fn splash_degrades_to_compact_then_nothing() {
+        let mut editor = splash_test_editor(50, 30, Config::default());
+        let dump = rendered_dump(&mut editor, 50, 30);
+        assert!(dump.contains("for commands"));
+        assert!(!dump.contains(":AgentReview"));
+
+        let mut editor = splash_test_editor(24, 6, Config::default());
+        assert!(!rendered_dump(&mut editor, 24, 6).contains("red v"));
     }
 
     fn test_config_diagnostic() -> ConfigDiagnostic {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -21548,13 +21548,17 @@ mod test {
 
     #[test]
     fn splash_respects_config_and_startup_files() {
-        let mut disabled = Config::default();
-        disabled.splash = Some(false);
+        let disabled = Config {
+            splash: Some(false),
+            ..Config::default()
+        };
         let mut editor = splash_test_editor(100, 30, disabled);
         assert!(!rendered_dump(&mut editor, 100, 30).contains("red v"));
 
-        let mut with_files = Config::default();
-        with_files.startup_file_count = 1;
+        let with_files = Config {
+            startup_file_count: 1,
+            ..Config::default()
+        };
         let mut editor = splash_test_editor(100, 30, with_files);
         assert!(!rendered_dump(&mut editor, 100, 30).contains("red v"));
     }

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -15,6 +15,7 @@ use crate::{
     editor::RenderCommand,
     lsp::Diagnostic,
     plugin::DecorationAnchor,
+    splash,
     theme::{SelectionForegroundPriority, Style},
     unicode_utils::{
         char_prefix, display_width, display_width_with_tabs, fit_display_width,
@@ -212,6 +213,9 @@ impl Editor {
 
         // Render window separators
         self.render_all_window_separators(buffer)?;
+
+        // Startup splash over the pristine scratch window (docs/SPLASH.md)
+        self.render_splash(buffer);
 
         self.panel_manager.render(buffer, &self.theme);
 
@@ -593,6 +597,65 @@ impl Editor {
     }
 
     /// Renders a single window
+    /// Whether the startup splash should render this frame. Visibility is
+    /// recomputed per render; once its conditions fail after it has been
+    /// shown, the splash is latched off for the rest of the session.
+    fn splash_should_render(&mut self) -> bool {
+        if self.splash_dismissed {
+            return false;
+        }
+        if !self.config.splash.unwrap_or(true) || self.config.startup_file_count != 0 {
+            return false;
+        }
+        let pristine = self.window_manager.windows().len() == 1
+            && self.buffers.len() == 1
+            && self.buffers[0].is_unnamed()
+            && self.buffers[0].is_blank()
+            && !self.buffers[0].is_dirty();
+        if !pristine {
+            if self.splash_shown {
+                self.splash_dismissed = true;
+            }
+            return false;
+        }
+        true
+    }
+
+    fn render_splash(&mut self, buffer: &mut RenderBuffer) {
+        if !self.splash_should_render() {
+            return;
+        }
+        let window_data = {
+            let windows = self.window_manager.windows();
+            let active = self.window_manager.active_window_id();
+            windows.get(active).map(|window| (*window).clone())
+        };
+        let Some(window) = window_data else {
+            return;
+        };
+        let content_width = self.window_content_width(&window);
+        let content_height = self.window_content_height(&window);
+        let Some(block) = splash::block(content_width, content_height, env!("CARGO_PKG_VERSION"))
+        else {
+            return;
+        };
+        self.splash_shown = true;
+        let palette = splash::palette(&self.theme);
+        let block_width = block.iter().map(splash::Line::width).max().unwrap_or(0);
+        let content_start = self.gutter_width_for_window(&window) + 1;
+        let x0 = self.window_to_terminal_x(&window, content_start)
+            + content_width.saturating_sub(block_width) / 2;
+        let top = content_height.saturating_sub(block.len()) / 2;
+        for (row, line) in block.iter().enumerate() {
+            let term_y = self.window_to_terminal_y(&window, top + row);
+            let mut x = x0;
+            for span in &line.spans {
+                buffer.set_text(x, term_y, &span.text, palette.style(span.role));
+                x += span.text.chars().count();
+            }
+        }
+    }
+
     fn render_window(&mut self, buffer: &mut RenderBuffer, window_id: usize) -> anyhow::Result<()> {
         // Clone the window data to avoid borrowing issues
         let window_data = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod plugin;
 pub mod preferences;
 mod self_check;
 pub mod session;
+pub mod splash;
 pub mod sync;
 pub mod theme;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -622,8 +622,8 @@ fn finalize_runtime_config(
                 format!("configured theme could not be loaded: {error}"),
                 "used the embedded default theme",
             );
-            loaded.config.theme = "mocha.json".to_string();
-            let contents = assets::bundled_theme("mocha.json")
+            loaded.config.theme = "red.json".to_string();
+            let contents = assets::bundled_theme("red.json")
                 .ok_or_else(|| anyhow::anyhow!("embedded default theme is missing"))?;
             parse_vscode_theme_contents(contents)
                 .map_err(|error| anyhow::anyhow!("embedded default theme is invalid: {error}"))?
@@ -676,7 +676,7 @@ mod tests {
 
         let (loaded, _, logger) = finalize_runtime_config(loaded).unwrap();
 
-        assert_eq!(loaded.config.theme, "mocha.json");
+        assert_eq!(loaded.config.theme, "red.json");
         assert!(loaded.config.log_file.is_none());
         assert!(logger.is_none());
         assert!(loaded

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -1,0 +1,365 @@
+//! Startup splash screen model.
+//!
+//! Layout and palette resolution are pure so rendering stays a thin paint
+//! pass; see `docs/SPLASH.md` for the design spec. The splash is a
+//! render-only overlay: it never touches buffer contents.
+
+use crate::color::Color;
+use crate::theme::{Style, Theme};
+
+/// Content cells required for the full splash block.
+pub const FULL_MIN_WIDTH: usize = 60;
+pub const FULL_MIN_HEIGHT: usize = 20;
+/// Content cells required for the compact wordmark-only variant.
+pub const COMPACT_MIN_WIDTH: usize = 26;
+pub const COMPACT_MIN_HEIGHT: usize = 7;
+
+/// Visual role of a splash span; each maps to one theme-derived style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// Wordmark strokes.
+    Mark,
+    /// The dot after the wordmark — always the theme's red.
+    Dot,
+    /// Version, tagline, hint verbs.
+    Muted,
+    /// Keystroke column.
+    Key,
+    /// Hint descriptions.
+    Text,
+    /// Horizontal rules.
+    Rule,
+    /// The closing trust-model epigraph.
+    Epigraph,
+}
+
+#[derive(Debug)]
+pub struct Span {
+    pub text: String,
+    pub role: Role,
+}
+
+#[derive(Debug)]
+pub struct Line {
+    pub spans: Vec<Span>,
+}
+
+impl Line {
+    fn new(spans: Vec<Span>) -> Self {
+        Self { spans }
+    }
+
+    fn blank() -> Self {
+        Self { spans: Vec::new() }
+    }
+
+    pub fn width(&self) -> usize {
+        self.spans
+            .iter()
+            .map(|span| span.text.chars().count())
+            .sum()
+    }
+}
+
+fn span(text: impl Into<String>, role: Role) -> Span {
+    Span {
+        text: text.into(),
+        role,
+    }
+}
+
+/// The wordmark rows without the trailing dot; 18 cells wide, 21 with it.
+const MARK_ROWS: [&str; 4] = [
+    "                 ╷",
+    "╭──╮   ╭──╮   ╭──┤",
+    "│      ├──╯   │  │",
+    "╵      ╰──╴   ╰──╯",
+];
+const MARK_WIDTH: usize = 21;
+
+const HINTS: [(&str, &str, &str); 6] = [
+    ("press", "Space ?", "to discover every command"),
+    ("press", "Ctrl-p", "to find a file"),
+    ("press", "Space A", "to ask the agent"),
+    (
+        "type",
+        ":AgentReview<Enter>",
+        "to review the agent's proposals",
+    ),
+    ("press", "Space t", "to change the theme"),
+    ("type", ":q<Enter>", "to exit"),
+];
+const HINT_VERB_WIDTH: usize = 7;
+const HINT_KEY_WIDTH: usize = 22;
+
+fn centered(text: &str, role: Role, width: usize) -> Line {
+    let pad = width.saturating_sub(text.chars().count()) / 2;
+    Line::new(vec![span(format!("{}{text}", " ".repeat(pad)), role)])
+}
+
+fn mark_lines(width: usize) -> Vec<Line> {
+    let pad = " ".repeat(width.saturating_sub(MARK_WIDTH) / 2);
+    let mut lines = Vec::new();
+    for (row, art) in MARK_ROWS.iter().enumerate() {
+        let mut spans = vec![span(format!("{pad}{art}"), Role::Mark)];
+        if row == MARK_ROWS.len() - 1 {
+            spans.push(span("  ", Role::Mark));
+            spans.push(span("●", Role::Dot));
+        }
+        lines.push(Line::new(spans));
+    }
+    lines
+}
+
+fn full_block(version: &str) -> Vec<Line> {
+    let width = FULL_MIN_WIDTH;
+    let mut lines = mark_lines(width);
+    lines.push(Line::blank());
+    lines.push(centered(&format!("red v{version}"), Role::Muted, width));
+    lines.push(centered(
+        "the modal editor for the agent era",
+        Role::Muted,
+        width,
+    ));
+    lines.push(centered("github.com/codersauce/red", Role::Muted, width));
+    lines.push(Line::blank());
+    lines.push(Line::new(vec![span("─".repeat(width), Role::Rule)]));
+    for (verb, key, description) in HINTS {
+        lines.push(Line::new(vec![
+            span(format!("{verb:<HINT_VERB_WIDTH$}"), Role::Muted),
+            span(format!("{key:<HINT_KEY_WIDTH$}"), Role::Key),
+            span(description, Role::Text),
+        ]));
+    }
+    lines.push(Line::new(vec![span("─".repeat(width), Role::Rule)]));
+    lines.push(Line::blank());
+    lines.push(centered(
+        "every agent edit is a proposal —",
+        Role::Epigraph,
+        width,
+    ));
+    lines.push(centered(
+        "nothing touches your files until you accept it",
+        Role::Epigraph,
+        width,
+    ));
+    lines
+}
+
+fn compact_block(version: &str) -> Vec<Line> {
+    let width = COMPACT_MIN_WIDTH;
+    let mut lines = mark_lines(width);
+    lines.push(Line::blank());
+    lines.push(centered(&format!("red v{version}"), Role::Muted, width));
+    lines.push(Line::new(vec![
+        span("press ", Role::Muted),
+        span("Space ?", Role::Key),
+        span(" for commands", Role::Muted),
+    ]));
+    lines
+}
+
+/// The splash block that fits a content area, or `None` when the area is too
+/// small for even the compact variant.
+pub fn block(width: usize, height: usize, version: &str) -> Option<Vec<Line>> {
+    if width >= FULL_MIN_WIDTH && height >= FULL_MIN_HEIGHT {
+        Some(full_block(version))
+    } else if width >= COMPACT_MIN_WIDTH && height >= COMPACT_MIN_HEIGHT {
+        Some(compact_block(version))
+    } else {
+        None
+    }
+}
+
+/// Theme-derived styles for each [`Role`]; never hardcoded colors, with the
+/// fallback chains documented in `docs/SPLASH.md`.
+pub struct Palette {
+    mark: Style,
+    dot: Style,
+    muted: Style,
+    key: Style,
+    text: Style,
+    rule: Style,
+    epigraph: Style,
+}
+
+impl Palette {
+    pub fn style(&self, role: Role) -> &Style {
+        match role {
+            Role::Mark => &self.mark,
+            Role::Dot => &self.dot,
+            Role::Muted => &self.muted,
+            Role::Key => &self.key,
+            Role::Text => &self.text,
+            Role::Rule => &self.rule,
+            Role::Epigraph => &self.epigraph,
+        }
+    }
+}
+
+const FALLBACK_RED: Color = Color::Rgb {
+    r: 0xE5,
+    g: 0x48,
+    b: 0x4D,
+};
+
+fn workbench_color(theme: &Theme, keys: &[&str]) -> Option<Color> {
+    keys.iter().find_map(|key| theme.colors.get(*key).copied())
+}
+
+fn theme_red(theme: &Theme, keys: &[&str]) -> Color {
+    workbench_color(theme, keys)
+        .or_else(|| theme.error_style.as_ref().and_then(|style| style.fg))
+        .unwrap_or(FALLBACK_RED)
+}
+
+pub fn palette(theme: &Theme) -> Palette {
+    let foreground = theme.style.fg;
+    let muted = workbench_color(theme, &["descriptionForeground"])
+        .or(theme.gutter_style.fg)
+        .or(foreground);
+    let plain = Style {
+        fg: foreground,
+        ..Default::default()
+    };
+    Palette {
+        mark: plain.clone(),
+        dot: Style {
+            fg: Some(theme_red(
+                theme,
+                &[
+                    "terminal.ansiBrightRed",
+                    "terminal.ansiRed",
+                    "errorForeground",
+                ],
+            )),
+            bold: true,
+            ..Default::default()
+        },
+        muted: Style {
+            fg: muted,
+            ..Default::default()
+        },
+        key: Style {
+            fg: Some(theme_red(
+                theme,
+                &[
+                    "terminal.ansiRed",
+                    "terminal.ansiBrightRed",
+                    "errorForeground",
+                ],
+            )),
+            ..Default::default()
+        },
+        text: plain,
+        rule: Style {
+            fg: workbench_color(theme, &["editorGroup.border"]).or(muted),
+            ..Default::default()
+        },
+        epigraph: Style {
+            fg: muted,
+            italic: true,
+            ..Default::default()
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block_text(lines: &[Line]) -> String {
+        lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.text.as_str())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn full_block_fits_declared_minimum() {
+        let lines = block(FULL_MIN_WIDTH, FULL_MIN_HEIGHT, "0.1.1").unwrap();
+        assert_eq!(lines.len(), FULL_MIN_HEIGHT);
+        assert!(lines.iter().all(|line| line.width() <= FULL_MIN_WIDTH));
+        let text = block_text(&lines);
+        assert!(text.contains("red v0.1.1"));
+        assert!(text.contains(":AgentReview<Enter>"));
+        assert!(text.contains("every agent edit is a proposal"));
+    }
+
+    #[test]
+    fn hint_columns_align() {
+        let lines = block(FULL_MIN_WIDTH, FULL_MIN_HEIGHT, "0.1.1").unwrap();
+        let hint_lines: Vec<_> = lines
+            .iter()
+            .filter(|line| line.spans.iter().any(|span| span.role == Role::Key))
+            .collect();
+        assert_eq!(hint_lines.len(), HINTS.len());
+        for line in hint_lines {
+            assert_eq!(line.spans[0].text.chars().count(), HINT_VERB_WIDTH);
+            assert_eq!(line.spans[1].text.chars().count(), HINT_KEY_WIDTH);
+        }
+    }
+
+    #[test]
+    fn compact_block_below_full_thresholds() {
+        let narrow = block(FULL_MIN_WIDTH - 1, FULL_MIN_HEIGHT, "0.1.1").unwrap();
+        assert_eq!(narrow.len(), COMPACT_MIN_HEIGHT);
+        assert!(narrow.iter().all(|line| line.width() <= COMPACT_MIN_WIDTH));
+        let short = block(FULL_MIN_WIDTH, FULL_MIN_HEIGHT - 1, "0.1.1").unwrap();
+        assert_eq!(short.len(), COMPACT_MIN_HEIGHT);
+        assert!(block_text(&narrow).contains("Space ?"));
+    }
+
+    #[test]
+    fn nothing_below_compact_thresholds() {
+        assert!(block(COMPACT_MIN_WIDTH - 1, COMPACT_MIN_HEIGHT, "0.1.1").is_none());
+        assert!(block(COMPACT_MIN_WIDTH, COMPACT_MIN_HEIGHT - 1, "0.1.1").is_none());
+    }
+
+    #[test]
+    fn every_mark_line_carries_only_mark_and_dot_roles() {
+        let lines = block(FULL_MIN_WIDTH, FULL_MIN_HEIGHT, "0.1.1").unwrap();
+        let dot_spans: Vec<_> = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .filter(|span| span.role == Role::Dot)
+            .collect();
+        assert_eq!(dot_spans.len(), 1);
+        assert_eq!(dot_spans[0].text, "●");
+    }
+
+    #[test]
+    fn palette_falls_back_to_brand_red_without_theme_colors() {
+        let palette = palette(&Theme::default());
+        assert_eq!(palette.style(Role::Dot).fg, Some(FALLBACK_RED));
+        assert_eq!(palette.style(Role::Key).fg, Some(FALLBACK_RED));
+        assert!(palette.style(Role::Dot).bold);
+        assert!(palette.style(Role::Epigraph).italic);
+    }
+
+    #[test]
+    fn palette_prefers_theme_workbench_colors() {
+        let mut theme = Theme::default();
+        let red = Color::Rgb {
+            r: 200,
+            g: 40,
+            b: 40,
+        };
+        let muted = Color::Rgb {
+            r: 90,
+            g: 90,
+            b: 100,
+        };
+        theme.colors.insert("terminal.ansiRed".into(), red);
+        theme.colors.insert("descriptionForeground".into(), muted);
+        let palette = palette(&theme);
+        assert_eq!(palette.style(Role::Key).fg, Some(red));
+        assert_eq!(palette.style(Role::Muted).fg, Some(muted));
+    }
+}

--- a/themes/red.json
+++ b/themes/red.json
@@ -1,0 +1,222 @@
+{
+  "name": "red",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#101014",
+    "editor.foreground": "#D8D8DE",
+    "editor.lineHighlightBackground": "#16161B",
+    "editor.selectionBackground": "#2B2B36",
+    "editor.findMatchBackground": "#5A3034",
+    "editor.findMatchHighlightBackground": "#33262A",
+    "editorCursor.foreground": "#E5484D",
+    "editorCursor.background": "#101014",
+    "editorLineNumber.foreground": "#3C3C46",
+    "editorLineNumber.activeForeground": "#6E6E78",
+    "editorWhitespace.foreground": "#26262E",
+    "editorIndentGuide.background": "#1C1C22",
+    "editorIndentGuide.activeBackground": "#2A2A32",
+    "editorGroup.border": "#2A2A32",
+    "editorWidget.background": "#17171C",
+    "editorWidget.foreground": "#D8D8DE",
+    "editorWidget.border": "#2A2A32",
+    "editorHoverWidget.background": "#17171C",
+    "editorHoverWidget.foreground": "#C8C8D0",
+    "editorHoverWidget.border": "#2A2A32",
+    "editorError.foreground": "#F2555A",
+    "editorWarning.foreground": "#D5A458",
+    "editorInfo.foreground": "#8FA8C8",
+    "editorInlayHint.foreground": "#5E5E6A",
+    "editorInlayHint.background": "#15151A",
+    "descriptionForeground": "#67676F",
+    "focusBorder": "#4A3236",
+    "badge.background": "#E5484D",
+    "badge.foreground": "#101014",
+    "input.background": "#17171C",
+    "input.foreground": "#D8D8DE",
+    "input.border": "#2A2A32",
+    "input.placeholderForeground": "#5E5E6A",
+    "quickInput.background": "#15151A",
+    "quickInput.foreground": "#C8C8D0",
+    "quickInputTitle.background": "#1A1A20",
+    "quickInputList.focusBackground": "#26262E",
+    "quickInputList.focusForeground": "#E8E8EC",
+    "list.activeSelectionBackground": "#26262E",
+    "list.activeSelectionForeground": "#E8E8EC",
+    "list.hoverBackground": "#1C1C22",
+    "list.warningForeground": "#D5A458",
+    "list.errorForeground": "#F2555A",
+    "sideBar.background": "#121217",
+    "sideBar.foreground": "#B4B4BE",
+    "sideBar.border": "#2A2A32",
+    "sideBarTitle.foreground": "#9A9AA4",
+    "statusBar.background": "#1A1A20",
+    "statusBar.foreground": "#9A9AA4",
+    "statusBar.noFolderBackground": "#1A1A20",
+    "statusBar.debuggingBackground": "#5A3034",
+    "tab.activeBackground": "#101014",
+    "tab.activeForeground": "#E8E8EC",
+    "tab.inactiveBackground": "#15151A",
+    "tab.inactiveForeground": "#67676F",
+    "errorForeground": "#F2555A",
+    "gitDecoration.addedResourceForeground": "#86B386",
+    "gitDecoration.modifiedResourceForeground": "#D5A458",
+    "gitDecoration.deletedResourceForeground": "#E5484D",
+    "gitDecoration.untrackedResourceForeground": "#8FBCB4",
+    "gitDecoration.ignoredResourceForeground": "#4A4A54",
+    "gitDecoration.conflictingResourceForeground": "#F2555A",
+    "terminal.ansiBlack": "#17171C",
+    "terminal.ansiRed": "#E5484D",
+    "terminal.ansiGreen": "#86B386",
+    "terminal.ansiYellow": "#D5A458",
+    "terminal.ansiBlue": "#8FA8C8",
+    "terminal.ansiMagenta": "#C08FAE",
+    "terminal.ansiCyan": "#8FBCB4",
+    "terminal.ansiWhite": "#D8D8DE",
+    "terminal.ansiBrightBlack": "#4A4A54",
+    "terminal.ansiBrightRed": "#F2555A",
+    "terminal.ansiBrightGreen": "#9BC49B",
+    "terminal.ansiBrightYellow": "#E2B36C",
+    "terminal.ansiBrightBlue": "#A4BAD6",
+    "terminal.ansiBrightMagenta": "#D0A4C2",
+    "terminal.ansiBrightCyan": "#A4CCC5",
+    "terminal.ansiBrightWhite": "#E8E8EC"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment"],
+      "settings": { "foreground": "#5A5A66", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["string", "string.quoted", "punctuation.definition.string"],
+      "settings": { "foreground": "#C2A78C" }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "constant.language",
+        "constant.character",
+        "constant.character.escape",
+        "constant.builtin",
+        "constant.other"
+      ],
+      "settings": { "foreground": "#D5A458" }
+    },
+    {
+      "scope": [
+        "keyword",
+        "keyword.control",
+        "storage.type",
+        "storage.modifier",
+        "variable.language.self",
+        "variable.language.this"
+      ],
+      "settings": { "foreground": "#E5666B" }
+    },
+    {
+      "scope": ["keyword.operator", "punctuation.accessor"],
+      "settings": { "foreground": "#B4B4C0" }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "entity.name.function.member",
+        "entity.name.function.constructor",
+        "support.function",
+        "function.method",
+        "meta.function-call"
+      ],
+      "settings": { "foreground": "#8FA8C8" }
+    },
+    {
+      "scope": ["entity.name.function.macro", "function.macro", "support.other.macro"],
+      "settings": { "foreground": "#D5A458" }
+    },
+    {
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "entity.name.struct",
+        "entity.name.enum",
+        "support.type",
+        "support.class",
+        "keyword.type"
+      ],
+      "settings": { "foreground": "#8FBCB4" }
+    },
+    {
+      "scope": ["variable", "variable.other", "meta.definition.variable"],
+      "settings": { "foreground": "#D8D8DE" }
+    },
+    {
+      "scope": ["variable.parameter"],
+      "settings": { "foreground": "#C8C8D2", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["entity.name.namespace", "entity.name.module"],
+      "settings": { "foreground": "#C8C8D2" }
+    },
+    {
+      "scope": ["entity.name.tag"],
+      "settings": { "foreground": "#E5666B" }
+    },
+    {
+      "scope": ["entity.other.attribute-name", "meta.attribute"],
+      "settings": { "foreground": "#C2A78C", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["entity.name.label", "constant.other.symbol"],
+      "settings": { "foreground": "#D5A458" }
+    },
+    {
+      "scope": [
+        "punctuation",
+        "punctuation.bracket",
+        "punctuation.delimiter",
+        "punctuation.separator",
+        "punctuation.section.block",
+        "punctuation.definition.brackets"
+      ],
+      "settings": { "foreground": "#7A7A86" }
+    },
+    {
+      "scope": ["markup.heading"],
+      "settings": { "foreground": "#E5666B", "fontStyle": "bold" }
+    },
+    {
+      "scope": ["markup.bold"],
+      "settings": { "foreground": "#E8E8EC", "fontStyle": "bold" }
+    },
+    {
+      "scope": ["markup.italic"],
+      "settings": { "foreground": "#D8D8DE", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["markup.underline.link", "string.other.link"],
+      "settings": { "foreground": "#8FA8C8" }
+    },
+    {
+      "scope": ["markup.quote"],
+      "settings": { "foreground": "#9A9AA4", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["markup.inline.raw", "markup.raw.block"],
+      "settings": { "foreground": "#C2A78C" }
+    },
+    {
+      "scope": ["markup.inserted"],
+      "settings": { "foreground": "#86B386" }
+    },
+    {
+      "scope": ["markup.deleted"],
+      "settings": { "foreground": "#E5484D" }
+    },
+    {
+      "scope": ["markup.changed"],
+      "settings": { "foreground": "#D5A458" }
+    },
+    {
+      "scope": ["invalid", "invalid.illegal"],
+      "settings": { "foreground": "#F2555A" }
+    }
+  ]
+}


### PR DESCRIPTION
Opening Red without files currently drops users into an unbranded empty buffer, leaving core discovery and proposal-review workflows hidden. The editor's generic default palette also does not carry Red's visual identity into a fresh installation.

This change adds a theme-aware startup splash for pristine scratch sessions, with a full layout for normal terminals and a compact fallback for smaller windows. The splash advertises the command palette, file picker, agent, proposal review, theme browser, and quit flow; it dismisses permanently after an edit, file open, or split, and can be disabled with `splash = false`.

It also bundles `themes/red.json` and makes it the embedded default, fail-closed recovery theme, and missing-theme runtime fallback. Explicit user theme overrides continue to take precedence. The layout, palette fallback rules, and behavior are documented in `docs/SPLASH.md` and covered by rendering, configuration, and bundled-asset tests.

## How to Test

1. Launch `cargo run --` without a file in a terminal at least 60×20 cells (decline first-run config creation if prompted). Expect the full branded splash and the Red palette.
2. Resize below 60×20 and expect the compact splash; resize below 26×7 and expect no splash. Type into the scratch buffer or open a split, then return to an empty scratch buffer and confirm the splash does not reappear.
3. Launch `cargo run -- README.md` or set `splash = false` in the user config. Expect the editor to open without the splash.
4. Set `theme = "missing-theme.json"` and launch Red. Expect a configuration diagnostic and fallback to the bundled Red theme.

Automated coverage passes with `cargo test --all-targets --all-features`, and the required `cargo clippy --all-targets --all-features -- -D warnings` gate is clean.