### PR TITLE
feat(picker): add semantic icons and colors

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -68,11 +68,11 @@ smartcase = false
 # "top". Bottom matches the default command-line-oriented picker layout.
 input_position = "bottom"
 
-# Picker icons use portable, monochrome Unicode by default. "nerd_font" uses
-# richer private-use glyphs and requires a patched terminal font. "ascii" is
-# the most conservative fallback; "none" hides the icon column contents.
+# Picker icons use nvim-web-devicons-compatible glyphs and colors by default
+# and require Nerd Font 3.3+. "unicode" and "ascii" are portable fallbacks;
+# "none" hides icon contents.
 [picker.icons]
-style = "unicode"
+style = "nerd_font"
 color = true
 
 # Show available continuations after a keymap prefix such as Space or Ctrl-w.

--- a/default_config.toml
+++ b/default_config.toml
@@ -68,6 +68,13 @@ smartcase = false
 # "top". Bottom matches the default command-line-oriented picker layout.
 input_position = "bottom"
 
+# Picker icons use portable, monochrome Unicode by default. "nerd_font" uses
+# richer private-use glyphs and requires a patched terminal font. "ascii" is
+# the most conservative fallback; "none" hides the icon column contents.
+[picker.icons]
+style = "unicode"
+color = true
+
 # Show available continuations after a keymap prefix such as Space or Ctrl-w.
 # Fast key sequences complete before the guide appears.
 [key_hints]
@@ -361,9 +368,9 @@ delete = "▁"
 topdelete = "▔"
 changedelete = "~"
 
-# Symbol kind icons use Nerd Font glyphs matching the Snacks picker defaults.
-# Set enabled to false to hide them. Override any lowercase LSP kind with a
-# custom string; an empty string hides only that kind.
+# Symbol pickers use the global picker icon style. Set enabled to false to hide
+# their icons. Override any lowercase LSP kind with a custom string; an empty
+# string hides only that kind.
 [plugin_config.lsp_symbols.icons]
 enabled = true
 

--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -807,7 +807,7 @@ fn failed(event: Json) {
     if red::string(red::state("agent_pending_prompt"), "") != "" || red::state("agent_session_id") == "" {
         red::execute("Print", "Codex unavailable: " + event.message + ". Your prompt is preserved");
         red::execute("OpenDynamicPicker", "Retry Codex", 803, [
-            PickerItem { id: "retry", label: "Retry the saved prompt" },
+            PickerItem { id: "retry", label: "Retry the saved prompt", kind: "Action" },
         ], PickerOptions {
             placeholder: "Retry after fixing the Codex setup",
             status: "Enter selects; Escape keeps the saved prompt",
@@ -1340,8 +1340,8 @@ fn permission_requested(event: Json) {
         items = red::push(items, PickerItem {
             id: option.option_id,
             label: option.name,
-            kind: option.kind,
-            annotation: option.option_id,
+            kind: "Permission",
+            annotation: red::string(option.kind, "permission") + " · " + option.option_id,
             detail: "Codex permission option " + option.option_id,
             data: Json { option_id: option.option_id },
         });

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -854,8 +854,8 @@ fn confirm_commit(mode: String, message: String) {
 
 fn open_confirmation(title: String, impact: String) {
     red::execute("OpenDynamicPicker", title, 493, [
-        PickerItem { id: "cancel", label: "Cancel" },
-        PickerItem { id: "proceed", label: "Proceed" },
+        PickerItem { id: "cancel", label: "Cancel", kind: "Cancel" },
+        PickerItem { id: "proceed", label: "Proceed", kind: "Proceed" },
     ], PickerOptions { status: impact });
 }
 
@@ -953,16 +953,16 @@ fn push_menu() {
 
 fn help_menu() {
     red::execute("OpenDynamicPicker", "Git keys", 492, [
-        PickerItem { id: "s", label: "s stage" },
-        PickerItem { id: "u", label: "u unstage" },
-        PickerItem { id: "x", label: "x discard" },
-        PickerItem { id: "c", label: "c commit" },
-        PickerItem { id: "f", label: "f fetch" },
-        PickerItem { id: "p", label: "p push" },
-        PickerItem { id: "P", label: "P pull --ff-only" },
-        PickerItem { id: "y", label: "y safe sync" },
-        PickerItem { id: "$", label: "$ command log" },
-        PickerItem { id: "q", label: "q close" },
+        PickerItem { id: "s", label: "s stage", kind: "Staged" },
+        PickerItem { id: "u", label: "u unstage", kind: "Action" },
+        PickerItem { id: "x", label: "x discard", kind: "Destructive" },
+        PickerItem { id: "c", label: "c commit", kind: "GitCommit" },
+        PickerItem { id: "f", label: "f fetch", kind: "Action" },
+        PickerItem { id: "p", label: "p push", kind: "Action" },
+        PickerItem { id: "P", label: "P pull --ff-only", kind: "Action" },
+        PickerItem { id: "y", label: "y safe sync", kind: "Success" },
+        PickerItem { id: "$", label: "$ command log", kind: "GitCommit" },
+        PickerItem { id: "q", label: "q close", kind: "Close" },
     ], PickerOptions {});
 }
 
@@ -972,13 +972,54 @@ fn command_log() {
         items = red::push(items, PickerItem {
             id: red::len(items),
             label: line,
+            kind: "GitCommit",
         });
     }
-    items = red::push(items, PickerItem { id: "Close", label: "Close" });
+    items = red::push(items, PickerItem { id: "Close", label: "Close", kind: "Close" });
     open_items("command-log", "Git command log", items);
 }
 
 fn help_closed(item: Json) {}
+
+fn git_choice_kind(choice: String) -> String {
+    if choice == "Cancel" || choice == "Close" {
+        return "Cancel";
+    }
+    if choice == "Delete" ||
+        choice == "Remove" ||
+        choice == "Drop" ||
+        choice == "Abort" ||
+        choice == "Discard" ||
+        choice == "Prune" {
+        return "Destructive";
+    }
+    if choice == "Continue" || choice == "Proceed" {
+        return "Proceed";
+    }
+    if red::starts_with(choice, "Create") || red::starts_with(choice, "Add") {
+        return "Created";
+    }
+    return "Action";
+}
+
+fn git_entity_kind(kind: String) -> String {
+    if red::starts_with(kind, "branches") {
+        return "GitBranch";
+    }
+    if red::starts_with(kind, "tags") {
+        return "GitTag";
+    }
+    if red::starts_with(kind, "stashes") {
+        return "GitStash";
+    }
+    if red::starts_with(kind, "remotes") {
+        return "GitRemote";
+    }
+    if red::starts_with(kind, "worktrees") {
+        return "GitWorktree";
+    }
+    return "Action";
+}
 
 fn open_choices(kind: String, title: String, choices: Json) {
     red::state_set("git_menu_kind", kind);
@@ -987,6 +1028,7 @@ fn open_choices(kind: String, title: String, choices: Json) {
         items = red::push(items, PickerItem {
             id: choice,
             label: choice,
+            kind: git_choice_kind(choice),
             data: Json { value: choice },
         });
     }
@@ -1007,6 +1049,7 @@ fn open_prompt(kind: String, title: String, initial: String) {
         PickerItem {
             id: "submit",
             label: "Submit",
+            kind: "Proceed",
             data: Json { query: initial },
         },
     ], PickerOptions {
@@ -1023,6 +1066,7 @@ fn prompt_query_changed(query: Json) {
         PickerItem {
             id: "submit",
             label: "Submit",
+            kind: "Proceed",
             data: Json { query: text },
         },
     ]);
@@ -1145,11 +1189,12 @@ fn open_line_items(kind: String, title: String, output: String) {
             items = red::push(items, PickerItem {
                 id: line,
                 label: line,
+                kind: git_entity_kind(kind),
                 data: Json { value: line },
             });
         }
     }
-    items = red::push(items, PickerItem { id: "Cancel", label: "Cancel" });
+    items = red::push(items, PickerItem { id: "Cancel", label: "Cancel", kind: "Cancel" });
     open_items(kind, title, items);
 }
 
@@ -1161,11 +1206,12 @@ fn open_detail_items(output: String) {
             items = red::push(items, PickerItem {
                 id: count,
                 label: line,
+                kind: "Text",
             });
             count = count + 1;
         }
     }
-    items = red::push(items, PickerItem { id: "Close", label: "Close" });
+    items = red::push(items, PickerItem { id: "Close", label: "Close", kind: "Close" });
     open_items("log-detail-view", "Commit details", items);
 }
 
@@ -1176,12 +1222,13 @@ fn open_tag_push_items(output: String) {
             items = red::push(items, PickerItem {
                 id: line,
                 label: line,
+                kind: "GitTag",
                 data: Json { value: line },
             });
         }
     }
-    items = red::push(items, PickerItem { id: "All tags", label: "All tags" });
-    items = red::push(items, PickerItem { id: "Cancel", label: "Cancel" });
+    items = red::push(items, PickerItem { id: "All tags", label: "All tags", kind: "GitTag" });
+    items = red::push(items, PickerItem { id: "Cancel", label: "Cancel", kind: "Cancel" });
     open_items("tags-push", "Push tag", items);
 }
 
@@ -1253,11 +1300,12 @@ fn open_worktree_items(output: String) {
             items = red::push(items, PickerItem {
                 id: path,
                 label: path,
+                kind: "GitWorktree",
                 data: Json { value: path },
             });
         }
     }
-    items = red::push(items, PickerItem { id: "Cancel", label: "Cancel" });
+    items = red::push(items, PickerItem { id: "Cancel", label: "Cancel", kind: "Cancel" });
     open_items("worktrees", "Worktrees", items);
 }
 
@@ -1270,6 +1318,7 @@ fn open_log_items(output: String) {
             items = red::push(items, PickerItem {
                 id: fields[0],
                 label: fields[1] + " " + fields[4],
+                kind: "GitCommit",
                 detail: fields[2] + " " + fields[3],
                 data: Json { oid: fields[0] },
             });
@@ -1529,10 +1578,10 @@ fn cancel_message() { finish_commit_scratch(false, ""); }
 
 fn commit_menu() {
     red::execute("OpenDynamicPicker", "Commit", 491, [
-        PickerItem { id: "create", label: "Create commit" },
-        PickerItem { id: "amend", label: "Amend commit" },
-        PickerItem { id: "no-edit", label: "Amend without editing" },
-        PickerItem { id: "cancel", label: "Cancel" },
+        PickerItem { id: "create", label: "Create commit", kind: "Created" },
+        PickerItem { id: "amend", label: "Amend commit", kind: "Amend" },
+        PickerItem { id: "no-edit", label: "Amend without editing", kind: "Amend" },
+        PickerItem { id: "cancel", label: "Cancel", kind: "Cancel" },
     ], PickerOptions {});
 }
 
@@ -1775,8 +1824,8 @@ fn hunk_cursor_loaded(cursor: Json) {
     red::state_set("git_hunk_patch", selected);
     if action == "reset" {
         red::execute("OpenDynamicPicker", "Reset hunk", 490, [
-            PickerItem { id: "cancel", label: "Cancel" },
-            PickerItem { id: "proceed", label: "Proceed" },
+            PickerItem { id: "cancel", label: "Cancel", kind: "Cancel" },
+            PickerItem { id: "proceed", label: "Proceed", kind: "Destructive" },
         ], PickerOptions { status: "This cannot be undone by Red." });
     } else {
         apply_hunk(action, selected);

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -1,4 +1,8 @@
 pub fn activate() {
+    red::state_set("lsp_symbol_icons_enabled", true);
+    red::state_set("lsp_symbol_icon_overrides", Json {});
+    red::request("GetConfig", icon_config_loaded, "plugin_config");
+
     red::add_command("LspDocumentSymbols", document_symbols, Json {
         title: "Show document symbols",
         category: "LSP",
@@ -22,6 +26,28 @@ pub fn activate() {
     red::on("picker:selected:202", open_symbol_selection);
     red::on("picker:selected:203", open_reference_selection);
     red::on("picker:query:202", workspace_query);
+}
+
+fn icon_config_loaded(event: Json) {
+    let options = event.value.lsp_symbols.icons;
+    if options == red::null() {
+        return;
+    }
+    red::state_set("lsp_symbol_icons_enabled", red::bool(options.enabled, true));
+    if options.overrides != red::null() {
+        red::state_set("lsp_symbol_icon_overrides", options.overrides);
+    }
+}
+
+fn symbol_icon(kind: String) -> Json {
+    if !red::state_bool("lsp_symbol_icons_enabled") {
+        return "";
+    }
+    let override = red::state("lsp_symbol_icon_overrides")[red::lower(kind)];
+    if override != red::null() {
+        return red::string(override, "");
+    }
+    return red::null();
 }
 
 fn document_symbols() {
@@ -125,7 +151,8 @@ fn symbol_item(symbol: Json) -> Json {
     let character = symbol.selection_range.start.character;
     return PickerItem {
         id: "symbol:" + symbol.kind_name + ":" + symbol.file + ":" + line + ":" + character + ":" + symbol.name,
-        label: symbol.kind_name + " " + symbol.name,
+        icon: symbol_icon(symbol.kind_name),
+        label: symbol.name,
         kind: symbol.kind_name,
         annotation: symbol.detail,
         detail: symbol.file + ":" + (line + 1) + ":" + (character + 1),
@@ -139,6 +166,7 @@ fn reference_item(location: Json) -> Json {
     let character = location.range.start.character;
     return PickerItem {
         id: "reference:" + location.file + ":" + line + ":" + character,
+        icon: symbol_icon("Reference"),
         label: location.file,
         kind: "Reference",
         annotation: ":" + (line + 1) + ":" + (character + 1),

--- a/plugins/project_search.hk
+++ b/plugins/project_search.hk
@@ -302,6 +302,21 @@ fn append_flag(flags: String, flag: String) -> String {
 
 fn match_item(data: Json, index: i32) -> Json {
     let path = red::text_field(data.path);
+    let normalized_path = red::replace_all(path, "\\", "/");
+    let path_parts = red::split(normalized_path, "/");
+    let display_name = red::string(path_parts[red::len(path_parts) - 1], normalized_path);
+    let display_parent = "";
+    if red::len(path_parts) > 1 {
+        let parent_parts = [];
+        let part_index = 0;
+        for part in path_parts {
+            if part_index < red::len(path_parts) - 1 {
+                parent_parts = red::push(parent_parts, part);
+            }
+            part_index = part_index + 1;
+        }
+        display_parent = red::join(parent_parts, "/") + "/";
+    }
     let line = red::int(data.line_number, 1) - 1;
     let text = red::trim_line_end(red::text_field(data.lines));
     let first_match = data.submatches[0];
@@ -332,9 +347,9 @@ fn match_item(data: Json, index: i32) -> Json {
 
     return PickerItem {
         id: path + ":" + line + ":" + start + ":" + index,
-        label: path,
-        kind: "Match",
-        annotation: ":" + (line + 1) + ":" + (start + 1),
+        label: display_name,
+        kind: "FileMatch",
+        annotation: display_parent + ":" + (line + 1) + ":" + (start + 1),
         detail: text,
         detail_matches: detail_matches,
         data: Json {
@@ -465,7 +480,10 @@ fn export_results() {
             expanded: red::null(),
             kind: "file",
             segments: [PanelSegment {
-                text: item.label + item.annotation + ": " + item.detail,
+                text: item.data.location.path +
+                    ":" + (item.data.location.line + 1) +
+                    ":" + (item.data.location.column + 1) +
+                    ": " + item.detail,
             }],
             right_segments: [],
         });

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -194,6 +194,7 @@ pub(crate) fn picker_items(entries: &[CommandPaletteEntry]) -> Vec<PickerItem> {
 
             PickerItem {
                 id: entry.id.clone(),
+                icon: None,
                 label: entry.title.clone(),
                 kind: Some("Command".to_string()),
                 annotation: Some(format!("{category}{category_padding}")),

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,7 +197,7 @@ pub struct PickerIconsConfig {
 impl Default for PickerIconsConfig {
     fn default() -> Self {
         Self {
-            style: PickerIconStyle::Unicode,
+            style: PickerIconStyle::NerdFont,
             color: true,
         }
     }
@@ -206,8 +206,8 @@ impl Default for PickerIconsConfig {
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PickerIconStyle {
-    #[default]
     Unicode,
+    #[default]
     NerdFont,
     Ascii,
     None,
@@ -2244,6 +2244,8 @@ theme = "mocha.json"
         .unwrap();
 
         assert_eq!(config.picker.input_position, PickerInputPosition::Bottom);
+        assert_eq!(config.picker.icons.style, PickerIconStyle::NerdFont);
+        assert!(config.picker.icons.color);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,6 +181,36 @@ pub struct AgentConfig {
 pub struct PickerConfig {
     #[serde(default)]
     pub input_position: PickerInputPosition,
+    #[serde(default)]
+    pub icons: PickerIconsConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PickerIconsConfig {
+    #[serde(default)]
+    pub style: PickerIconStyle,
+    #[serde(default = "default_true")]
+    pub color: bool,
+}
+
+impl Default for PickerIconsConfig {
+    fn default() -> Self {
+        Self {
+            style: PickerIconStyle::Unicode,
+            color: true,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PickerIconStyle {
+    #[default]
+    Unicode,
+    NerdFont,
+    Ascii,
+    None,
 }
 
 /// Configuration for the delayed keymap-prefix guide.
@@ -211,6 +241,7 @@ impl Default for PickerConfig {
     fn default() -> Self {
         Self {
             input_position: PickerInputPosition::Bottom,
+            icons: PickerIconsConfig::default(),
         }
     }
 }
@@ -2230,6 +2261,31 @@ input_position = "top"
         .unwrap();
 
         assert_eq!(config.picker.input_position, PickerInputPosition::Top);
+    }
+
+    #[test]
+    fn picker_icon_config_parses_all_styles_and_defaults_to_color() {
+        for (value, expected) in [
+            ("unicode", PickerIconStyle::Unicode),
+            ("nerd_font", PickerIconStyle::NerdFont),
+            ("ascii", PickerIconStyle::Ascii),
+            ("none", PickerIconStyle::None),
+        ] {
+            let config: Config = toml::from_str(&format!(
+                r#"
+theme = "mocha.json"
+
+[picker.icons]
+style = "{value}"
+
+[keys]
+"#
+            ))
+            .unwrap();
+
+            assert_eq!(config.picker.icons.style, expected);
+            assert!(config.picker.icons.color);
+        }
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2552,6 +2552,7 @@ impl Editor {
                 };
                 PickerItem {
                     id: index.to_string(),
+                    icon: None,
                     label: format!("{}  {}", diagnostic.code, diagnostic.path),
                     kind: Some(format!("{:?}", diagnostic.severity)),
                     annotation: Some(location),
@@ -3167,6 +3168,10 @@ impl Editor {
 
     pub(crate) fn picker_input_position(&self) -> crate::config::PickerInputPosition {
         self.config.picker.input_position
+    }
+
+    pub(crate) fn picker_icons(&self) -> crate::config::PickerIconsConfig {
+        self.config.picker.icons
     }
 
     /// Window-aware coordinate transformation methods
@@ -8141,20 +8146,26 @@ impl Editor {
                 continue;
             }
 
-            let kind = value
+            let annotation = value
                 .get("kind")
                 .and_then(Value::as_str)
-                .map(|kind| format!(" [{kind}]"))
-                .unwrap_or_default();
-            let preferred = if value.get("isPreferred").and_then(Value::as_bool) == Some(true) {
-                " *"
-            } else {
-                ""
-            };
-            let item = format!("{}. {}{}{}", index + 1, title, kind, preferred);
-            items.push(item.clone());
+                .map(ToString::to_string);
+            let preferred = value.get("isPreferred").and_then(Value::as_bool) == Some(true);
+            let item_id = index.to_string();
+            items.push(PickerItem {
+                id: item_id.clone(),
+                icon: None,
+                label: title.to_string(),
+                kind: Some(if preferred { "Preferred" } else { "CodeAction" }.to_string()),
+                annotation,
+                detail: preferred.then(|| "preferred".to_string()),
+                data: serde_json::Value::Null,
+                matches: Vec::new(),
+                detail_matches: Vec::new(),
+                preview: None,
+            });
             actions.insert(
-                item,
+                item_id,
                 self.workspace_edit_action(
                     operations,
                     expected_revisions,
@@ -8176,7 +8187,7 @@ impl Editor {
         }
         let picker = Picker::builder()
             .title("Code actions")
-            .items(items)
+            .structured_items(items)
             .select_action(move |item| {
                 actions.get(&item).cloned().unwrap_or_else(|| {
                     Action::Print("code action is no longer available".to_string())

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -6422,8 +6422,12 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         };
 
-        assert!(Path::new(&item.label).ends_with(Path::new("plugins").join("project_search.hk")));
-        assert_eq!(item.kind.as_deref(), Some("Match"));
+        assert_eq!(item.label, "project_search.hk");
+        assert!(item
+            .annotation
+            .as_deref()
+            .is_some_and(|annotation| annotation.starts_with("plugins/:")));
+        assert_eq!(item.kind.as_deref(), Some("FileMatch"));
         assert!(item
             .detail
             .as_deref()

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -7322,6 +7322,29 @@ mod tests {
             .load_plugin("lsp_symbols", include_str!("../../plugins/lsp_symbols.hk"))
             .await
             .unwrap();
+        let config_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetConfig { request_id, key } => {
+                assert_eq!(key.as_deref(), Some("plugin_config"));
+                request_id
+            }
+            _ => panic!("unexpected plugin request"),
+        };
+        runtime
+            .resolve_request(
+                config_request_id,
+                serde_json::json!({
+                    "value": {
+                        "lsp_symbols": {
+                            "icons": {
+                                "enabled": true,
+                                "overrides": {}
+                            }
+                        }
+                    }
+                }),
+            )
+            .await
+            .unwrap();
 
         runtime.execute_command("LspDocumentSymbols").await.unwrap();
 
@@ -7347,7 +7370,8 @@ mod tests {
             } => {
                 assert_eq!(title.as_deref(), Some("Document Symbols"));
                 assert_eq!(id, 201);
-                assert_eq!(items[0].label, "Function main");
+                assert_eq!(items[0].label, "main");
+                assert_eq!(items[0].kind.as_deref(), Some("Function"));
             }
             _ => panic!("unexpected plugin request"),
         }
@@ -7361,6 +7385,29 @@ mod tests {
         let mut runtime = Runtime::new();
         runtime
             .load_plugin("lsp_symbols", include_str!("../../plugins/lsp_symbols.hk"))
+            .await
+            .unwrap();
+        let config_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetConfig { request_id, key } => {
+                assert_eq!(key.as_deref(), Some("plugin_config"));
+                request_id
+            }
+            _ => panic!("unexpected plugin request"),
+        };
+        runtime
+            .resolve_request(
+                config_request_id,
+                serde_json::json!({
+                    "value": {
+                        "lsp_symbols": {
+                            "icons": {
+                                "enabled": true,
+                                "overrides": {}
+                            }
+                        }
+                    }
+                }),
+            )
             .await
             .unwrap();
 
@@ -7405,7 +7452,8 @@ mod tests {
         match ACTION_DISPATCHER.recv_request() {
             PluginRequest::UpdatePickerItems { id, items } => {
                 assert_eq!(id, 202);
-                assert_eq!(items[0].label, "Function main");
+                assert_eq!(items[0].label, "main");
+                assert_eq!(items[0].kind.as_deref(), Some("Function"));
             }
             _ => panic!("unexpected plugin request"),
         }
@@ -7426,6 +7474,29 @@ mod tests {
         let mut runtime = Runtime::new();
         runtime
             .load_plugin("lsp_symbols", include_str!("../../plugins/lsp_symbols.hk"))
+            .await
+            .unwrap();
+        let config_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetConfig { request_id, key } => {
+                assert_eq!(key.as_deref(), Some("plugin_config"));
+                request_id
+            }
+            _ => panic!("unexpected plugin request"),
+        };
+        runtime
+            .resolve_request(
+                config_request_id,
+                serde_json::json!({
+                    "value": {
+                        "lsp_symbols": {
+                            "icons": {
+                                "enabled": true,
+                                "overrides": {}
+                            }
+                        }
+                    }
+                }),
+            )
             .await
             .unwrap();
         runtime.execute_command("LspDocumentSymbols").await.unwrap();

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -14,7 +14,7 @@ use crate::{
     theme::Theme,
 };
 
-use super::{Component, Picker};
+use super::{Component, Picker, PickerItem, PickerPreview};
 
 pub struct FilePicker {
     picker: Picker,
@@ -109,14 +109,33 @@ impl FilePicker {
 
         match load.result {
             Ok(files) => {
-                self.picker
-                    .replace_items_with_preview_root(files, self.root_path.clone());
+                let items = files
+                    .into_iter()
+                    .map(|path| PickerItem {
+                        id: path.clone(),
+                        icon: None,
+                        label: path.clone(),
+                        kind: Some("File".to_string()),
+                        annotation: None,
+                        detail: None,
+                        data: serde_json::Value::Null,
+                        matches: Vec::new(),
+                        detail_matches: Vec::new(),
+                        preview: Some(PickerPreview::Location {
+                            path: self.root_path.join(path).to_string_lossy().into_owned(),
+                            line: None,
+                            column: None,
+                            matches: Vec::new(),
+                        }),
+                    })
+                    .collect();
+                self.picker.replace_structured_items(items);
                 self.picker
                     .set_empty_message(Some("No matching files".to_string()));
             }
             Err(err) => {
                 log!("file picker load failed: {}", err);
-                self.picker.replace_items(vec![]);
+                self.picker.replace_structured_items(vec![]);
                 self.picker
                     .set_empty_message(Some("Failed to load files".to_string()));
             }
@@ -133,7 +152,7 @@ impl Component for FilePicker {
                 Ok(load) => changed |= self.apply_load(load),
                 Err(TryRecvError::Empty) => return Ok(changed),
                 Err(TryRecvError::Disconnected) => {
-                    self.picker.replace_items(vec![]);
+                    self.picker.replace_structured_items(vec![]);
                     self.picker
                         .set_empty_message(Some("Failed to load files".to_string()));
                     return Ok(true);

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::Context;
 use crossterm::event::{self};
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use ignore::{DirEntry, WalkBuilder};
 
 use crate::{
@@ -67,9 +68,11 @@ impl FilePicker {
         sender: mpsc::Sender<FilePickerLoad>,
         receiver: Receiver<FilePickerLoad>,
     ) -> Self {
+        let matcher = SkimMatcherV2::default();
         let mut picker = Picker::builder()
             .title("Find Files")
             .items(vec![])
+            .filter_action(move |item, query| matcher.fuzzy_match(&item.id, query))
             .history_key("find_files")
             .select_action(Action::OpenFile)
             .build(editor);
@@ -111,22 +114,33 @@ impl FilePicker {
             Ok(files) => {
                 let items = files
                     .into_iter()
-                    .map(|path| PickerItem {
-                        id: path.clone(),
-                        icon: None,
-                        label: path.clone(),
-                        kind: Some("File".to_string()),
-                        annotation: None,
-                        detail: None,
-                        data: serde_json::Value::Null,
-                        matches: Vec::new(),
-                        detail_matches: Vec::new(),
-                        preview: Some(PickerPreview::Location {
-                            path: self.root_path.join(path).to_string_lossy().into_owned(),
-                            line: None,
-                            column: None,
+                    .map(|path| {
+                        let relative = Path::new(&path);
+                        let label = relative
+                            .file_name()
+                            .map(|name| name.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| path.clone());
+                        let annotation = relative
+                            .parent()
+                            .filter(|parent| !parent.as_os_str().is_empty())
+                            .map(|parent| parent.to_string_lossy().into_owned());
+                        PickerItem {
+                            id: path.clone(),
+                            icon: None,
+                            label,
+                            kind: Some("FilePath".to_string()),
+                            annotation,
+                            detail: None,
+                            data: serde_json::Value::Null,
                             matches: Vec::new(),
-                        }),
+                            detail_matches: Vec::new(),
+                            preview: Some(PickerPreview::Location {
+                                path: self.root_path.join(path).to_string_lossy().into_owned(),
+                                line: None,
+                                column: None,
+                                matches: Vec::new(),
+                            }),
+                        }
                     })
                     .collect();
                 self.picker.replace_structured_items(items);
@@ -363,6 +377,39 @@ mod tests {
                 },
                 Action::CloseDialog,
                 Action::OpenFile("src/main.rs".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn file_picker_filters_full_paths_but_displays_basename_and_parent() {
+        let editor = test_editor();
+        let mut picker = FilePicker::loading(&editor);
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        for character in "husk-parser".chars() {
+            picker.handle_event(&key(KeyCode::Char(character)));
+        }
+        send_load(
+            &picker,
+            picker.load_generation,
+            Ok(vec!["crates/husk-parser/src/lib.rs".to_string()]),
+        );
+
+        assert!(picker.tick().unwrap());
+        picker.draw(&mut buffer).unwrap();
+        let text = buffer_text(&buffer);
+        assert!(text.contains("lib.rs crates/husk-parser/src"), "{text}");
+        assert!(text.contains("1/1"), "{text}");
+        assert_eq!(
+            picker.handle_event(&key(KeyCode::Enter)),
+            Some(KeyAction::Multiple(vec![
+                Action::RecordPickerHistory {
+                    key: "find_files".to_string(),
+                    query: "husk-parser".to_string(),
+                },
+                Action::CloseDialog,
+                Action::OpenFile("crates/husk-parser/src/lib.rs".to_string()),
             ]))
         );
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,8 +19,8 @@ pub use input_prompt::InputPrompt;
 pub(crate) use keymap_hints::draw_keymap_hints;
 use list::List;
 pub use picker::{
-    LegacyPickerOptions, Picker, PickerItem, PickerOptions, PickerPresentation, PickerPreview,
-    PickerUpdate,
+    LegacyPickerOptions, Picker, PickerIcon, PickerItem, PickerOptions, PickerPresentation,
+    PickerPreview, PickerUpdate,
 };
 
 use crate::{

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -17,7 +17,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
     color::Color,
-    config::{KeyAction, PickerInputPosition},
+    config::{KeyAction, PickerIconStyle, PickerIconsConfig, PickerInputPosition},
     editor::{Action, Editor, RenderBuffer, StyleInfo},
     highlighter::Highlighter,
     theme::{SelectionForegroundPriority, Style, Theme},
@@ -36,11 +36,15 @@ const MAX_UNFOCUSED_PREVIEW_BYTES: u64 = 256 * 1024;
 const MAX_LOCATION_PREVIEW_SCAN_BYTES: usize = 8 * 1024 * 1024;
 const LOCATION_PREVIEW_CACHE_CAPACITY: usize = 8;
 const COMMAND_COLUMN_GAP: usize = 2;
+const PICKER_ICON_WIDTH: usize = 2;
+const PICKER_ITEM_PREFIX_WIDTH: usize = 2 + PICKER_ICON_WIDTH;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct PickerItem {
     pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<PickerIcon>,
     pub label: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
@@ -56,6 +60,32 @@ pub struct PickerItem {
     pub detail_matches: Vec<[usize; 2]>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preview: Option<PickerPreview>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", untagged)]
+pub enum PickerIcon {
+    Text(String),
+    Styled {
+        text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        role: Option<String>,
+    },
+}
+
+impl PickerIcon {
+    fn text(&self) -> &str {
+        match self {
+            Self::Text(text) | Self::Styled { text, .. } => text,
+        }
+    }
+
+    fn role(&self) -> Option<&str> {
+        match self {
+            Self::Text(_) => None,
+            Self::Styled { role, .. } => role.as_deref(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -255,6 +285,7 @@ pub struct Picker {
     history: Vec<String>,
     history_navigation: Option<PickerHistoryNavigation>,
     input_position: PickerInputPosition,
+    icons: PickerIconsConfig,
     presentation: PickerPresentation,
 }
 
@@ -405,6 +436,7 @@ impl Picker {
             history: Vec::new(),
             history_navigation: None,
             input_position: editor.picker_input_position(),
+            icons: editor.picker_icons(),
             presentation,
         }
     }
@@ -579,6 +611,8 @@ impl Picker {
 
     pub fn replace_items(&mut self, items: Vec<String>) {
         self.item_preview_root = None;
+        self.dynamic_items = None;
+        self.visible_dynamic_items.clear();
         self.items = items;
         let search = self.search.clone();
         self.filter(&search);
@@ -586,7 +620,17 @@ impl Picker {
 
     pub fn replace_items_with_preview_root(&mut self, items: Vec<String>, root: PathBuf) {
         self.item_preview_root = Some(root);
+        self.dynamic_items = None;
+        self.visible_dynamic_items.clear();
         self.items = items;
+        let search = self.search.clone();
+        self.filter(&search);
+    }
+
+    pub fn replace_structured_items(&mut self, items: Vec<PickerItem>) {
+        self.item_preview_root = None;
+        self.items.clear();
+        self.dynamic_items = Some(items);
         let search = self.search.clone();
         self.filter(&search);
     }
@@ -835,27 +879,127 @@ impl Picker {
             .selected_style(&base, &selection, SelectionForegroundPriority::Selection)
     }
 
-    fn result_file_style(&self, base: &Style, selected: bool) -> Style {
-        let semantic = self
-            .theme
-            .get_style("markup.underline.link")
-            .or_else(|| {
-                self.theme_color("peekViewResult.fileForeground")
-                    .map(|fg| Style {
-                        fg: Some(fg),
-                        ..Style::default()
-                    })
-            })
-            .or_else(|| self.theme.get_style("string.other.link"))
-            .or_else(|| Some(self.theme.ui_style.picker_prompt.clone()));
-        self.semantic_foreground(base, semantic, selected)
+    fn result_label_style(&self, base: &Style) -> Style {
+        base.clone()
     }
 
-    fn result_label_style(&self, item: &PickerItem, base: &Style, selected: bool) -> Style {
-        let Some(scope) = item.kind.as_deref().and_then(symbol_kind_scope) else {
-            return self.result_file_style(base, selected);
-        };
-        self.semantic_foreground(base, self.theme.get_style(scope), selected)
+    fn color_style(&self, keys: &[&str]) -> Option<Style> {
+        keys.iter().find_map(|key| {
+            self.theme_color(key).map(|fg| Style {
+                fg: Some(fg),
+                ..Style::default()
+            })
+        })
+    }
+
+    fn role_style(&self, role: &str) -> Option<Style> {
+        match role.to_ascii_lowercase().as_str() {
+            "file" | "folder" | "buffer" => self
+                .color_style(&["peekViewResult.fileForeground", "symbolIcon.fileForeground"])
+                .or_else(|| self.theme.get_style("string.other.link")),
+            "command" | "action" | "codeaction" | "theme" | "accent" => {
+                Some(self.theme.ui_style.picker_prompt.clone())
+            }
+            "success" | "preferred" | "proceed" | "added" | "created" | "staged" => self
+                .color_style(&[
+                    "gitDecoration.addedResourceForeground",
+                    "editorGutter.addedBackground",
+                    "testing.iconPassed",
+                ])
+                .or_else(|| self.theme.get_style("markup.inserted")),
+            "warning" | "warn" | "modified" | "amend" | "permission" => self
+                .color_style(&[
+                    "editorWarning.foreground",
+                    "notificationsWarningIcon.foreground",
+                    "gitDecoration.modifiedResourceForeground",
+                ])
+                .or_else(|| self.theme.get_style("markup.changed")),
+            "error" | "failed" | "deleted" | "conflict" | "destructive" => self
+                .color_style(&[
+                    "editorError.foreground",
+                    "errorForeground",
+                    "gitDecoration.deletedResourceForeground",
+                ])
+                .or_else(|| self.theme.get_style("markup.deleted")),
+            "info" | "reference" | "match" | "search" => self
+                .color_style(&[
+                    "editorInfo.foreground",
+                    "notificationsInfoIcon.foreground",
+                    "peekViewResult.fileForeground",
+                ])
+                .or_else(|| Some(self.theme.ui_style.picker_prompt.clone())),
+            "gitbranch" | "gitremote" => self
+                .color_style(&[
+                    "gitDecoration.submoduleResourceForeground",
+                    "editorInfo.foreground",
+                    "peekViewResult.fileForeground",
+                ])
+                .or_else(|| Some(self.theme.ui_style.picker_prompt.clone())),
+            "gittag" | "gitstash" => self
+                .color_style(&[
+                    "gitDecoration.modifiedResourceForeground",
+                    "editorWarning.foreground",
+                ])
+                .or_else(|| self.theme.get_style("markup.changed")),
+            "gitcommit" => self
+                .color_style(&[
+                    "gitDecoration.untrackedResourceForeground",
+                    "descriptionForeground",
+                ])
+                .or_else(|| Some(self.theme.ui_style.muted.clone())),
+            "gitworktree" => self
+                .color_style(&["peekViewResult.fileForeground", "symbolIcon.fileForeground"])
+                .or_else(|| self.theme.get_style("string.other.link")),
+            "muted" | "cancel" | "close" => Some(self.theme.ui_style.muted.clone()),
+            _ => symbol_kind_scope(role).and_then(|scope| self.theme.get_style(scope)),
+        }
+    }
+
+    fn result_icon_style(&self, item: &PickerItem, base: &Style, selected: bool) -> Style {
+        if !self.icons.color {
+            return base.clone();
+        }
+        let role = item
+            .icon
+            .as_ref()
+            .and_then(PickerIcon::role)
+            .or(item.kind.as_deref());
+        self.semantic_foreground(base, role.and_then(|role| self.role_style(role)), selected)
+    }
+
+    fn item_icon<'a>(&self, item: &'a PickerItem) -> &'a str {
+        if self.icons.style == PickerIconStyle::None {
+            return "";
+        }
+        item.icon.as_ref().map(PickerIcon::text).unwrap_or_else(|| {
+            item.kind
+                .as_deref()
+                .map(|kind| picker_kind_icon(kind, self.icons.style))
+                .unwrap_or_default()
+        })
+    }
+
+    fn draw_item_prefix(
+        &self,
+        buffer: &mut RenderBuffer,
+        x: usize,
+        y: usize,
+        item: &PickerItem,
+        row_style: &Style,
+        selected: bool,
+    ) {
+        if selected {
+            let marker_style = self.semantic_foreground(
+                row_style,
+                Some(self.theme.ui_style.picker_prompt.clone()),
+                true,
+            );
+            buffer.set_text(x, y, "›", &marker_style);
+        }
+
+        let icon = fit_display_width(self.item_icon(item), PICKER_ICON_WIDTH);
+        let icon_style = self.result_icon_style(item, row_style, selected);
+        buffer.set_text(x + 2, y, &icon, &icon_style);
     }
 
     fn result_annotation_style(&self, base: &Style, selected: bool) -> Style {
@@ -1096,13 +1240,19 @@ impl Picker {
 
     fn draw_prompt(&self, buffer: &mut RenderBuffer, layout: PickerLayout) {
         self.draw_separator(buffer, layout.separator_y);
-        let query_width = self.width.saturating_sub(1);
+        let query_width = self.width.saturating_sub(2);
+        buffer.set_text(
+            self.x + 1,
+            layout.query_y,
+            "›",
+            &self.theme.ui_style.picker_prompt,
+        );
 
         if self.search.is_empty() {
             if let Some(placeholder) = &self.placeholder {
                 let placeholder = truncate_display_width(placeholder, query_width);
                 buffer.set_text(
-                    self.x + 2,
+                    self.x + 3,
                     layout.query_y,
                     &placeholder,
                     &self.theme.ui_style.picker_item,
@@ -1111,7 +1261,7 @@ impl Picker {
         } else {
             let visible_query = display_width_tail(&self.search, query_width);
             buffer.set_text(
-                self.x + 2,
+                self.x + 3,
                 layout.query_y,
                 visible_query,
                 &self.theme.ui_style.picker_prompt,
@@ -1152,7 +1302,7 @@ impl Picker {
         let Some(items) = self.dynamic_items.as_ref() else {
             return;
         };
-        let content_width = rect.width.saturating_sub(1);
+        let content_width = rect.width.saturating_sub(PICKER_ITEM_PREFIX_WIDTH);
         let command_columns = self.command_columns(items, content_width);
         let selected = self.list.selected_index();
         let top = self.list.top_index();
@@ -1170,7 +1320,8 @@ impl Picker {
             let y = rect.y + offset;
             buffer.set_text(rect.x, y, &" ".repeat(rect.width), &row_style);
 
-            let x = rect.x + 1;
+            self.draw_item_prefix(buffer, rect.x, y, item, &row_style, is_selected);
+            let x = rect.x + PICKER_ITEM_PREFIX_WIDTH;
             if item.kind.as_deref() == Some("Command") {
                 let category = item.annotation.as_deref().unwrap_or_default().trim_end();
                 if command_columns.category > 0 {
@@ -1181,7 +1332,7 @@ impl Picker {
 
                 let category_gap = usize::from(command_columns.category > 0) * COMMAND_COLUMN_GAP;
                 let label_x = x + command_columns.category + category_gap;
-                let label_style = self.result_label_style(item, &row_style, is_selected);
+                let label_style = self.result_label_style(&row_style);
                 let match_style = self.result_match_style(&label_style);
                 self.draw_text_with_matches(
                     buffer,
@@ -1251,7 +1402,7 @@ impl Picker {
             let primary_width = content_width.saturating_sub(detail_width + separator_width);
             let label_x = x;
             let label_width = display_width(&item.label).min(primary_width);
-            let label_style = self.result_label_style(item, &row_style, is_selected);
+            let label_style = self.result_label_style(&row_style);
             let match_style = self.result_match_style(&label_style);
             let used = self.draw_text_with_matches(
                 buffer,
@@ -1374,17 +1525,27 @@ impl Picker {
         {
             let item_index = top + offset;
             let y = rect.y + offset;
-            let row_style = self.result_row_style(selected == Some(item_index));
-            let visible = fit_display_width(&format!(" {item}"), rect.width);
-            buffer.set_text(rect.x, y, &visible, &row_style);
+            let is_selected = selected == Some(item_index);
+            let row_style = self.result_row_style(is_selected);
+            buffer.set_text(rect.x, y, &" ".repeat(rect.width), &row_style);
+            if is_selected {
+                let marker_style = self.semantic_foreground(
+                    &row_style,
+                    Some(self.theme.ui_style.picker_prompt.clone()),
+                    true,
+                );
+                buffer.set_text(rect.x, y, "›", &marker_style);
+            }
+            let visible = fit_display_width(item, rect.width.saturating_sub(2));
+            buffer.set_text(rect.x + 2, y, &visible, &row_style);
         }
     }
 
     fn draw_legacy_items_with_preview(&self, buffer: &mut RenderBuffer, rect: PickerRect) {
         let selected = self.list.selected_index();
         let top = self.list.top_index();
-        let x = rect.x + 1;
-        let content_width = rect.width.saturating_sub(1);
+        let x = rect.x + 2;
+        let content_width = rect.width.saturating_sub(2);
 
         for (offset, item) in self
             .list
@@ -1396,8 +1557,17 @@ impl Picker {
         {
             let item_index = top + offset;
             let y = rect.y + offset;
-            let row_style = self.result_row_style(selected == Some(item_index));
+            let is_selected = selected == Some(item_index);
+            let row_style = self.result_row_style(is_selected);
             buffer.set_text(rect.x, y, &" ".repeat(rect.width), &row_style);
+            if is_selected {
+                let marker_style = self.semantic_foreground(
+                    &row_style,
+                    Some(self.theme.ui_style.picker_prompt.clone()),
+                    true,
+                );
+                buffer.set_text(rect.x, y, "›", &marker_style);
+            }
             let visible = fit_display_width(item, content_width);
             buffer.set_text(x, y, &visible, &row_style);
         }
@@ -1764,6 +1934,154 @@ fn symbol_kind_scope(kind: &str) -> Option<&'static str> {
         "Variable" => Some("variable.other"),
         "TypeParameter" => Some("entity.name.type.parameter"),
         _ => None,
+    }
+}
+
+fn picker_kind_icon(kind: &str, style: PickerIconStyle) -> &'static str {
+    match style {
+        PickerIconStyle::Unicode => unicode_picker_kind_icon(kind),
+        PickerIconStyle::NerdFont => nerd_font_picker_kind_icon(kind),
+        PickerIconStyle::Ascii => ascii_picker_kind_icon(kind),
+        PickerIconStyle::None => "",
+    }
+}
+
+fn unicode_picker_kind_icon(kind: &str) -> &'static str {
+    match kind {
+        "Array" => "[]",
+        "Boolean" => "◐",
+        "Class" => "○",
+        "Color" => "◉",
+        "Constant" => "π",
+        "Constructor" => "◇",
+        "Enum" => "ℰ",
+        "EnumMember" => "ℯ",
+        "Event" => "↯",
+        "Field" => "◆",
+        "File" => "▤",
+        "Folder" => "▸",
+        "Function" => "λ",
+        "Interface" | "Trait" => "◌",
+        "Key" => "⌁",
+        "Keyword" => "κ",
+        "Method" => "ƒ",
+        "Module" => "□",
+        "Namespace" => "§",
+        "Null" | "Unit" => "∅",
+        "Number" => "#",
+        "Object" => "◈",
+        "Operator" => "±",
+        "Package" | "Struct" => "▦",
+        "Property" => "◇",
+        "Reference" => "→",
+        "Snippet" => "✂",
+        "String" => "″",
+        "Text" => "≡",
+        "TypeParameter" => "𝑇",
+        "Value" => "=",
+        "Variable" => "𝑥",
+        "Buffer" => "▣",
+        "Command" => "⌘",
+        "Theme" => "◐",
+        "Match" | "Search" => "⌕",
+        "CodeAction" | "Action" => "◇",
+        "Preferred" | "Proceed" | "Success" | "Added" | "Created" | "Staged" => "✓",
+        "Warning" | "Warn" | "Modified" | "Permission" | "Amend" => "⚠",
+        "Error" | "Failed" | "Deleted" | "Conflict" | "Destructive" => "✗",
+        "Cancel" | "Close" => "×",
+        "GitCommit" => "●",
+        "GitBranch" => "⌁",
+        "GitTag" => "◆",
+        "GitStash" => "≡",
+        "GitRemote" => "↗",
+        "GitWorktree" => "▦",
+        "Unknown" => "?",
+        _ => "",
+    }
+}
+
+fn nerd_font_picker_kind_icon(kind: &str) -> &'static str {
+    match kind {
+        "Array" => "",
+        "Boolean" => "󰨙",
+        "Class" => "",
+        "Color" => "",
+        "Constant" => "󰏿",
+        "Constructor" => "",
+        "Enum" | "EnumMember" => "",
+        "Event" => "",
+        "Field" | "Property" => "",
+        "File" => "",
+        "Folder" => "",
+        "Function" | "Method" => "󰊕",
+        "Interface" => "",
+        "Key" | "Text" | "Value" => "",
+        "Keyword" => "",
+        "Module" | "Package" => "",
+        "Namespace" => "󰦮",
+        "Null" => "",
+        "Number" => "󰎠",
+        "Object" => "",
+        "Operator" => "",
+        "Reference" => "",
+        "Snippet" => "󱄽",
+        "String" => "",
+        "Struct" => "󰆼",
+        "TypeParameter" => "",
+        "Unit" => "",
+        "Variable" => "󰀫",
+        "Buffer" => "󰓩",
+        "Command" => "",
+        "Theme" => "",
+        "Match" | "Search" => "",
+        "CodeAction" | "Action" => "",
+        "Preferred" | "Proceed" | "Success" | "Added" | "Created" | "Staged" => "",
+        "Warning" | "Warn" | "Modified" | "Permission" | "Amend" => "",
+        "Error" | "Failed" | "Deleted" | "Conflict" | "Destructive" => "",
+        "Cancel" | "Close" => "󰅖",
+        "GitCommit" => "",
+        "GitBranch" => "",
+        "GitTag" => "",
+        "GitStash" => "",
+        "GitRemote" => "",
+        "GitWorktree" => "",
+        "Trait" => "",
+        "Unknown" => "",
+        _ => "",
+    }
+}
+
+fn ascii_picker_kind_icon(kind: &str) -> &'static str {
+    match kind {
+        "File" => "F",
+        "Folder" => "D",
+        "Buffer" => "B",
+        "Command" => ">",
+        "Theme" => "T",
+        "Match" | "Search" => "/",
+        "Reference" => "->",
+        "Function" | "Method" => "fn",
+        "Class" => "C",
+        "Interface" | "Trait" => "I",
+        "Struct" => "S",
+        "Enum" | "EnumMember" => "E",
+        "Module" | "Namespace" | "Package" => "M",
+        "Variable" | "Field" | "Property" => "v",
+        "Constant" => "c",
+        "TypeParameter" => "T",
+        "CodeAction" | "Action" => "*",
+        "Preferred" | "Proceed" | "Success" | "Added" | "Created" | "Staged" => "+",
+        "Warning" | "Warn" | "Modified" | "Permission" | "Amend" => "!",
+        "Error" | "Failed" | "Deleted" | "Conflict" | "Destructive" => "x",
+        "Cancel" | "Close" => "x",
+        "GitCommit" => "o",
+        "GitBranch" => "b",
+        "GitTag" => "t",
+        "GitStash" => "s",
+        "GitRemote" => "r",
+        "GitWorktree" => "w",
+        "Unknown" => "?",
+        _ => "",
     }
 }
 
@@ -2266,9 +2584,9 @@ impl Component for Picker {
     }
 
     fn cursor_position(&self) -> Option<(usize, usize)> {
-        let query_width = self.width.saturating_sub(1);
+        let query_width = self.width.saturating_sub(2);
         let visible_query = display_width_tail(&self.search, query_width);
-        let cx = self.x + 2 + display_width(visible_query).min(query_width.saturating_sub(1));
+        let cx = self.x + 3 + display_width(visible_query).min(query_width.saturating_sub(1));
         let cy = self.layout().query_y;
 
         Some((cx, cy))
@@ -2466,13 +2784,13 @@ mod tests {
     use crate::{
         buffer::Buffer,
         color::{contrast_ratio, Color},
-        config::{Config, KeyAction, PickerInputPosition},
+        config::{Config, KeyAction, PickerIconStyle, PickerInputPosition},
         editor::{Action, Editor, RenderBuffer},
         lsp::LspManager,
         theme::{SelectionForegroundPriority, Style, Theme, TokenStyle},
         ui::{
-            Component, LegacyPickerOptions, Picker, PickerItem, PickerOptions, PickerPresentation,
-            PickerPreview, PickerUpdate,
+            Component, LegacyPickerOptions, Picker, PickerIcon, PickerItem, PickerOptions,
+            PickerPresentation, PickerPreview, PickerUpdate,
         },
         unicode_utils::display_width,
     };
@@ -2517,9 +2835,14 @@ mod tests {
             .collect()
     }
 
+    fn display_column(row: &str, needle: &str) -> Option<usize> {
+        row.find(needle).map(|index| display_width(&row[..index]))
+    }
+
     fn dynamic_item(id: &str, label: &str) -> PickerItem {
         PickerItem {
             id: id.to_string(),
+            icon: None,
             label: label.to_string(),
             kind: None,
             annotation: None,
@@ -3122,8 +3445,9 @@ mod tests {
         let editor = test_editor_with_theme(theme.clone());
         let item = PickerItem {
             id: "result".to_string(),
+            icon: None,
             label: "src/main.rs".to_string(),
-            kind: None,
+            kind: Some("File".to_string()),
             annotation: Some(":7:3".to_string()),
             detail: Some("let needle = 1".to_string()),
             data: json!({}),
@@ -3134,7 +3458,7 @@ mod tests {
         let picker = Picker::new_dynamic(
             /*title*/ Some("Find in Files".to_string()),
             &editor,
-            vec![item],
+            vec![dynamic_item("selected", "selected"), item],
             /*id*/ 16,
             PickerOptions::default(),
         );
@@ -3143,17 +3467,23 @@ mod tests {
 
         picker.draw(&mut buffer).unwrap();
 
-        let row_start = (picker.y + 1) * buffer.width + picker.x + 2;
+        let selected_row_start = (picker.y + 1) * buffer.width + picker.x + 5;
+        let row_start = (picker.y + 2) * buffer.width + picker.x + 5;
+        let icon_start = (picker.y + 2) * buffer.width + picker.x + 3;
         let annotation_start = row_start + "src/main.rs ".len();
         let detail_start =
-            (picker.y + 1) * buffer.width + picker.x + picker.width + 1 - "let needle = 1".len();
-        assert_eq!(buffer.cells[row_start].style.fg, Some(file_color));
+            (picker.y + 2) * buffer.width + picker.x + picker.width + 1 - "let needle = 1".len();
+        assert_eq!(buffer.cells[icon_start].style.fg, Some(file_color));
+        assert_eq!(
+            buffer.cells[row_start].style.fg,
+            theme.ui_style.picker_item.fg
+        );
         assert_eq!(
             buffer.cells[annotation_start].style.fg,
             Some(location_color)
         );
         assert_eq!(buffer.cells[detail_start].style.fg, Some(content_color));
-        let selected_bg = buffer.cells[row_start].style.bg.unwrap();
+        let selected_bg = buffer.cells[selected_row_start].style.bg.unwrap();
         let surface_bg = theme.ui_style.picker_item.bg.unwrap();
         assert!(contrast_ratio(selected_bg, surface_bg) >= 3.0);
         assert_ne!(selected_bg, selection_color);
@@ -3193,6 +3523,7 @@ mod tests {
         let items = vec![
             PickerItem {
                 id: "git.open".to_string(),
+                icon: None,
                 label: "Open Git dashboard".to_string(),
                 kind: Some("Command".to_string()),
                 annotation: Some("Git   ".to_string()),
@@ -3210,6 +3541,7 @@ mod tests {
             },
             PickerItem {
                 id: "other.open".to_string(),
+                icon: None,
                 label: "Open dashboard".to_string(),
                 kind: Some("Command".to_string()),
                 annotation: Some("Other ".to_string()),
@@ -3227,6 +3559,7 @@ mod tests {
             },
             PickerItem {
                 id: "tree.toggle".to_string(),
+                icon: None,
                 label: "Toggle file tree".to_string(),
                 kind: Some("Command".to_string()),
                 annotation: Some("File  ".to_string()),
@@ -3260,8 +3593,14 @@ mod tests {
         assert!(second.contains("Other  Open dashboard"), "{second:?}");
         assert!(third.contains("File   Toggle file tree"), "{third:?}");
         assert!(first.contains("Space G  :GitDashboard"), "{first:?}");
-        assert_eq!(first.find(":GitDashboard"), second.find(":Other"));
-        assert_eq!(first.find("Space G"), third.find("Ctrl-e"));
+        assert_eq!(
+            display_column(&first, ":GitDashboard"),
+            display_column(&second, ":Other")
+        );
+        assert_eq!(
+            display_column(&first, "Space G"),
+            display_column(&third, "Ctrl-e")
+        );
         assert!(render_row(&buffer, picker.layout().separator_y)
             .contains("Inspect workspace changes · 3/3 commands"));
 
@@ -3291,6 +3630,7 @@ mod tests {
         let items = vec![
             PickerItem {
                 id: "agent.cancel".to_string(),
+                icon: None,
                 label: "Cancel agent request".to_string(),
                 kind: Some("Command".to_string()),
                 annotation: Some("Agent ".to_string()),
@@ -3306,6 +3646,7 @@ mod tests {
             },
             PickerItem {
                 id: "buffer.next".to_string(),
+                icon: None,
                 label: "Next buffer".to_string(),
                 kind: Some("Command".to_string()),
                 annotation: Some("Buffer".to_string()),
@@ -3321,6 +3662,7 @@ mod tests {
             },
             PickerItem {
                 id: "edit.join-preserve".to_string(),
+                icon: None,
                 label: "Join lines without trimming".to_string(),
                 kind: Some("Command".to_string()),
                 annotation: Some("Edit  ".to_string()),
@@ -3355,8 +3697,14 @@ mod tests {
         assert!(first.contains("Space A"), "{first:?}");
         assert!(second.contains("Space Space +1"), "{second:?}");
         assert!(third.contains("g J"), "{third:?}");
-        assert_eq!(first.find("Space A"), second.find("Space Space +1"));
-        assert_eq!(first.find("Space A"), third.find("g J"));
+        assert_eq!(
+            display_column(&first, "Space A"),
+            display_column(&second, "Space Space +1")
+        );
+        assert_eq!(
+            display_column(&first, "Space A"),
+            display_column(&third, "g J")
+        );
         assert!(!first.contains(":AgentCancel"), "{first:?}");
         assert!(!second.contains(":bn"), "{second:?}");
         assert!(!third.contains(":join!"), "{third:?}");
@@ -3368,6 +3716,7 @@ mod tests {
         let items = vec![
             PickerItem {
                 id: "buffer.next".to_string(),
+                icon: None,
                 label: "Next buffer".to_string(),
                 kind: Some("Command".to_string()),
                 annotation: Some("Buffer".to_string()),
@@ -3383,6 +3732,7 @@ mod tests {
             },
             PickerItem {
                 id: "edit.join-preserve".to_string(),
+                icon: None,
                 label: "Join lines without trimming".to_string(),
                 kind: Some("Command".to_string()),
                 annotation: Some("Edit  ".to_string()),
@@ -3442,7 +3792,7 @@ mod tests {
         picker.draw(&mut buffer).unwrap();
 
         let border = &buffer.cells[picker.y * buffer.width + picker.x];
-        let prompt = &buffer.cells[picker.layout().query_y * buffer.width + picker.x + 2];
+        let prompt = &buffer.cells[picker.layout().query_y * buffer.width + picker.x + 3];
         assert_eq!(picker.search, "lack");
         assert_eq!(border.style.fg, Some(border_fg));
         assert_eq!(prompt.style.fg, Some(prompt_fg));
@@ -3450,7 +3800,7 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_picker_uses_symbol_kind_theme_scope_for_label() {
+    fn dynamic_picker_uses_symbol_kind_theme_scope_for_icon() {
         let function_color = Color::Rgb {
             r: 31,
             g: 32,
@@ -3466,12 +3816,12 @@ mod tests {
             },
         });
         let editor = test_editor_with_theme(theme);
-        let mut item = dynamic_item("render", "󰊕 render");
+        let mut item = dynamic_item("render", "render");
         item.kind = Some("Function".to_string());
         let picker = Picker::new_dynamic(
             Some("Workspace Symbols".to_string()),
             &editor,
-            vec![item],
+            vec![dynamic_item("selected", "selected"), item],
             18,
             PickerOptions::default(),
         );
@@ -3479,8 +3829,81 @@ mod tests {
 
         picker.draw(&mut buffer).unwrap();
 
-        let row_start = (picker.y + 1) * buffer.width + picker.x + 2;
-        assert_eq!(buffer.cells[row_start].style.fg, Some(function_color));
+        let icon_start = (picker.y + 2) * buffer.width + picker.x + 3;
+        let label_start = (picker.y + 2) * buffer.width + picker.x + 5;
+        assert_eq!(buffer.cells[icon_start].text, "λ");
+        assert_eq!(buffer.cells[icon_start].style.fg, Some(function_color));
+        assert_eq!(
+            buffer.cells[label_start].style.fg,
+            editor.theme.ui_style.picker_item.fg
+        );
+    }
+
+    #[test]
+    fn picker_icon_style_switches_between_unicode_ascii_and_hidden() {
+        for (style, expected, unexpected) in [
+            (PickerIconStyle::Unicode, "λ", "fn"),
+            (PickerIconStyle::Ascii, "fn", "λ"),
+            (PickerIconStyle::None, "render", "λ"),
+        ] {
+            let mut config = Config::default();
+            config.picker.icons.style = style;
+            let editor = test_editor_with_config_and_size(config, Theme::default(), 80, 24);
+            let mut item = dynamic_item("render", "render");
+            item.kind = Some("Function".to_string());
+            let picker = Picker::new_dynamic(
+                Some("Workspace Symbols".to_string()),
+                &editor,
+                vec![item],
+                18,
+                PickerOptions::default(),
+            );
+            let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+            picker.draw(&mut buffer).unwrap();
+
+            let row = render_row(&buffer, picker.y + 1);
+            assert!(row.contains(expected), "{style:?}: {row:?}");
+            assert!(!row.contains(unexpected), "{style:?}: {row:?}");
+        }
+    }
+
+    #[test]
+    fn explicit_picker_icon_uses_its_role_without_coloring_the_label() {
+        let error_color = Color::Rgb {
+            r: 220,
+            g: 40,
+            b: 50,
+        };
+        let mut theme = Theme::default();
+        theme
+            .colors
+            .insert("editorError.foreground".to_string(), error_color);
+        let editor = test_editor_with_theme(theme.clone());
+        let mut item = dynamic_item("danger", "Discard changes");
+        item.icon = Some(PickerIcon::Styled {
+            text: "−".to_string(),
+            role: Some("error".to_string()),
+        });
+        let picker = Picker::new_dynamic(
+            Some("Confirm".to_string()),
+            &editor,
+            vec![dynamic_item("selected", "Cancel"), item],
+            19,
+            PickerOptions::default(),
+        );
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        picker.draw(&mut buffer).unwrap();
+
+        let icon_start = (picker.y + 2) * buffer.width + picker.x + 3;
+        let label_start = (picker.y + 2) * buffer.width + picker.x + 5;
+        assert_eq!(buffer.cells[icon_start].text, "−");
+        assert_eq!(buffer.cells[icon_start].style.fg, Some(error_color));
+        assert_eq!(
+            buffer.cells[label_start].style.fg,
+            theme.ui_style.picker_item.fg
+        );
     }
 
     #[test]
@@ -4533,7 +4956,7 @@ mod tests {
         let border_cell = &buffer.cells[picker.y * buffer.width + picker.x];
         assert_eq!(border_cell.style, theme.ui_style.popup_border);
 
-        let selected_cell = &buffer.cells[(picker.y + 1) * buffer.width + picker.x + 1];
+        let selected_cell = &buffer.cells[(picker.y + 1) * buffer.width + picker.x + 3];
         assert_eq!(
             selected_cell.style,
             theme.selected_style(
@@ -4543,11 +4966,11 @@ mod tests {
             )
         );
 
-        let item_cell = &buffer.cells[(picker.y + 2) * buffer.width + picker.x + 1];
+        let item_cell = &buffer.cells[(picker.y + 2) * buffer.width + picker.x + 3];
         assert_eq!(item_cell.style, theme.ui_style.picker_item);
 
         let prompt_cell = &buffer.cells
-            [(picker.y + picker.height.saturating_sub(1)) * buffer.width + picker.x + 2];
+            [(picker.y + picker.height.saturating_sub(1)) * buffer.width + picker.x + 3];
         assert_eq!(prompt_cell.style, theme.ui_style.picker_prompt);
     }
 }

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -894,7 +894,7 @@ impl Picker {
 
     fn role_style(&self, role: &str) -> Option<Style> {
         match role.to_ascii_lowercase().as_str() {
-            "file" | "folder" | "buffer" => self
+            "file" | "filepath" | "filematch" | "folder" | "buffer" => self
                 .color_style(&["peekViewResult.fileForeground", "symbolIcon.fileForeground"])
                 .or_else(|| self.theme.get_style("string.other.link")),
             "command" | "action" | "codeaction" | "theme" | "accent" => {
@@ -959,6 +959,17 @@ impl Picker {
         if !self.icons.color {
             return base.clone();
         }
+        if item.icon.is_none() {
+            if let Some(path) = item_file_path(item) {
+                let semantic = picker_file_icon_color(path)
+                    .map(|fg| Style {
+                        fg: Some(fg),
+                        ..Style::default()
+                    })
+                    .or_else(|| self.role_style("file"));
+                return self.semantic_foreground(base, semantic, selected);
+            }
+        }
         let role = item
             .icon
             .as_ref()
@@ -970,6 +981,11 @@ impl Picker {
     fn item_icon<'a>(&self, item: &'a PickerItem) -> &'a str {
         if self.icons.style == PickerIconStyle::None {
             return "";
+        }
+        if item.icon.is_none() {
+            if let Some(path) = item_file_path(item) {
+                return picker_file_icon(path, self.icons.style);
+            }
         }
         item.icon.as_ref().map(PickerIcon::text).unwrap_or_else(|| {
             item.kind
@@ -1285,7 +1301,19 @@ impl Picker {
                     format!("{description} · {visible}/{total} commands")
                 }
             });
-        if let Some(status) = command_status.as_deref().or(self.status.as_deref()) {
+        let file_status = self
+            .selected_dynamic_item()
+            .filter(|item| item.kind.as_deref() == Some("FilePath"))
+            .map(|_| {
+                let total = self.dynamic_items.as_ref().map_or(0, Vec::len);
+                let visible = self.visible_dynamic_items.len();
+                format!("{visible}/{total}")
+            });
+        if let Some(status) = command_status
+            .as_deref()
+            .or(self.status.as_deref())
+            .or(file_status.as_deref())
+        {
             let status = truncate_display_width(status, self.width.saturating_sub(4));
             let status = format!(" {status} ");
             let status_x = self.x + self.width + 1 - display_width(&status);
@@ -1389,7 +1417,14 @@ impl Picker {
             }
 
             let detail_separator_width = 2;
-            let min_primary_width = content_width.min(8);
+            let min_primary_width = if item.kind.as_deref() == Some("FileMatch") {
+                let max_primary_width = content_width.saturating_sub(detail_separator_width + 8);
+                (content_width * 2 / 5)
+                    .max(display_width(&item.label))
+                    .min(max_primary_width)
+            } else {
+                content_width.min(8)
+            };
             let max_detail_width =
                 content_width.saturating_sub(min_primary_width + detail_separator_width);
             let detail_width = item
@@ -1946,6 +1981,177 @@ fn picker_kind_icon(kind: &str, style: PickerIconStyle) -> &'static str {
     }
 }
 
+fn item_file_path(item: &PickerItem) -> Option<&str> {
+    match item.kind.as_deref()? {
+        "FilePath" => Some(item.id.as_str()),
+        "FileMatch" => item
+            .data
+            .get("location")
+            .and_then(|location| location.get("path"))
+            .and_then(Value::as_str)
+            .or(match item.preview.as_ref() {
+                Some(PickerPreview::Location { path, .. }) => Some(path.as_str()),
+                _ => None,
+            }),
+        _ => None,
+    }
+}
+
+fn picker_file_icon(path: &str, style: PickerIconStyle) -> &'static str {
+    let extension = picker_file_extension(path);
+    match style {
+        PickerIconStyle::Unicode => match extension {
+            "c" | "h" => "Ⓒ",
+            "cpp" | "cc" | "cxx" | "hpp" => "C+",
+            "css" | "scss" | "sass" => "♯",
+            "fish" | "sh" | "zsh" => "$",
+            "html" | "htm" | "xml" => "<>",
+            "js" | "cjs" | "mjs" => "JS",
+            "json" | "jsonc" => "{}",
+            "lua" => "☾",
+            "md" | "markdown" | "mdx" => "M↓",
+            "py" => "Py",
+            "rs" => "ⓡ",
+            "toml" => "ⓣ",
+            "ts" => "TS",
+            "tsx" | "jsx" => "TX",
+            "yaml" | "yml" => "Y",
+            "lock" => "▣",
+            _ => "▤",
+        },
+        PickerIconStyle::NerdFont => picker_file_devicon(path).0,
+        PickerIconStyle::Ascii => match extension {
+            "c" | "h" => "C",
+            "cpp" | "cc" | "cxx" | "hpp" => "C+",
+            "css" | "scss" | "sass" => "#",
+            "fish" | "sh" | "zsh" => "$",
+            "html" | "htm" | "xml" => "<>",
+            "js" | "cjs" | "mjs" => "JS",
+            "json" | "jsonc" => "{}",
+            "lua" => "L",
+            "md" | "markdown" | "mdx" => "MD",
+            "py" => "Py",
+            "rs" => "Rs",
+            "toml" => "T",
+            "ts" => "TS",
+            "tsx" | "jsx" => "TX",
+            "yaml" | "yml" => "Y",
+            "lock" => "L",
+            _ => "F",
+        },
+        PickerIconStyle::None => "",
+    }
+}
+
+fn picker_file_icon_color(path: &str) -> Option<Color> {
+    picker_file_devicon(path)
+        .1
+        .map(|(r, g, b)| Color::Rgb { r, g, b })
+}
+
+/// The filename-first, extension-second subset of nvim-web-devicons used by
+/// Red's common picker file types. Unknown files use Snacks' generic fallback.
+fn picker_file_devicon(path: &str) -> (&'static str, Option<(u8, u8, u8)>) {
+    let filename = picker_file_name(path);
+    let filename_icon = if matches_ignore_ascii_case(filename, &["readme", "readme.md"]) {
+        Some(("󰂺", (237, 237, 237)))
+    } else if matches_ignore_ascii_case(filename, &["license", "license.md", "unlicense"]) {
+        Some(("", (208, 191, 65)))
+    } else if matches_ignore_ascii_case(filename, &["copying", "copying.lesser"]) {
+        Some(("", (203, 203, 65)))
+    } else if matches_ignore_ascii_case(filename, &[".gitignore", ".gitattributes"]) {
+        Some(("", (245, 77, 39)))
+    } else if filename.eq_ignore_ascii_case("dockerfile") {
+        Some(("󰡨", (69, 142, 230)))
+    } else if matches_ignore_ascii_case(filename, &["makefile", "gnumakefile"]) {
+        Some(("", (109, 128, 134)))
+    } else if filename.eq_ignore_ascii_case("package.json") {
+        Some(("", (232, 39, 75)))
+    } else if filename.eq_ignore_ascii_case("tsconfig.json") {
+        Some(("", (81, 154, 186)))
+    } else if matches_ignore_ascii_case(filename, &["go.mod", "go.sum"]) {
+        Some(("", (0, 173, 216)))
+    } else if filename.eq_ignore_ascii_case("gemfile") {
+        Some(("", (112, 21, 22)))
+    } else if filename.eq_ignore_ascii_case("justfile") {
+        Some(("", (109, 128, 134)))
+    } else {
+        None
+    };
+    if let Some((icon, color)) = filename_icon {
+        return (icon, Some(color));
+    }
+
+    let (icon, color) = match picker_file_extension(path) {
+        "c" => ("", (89, 158, 255)),
+        "h" | "hpp" => ("", (160, 116, 196)),
+        "cc" => ("", (243, 75, 125)),
+        "cpp" | "cxx" => ("", (81, 154, 186)),
+        "conf" | "ini" => ("", (109, 128, 134)),
+        "cs" => ("󰌛", (89, 103, 6)),
+        "css" => ("", (102, 51, 153)),
+        "sass" | "scss" => ("", (245, 83, 133)),
+        "erl" | "hrl" => ("", (184, 57, 152)),
+        "ex" | "exs" => ("", (160, 116, 196)),
+        "env" => ("", (250, 247, 67)),
+        "fish" | "sh" => ("", (77, 90, 94)),
+        "zsh" => ("", (137, 224, 81)),
+        "fs" | "fsx" => ("", (81, 154, 186)),
+        "gif" | "jpeg" | "jpg" | "png" | "webp" => ("", (160, 116, 196)),
+        "go" => ("", (0, 173, 216)),
+        "gql" | "graphql" => ("", (229, 53, 171)),
+        "htm" => ("", (227, 76, 38)),
+        "html" => ("", (228, 77, 38)),
+        "java" => ("", (204, 62, 68)),
+        "js" | "cjs" => ("", (203, 203, 65)),
+        "mjs" => ("", (241, 224, 90)),
+        "json" | "jsonc" => ("", (203, 203, 65)),
+        "jsx" => ("", (32, 194, 227)),
+        "kt" | "kts" => ("", (127, 82, 255)),
+        "lock" => ("", (187, 187, 187)),
+        "log" => ("󰌱", (221, 221, 221)),
+        "lua" => ("", (81, 160, 207)),
+        "markdown" => ("", (221, 221, 221)),
+        "md" => ("", (221, 221, 221)),
+        "mdx" => ("", (81, 154, 186)),
+        "pdf" => ("", (179, 11, 0)),
+        "php" => ("", (160, 116, 196)),
+        "py" => ("", (255, 188, 3)),
+        "rb" => ("", (112, 21, 22)),
+        "rs" => ("", (222, 165, 132)),
+        "sql" => ("", (218, 216, 216)),
+        "svelte" => ("", (255, 62, 0)),
+        "swift" => ("", (227, 121, 51)),
+        "toml" => ("", (156, 66, 33)),
+        "ts" => ("", (81, 154, 186)),
+        "tsx" => ("", (19, 84, 191)),
+        "txt" => ("󰈙", (137, 224, 81)),
+        "vue" => ("", (141, 193, 73)),
+        "xml" => ("󰗀", (227, 121, 51)),
+        "yaml" | "yml" => ("", (215, 0, 0)),
+        "zig" => ("", (246, 154, 27)),
+        _ => return ("󰈔", None),
+    };
+    (icon, Some(color))
+}
+
+fn picker_file_extension(path: &str) -> &str {
+    let file = picker_file_name(path);
+    file.rsplit_once('.')
+        .map(|(_, extension)| extension)
+        .unwrap_or_default()
+}
+
+fn picker_file_name(path: &str) -> &str {
+    path.rsplit(['/', '\\']).next().unwrap_or(path)
+}
+
+fn matches_ignore_ascii_case(value: &str, candidates: &[&str]) -> bool {
+    candidates
+        .iter()
+        .any(|candidate| value.eq_ignore_ascii_case(candidate))
+}
+
 fn unicode_picker_kind_icon(kind: &str) -> &'static str {
     match kind {
         "Array" => "[]",
@@ -1958,7 +2164,7 @@ fn unicode_picker_kind_icon(kind: &str) -> &'static str {
         "EnumMember" => "ℯ",
         "Event" => "↯",
         "Field" => "◆",
-        "File" => "▤",
+        "File" | "FilePath" | "FileMatch" => "▤",
         "Folder" => "▸",
         "Function" => "λ",
         "Interface" | "Trait" => "◌",
@@ -2011,7 +2217,7 @@ fn nerd_font_picker_kind_icon(kind: &str) -> &'static str {
         "Enum" | "EnumMember" => "",
         "Event" => "",
         "Field" | "Property" => "",
-        "File" => "",
+        "File" | "FilePath" | "FileMatch" => "",
         "Folder" => "",
         "Function" | "Method" => "󰊕",
         "Interface" => "",
@@ -2053,7 +2259,7 @@ fn nerd_font_picker_kind_icon(kind: &str) -> &'static str {
 
 fn ascii_picker_kind_icon(kind: &str) -> &'static str {
     match kind {
-        "File" => "F",
+        "File" | "FilePath" | "FileMatch" => "F",
         "Folder" => "D",
         "Buffer" => "B",
         "Command" => ">",
@@ -2781,6 +2987,7 @@ mod tests {
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
     use serde_json::json;
 
+    use super::{picker_file_icon, picker_file_icon_color};
     use crate::{
         buffer::Buffer,
         color::{contrast_ratio, Color},
@@ -3518,6 +3725,36 @@ mod tests {
     }
 
     #[test]
+    fn file_match_rows_keep_the_filename_visible_before_match_text() {
+        let editor = test_editor();
+        let mut item = dynamic_item("match", "default_config.toml");
+        item.kind = Some("FileMatch".to_string());
+        item.annotation = Some("crates/config/:10:2".to_string());
+        item.detail = Some(
+            "# Name of the VSCode theme to use. The theme file should remain readable".to_string(),
+        );
+        item.data = json!({
+            "location": {
+                "path": "crates/config/default_config.toml"
+            }
+        });
+        let picker = Picker::new_dynamic(
+            Some("Find in Files".to_string()),
+            &editor,
+            vec![item],
+            20,
+            PickerOptions::default(),
+        );
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        picker.draw(&mut buffer).unwrap();
+
+        let row = render_row(&buffer, picker.y + 1);
+        assert!(row.contains("default_config.toml"), "{row:?}");
+        assert!(row.contains("# Name of"), "{row:?}");
+    }
+
+    #[test]
     fn structured_command_picker_aligns_fields_filters_noise_and_selects_by_id() {
         let editor = test_editor_with_theme_and_size(Theme::default(), 120, 24);
         let items = vec![
@@ -3831,7 +4068,7 @@ mod tests {
 
         let icon_start = (picker.y + 2) * buffer.width + picker.x + 3;
         let label_start = (picker.y + 2) * buffer.width + picker.x + 5;
-        assert_eq!(buffer.cells[icon_start].text, "λ");
+        assert_eq!(buffer.cells[icon_start].text, "󰊕");
         assert_eq!(buffer.cells[icon_start].style.fg, Some(function_color));
         assert_eq!(
             buffer.cells[label_start].style.fg,
@@ -3866,6 +4103,48 @@ mod tests {
             assert!(row.contains(expected), "{style:?}: {row:?}");
             assert!(!row.contains(unexpected), "{style:?}: {row:?}");
         }
+    }
+
+    #[test]
+    fn file_icons_follow_extension_and_configured_icon_style() {
+        assert_eq!(
+            picker_file_icon("crates/husk/src/lib.rs", PickerIconStyle::Unicode),
+            "ⓡ"
+        );
+        assert_eq!(
+            picker_file_icon("default_config.toml", PickerIconStyle::NerdFont),
+            ""
+        );
+        assert_eq!(
+            picker_file_icon("Cargo.lock", PickerIconStyle::NerdFont),
+            ""
+        );
+        assert_eq!(
+            picker_file_icon("README.md", PickerIconStyle::NerdFont),
+            "󰂺"
+        );
+        assert_eq!(
+            picker_file_icon("AGENTS.md", PickerIconStyle::NerdFont),
+            ""
+        );
+        assert_eq!(picker_file_icon("LICENSE", PickerIconStyle::NerdFont), "");
+        assert_eq!(
+            picker_file_icon("src/plugin.hk", PickerIconStyle::NerdFont),
+            "󰈔"
+        );
+        assert_eq!(
+            picker_file_icon("docs/README.md", PickerIconStyle::Ascii),
+            "MD"
+        );
+        assert_eq!(picker_file_icon("LICENSE", PickerIconStyle::Unicode), "▤");
+        assert_eq!(
+            picker_file_icon_color("src/lib.rs"),
+            Some(Color::Rgb {
+                r: 222,
+                g: 165,
+                b: 132,
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
Pickers currently rely heavily on text and sometimes color entire labels, which makes result types and action states harder to scan. File icons were also generic or approximated with portable Unicode, so they did not match the Nerd Font glyphs used by Neovim's Snacks picker and nvim-web-devicons.

This change introduces a shared picker icon and color system and brings file-oriented pickers in line with that Neovim presentation:

- add configurable `nerd_font`, `unicode`, `ascii`, and `none` icon styles under `[picker.icons]`, with independent semantic color control
- use `nerd_font` by default with nvim-web-devicons-compatible filename/extension glyphs and colors, including a generic Snacks-style fallback
- render icons in a fixed-width column with theme-aware colors, readable selected-state contrast, and consistent prompt/selection markers
- show file results as basename first with a muted parent path while keeping the complete path searchable and selectable
- show find-in-files results as icon, filename, parent/location, and match text, reserving enough width to keep filenames legible
- extend structured picker items with optional explicit icons and semantic roles without including icon text in fuzzy matching
- migrate code-action, bundled LSP, Git, and agent pickers to semantic item kinds
- keep LSP symbol icon disabling and per-kind overrides while using the global picker style by default

The file mappings follow the same filename-first, extension-second lookup model used by [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) and consumed by [Snacks](https://github.com/folke/snacks.nvim). Nerd Font 3.3 or newer is required for that exact presentation; the portable styles remain available for other terminals.

## How to Test

1. With a Nerd Font 3.3+ terminal and the default configuration, open quick-open. Verify Markdown, TOML, Rust, lock, license, and unknown files use their expected devicons/colors; rows show the basename followed by a muted parent path.
2. Type a directory name that is absent from the basename. Verify the file remains searchable by its full path and Enter opens the expected file.
3. Open find-in-files and search for a common term. Verify each row keeps the filename visible, then shows the parent/location and highlighted match text; selection and preview still target the full source location.
4. Open command, code-action, document-symbol, Git, and agent pickers. Verify semantic icons align in one column and selected labels remain readable.
5. Switch `picker.icons.style` to `unicode`, `ascii`, and `none`. Verify each fallback changes or hides only icon contents without affecting matching, selection, previews, or column alignment. Set `picker.icons.color = false` and verify semantic icon colors are disabled.
6. For LSP symbols, set an icon override and then disable `plugin_config.lsp_symbols.icons.enabled`. Verify the override is used when enabled and all symbol icons are hidden when disabled.

Automated validation:

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
