### PR TITLE
feat(install): add verified cross-platform installers

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -1,0 +1,72 @@
+name: Installers
+
+on:
+  push:
+    branches: [main, master, develop]
+    paths:
+      - "install/**"
+      - "tests/installers/**"
+      - ".github/workflows/installers.yml"
+  pull_request:
+    branches: [main, master, develop]
+    paths:
+      - "install/**"
+      - "tests/installers/**"
+      - ".github/workflows/installers.yml"
+      - "README.md"
+      - "docs/RELEASING.md"
+      - ".github/workflows/release.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint installers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        run: shellcheck install/install.sh tests/installers/install-sh.sh
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+
+      - name: Parse and analyze PowerShell
+        shell: pwsh
+        run: ./tests/installers/install-ps1.ps1
+
+  unix-fixture:
+    name: Unix fixture (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - run: sh tests/installers/install-sh.sh
+
+  release-smoke:
+    name: Latest release (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15-intel, macos-15, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install and verify latest release (Unix)
+        if: runner.os != 'Windows'
+        env:
+          RED_INSTALL_DIR: ${{ runner.temp }}/red/bin
+        run: sh install/install.sh
+
+      - name: Install and verify latest release (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./install/install.ps1 -InstallDir "$env:RUNNER_TEMP\red\bin" -NoModifyPath

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,10 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Add installer scripts
+        run: |
+          cp install/install.sh install/install.ps1 dist/
+
       - name: Extract release changelog
         env:
           TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
@@ -273,22 +277,22 @@ jobs:
           ### macOS
 
           \`\`\`bash
-          curl -L https://github.com/${{ github.repository }}/releases/download/${tag}/red-aarch64-apple-darwin.tar.gz | tar xz
-          chmod +x red
-          sudo mv red /usr/local/bin/
+          curl --proto '=https' --tlsv1.2 -fsSL https://getred.dev/install.sh | sh
           \`\`\`
 
           ### Linux
 
           \`\`\`bash
-          curl -L https://github.com/${{ github.repository }}/releases/download/${tag}/red-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          chmod +x red
-          sudo mv red /usr/local/bin/
+          curl --proto '=https' --tlsv1.2 -fsSL https://getred.dev/install.sh | sh
           \`\`\`
 
           ### Windows
 
-          Download \`red-x86_64-pc-windows-msvc.zip\`, extract \`red.exe\`, and place it in a directory on your PATH. Install Codex separately and run \`codex login\`.
+          \`\`\`powershell
+          irm https://getred.dev/install.ps1 | iex
+          \`\`\`
+
+          Install Codex separately and run \`codex login\` to enable agent support.
 
           ## Checksums
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ https://discord.gg/5PWvAUNRHU
 
 ## Installation
 
+### macOS and Linux
+
+```shell
+curl --proto '=https' --tlsv1.2 -fsSL https://getred.dev/install.sh | sh
+```
+
+The installer verifies the release checksum, installs to `~/.local/bin`, and runs
+Red's built-in self-check. Set `RED_INSTALL_DIR` to choose another directory or
+`RED_VERSION=0.2.0` to install a specific release.
+
+### Windows
+
+```powershell
+irm https://getred.dev/install.ps1 | iex
+```
+
+The PowerShell installer verifies the release checksum, installs to
+`%LOCALAPPDATA%\Programs\Red\bin`, and adds that directory to your user PATH.
+
 ### Homebrew
 
 ```shell

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -52,6 +52,7 @@ the release publishing job.
 7. Review the draft GitHub release and confirm:
    - all four archives are attached
    - `SHA256SUMS.txt` is attached
+   - `install.sh` and `install.ps1` are attached
    - install instructions match the release tag
 8. Publish the draft release.
 9. Watch the **Release** workflow run triggered by the `release.published`
@@ -63,6 +64,22 @@ the release publishing job.
    brew install codersauce/tap/red
    red --version
    ```
+
+11. Verify the stable installers against the published release in temporary
+    directories:
+
+    ```shell
+    RED_VERSION=0.2.0 RED_INSTALL_DIR="$(mktemp -d)/bin" \
+      sh install/install.sh
+    ```
+
+    ```powershell
+    ./install/install.ps1 -Version 0.2.0 `
+      -InstallDir (Join-Path $env:TEMP "red-release-check") -NoModifyPath
+    ```
+
+    Both commands must print the expected version and end their self-check with
+    `red self-check ok`.
 
 ## What the Workflow Builds
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,0 +1,111 @@
+[CmdletBinding()]
+param(
+    [string]$Version = $env:RED_VERSION,
+    [string]$InstallDir = $env:RED_INSTALL_DIR,
+    [switch]$NoModifyPath,
+    [string]$ReleasesUrl = $env:RED_RELEASES_URL
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not [Environment]::Is64BitOperatingSystem) {
+    throw "Red currently supports only 64-bit Windows."
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = "latest"
+}
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "Programs\Red\bin"
+}
+if ([string]::IsNullOrWhiteSpace($ReleasesUrl)) {
+    $ReleasesUrl = "https://github.com/codersauce/red/releases"
+}
+
+$archive = "red-x86_64-pc-windows-msvc.zip"
+if ($Version -eq "latest") {
+    $downloadBase = "$ReleasesUrl/latest/download"
+} else {
+    $tag = if ($Version.StartsWith("v")) { $Version } else { "v$Version" }
+    $downloadBase = "$ReleasesUrl/download/$tag"
+}
+
+$tempDir = Join-Path ([IO.Path]::GetTempPath()) ("red-install-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+try {
+    $archivePath = Join-Path $tempDir $archive
+    $checksumsPath = Join-Path $tempDir "SHA256SUMS.txt"
+
+    Write-Host "Downloading Red $Version for x86_64-pc-windows-msvc..."
+    Invoke-WebRequest -UseBasicParsing -Uri "$downloadBase/$archive" -OutFile $archivePath
+    Invoke-WebRequest -UseBasicParsing -Uri "$downloadBase/SHA256SUMS.txt" -OutFile $checksumsPath
+
+    $escapedArchive = [regex]::Escape($archive)
+    $checksumLine = Get-Content $checksumsPath |
+        Where-Object { $_ -match "^([a-fA-F0-9]{64})\s+\*?$escapedArchive$" } |
+        Select-Object -First 1
+    if (-not $checksumLine) {
+        throw "The release did not publish a checksum for $archive."
+    }
+
+    $expectedChecksum = ([regex]::Match(
+        $checksumLine,
+        "^([a-fA-F0-9]{64})"
+    )).Groups[1].Value.ToLowerInvariant()
+    $actualChecksum = (Get-FileHash -Algorithm SHA256 $archivePath).Hash.ToLowerInvariant()
+    if ($actualChecksum -ne $expectedChecksum) {
+        throw "Checksum mismatch for $archive."
+    }
+
+    $extractDir = Join-Path $tempDir "extracted"
+    Expand-Archive -Path $archivePath -DestinationPath $extractDir
+    $sourceBinary = Join-Path $extractDir "red.exe"
+    if (-not (Test-Path -LiteralPath $sourceBinary -PathType Leaf)) {
+        throw "The release archive did not contain red.exe."
+    }
+
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    $destination = Join-Path $InstallDir "red.exe"
+    $stagedBinary = Join-Path $InstallDir (".red.install." + [guid]::NewGuid() + ".exe")
+    Copy-Item -LiteralPath $sourceBinary -Destination $stagedBinary
+    try {
+        Move-Item -LiteralPath $stagedBinary -Destination $destination -Force
+    } catch {
+        Remove-Item -LiteralPath $stagedBinary -Force -ErrorAction SilentlyContinue
+        throw "Could not replace $destination. Close any running Red process and try again."
+    }
+
+    if (-not $NoModifyPath) {
+        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        $entries = @($userPath -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if (-not ($entries | Where-Object { $_.TrimEnd("\") -ieq $InstallDir.TrimEnd("\") })) {
+            $newUserPath = (($entries + $InstallDir) -join ";")
+            [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+        }
+        if (-not (($env:Path -split ";") | Where-Object { $_.TrimEnd("\") -ieq $InstallDir.TrimEnd("\") })) {
+            $env:Path = "$InstallDir;$env:Path"
+        }
+    }
+
+    & $destination --version
+    if ($LASTEXITCODE -ne 0) {
+        throw "red --version exited with code $LASTEXITCODE."
+    }
+    $env:NO_COLOR = "1"
+    & $destination --self-check
+    if ($LASTEXITCODE -ne 0) {
+        throw "red --self-check exited with code $LASTEXITCODE."
+    }
+
+    Write-Host ""
+    Write-Host "Red is installed at $destination."
+    if ($NoModifyPath) {
+        Write-Host "Add $InstallDir to PATH to run red from any directory."
+    } else {
+        Write-Host "Open a new terminal if the red command is not available yet."
+    }
+    Write-Host "Agent support is optional: install Codex CLI, then run codex login."
+} finally {
+    Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -37,7 +37,7 @@ try {
     $archivePath = Join-Path $tempDir $archive
     $checksumsPath = Join-Path $tempDir "SHA256SUMS.txt"
 
-    Write-Host "Downloading Red $Version for x86_64-pc-windows-msvc..."
+    Write-Output "Downloading Red $Version for x86_64-pc-windows-msvc..."
     Invoke-WebRequest -UseBasicParsing -Uri "$downloadBase/$archive" -OutFile $archivePath
     Invoke-WebRequest -UseBasicParsing -Uri "$downloadBase/SHA256SUMS.txt" -OutFile $checksumsPath
 
@@ -98,14 +98,14 @@ try {
         throw "red --self-check exited with code $LASTEXITCODE."
     }
 
-    Write-Host ""
-    Write-Host "Red is installed at $destination."
+    Write-Output ""
+    Write-Output "Red is installed at $destination."
     if ($NoModifyPath) {
-        Write-Host "Add $InstallDir to PATH to run red from any directory."
+        Write-Output "Add $InstallDir to PATH to run red from any directory."
     } else {
-        Write-Host "Open a new terminal if the red command is not available yet."
+        Write-Output "Open a new terminal if the red command is not available yet."
     }
-    Write-Host "Agent support is optional: install Codex CLI, then run codex login."
+    Write-Output "Agent support is optional: install Codex CLI, then run codex login."
 } finally {
     Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+
+set -eu
+
+repository="codersauce/red"
+releases_url="${RED_RELEASES_URL:-https://github.com/$repository/releases}"
+version="${RED_VERSION:-latest}"
+install_dir="${RED_INSTALL_DIR:-${HOME:-}/.local/bin}"
+os="${RED_INSTALLER_OS:-$(uname -s)}"
+arch="${RED_INSTALLER_ARCH:-$(uname -m)}"
+
+fail() {
+  printf 'red installer: %s\n' "$*" >&2
+  exit 1
+}
+
+if [ -z "$install_dir" ]; then
+  fail 'HOME is not set; set RED_INSTALL_DIR to choose an installation directory'
+fi
+
+case "$os:$arch" in
+  Darwin:arm64|Darwin:aarch64)
+    target="aarch64-apple-darwin"
+    ;;
+  Darwin:x86_64|Darwin:amd64)
+    target="x86_64-apple-darwin"
+    ;;
+  Linux:x86_64|Linux:amd64)
+    if command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; then
+      fail 'musl Linux is not supported yet; install Red from source with Cargo'
+    fi
+    target="x86_64-unknown-linux-gnu"
+    ;;
+  Linux:arm64|Linux:aarch64)
+    fail 'Linux ARM64 is not supported yet; install Red from source with Cargo'
+    ;;
+  *)
+    fail "unsupported platform: $os $arch"
+    ;;
+esac
+
+archive="red-$target.tar.gz"
+case "$version" in
+  latest)
+    download_base="$releases_url/latest/download"
+    ;;
+  v*)
+    download_base="$releases_url/download/$version"
+    ;;
+  *)
+    download_base="$releases_url/download/v$version"
+    ;;
+esac
+
+command -v curl >/dev/null 2>&1 || fail 'curl is required'
+command -v tar >/dev/null 2>&1 || fail 'tar is required'
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/red-install.XXXXXX")" ||
+  fail 'could not create a temporary directory'
+staged_binary=""
+
+cleanup() {
+  rm -rf "$tmp_dir"
+  if [ -n "$staged_binary" ]; then
+    rm -f "$staged_binary"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+printf 'Downloading Red %s for %s...\n' "$version" "$target"
+curl --fail --location --silent --show-error \
+  "$download_base/$archive" --output "$tmp_dir/$archive" ||
+  fail "could not download $archive"
+curl --fail --location --silent --show-error \
+  "$download_base/SHA256SUMS.txt" --output "$tmp_dir/SHA256SUMS.txt" ||
+  fail 'could not download SHA256SUMS.txt'
+
+expected_checksum="$(
+  awk -v archive="$archive" '
+    $2 == archive || $2 == "*" archive { print $1; exit }
+  ' "$tmp_dir/SHA256SUMS.txt"
+)"
+[ -n "$expected_checksum" ] || fail "checksum for $archive was not published"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_checksum="$(sha256sum "$tmp_dir/$archive" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_checksum="$(shasum -a 256 "$tmp_dir/$archive" | awk '{ print $1 }')"
+else
+  fail 'sha256sum or shasum is required'
+fi
+
+[ "$actual_checksum" = "$expected_checksum" ] ||
+  fail "checksum mismatch for $archive"
+
+mkdir "$tmp_dir/extracted"
+tar -xzf "$tmp_dir/$archive" -C "$tmp_dir/extracted" ||
+  fail "could not extract $archive"
+[ -f "$tmp_dir/extracted/red" ] ||
+  fail 'release archive did not contain the red binary'
+
+mkdir -p "$install_dir"
+staged_binary="$install_dir/.red.install.$$"
+cp "$tmp_dir/extracted/red" "$staged_binary"
+chmod 755 "$staged_binary"
+mv -f "$staged_binary" "$install_dir/red"
+staged_binary=""
+
+"$install_dir/red" --version
+NO_COLOR=1 "$install_dir/red" --self-check
+
+case ":${PATH:-}:" in
+  *":$install_dir:"*) ;;
+  *)
+    printf '\nAdd %s to PATH to run red from any directory.\n' "$install_dir"
+    ;;
+esac
+
+printf '\nRed is installed at %s/red.\n' "$install_dir"
+printf 'Agent support is optional: install Codex CLI, then run codex login.\n'

--- a/tests/installers/install-ps1.ps1
+++ b/tests/installers/install-ps1.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$Installer = "install/install.ps1"
+)
+
+$ErrorActionPreference = "Stop"
+$contents = Get-Content -Raw $Installer
+$errors = $null
+$tokens = $null
+[Management.Automation.Language.Parser]::ParseInput(
+    $contents,
+    [ref]$tokens,
+    [ref]$errors
+) | Out-Null
+if ($errors.Count -ne 0) {
+    throw "PowerShell parser errors: $($errors -join [Environment]::NewLine)"
+}
+
+$analysis = Invoke-ScriptAnalyzer -Path $Installer -Severity Warning,Error
+if ($analysis) {
+    $analysis | Format-Table -AutoSize | Out-String | Write-Error
+}

--- a/tests/installers/install-sh.sh
+++ b/tests/installers/install-sh.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+set -eu
+
+installer="${1:-install/install.sh}"
+root="$(mktemp -d "${TMPDIR:-/tmp}/red-installer-test.XXXXXX")"
+
+cleanup() {
+  rm -rf "$root"
+}
+trap cleanup EXIT HUP INT TERM
+
+release_dir="$root/releases/download/v9.9.9"
+payload_dir="$root/payload"
+mkdir -p "$release_dir" "$payload_dir"
+
+cat > "$payload_dir/red" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  --version) printf 'red 9.9.9\n' ;;
+  --self-check) printf 'red self-check ok\n' ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$payload_dir/red"
+tar -C "$payload_dir" -czf "$release_dir/red-x86_64-unknown-linux-gnu.tar.gz" red
+
+if command -v sha256sum >/dev/null 2>&1; then
+  checksum="$(sha256sum "$release_dir/red-x86_64-unknown-linux-gnu.tar.gz" | awk '{ print $1 }')"
+else
+  checksum="$(shasum -a 256 "$release_dir/red-x86_64-unknown-linux-gnu.tar.gz" | awk '{ print $1 }')"
+fi
+printf '%s  %s\n' "$checksum" "red-x86_64-unknown-linux-gnu.tar.gz" > "$release_dir/SHA256SUMS.txt"
+
+install_dir="$root/install dir"
+RED_VERSION=9.9.9 \
+RED_INSTALL_DIR="$install_dir" \
+RED_RELEASES_URL="file://$root/releases" \
+RED_INSTALLER_OS=Linux \
+RED_INSTALLER_ARCH=x86_64 \
+sh "$installer"
+
+"$install_dir/red" --self-check | grep -qx 'red self-check ok'
+
+# Reinstalling over an existing binary must remain safe.
+RED_VERSION=v9.9.9 \
+RED_INSTALL_DIR="$install_dir" \
+RED_RELEASES_URL="file://$root/releases" \
+RED_INSTALLER_OS=Linux \
+RED_INSTALLER_ARCH=amd64 \
+sh "$installer"
+
+printf '%064d  %s\n' 0 "red-x86_64-unknown-linux-gnu.tar.gz" > "$release_dir/SHA256SUMS.txt"
+if RED_VERSION=9.9.9 \
+  RED_INSTALL_DIR="$root/bad-checksum" \
+  RED_RELEASES_URL="file://$root/releases" \
+  RED_INSTALLER_OS=Linux \
+  RED_INSTALLER_ARCH=x86_64 \
+  sh "$installer"; then
+  printf 'checksum mismatch unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if RED_INSTALLER_OS=Linux RED_INSTALLER_ARCH=aarch64 sh "$installer"; then
+  printf 'unsupported architecture unexpectedly succeeded\n' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

Red’s release archives are verified, but installation still requires users to choose and unpack the correct artifact manually. Stable, repository-owned installers give macOS, Linux, and Windows users a short install path without bypassing release checksums or requiring administrator access.

## What

- add POSIX `install/install.sh` for Apple Silicon/Intel macOS and x86_64 glibc Linux
- add PowerShell 5.1-compatible `install/install.ps1` for 64-bit Windows
- verify published SHA-256 checksums, install atomically, and run `red --version` plus `red --self-check`
- add fixture, lint, and live latest-release CI coverage
- attach both scripts to future GitHub releases and use stable getred.dev commands in release notes
- document default paths, version pinning, and release acceptance checks

## How to Test

1. Run `sh tests/installers/install-sh.sh`; it must cover a pinned install, reinstall, checksum rejection, and unsupported architecture rejection.
2. Run `RED_VERSION=0.2.0 RED_INSTALL_DIR="$(mktemp -d)/bin" sh install/install.sh`; it must print `red 0.2.0` and finish with `red self-check ok`.
3. On Windows, run `./install/install.ps1 -Version 0.2.0 -InstallDir "$env:TEMP\red-test" -NoModifyPath`; it must verify the archive and complete the same version/self-check sequence.