### PR TITLE
perf(editor): optimize rendering and interactive hot paths

### DIFF
--- a/docs/performance-baseline-2026-07-19.md
+++ b/docs/performance-baseline-2026-07-19.md
@@ -1,0 +1,84 @@
+# Red performance baseline — 2026-07-19
+
+This pass compares the clean `8e20896a45d71bc7396ad493d044d34979ef447e`
+release build with the rendering and editor-hot-path working tree on the same
+macOS arm64 workstation. LSP was disabled for the PTY scenarios. All timings
+below are p95 microseconds unless noted; lower is better.
+
+Environment: Darwin 25.5.0 arm64, `rustc 1.94.1 (e408947bf 2026-03-25)`,
+Cargo 1.94.1, `--locked --release`.
+
+| Scenario / metric | Before | After | Change |
+|---|---:|---:|---:|
+| Husk `indent_guides` cursor callback | 1,947 | 922 | -53% |
+| Scroll 80x200 key event | 2,623 | 1,467 | -44% |
+| Scroll cursor callback | 998 | 714 | -28% |
+| Scroll full render | 1,232 | 655 | -47% |
+| Scroll diff and flush | 731 | 158 | -78% |
+| Scroll motion frame | 347 | 303 | -13% |
+| Typing key event | 2,646 | 1,605 | -39% |
+| Typing full render | 1,246 | 789 | -37% |
+| Typing highlight miss | 881 | 568 | -36% |
+| Incremental-search key event | 5,752 | 3,341 | -42% |
+| Incremental-search full render | 1,027 | 538 | -48% |
+| Incremental-search diff and flush | 500 | 98 | -80% |
+| Picker full render | 4,077 | 3,557 | -13% |
+| Picker chrome render | 3,841 | 2,145 | -44% |
+| Detached frame serialization | 48 | 44 | -8% |
+
+The Husk result was stable across four post-change runs (p95 922, 921, 904,
+and 927 us). The PTY numbers are single runs and include scheduling noise.
+Two noisy tails moved in the opposite direction: search action resolution was
+1,800 to 2,638 us p95 (p50 1,079 to 1,152 us), and picker key events were 988
+to 3,791 us p95 while p50 improved from 392 to 344 us. Picker output stayed at
+16 KiB. Scroll output was 2,023 to 2,105 KiB and the post-change run processed
+all 500 cursor callbacks versus 480 before. Detached output stayed at 101 KiB;
+serialization max improved from 113 to 62 us.
+
+Targeted release-dependency microbenchmarks also confirmed the algorithmic
+changes: the linear word-start scan improved approximately 68x on an 8 KiB
+identifier, tab-aware grapheme-column conversion improved 35-42%, boundary
+lookup improved 31-47%, display-width truncation improved 17-26%, and
+display-width fitting improved 12-24%. A proposed `grapheme_to_char` rewrite
+regressed long ASCII lines by about 15% and was intentionally discarded.
+
+## What changed
+
+- Rendering now indexes layout rows directly, reuses previous-frame cell text,
+  bulk-fills rows and dialog rectangles with one RGBA blend, bounds diagnostic
+  grouping to visible lines, and draws split separators once with linear edge
+  discovery. Splitting a non-final window now advances traversal correctly,
+  preventing unintended duplicate splits and stable-window-id collisions.
+- Cursor motion, backspace, word scanning, and Unicode-width helpers avoid
+  redundant full-line passes and temporary grapheme collections. Undo/redo no
+  longer clones transaction text, selective revert compares Rope slices, and
+  whole-buffer replacements avoid flattening merely to find their end.
+- Syntax highlighting caches capture and Husk styles. Completion filtering
+  retains indices and uses allocation-free ASCII matching. LSP document
+  selectors, active clients, and polling order are cached instead of being
+  rebuilt on every request or poll.
+- Dynamic pickers no longer materialize and truncate every item's display
+  string. Command-column maxima are cached per filtered result set, retaining
+  stable alignment while scrolling. The indent-guide plugin preserves host
+  widths and processes blank runs and active scopes linearly.
+
+## Reproduction and validation
+
+```shell
+cargo fmt --all -- --check
+cargo test --locked --all-targets --all-features -- --test-threads=1
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo build --locked --release
+cargo run --locked --release --example husk_cursor_bench -- --assert
+target/release/red --self-check
+python3 scripts/scroll_bench.py 80 200 500 5
+python3 scripts/interaction_bench.py typing --cycles 160 --delay-ms 5
+python3 scripts/interaction_bench.py search --query self --cycles 16 --delay-ms 5
+python3 scripts/interaction_bench.py picker --query src/editor.rs --cycles 12 --delay-ms 5
+python3 scripts/detach_bench.py 50 120 100 512
+```
+
+All 1,382 Rust tests passed serialized; the two home-directory expansion tests
+require filesystem access outside the workspace sandbox. Clippy passed with
+warnings denied, all bundled plugins passed self-check, and the Husk callback
+remained well below the 4 ms release gate.

--- a/plugins/indent_guides.hk
+++ b/plugins/indent_guides.hk
@@ -88,6 +88,7 @@ fn unique_first_segment_rows(source_rows: Json) -> Json {
             rows = red::push(rows, Row {
                 line: line,
                 text: red::string(row.text, ""),
+                indent_width: red::int(row.indent_width, -1),
             });
         }
         i = i + 1;
@@ -99,93 +100,90 @@ fn unique_first_segment_rows(source_rows: Json) -> Json {
 fn measured_rows(rows: Json, tab_width: int) -> Json {
     let measured = [];
     let i = 0;
+    let previous = -1;
 
     while i < red::len(rows) {
         let row = rows[i];
-        measured = red::push(measured, Row {
-            line: row.line,
-            text: row.text,
-            width: inferred_width(rows, i, tab_width),
-        });
-        i = i + 1;
+        if !is_blank(row.text) {
+            let width = non_blank_indent(row, tab_width);
+            measured = red::push(measured, Row { line: row.line, width: width });
+            previous = width;
+            i = i + 1;
+            continue;
+        }
+
+        let end = i + 1;
+        while end < red::len(rows) && is_blank(rows[end].text) {
+            end = end + 1;
+        }
+        let after = -1;
+        if end < red::len(rows) {
+            after = non_blank_indent(rows[end], tab_width);
+        }
+        let width = 0;
+        if previous >= 0 && after >= 0 {
+            width = min_int(previous, after);
+        } else if previous >= 0 {
+            width = previous;
+        } else if after >= 0 {
+            width = after;
+        }
+        while i < end {
+            measured = red::push(measured, Row { line: rows[i].line, width: width });
+            i = i + 1;
+        }
     }
 
     return measured;
 }
 
-fn inferred_width(rows: Json, index: int, tab_width: int) -> int {
-    let row = rows[index];
-    if !is_blank(row.text) {
-        return red::int(row.indent_width, leading_indent_width(row.text, tab_width));
+fn non_blank_indent(row: Json, tab_width: int) -> int {
+    let width = red::int(row.indent_width, -1);
+    if width >= 0 {
+        return width;
     }
-
-    let before = previous_indent(rows, index, tab_width);
-    let after = next_indent(rows, index, tab_width);
-    if before >= 0 && after >= 0 {
-        return min_int(before, after);
-    }
-    if before >= 0 {
-        return before;
-    }
-    if after >= 0 {
-        return after;
-    }
-    return 0;
-}
-
-fn previous_indent(rows: Json, index: int, tab_width: int) -> int {
-    let i = index - 1;
-    while i >= 0 {
-        let row = rows[i];
-        if !is_blank(row.text) {
-            return leading_indent_width(row.text, tab_width);
-        }
-        i = i - 1;
-    }
-    return -1;
-}
-
-fn next_indent(rows: Json, index: int, tab_width: int) -> int {
-    let i = index + 1;
-    while i < red::len(rows) {
-        let row = rows[i];
-        if !is_blank(row.text) {
-            return leading_indent_width(row.text, tab_width);
-        }
-        i = i + 1;
-    }
-    return -1;
+    return leading_indent_width(row.text, tab_width);
 }
 
 fn active_scope(layout: Json, rows: Json, shift_width: int) -> Json {
     let cursor_line = red::int(layout.cursor.y, 0);
-    let current_indent = width_for_line(rows, cursor_line);
+    let cursor_index = 0;
+    while cursor_index < red::len(rows) && rows[cursor_index].line != cursor_line {
+        cursor_index = cursor_index + 1;
+    }
+    if cursor_index >= red::len(rows) {
+        return Scope { active: false };
+    }
+    let current_indent = rows[cursor_index].width;
     if current_indent < shift_width {
         return Scope { active: false };
     }
 
     let level = (current_indent / shift_width) * shift_width;
     let start = cursor_line;
-    let line = cursor_line - 1;
-    while line >= 0 {
-        let width = width_for_line(rows, line);
-        if width < level {
+    let expected_line = cursor_line - 1;
+    let index = cursor_index - 1;
+    while index >= 0 {
+        let row = rows[index];
+        if row.line != expected_line || row.width < level {
             break;
         }
-        start = line;
-        line = line - 1;
+        start = row.line;
+        expected_line = expected_line - 1;
+        index = index - 1;
     }
 
     let end = cursor_line;
-    let max_line = max_row_line(rows, cursor_line);
-    line = cursor_line + 1;
-    while line <= max_line {
-        let width = width_for_line(rows, line);
-        if width < level {
+    expected_line = cursor_line + 1;
+    index = cursor_index + 1;
+    while index < red::len(rows) {
+        let row = rows[index];
+        if row.line != expected_line || row.width < level {
             break;
         }
-        end = line;
-        line = line + 1;
+        end = row.line;
+        expected_line = expected_line + 1;
+        index = index + 1;
     }
 
     return Scope {
@@ -194,31 +192,6 @@ fn active_scope(layout: Json, rows: Json, shift_width: int) -> Json {
         start: start,
         end: end,
     };
-}
-
-fn width_for_line(rows: Json, line: int) -> int {
-    let i = 0;
-    while i < red::len(rows) {
-        let row = rows[i];
-        if row.line == line {
-            return row.width;
-        }
-        i = i + 1;
-    }
-    return -1;
-}
-
-fn max_row_line(rows: Json, fallback: int) -> int {
-    let max = fallback;
-    let i = 0;
-    while i < red::len(rows) {
-        let row = rows[i];
-        if row.line > max {
-            max = row.line;
-        }
-        i = i + 1;
-    }
-    return max;
 }
 
 fn leading_indent_width(line: String, tab_width: int) -> int {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -526,6 +526,12 @@ impl Buffer {
             .unwrap_or_default()
     }
 
+    pub(crate) fn text_in_char_range_matches(&self, start: usize, end: usize, text: &str) -> bool {
+        self.content
+            .get_slice(start..end)
+            .is_some_and(|slice| slice == text)
+    }
+
     pub fn replace_range_raw(&mut self, range: TextRange, text: &str) {
         let start_char = self.position_to_char_idx(range.start);
         let end_char = self.position_to_char_idx(range.end);
@@ -622,15 +628,10 @@ impl Buffer {
     /// Checks if a position is within a word
     /// Note: x is a character index, not a display column
     pub fn is_in_word(&self, (x, y): (usize, usize)) -> bool {
-        if let Some(line) = self.get(y) {
-            if x >= line.chars().count() {
-                return false;
-            }
-            let c = line.chars().nth(x).unwrap();
-            c.is_alphanumeric() || c == '_'
-        } else {
-            false
-        }
+        self.content
+            .get_line(y)
+            .and_then(|line| line.chars().nth(x))
+            .is_some_and(|c| c.is_alphanumeric() || c == '_')
     }
 
     /// Finds the start of the current word
@@ -640,7 +641,8 @@ impl Buffer {
 
         loop {
             let line = self.get(y)?;
-            if x >= line.chars().count() {
+            let mut characters = line.chars().enumerate().skip(x);
+            let Some((_, current_char)) = characters.next() else {
                 // Move to next line if at end
                 y += 1;
                 x = 0;
@@ -648,37 +650,30 @@ impl Buffer {
                     return None;
                 }
                 continue;
-            }
+            };
 
-            let current_char = line.chars().nth(x)?;
             let current_type = Self::get_char_type(current_char);
+            let mut skipping_current = true;
 
             // Skip current word/sequence
-            let line_len = line.chars().count();
-            while x < line_len {
-                let c = line.chars().nth(x)?;
-                if Self::get_char_type(c) != current_type {
-                    break;
+            for (index, c) in characters {
+                let char_type = Self::get_char_type(c);
+                if skipping_current && char_type == current_type {
+                    continue;
                 }
-                x += 1;
-            }
+                skipping_current = false;
 
-            // Skip whitespace
-            while x < line_len {
-                let c = line.chars().nth(x)?;
-                if !c.is_whitespace() {
-                    return Some((x, y));
+                // Skip whitespace
+                if char_type != CharType::Whitespace {
+                    return Some((index, y));
                 }
-                x += 1;
             }
 
             // If we reach end of line, continue to next line
-            if x >= line_len {
-                y += 1;
-                x = 0;
-                if y > self.len() {
-                    return None;
-                }
+            y += 1;
+            x = 0;
+            if y > self.len() {
+                return None;
             }
         }
     }
@@ -704,8 +699,8 @@ impl Buffer {
     /// Finds the next word from the current position
     pub fn find_next_word(&self, (mut x, mut y): (usize, usize)) -> Option<(usize, usize)> {
         // Get current line
-        let line = self.get(y)?;
-        let line = trim_line_ending(&line);
+        let mut current_line = self.get(y)?;
+        let line = trim_line_ending(&current_line);
 
         // Check if we're at the last character of the buffer
         let line_len = Self::char_len(line);
@@ -730,8 +725,8 @@ impl Buffer {
                 return None;
             }
             x = 0;
-            let next_line = self.get(y)?;
-            let next_line = trim_line_ending(&next_line);
+            current_line = self.get(y)?;
+            let next_line = trim_line_ending(&current_line);
             if next_line.is_empty() {
                 return Some((0, y));
             }
@@ -741,7 +736,6 @@ impl Buffer {
             }
         }
 
-        let current_line = self.get(y)?;
         let current_line = trim_line_ending(&current_line);
         if current_line.is_empty() {
             return Some((0, y));
@@ -1446,6 +1440,20 @@ mod test {
         assert_eq!(unicode.line_prefix_contents(0, 2), "αβ");
         assert_eq!(unicode.line_prefix_contents(1, 99), "終わり");
         assert_eq!(unicode.line_prefix_contents(2, 99), "");
+    }
+
+    #[test]
+    fn text_in_char_range_matches_across_rope_chunks() {
+        let prefix = "a".repeat(4095);
+        let target = "👋終λ";
+        let suffix = "b".repeat(4095);
+        let buffer = Buffer::new(None, format!("{prefix}{target}{suffix}"));
+        let start = prefix.chars().count();
+        let end = start + target.chars().count();
+
+        assert!(buffer.text_in_char_range_matches(start, end, target));
+        assert!(!buffer.text_in_char_range_matches(start, end, "👋終x"));
+        assert!(!buffer.text_in_char_range_matches(start, end + suffix.len() + 1, target));
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -18,9 +18,8 @@ use std::{
 
 use crate::unicode_utils::{
     char_prefix, char_slice, char_suffix, char_to_grapheme, column_to_grapheme_with_tabs,
-    display_width, display_width_with_tabs, grapheme_len, grapheme_to_byte, grapheme_to_char,
-    grapheme_to_column_with_tabs, next_grapheme_boundary, prev_grapheme_boundary, trim_line_ending,
-    truncate_chars,
+    display_width, display_width_with_tabs, grapheme_char_range, grapheme_len, grapheme_to_byte,
+    grapheme_to_char, grapheme_to_column_with_tabs, trim_line_ending, truncate_chars,
 };
 
 /// Editor is the main component that handles:
@@ -5309,9 +5308,7 @@ impl Editor {
                     self.set_current_buffer(render_buffer, index).await?;
                 }
                 self.commit_agent_acceptance(acceptance)?;
-                let end = self
-                    .current_buffer()
-                    .char_idx_to_position(self.current_buffer().contents().chars().count());
+                let end = self.current_buffer().char_idx_to_position(usize::MAX);
                 self.begin_transaction_with_origin(
                     "accept agent proposal",
                     EditOrigin::Agent {
@@ -11885,42 +11882,12 @@ impl Editor {
                 }
             }
             Action::MoveLeft => {
-                // Move by grapheme clusters
-                if let Some(line) = self.current_line_contents() {
-                    let line = line.trim_end_matches('\n');
-
-                    let byte_offset = grapheme_to_byte(line, self.cx);
-
-                    // Find previous grapheme boundary
-                    if let Some(prev_byte) = prev_grapheme_boundary(line, byte_offset) {
-                        self.cx = crate::unicode_utils::byte_to_grapheme(line, prev_byte);
-                    } else if self.cx > 0 {
-                        self.cx = 0;
-                    }
-                }
+                self.cx = self.cx.saturating_sub(1);
                 self.finish_cursor_motion(buffer, false)?;
             }
             Action::MoveRight => {
-                // Move by grapheme clusters
-                if let Some(line) = self.current_line_contents() {
-                    let line = line.trim_end_matches('\n');
-                    let max_graphemes = grapheme_len(line);
-                    let max_cursor_x = self.max_cursor_x_for_line_length(max_graphemes);
-
-                    if self.cx < max_cursor_x {
-                        let current_byte = grapheme_to_byte(line, self.cx);
-
-                        // Find next grapheme boundary
-                        if let Some(next_byte) = next_grapheme_boundary(line, current_byte) {
-                            self.cx = crate::unicode_utils::byte_to_grapheme(line, next_byte)
-                                .min(max_cursor_x);
-                        } else {
-                            self.cx = max_cursor_x;
-                        }
-                    } else if self.cx > max_cursor_x {
-                        self.cx = max_cursor_x;
-                    }
-                }
+                let max_cursor_x = self.max_cursor_x_for_line_length(self.line_length());
+                self.cx = self.cx.saturating_add(1).min(max_cursor_x);
                 self.finish_cursor_motion(buffer, false)?;
             }
             Action::FindCharForward { target, count } => {
@@ -12931,15 +12898,11 @@ impl Editor {
                     // Get the current line to find the previous grapheme boundary
                     if let Some(line) = self.current_line_contents() {
                         let line = line.trim_end_matches('\n');
-                        let current_byte = grapheme_to_byte(line, self.cx);
+                        let prev_grapheme_idx = self.cx - 1;
 
-                        if let Some(prev_byte) =
-                            crate::unicode_utils::prev_grapheme_boundary(line, current_byte)
+                        if let Some((start_char, end_char)) =
+                            grapheme_char_range(line, prev_grapheme_idx)
                         {
-                            let prev_grapheme_idx =
-                                crate::unicode_utils::byte_to_grapheme(line, prev_byte);
-                            let start_char = crate::unicode_utils::byte_to_char(line, prev_byte);
-                            let end_char = crate::unicode_utils::byte_to_char(line, current_byte);
                             let line_num = self.buffer_line();
                             self.replace_range(
                                 TextRange::new(
@@ -18138,9 +18101,7 @@ impl Editor {
             if self.transaction_active() {
                 self.commit_transaction(self.cursor_snapshot());
             }
-            let end = self
-                .current_buffer()
-                .char_idx_to_position(self.current_buffer().contents().chars().count());
+            let end = self.current_buffer().char_idx_to_position(usize::MAX);
             self.begin_transaction_with_origin(
                 label,
                 EditOrigin::Lsp {

--- a/src/editor/display_layout.rs
+++ b/src/editor/display_layout.rs
@@ -114,7 +114,7 @@ pub struct DisplayLayout {
 
 impl DisplayLayout {
     pub fn row(&self, row: usize) -> Option<&LineSegment> {
-        self.rows.iter().find(|segment| segment.row == row)
+        self.rows.get(row)
     }
 
     pub fn segment_for_cursor(&self, line: usize, display_col: usize) -> Option<&LineSegment> {
@@ -137,11 +137,10 @@ pub struct LayoutConfig {
 }
 
 pub fn layout_lines(lines: &[String], line_count: usize, config: LayoutConfig) -> DisplayLayout {
-    let mut rows = Vec::new();
-
     if config.content_width == 0 || config.height == 0 {
-        return DisplayLayout { rows };
+        return DisplayLayout { rows: Vec::new() };
     }
+    let mut rows = Vec::with_capacity(config.height);
 
     // Byte offset of the current line within the viewport lines laid end to
     // end. Highlight spans from `viewport_highlight_spans` use the same
@@ -686,5 +685,31 @@ mod tests {
         assert_eq!(layout.rows.len(), 1);
         assert_eq!(layout.rows[0].start_byte, 0);
         assert_eq!(layout.rows[0].end_byte, 80);
+    }
+
+    #[test]
+    fn row_indexes_the_contiguous_layout_rows() {
+        let lines = vec![
+            "one\n".to_string(),
+            "two\n".to_string(),
+            "three\n".to_string(),
+        ];
+        let layout = layout_lines(
+            &lines,
+            3,
+            LayoutConfig {
+                content_width: 80,
+                height: 3,
+                wrap: true,
+                vtop: 0,
+                vleft: 0,
+                skipcol: 0,
+                break_indent: BreakIndentOptions::disabled(),
+            },
+        );
+
+        assert_eq!(layout.row(0).map(|segment| segment.line), Some(0));
+        assert_eq!(layout.row(2).map(|segment| segment.line), Some(2));
+        assert!(layout.row(3).is_none());
     }
 }

--- a/src/editor/render_buffer.rs
+++ b/src/editor/render_buffer.rs
@@ -228,6 +228,49 @@ impl RenderBuffer {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn fill_rect(
+        &mut self,
+        x: usize,
+        y: usize,
+        width: usize,
+        height: usize,
+        c: char,
+        style: &Style,
+        theme: &Theme,
+    ) {
+        let end_x = x.saturating_add(width).min(self.width);
+        let end_y = y.saturating_add(height).min(self.height);
+        if x >= end_x || y >= end_y {
+            return;
+        }
+
+        let bg = style.bg.map(|color| match color {
+            Color::Rgba { r, g, b, a } => blend_color(
+                Color::Rgba { r, g, b, a },
+                theme.style.bg.unwrap_or(Color::Rgb { r: 0, g: 0, b: 0 }),
+            ),
+            _ => color,
+        });
+        let style = Style {
+            fg: style.fg,
+            bg,
+            bold: style.bold,
+            italic: style.italic,
+        };
+
+        for row in y..end_y {
+            let start = row * self.width + x;
+            let end = row * self.width + end_x;
+            let Some(cells) = self.cells.get_mut(start..end) else {
+                continue;
+            };
+            for cell in cells {
+                cell.set_char_in_place(c, &style);
+            }
+        }
+    }
+
     pub fn set_text(&mut self, x: usize, y: usize, text: &str, style: &Style) {
         if x >= self.width || y >= self.height {
             return;
@@ -378,7 +421,77 @@ impl RenderBuffer {
     pub(crate) fn apply_changes(&mut self, changes: &[Change<'_>]) {
         for change in changes {
             let pos = (change.y * self.width) + change.x;
-            self.cells[pos] = change.cell.clone();
+            let cell = &mut self.cells[pos];
+            cell.c = change.cell.c;
+            cell.text.clone_from(&change.cell.text);
+            cell.style = change.cell.style.clone();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applying_changes_reuses_cell_text_capacity() {
+        let style = Style::default();
+        let mut previous = RenderBuffer::new(1, 1, &style);
+        previous.cells[0].text.reserve(32);
+        let capacity = previous.cells[0].text.capacity();
+
+        let mut next = RenderBuffer::new(1, 1, &style);
+        next.set_text(0, 0, "x", &style);
+        let changes = next.diff(&previous);
+        previous.apply_changes(&changes);
+
+        assert_eq!(previous.cells[0], next.cells[0]);
+        assert_eq!(previous.cells[0].text.capacity(), capacity);
+    }
+
+    #[test]
+    fn fill_rect_clips_blends_rgba_once_and_reuses_cell_text_capacity() {
+        let mut theme = Theme::default();
+        theme.style.bg = Some(Color::Rgb {
+            r: 20,
+            g: 30,
+            b: 40,
+        });
+        let background = Color::Rgba {
+            r: 220,
+            g: 120,
+            b: 20,
+            a: 128,
+        };
+        let style = Style {
+            fg: Some(Color::Rgb { r: 1, g: 2, b: 3 }),
+            bg: Some(background),
+            bold: true,
+            italic: true,
+        };
+        let mut buffer = RenderBuffer::new(4, 3, &Style::default());
+        buffer.cells[6].text.reserve(32);
+        let capacity = buffer.cells[6].text.capacity();
+
+        buffer.fill_rect(2, 1, usize::MAX, usize::MAX, 'x', &style, &theme);
+        buffer.fill_rect(20, 20, 2, 2, 'z', &style, &theme);
+
+        let blended = blend_color(background, theme.style.bg.unwrap());
+        for (index, cell) in buffer.cells.iter().enumerate() {
+            let x = index % buffer.width;
+            let y = index / buffer.width;
+            if x >= 2 && y >= 1 {
+                assert_eq!(cell.c, 'x');
+                assert_eq!(cell.text, "x");
+                assert_eq!(cell.style.fg, style.fg);
+                assert_eq!(cell.style.bg, Some(blended));
+                assert!(cell.style.bold);
+                assert!(cell.style.italic);
+            } else {
+                assert_eq!(cell.c, ' ');
+                assert_eq!(cell.style, Style::default());
+            }
+        }
+        assert_eq!(buffer.cells[6].text.capacity(), capacity);
     }
 }

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     io::{self, Write as _},
 };
 
@@ -54,6 +54,23 @@ fn diagnostic_row(diagnostics: &[&Diagnostic], available_width: usize) -> Option
     let mut row = truncate_display_width(&row, available_width - 1);
     row.push('…');
     Some(fit_display_width(&row, available_width))
+}
+
+fn diagnostics_by_visible_line(
+    diagnostics: &[Diagnostic],
+    visible_start: usize,
+    visible_end: usize,
+) -> HashMap<usize, Vec<&Diagnostic>> {
+    diagnostics
+        .iter()
+        .filter(|diagnostic| (visible_start..=visible_end).contains(&diagnostic.range.start.line))
+        .fold(HashMap::new(), |mut by_line, diagnostic| {
+            by_line
+                .entry(diagnostic.range.start.line)
+                .or_default()
+                .push(diagnostic);
+            by_line
+        })
 }
 
 fn statusline_file_name(name: &str) -> &str {
@@ -205,7 +222,7 @@ impl Editor {
         self.sync_to_window();
         // Render all windows
         let windows_span = super::perf::PerfSpan::start("render:windows");
-        let window_count = self.window_manager.windows().len();
+        let window_count = self.window_manager.window_count();
         for window_id in 0..window_count {
             self.render_window(buffer, window_id)?;
         }
@@ -388,10 +405,7 @@ impl Editor {
         window_id: usize,
         terminal_rows: &[usize],
     ) -> anyhow::Result<()> {
-        let window_data = {
-            let windows = self.window_manager.windows();
-            windows.get(window_id).map(|window| (*window).clone())
-        };
+        let window_data = self.window_manager.window_at_index(window_id).cloned();
         let Some(window) = window_data else {
             return Ok(());
         };
@@ -658,16 +672,7 @@ impl Editor {
 
     fn render_window(&mut self, buffer: &mut RenderBuffer, window_id: usize) -> anyhow::Result<()> {
         // Clone the window data to avoid borrowing issues
-        let window_data = {
-            let windows = self.window_manager.windows();
-            let window_count = windows.len();
-
-            windows
-                .get(window_id)
-                .map(|window| ((*window).clone(), window_count))
-        };
-
-        if let Some((window, window_count)) = window_data {
+        if let Some(window) = self.window_manager.window_at_index(window_id).cloned() {
             self.render_window_bar(buffer, &window);
 
             // Render the gutter for this window
@@ -678,12 +683,6 @@ impl Editor {
 
             // Render overlays within window bounds
             self.render_overlays_in_window(buffer, &window)?;
-
-            // Draw window separator if not the last window
-            if window_id < window_count - 1 {
-                // TODO: Draw separator
-                self.render_window_separator(buffer, &window)?;
-            }
         }
 
         Ok(())
@@ -717,35 +716,6 @@ impl Editor {
         }
     }
 
-    /// Render window separator (placeholder for now)
-    fn render_window_separator(
-        &mut self,
-        buffer: &mut RenderBuffer,
-        window: &crate::window::Window,
-    ) -> anyhow::Result<()> {
-        // For now, just draw a simple vertical line on the right edge of the window
-        let separator_style = Style {
-            fg: Some(Color::Rgb {
-                r: 100,
-                g: 100,
-                b: 100,
-            }),
-            bg: None,
-            bold: false,
-            italic: false,
-        };
-
-        let x = window.position.x + window.size.0;
-        if x < self.size.0 as usize {
-            for y in 0..window.size.1 {
-                let term_y = window.position.y + y;
-                buffer.set_char(x, term_y, '│', &separator_style, &self.theme);
-            }
-        }
-
-        Ok(())
-    }
-
     /// Render all window separators based on the split tree
     fn render_all_window_separators(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         let separator_style = Style {
@@ -771,85 +741,36 @@ impl Editor {
         // Use ASCII or Unicode characters based on configuration
         let use_ascii = self.config.window_borders_ascii;
 
-        // First, collect all unique vertical and horizontal separator lines
-        let mut vertical_lines: Vec<(usize, usize, usize)> = Vec::new(); // (x, y_start, y_end)
-        let mut horizontal_lines: Vec<(usize, usize, usize)> = Vec::new(); // (y, x_start, x_end)
+        let left_positions = windows
+            .iter()
+            .map(|window| window.position.x)
+            .collect::<HashSet<_>>();
+        let top_positions = windows
+            .iter()
+            .map(|window| window.position.y)
+            .collect::<HashSet<_>>();
 
-        // Find all vertical separators by looking for adjacent windows
-        // We need to find continuous vertical lines, not segments
-        let mut vertical_x_positions: std::collections::HashSet<usize> =
-            std::collections::HashSet::new();
-
-        for i in 0..windows.len() {
-            for j in 0..windows.len() {
-                if i == j {
-                    continue;
-                }
-                let w1 = windows[i];
-                let w2 = windows[j];
-
-                // Check if w1 is directly to the left of w2
-                if w1.position.x + w1.size.0 + 1 == w2.position.x {
-                    let x = w1.position.x + w1.size.0;
-                    vertical_x_positions.insert(x);
-                }
-            }
-        }
-
-        // Now for each vertical separator position, find the full extent
-        for x in vertical_x_positions {
-            let mut min_y = term_height;
-            let mut max_y = 0;
-
-            // Find all windows that have this separator on their right edge
-            for window in &windows {
-                if window.position.x + window.size.0 == x {
-                    min_y = min_y.min(window.position.y);
-                    max_y = max_y.max(window.position.y + window.size.1);
-                }
+        // Group each shared edge and its full extent in one pass. Looking up
+        // the adjacent left/top position avoids comparing every window pair.
+        let mut vertical_lines = HashMap::<usize, (usize, usize)>::new();
+        let mut horizontal_lines = HashMap::<usize, (usize, usize)>::new();
+        for window in &windows {
+            let right = window.position.x + window.size.0;
+            if left_positions.contains(&right.saturating_add(1)) {
+                let extent = vertical_lines
+                    .entry(right)
+                    .or_insert((window.position.y, window.position.y + window.size.1));
+                extent.0 = extent.0.min(window.position.y);
+                extent.1 = extent.1.max(window.position.y + window.size.1);
             }
 
-            if min_y < max_y {
-                vertical_lines.push((x, min_y, max_y));
-            }
-        }
-
-        // Find all horizontal separators by looking for adjacent windows
-        // Similar approach for horizontal lines
-        let mut horizontal_y_positions: std::collections::HashSet<usize> =
-            std::collections::HashSet::new();
-
-        for i in 0..windows.len() {
-            for j in 0..windows.len() {
-                if i == j {
-                    continue;
-                }
-                let w1 = windows[i];
-                let w2 = windows[j];
-
-                // Check if w1 is directly above w2
-                if w1.position.y + w1.size.1 + 1 == w2.position.y {
-                    let y = w1.position.y + w1.size.1;
-                    horizontal_y_positions.insert(y);
-                }
-            }
-        }
-
-        // Now for each horizontal separator position, find the full extent
-        for y in horizontal_y_positions {
-            let mut min_x = term_width;
-            let mut max_x = 0;
-
-            // Find all windows that have this separator on their bottom edge
-            for window in &windows {
-                if window.position.y + window.size.1 == y {
-                    min_x = min_x.min(window.position.x);
-                    max_x = max_x.max(window.position.x + window.size.0);
-                }
-            }
-
-            if min_x < max_x {
-                horizontal_lines.push((y, min_x, max_x));
+            let bottom = window.position.y + window.size.1;
+            if top_positions.contains(&bottom.saturating_add(1)) {
+                let extent = horizontal_lines
+                    .entry(bottom)
+                    .or_insert((window.position.x, window.position.x + window.size.0));
+                extent.0 = extent.0.min(window.position.x);
+                extent.1 = extent.1.max(window.position.x + window.size.0);
             }
         }
 
@@ -857,14 +778,14 @@ impl Editor {
         let mut temp_grid: HashMap<(usize, usize), char> = HashMap::new();
 
         // Draw vertical lines
-        for (x, y_start, y_end) in &vertical_lines {
+        for (x, (y_start, y_end)) in &vertical_lines {
             for y in *y_start..*y_end {
                 temp_grid.insert((*x, y), if use_ascii { '|' } else { '│' });
             }
         }
 
         // Draw horizontal lines, marking overlaps as cross
-        for (y, x_start, x_end) in &horizontal_lines {
+        for (y, (x_start, x_end)) in &horizontal_lines {
             for x in *x_start..*x_end {
                 if let Some(existing) = temp_grid.get(&(x, *y)) {
                     if *existing == '|' || *existing == '│' {
@@ -892,9 +813,8 @@ impl Editor {
             )
         };
 
-        // Pass 2: Refine intersections based on adjacent cells
-        let mut final_grid: HashMap<(usize, usize), char> = HashMap::new();
-
+        // Pass 2: Refine intersections based on adjacent cells and draw each
+        // final character directly, avoiding a second full grid allocation.
         for (x, y) in temp_grid.keys() {
             // Check adjacent cells
             let connects_up = if *y > 0 {
@@ -975,12 +895,7 @@ impl Editor {
                 }
             };
 
-            final_grid.insert((*x, *y), junction_char);
-        }
-
-        // Draw all separator characters from the final grid
-        for ((x, y), char) in final_grid {
-            buffer.set_char(x, y, char, &separator_style, &self.theme);
+            buffer.set_char(*x, *y, junction_char, &separator_style, &self.theme);
         }
 
         Ok(())
@@ -1181,9 +1096,7 @@ impl Editor {
         width: usize,
         style: &Style,
     ) {
-        for i in 0..width {
-            buffer.set_char(x + i, y, ' ', style, &self.theme);
-        }
+        buffer.fill_rect(x, y, width, 1, ' ', style, &self.theme);
     }
 
     /// Renders overlays like selections, search highlights, diagnostics within a window
@@ -1452,13 +1365,15 @@ impl Editor {
             ..Default::default()
         });
 
-        let diagnostics_by_line: HashMap<_, Vec<_>> =
-            diagnostics.iter().fold(HashMap::new(), |mut acc, d| {
-                acc.entry(d.range.start.line).or_default().push(d);
-                acc
-            });
-
         let layout = self.layout_for_window(window);
+        let Some(visible_start) = layout.rows.first().map(|segment| segment.line) else {
+            return Ok(());
+        };
+        let Some(visible_end) = layout.rows.last().map(|segment| segment.line) else {
+            return Ok(());
+        };
+        let diagnostics_by_line =
+            diagnostics_by_visible_line(diagnostics, visible_start, visible_end);
 
         // Render diagnostics for visible lines in this window
         for (line_num, diagnostics) in diagnostics_by_line {
@@ -1690,7 +1605,7 @@ impl Editor {
             let pos = format!(" {}:{} ", window.vtop + window.cy + 1, window.cx + 1);
 
             // Add window indicator if there are multiple windows
-            let window_count = self.window_manager.windows().len();
+            let window_count = self.window_manager.window_count();
             let window_indicator = if window_count > 1 {
                 format!(
                     " [{}/{}]",
@@ -2083,6 +1998,24 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_grouping_ignores_offscreen_lines() {
+        let mut first_visible = diagnostic("first visible");
+        first_visible.range.start.line = 4;
+        let mut second_visible = diagnostic("second visible");
+        second_visible.range.start.line = 4;
+        let mut offscreen = diagnostic("offscreen");
+        offscreen.range.start.line = 400;
+        let diagnostics = vec![offscreen, first_visible, second_visible];
+
+        let by_line = diagnostics_by_visible_line(&diagnostics, 3, 8);
+
+        assert_eq!(by_line.len(), 1);
+        assert_eq!(by_line[&4].len(), 2);
+        assert_eq!(by_line[&4][0].message, "first visible");
+        assert_eq!(by_line[&4][1].message, "second visible");
+    }
+
+    #[test]
     fn statusline_file_name_omits_dot_slash_prefix() {
         assert_eq!(statusline_file_name("./src/color.rs"), "src/color.rs");
     }
@@ -2138,6 +2071,66 @@ mod tests {
             .unwrap();
 
         assert!(editor.search_match_cache.is_none());
+    }
+
+    #[test]
+    fn per_window_render_leaves_separator_to_split_renderer() {
+        let config = Config {
+            window_borders_ascii: true,
+            ..Config::default()
+        };
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let source = Buffer::new(None, "content\n".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![source]).unwrap();
+        editor.window_manager.split_vertical(0).unwrap();
+        let left = editor.window_manager.window_at_index(0).unwrap();
+        let separator_x = left.position.x + left.size.0;
+        let separator_height = left.size.1;
+        let mut buffer = RenderBuffer::new(40, 10, &Style::default());
+
+        editor.render_window(&mut buffer, 0).unwrap();
+
+        assert!(
+            (0..separator_height).all(|y| buffer.cells[y * buffer.width + separator_x].c == ' ')
+        );
+
+        editor.render_all_window_separators(&mut buffer).unwrap();
+
+        assert!(
+            (0..separator_height).all(|y| buffer.cells[y * buffer.width + separator_x].c == '|')
+        );
+    }
+
+    #[test]
+    fn nested_split_separators_preserve_unicode_junctions() {
+        let config = Config::default();
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let source = Buffer::new(None, "content\n".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![source]).unwrap();
+        editor.window_manager.split_vertical(0).unwrap();
+        editor.window_manager.set_active(0);
+        editor.window_manager.split_horizontal(0).unwrap();
+        editor.window_manager.set_active(0);
+        editor.window_manager.split_vertical(0).unwrap();
+        let windows = editor.window_manager.windows();
+        let top_left = windows[0];
+        let top_right = windows[1];
+        let bottom_left = windows[2];
+        let inner_x = top_left.position.x + top_left.size.0;
+        let outer_x = bottom_left.position.x + bottom_left.size.0;
+        let horizontal_y = top_right.position.y + top_right.size.1;
+        let mut buffer = RenderBuffer::new(40, 10, &Style::default());
+
+        editor.render_all_window_separators(&mut buffer).unwrap();
+
+        let cell = |x: usize, y: usize| buffer.cells[y * buffer.width + x].c;
+        assert_eq!(cell(inner_x, 1), '│');
+        assert_eq!(cell(outer_x, 1), '│');
+        assert_eq!(cell(1, horizontal_y), '─');
+        assert_eq!(cell(inner_x, horizontal_y), '┴');
+        assert_eq!(cell(outer_x, horizontal_y), '┤');
     }
 
     #[test]

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -1,13 +1,12 @@
-use std::{
-    collections::HashMap,
-    ops::Range,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, ops::Range, path::Path};
 
 use husk_lexer::{Keyword, Lexer, TokenKind, Trivia};
 use tree_sitter::{Language, Parser, Query, QueryCursor, StreamingIterator};
 
-use crate::{editor::StyleInfo, theme::Theme};
+use crate::{
+    editor::StyleInfo,
+    theme::{Style, Theme},
+};
 
 #[derive(Clone, Copy)]
 struct LanguageDefinition {
@@ -22,6 +21,7 @@ struct LanguageHighlighter {
     parser: Parser,
     query: Query,
     injection_query: Option<Query>,
+    capture_styles: Vec<Option<Style>>,
 }
 
 struct Injection {
@@ -41,6 +41,33 @@ pub struct Highlighter {
     extensions: HashMap<&'static str, &'static str>,
     highlighters: HashMap<&'static str, LanguageHighlighter>,
     theme: Theme,
+    husk_styles: HuskStyles,
+}
+
+struct HuskStyles {
+    comment: Option<Style>,
+    constant_builtin: Option<Style>,
+    variable_builtin: Option<Style>,
+    keyword: Option<Style>,
+    numeric: Option<Style>,
+    string: Option<Style>,
+    type_builtin: Option<Style>,
+    operator: Option<Style>,
+}
+
+impl HuskStyles {
+    fn new(theme: &Theme) -> Self {
+        Self {
+            comment: theme.get_style("comment"),
+            constant_builtin: theme.get_style("constant.builtin"),
+            variable_builtin: theme.get_style("variable.builtin"),
+            keyword: theme.get_style("keyword"),
+            numeric: theme.get_style("constant.numeric"),
+            string: theme.get_style("string"),
+            type_builtin: theme.get_style("type.builtin"),
+            operator: theme.get_style("operator"),
+        }
+    }
 }
 
 const MAX_INJECTION_DEPTH: usize = 3;
@@ -66,6 +93,7 @@ impl Highlighter {
             extensions,
             highlighters: HashMap::new(),
             theme: theme.clone(),
+            husk_styles: HuskStyles::new(theme),
         })
     }
 
@@ -105,7 +133,7 @@ impl Highlighter {
         depth: usize,
     ) -> anyhow::Result<Vec<StyleInfo>> {
         if language_id == "husk" {
-            return Ok(highlight_husk(code, &self.theme));
+            return Ok(highlight_husk(code, &self.husk_styles));
         }
 
         let Some(definition) = self.languages.get(language_id).copied() else {
@@ -118,6 +146,11 @@ impl Highlighter {
             parser.set_language(&language)?;
             let highlight_query = definition.highlight_queries.join("\n");
             let query = Query::new(&language, &highlight_query)?;
+            let capture_styles = query
+                .capture_names()
+                .iter()
+                .map(|scope| self.theme.get_style(scope))
+                .collect();
             let injection_query = definition
                 .injection_query
                 .map(|query| Query::new(&language, query))
@@ -128,6 +161,7 @@ impl Highlighter {
                     parser,
                     query,
                     injection_query,
+                    capture_styles,
                 },
             );
         }
@@ -151,10 +185,12 @@ impl Highlighter {
                     let node = cap.node;
                     let start = node.start_byte();
                     let end = node.end_byte();
-                    let scope = highlighter.query.capture_names()[cap.index as usize];
-
-                    if let Some(style) = self.theme.get_style(scope) {
-                        colors.push(StyleInfo { start, end, style });
+                    if let Some(style) = highlighter.capture_styles[cap.index as usize].as_ref() {
+                        colors.push(StyleInfo {
+                            start,
+                            end,
+                            style: style.clone(),
+                        });
                     }
                 }
             }
@@ -369,7 +405,7 @@ fn language_definitions() -> Vec<LanguageDefinition> {
     ]
 }
 
-fn highlight_husk(code: &str, theme: &Theme) -> Vec<StyleInfo> {
+fn highlight_husk(code: &str, theme: &HuskStyles) -> Vec<StyleInfo> {
     let mut styles = Vec::new();
     let mut cursor = 0;
 
@@ -398,7 +434,7 @@ fn highlight_husk(code: &str, theme: &Theme) -> Vec<StyleInfo> {
 fn highlight_trivia(
     trivia: &[Trivia],
     mut cursor: usize,
-    theme: &Theme,
+    theme: &HuskStyles,
     styles: &mut Vec<StyleInfo>,
 ) -> usize {
     for item in trivia {
@@ -406,7 +442,7 @@ fn highlight_trivia(
         let start = cursor;
         cursor += len;
         if matches!(item, Trivia::LineComment(_)) {
-            push_style(theme, "comment", start..cursor, styles);
+            push_style(theme.comment.as_ref(), start..cursor, styles);
         }
     }
     cursor
@@ -424,29 +460,29 @@ fn highlight_husk_token(
     kind: &TokenKind,
     range: Range<usize>,
     code: &str,
-    theme: &Theme,
+    theme: &HuskStyles,
     styles: &mut Vec<StyleInfo>,
 ) {
     match kind {
         TokenKind::Keyword(Keyword::True | Keyword::False) => {
-            push_style(theme, "constant.builtin", range, styles);
+            push_style(theme.constant_builtin.as_ref(), range, styles);
         }
         TokenKind::Keyword(Keyword::SelfType) => {
-            push_style(theme, "variable.builtin", range, styles);
+            push_style(theme.variable_builtin.as_ref(), range, styles);
         }
         TokenKind::Keyword(_) => {
-            push_style(theme, "keyword", range, styles);
+            push_style(theme.keyword.as_ref(), range, styles);
         }
         TokenKind::IntLiteral(_) | TokenKind::FloatLiteral(_) => {
-            push_style(theme, "constant.numeric", range, styles);
+            push_style(theme.numeric.as_ref(), range, styles);
         }
         TokenKind::StringLiteral(_) => {
-            push_style(theme, "string", range, styles);
+            push_style(theme.string.as_ref(), range, styles);
         }
         TokenKind::Ident(_) => {
             if let Some(text) = code.get(range.clone()) {
                 if is_husk_builtin_type(text) {
-                    push_style(theme, "type.builtin", range, styles);
+                    push_style(theme.type_builtin.as_ref(), range, styles);
                 }
             }
         }
@@ -475,7 +511,7 @@ fn highlight_husk_token(
         | TokenKind::Question
         | TokenKind::DotDot
         | TokenKind::DotDotEq => {
-            push_style(theme, "operator", range, styles);
+            push_style(theme.operator.as_ref(), range, styles);
         }
         _ => {}
     }
@@ -504,16 +540,16 @@ fn is_husk_builtin_type(text: &str) -> bool {
     )
 }
 
-fn push_style(theme: &Theme, scope: &str, range: Range<usize>, styles: &mut Vec<StyleInfo>) {
+fn push_style(style: Option<&Style>, range: Range<usize>, styles: &mut Vec<StyleInfo>) {
     if range.start >= range.end {
         return;
     }
 
-    if let Some(style) = theme.get_style(scope) {
+    if let Some(style) = style {
         styles.push(StyleInfo {
             start: range.start,
             end: range.end,
-            style,
+            style: style.clone(),
         });
     }
 }
@@ -621,7 +657,7 @@ const MARKDOWN_INJECTION_QUERY: &str = r#"
 "#;
 
 pub fn normalized_extension(file: &str) -> Option<String> {
-    PathBuf::from(file)
+    Path::new(file)
         .extension()
         .map(|extension| extension.to_string_lossy().to_ascii_lowercase())
 }

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -26,21 +26,50 @@ pub struct DocumentInfo {
     pub server_name: String,
 }
 
+struct DocumentSelector {
+    server_name: String,
+    language_id: String,
+}
+
 pub struct LspManager {
     config: LspConfig,
+    document_selectors: HashMap<String, DocumentSelector>,
     clients: HashMap<String, RealLspClient>,
+    client_poll_order: Vec<String>,
     failed_clients: HashSet<String>,
     opened_documents: HashSet<String>,
+    document_clients: HashMap<String, String>,
     next_client_poll: usize,
 }
 
 impl LspManager {
     pub fn new(config: LspConfig) -> Self {
+        let mut document_selectors = HashMap::new();
+        if config.enabled {
+            let mut servers = config.servers.iter().collect::<Vec<_>>();
+            servers.sort_unstable_by_key(|(name, _)| *name);
+            for (server_name, server) in servers {
+                for document in server.documents() {
+                    for extension in document.file_extensions {
+                        document_selectors
+                            .entry(extension.trim_start_matches('.').to_ascii_lowercase())
+                            .or_insert_with(|| DocumentSelector {
+                                server_name: server_name.clone(),
+                                language_id: document.language_id.clone(),
+                            });
+                    }
+                }
+            }
+        }
+
         Self {
             config,
+            document_selectors,
             clients: HashMap::new(),
+            client_poll_order: Vec::new(),
             failed_clients: HashSet::new(),
             opened_documents: HashSet::new(),
+            document_clients: HashMap::new(),
             next_client_poll: 0,
         }
     }
@@ -51,19 +80,8 @@ impl LspManager {
         }
 
         let extension = normalized_extension(file)?;
-        let mut servers = self.config.servers.iter().collect::<Vec<_>>();
-        servers.sort_by_key(|(name, _)| *name);
-        let (server_name, server, document) =
-            servers.into_iter().find_map(|(server_name, server)| {
-                let document = server.documents().into_iter().find(|document| {
-                    document.file_extensions.iter().any(|candidate| {
-                        candidate
-                            .trim_start_matches('.')
-                            .eq_ignore_ascii_case(&extension)
-                    })
-                })?;
-                Some((server_name, server, document))
-            })?;
+        let selector = self.document_selectors.get(&extension)?;
+        let server = self.config.servers.get(&selector.server_name)?;
 
         let path = Path::new(file);
         let path = path.absolutize().ok()?.to_path_buf();
@@ -73,9 +91,9 @@ impl LspManager {
         Some(DocumentInfo {
             path,
             uri,
-            language_id: document.language_id,
+            language_id: selector.language_id.clone(),
             workspace_root,
-            server_name: server_name.clone(),
+            server_name: selector.server_name.clone(),
         })
     }
 
@@ -116,6 +134,11 @@ impl LspManager {
                 return Ok(None);
             }
             self.clients.insert(key.clone(), client);
+            let index = self
+                .client_poll_order
+                .binary_search(&key)
+                .unwrap_or_else(|index| index);
+            self.client_poll_order.insert(index, key.clone());
         }
 
         Ok(self.clients.get_mut(&key))
@@ -125,6 +148,11 @@ impl LspManager {
         &mut self,
         file: &str,
     ) -> Result<Option<&mut RealLspClient>, LspError> {
+        if let Some(key) = self.document_clients.get(file) {
+            if self.clients.contains_key(key) {
+                return Ok(self.clients.get_mut(key));
+            }
+        }
         let Some(document) = self.resolve_document(file) else {
             return Ok(None);
         };
@@ -133,6 +161,11 @@ impl LspManager {
 
     fn client_for_uri_mut(&mut self, uri: &str) -> Option<&mut RealLspClient> {
         let file = file_path(uri).ok()?;
+        if let Some(key) = self.document_clients.get(&file) {
+            if self.clients.contains_key(key) {
+                return self.clients.get_mut(key);
+            }
+        }
         let document = self.resolve_document(&file)?;
         let key = client_key(&document);
         self.clients.get_mut(&key)
@@ -182,11 +215,16 @@ impl LspClient for LspManager {
     }
 
     async fn did_open(&mut self, file: &str, contents: &str) -> Result<(), LspError> {
+        if self.document_clients.contains_key(file) {
+            return Ok(());
+        }
         let Some(document) = self.resolve_document(file) else {
             return Ok(());
         };
         let key = document_key(&document);
         if self.opened_documents.contains(&key) {
+            self.document_clients
+                .insert(file.to_string(), client_key(&document));
             return Ok(());
         }
 
@@ -197,10 +235,17 @@ impl LspClient for LspManager {
             .did_open_with_language_id(file, contents, &document.language_id)
             .await?;
         self.opened_documents.insert(key);
+        self.document_clients
+            .insert(file.to_string(), client_key(&document));
         Ok(())
     }
 
     async fn did_change(&mut self, file: &str, contents: String) -> Result<(), LspError> {
+        if let Some(key) = self.document_clients.get(file) {
+            if let Some(client) = self.clients.get_mut(key) {
+                return client.did_change(file, contents).await;
+            }
+        }
         let Some(document) = self.resolve_document(file) else {
             return Ok(());
         };
@@ -219,10 +264,13 @@ impl LspClient for LspManager {
         if needs_open {
             self.opened_documents.insert(key);
         }
+        self.document_clients
+            .insert(file.to_string(), client_key(&document));
         result
     }
 
     async fn did_close(&mut self, file: &str) -> Result<(), LspError> {
+        self.document_clients.remove(file);
         let Some(document) = self.resolve_document(file) else {
             return Ok(());
         };
@@ -491,20 +539,24 @@ impl LspClient for LspManager {
     async fn recv_response(
         &mut self,
     ) -> Result<Option<(InboundMessage, Option<String>)>, LspError> {
-        let mut keys = self.clients.keys().cloned().collect::<Vec<_>>();
-        keys.sort();
-        if keys.is_empty() {
+        if self.client_poll_order.len() != self.clients.len() {
+            self.client_poll_order.clear();
+            self.client_poll_order.extend(self.clients.keys().cloned());
+            self.client_poll_order.sort_unstable();
+        }
+        let client_count = self.client_poll_order.len();
+        if client_count == 0 {
             return Ok(None);
         }
-        let start = self.next_client_poll % keys.len();
-        for offset in 0..keys.len() {
-            let index = (start + offset) % keys.len();
-            let client_key = &keys[index];
+        let start = self.next_client_poll % client_count;
+        for offset in 0..client_count {
+            let index = (start + offset) % client_count;
+            let client_key = &self.client_poll_order[index];
             let Some(client) = self.clients.get_mut(client_key) else {
                 continue;
             };
             if let Some((mut message, method)) = client.recv_response().await? {
-                self.next_client_poll = (index + 1) % keys.len();
+                self.next_client_poll = (index + 1) % client_count;
                 if let InboundMessage::Notification(ParsedNotification::Progress(progress)) =
                     &mut message
                 {
@@ -527,6 +579,9 @@ impl LspClient for LspManager {
     }
 
     fn server_capabilities_for_file(&self, file: &str) -> Option<&ServerCapabilities> {
+        if let Some(key) = self.document_clients.get(file) {
+            return self.clients.get(key)?.get_server_capabilities();
+        }
         let document = self.resolve_document(file)?;
         self.clients
             .get(&client_key(&document))?
@@ -534,6 +589,12 @@ impl LspClient for LspManager {
     }
 
     fn supports_document_formatting(&self, file: &str) -> bool {
+        if let Some(key) = self.document_clients.get(file) {
+            return self
+                .clients
+                .get(key)
+                .is_some_and(|client| client.supports_document_formatting(file));
+        }
         let Some(document) = self.resolve_document(file) else {
             return false;
         };
@@ -543,6 +604,9 @@ impl LspClient for LspManager {
     }
 
     fn document_version(&self, file: &str) -> Option<i64> {
+        if let Some(key) = self.document_clients.get(file) {
+            return self.clients.get(key)?.document_version(file);
+        }
         let document = self.resolve_document(file)?;
         self.clients
             .get(&client_key(&document))?
@@ -550,6 +614,9 @@ impl LspClient for LspManager {
     }
 
     fn workspace_root_for_file(&self, file: &str) -> Option<PathBuf> {
+        if let Some(key) = self.document_clients.get(file) {
+            return self.clients.get(key)?.workspace_root_for_file(file);
+        }
         self.resolve_document(file)
             .map(|document| document.workspace_root)
     }
@@ -749,6 +816,7 @@ mod tests {
             ]
         );
         assert_eq!(manager.opened_documents.len(), 1);
+        assert_eq!(manager.document_clients.len(), 1);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,14 +504,21 @@ fn paint_detached_delta(
         rows[patch.row] = patch.clone();
         paint_detached_row(output, patch)?;
     }
+    finish_detached_paint(output, delta.cursor)
+}
+
+fn finish_detached_paint(
+    output: &mut impl std::io::Write,
+    cursor: (usize, usize),
+) -> anyhow::Result<()> {
     output
         .queue(style::ResetColor)?
         .queue(style::SetAttribute(style::Attribute::Reset))?;
     write!(
         output,
         "\x1b[{};{}H",
-        delta.cursor.1.saturating_add(1),
-        delta.cursor.0.saturating_add(1)
+        cursor.1.saturating_add(1),
+        cursor.0.saturating_add(1)
     )?;
     output.flush()?;
     Ok(())
@@ -565,12 +572,10 @@ fn paint_detached_resize(
         rows[patch.row] = patch.clone();
     }
     write!(output, "\x1b[H\x1b[2J")?;
-    let repaint = red::headless::RenderDelta {
-        revision: delta.revision,
-        lines: rows.clone(),
-        cursor: delta.cursor,
-    };
-    paint_detached_delta(output, rows, &repaint)
+    for row in rows {
+        paint_detached_row(output, row)?;
+    }
+    finish_detached_paint(output, delta.cursor)
 }
 
 fn print_error(error: &anyhow::Error) {

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -5153,6 +5153,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn indent_guides_reuses_precomputed_widths_and_infers_blank_runs() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let mut layout = sample_indent_layout();
+        layout["cursor"]["y"] = serde_json::json!(3);
+        layout["rows"] = serde_json::json!([
+            { "line": 0, "text": "root", "first_segment": true, "indent_width": 0 },
+            { "line": 1, "text": "not visibly indented", "first_segment": true, "indent_width": 8 },
+            { "line": 2, "text": "", "first_segment": true, "indent_width": 0 },
+            { "line": 3, "text": "   ", "first_segment": true, "indent_width": 3 },
+            { "line": 4, "text": "", "first_segment": true, "indent_width": 0 },
+            { "line": 5, "text": "tail", "first_segment": true, "indent_width": 4 }
+        ]);
+        let mut runtime = Runtime::new();
+        runtime.set_snapshot(
+            "editor_info",
+            sample_indent_editor_info(
+                Color::Rgb {
+                    r: 40,
+                    g: 41,
+                    b: 42,
+                },
+                Color::Rgb {
+                    r: 80,
+                    g: 81,
+                    b: 82,
+                },
+            ),
+        );
+        runtime.set_snapshot("viewport_layout", layout);
+
+        runtime
+            .load_plugin(
+                "indent_guides",
+                include_str!("../../plugins/indent_guides.hk"),
+            )
+            .await
+            .unwrap();
+
+        let PluginRequest::SetDecorations { decorations, .. } = ACTION_DISPATCHER.recv_request()
+        else {
+            panic!("unexpected plugin request");
+        };
+        assert_eq!(
+            decorations
+                .iter()
+                .find(|decoration| decoration.line == 1 && decoration.priority == 1)
+                .unwrap()
+                .text,
+            "\u{2502}   \u{2502}   "
+        );
+        for line in 2..=4 {
+            assert_eq!(
+                decorations
+                    .iter()
+                    .find(|decoration| decoration.line == line && decoration.priority == 1)
+                    .unwrap()
+                    .text,
+                "\u{2502}   "
+            );
+        }
+        assert!(decorations
+            .iter()
+            .any(|decoration| decoration.line == 3 && decoration.priority == 1024));
+    }
+
+    #[tokio::test]
     async fn indent_guides_rebuild_theme_styles_without_layout_changes() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -19,7 +19,7 @@ const PREVIEW_MAX_ROWS: usize = 7;
 #[derive(Default, Clone)]
 pub struct CompletionUI {
     all_items: Vec<CompletionResponseItem>,
-    items: Vec<CompletionResponseItem>,
+    items: Vec<usize>,
     filter: String,
     selected: usize,
     scroll_offset: usize,
@@ -73,9 +73,9 @@ impl CompletionUI {
             .filter_map(|item| item.commit_characters.as_ref())
             .flat_map(|chars| chars.iter())
             .filter_map(|s| s.chars().next())
-            .collect::<std::collections::HashSet<_>>()
-            .into_iter()
             .collect();
+        self.commit_chars.sort_unstable();
+        self.commit_chars.dedup();
         // Sort items by preselect and label
         items.sort_by(|a, b| {
             b.preselect
@@ -115,8 +115,9 @@ impl CompletionUI {
             x = 0;
         }
 
-        self.all_items = items.clone();
-        self.items = items;
+        self.items.clear();
+        self.items.extend(0..items.len());
+        self.all_items = items;
         self.filter.clear();
         self.selected = selected;
         self.scroll_offset = 0;
@@ -140,7 +141,9 @@ impl CompletionUI {
     }
 
     pub fn selected_item(&self) -> Option<&CompletionResponseItem> {
-        self.items.get(self.selected)
+        self.items
+            .get(self.selected)
+            .and_then(|index| self.all_items.get(*index))
     }
 
     pub fn set_filter(&mut self, filter: &str) {
@@ -170,7 +173,9 @@ impl CompletionUI {
             return Some(0);
         }
 
-        [
+        let filter = filter.as_bytes();
+        let mut contains = false;
+        for candidate in [
             item.filter_text.as_deref(),
             Some(item.label.as_str()),
             item.sort_text.as_deref(),
@@ -178,35 +183,38 @@ impl CompletionUI {
         ]
         .into_iter()
         .flatten()
-        .filter_map(|candidate| {
-            let candidate = candidate.to_ascii_lowercase();
-            if candidate.starts_with(filter) {
-                Some(0)
-            } else {
-                candidate.contains(filter).then_some(1)
+        {
+            let candidate = candidate.as_bytes();
+            if candidate
+                .get(..filter.len())
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(filter))
+            {
+                return Some(0);
             }
-        })
-        .min()
+            contains |= candidate
+                .windows(filter.len())
+                .any(|window| window.eq_ignore_ascii_case(filter));
+        }
+
+        contains.then_some(1)
     }
 
     fn refilter_items(&mut self) {
         if self.filter.is_empty() {
-            self.items = self.all_items.clone();
+            self.items.clear();
+            self.items.extend(0..self.all_items.len());
         } else {
-            let filter = self.filter.to_ascii_lowercase();
             let mut matches = self
                 .all_items
                 .iter()
                 .enumerate()
                 .filter_map(|(idx, item)| {
-                    Self::item_filter_score(item, &filter).map(|score| (score, idx, item))
+                    Self::item_filter_score(item, &self.filter).map(|score| (score, idx))
                 })
                 .collect::<Vec<_>>();
-            matches.sort_unstable_by_key(|(score, idx, _)| (*score, *idx));
-            self.items = matches
-                .into_iter()
-                .map(|(_, _, item)| item.clone())
-                .collect();
+            matches.sort_unstable();
+            self.items.clear();
+            self.items.extend(matches.into_iter().map(|(_, idx)| idx));
         }
 
         self.selected = 0;
@@ -402,7 +410,12 @@ impl CompletionUI {
             };
             offset.min(max_scroll_offset)
         };
-        let visible_items = self.items.iter().skip(scroll_offset).take(visible_count);
+        let visible_items = self
+            .items
+            .iter()
+            .skip(scroll_offset)
+            .take(visible_count)
+            .filter_map(|index| self.all_items.get(*index));
 
         // Render completion items.
         for (idx, item) in visible_items.enumerate() {
@@ -957,7 +970,7 @@ mod tests {
         let labels = ui
             .items
             .iter()
-            .map(|item| item.label.as_str())
+            .map(|index| ui.all_items[*index].label.as_str())
             .collect::<Vec<_>>();
         assert_eq!(labels, vec!["as_mut_os_str", "as_os_str"]);
         assert_eq!(ui.selected_item().unwrap().label, "as_mut_os_str");
@@ -981,7 +994,7 @@ mod tests {
         assert_eq!(
             ui.items
                 .iter()
-                .map(|item| item.label.as_str())
+                .map(|index| ui.all_items[*index].label.as_str())
                 .collect::<Vec<_>>(),
             vec!["exists", "add_extension"]
         );
@@ -990,9 +1003,25 @@ mod tests {
         assert_eq!(
             ui.items
                 .iter()
-                .map(|item| item.label.as_str())
+                .map(|index| ui.all_items[*index].label.as_str())
                 .collect::<Vec<_>>(),
             vec!["exists", "add_extension", "ancestors"]
         );
+    }
+
+    #[test]
+    fn filtering_keeps_completion_payloads_in_place_and_matches_ascii_case() {
+        let mut completion = item("target", Some(CompletionItemKind::Function));
+        completion.filter_text = Some("prefix🎯VALUE".to_string());
+        completion.detail = Some("large completion payload".repeat(64));
+        let mut ui = CompletionUI::new();
+        ui.show(vec![item("other", None), completion], 0, 0);
+        let payload = ui.all_items[1].detail.as_ref().unwrap().as_ptr();
+
+        ui.set_filter("🎯value");
+
+        assert_eq!(ui.items, vec![1]);
+        assert_eq!(ui.selected_item().unwrap().label, "target");
+        assert_eq!(ui.all_items[1].detail.as_ref().unwrap().as_ptr(), payload);
     }
 }

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -79,11 +79,7 @@ impl Component for Dialog {
         }
 
         // Draw the dialog box
-        for y in self.y..self.y + height {
-            for x in self.x..self.x + width {
-                buffer.set_char(x, y, ' ', &self.style, &self.theme);
-            }
-        }
+        buffer.fill_rect(self.x, self.y, width, height, ' ', &self.style, &self.theme);
 
         // Draw the border
         if self.border_style != BorderStyle::None {
@@ -102,27 +98,42 @@ impl Component for Dialog {
             let bottom_left = char_indices.next().unwrap().1;
             let bottom_right = char_indices.next().unwrap().1;
 
-            for x in self.x..self.x + width {
-                buffer.set_char(x, self.y, top, &self.border_draw_style, &self.theme);
-                buffer.set_char(
-                    x,
-                    self.y + height - 1,
-                    bottom,
-                    &self.border_draw_style,
-                    &self.theme,
-                );
-            }
-
-            for y in self.y..self.y + height {
-                buffer.set_char(self.x, y, left, &self.border_draw_style, &self.theme);
-                buffer.set_char(
-                    self.x + width - 1,
-                    y,
-                    right,
-                    &self.border_draw_style,
-                    &self.theme,
-                );
-            }
+            buffer.fill_rect(
+                self.x,
+                self.y,
+                width,
+                1,
+                top,
+                &self.border_draw_style,
+                &self.theme,
+            );
+            buffer.fill_rect(
+                self.x,
+                self.y + height - 1,
+                width,
+                1,
+                bottom,
+                &self.border_draw_style,
+                &self.theme,
+            );
+            buffer.fill_rect(
+                self.x,
+                self.y,
+                1,
+                height,
+                left,
+                &self.border_draw_style,
+                &self.theme,
+            );
+            buffer.fill_rect(
+                self.x + width - 1,
+                self.y,
+                1,
+                height,
+                right,
+                &self.border_draw_style,
+                &self.theme,
+            );
 
             buffer.set_char(
                 self.x,

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -12,6 +12,7 @@ pub struct List {
     width: usize,
     height: usize,
     items: Vec<String>,
+    item_count: usize,
     display_items: Vec<String>,
     item_style: Style,
     selected_item_style: Style,
@@ -30,12 +31,14 @@ impl List {
         selected_item_style: &Style,
     ) -> Self {
         let display_items = items.iter().map(|s| truncate(s, width)).collect();
+        let item_count = items.len();
         List {
             x,
             y,
             width,
             height,
             items,
+            item_count,
             display_items,
             item_style: item_style.clone(),
             selected_item_style: selected_item_style.clone(),
@@ -45,11 +48,11 @@ impl List {
     }
 
     pub fn move_down(&mut self) {
-        if self.items.is_empty() {
+        if self.item_count == 0 {
             return;
         }
 
-        self.selected_item = (self.selected_item + 1).min(self.items.len() - 1);
+        self.selected_item = (self.selected_item + 1).min(self.item_count - 1);
         if self.height > 0 && self.selected_item >= self.top_index + self.height {
             self.top_index = self.selected_item.saturating_sub(self.height - 1);
         }
@@ -71,7 +74,7 @@ impl List {
     }
 
     fn move_by(&mut self, delta: isize) {
-        if self.items.is_empty() || self.height == 0 {
+        if self.item_count == 0 || self.height == 0 {
             return;
         }
 
@@ -81,7 +84,7 @@ impl List {
             self.selected_item.saturating_add(delta as usize)
         };
 
-        self.selected_item = new_selected.min(self.items.len() - 1);
+        self.selected_item = new_selected.min(self.item_count - 1);
         if self.selected_item < self.top_index {
             self.top_index = self.selected_item;
         } else if self.selected_item >= self.top_index + self.height {
@@ -97,7 +100,7 @@ impl List {
     }
 
     pub fn selected_index(&self) -> Option<usize> {
-        (!self.items.is_empty()).then_some(self.selected_item)
+        (self.item_count > 0).then_some(self.selected_item)
     }
 
     pub fn set_items(&mut self, new_items: Vec<String>) {
@@ -108,6 +111,15 @@ impl List {
             .map(|item| truncate(item, self.width))
             .collect();
         self.items = new_items;
+        self.item_count = self.items.len();
+    }
+
+    pub(crate) fn set_item_count(&mut self, count: usize) {
+        self.selected_item = 0;
+        self.top_index = 0;
+        self.items.clear();
+        self.display_items.clear();
+        self.item_count = count;
     }
 
     pub(crate) fn set_bounds(&mut self, x: usize, y: usize, width: usize, height: usize) {
@@ -145,10 +157,10 @@ impl List {
     }
 
     pub fn set_selected_index(&mut self, index: usize) {
-        if self.items.is_empty() {
+        if self.item_count == 0 {
             return;
         }
-        self.selected_item = index.min(self.items.len() - 1);
+        self.selected_item = index.min(self.item_count - 1);
         if self.height > 0 && self.selected_item >= self.top_index + self.height {
             self.top_index = self.selected_item.saturating_sub(self.height - 1);
         } else if self.selected_item < self.top_index {
@@ -158,6 +170,10 @@ impl List {
 
     pub fn items(&self) -> &Vec<String> {
         &self.items
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.item_count == 0
     }
 
     pub(crate) fn top_index(&self) -> usize {
@@ -258,5 +274,20 @@ mod test {
 
         assert_eq!(list.selected_item(), "ab👋cd");
         assert_eq!(display_width(&list.display_items[0]), 5);
+    }
+
+    #[test]
+    fn dynamic_item_count_supports_navigation_without_materializing_labels() {
+        let style = Style::default();
+        let mut list = List::new(0, 0, 10, 2, vec![], &style, &style);
+
+        list.set_item_count(3);
+        list.move_down();
+        list.move_down();
+
+        assert!(list.items.is_empty());
+        assert!(list.display_items.is_empty());
+        assert_eq!(list.selected_index(), Some(2));
+        assert_eq!(list.top_index(), 1);
     }
 }

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{
     borrow::Cow,
-    cell::RefCell,
+    cell::{Cell, RefCell},
     cmp::Reverse,
     collections::VecDeque,
     io::{self, BufRead as _, BufReader, Read as _, Seek as _, SeekFrom},
@@ -56,25 +56,6 @@ pub struct PickerItem {
     pub detail_matches: Vec<[usize; 2]>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preview: Option<PickerPreview>,
-}
-
-impl PickerItem {
-    fn display_text(&self) -> String {
-        let mut text = self.label.clone();
-        if let Some(annotation) = self
-            .annotation
-            .as_deref()
-            .filter(|annotation| !annotation.is_empty())
-        {
-            text.push(' ');
-            text.push_str(annotation);
-        }
-        if let Some(detail) = self.detail.as_deref().filter(|detail| !detail.is_empty()) {
-            text.push_str("  ");
-            text.push_str(detail);
-        }
-        text
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -260,6 +241,7 @@ pub struct Picker {
     live: bool,
     dynamic_items: Option<Vec<PickerItem>>,
     visible_dynamic_items: Vec<usize>,
+    command_column_widths: Cell<Option<CommandColumns>>,
     external_filter: bool,
     status: Option<String>,
     key_actions: Vec<PickerKeyAction>,
@@ -310,7 +292,7 @@ struct PickerLayout {
     query_y: usize,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct CommandColumns {
     category: usize,
     title: usize,
@@ -409,6 +391,7 @@ impl Picker {
             live: false,
             dynamic_items: None,
             visible_dynamic_items: Vec::new(),
+            command_column_widths: Cell::new(None),
             external_filter: false,
             status: None,
             key_actions: Vec::new(),
@@ -472,13 +455,10 @@ impl Picker {
         id: i32,
         options: PickerOptions,
     ) -> Self {
-        let labels = items
-            .iter()
-            .map(PickerItem::display_text)
-            .collect::<Vec<_>>();
-        let mut picker = Self::new(title, editor, &labels, Some(id));
+        let mut picker = Self::new(title, editor, &[], Some(id));
         picker.live = true;
         picker.visible_dynamic_items = (0..items.len()).collect();
+        picker.list.set_item_count(items.len());
         picker.dynamic_items = Some(items);
         picker.external_filter = options.external_filter;
         picker.placeholder = options.placeholder;
@@ -569,12 +549,8 @@ impl Picker {
                 matches.sort_unstable_by_key(|(index, score)| (Reverse(*score), *index));
                 self.visible_dynamic_items = matches.into_iter().map(|(index, _)| index).collect();
             }
-            self.list.set_items(
-                self.visible_dynamic_items
-                    .iter()
-                    .map(|index| items[*index].display_text())
-                    .collect(),
-            );
+            self.list.set_item_count(self.visible_dynamic_items.len());
+            self.command_column_widths.set(None);
             return;
         }
         if term.is_empty() {
@@ -674,7 +650,10 @@ impl Picker {
     }
 
     fn selected_item(&self) -> Option<String> {
-        if self.list.items().is_empty() {
+        if let Some(item) = self.selected_dynamic_item() {
+            return Some(item.id.clone());
+        }
+        if self.list.is_empty() {
             return None;
         }
         Some(self.list.selected_item())
@@ -1318,29 +1297,33 @@ impl Picker {
     }
 
     fn command_columns(&self, items: &[PickerItem], content_width: usize) -> CommandColumns {
-        let mut columns = CommandColumns::default();
-        for item in self
-            .visible_dynamic_items
-            .iter()
-            .filter_map(|index| items.get(*index))
-            .filter(|item| item.kind.as_deref() == Some("Command"))
-        {
-            let category = item.annotation.as_deref().unwrap_or_default().trim_end();
-            let shortcut = item
-                .data
-                .get("primary_shortcut")
-                .and_then(Value::as_str)
-                .unwrap_or_default();
-            let colon = item
-                .data
-                .get("colon")
-                .and_then(Value::as_str)
-                .unwrap_or_default();
-            columns.category = columns.category.max(display_width(category));
-            columns.title = columns.title.max(display_width(&item.label));
-            columns.shortcut = columns.shortcut.max(display_width(shortcut));
-            columns.colon = columns.colon.max(display_width(colon));
-        }
+        let mut columns = self.command_column_widths.get().unwrap_or_else(|| {
+            let mut columns = CommandColumns::default();
+            for item in self
+                .visible_dynamic_items
+                .iter()
+                .filter_map(|index| items.get(*index))
+                .filter(|item| item.kind.as_deref() == Some("Command"))
+            {
+                let category = item.annotation.as_deref().unwrap_or_default().trim_end();
+                let shortcut = item
+                    .data
+                    .get("primary_shortcut")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let colon = item
+                    .data
+                    .get("colon")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                columns.category = columns.category.max(display_width(category));
+                columns.title = columns.title.max(display_width(&item.label));
+                columns.shortcut = columns.shortcut.max(display_width(shortcut));
+                columns.colon = columns.colon.max(display_width(colon));
+            }
+            self.command_column_widths.set(Some(columns));
+            columns
+        });
 
         let category_gap = usize::from(columns.category > 0) * COMMAND_COLUMN_GAP;
         let primary_width = columns.category + category_gap + columns.title;
@@ -2207,7 +2190,7 @@ impl Component for Picker {
                         self.changed_actions(previous)
                     }
                     KeyCode::Enter => {
-                        if self.list.items().is_empty() {
+                        if self.list.is_empty() {
                             return None;
                         }
                         let action = if let Some(select_action) = &self.select_action {
@@ -2261,7 +2244,7 @@ impl Component for Picker {
         } else {
             self.draw_plain_items(buffer, layout.results);
         }
-        if self.list.items().is_empty() {
+        if self.list.is_empty() {
             if let Some(message) = &self.empty_message {
                 let line = fit_display_width(message, layout.results.width.saturating_sub(2));
                 buffer.set_text(
@@ -2442,9 +2425,11 @@ impl PickerBuilder {
     pub fn build(self, editor: &Editor) -> Picker {
         let title = self.title;
         let structured_items = self.structured_items;
-        let items = structured_items.as_ref().map_or(self.items, |items| {
-            items.iter().map(PickerItem::display_text).collect()
-        });
+        let items = if structured_items.is_some() {
+            Vec::new()
+        } else {
+            self.items
+        };
         let id = self.id;
         let select_action = self.select_action;
         let filter_action = self.filter_action;
@@ -2454,6 +2439,7 @@ impl PickerBuilder {
         let mut picker = Picker::new(title, editor, &items, id);
         if let Some(structured_items) = structured_items {
             picker.visible_dynamic_items = (0..structured_items.len()).collect();
+            picker.list.set_item_count(structured_items.len());
             picker.dynamic_items = Some(structured_items);
         }
         if let Some(select_action) = select_action {
@@ -4409,6 +4395,41 @@ mod tests {
         let selected = picker.selected_dynamic_item().unwrap();
         assert_eq!(selected.id, "b");
         assert_eq!(selected.label.as_ptr(), original_label);
+        assert!(picker.list.items().is_empty());
+    }
+
+    #[test]
+    fn structured_command_columns_stay_aligned_across_scrolled_pages() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 200, 12);
+        let mut items = (0..24)
+            .map(|index| {
+                let mut item =
+                    dynamic_item(&format!("command-{index}"), &format!("Action {index}"));
+                item.kind = Some("Command".to_string());
+                item.annotation = Some("Edit".to_string());
+                item.data = json!({ "primary_shortcut": "Ctrl-x", "colon": ":Action" });
+                item
+            })
+            .collect::<Vec<_>>();
+        items[20].label = "The much longer action that only appears on the next page".to_string();
+        let mut picker = Picker::builder().structured_items(items).build(&editor);
+        let content_width = picker.layout().results.width.saturating_sub(1);
+
+        let first_page =
+            picker.command_columns(picker.dynamic_items.as_ref().unwrap(), content_width);
+        assert!(picker.command_column_widths.get().is_some());
+        picker.list.set_selected_index(20);
+        let next_page =
+            picker.command_columns(picker.dynamic_items.as_ref().unwrap(), content_width);
+
+        assert_eq!(first_page, next_page);
+        assert_eq!(
+            first_page.title,
+            display_width("The much longer action that only appears on the next page")
+        );
+
+        picker.filter("Action 1");
+        assert!(picker.command_column_widths.get().is_none());
     }
 
     #[test]

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -514,13 +514,7 @@ impl UndoHistory {
                 );
             }
             anyhow::ensure!(
-                buffer
-                    .contents()
-                    .chars()
-                    .skip(start)
-                    .take(end.saturating_sub(start))
-                    .collect::<String>()
-                    == *new_text,
+                buffer.text_in_char_range_matches(start, end, new_text),
                 "transaction post-image no longer matches the buffer"
             );
             revert.push(RevertEdit {
@@ -556,7 +550,7 @@ impl UndoHistory {
 
     pub fn undo(&mut self, buffer: &mut Buffer) -> Option<(CursorSnapshot, Vec<AppliedTextEdit>)> {
         let index = self.current?;
-        let transaction = self.nodes[index].transaction.clone();
+        let transaction = &self.nodes[index].transaction;
         let mut applied_edits = Vec::with_capacity(transaction.edits.len());
         for edit in transaction.edits.iter().rev() {
             match edit {
@@ -590,7 +584,7 @@ impl UndoHistory {
             .copied()
             .unwrap_or_else(|| children.len().saturating_sub(1));
         let index = *children.get(selected)?;
-        let transaction = self.nodes[index].transaction.clone();
+        let transaction = &self.nodes[index].transaction;
         let mut applied_edits = Vec::with_capacity(transaction.edits.len());
         for edit in &transaction.edits {
             match edit {

--- a/src/unicode_utils.rs
+++ b/src/unicode_utils.rs
@@ -97,6 +97,19 @@ pub fn grapheme_to_char(line: &str, grapheme_idx: usize) -> usize {
     byte_to_char(line, grapheme_to_byte(line, grapheme_idx))
 }
 
+/// Return the character-index range occupied by one grapheme cluster.
+pub fn grapheme_char_range(line: &str, grapheme_idx: usize) -> Option<(usize, usize)> {
+    let mut start = 0;
+    for (index, grapheme) in line.graphemes(true).enumerate() {
+        let end = start + grapheme.chars().count();
+        if index == grapheme_idx {
+            return Some((start, end));
+        }
+        start = end;
+    }
+    None
+}
+
 /// Convert Ropey's character index to a grapheme cluster index.
 pub fn char_to_grapheme(line: &str, char_idx: usize) -> usize {
     byte_to_grapheme(line, char_to_byte(line, char_idx))
@@ -128,25 +141,25 @@ pub fn truncate_chars(line: &str, max_chars: usize) -> &str {
 /// Truncate a string to at most `max_width` terminal display columns.
 pub fn truncate_display_width(s: &str, max_width: usize) -> String {
     let mut width = 0;
-    let mut result = String::new();
 
-    for grapheme in s.graphemes(true) {
+    for (start, grapheme) in s.grapheme_indices(true) {
         let grapheme_width = display_width(grapheme);
         if width + grapheme_width > max_width {
-            break;
+            return s[..start].to_owned();
         }
-
-        result.push_str(grapheme);
         width += grapheme_width;
     }
 
-    result
+    s.to_owned()
 }
 
 /// Pad or truncate a string so it occupies exactly `width` display columns.
 pub fn fit_display_width(s: &str, width: usize) -> String {
     let mut result = truncate_display_width(s, width);
-    result.push_str(&" ".repeat(width.saturating_sub(display_width(&result))));
+    result.extend(std::iter::repeat_n(
+        ' ',
+        width.saturating_sub(display_width(&result)),
+    ));
     result
 }
 
@@ -169,41 +182,18 @@ pub fn nth_grapheme(s: &str, n: usize) -> Option<&str> {
 /// Move to the next grapheme cluster boundary
 /// Returns the byte offset of the next grapheme boundary, or None if at the end
 pub fn next_grapheme_boundary(s: &str, byte_offset: usize) -> Option<usize> {
-    let graphemes: Vec<(usize, &str)> = s.grapheme_indices(true).collect();
-
-    // Find which grapheme contains our byte offset
-    for i in 0..graphemes.len() {
-        let (start, _grapheme) = graphemes[i];
-        let end = if i + 1 < graphemes.len() {
-            graphemes[i + 1].0
-        } else {
-            s.len()
-        };
-
-        if byte_offset >= start && byte_offset < end {
-            // We're inside this grapheme, return its end
-            return Some(end);
-        }
-    }
-
-    // We're at or past the end
-    None
+    s.grapheme_indices(true)
+        .map(|(start, grapheme)| start + grapheme.len())
+        .find(|&end| byte_offset < end)
 }
 
 /// Move to the previous grapheme cluster boundary
 /// Returns the byte offset of the previous grapheme, or None if at the beginning
 pub fn prev_grapheme_boundary(s: &str, byte_offset: usize) -> Option<usize> {
-    let graphemes: Vec<(usize, &str)> = s.grapheme_indices(true).collect();
-
-    // Find the grapheme that contains or is after our position
-    for i in (0..graphemes.len()).rev() {
-        if graphemes[i].0 < byte_offset {
-            return Some(graphemes[i].0);
-        }
-    }
-
-    // We're at the beginning
-    None
+    s.grapheme_indices(true)
+        .map(|(start, _)| start)
+        .take_while(|&start| start < byte_offset)
+        .last()
 }
 
 /// Calculate the display column of a character at a given character index
@@ -214,6 +204,7 @@ pub fn char_to_column(line: &str, char_idx: usize) -> usize {
 /// Find the character index that contains the given display column
 pub fn column_to_char(line: &str, target_column: usize) -> usize {
     let mut current_column = 0;
+    let mut char_count = 0;
 
     for (idx, ch) in line.chars().enumerate() {
         let char_width = char_display_width(ch);
@@ -222,10 +213,11 @@ pub fn column_to_char(line: &str, target_column: usize) -> usize {
             return idx;
         }
         current_column += char_width;
+        char_count = idx + 1;
     }
 
     // Return the character count if column is beyond the line
-    line.chars().count()
+    char_count
 }
 
 /// Calculate the display column of a grapheme at a given grapheme index.
@@ -238,13 +230,22 @@ pub fn grapheme_to_column(line: &str, grapheme_idx: usize) -> usize {
 
 /// Calculate a grapheme's display column while expanding tabs.
 pub fn grapheme_to_column_with_tabs(line: &str, grapheme_idx: usize, tab_width: usize) -> usize {
-    let byte_offset = grapheme_to_byte(line, grapheme_idx);
-    display_width_with_tabs(&line[..byte_offset], tab_width)
+    let tab_width = tab_width.max(1);
+    let mut column = 0;
+    for grapheme in line.graphemes(true).take(grapheme_idx) {
+        column += if grapheme == "\t" {
+            tab_width - (column % tab_width)
+        } else {
+            display_width(grapheme)
+        };
+    }
+    column
 }
 
 /// Find the grapheme index that contains the given display column.
 pub fn column_to_grapheme(line: &str, target_column: usize) -> usize {
     let mut current_column = 0;
+    let mut grapheme_count = 0;
 
     for (idx, grapheme) in line.graphemes(true).enumerate() {
         let grapheme_width = display_width(grapheme);
@@ -252,15 +253,17 @@ pub fn column_to_grapheme(line: &str, target_column: usize) -> usize {
             return idx;
         }
         current_column += grapheme_width;
+        grapheme_count = idx + 1;
     }
 
-    line.graphemes(true).count()
+    grapheme_count
 }
 
 /// Find the grapheme containing a display column while expanding tabs.
 pub fn column_to_grapheme_with_tabs(line: &str, target_column: usize, tab_width: usize) -> usize {
     let tab_width = tab_width.max(1);
     let mut current_column = 0;
+    let mut grapheme_count = 0;
 
     for (idx, grapheme) in line.graphemes(true).enumerate() {
         let grapheme_width = if grapheme == "\t" {
@@ -272,9 +275,10 @@ pub fn column_to_grapheme_with_tabs(line: &str, target_column: usize, tab_width:
             return idx;
         }
         current_column += grapheme_width;
+        grapheme_count = idx + 1;
     }
 
-    line.graphemes(true).count()
+    grapheme_count
 }
 
 #[cfg(test)]
@@ -358,6 +362,13 @@ mod tests {
         let s = "👨‍👩‍👧‍👦"; // Family emoji with ZWJ
         assert_eq!(grapheme_len(s), 1);
         assert_eq!(display_width(s), 2);
+
+        let line = "a👨‍👩‍👧‍👦e\u{0301}z";
+        assert_eq!(grapheme_char_range(line, 0), Some((0, 1)));
+        assert_eq!(grapheme_char_range(line, 1), Some((1, 8)));
+        assert_eq!(grapheme_char_range(line, 2), Some((8, 10)));
+        assert_eq!(grapheme_char_range(line, 3), Some((10, 11)));
+        assert_eq!(grapheme_char_range(line, 4), None);
     }
 
     #[test]
@@ -372,6 +383,19 @@ mod tests {
         assert_eq!(prev_grapheme_boundary(s, 5), Some(1));
         assert_eq!(prev_grapheme_boundary(s, 1), Some(0));
         assert_eq!(prev_grapheme_boundary(s, 0), None);
+
+        let family = "👨‍👩‍👧‍👦";
+        for byte_offset in 0..family.len() {
+            assert_eq!(
+                next_grapheme_boundary(family, byte_offset),
+                Some(family.len())
+            );
+        }
+        for byte_offset in 1..=family.len() {
+            assert_eq!(prev_grapheme_boundary(family, byte_offset), Some(0));
+        }
+        assert_eq!(next_grapheme_boundary(family, family.len()), None);
+        assert_eq!(prev_grapheme_boundary(family, family.len() + 1), Some(0));
     }
 
     #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -277,6 +277,30 @@ mod tests {
             .into_iter()
             .all(|window| !original_ids.contains(&window.id)));
     }
+
+    #[test]
+    fn indexed_window_access_matches_tree_order() {
+        let mut manager = WindowManager::new(0, (80, 26));
+        manager.split_vertical(1).unwrap();
+        manager.set_active(0);
+        manager.split_horizontal(2).unwrap();
+
+        let windows = manager.windows();
+        assert_eq!(windows.len(), 3);
+        assert_eq!(manager.window_count(), windows.len());
+        for (index, window) in windows.iter().enumerate() {
+            assert_eq!(
+                manager.window_at_index(index).map(|found| found.id),
+                Some(window.id)
+            );
+            assert_eq!(manager.window_index(window.id), Some(index));
+            assert_eq!(
+                manager.window(window.id).map(|found| found.id),
+                Some(window.id)
+            );
+        }
+        assert!(manager.window_at_index(windows.len()).is_none());
+    }
 }
 
 /// Represents a split in the window layout
@@ -542,7 +566,7 @@ impl WindowManager {
 
     /// Returns the currently active window
     pub fn active_window(&self) -> Option<&Window> {
-        self.root.windows().get(self.active_window_id).copied()
+        self.window_at_index(self.active_window_id)
     }
 
     /// Returns the currently active window (mutable)
@@ -558,18 +582,69 @@ impl WindowManager {
 
     /// Finds a window by its stable identity.
     pub fn window(&self, id: WindowId) -> Option<&Window> {
-        self.root
-            .windows()
-            .into_iter()
-            .find(|window| window.id == id)
+        Self::find_window_recursive(&self.root, id, &mut 0).map(|(_, window)| window)
     }
 
     /// Returns the current tree-order index for a stable window identity.
     pub fn window_index(&self, id: WindowId) -> Option<usize> {
-        self.root
-            .windows()
-            .into_iter()
-            .position(|window| window.id == id)
+        Self::find_window_recursive(&self.root, id, &mut 0).map(|(index, _)| index)
+    }
+
+    /// Returns a window by its current tree-order index.
+    pub fn window_at_index(&self, index: usize) -> Option<&Window> {
+        Self::get_window_recursive(&self.root, &mut 0, index)
+    }
+
+    /// Returns the number of windows without allocating a flattened list.
+    pub fn window_count(&self) -> usize {
+        Self::count_windows(&self.root)
+    }
+
+    fn get_window_recursive<'a>(
+        node: &'a Split,
+        current_id: &mut usize,
+        target_id: usize,
+    ) -> Option<&'a Window> {
+        match node {
+            Split::Window(window) => {
+                if *current_id == target_id {
+                    Some(window)
+                } else {
+                    *current_id += 1;
+                    None
+                }
+            }
+            Split::Horizontal { top, bottom, .. } => {
+                Self::get_window_recursive(top, current_id, target_id)
+                    .or_else(|| Self::get_window_recursive(bottom, current_id, target_id))
+            }
+            Split::Vertical { left, right, .. } => {
+                Self::get_window_recursive(left, current_id, target_id)
+                    .or_else(|| Self::get_window_recursive(right, current_id, target_id))
+            }
+        }
+    }
+
+    fn find_window_recursive<'a>(
+        node: &'a Split,
+        id: WindowId,
+        current_id: &mut usize,
+    ) -> Option<(usize, &'a Window)> {
+        match node {
+            Split::Window(window) => {
+                let index = *current_id;
+                *current_id += 1;
+                (window.id == id).then_some((index, window))
+            }
+            Split::Horizontal { top, bottom, .. } => {
+                Self::find_window_recursive(top, id, current_id)
+                    .or_else(|| Self::find_window_recursive(bottom, id, current_id))
+            }
+            Split::Vertical { left, right, .. } => {
+                Self::find_window_recursive(left, id, current_id)
+                    .or_else(|| Self::find_window_recursive(right, id, current_id))
+            }
+        }
     }
 
     fn get_window_mut_recursive<'a>(
@@ -1060,7 +1135,7 @@ impl WindowManager {
                     }
                 }
 
-                *current_id = subtree_start + Self::window_count(top);
+                *current_id = subtree_start + Self::count_windows(top);
 
                 let bottom_start = *current_id;
                 let in_bottom = Self::window_in_subtree_from(bottom, bottom_start, target_id);
@@ -1092,7 +1167,7 @@ impl WindowManager {
                     }
                 }
 
-                *current_id = bottom_start + Self::window_count(bottom);
+                *current_id = bottom_start + Self::count_windows(bottom);
                 false
             }
             Split::Vertical { left, right, ratio } => {
@@ -1145,7 +1220,7 @@ impl WindowManager {
                     }
                 }
 
-                *current_id = subtree_start + Self::window_count(left);
+                *current_id = subtree_start + Self::count_windows(left);
 
                 let right_start = *current_id;
                 let in_right = Self::window_in_subtree_from(right, right_start, target_id);
@@ -1177,13 +1252,13 @@ impl WindowManager {
                     }
                 }
 
-                *current_id = right_start + Self::window_count(right);
+                *current_id = right_start + Self::count_windows(right);
                 false
             }
         }
     }
 
-    fn window_count(node: &Split) -> usize {
+    fn count_windows(node: &Split) -> usize {
         match node {
             Split::Window(_) => 1,
             Split::Horizontal { top, bottom, .. }
@@ -1191,7 +1266,7 @@ impl WindowManager {
                 left: top,
                 right: bottom,
                 ..
-            } => Self::window_count(top) + Self::window_count(bottom),
+            } => Self::count_windows(top) + Self::count_windows(bottom),
         }
     }
 
@@ -1362,6 +1437,7 @@ impl WindowManager {
                 );
                 if *current_id == target_window_id {
                     log!("  Found target window to split!");
+                    *current_id += 1;
                     // This is the window to split
                     let mut new_window = Window::new_with_id(
                         new_window_id,


### PR DESCRIPTION
Stacked on #114. The first commit carries the responsive command-picker change; the performance commit builds on that behavior. Once #114 merges, this PR's diff will collapse to the performance change.

## Why

Rendering, cursor callbacks, completion filtering, and common editor actions repeatedly allocated, scanned full collections, or rebuilt metadata on interactive paths. Those costs compound on large viewports, long lines, diagnostics-heavy buffers, and nested splits. This pass removes the avoidable work while preserving display, Unicode, plugin, and LSP behavior.

## What changed

- Make rendering and layout work proportional to the visible viewport: index layout rows directly, reuse previous-frame cell text, bulk-fill rows and dialogs with one RGBA blend, group only visible diagnostics, and discover/draw split separators in one linear pass. Fix the non-final-window split traversal that could split later siblings and duplicate stable window IDs.
- Remove repeated line scans and allocations from cursor motion, backspace, word navigation, Unicode-width helpers, undo/redo, selective revert, and whole-buffer replacements.
- Cache highlighter capture/Husk styles, LSP document selectors/active clients/poll order, completion indices, and command-column widths. Structured pickers no longer materialize every display string and keep action/group columns stable while scrolling.
- Make `indent_guides` reuse host-computed indentation and process blank runs and active scopes linearly; avoid cloning every detached row twice during resize.

## Performance

Release-mode p95 measurements on the same macOS arm64 workstation (lower is better):

| Scenario | Before | After | Change |
|---|---:|---:|---:|
| Husk `indent_guides` cursor callback | 1,947 us | 922 us | -53% |
| Scroll key event / full render / diff and flush | 2,623 / 1,232 / 731 us | 1,467 / 655 / 158 us | -44% / -47% / -78% |
| Typing key event / full render / highlight miss | 2,646 / 1,246 / 881 us | 1,605 / 789 / 568 us | -39% / -37% / -36% |
| Search key event / full render / diff and flush | 5,752 / 1,027 / 500 us | 3,341 / 538 / 98 us | -42% / -48% / -80% |
| Picker chrome / full render | 3,841 / 4,077 us | 2,145 / 3,557 us | -44% / -13% |

The full baseline, reproduction commands, microbenchmark results, and the two noisy opposite-direction tails are documented in `docs/performance-baseline-2026-07-19.md`. The post-rebase release gate measured the Husk callback at p95 **913 us**, comfortably below the 4 ms assertion.

## How to Test

1. Run the release performance gate and plugin self-check:

   ```shell
   cargo run --locked --release --example husk_cursor_bench -- --assert
   cargo build --locked --release
   target/release/red --self-check
   ```

   Expect the cursor callback to remain below 4 ms and every bundled plugin to report `active`.

2. Exercise the interactive paths with the included PTY benches:

   ```shell
   python3 scripts/scroll_bench.py 80 200 500 5
   python3 scripts/interaction_bench.py typing --cycles 160 --delay-ms 5
   python3 scripts/interaction_bench.py search --query self --cycles 16 --delay-ms 5
   python3 scripts/interaction_bench.py picker --query src/editor.rs --cycles 12 --delay-ms 5
   python3 scripts/detach_bench.py 50 120 100 512
   ```

   Expect responsive scroll/type/search/picker updates, intact decorations and previews, and correct detached repainting.

3. Check focused regressions: create nested horizontal/vertical splits and split a non-final window (no extra split or broken junctions); edit and backspace through CJK, combining marks, and ZWJ emoji (one grapheme at a time); scroll/filter the command picker at narrow and wide widths (actions stay readable and columns remain aligned); and inspect indent guides across consecutive blank lines.

Validation completed after rebasing onto current `master`: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, the full serialized all-target/all-feature test suite, release build, performance gate, and plugin self-check all pass.
