### PR TITLE
docs: document architecture and safety contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,8 +310,13 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build documentation
-        run: cargo doc --no-deps --all-features --document-private-items
+      - name: Build documentation and deny rustdoc warnings
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps --all-features --document-private-items
+
+      - name: Run documentation tests
+        run: cargo test --workspace --doc
 
       - name: Check documentation links
         run: |

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ platform details.
 | [Detach and attach](docs/DETACH.md) | Persistent Unix sessions |
 | [Session recovery](docs/SESSION_RECOVERY.md) | Atomic recovery and dirty-buffer restoration |
 | [Performance](docs/performance.md) | Measurement, budgets, and regression process |
+| [Debugging](docs/DEBUGGING.md) | Invariant owners, logs, diagnostic commands, and tracing paths |
 | [Releasing](docs/RELEASING.md) | Release preparation, publication, and verification |
 
 ## Status and community

--- a/crates/husk-ast/src/lib.rs
+++ b/crates/husk-ast/src/lib.rs
@@ -258,8 +258,8 @@ pub enum ExprKind {
         index: usize,
     },
     /// Try expression: `expr?`
-    /// For Result<T, E>: returns early with Err(e) if Err, otherwise unwraps Ok(t) to t.
-    /// For Option<T>: returns early with None if None, otherwise unwraps Some(t) to t.
+    /// For `Result<T, E>`, returns early with `Err(e)` or unwraps `Ok(t)` to `t`.
+    /// For `Option<T>`, returns early with `None` or unwraps `Some(t)` to `t`.
     Try {
         expr: Box<Expr>,
     },
@@ -636,7 +636,7 @@ pub enum ImplItemKind {
 /// Example: `#[getter] #[setter] extern "js" text_content: String;`
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExternProperty {
-    /// Attributes on this property (e.g., #[getter], #[setter], #[js_name = "..."])
+    /// Attributes on this property, such as `#[getter]`, `#[setter]`, or `#[js_name = "..."]`.
     pub attributes: Vec<Attribute>,
     /// The property name in Husk (e.g., "text_content")
     pub name: Ident,
@@ -646,12 +646,12 @@ pub struct ExternProperty {
 }
 
 impl ExternProperty {
-    /// Returns true if the property has a #[getter] attribute.
+    /// Returns whether the property has a `#[getter]` attribute.
     pub fn has_getter(&self) -> bool {
         self.attributes.iter().any(|a| a.name.name == "getter")
     }
 
-    /// Returns true if the property has a #[setter] attribute.
+    /// Returns whether the property has a `#[setter]` attribute.
     pub fn has_setter(&self) -> bool {
         self.attributes.iter().any(|a| a.name.name == "setter")
     }
@@ -713,7 +713,7 @@ pub enum EnumVariantFields {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Item {
-    /// Attributes on this item (e.g., #[test], #[cfg(test)], #[ignore])
+    /// Attributes on this item, such as `#[test]`, `#[cfg(test)]`, or `#[ignore]`.
     pub attributes: Vec<Attribute>,
     pub visibility: Visibility,
     pub kind: ItemKind,
@@ -734,12 +734,12 @@ impl Item {
         self.attributes.iter().any(|a| a.name.name == "test")
     }
 
-    /// Returns true if this item has a #[ignore] attribute.
+    /// Returns whether this item has an `#[ignore]` attribute.
     pub fn is_ignored(&self) -> bool {
         self.attributes.iter().any(|a| a.name.name == "ignore")
     }
 
-    /// Returns true if this item has a #[should_panic] attribute.
+    /// Returns whether this item has a `#[should_panic]` attribute.
     pub fn should_panic(&self) -> bool {
         self.attributes
             .iter()
@@ -754,7 +754,7 @@ impl Item {
             .and_then(|a| a.value.as_deref())
     }
 
-    /// Returns true if this item (usually an enum) has an #[untagged] attribute.
+    /// Returns whether this item, usually an enum, has an `#[untagged]` attribute.
     /// Untagged enums serialize without a tag field, matching TypeScript's untagged unions.
     pub fn is_untagged(&self) -> bool {
         self.attributes.iter().any(|a| a.name.name == "untagged")
@@ -853,7 +853,7 @@ pub struct ExternItem {
 }
 
 impl ExternItem {
-    /// Returns true if this extern item has a #[default] attribute.
+    /// Returns whether this extern item has a `#[default]` attribute.
     /// When on a `mod` declaration, indicates the module uses default import
     /// and all functions are methods on the default export.
     pub fn is_default(&self) -> bool {

--- a/crates/husk-parser/benches/parser_benchmarks.rs
+++ b/crates/husk-parser/benches/parser_benchmarks.rs
@@ -1,3 +1,9 @@
+//! Criterion throughput benchmarks for representative Husk source sizes.
+//!
+//! Fixtures are parsed repeatedly after input loading so measurements focus on lexer and
+//! parser work rather than filesystem access. These benchmarks detect relative parser
+//! regressions; release editor-frame budgets are maintained separately.
+
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use husk_parser::parse_str;
 

--- a/crates/husk-parser/examples/profile_parser.rs
+++ b/crates/husk-parser/examples/profile_parser.rs
@@ -1,3 +1,8 @@
+//! Command-line parser profiler for a supplied Husk source file.
+//!
+//! The example reports lexing and parsing duration plus approximate throughput and is
+//! intended for local investigations, not as a stable machine-readable benchmark.
+
 use husk_lexer::Lexer;
 use husk_parser::parse_str;
 use std::env;

--- a/crates/husk-parser/src/lib.rs
+++ b/crates/husk-parser/src/lib.rs
@@ -24,8 +24,11 @@ fn debug_log(msg: &str) {
 // Removed DepthGuard - using thread_local instead
 
 #[derive(Debug)]
+/// Recoverable syntax error associated with a source byte span.
 pub struct ParseError {
+    /// Human-readable parser expectation or failure.
     pub message: String,
+    /// Byte range in the original Husk source.
     pub span: Span,
 }
 
@@ -42,8 +45,14 @@ enum JsParseState {
 }
 
 #[derive(Debug)]
+/// Best-effort parse output, diagnostics, and the lossless token stream.
+///
+/// Parsing retains tokens even when errors are present so callers can inspect
+/// trivia and present multiple diagnostics from one pass.
 pub struct ParseResult {
+    /// Parsed file. The current recovery parser always returns a file node.
     pub file: Option<File>,
+    /// Syntax errors collected during recovery.
     pub errors: Vec<ParseError>,
     /// The tokens from lexing, useful for accessing trivia (comments).
     pub tokens: Vec<Token>,
@@ -3376,7 +3385,7 @@ impl<'src> Parser<'src> {
     }
 
     /// Parse format spec like "?", "#?", "x", "08x", "<10", "*^20.5", etc.
-    /// Format: [[fill]align][sign]['#']['0'][width]['.' precision][type]
+    /// Format: `[[fill]align][sign]['#']['0'][width]['.' precision][type]`
     fn parse_format_spec(&self, s: &str) -> FormatSpec {
         let mut spec = FormatSpec::default();
         let mut chars = s.chars().peekable();

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -367,8 +367,9 @@ static PRELUDE_SRC: &str = include_str!("stdlib/core.hk");
 static PRELUDE_AST: OnceLock<File> = OnceLock::new();
 static STDLIB_INDEX: OnceLock<StdlibIndex> = OnceLock::new();
 
-/// Returns the stdlib prelude file for use by codegen to collect method
-/// name mappings (e.g., #[js_name] attributes).
+/// Returns the standard-library prelude used to collect code-generation name mappings.
+///
+/// These mappings include attributes such as `#[js_name]`.
 pub fn get_prelude_file() -> &'static File {
     PRELUDE_AST.get_or_init(|| {
         let parsed = parse_str(PRELUDE_SRC);
@@ -645,7 +646,7 @@ impl TypeEnv {
     }
 }
 
-/// Extract the inner type from a trait name like "From<i32>" -> Some("i32")
+/// Extract the inner type from a trait name like `From<i32>` -> `Some("i32")`.
 /// Returns None if the trait name doesn't match the expected prefix/suffix pattern.
 fn extract_trait_type_arg<'a>(trait_name: &'a str, prefix: &str) -> Option<&'a str> {
     if trait_name.starts_with(prefix) && trait_name.ends_with('>') {
@@ -4476,7 +4477,7 @@ impl<'a> FnContext<'a> {
         }
     }
 
-    /// Handle .parse() method call: "str".parse::<i32>() -> Result<i32, String>
+    /// Handle `.parse()` method calls: `"str".parse::<i32>() -> Result<i32, String>`.
     fn check_parse_method(
         &mut self,
         receiver: &Expr,
@@ -4607,7 +4608,7 @@ impl<'a> FnContext<'a> {
         }
     }
 
-    /// Handle .collect() method call: iter.collect::<[T]>() -> [T]
+    /// Handle `.collect()` method calls: `iter.collect::<[T]>() -> [T]`.
     /// Infers collection type from context or turbofish syntax
     fn check_collect_method(
         &mut self,
@@ -4847,7 +4848,7 @@ impl<'a> FnContext<'a> {
         }
     }
 
-    /// Check if TargetType implements From<SourceType>
+    /// Check whether `TargetType` implements `From<SourceType>`.
     fn type_implements_from(&self, target: &Type, source: &Type) -> bool {
         let target_name = self.format_type(target);
         let source_name = self.format_type(source);
@@ -4872,7 +4873,7 @@ impl<'a> FnContext<'a> {
         false
     }
 
-    /// Check if TargetType implements TryFrom<SourceType>
+    /// Check whether `TargetType` implements `TryFrom<SourceType>`.
     fn type_implements_try_from(&self, target: &Type, source: &Type) -> bool {
         let target_name = self.format_type(target);
         let source_name = self.format_type(source);

--- a/crates/husk-semantic/src/stdlib_index.rs
+++ b/crates/husk-semantic/src/stdlib_index.rs
@@ -14,7 +14,7 @@ use husk_ast::{
 /// Lookup key for stdlib methods
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MethodKey {
-    /// The trait or type name (e.g., "Iterator", "String", "[T]")
+    /// The trait or type name, such as `Iterator`, `String`, or `[T]`.
     pub trait_or_type: String,
     /// The method name (e.g., "map", "len")
     pub method_name: String,
@@ -27,15 +27,15 @@ pub enum InferenceStrategy {
     #[default]
     Standard,
 
-    /// Iterator adaptor: closure T -> U, returns Iterator<U>
+    /// Iterator adaptor taking `T -> U` and returning `Iterator<U>`.
     /// Used by: map
     MapLike,
 
-    /// Iterator filter: closure &T -> bool, returns Iterator<T>
+    /// Iterator filter taking `&T -> bool` and returning `Iterator<T>`.
     /// Used by: filter
     FilterLike,
 
-    /// Find element: closure &T -> bool, returns Option<T>
+    /// Element search taking `&T -> bool` and returning `Option<T>`.
     /// Used by: find
     FindLike,
 
@@ -51,7 +51,7 @@ pub enum InferenceStrategy {
     /// Used by: take, skip, enumerate, chain, zip
     PassThrough,
 
-    /// Filter + map combined: closure T -> Option<U>, returns Iterator<U>
+    /// Combined filter and map taking `T -> Option<U>` and returning `Iterator<U>`.
     /// Used by: filter_map
     FilterMapLike,
 
@@ -63,7 +63,7 @@ pub enum InferenceStrategy {
     /// Used by: count
     CountLike,
 
-    /// Collect into array: returns [T]
+    /// Collection into an array `[T]`.
     /// Used by: collect
     CollectLike,
 }
@@ -318,7 +318,7 @@ impl StdlibIndex {
             .unwrap_or_default()
     }
 
-    /// Get type parameters for a trait (e.g., ["T"] for Iterator<T>)
+    /// Gets the type parameters for a trait, such as `["T"]` for `Iterator<T>`.
     pub fn get_trait_type_params(&self, trait_name: &str) -> Option<&[String]> {
         self.trait_type_params.get(trait_name).map(|v| v.as_slice())
     }

--- a/crates/husk/src/lib.rs
+++ b/crates/husk/src/lib.rs
@@ -19,18 +19,28 @@ use serde::{Deserialize, Serialize};
 /// A dynamically typed value crossing the Husk/host boundary.
 #[derive(Debug, Clone)]
 pub enum Value {
+    /// Husk's no-value result.
     Unit,
+    /// Explicit JSON-like null.
     Null,
+    /// Boolean value.
     Bool(bool),
+    /// Signed integer value.
     Int(i64),
+    /// Floating-point value.
     Float(f64),
+    /// Owned UTF-8 string.
     String(String),
+    /// Shared array whose cloning does not recursively clone its elements.
     Array(Arc<Vec<Value>>),
+    /// Shared string-keyed object whose cloning does not recursively clone its fields.
     Object(Arc<BTreeMap<String, Value>>),
     /// Opaque JSON from legacy host paths. New runtime values use `Array` and
     /// `Object` so cloning plugin state does not recursively clone JSON.
     Json(serde_json::Value),
+    /// Reference to a loaded plugin function.
     Callback(Callback),
+    /// Deferred missing-field value that preserves diagnostic context.
     Missing(MissingValue),
 }
 
@@ -74,6 +84,7 @@ impl PartialEq for Value {
 }
 
 impl Value {
+    /// Returns the borrowed string when this value is [`Value::String`].
     #[must_use]
     pub fn as_str(&self) -> Option<&str> {
         match self {
@@ -82,6 +93,7 @@ impl Value {
         }
     }
 
+    /// Returns the boolean when this value is [`Value::Bool`].
     #[must_use]
     pub fn as_bool(&self) -> Option<bool> {
         match self {
@@ -107,11 +119,13 @@ impl Value {
         }
     }
 
+    /// Converts JSON into Husk's shared runtime representation.
     #[must_use]
     pub fn from_json(value: serde_json::Value) -> Self {
         json_to_value(&value)
     }
 
+    /// Converts a runtime value into its JSON boundary representation.
     #[must_use]
     pub fn to_json(&self) -> serde_json::Value {
         value_to_json(self)
@@ -140,6 +154,7 @@ pub struct CommandMetadata {
 }
 
 impl Callback {
+    /// Creates a function reference owned by `plugin`.
     #[must_use]
     pub fn new(plugin: impl Into<String>, function: impl Into<String>) -> Self {
         Self {
@@ -148,6 +163,7 @@ impl Callback {
         }
     }
 
+    /// Returns the plugin that owns this callback.
     #[must_use]
     pub fn plugin(&self) -> &str {
         &self.plugin
@@ -170,6 +186,7 @@ impl RequestId {
     }
 
     #[must_use]
+    /// Returns the integer representation exposed to Husk code.
     pub fn get(self) -> i64 {
         self.0
     }
@@ -177,7 +194,9 @@ impl RequestId {
 
 /// Rust host operations callable from Husk.
 pub trait Host {
+    /// Writes a plugin-scoped diagnostic message.
     fn log(&mut self, message: &str);
+    /// Executes a synchronous host action for `plugin`.
     fn execute(&mut self, plugin: &str, action: &str, args: &[Value]) -> anyhow::Result<Value>;
 
     /// Schedule a one-shot host request that will later resolve through
@@ -307,6 +326,7 @@ pub struct Vm {
 const MAX_CALL_DEPTH: usize = 512;
 
 impl Vm {
+    /// Creates an empty VM with the default per-callback instruction budget.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -422,6 +442,10 @@ impl Vm {
         result
     }
 
+    /// Removes a plugin and every VM-owned registration or pending request.
+    ///
+    /// This does not call `deactivate`; use [`Self::deactivate_plugin`] when
+    /// plugin teardown code must run.
     pub fn unload_plugin(&mut self, name: &str) {
         self.remove_plugin_registrations(name);
         self.plugin_states.remove(name);
@@ -429,6 +453,7 @@ impl Vm {
     }
 
     #[must_use]
+    /// Returns whether a program with `name` is currently loaded.
     pub fn has_plugin(&self, name: &str) -> bool {
         self.programs.contains_key(name)
     }
@@ -605,6 +630,7 @@ impl Vm {
     }
 
     #[must_use]
+    /// Returns the registered command-to-callback map.
     pub fn commands(&self) -> &HashMap<String, Callback> {
         &self.commands
     }

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,81 @@
+# Debugging Red
+
+Start with the narrowest owner of the failed invariant. Red deliberately keeps editor mutation on the core task, so background process output is evidence delivered to that owner rather than proof that visible editor state changed.
+
+## Startup, configuration, and runtime assets
+
+Run `red --check-config` before debugging downstream behavior. It prints every recoverable configuration diagnostic with its source path and fallback; malformed whole-file input uses the safe profile rather than partially trusting unknown values. `src/config.rs` owns layering and diagnostics, while `src/main.rs` adds runtime validation for themes and log paths.
+
+Run `red --runtime-files` when a plugin or theme is absent or unexpectedly old. Resolution order is user configuration, `RED_RUNTIME`, then embedded assets. The listing marks shadowed sources, so a user copy or development runtime can be identified without guessing which bytes were loaded.
+
+The default log is `/tmp/red.log`. A configured `log_file` replaces that destination. Failure to open the configured path becomes a configuration diagnostic and disables logging rather than preventing startup.
+
+## Input, editing, undo, and rendering
+
+Trace a content change through `Editor::process_editor_event`, key resolution, `Editor::execute`, transaction start, `Editor::replace_range`, transaction commit, and `Editor::notify_change`. `Editor::replace_range` asserts that a transaction is active; `Buffer::replace_range_raw` is the lower seam used by the editor and undo replay and must not be a new feature entry point.
+
+When text is correct but the cursor or paint is wrong, identify the coordinate system before inspecting arithmetic. Editor cursor `x` is a grapheme index, `TextPosition::character` is a Unicode scalar index, rendering uses terminal columns, tree-sitter spans use UTF-8 bytes, and LSP positions use UTF-16 code units. `src/unicode_utils.rs` owns the named conversions and `src/editor/display_layout.rs` owns wrapped-row mapping.
+
+Run with `RED_PERF=summary` for aggregate event, render, plugin, detach, and session timings. Use `RED_PERF=trace` only for a short reproduction because per-sample logging perturbs the measured path and may produce a large log. If a visible non-text update is missing, inspect whether the feature requested a render or advanced the editor render generation; a buffer revision alone covers only text-derived caches.
+
+## Language servers
+
+Search the log for `[lsp]`. `src/lsp/manager.rs` owns document-to-client routing, while `src/lsp/client.rs` owns process stdio, initialization, request IDs, pending queues, document versions, diagnostic debounce, and shutdown. An incoming response is correlated with the original request before the editor interprets it.
+
+For a failed edit, inspect conversion and preparation before filesystem application. `src/lsp/edit.rs` validates URIs, UTF-16 boundaries, and overlap. `src/lsp/workspace_edit.rs` validates workspace confinement, revisions, versions, resource-operation support, total size, protected paths, and rollback. Failure is intentionally closed; retrying with a looser path is not a supported recovery technique.
+
+Tests that launch a real configured language server are opt-in through `RED_RUN_REAL_LSP_TESTS`. Default integration coverage uses mock servers so protocol ordering and failure paths remain deterministic.
+
+## Husk plugins
+
+Run `red --self-check` to parse themes, resolve bundled assets, seed production-equivalent snapshots, and activate every bundled plugin without entering the terminal. A single invalid plugin is quarantined and reported with its stage; it should not prevent unrelated plugins from activating.
+
+Search the log for `[PLUGIN:HUSK]` and the plugin name. `src/plugin/registry.rs` owns status, dependency ordering, quarantine, command routing, and hot reload. `src/plugin/runtime.rs` owns the Husk VM, host translation, callback instruction budget, snapshots, and staged reload effects. A reload error leaves the previous plugin active, so inspect `PluginStatus` rather than assuming the edited source is live.
+
+For missing UI, identify the stable resource ID and owning manager: panels, workspaces, overlays, gutter signs, decorations, and window bars replace namespaced or ID-addressed state. A plugin refresh using a different ID creates a second lifecycle instead of updating the first.
+
+For a process failure, inspect the requesting plugin's configured allowlist and direct argument vector. The process API does not invoke a shell, and unapproved environment variables are removed. Process events are polled by the editor; child exit alone does not update plugin UI until its event handler runs.
+
+## Codex and reviewable proposals
+
+Run `red --agent-check` for the installed executable and minimum-version report, or `red --agent-check --strict` when readiness should control an automated check. Authentication is verified when the app-server starts, not by the offline prerequisite report.
+
+`src/codex/mod.rs` owns bounded JSONL transport, sessions, turns, cancellation, and dynamic-tool dispatch. `src/agent_tools.rs` validates editor tool shapes and UTF-16 edits. `src/agent_workspace.rs` owns session-scoped proposed contents and physical workspace confinement. Reads in one session see its staged proposal, but visible buffers and disk remain unchanged until the editor accepts a staged result through its transaction boundary.
+
+When review reports a conflict, compare the proposal base revision and contents with the current visible buffer. Do not bypass the conflict by writing the proposed text directly: that would discard user work and lose agent attribution. Recovered proposals are archived and do not imply that a prior Codex thread or process is still live.
+
+Structured `agent_proposal_notification_failed` records mean the attributed buffer change committed but a later notification, workspace sync, plugin event, or render failed. The editor reports that partial operational failure instead of rolling back an already accepted user decision.
+
+## Recovery snapshots
+
+Use `red --resume` only after the prior editor owner has stopped. Interactive owners do not currently hold an exclusive recovery lock.
+
+`src/session.rs` owns schema validation, generation fallback, bounded and no-follow reads, atomic writes, and disk-divergence evidence. `Editor::persist_session_snapshot` freezes cheap Rope snapshots and delegates disk reads and writes to a worker thread. Search for structured `session_snapshot_failed` records and inspect the `session:snapshot` performance sample when persistence stalls.
+
+Recovered dirty contents remain in memory and are never written to their backing files until an explicit save. A divergence report means Red could not prove that the snapshot's disk base still names the same unchanged regular file; keeping the recovered buffer dirty is the safe result.
+
+## Detach and attach
+
+`red --detach=name` starts the terminal-independent owner, `Ctrl-\` disconnects the current client, `red --attach name` reconnects, and `red --stop name` requests owner shutdown. A dropped SSH or terminal connection should leave the owner, buffers, LSP, plugins, timers, watchers, snapshots, and Codex process alive.
+
+`src/headless/mod.rs` owns the versioned local protocol, authentication token, one-client lease, frame and terminal-size limits, heartbeat, timeouts, and row deltas. `DetachedEditorCore` in `src/editor.rs` owns the real editor and services background work while no client is attached.
+
+With `RED_PERF=summary`, `detach:idle_tick` should rise while idle without matching serialization work. `detach:rendered_tick`, `detach:serialize_frame`, and `detach:changed_rows` should track actual visible updates. A full-frame delta is expected on connect or resize but suspicious during ordinary single-key input.
+
+## Choosing the first code entry point
+
+| Symptom | First owner |
+| --- | --- |
+| Configuration value ignored or replaced | `config::LoadedConfig` diagnostics |
+| Wrong plugin or theme source | `assets::list_runtime_assets` |
+| Key produces the wrong action | `Editor::process_editor_event` and configured `KeyAction` |
+| Edit cannot undo as one unit | editor transaction start/commit and `UndoHistory` |
+| Unicode cursor or selection drift | `unicode_utils`, display layout, then the boundary conversion |
+| Stale syntax or frame output | buffer revision, render generation, layout/highlight cache key |
+| LSP request never completes | `RealLspClient` pending request map and inbound correlation |
+| Workspace edit rejected | LSP edit preparation and resource-operation validation |
+| Plugin missing after reload | `PluginRegistry::statuses` and quarantine diagnostic |
+| Plugin process has no output | process permission, process ID, and polled process events |
+| Agent changed disk before review | proposal workspace boundary; treat as a safety defect |
+| Snapshot not advancing | session worker result, generation tuple, and structured failure log |
+| Attach paints stale content | headless revision handshake and detached-core render generation |

--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -1,3 +1,10 @@
+// Bundled Codex conversation, review, permission, and attributed-history interface.
+//
+// Rust owns process and thread lifecycle, dynamic tools, proposal isolation, acceptance,
+// and recovery. This plugin owns only presentation and session-scoped UI state. Event
+// handlers ignore foreign session IDs, queued prompts remain FIFO, and deactivate closes
+// plugin UI resources without claiming that an active Codex process survived recovery.
+
 pub fn activate() {
     red::add_command("Agent", prompt, Json {
         title: "Ask the agent",

--- a/plugins/barbecue.hk
+++ b/plugins/barbecue.hk
@@ -1,3 +1,9 @@
+// Per-window breadcrumb bar derived from buffers, symbols, cursor state, and theme.
+//
+// Refreshes are coalesced through one timeout so cursor and window event bursts do not
+// repeatedly query LSP. Window IDs, rather than tree-order indexes, own rendered bars;
+// deactivate cancels pending work and removes the plugin's chrome.
+
 pub fn activate() {
     red::on("editor:ready", refresh);
     red::on("editor:state_restored", refresh);

--- a/plugins/buffer_picker.hk
+++ b/plugins/buffer_picker.hk
@@ -1,3 +1,8 @@
+// Fuzzy picker for the editor's current buffer list.
+//
+// The editor snapshot is authoritative for buffer identity and active state. Selection
+// requests a normal buffer switch and never mutates buffer contents.
+
 pub fn activate() {
     red::add_command("BufferPicker", buffer_picker, Json {
         title: "Open buffer picker",

--- a/plugins/cool_search.hk
+++ b/plugins/cool_search.hk
@@ -1,3 +1,8 @@
+// Search-match decoration lifecycle for the active editor search.
+//
+// Search and cursor events replace one decoration namespace atomically. Leaving a
+// search-related mode clears that namespace so highlights cannot survive stale state.
+
 pub fn activate() {
     red::on("search:highlighted", search_highlighted);
     red::on("search:cleared", search_cleared);

--- a/plugins/fidget.hk
+++ b/plugins/fidget.hk
@@ -1,3 +1,9 @@
+// Compact LSP progress overlay with grouped tokens and bounded animation timers.
+//
+// Progress tokens are scoped by server identity, terminal resizes recompute placement,
+// and completion schedules removal rather than blocking the editor. Deactivation cancels
+// animation and completion timers before removing the overlay.
+
 pub fn activate() {
     red::on("editor:resize", resized);
     red::on("lsp:progress", progress);

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -1,3 +1,11 @@
+// Full-screen Git workspace, gutter signs, hunk actions, and repository operation UI.
+//
+// All Git commands run through the plugin process permission boundary without a shell.
+// Destructive or history-changing actions pass through explicit confirmation, operation
+// responses are correlated by plugin-owned process state, and unsaved-buffer hunk work
+// uses editor text rather than assuming disk is authoritative. Deactivation cancels
+// watchers, processes, timers, panels, workspace state, and gutter namespaces.
+
 pub fn activate() {
     red::add_command("GitDashboard", dashboard, Json {
         title: "Open Git dashboard",

--- a/plugins/indent_guides.hk
+++ b/plugins/indent_guides.hk
@@ -1,3 +1,9 @@
+// Viewport-scoped indentation and active-scope decorations.
+//
+// The plugin consumes the editor's width-aware viewport snapshot, measures indentation
+// in display columns, and replaces one namespace per refresh. It does not infer cursor
+// coordinates from UTF-8 bytes, and deactivate clears every guide atomically.
+
 pub fn activate() {
     red::on("editor:ready", refresh);
     red::on("editor:state_restored", refresh);

--- a/plugins/inlay_hints.hk
+++ b/plugins/inlay_hints.hk
@@ -1,3 +1,9 @@
+// Debounced LSP inlay hints rendered as line decorations.
+//
+// Viewport, editor-info, and response snapshots must refer to the same requested state
+// before rendering. Request IDs reject stale LSP results, and deactivation cancels the
+// pending timeout and clears the decoration namespace.
+
 pub fn activate() {
     red::on("buffer:changed", schedule_refresh);
     red::on("file:opened", schedule_refresh);

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -1,3 +1,9 @@
+// Document-symbol, workspace-symbol, and reference pickers backed by LSP requests.
+//
+// Picker rows retain serialized source locations and open them through the plugin
+// location contract, including explicit column encoding. Live workspace queries replace
+// results for the active picker instead of creating competing dialogs.
+
 pub fn activate() {
     red::add_command("LspDocumentSymbols", document_symbols, Json {
         title: "Show document symbols",

--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -1,3 +1,10 @@
+// Watched project tree panel with lazy directory expansion and Git status decoration.
+//
+// Directory listings are authoritative snapshots supplied by Rust and may be truncated.
+// Reveal walks one path segment at a time, watchers follow the displayed root, and row
+// IDs are normalized project-relative paths. Deactivation stops watching and removes the
+// panel without changing files.
+
 pub fn activate() {
     red::add_command("NeoTree", neotree, Json {
         title: "Toggle file tree",

--- a/plugins/project_search.hk
+++ b/plugins/project_search.hk
@@ -1,3 +1,9 @@
+// Debounced project search picker and export panel backed by a permitted ripgrep process.
+//
+// A new query cancels older process and timer state, parsed matches retain byte-encoded
+// locations explicitly, and refreshes are batched to protect the editor loop. Query
+// history is plugin storage, while result text belongs to the current process only.
+
 pub fn activate() {
     red::add_command("ProjectSearch", project_search, Json {
         title: "Search project",

--- a/plugins/session_restore.hk
+++ b/plugins/session_restore.hk
@@ -1,3 +1,10 @@
+// Thin Husk lifecycle adapter for core-owned crash recovery and editor-state restore.
+//
+// Rust owns durable snapshots and safety checks. This plugin only decides whether startup
+// context should offer restoration and forwards accepted state through the host request
+// boundary. `before_exit` stores presentation-compatible state but does not write dirty
+// buffers to their backing files.
+
 pub fn activate() {
     red::on("editor:ready", ready);
     red::state_set("session_snapshot", red::null());

--- a/plugins/theme_browser.hk
+++ b/plugins/theme_browser.hk
@@ -1,3 +1,9 @@
+// Live theme picker with preview, cancellation rollback, and final persistence.
+//
+// The original theme is retained until selection. Query movement previews a candidate,
+// cancellation restores the original, and only explicit selection persists the chosen
+// theme through the core configuration boundary.
+
 pub fn activate() {
     red::add_command("ThemeBrowser", theme_browser, Json {
         title: "Browse themes",

--- a/src/agent_check.rs
+++ b/src/agent_check.rs
@@ -6,22 +6,33 @@ use serde::Serialize;
 
 use crate::{codex, config::Config};
 
+/// Minimum Codex CLI version tested with Red's dynamic-tool app-server contract.
 pub const MINIMUM_CODEX_VERSION: &str = "0.144.1";
 
+/// Offline prerequisite report for the direct Codex integration.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AgentCheckReport {
+    /// Whether agent features are enabled by configuration.
     pub enabled: bool,
+    /// Configured executable name or path.
     pub command: String,
+    /// Executable resolved from the configured command.
     pub executable: Option<PathBuf>,
+    /// Raw version output reported by the installed CLI.
     pub installed_version: Option<String>,
+    /// Minimum accepted semantic version.
     pub minimum_version: String,
+    /// Human-readable authentication expectation.
     pub authentication: String,
+    /// Whether executable discovery and version checks passed.
     pub production_ready: bool,
+    /// Actionable findings in display order.
     pub messages: Vec<String>,
 }
 
 impl AgentCheckReport {
     #[must_use]
+    /// Formats a stable multiline report for terminal output.
     pub fn format(&self) -> String {
         let mut lines = vec![
             format!(
@@ -53,11 +64,16 @@ impl AgentCheckReport {
 }
 
 #[must_use]
+/// Resolves a configured executable without launching or installing it.
 pub fn find_executable_on_path(command: &str) -> Option<PathBuf> {
     codex::find_executable(command)
 }
 
 #[must_use]
+/// Performs the offline executable and version readiness check.
+///
+/// Authentication is intentionally not attempted; the first live app-server session
+/// verifies the account.
 pub fn run(config: &Config) -> AgentCheckReport {
     let command = config
         .agent

--- a/src/agent_tools.rs
+++ b/src/agent_tools.rs
@@ -11,7 +11,9 @@ pub const MAX_EDITOR_EDITS: usize = 128;
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EditorPosition {
+    /// Zero-based line.
     pub line: usize,
+    /// Zero-based UTF-16 code-unit offset within the line.
     pub character: usize,
 }
 
@@ -19,8 +21,11 @@ pub struct EditorPosition {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct EditorTextEdit {
+    /// Inclusive start position.
     pub start: EditorPosition,
+    /// Exclusive end position.
     pub end: EditorPosition,
+    /// Replacement UTF-8 text.
     pub new_text: String,
 }
 
@@ -28,9 +33,12 @@ pub struct EditorTextEdit {
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EditorSelectionKind {
+    /// Characterwise visual selection.
     #[default]
     Character,
+    /// Whole-line visual selection.
     Line,
+    /// Rectangular visual-block selection.
     Block,
 }
 
@@ -38,13 +46,21 @@ pub enum EditorSelectionKind {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EditorActionName {
+    /// Request the active language server's definition target.
     GoToDefinition,
+    /// Request hover information at the active cursor.
     Hover,
+    /// Request fresh diagnostics for the active document.
     RefreshDiagnostics,
+    /// Request signature help at the active cursor.
     SignatureHelp,
+    /// Move backward in the editor jumplist.
     JumpBack,
+    /// Move forward in the editor jumplist.
     JumpForward,
+    /// Activate the next buffer.
     NextBuffer,
+    /// Activate the previous buffer.
     PreviousBuffer,
 }
 
@@ -52,29 +68,46 @@ pub enum EditorActionName {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "tool", rename_all = "snake_case", deny_unknown_fields)]
 pub enum EditorToolCall {
+    /// Read a bounded snapshot of active editor state.
     GetEditorState {},
+    /// Open a workspace file and reveal a UTF-16 position.
     OpenFile {
+        /// Workspace-relative or accepted absolute path.
         path: String,
+        /// Zero-based destination line.
         #[serde(default)]
         line: usize,
+        /// Zero-based UTF-16 destination offset.
         #[serde(default)]
         character: usize,
+        /// Window placement requested for the file.
         #[serde(default)]
         target: EditorOpenTarget,
     },
+    /// Open a file and create a visual selection.
     SelectText {
+        /// Workspace file containing the selection.
         path: String,
+        /// Inclusive UTF-16 selection start.
         start: EditorPosition,
+        /// Exclusive UTF-16 selection end.
         end: EditorPosition,
+        /// Requested visual selection mode.
         #[serde(default)]
         kind: EditorSelectionKind,
     },
+    /// Stage atomic, revision-checked replacements as a reviewable proposal.
     ApplyEdits {
+        /// Workspace file to change.
         path: String,
+        /// Visible buffer revision on which the edits were based.
         expected_revision: u64,
+        /// Non-overlapping half-open UTF-16 replacements.
         edits: Vec<EditorTextEdit>,
     },
+    /// Invoke one allow-listed non-mutating editor or LSP action.
     RunEditorAction {
+        /// Registered safe action.
         action: EditorActionName,
     },
 }
@@ -95,11 +128,13 @@ impl EditorToolCall {
     }
 
     #[must_use]
+    /// Returns whether the call stages textual edits.
     pub fn is_edit(&self) -> bool {
         matches!(self, Self::ApplyEdits { .. })
     }
 
     #[must_use]
+    /// Formats a bounded user-facing description of the in-progress call.
     pub fn activity_title(&self) -> String {
         match self {
             Self::GetEditorState {} => "Inspecting editor state".to_string(),
@@ -117,9 +152,12 @@ impl EditorToolCall {
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EditorOpenTarget {
+    /// Reuse the active window.
     #[default]
     Current,
+    /// Open in a horizontal split.
     Horizontal,
+    /// Open in a vertical split.
     Vertical,
 }
 
@@ -127,7 +165,9 @@ pub enum EditorOpenTarget {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct EditorToolRequest {
+    /// Active Codex session that owns the call and any resulting proposal.
     pub session_id: String,
+    /// Strictly parsed semantic operation.
     #[serde(flatten)]
     pub call: EditorToolCall,
 }
@@ -135,7 +175,9 @@ pub struct EditorToolRequest {
 /// One bounded request waiting for the editor main loop to produce a result.
 #[derive(Debug)]
 pub struct PendingEditorTool {
+    /// Request to execute on the editor owner task.
     pub request: EditorToolRequest,
+    /// One-shot result channel back to the Codex worker.
     pub response: oneshot::Sender<Result<Value, String>>,
 }
 

--- a/src/agent_workspace.rs
+++ b/src/agent_workspace.rs
@@ -59,37 +59,65 @@ struct TextChange {
     replacement: String,
 }
 
+/// One reviewable diff hunk computed against a proposal's stable base contents.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProposalHunk {
+    /// Stable content-derived hunk identifier used by review actions.
     pub id: String,
+    /// Normalized path relative to the proposal workspace.
     pub path: PathBuf,
+    /// One-based first line in the base image.
     pub old_start: usize,
+    /// One-based exclusive end line in the base image.
     pub old_end: usize,
+    /// Base text displayed for removal.
     pub old_text: String,
+    /// Proposed replacement text.
     pub new_text: String,
 }
 
+/// Result of staging or applying a complete proposal selection.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ProposalDisposition {
+    /// Proposal can be applied against the current visible contents.
     Applied {
+        /// Normalized workspace path.
         path: PathBuf,
+        /// Complete accepted result.
         contents: String,
+        /// Visible contents against which acceptance was prepared.
         current_contents: String,
+        /// Visible revision at proposal creation.
         base_revision: u64,
+        /// Owning agent session.
         session_id: String,
+        /// Turn that last changed the proposal.
         turn_id: String,
+        /// Whether the proposal creates a previously absent file.
         created: bool,
     },
+    /// Current visible contents overlap changes made from the proposal base.
     Conflict {
+        /// Normalized workspace path.
         path: PathBuf,
+        /// Stable contents from which the proposal was produced.
         base: String,
+        /// Current editor-visible contents.
         current: String,
+        /// Complete proposed contents.
         proposed: String,
     },
+    /// Selection produced no effective textual change.
     NoChanges,
 }
 
+/// Two-phase acceptance token that must be committed after the editor change succeeds.
+///
+/// Staging computes and validates the disposition without mutating proposal state.
+/// [`ProposalWorkspace::commit_acceptance`] consumes this token only after the editor has
+/// applied the attributed transaction, preventing review state from getting ahead of the
+/// visible buffer.
 #[derive(Debug, Clone)]
 pub struct StagedProposalAcceptance {
     disposition: ProposalDisposition,
@@ -101,6 +129,7 @@ pub struct StagedProposalAcceptance {
 
 impl StagedProposalAcceptance {
     #[must_use]
+    /// Returns the validated outcome the editor should apply or display.
     pub fn disposition(&self) -> &ProposalDisposition {
         &self.disposition
     }
@@ -118,6 +147,10 @@ pub struct ProposalWorkspace {
     generation: u64,
 }
 
+/// Serializable proposal state included in crash-recovery snapshots.
+///
+/// Restored sessions begin archived and must be explicitly adopted by a new live session
+/// before review actions can address them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProposalWorkspaceSnapshot {
     root: PathBuf,
@@ -153,16 +186,19 @@ impl ProposalWorkspace {
     }
 
     #[must_use]
+    /// Returns the pinned physical workspace root.
     pub fn root(&self) -> &Path {
         &self.root
     }
 
     #[must_use]
+    /// Returns a monotonic generation for snapshot invalidation.
     pub fn generation(&self) -> u64 {
         self.generation
     }
 
     #[must_use]
+    /// Captures visible files, session proposals, and ownership metadata.
     pub fn snapshot(&self) -> ProposalWorkspaceSnapshot {
         ProposalWorkspaceSnapshot {
             root: self.root.clone(),
@@ -172,6 +208,7 @@ impl ProposalWorkspace {
     }
 
     #[must_use]
+    /// Restores archived proposal state without reading or writing workspace files.
     pub fn from_snapshot(snapshot: ProposalWorkspaceSnapshot) -> Self {
         let recovered_sessions = snapshot.sessions.keys().cloned().collect();
         Self {
@@ -257,6 +294,10 @@ impl ProposalWorkspace {
         Ok(())
     }
 
+    /// Reads authoritative contents for one session, optionally sliced by lines.
+    ///
+    /// A session with a staged proposal reads that proposal; otherwise the visible
+    /// buffer or safely read disk file becomes its stable base.
     pub fn read(
         &mut self,
         session_id: &str,
@@ -269,6 +310,9 @@ impl ProposalWorkspace {
         Ok(slice_lines(&proposal.proposed_contents, line, limit))
     }
 
+    /// Replaces the session's complete proposed contents for one workspace file.
+    ///
+    /// The write is in-memory, bounded, and does not mutate an editor buffer or disk.
     pub fn write(&mut self, session_id: &str, path: &Path, contents: String) -> anyhow::Result<()> {
         let path = self.normalize_path(path)?;
         anyhow::ensure!(
@@ -338,6 +382,7 @@ impl ProposalWorkspace {
         self.hunks(session_id, &path, &current_contents)
     }
 
+    /// Marks the active turn used to attribute subsequent proposal changes.
     pub fn begin_turn(&mut self, session_id: &str, turn_id: String) {
         self.adopt_recovered_sessions(session_id);
         let session = self.sessions.entry(session_id.to_string()).or_default();
@@ -347,6 +392,7 @@ impl ProposalWorkspace {
         }
     }
 
+    /// Drops all proposal state for a live session.
     pub fn close_session(&mut self, session_id: &str) {
         let changed = self.sessions.remove(session_id).is_some();
         self.recovered_sessions.remove(session_id);
@@ -356,6 +402,7 @@ impl ProposalWorkspace {
     }
 
     /// Retain reviewable proposals when their agent session closes; discard empty sessions.
+    /// Archives a session so its pending proposals remain reviewable after process loss.
     pub fn archive_session(&mut self, session_id: &str) {
         let Some(session) = self.sessions.get_mut(session_id) else {
             self.recovered_sessions.remove(session_id);
@@ -378,6 +425,7 @@ impl ProposalWorkspace {
 
     /// Return the active session and every archived session with reviewable changes.
     #[must_use]
+    /// Returns the live and recovered session IDs visible to a review session.
     pub fn review_sessions(&self, session_id: &str) -> Vec<String> {
         let mut sessions = self
             .recovered_sessions
@@ -396,6 +444,9 @@ impl ProposalWorkspace {
     /// Attach non-conflicting archived proposals to a replacement agent session.
     ///
     /// Archived sessions that overlap an existing proposal remain independently reviewable.
+    /// Transfers every archived recovered session into a new live review session.
+    ///
+    /// Returns the number of recovered sessions adopted.
     pub fn adopt_recovered_sessions(&mut self, session_id: &str) -> usize {
         if session_id.is_empty() {
             return 0;
@@ -441,11 +492,13 @@ impl ProposalWorkspace {
 
     /// Read the current on-disk contents of an unopened proposal file without following
     /// symlinks, blocking on special files, or exceeding the agent content bound.
+    /// Returns current authoritative contents without creating a session proposal.
     pub fn read_current_file(&self, path: &Path) -> anyhow::Result<Option<String>> {
         let path = self.normalize_path(path)?;
         read_bounded_file(self, &path)
     }
 
+    /// Lists normalized files with effective pending changes for a review session.
     pub fn pending_files(&self, session_id: &str) -> Vec<PathBuf> {
         let mut files = self
             .sessions
@@ -459,6 +512,7 @@ impl ProposalWorkspace {
         files
     }
 
+    /// Computes review hunks for one pending file without mutating proposal state.
     pub fn hunks(
         &self,
         session_id: &str,
@@ -486,6 +540,10 @@ impl ProposalWorkspace {
             .collect())
     }
 
+    /// Accepts a complete file proposal and immediately advances proposal state.
+    ///
+    /// Editor code should prefer two-phase staging and commit so a failed attributed edit
+    /// cannot consume the proposal.
     pub fn accept_all(
         &mut self,
         session_id: &str,
@@ -500,6 +558,7 @@ impl ProposalWorkspace {
         Ok(disposition)
     }
 
+    /// Validates and stages complete-file acceptance without mutating proposal state.
     pub fn stage_accept_all(
         &self,
         session_id: &str,
@@ -556,6 +615,9 @@ impl ProposalWorkspace {
         })
     }
 
+    /// Accepts one hunk and immediately advances proposal state.
+    ///
+    /// Editor code should prefer two-phase staging and commit.
     pub fn accept_hunk(
         &mut self,
         session_id: &str,
@@ -576,6 +638,7 @@ impl ProposalWorkspace {
         Ok(disposition)
     }
 
+    /// Validates and stages one-hunk acceptance without mutating proposal state.
     pub fn stage_accept_hunk(
         &self,
         session_id: &str,
@@ -634,6 +697,10 @@ impl ProposalWorkspace {
         })
     }
 
+    /// Commits a previously staged acceptance token.
+    ///
+    /// The token must still match proposal state; concurrent proposal changes are
+    /// rejected rather than silently discarded.
     pub fn commit_acceptance(
         &mut self,
         acceptance: StagedProposalAcceptance,
@@ -650,6 +717,7 @@ impl ProposalWorkspace {
         Ok(())
     }
 
+    /// Rejects all proposed changes for one file.
     pub fn reject_all(
         &mut self,
         session_id: &str,
@@ -661,6 +729,7 @@ impl ProposalWorkspace {
         self.reset_file(session_id, &path, current_revision, current_contents)
     }
 
+    /// Rejects one hunk while retaining other changes in the same proposal.
     pub fn reject_hunk(
         &mut self,
         session_id: &str,
@@ -940,6 +1009,7 @@ pub struct ProposalToolHost {
 
 impl ProposalToolHost {
     #[must_use]
+    /// Creates a dynamic-tool host for shared proposal state.
     pub fn new(workspace: Arc<Mutex<ProposalWorkspace>>) -> Self {
         Self {
             workspace,
@@ -948,11 +1018,13 @@ impl ProposalToolHost {
     }
 
     #[must_use]
+    /// Returns a clone of the shared proposal workspace handle.
     pub fn workspace(&self) -> Arc<Mutex<ProposalWorkspace>> {
         Arc::clone(&self.workspace)
     }
 
     #[must_use]
+    /// Adds the bounded channel used to dispatch editor-owned tools.
     pub fn with_editor_tools(mut self, editor_tools: mpsc::Sender<PendingEditorTool>) -> Self {
         self.editor_tools = Some(editor_tools);
         self

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,3 +1,11 @@
+//! Resolution and extraction of Red's embedded, development, and user runtime assets.
+//!
+//! Plugins and themes resolve in the order user configuration, `RED_RUNTIME`, then
+//! embedded assets. Listing reports shadowed sources, while ejection copies a resolved
+//! non-user asset into the user directory for customization. All public lookup paths are
+//! relative asset specifiers; accepting parent traversal would let a runtime operation
+//! escape the configured asset roots.
+
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     env,
@@ -8,6 +16,7 @@ use std::{
 
 use include_dir::{include_dir, Dir};
 
+/// Complete configuration defaults embedded in the Red binary.
 pub const DEFAULT_CONFIG: &str = include_str!("../default_config.toml");
 
 static THEMES: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/themes");
@@ -17,12 +26,16 @@ const BUNDLED_PLUGIN_SCHEME: &str = "red-bundled";
 const STARTER_CONFIG_HEADER: &str = "# Red user config.\n# Defaults are built into this version of red.\n# Uncomment settings below to override them.\n# Uncomment the matching table header, such as [keys.normal], with any setting inside it.\n\n";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Category of runtime file resolved by the asset system.
 pub enum RuntimeAssetKind {
+    /// Husk plugin source.
     Plugin,
+    /// JSON theme definition.
     Theme,
 }
 
 impl RuntimeAssetKind {
+    /// Returns the directory component used for this asset category.
     pub fn dir_name(self) -> &'static str {
         match self {
             Self::Plugin => "plugins",
@@ -75,9 +88,13 @@ impl RuntimeAssetKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Layer that supplied a resolved runtime asset.
 pub enum RuntimeAssetSource {
+    /// User configuration directory; highest precedence.
     User,
+    /// Development directory selected by `RED_RUNTIME`.
     Runtime,
+    /// File compiled into the Red binary; lowest precedence.
     Embedded,
 }
 
@@ -102,19 +119,25 @@ impl Display for RuntimeAssetSource {
 }
 
 #[derive(Debug, Clone)]
+/// One runtime asset selected according to Red's precedence rules.
 pub struct ResolvedRuntimeAsset {
+    /// Asset category.
     pub kind: RuntimeAssetKind,
+    /// Safe relative file name.
     pub file: String,
+    /// Winning source layer.
     pub source: RuntimeAssetSource,
     path: Option<PathBuf>,
     embedded_contents: Option<&'static str>,
 }
 
 impl ResolvedRuntimeAsset {
+    /// Returns the filesystem path, or `None` for an embedded asset.
     pub fn path(&self) -> Option<&Path> {
         self.path.as_deref()
     }
 
+    /// Reads filesystem content or clones the embedded source.
     pub fn read_to_string(&self) -> anyhow::Result<String> {
         if let Some(contents) = self.embedded_contents {
             return Ok(contents.to_string());
@@ -127,6 +150,9 @@ impl ResolvedRuntimeAsset {
         Ok(fs::read_to_string(path)?)
     }
 
+    /// Returns a filesystem path or private bundled URI suitable for the Husk loader.
+    ///
+    /// Returns an error when called for a theme.
     pub fn plugin_specifier(&self) -> anyhow::Result<String> {
         anyhow::ensure!(
             self.kind == RuntimeAssetKind::Plugin,
@@ -144,14 +170,21 @@ impl ResolvedRuntimeAsset {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// One asset-list row including shadowed lower-precedence sources.
 pub struct RuntimeAssetListEntry {
+    /// Asset category.
     pub kind: RuntimeAssetKind,
+    /// Safe relative file name.
     pub file: String,
+    /// Theme display name parsed from JSON, when available.
     pub name: Option<String>,
+    /// Winning source layer.
     pub source: RuntimeAssetSource,
+    /// Lower-precedence sources hidden by `source`.
     pub shadows: Vec<RuntimeAssetSource>,
 }
 
+/// Produces a commented copy of embedded defaults for a new user config.
 pub fn starter_config() -> String {
     let mut out = String::from(STARTER_CONFIG_HEADER);
 
@@ -168,14 +201,19 @@ pub fn starter_config() -> String {
     out
 }
 
+/// Resolves a theme by display file name and precedence.
 pub fn resolve_theme(name: &str, config_dir: &Path) -> Option<ResolvedRuntimeAsset> {
     resolve_runtime_asset(RuntimeAssetKind::Theme, name, config_dir)
 }
 
+/// Resolves a plugin by display file name and precedence.
 pub fn resolve_plugin(name: &str, config_dir: &Path) -> Option<ResolvedRuntimeAsset> {
     resolve_runtime_asset(RuntimeAssetKind::Plugin, name, config_dir)
 }
 
+/// Resolves an asset from user, development runtime, then embedded layers.
+///
+/// Unsafe or category-incompatible relative paths return `None`.
 pub fn resolve_runtime_asset(
     kind: RuntimeAssetKind,
     name: &str,
@@ -184,6 +222,10 @@ pub fn resolve_runtime_asset(
     resolve_runtime_asset_with_user(kind, name, config_dir, true)
 }
 
+/// Resolves an asset while excluding the user layer.
+///
+/// This is the source selection used by ejection so an existing customized
+/// file is never copied onto itself.
 pub fn resolve_non_user_runtime_asset(
     kind: RuntimeAssetKind,
     name: &str,
@@ -192,10 +234,12 @@ pub fn resolve_non_user_runtime_asset(
     resolve_runtime_asset_with_user(kind, name, config_dir, false)
 }
 
+/// Returns an embedded theme's JSON source.
 pub fn bundled_theme(name: &str) -> Option<&'static str> {
     embedded_contents(RuntimeAssetKind::Theme, name)
 }
 
+/// Lists all public embedded theme files and their JSON source.
 pub fn bundled_theme_files() -> Vec<(&'static str, &'static str)> {
     embedded_files(RuntimeAssetKind::Theme)
         .into_iter()
@@ -205,6 +249,7 @@ pub fn bundled_theme_files() -> Vec<(&'static str, &'static str)> {
         .collect()
 }
 
+/// Converts an embedded plugin file name into the private loader URI.
 pub fn bundled_plugin_specifier(name: &str) -> Option<String> {
     let path = safe_relative_path(name)?;
     PLUGINS
@@ -212,15 +257,18 @@ pub fn bundled_plugin_specifier(name: &str) -> Option<String> {
         .map(|_| format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/{path}"))
 }
 
+/// Resolves a private bundled plugin URI back to embedded source.
 pub fn bundled_plugin_contents(specifier: &str) -> Option<&'static str> {
     let path = specifier.strip_prefix(&format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/"))?;
     embedded_contents(RuntimeAssetKind::Plugin, path)
 }
 
+/// Returns whether a specifier uses Red's private embedded-plugin scheme.
 pub fn is_bundled_plugin_specifier(specifier: &str) -> bool {
     specifier.starts_with(&format!("{BUNDLED_PLUGIN_SCHEME}:///plugins/"))
 }
 
+/// Lists effective assets and all lower-precedence shadowed sources.
 pub fn list_runtime_assets(
     kind: RuntimeAssetKind,
     config_dir: &Path,
@@ -281,6 +329,7 @@ pub fn list_runtime_assets(
     Ok(entries)
 }
 
+/// Formats the runtime asset inventory used by `red --runtime-files`.
 pub fn format_runtime_files(config_dir: &Path) -> anyhow::Result<String> {
     let mut out = String::new();
 
@@ -325,6 +374,10 @@ pub fn format_runtime_files(config_dir: &Path) -> anyhow::Result<String> {
     Ok(out)
 }
 
+/// Copies a development or embedded asset into the user configuration layer.
+///
+/// The asset path must name `plugins/<file>` or `themes/<file>`. Existing
+/// targets are preserved unless `force` is true.
 pub fn eject_runtime_asset(asset: &str, config_dir: &Path, force: bool) -> anyhow::Result<PathBuf> {
     let (kind, file) = parse_asset_path(asset)?;
     let target = config_dir.join(kind.dir_name()).join(&file);
@@ -351,6 +404,7 @@ pub fn eject_runtime_asset(asset: &str, config_dir: &Path, force: bool) -> anyho
     Ok(target)
 }
 
+/// Appends unshadowed bundled themes after user-provided theme entries.
 pub fn dedupe_theme_entries(
     user_entries: impl IntoIterator<Item = (String, String)>,
 ) -> Vec<(String, String)> {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,3 +1,16 @@
+//! Editable text storage and the raw mutation seam beneath editor transactions.
+//!
+//! A [`Buffer`] stores UTF-8 text in a Ropey rope, assigns it a stable process-local
+//! [`BufferId`], and tracks content revision, dirty state, cursor fallback state, and
+//! buffer-local [`UndoHistory`]. Public positions used for edits are line plus Unicode
+//! scalar index; display columns and grapheme cursor positions must be converted before
+//! entering this module.
+//!
+//! Methods such as [`Buffer::replace_range_raw`] mutate text without opening an undo
+//! transaction or notifying LSP and plugins. Production features must call the editor's
+//! transaction boundary instead; raw replacement exists for that boundary and for
+//! controlled undo/redo replay.
+
 use ropey::Rope;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -25,11 +38,16 @@ impl BufferId {
     }
 }
 
+/// Half-open regular-expression match in zero-based line and scalar coordinates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SearchMatch {
+    /// Inclusive Unicode scalar index on `start_y`.
     pub start_x: usize,
+    /// Zero-based start line.
     pub start_y: usize,
+    /// Exclusive Unicode scalar index on `end_y`.
     pub end_x: usize,
+    /// Zero-based end line.
     pub end_y: usize,
 }
 
@@ -112,6 +130,11 @@ impl Buffer {
         }
     }
 
+    /// Loads an existing UTF-8 file or creates an unsaved buffer for a missing path.
+    ///
+    /// A path whose directory entry exists but cannot be followed as a regular file is
+    /// an error rather than a new-file buffer. The method reads synchronously despite its
+    /// async signature and does not create the file on disk.
     pub async fn load_or_create(file: Option<String>) -> anyhow::Result<Self> {
         match &file {
             Some(file) => {
@@ -133,6 +156,10 @@ impl Buffer {
         }
     }
 
+    /// Replaces the buffer with its current file contents and clears undo history.
+    ///
+    /// The method increments the content revision but does not notify LSP or plugins.
+    /// It fails for unnamed, missing, unreadable, or non-UTF-8 files.
     pub fn reload_from_file(&mut self) -> anyhow::Result<String> {
         let Some(file) = self.file.clone() else {
             return Err(anyhow::anyhow!("No file name"));
@@ -235,6 +262,7 @@ impl Buffer {
         end_byte.saturating_sub(start_byte)
     }
 
+    /// Returns the monotonic content revision used to invalidate external caches.
     pub fn revision(&self) -> u64 {
         self.revision
     }
@@ -255,10 +283,12 @@ impl Buffer {
         buffer
     }
 
+    /// Returns the stable process-local buffer identity.
     pub fn id(&self) -> BufferId {
         self.id
     }
 
+    /// Finds every regex match and converts byte offsets into line and scalar coordinates.
     pub fn regex_matches(&self, regex: &Regex) -> Vec<SearchMatch> {
         let contents = self.contents();
         let bytes = contents.as_bytes();
@@ -388,6 +418,7 @@ impl Buffer {
         Ok(message)
     }
 
+    /// Returns the display name used by buffer and status UI.
     pub fn name(&self) -> &str {
         self.file.as_deref().unwrap_or("[No Name]")
     }
@@ -404,6 +435,9 @@ impl Buffer {
         self.content.len_bytes() <= 1 && self.content.chars().all(|c| c == '\n')
     }
 
+    /// Returns a file URI for named buffers and `None` for unnamed buffers.
+    ///
+    /// Invalid or non-absolute file paths are reported as conversion errors.
     pub fn uri(&self) -> anyhow::Result<Option<String>> {
         let Some(file) = &self.file else {
             return Ok(None);
@@ -441,10 +475,12 @@ impl Buffer {
         self.content.len_lines() - 1
     }
 
+    /// Returns the UTF-8 byte length of the complete buffer.
     pub fn byte_len(&self) -> usize {
         self.content.len_bytes()
     }
 
+    /// Returns the last line that can hold an editor cursor.
     pub fn last_navigable_line(&self) -> usize {
         let last_line = self.len();
         if last_line > 0 && self.get(last_line).is_some_and(|line| line.is_empty()) {
@@ -454,6 +490,7 @@ impl Buffer {
         }
     }
 
+    /// Returns the logical line count after excluding Ropey's synthetic trailing line.
     pub fn navigable_line_count(&self) -> usize {
         self.last_navigable_line() + 1
     }
@@ -510,6 +547,9 @@ impl Buffer {
         }
     }
 
+    /// Removes a half-open scalar-coordinate range without opening an undo transaction.
+    ///
+    /// Production editor actions should use the canonical editor transaction boundary.
     pub fn remove_range(&mut self, x0: usize, y0: usize, x1: usize, y1: usize) {
         let start_char = self.xy_to_char_idx(x0, y0);
         let end_char = self.xy_to_char_idx(x1, y1);
@@ -517,6 +557,7 @@ impl Buffer {
         self.mark_changed();
     }
 
+    /// Returns the exact text in a half-open canonical range.
     pub fn text_in_range(&self, range: TextRange) -> String {
         let start_char = self.position_to_char_idx(range.start);
         let end_char = self.position_to_char_idx(range.end);
@@ -532,6 +573,11 @@ impl Buffer {
             .is_some_and(|slice| slice == text)
     }
 
+    /// Applies a replacement directly and advances the buffer revision.
+    ///
+    /// This method does not record undo history, update marks, refresh dirty state, or
+    /// notify external consumers. Using it from a new action handler would create an
+    /// untracked edit; production changes must go through `Editor::replace_range`.
     pub fn replace_range_raw(&mut self, range: TextRange, text: &str) {
         let start_char = self.position_to_char_idx(range.start);
         let end_char = self.position_to_char_idx(range.end);
@@ -540,6 +586,7 @@ impl Buffer {
         self.mark_changed();
     }
 
+    /// Computes the half-open range occupied by `text` when inserted at `start`.
     pub fn range_for_text(&self, start: TextPosition, text: &str) -> TextRange {
         let mut line = start.line;
         let mut character = start.character;
@@ -556,6 +603,9 @@ impl Buffer {
         TextRange::new(start, TextPosition::new(line, character))
     }
 
+    /// Converts a canonical line and scalar position to an absolute Ropey character index.
+    ///
+    /// Positions beyond the current buffer clamp to its final character boundary.
     pub fn position_to_char_idx(&self, position: TextPosition) -> usize {
         if position.line >= self.content.len_lines() {
             return self.content.len_chars();
@@ -566,6 +616,9 @@ impl Buffer {
         line_start + position.character.min(line_len)
     }
 
+    /// Converts an absolute Ropey character index to a canonical line and scalar position.
+    ///
+    /// Indexes beyond the current buffer clamp to its final character boundary.
     pub fn char_idx_to_position(&self, char_index: usize) -> TextPosition {
         let char_index = char_index.min(self.content.len_chars());
         let line = self.content.char_to_line(char_index);
@@ -948,10 +1001,12 @@ impl Buffer {
         self.dirty
     }
 
+    /// Recomputes the public dirty flag from undo history's saved revision.
     pub fn refresh_dirty_from_history(&mut self) {
         self.dirty = self.undo_history.is_dirty();
     }
 
+    /// Marks the current history revision as saved and clears the public dirty flag.
     pub fn mark_saved(&mut self) {
         self.undo_history.mark_saved();
         self.refresh_dirty_from_history();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,10 @@
+//! Command-line contract for interactive, utility, recovery, and detach modes.
+//!
+//! Clap enforces syntactic conflicts while [`Args::validate_utility_args`] handles
+//! constraints that depend on positional files. Hidden flags are internal process
+//! boundaries rather than supported interactive workflows, so callers should prefer the
+//! public modes documented by the CLI.
+
 use clap::Parser;
 
 #[derive(Debug, Parser)]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,16 +1,29 @@
+//! Replaceable clipboard boundary for native operation, disabled environments, and tests.
+//!
+//! [`ClipboardProvider`] keeps platform clipboard failures outside editor logic.
+//! [`NativeClipboardProvider`] delegates to the operating system, while the disabled and
+//! in-memory implementations give headless or test callers predictable behavior.
+
 use anyhow::Context;
 use std::sync::{Arc, Mutex};
 
+/// Fallible text clipboard operations required by the editor.
 pub trait ClipboardProvider: Send {
+    /// Reads the current text value, returning `None` when no text is available.
     fn get_text(&mut self) -> anyhow::Result<Option<String>>;
+    /// Replaces the current text value.
     fn set_text(&mut self, text: &str) -> anyhow::Result<()>;
 }
 
+/// Operating-system clipboard provider backed by `arboard`.
 pub struct NativeClipboardProvider {
     clipboard: arboard::Clipboard,
 }
 
 impl NativeClipboardProvider {
+    /// Connects to the platform clipboard service.
+    ///
+    /// Construction fails when no supported display or clipboard service is available.
     pub fn new() -> anyhow::Result<Self> {
         Ok(Self {
             clipboard: arboard::Clipboard::new()
@@ -35,6 +48,7 @@ impl ClipboardProvider for NativeClipboardProvider {
     }
 }
 
+/// Provider that treats clipboard operations as explicitly unavailable no-ops.
 pub struct DisabledClipboardProvider;
 
 impl ClipboardProvider for DisabledClipboardProvider {
@@ -48,17 +62,20 @@ impl ClipboardProvider for DisabledClipboardProvider {
 }
 
 #[derive(Debug, Clone, Default)]
+/// Deterministic shared-memory clipboard used by tests and embedded callers.
 pub struct MemoryClipboardProvider {
     text: Arc<Mutex<Option<String>>>,
 }
 
 impl MemoryClipboardProvider {
+    /// Creates an in-memory clipboard containing `text`.
     pub fn with_text(text: impl Into<String>) -> Self {
         let provider = Self::default();
         provider.set_shared_text(Some(text.into()));
         provider
     }
 
+    /// Returns shared storage for assertions or coordination with a test peer.
     pub fn shared_text(&self) -> Arc<Mutex<Option<String>>> {
         self.text.clone()
     }

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -48,16 +48,22 @@ const SETUP_TIMEOUT: Duration = Duration::from_secs(30);
 const TOOL_TIMEOUT: Duration = Duration::from_secs(30);
 const INSTRUCTIONS: &str = "You are Red's coding assistant. You have no shell or native patch tool. Use list_files and search_files to locate relevant code. Use get_editor_state, open_file, select_text, and run_editor_action to inspect and navigate the editor. Always use read_file before reasoning about a file, and use apply_edits or write_file for every edit. Edits are reviewable editor proposals and never touch disk. Do not claim a change was saved. Keep responses concise.";
 
+/// Exact process launch specification for one Codex app-server worker.
 #[derive(Debug, Clone)]
 pub struct CodexProcessSpec {
+    /// Resolved executable path.
     pub command: PathBuf,
+    /// Additional literal arguments appended after Red's app-server arguments.
     pub args: Vec<OsString>,
+    /// Explicit environment overrides.
     pub environment: HashMap<OsString, OsString>,
+    /// Working directory used for process launch and thread configuration.
     pub current_dir: PathBuf,
 }
 
 impl CodexProcessSpec {
     #[must_use]
+    /// Creates a launch specification with no additional arguments or environment.
     pub fn new(command: impl Into<PathBuf>, current_dir: impl Into<PathBuf>) -> Self {
         Self {
             command: command.into(),
@@ -68,79 +74,124 @@ impl CodexProcessSpec {
     }
 
     #[must_use]
+    /// Appends literal process arguments without shell expansion.
     pub fn args(mut self, args: impl IntoIterator<Item = impl Into<OsString>>) -> Self {
         self.args.extend(args.into_iter().map(Into::into));
         self
     }
 }
 
+/// Commands sent from the editor owner to the Codex worker.
 #[derive(Debug, Clone)]
 pub enum CodexCommand {
+    /// Creates an ephemeral app-server thread for a workspace.
     NewSession {
+        /// Physical workspace root.
         cwd: PathBuf,
     },
+    /// Submits plain user text to a session.
     Prompt {
+        /// Red session identifier.
         session_id: String,
+        /// User prompt.
         text: String,
     },
+    /// Submits user text with bounded editor context.
     PromptWithContext {
+        /// Red session identifier.
         session_id: String,
+        /// User prompt.
         text: String,
+        /// Active document URI.
         uri: String,
+        /// Bounded editor-provided context.
         context: String,
     },
+    /// Interrupts the active turn for a session.
     Cancel {
+        /// Red session identifier.
         session_id: String,
     },
+    /// Closes the remote thread associated with a session.
     CloseSession {
+        /// Red session identifier.
         session_id: String,
     },
+    /// Resolves a surfaced permission request with an exact offered choice.
     PermissionResponse {
+        /// App-server request identifier.
         request_id: String,
+        /// Selected option, or `None` for denial/cancellation.
         option_id: Option<String>,
     },
 }
 
+/// Events delivered from the Codex worker to the editor owner.
 #[derive(Debug, Clone)]
 pub enum CodexEvent {
+    /// A local session is associated with a started app-server thread.
     SessionCreated {
+        /// Red session identifier.
         session_id: String,
     },
+    /// Streamed assistant text for the active turn.
     Update {
+        /// Owning session.
         session_id: String,
+        /// Text delta.
         text: String,
     },
+    /// Structured activity update for tool and reasoning presentation.
     Activity {
+        /// Owning session.
         session_id: String,
+        /// Bounded app-server update payload.
         update: Value,
     },
+    /// Proposal contents changed for a session.
     ProposalsChanged {
+        /// Owning session.
         session_id: String,
     },
+    /// Active turn reached a terminal success state.
     Completed {
+        /// Owning session.
         session_id: String,
+        /// App-server stop reason.
         stop_reason: String,
     },
+    /// Active turn was interrupted.
     Cancelled {
+        /// Owning session.
         session_id: String,
     },
+    /// App-server requested a user choice that Red can safely surface.
     PermissionRequested {
+        /// App-server request identifier.
         request_id: String,
+        /// Owning session.
         session_id: String,
+        /// Descriptive tool-call payload.
         tool_call: Value,
+        /// Exact selectable options supplied by the app-server.
         options: Value,
     },
+    /// Session or worker operation failed.
     Failed {
+        /// Owning session when the failure can be attributed.
         session_id: Option<String>,
+        /// Sanitized user-facing failure message.
         message: String,
     },
 }
 
+/// Editor-side bounded command sender and non-blocking event receiver.
 pub struct CodexBridge {
     commands: mpsc::Sender<CodexCommand>,
     events: mpsc::Receiver<CodexEvent>,
 }
 
+/// Worker-side bounded command receiver and event sender.
 pub struct CodexBridgeWorker {
     commands: mpsc::Receiver<CodexCommand>,
     events: mpsc::Sender<CodexEvent>,
@@ -148,6 +199,7 @@ pub struct CodexBridgeWorker {
 
 impl CodexBridge {
     #[must_use]
+    /// Creates paired editor and worker endpoints with the supplied non-zero capacity.
     pub fn channel(capacity: NonZeroUsize) -> (Self, CodexBridgeWorker) {
         let (commands, command_rx) = mpsc::channel(capacity.get());
         let (event_tx, events) = mpsc::channel(capacity.get());
@@ -160,6 +212,7 @@ impl CodexBridge {
         )
     }
 
+    /// Sends a command with backpressure.
     pub async fn send(&self, command: CodexCommand) -> Result<()> {
         self.commands
             .send(command)
@@ -167,27 +220,32 @@ impl CodexBridge {
             .context("Codex command channel is closed")
     }
 
+    /// Attempts to send a command without waiting for channel capacity.
     pub fn try_send(&self, command: CodexCommand) -> Result<()> {
         self.commands
             .try_send(command)
             .context("Codex command channel is unavailable")
     }
 
+    /// Returns the next ready worker event without blocking.
     pub fn try_recv(&mut self) -> Option<CodexEvent> {
         self.events.try_recv().ok()
     }
 
     #[must_use]
+    /// Returns whether at least one worker event is buffered.
     pub fn has_pending_events(&self) -> bool {
         !self.events.is_empty()
     }
 }
 
 impl CodexBridgeWorker {
+    /// Waits for the next editor command or channel closure.
     pub async fn recv(&mut self) -> Option<CodexCommand> {
         self.commands.recv().await
     }
 
+    /// Sends an event to the editor with backpressure.
     pub async fn send(&self, event: CodexEvent) -> Result<()> {
         self.events
             .send(event)
@@ -197,9 +255,13 @@ impl CodexBridgeWorker {
 }
 
 #[async_trait]
+/// Editor and proposal operations exposed to bounded Codex dynamic tools.
 pub trait CodexToolHost: Send + 'static {
+    /// Reads authoritative visible or staged contents for one session.
     async fn read_file(&mut self, session_id: &str, path: &str) -> Result<Value>;
+    /// Stages complete proposed contents without mutating disk.
     async fn write_file(&mut self, session_id: &str, path: &str, content: String) -> Result<Value>;
+    /// Dispatches an editor-owned semantic tool request.
     async fn editor_tool(&mut self, request: EditorToolRequest) -> Result<Value>;
 }
 
@@ -228,6 +290,7 @@ enum InternalEvent {
     },
 }
 
+/// Starts a bounded Codex app-server worker and returns its editor bridge.
 pub fn start_codex(
     spec: CodexProcessSpec,
     host: impl CodexToolHost,

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,3 +1,9 @@
+//! Terminal color representation, parsing, blending, and contrast helpers.
+//!
+//! [`Color`] preserves terminal palette values and true-color RGB values without
+//! assuming a background. Theme and plugin code can resolve semantic choices before
+//! using these helpers for deterministic color arithmetic.
+
 use std::fmt;
 
 use serde::{Deserialize, Serialize};

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,21 +1,39 @@
+//! Parsing of built-in colon-command abbreviations, arguments, and force flags.
+//!
+//! Parsing receives the authoritative command-name list from the caller. Exact names,
+//! conventional initial-based abbreviations, and command chains are resolved before
+//! arguments are returned; unknown input fails as a whole so a partially recognized
+//! chain cannot execute unintended commands.
+
+/// Modifier parsed from a built-in colon command.
 #[derive(Debug, PartialEq)]
 pub enum CommandFlag {
+    /// The trailing `!` force modifier.
     Force,
 }
 
+/// Resolved built-in command chain, arguments, and modifiers.
 #[derive(Debug, Default, PartialEq)]
 pub struct ParsedCommand {
+    /// Canonical command names in execution order.
     pub commands: Vec<String>,
+    /// Space-separated arguments following the command token.
     pub args: Vec<String>,
+    /// Parsed command modifiers.
     pub flags: Vec<CommandFlag>,
 }
 
 impl ParsedCommand {
+    /// Returns whether the command included a trailing force modifier.
     pub fn is_forced(&self) -> bool {
         self.flags.contains(&CommandFlag::Force)
     }
 }
 
+/// Resolves a command line against the supplied canonical command names.
+///
+/// Returns `None` when any command in a chain is unknown. Arguments are split on spaces
+/// without shell quoting or expansion.
 pub fn parse(commands: &[&str], input: &str) -> Option<ParsedCommand> {
     let (flags, input) = parse_flags(input);
     let mut parts = input.splitn(2, ' ');

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,15 @@
+//! Layered configuration loading with diagnostic recovery instead of startup-wide failure.
+//!
+//! Embedded defaults form the complete baseline, user TOML applies independent
+//! overrides, and command-line fragments are strict final overrides. Invalid user
+//! fields are diagnosed and replaced by their corresponding safe defaults when that can
+//! be done independently; malformed whole-file input falls back to a deliberately
+//! restricted profile. Loading never rewrites the user's configuration.
+//!
+//! [`LoadedConfig`] retains both the usable [`Config`] and the diagnostics explaining
+//! every fallback. Runtime validation can append diagnostics through the same model so
+//! the editor has one acknowledgement and display path.
+
 use std::{
     collections::{HashMap, HashSet},
     fmt, fs, io,
@@ -13,15 +25,21 @@ use crate::editor::Action;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// User-facing importance of a recovered configuration problem.
 pub enum ConfigDiagnosticSeverity {
+    /// Configuration remains usable with a non-critical fallback.
     Warning,
+    /// The requested value could not be honored.
     Error,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Input layer that produced a configuration diagnostic.
 pub enum ConfigDiagnosticSource {
+    /// User configuration file at this path.
     UserFile(PathBuf),
+    /// Zero-based command-line override index.
     CliOverride(usize),
 }
 
@@ -35,19 +53,30 @@ impl fmt::Display for ConfigDiagnosticSource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Source-located configuration problem and the fallback Red selected.
 pub struct ConfigDiagnostic {
+    /// Diagnostic importance.
     pub severity: ConfigDiagnosticSeverity,
+    /// Stable machine-readable diagnostic code.
     pub code: String,
+    /// Configuration layer that supplied the invalid value.
     pub source: ConfigDiagnosticSource,
+    /// Byte range in the source text, when it can be recovered.
     pub span: Option<Range<usize>>,
+    /// One-based source line.
     pub line: Option<usize>,
+    /// One-based source column.
     pub column: Option<usize>,
+    /// Dotted configuration key path.
     pub path: String,
+    /// Human-readable explanation.
     pub message: String,
+    /// Safe behavior Red selected instead.
     pub fallback: String,
 }
 
 impl ConfigDiagnostic {
+    /// Formats a compact source-located diagnostic for terminal output.
     pub fn format(&self) -> String {
         let location = match (self.line, self.column) {
             (Some(line), Some(column)) => format!("{}:{line}:{column}", self.source),
@@ -68,26 +97,36 @@ impl ConfigDiagnostic {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Extent to which loading had to recover from invalid user input.
 pub enum ConfigRecovery {
+    /// Every supplied value was accepted.
     Clean,
+    /// One or more fields fell back independently.
     Partial,
+    /// The user file was unusable and a restricted fallback profile was used.
     WholeFileFallback,
 }
 
 #[derive(Debug)]
+/// Usable configuration paired with all diagnostics from layered loading.
 pub struct LoadedConfig {
+    /// Effective configuration after defaults, recovery, and overrides.
     pub config: Config,
+    /// Problems encountered while producing `config`.
     pub diagnostics: Vec<ConfigDiagnostic>,
+    /// Coarse summary of the recovery path.
     pub recovery: ConfigRecovery,
     source_path: PathBuf,
     source_text: String,
 }
 
 impl LoadedConfig {
+    /// Returns whether loading required no fallback and produced no diagnostics.
     pub fn is_clean(&self) -> bool {
         self.recovery == ConfigRecovery::Clean && self.diagnostics.is_empty()
     }
 
+    /// Adds a post-load validation problem using the original user source.
     pub fn add_runtime_diagnostic(
         &mut self,
         code: &str,
@@ -112,41 +151,65 @@ impl LoadedConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
+/// Complete effective editor configuration.
+///
+/// Optional scalar fields preserve whether the user supplied a value while
+/// access sites apply embedded defaults. Collections use Serde defaults so
+/// older user files remain compatible.
 pub struct Config {
+    /// Per-mode key mappings.
     pub keys: Keys,
+    /// Runtime theme name.
     pub theme: String,
+    /// Cursor shape by editor mode.
     #[serde(default)]
     pub cursor: CursorConfig,
+    /// User plugin name-to-path overrides.
     #[serde(default)]
     pub plugins: HashMap<String, String>,
+    /// Plugin names excluded from discovery or activation.
     #[serde(default)]
     pub disabled_plugins: Vec<String>,
+    /// Capabilities granted to individual plugins.
     #[serde(default)]
     pub plugin_permissions: HashMap<String, PluginPermissions>,
+    /// Plugin-specific JSON-compatible settings.
     #[serde(default)]
     pub plugin_config: HashMap<String, Value>,
+    /// Log destination override.
     pub log_file: Option<String>,
+    /// Lines moved per terminal mouse-wheel event.
     pub mouse_scroll_lines: Option<usize>,
+    /// Preferred visible lines retained above and below the cursor.
     pub scrolloff: Option<usize>,
+    /// Whether long lines wrap to continuation rows.
     pub wrap: Option<bool>,
     /// Indent wrapped continuation rows to the line's leading whitespace,
     /// like vim's 'breakindent'. Defaults to on.
     pub breakindent: Option<bool>,
+    /// Horizontal columns moved when the cursor leaves an unwrapped viewport.
     pub sidescroll: Option<usize>,
+    /// Preferred visible columns retained beside the cursor.
     pub sidescrolloff: Option<usize>,
     /// Show the startup splash when red opens without file arguments.
     /// Defaults to on.
     pub splash: Option<bool>,
+    /// Interactive search behavior.
     #[serde(default)]
     pub search: SearchConfig,
+    /// Picker layout behavior.
     #[serde(default)]
     pub picker: PickerConfig,
+    /// Delayed key-prefix guide behavior.
     #[serde(default)]
     pub key_hints: KeyHintsConfig,
+    /// System clipboard integration.
     #[serde(default)]
     pub clipboard: ClipboardConfig,
+    /// Language-server routing and behavior.
     #[serde(default)]
     pub lsp: LspConfig,
+    /// Matching-token navigation.
     #[serde(default)]
     pub matchit: MatchitConfig,
     /// Disable every agent surface, adapter check, and process launch.
@@ -155,12 +218,16 @@ pub struct Config {
     /// Unsupported development escape hatch set by `--no-typecheck`.
     #[serde(default, skip_serializing)]
     pub disable_plugin_typecheck: bool,
+    /// Codex adapter launch configuration.
     #[serde(default)]
     pub agent: AgentConfig,
+    /// Whether diagnostics appear in editor UI.
     #[serde(default = "default_true")]
     pub show_diagnostics: bool,
+    /// Whether split borders use only ASCII characters.
     #[serde(default = "default_false")]
     pub window_borders_ascii: bool,
+    /// Number of files supplied at startup; runtime-only context.
     #[serde(default, skip_serializing)]
     pub startup_file_count: usize,
 }
@@ -171,14 +238,18 @@ pub struct Config {
 pub struct AgentConfig {
     /// Codex executable override. Red uses `codex` from PATH when absent.
     pub command: Option<String>,
+    /// Additional arguments appended to the Codex command.
     #[serde(default)]
     pub args: Vec<String>,
+    /// Environment additions supplied only to the Codex child process.
     #[serde(default)]
     pub env: HashMap<String, String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+/// Picker input placement.
 pub struct PickerConfig {
+    /// Whether the query row appears above or below results.
     #[serde(default)]
     pub input_position: PickerInputPosition,
 }
@@ -217,18 +288,25 @@ impl Default for PickerConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
+/// Vertical placement of the picker query row.
 pub enum PickerInputPosition {
+    /// Place input before results.
     Top,
+    /// Place input after results.
     #[default]
     Bottom,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+/// System clipboard synchronization policy.
 pub struct ClipboardConfig {
+    /// Master switch for system clipboard access.
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// Copy yanked editor text to the system clipboard.
     #[serde(default = "default_true")]
     pub sync_on_yank: bool,
+    /// Prefer system clipboard text for paste operations.
     #[serde(default = "default_true")]
     pub sync_on_paste: bool,
 }
@@ -255,11 +333,15 @@ pub struct PluginPermissions {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+/// Matching-token navigation configuration.
 pub struct MatchitConfig {
+    /// Master switch for matching-token navigation.
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// Literal opener/closer pairs.
     #[serde(default = "default_matchit_pairs")]
     pub pairs: Vec<[String; 2]>,
+    /// Language-specific token groups keyed by normalized extension.
     #[serde(default)]
     pub languages: HashMap<String, MatchitLanguageConfig>,
 }
@@ -275,7 +357,9 @@ impl Default for MatchitConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+/// Language-specific groups whose members cycle as matching tokens.
 pub struct MatchitLanguageConfig {
+    /// Ordered groups of equivalent matching constructs.
     #[serde(default)]
     pub groups: Vec<Vec<String>>,
 }
@@ -289,15 +373,21 @@ fn default_matchit_pairs() -> Vec<[String; 2]> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+/// Interactive search policy.
 pub struct SearchConfig {
+    /// Update the current match while the query changes.
     #[serde(default = "default_true")]
     pub incsearch: bool,
+    /// Keep matches highlighted after search completes.
     #[serde(default = "default_true")]
     pub hlsearch: bool,
+    /// Continue searching from the opposite buffer end.
     #[serde(default = "default_true")]
     pub wrapscan: bool,
+    /// Compare case-insensitively by default.
     #[serde(default = "default_false")]
     pub ignorecase: bool,
+    /// Restore case sensitivity when the query contains uppercase characters.
     #[serde(default = "default_false")]
     pub smartcase: bool,
 }
@@ -316,33 +406,50 @@ impl Default for SearchConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
+/// Terminal cursor shape requested for an editor mode.
 pub enum CursorShape {
+    /// Leave cursor shape selection to the terminal.
     #[default]
     Default,
+    /// Blinking full cell.
     BlinkingBlock,
+    /// Steady full cell.
     SteadyBlock,
+    /// Blinking underline.
     BlinkingUnderscore,
+    /// Steady underline.
     SteadyUnderscore,
+    /// Blinking vertical bar.
     BlinkingBar,
+    /// Steady vertical bar.
     SteadyBar,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+/// Cursor shape selected for each editor mode.
 pub struct CursorConfig {
+    /// Normal mode.
     #[serde(default)]
     pub normal: CursorShape,
+    /// Insert mode.
     #[serde(default = "cursor_shape_steady_bar")]
     pub insert: CursorShape,
+    /// Command-line mode.
     #[serde(default)]
     pub command: CursorShape,
+    /// Search prompt mode.
     #[serde(default)]
     pub search: CursorShape,
+    /// Characterwise visual mode.
     #[serde(default)]
     pub visual: CursorShape,
+    /// Linewise visual mode.
     #[serde(default)]
     pub visual_line: CursorShape,
+    /// Blockwise visual mode.
     #[serde(default)]
     pub visual_block: CursorShape,
+    /// Waiting or busy mode.
     #[serde(default = "cursor_shape_steady_underscore")]
     pub waiting: CursorShape,
 }
@@ -372,11 +479,15 @@ fn cursor_shape_steady_underscore() -> CursorShape {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
+/// Language-server subsystem configuration.
 pub struct LspConfig {
+    /// Master switch for all language-server activity.
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// Apply server formatting before saving supported documents.
     #[serde(default)]
     pub format_on_save: bool,
+    /// Named language-server launch and routing definitions.
     #[serde(
         default = "default_language_servers",
         deserialize_with = "deserialize_language_servers"
@@ -396,34 +507,48 @@ impl Default for LspConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
+/// Launch, routing, and initialization settings for one language server.
 pub struct LanguageServerConfig {
+    /// Executable launched without a shell.
     pub command: String,
+    /// Command arguments.
     #[serde(default)]
     pub args: Vec<String>,
+    /// Legacy single-document-selector language identifier.
     #[serde(default)]
     pub language_id: String,
+    /// Legacy single-document-selector extensions.
     #[serde(default)]
     pub file_extensions: Vec<String>,
+    /// Preferred set of document selectors sharing this server.
     #[serde(default)]
     pub documents: Vec<LanguageDocumentConfig>,
+    /// Files or directories searched upward to select a workspace root.
     #[serde(default)]
     pub root_markers: Vec<String>,
+    /// Environment additions supplied only to the server process.
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// JSON passed as LSP initialization options.
     #[serde(default, skip_serializing)]
     pub initialization_options: Option<Value>,
+    /// Optional display name reported for the workspace folder.
     pub workspace_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
+/// Language identifier and extensions routed to a server.
 pub struct LanguageDocumentConfig {
+    /// LSP language identifier.
     pub language_id: String,
+    /// File extensions, with or without leading dots.
     #[serde(default)]
     pub file_extensions: Vec<String>,
 }
 
 impl LanguageServerConfig {
+    /// Returns normalized selectors, adapting the legacy single-selector fields.
     pub fn documents(&self) -> Vec<LanguageDocumentConfig> {
         if !self.documents.is_empty() {
             return self.documents.clone();
@@ -440,6 +565,7 @@ impl LanguageServerConfig {
     }
 }
 
+/// Returns Red's embedded language-server definitions.
 pub fn default_language_servers() -> HashMap<String, LanguageServerConfig> {
     HashMap::from([
         (
@@ -577,6 +703,7 @@ where
     Ok(servers)
 }
 
+/// Returns Red's default rust-analyzer initialization options.
 pub fn rust_analyzer_initialization_options() -> Value {
     json!({
       "restartServerOnConfigChange": false,
@@ -648,6 +775,10 @@ pub fn rust_analyzer_initialization_options() -> Value {
 }
 
 impl Config {
+    /// Returns Red's platform configuration directory.
+    ///
+    /// `XDG_CONFIG_HOME` takes precedence; otherwise Red uses
+    /// `$HOME/.config/red`.
     pub fn config_dir() -> PathBuf {
         if let Some(config_home) =
             std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty())
@@ -666,10 +797,15 @@ impl Config {
         home.join(".config").join("red")
     }
 
+    /// Resolves a configuration-relative path.
     pub fn path(p: &str) -> PathBuf {
         Self::config_dir().join(p)
     }
 
+    /// Strictly parses TOML, applies ordered override fragments, and deserializes it.
+    ///
+    /// Unlike [`Self::load_user_toml`], this constructor does not recover
+    /// invalid individual fields.
     pub fn from_toml_with_overrides(contents: &str, overrides: &[String]) -> anyhow::Result<Self> {
         let mut value: toml::Value = toml::from_str(contents)
             .map_err(|err| anyhow::anyhow!("failed to parse config.toml: {err}"))?;
@@ -688,6 +824,7 @@ impl Config {
         Ok(config)
     }
 
+    /// Loads recoverable user TOML and returns only its effective configuration.
     pub fn from_user_toml_with_overrides(
         contents: &str,
         overrides: &[String],
@@ -695,6 +832,11 @@ impl Config {
         Ok(Self::load_user_toml(contents, Path::new("<user config>"), overrides)?.config)
     }
 
+    /// Loads a user file over embedded defaults with field-level recovery.
+    ///
+    /// A missing file is equivalent to an empty user layer. Unreadable or
+    /// malformed whole files use the restricted fallback profile, while CLI
+    /// overrides remain strict.
     pub fn load_user_file(path: &Path, overrides: &[String]) -> anyhow::Result<LoadedConfig> {
         match fs::read_to_string(path) {
             Ok(contents) => Self::load_user_toml(&contents, path, overrides),
@@ -713,6 +855,10 @@ impl Config {
         }
     }
 
+    /// Applies recoverable user TOML and strict ordered CLI overrides.
+    ///
+    /// Unknown or independently invalid user fields become diagnostics and
+    /// retain safe defaults. This function never rewrites `path`.
     pub fn load_user_toml(
         contents: &str,
         path: &Path,
@@ -830,6 +976,7 @@ impl Config {
         })
     }
 
+    /// Persists the selected theme without rewriting unrelated user settings.
     pub fn persist_theme(theme_name: &str) -> anyhow::Result<()> {
         let config_path = Self::path("config.toml");
         let contents = fs::read_to_string(&config_path).unwrap_or_default();
@@ -840,6 +987,7 @@ impl Config {
         Ok(())
     }
 
+    /// Resolves a plugin path or bundled-plugin specifier for runtime loading.
     pub fn resolve_plugin_path(configured_path: &str) -> String {
         let configured = PathBuf::from(configured_path);
         if configured.is_absolute() {
@@ -861,6 +1009,7 @@ impl Config {
             .into_owned()
     }
 
+    /// Returns enabled configured plugins that cannot be resolved.
     pub fn missing_plugins(&self, config_dir: &Path) -> Vec<String> {
         let mut missing = self
             .plugins
@@ -1653,36 +1802,51 @@ fn starts_table_header(line: &str) -> bool {
     !line.starts_with('#') && line.starts_with('[')
 }
 
+/// Serde default helper for options that are enabled by default.
 pub fn default_true() -> bool {
     true
 }
 
+/// Serde default helper for options that are disabled by default.
 pub fn default_false() -> bool {
     false
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
+/// One configured key mapping, including prefixes and repeat counts.
 pub enum KeyAction {
+    /// Explicitly consume the mapping without an editor action.
     None,
+    /// Execute one editor action.
     Single(Action),
+    /// Execute actions in order.
     Multiple(Vec<Action>),
+    /// Continue resolving a key-prefix map.
     Nested(HashMap<String, KeyAction>),
+    /// Execute a mapping a fixed number of times.
     Repeating(u16, Box<KeyAction>),
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
+/// Key mappings grouped by editor mode.
 pub struct Keys {
+    /// Normal-mode mappings.
     #[serde(default)]
     pub normal: HashMap<String, KeyAction>,
+    /// Insert-mode mappings.
     #[serde(default)]
     pub insert: HashMap<String, KeyAction>,
+    /// Command-line-mode mappings.
     #[serde(default)]
     pub command: HashMap<String, KeyAction>,
+    /// Characterwise visual-mode mappings.
     #[serde(default)]
     pub visual: HashMap<String, KeyAction>,
+    /// Linewise visual-mode mappings.
     #[serde(default)]
     pub visual_line: HashMap<String, KeyAction>,
+    /// Blockwise visual-mode mappings.
     #[serde(default)]
     pub visual_block: HashMap<String, KeyAction>,
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1,6 +1,14 @@
+//! Synchronous request and response channels used by the Husk host bridge.
+//!
+//! [`Dispatcher`] exposes independently clonable channel endpoints behind a shared
+//! receiver lock. The current global plugin dispatcher assumes its channels remain
+//! connected for the process lifetime; send, blocking receive, and poisoned-lock
+//! failures therefore panic rather than representing recoverable plugin errors.
+
 use std::sync::{mpsc, Arc, Mutex};
 
 #[allow(unused)]
+/// Paired synchronous channels for host requests and their responses.
 pub struct Dispatcher<T, U> {
     request_tx: mpsc::Sender<T>,
     request_rx: Arc<Mutex<mpsc::Receiver<T>>>,
@@ -16,6 +24,7 @@ impl<T, U> Default for Dispatcher<T, U> {
 }
 
 impl<T, U> Dispatcher<T, U> {
+    /// Creates empty request and response channels.
     pub fn new() -> Self {
         let (request_tx, request_rx) = mpsc::channel();
         let (response_tx, response_rx) = mpsc::channel();
@@ -28,22 +37,36 @@ impl<T, U> Dispatcher<T, U> {
         }
     }
 
+    /// Enqueues a request.
+    ///
+    /// The process-lifetime dispatcher treats a disconnected receiver as a programming
+    /// error and panics.
     pub fn send_request(&self, request: T) {
         self.request_tx.send(request).unwrap();
     }
 
+    /// Blocks until the next request arrives.
+    ///
+    /// A disconnected channel or poisoned receiver lock panics.
     pub fn recv_request(&self) -> T {
         self.request_rx.lock().unwrap().recv().unwrap()
     }
 
+    /// Returns the next request without blocking.
+    ///
+    /// Empty and disconnected channels both return `None`; a poisoned lock panics.
     pub fn try_recv_request(&self) -> Option<T> {
         self.request_rx.lock().unwrap().try_recv().ok()
     }
 
+    /// Enqueues a response, panicking if its receiver has disconnected.
     pub fn send_response(&self, response: U) {
         self.response_tx.send(response).unwrap();
     }
 
+    /// Blocks until the next response arrives.
+    ///
+    /// A disconnected channel or poisoned receiver lock panics.
     pub fn recv_response(&self) -> U {
         self.response_rx.lock().unwrap().recv().unwrap()
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,3 +1,20 @@
+//! Central coordinator for Red's input, editing, rendering, and background services.
+//!
+//! [`Editor`] owns mutable application state on one async task. Terminal events resolve
+//! into [`Action`] values, content changes enter an undo transaction, and the canonical
+//! replacement seam updates the buffer, marks, attribution, revisions, LSP, and plugin
+//! notifications. Background LSP, plugin-process, filesystem-watch, recovery, and Codex
+//! work is polled between input batches so no subsystem mutates editor state directly.
+//!
+//! Cursor `x` values in editor and window state are grapheme indices. Buffer and undo
+//! ranges use Unicode scalar indices, rendering uses terminal columns, syntax spans use
+//! UTF-8 bytes, and LSP conversion uses UTF-16 code units. Crossing one of those
+//! boundaries requires a helper that names the conversion.
+//!
+//! This module coordinates subsystem lifecycles; detailed layout and painting live in
+//! `display_layout` and `rendering`, while `render_buffer` owns the terminal-cell
+//! model.
+
 mod display_layout;
 pub(crate) mod perf;
 pub mod render_buffer;
@@ -22,16 +39,6 @@ use crate::unicode_utils::{
     grapheme_to_char, grapheme_to_column_with_tabs, trim_line_ending, truncate_chars,
 };
 
-/// Editor is the main component that handles:
-/// - Text editing operations
-/// - Buffer management
-/// - User input processing
-/// - Screen rendering
-/// - LSP integration
-/// - Plugin system
-/// - Visual modes (normal, insert, visual, etc)
-///
-/// It maintains the terminal UI and coordinates all editor functionality.
 use crossterm::{
     event::{
         self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
@@ -264,6 +271,7 @@ struct MacroReplayEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Parsed and line-resolved substitute command awaiting execution.
 pub struct SubstituteCommand {
     start_line: usize,
     end_line: usize,
@@ -275,11 +283,17 @@ pub struct SubstituteCommand {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// User response while confirming individual substitute matches.
 pub enum SubstituteDecision {
+    /// Replace this match.
     Yes,
+    /// Skip this match.
     No,
+    /// Replace this and every remaining match without prompting.
     All,
+    /// Stop without replacing this or later matches.
     Quit,
+    /// Replace this match and then stop.
     Last,
 }
 
@@ -513,6 +527,11 @@ fn snake_case_key(key: &str) -> String {
     result
 }
 
+/// Effect requested by the Husk runtime for the editor owner to apply.
+///
+/// This enum is the typed Rust side of the plugin host contract. The runtime
+/// may construct requests, but only the editor event loop mutates buffers,
+/// windows, UI resources, agent state, LSP state, or the filesystem.
 pub enum PluginRequest {
     Action(Action),
     AgentNewSession {
@@ -929,16 +948,23 @@ impl PluginRequest {
 }
 
 #[derive(Debug)]
+/// Low-level terminal painting command retained for plugin compatibility.
 pub enum RenderCommand {
+    /// Paint styled text at a terminal-cell coordinate.
     BufferText {
+        /// Zero-based terminal column.
         x: usize,
+        /// Zero-based terminal row.
         y: usize,
+        /// Text to paint.
         text: String,
+        /// Concrete cell style.
         style: Style,
     },
 }
 
 #[allow(unused)]
+/// JSON-compatible result returned to a synchronous plugin request.
 pub struct PluginResponse(serde_json::Value);
 
 struct DirectoryWatcher {
@@ -950,15 +976,22 @@ struct DirectoryWatcher {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+/// Direction in which an editor search traverses the buffer.
 pub enum SearchDirection {
+    /// Search toward the end of the buffer.
     Forward,
+    /// Search toward the beginning of the buffer.
     Backward,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+/// Case transformation applied by an editor action.
 pub enum CaseTransform {
+    /// Convert cased characters to lowercase.
     Lower,
+    /// Convert cased characters to uppercase.
     Upper,
+    /// Invert the case of each cased character.
     Toggle,
 }
 
@@ -972,6 +1005,11 @@ impl SearchDirection {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+/// Semantic editor operation produced by keymaps, commands, UI, or plugins.
+///
+/// Actions describe intent but do not mutate state themselves. [`Editor`]
+/// serializes their execution through its event loop and canonical edit
+/// transaction boundary.
 pub enum Action {
     Quit(bool),
     Save,
@@ -1270,9 +1308,13 @@ pub enum Action {
 }
 
 #[allow(unused)]
+/// Viewport placement requested after jumping to a line.
 pub enum GoToLinePosition {
+    /// Place the target at the top of the viewport.
     Top,
+    /// Place the target near the viewport center.
     Center,
+    /// Place the target at the bottom of the viewport.
     Bottom,
 }
 
@@ -1289,38 +1331,56 @@ impl Default for CursorGoal {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+/// Editor interaction mode used by keymaps, cursor styling, and selection.
 pub enum Mode {
+    /// Command-oriented navigation mode.
     Normal,
+    /// Direct text insertion mode.
     Insert,
+    /// Colon-command prompt.
     Command,
+    /// Incremental search prompt.
     Search,
+    /// Characterwise selection.
     Visual,
+    /// Linewise selection.
     VisualLine,
+    /// Rectangular selection.
     VisualBlock,
 }
 
 #[derive(Debug)]
+/// Concrete syntax style over a UTF-8 byte range.
 pub struct StyleInfo {
+    /// Inclusive byte offset.
     pub start: usize,
+    /// Exclusive byte offset.
     pub end: usize,
+    /// Resolved style for the range.
     pub style: Style,
 }
 
 impl StyleInfo {
+    /// Returns whether `pos` lies in this half-open byte range.
     pub fn contains(&self, pos: usize) -> bool {
         pos >= self.start && pos < self.end
     }
 }
 
 #[derive(Debug, Clone)]
+/// Ordered syntax-highlight candidate over a UTF-8 byte range.
 pub struct HighlightSpan {
+    /// Inclusive byte offset.
     pub start: usize,
+    /// Exclusive byte offset.
     pub end: usize,
+    /// Original capture order used as a stable tie-breaker.
     pub order: usize,
     /// Original capture length in bytes. Used to pick the most specific
     /// (shortest) span; kept separate from start/end so spans clipped to a
     /// viewport slice keep their true specificity.
     pub priority: usize,
+    /// Concrete theme style selected for the capture.
     pub style: Style,
 }
 
@@ -1447,12 +1507,16 @@ impl From<Rect> for (usize, usize, usize, usize) {
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Zero-based terminal-cell point.
 pub struct Point {
+    /// Terminal column.
     pub x: usize,
+    /// Terminal row.
     pub y: usize,
 }
 
 impl Point {
+    /// Creates a terminal-cell point.
     pub fn new(x: usize, y: usize) -> Self {
         Self { x, y }
     }
@@ -1474,6 +1538,7 @@ impl PartialOrd for Point {
 }
 
 #[derive(Debug, Clone)]
+/// Editor action captured with the selection it should operate on.
 pub struct ActionOnSelection {
     action: Action,
     selection: Rect,
@@ -1490,6 +1555,11 @@ impl ActionOnSelection {
     }
 }
 
+/// Single-task owner of Red's interactive application state.
+///
+/// The editor coordinates buffers, windows, rendering, LSP, plugins,
+/// persistence, and agent proposals. External tasks communicate through
+/// messages; they do not mutate this state directly.
 pub struct Editor {
     /// LSP client for code intelligence features
     lsp: Box<dyn LspClient>,
@@ -1813,6 +1883,10 @@ pub struct DetachedEditorCore {
 }
 
 impl DetachedEditorCore {
+    /// Moves an editor into terminal-independent detached ownership.
+    ///
+    /// The constructor initializes a fresh plugin runtime and render model
+    /// while retaining all editor, LSP, recovery, and Codex state.
     pub async fn new(mut editor: Editor) -> anyhow::Result<Self> {
         editor.terminal_output_enabled = false;
         let mut runtime =
@@ -18838,73 +18912,112 @@ fn parse_snippet_placeholder(chars: &[char], start: usize) -> Option<(usize, usi
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Versioned editor snapshot exposed to Husk plugin lifecycle hooks.
 pub struct EditorStateSnapshot {
+    /// Snapshot schema version.
     pub version: u32,
+    /// Editor working directory.
     pub cwd: String,
+    /// Unix epoch capture time in milliseconds.
     #[serde(alias = "savedAt")]
     pub saved_at: u64,
+    /// Open-buffer summaries in editor index order.
     pub buffers: Vec<BufferStateSnapshot>,
+    /// Active buffer index.
     #[serde(alias = "currentBufferIndex")]
     pub current_buffer_index: usize,
+    /// Split layout and per-window viewport state.
     #[serde(alias = "windowLayout")]
     pub window_layout: WindowManagerSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Plugin-visible summary of one open buffer.
 pub struct BufferStateSnapshot {
+    /// Editor buffer index.
     pub index: usize,
+    /// Buffer display path.
     pub path: String,
+    /// Whether in-memory text differs from saved state.
     pub dirty: bool,
+    /// Current grapheme cursor position.
     pub cursor: CursorStateSnapshot,
+    /// First buffer line visible in the active viewport.
     #[serde(alias = "viewportTop")]
     pub viewport_top: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Plugin-visible grapheme cursor coordinate.
 pub struct CursorStateSnapshot {
+    /// Zero-based grapheme column.
     pub x: usize,
+    /// Zero-based line.
     pub y: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Result returned by session-restore plugin requests.
 pub struct RestoreResult {
+    /// Whether a matching snapshot was found and considered.
     pub restored: bool,
+    /// Files successfully opened from the snapshot.
     pub opened_files: Vec<String>,
+    /// Files deliberately skipped with reasons.
     pub skipped_files: Vec<SkippedFile>,
+    /// Non-fatal restore diagnostics.
     pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// File omitted during best-effort plugin session restoration.
 pub struct SkippedFile {
+    /// Requested file path.
     pub path: String,
+    /// Human-readable reason the file was not restored.
     pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
+/// Flattened document symbol serialized for bundled plugin pickers.
 pub struct PluginDocumentSymbol {
+    /// Stable symbol identity within this response.
     pub id: String,
+    /// Parent symbol identity for rebuilding hierarchy.
     pub parent_id: Option<String>,
+    /// Symbol name.
     pub name: String,
+    /// Optional language-server detail text.
     pub detail: Option<String>,
+    /// Numeric LSP symbol kind.
     pub kind: i32,
+    /// Human-readable symbol kind.
     pub kind_name: String,
+    /// Document path.
     pub file: String,
+    /// Full symbol range in LSP UTF-16 coordinates.
     pub range: Range,
+    /// Preferred navigation range in LSP UTF-16 coordinates.
     pub selection_range: Range,
+    /// Flattened hierarchy depth.
     pub depth: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
+/// File and UTF-16 range serialized for plugin navigation surfaces.
 pub struct PluginLocation {
+    /// Document path.
     pub file: String,
+    /// LSP range.
     pub range: Range,
 }
 
 #[derive(Debug, Clone, Serialize)]
+/// Read-only editor state supplied to legacy plugin snapshots.
 pub struct EditorInfo {
     buffers: Vec<BufferInfo>,
     theme: Theme,
@@ -18919,6 +19032,7 @@ pub struct EditorInfo {
 }
 
 #[derive(Debug, Clone, Serialize)]
+/// Read-only buffer summary nested in [`EditorInfo`].
 pub struct BufferInfo {
     name: String,
     path: Option<String>,

--- a/src/editor/display_layout.rs
+++ b/src/editor/display_layout.rs
@@ -1,3 +1,15 @@
+//! Width-aware mapping between buffer lines, wrapped screen rows, and cursor coordinates.
+//!
+//! Layout consumes grapheme boundaries and terminal-cell widths to build an immutable
+//! [`DisplayLayout`] for one viewport configuration. It owns wrapping, horizontal
+//! offsets, continuation indentation, and the conversions used by vertical screen-line
+//! motion. It does not paint styles or mutate window state.
+//!
+//! Callers must include every layout-affecting input in their cache key. Reusing a
+//! layout across a buffer revision, viewport width, wrap mode, or indentation change
+//! would produce incorrect cursor and hit-test positions even when the underlying text
+//! looks similar.
+
 use unicode_segmentation::UnicodeSegmentation as _;
 
 use crate::unicode_utils::{char_display_width, display_width, trim_line_ending};

--- a/src/editor/render_buffer.rs
+++ b/src/editor/render_buffer.rs
@@ -1,3 +1,11 @@
+//! In-memory terminal-cell grid used to compose and diff complete editor frames.
+//!
+//! [`RenderBuffer`] stores grapheme text, width, continuation cells, and style for every
+//! terminal position. Rendering code draws into the grid without writing escape
+//! sequences; the final flush compares frames and emits only changed cells or rows.
+//! Wide graphemes reserve continuation cells, so callers must use the buffer APIs rather
+//! than indexing a string by terminal column.
+
 use crate::{
     color::{blend_color, Color},
     log,

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1,3 +1,14 @@
+//! Painting of editor, plugin, diagnostic, and window state into a [`RenderBuffer`].
+//!
+//! This module translates the editor's logical layout into terminal cells and computes
+//! incremental frame output. It owns clipping, style precedence, gutter and window
+//! chrome, wrapped rows, cursor placement, and terminal attribute transitions. It does
+//! not mutate buffer text or decide input behavior.
+//!
+//! Rendering caches are keyed by stable buffer identity inputs and content revisions.
+//! Any feature that changes visible state without changing text must also advance the
+//! editor's render generation or request an explicit render.
+
 use std::{
     collections::{HashMap, HashSet},
     io::{self, Write as _},

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -25,6 +25,10 @@ use tokio::net::{UnixListener, UnixStream};
 pub const IPC_PROTOCOL_VERSION: u32 = 3;
 
 const MAX_FRAME_BYTES: usize = 2 * 1024 * 1024;
+/// Maximum aggregate size accepted for a chunked paste operation.
+///
+/// The owner rejects the paste once accumulated UTF-8 bytes exceed this
+/// boundary and clears the pending paste state.
 pub const MAX_PENDING_PASTE_BYTES: usize = 16 * 1024 * 1024;
 const CLIENT_HEARTBEAT_LEASE: Duration = Duration::from_secs(15);
 const CLIENT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -38,48 +42,79 @@ const MAX_TERMINAL_CELLS: usize = 12 * 1024;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum InputEvent {
+    /// A normalized keyboard event.
     Key {
+        /// Key identity independent of the terminal backend.
         code: KeyCode,
+        /// Active modifiers; order has no semantic meaning.
         modifiers: Vec<KeyModifier>,
     },
+    /// A complete paste payload.
     Paste {
+        /// UTF-8 text to insert.
         text: String,
     },
+    /// One frame of a paste split across protocol messages.
     PasteChunk {
+        /// UTF-8 fragment to append to the pending paste.
         text: String,
+        /// Whether this fragment completes and applies the paste.
         final_chunk: bool,
     },
+    /// A terminal mouse event represented by Crossterm's portable DTO.
     Mouse {
+        /// Mouse kind, location, and modifiers.
         event: crossterm::event::MouseEvent,
     },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Terminal-independent key identity used by [`InputEvent::Key`].
 pub enum KeyCode {
+    /// Unicode character input.
     Character(char),
+    /// Enter or Return.
     Enter,
+    /// Delete the preceding character.
     Backspace,
+    /// Escape.
     Escape,
+    /// Forward tab.
     Tab,
+    /// Reverse tab.
     BackTab,
+    /// Numbered function key.
     Function(u8),
+    /// Delete the character at the cursor.
     Delete,
+    /// Move left.
     Left,
+    /// Move right.
     Right,
+    /// Move up.
     Up,
+    /// Move down.
     Down,
+    /// Move to the beginning of a line or region.
     Home,
+    /// Move to the end of a line or region.
     End,
+    /// Move one viewport page upward.
     PageUp,
+    /// Move one viewport page downward.
     PageDown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Keyboard modifier transmitted with a normalized key event.
 pub enum KeyModifier {
+    /// Control modifier.
     Control,
+    /// Alt or Option modifier.
     Alt,
+    /// Shift modifier.
     Shift,
 }
 
@@ -87,35 +122,56 @@ pub enum KeyModifier {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ClientMessage {
+    /// Authenticate and attach a rendering client.
     Connect {
+        /// Protocol version understood by the client.
         protocol_version: u32,
+        /// Secret read from the owner-created token file.
         #[serde(default)]
         reconnect_token: String,
+        /// Last rendered owner revision, used to avoid redundant line patches.
         last_revision: Option<u64>,
+        /// Client viewport width.
         #[serde(default = "default_columns")]
         columns: u16,
+        /// Client viewport height.
         #[serde(default = "default_rows")]
         rows: u16,
+        /// Whether this client currently owns interactive focus.
         #[serde(default = "default_focused")]
         focused: bool,
     },
+    /// Authenticate a control-only request to stop the owner process.
     StopControl {
+        /// Protocol version understood by the controller.
         protocol_version: u32,
+        /// Secret read from the owner-created token file.
         reconnect_token: String,
     },
+    /// Apply one ordered input event.
     Input {
+        /// Client sequence used to correlate the returned render.
         sequence: u64,
+        /// Normalized input payload.
         event: InputEvent,
     },
+    /// Update the client's viewport dimensions.
     Resize {
+        /// Viewport width.
         columns: u16,
+        /// Viewport height.
         rows: u16,
     },
+    /// Update whether this attachment owns interactive focus.
     Focus {
+        /// New focus state.
         focused: bool,
     },
+    /// Renew the client's owner lease without changing editor state.
     Heartbeat,
+    /// Close this attachment while leaving the owner alive.
     Detach,
+    /// Stop the owner after authenticating through an attached connection.
     Stop,
 }
 
@@ -134,7 +190,9 @@ const fn default_focused() -> bool {
 /// A complete logical line replacement in the next client frame.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinePatch {
+    /// Zero-based screen row replaced by this patch.
     pub row: usize,
+    /// Plain-text fallback for clients that do not consume styled spans.
     pub text: String,
     /// Run-length encoded cells. `text` remains as a plain fallback for older clients.
     #[serde(default)]
@@ -143,15 +201,20 @@ pub struct LinePatch {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StyledSpan {
+    /// Text cells sharing the accompanying style.
     pub text: String,
+    /// Resolved display style for this run.
     pub style: crate::theme::Style,
 }
 
 /// Minimal render delta returned by the headless owner.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RenderDelta {
+    /// Monotonic owner render revision represented by this frame.
     pub revision: u64,
+    /// Complete replacements for changed logical screen rows.
     pub lines: Vec<LinePatch>,
+    /// Cursor as `(character column, zero-based row)`.
     pub cursor: (usize, usize),
 }
 
@@ -159,17 +222,27 @@ pub struct RenderDelta {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerMessage {
+    /// Successful handshake and initial render state.
     Connected {
+        /// Protocol version spoken by the owner.
         protocol_version: u32,
+        /// Initial full or revision-aware render.
         render: RenderDelta,
     },
+    /// Render response correlated with an input sequence.
     Render {
+        /// Sequence from the triggering [`ClientMessage::Input`].
         sequence: u64,
+        /// Resulting render state.
         delta: RenderDelta,
     },
+    /// Confirmation that the connection detached cleanly.
     Detached,
+    /// Confirmation that the owner accepted a stop request.
     Stopped,
+    /// Protocol or editor error safe to report to the client.
     Error {
+        /// Human-readable failure detail.
         message: String,
     },
 }
@@ -184,6 +257,7 @@ pub struct HeadlessOwner {
 }
 
 impl HeadlessOwner {
+    /// Creates a minimal owner initialized with `text` and a cursor at origin.
     #[must_use]
     pub fn new(text: &str) -> Self {
         let mut lines = text.split('\n').map(str::to_string).collect::<Vec<_>>();
@@ -199,6 +273,7 @@ impl HeadlessOwner {
     }
 
     #[must_use]
+    /// Returns the current render revision.
     pub fn revision(&self) -> u64 {
         self.revision
     }
@@ -380,13 +455,21 @@ fn char_to_byte(text: &str, character_index: usize) -> usize {
 }
 
 #[derive(Debug, Clone)]
+/// Filesystem rendezvous points for one named detachable session.
 pub struct SessionPaths {
+    /// Unix-domain socket used for local IPC.
     pub socket: PathBuf,
+    /// Private reconnect token used to authenticate clients.
     pub token: PathBuf,
+    /// Owner process identifier used to reject stale or spoofed sockets.
     pub pid: PathBuf,
 }
 
 impl SessionPaths {
+    /// Derives safe session paths beneath `directory`.
+    ///
+    /// `name` must be a single component containing only ASCII letters,
+    /// numbers, dash, underscore, or dot.
     pub fn new(directory: &Path, name: &str) -> anyhow::Result<Self> {
         anyhow::ensure!(
             !name.is_empty()
@@ -404,6 +487,9 @@ impl SessionPaths {
 }
 
 #[cfg(unix)]
+/// Bound owner endpoint and its private authentication material.
+///
+/// Dropping this value removes all rendezvous files.
 pub struct BoundSession {
     listener: UnixListener,
     paths: SessionPaths,
@@ -412,6 +498,7 @@ pub struct BoundSession {
 
 #[cfg(unix)]
 impl BoundSession {
+    /// Returns the reconnect token required by clients.
     pub fn token(&self) -> &str {
         &self.token
     }
@@ -427,6 +514,11 @@ impl Drop for BoundSession {
 }
 
 #[cfg(unix)]
+/// Creates the authenticated IPC endpoint for a named session.
+///
+/// The directory, socket, token, and PID file receive owner-only
+/// permissions. Existing rendezvous files are removed only after verifying
+/// that they do not identify a live owner.
 pub fn bind_session(directory: &Path, name: &str) -> anyhow::Result<BoundSession> {
     use std::os::unix::fs::PermissionsExt as _;
 
@@ -463,6 +555,10 @@ pub fn bind_session(directory: &Path, name: &str) -> anyhow::Result<BoundSession
 }
 
 #[cfg(unix)]
+/// Checks whether a named session has a live, matching socket owner.
+///
+/// A PID file alone is insufficient: the socket must connect and its peer PID
+/// must match the recorded owner.
 pub fn session_is_active(directory: &Path, name: &str) -> anyhow::Result<bool> {
     use std::os::unix::fs::FileTypeExt as _;
 
@@ -575,6 +671,11 @@ fn socket_peer_pid(_socket: &std::os::unix::net::UnixStream) -> std::io::Result<
 }
 
 #[cfg(unix)]
+/// Runs the detachable editor owner until an authenticated client stops it.
+///
+/// Only one interactive client may be attached at a time. Background editor
+/// work continues while detached, and pending paste state is cleared whenever
+/// an attachment ends.
 pub async fn serve_editor_session(
     session: &BoundSession,
     core: crate::editor::DetachedEditorCore,
@@ -834,6 +935,10 @@ async fn reject_busy_connection(
 }
 
 #[cfg(unix)]
+/// Connects an interactive client to a named detachable session.
+///
+/// The reconnect token is read from the private rendezvous file and presented
+/// during the protocol handshake.
 pub async fn connect_session(
     directory: &Path,
     name: &str,
@@ -847,6 +952,7 @@ pub async fn connect_session(
 }
 
 #[cfg(unix)]
+/// Authenticates a control connection and asks a named owner to shut down.
 pub async fn stop_session(directory: &Path, name: &str) -> anyhow::Result<()> {
     let paths = SessionPaths::new(directory, name)?;
     let token = std::fs::read_to_string(&paths.token)?;
@@ -1005,6 +1111,7 @@ where
     reader: BufReader<ReadHalf<S>>,
     writer: WriteHalf<S>,
     next_sequence: u64,
+    /// Render returned by the successful connection handshake.
     pub initial_render: RenderDelta,
 }
 
@@ -1021,6 +1128,10 @@ where
         Self::connect_session(stream, "", last_revision, (80, 24), true).await
     }
 
+    /// Connects with explicit authentication, viewport, and focus state.
+    ///
+    /// `last_revision` lets a reconnecting client request an empty initial
+    /// line set when it already holds the owner's current render.
     pub async fn connect_session(
         stream: S,
         reconnect_token: &str,
@@ -1094,22 +1205,26 @@ where
         }
     }
 
+    /// Updates the remote viewport size and returns the resulting render.
     pub async fn resize(&mut self, columns: u16, rows: u16) -> anyhow::Result<RenderDelta> {
         validate_terminal_size(columns, rows)?;
         write_frame(&mut self.writer, &ClientMessage::Resize { columns, rows }).await?;
         self.expect_control_render().await
     }
 
+    /// Updates interactive focus and returns the resulting render.
     pub async fn focus(&mut self, focused: bool) -> anyhow::Result<RenderDelta> {
         write_frame(&mut self.writer, &ClientMessage::Focus { focused }).await?;
         self.expect_control_render().await
     }
 
+    /// Renews the owner lease and obtains any render newer than the client state.
     pub async fn heartbeat(&mut self) -> anyhow::Result<RenderDelta> {
         write_frame(&mut self.writer, &ClientMessage::Heartbeat).await?;
         self.expect_control_render().await
     }
 
+    /// Closes this attachment while leaving the remote editor owner running.
     pub async fn detach(&mut self) -> anyhow::Result<()> {
         write_frame(&mut self.writer, &ClientMessage::Detach).await?;
         match read_frame_with_timeout(
@@ -1124,6 +1239,7 @@ where
         }
     }
 
+    /// Requests shutdown through this authenticated attachment.
     pub async fn stop(&mut self) -> anyhow::Result<()> {
         write_frame(&mut self.writer, &ClientMessage::Stop).await?;
         match read_frame_with_timeout(

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -1,3 +1,10 @@
+//! Tree-sitter language selection and byte-span syntax highlighting.
+//!
+//! [`Highlighter`] maps file names to bundled grammars and queries, parses supplied
+//! source text, and returns [`StyleInfo`] byte ranges resolved
+//! against the current theme. Parsing is scoped to the text supplied by the caller;
+//! viewport caching and conversion from slice-relative spans belong to the editor.
+
 use std::{collections::HashMap, ops::Range, path::Path};
 
 use husk_lexer::{Keyword, Lexer, TokenKind, Trivia};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,16 @@
+//! Core library for Red's terminal editor, embedded plugin runtime, and persistent services.
+//!
+//! The interactive binary in `main.rs` assembles these modules, while this crate owns
+//! the reusable state machines behind editing, rendering, language servers, plugins,
+//! agent proposals, recovery, and detachable sessions. Most state is coordinated by
+//! [`editor::Editor`] on one async task. Background processes and blocking persistence
+//! work communicate with that owner through bounded channels or explicit join handles.
+//!
+//! Red currently exports a broad implementation-facing surface so the binary and
+//! integration harnesses can share the same code. Visibility does not by itself promise
+//! that every module is a stable third-party API; versioned compatibility commitments
+//! are called out explicitly at boundaries such as the plugin host protocol.
+
 #![recursion_limit = "256"]
 
 pub mod agent_check;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,3 +1,10 @@
+//! Minimal process-wide file logging used by editor subsystems and background services.
+//!
+//! A [`Logger`] serializes append operations with a mutex and filters messages before
+//! acquiring the file. Logging intentionally ignores individual write failures so an
+//! unavailable diagnostic sink cannot terminate an editor session; construction errors
+//! remain visible to startup configuration recovery.
+
 #![allow(unused)]
 use std::{
     fmt,

--- a/src/lsp/capabilities.rs
+++ b/src/lsp/capabilities.rs
@@ -1,3 +1,10 @@
+//! Construction of the exact LSP client capabilities advertised by Red.
+//!
+//! Capability values must match features that the client transport, editor dispatcher,
+//! and edit-validation layers actually implement. Advertising a capability prematurely
+//! can cause a server to send requests Red cannot apply safely, so additions should be
+//! paired with protocol and editor-path coverage.
+
 use std::process;
 
 use serde_json::Value;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1,3 +1,15 @@
+//! One language-server process, bounded JSON-RPC transport, and client-side protocol state.
+//!
+//! [`RealLspClient`] owns process stdio, monotonically increasing document versions,
+//! request correlation, capabilities, queued pre-initialization messages, diagnostics
+//! debounce, and orderly shutdown. Reader and writer tasks communicate through bounded
+//! channels; they never mutate editor state directly.
+//!
+//! Frames, headers, stderr lines, pending message counts, and pending bytes are bounded.
+//! A malformed or oversized stream becomes a processing error rather than allocating
+//! without limit. Requests sent before successful initialization are retained only
+//! within the documented queue budgets.
+
 use std::{
     collections::HashMap,
     path::PathBuf,

--- a/src/lsp/edit.rs
+++ b/src/lsp/edit.rs
@@ -1,3 +1,14 @@
+//! LSP URI, UTF-16 range, text-edit, and workspace-operation conversion.
+//!
+//! Functions in this module convert protocol edits into buffer character ranges without
+//! applying them. UTF-16 positions are checked against real scalar boundaries, edits are
+//! ordered so earlier replacements cannot invalidate later ranges, and overlapping
+//! operations are rejected.
+//!
+//! URI normalization is a protocol boundary, not a general filesystem authorization
+//! check. Multi-file confinement, resource-operation safety, revisions, and rollback are
+//! enforced by [`super::workspace_edit`].
+
 use std::{collections::HashMap, path::Path};
 
 use path_absolutize::Absolutize;

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -1,3 +1,14 @@
+//! Routing and lazy lifecycle management for language servers across workspace documents.
+//!
+//! [`LspManager`] matches configured document selectors, associates each opened document
+//! with one client key, starts clients on demand, and forwards the [`LspClient`] surface
+//! to the correct process. A document is opened once per managed lifecycle; later
+//! changes reuse its association and version stream.
+//!
+//! Unsupported files are valid no-op targets for most editor operations. Process or
+//! protocol failures remain errors so the editor can surface them without silently
+//! pretending code intelligence succeeded.
+
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
@@ -18,11 +29,17 @@ use super::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Resolved language-server routing information for one file.
 pub struct DocumentInfo {
+    /// Absolute document path.
     pub path: PathBuf,
+    /// Percent-encoded `file:` URI sent to the server.
     pub uri: String,
+    /// Language identifier selected by the configured document selector.
     pub language_id: String,
+    /// Workspace root found from configured root markers.
     pub workspace_root: PathBuf,
+    /// Configuration key of the server that owns this document.
     pub server_name: String,
 }
 
@@ -31,6 +48,7 @@ struct DocumentSelector {
     language_id: String,
 }
 
+/// Lazily starts and routes documents across configured language servers.
 pub struct LspManager {
     config: LspConfig,
     document_selectors: HashMap<String, DocumentSelector>,
@@ -43,6 +61,7 @@ pub struct LspManager {
 }
 
 impl LspManager {
+    /// Builds routing tables without starting any server processes.
     pub fn new(config: LspConfig) -> Self {
         let mut document_selectors = HashMap::new();
         if config.enabled {
@@ -74,6 +93,10 @@ impl LspManager {
         }
     }
 
+    /// Resolves a file to its configured server, language, URI, and workspace.
+    ///
+    /// Returns `None` when LSP is disabled, the extension has no selector, or
+    /// the file cannot be normalized safely.
     pub fn resolve_document(&self, file: &str) -> Option<DocumentInfo> {
         if !self.config.enabled {
             return None;

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,3 +1,16 @@
+//! Language Server Protocol process abstraction, routing, synchronization, and edit safety.
+//!
+//! [`LspManager`] selects or lazily starts a client for each document, while
+//! [`RealLspClient`] owns one server process, JSON-RPC framing, initialization state,
+//! request correlation, pending messages, diagnostics debounce, and shutdown. The editor
+//! polls [`InboundMessage`] values and remains the authority that applies resulting
+//! state.
+//!
+//! Editor cursor positions are grapheme indices and buffer edits use Unicode scalar
+//! indices; LSP [`Position`] values use UTF-16 code units. Conversion belongs in
+//! [`edit`] and [`workspace_edit`], including split-surrogate rejection, revision
+//! validation, workspace confinement, and rollback of ordered resource operations.
+
 use std::{
     fmt::{self, Display, Formatter},
     path::PathBuf,
@@ -30,15 +43,25 @@ pub mod types;
 pub mod workspace_edit;
 
 #[derive(Debug)]
+/// Failure returned by the LSP transport, protocol, or lifecycle boundary.
 pub enum LspError {
+    /// A request exceeded its configured deadline.
     RequestTimeout(Duration),
+    /// The server returned a JSON-RPC error response.
     ServerError(String),
+    /// A message violated Red's expected protocol shape or lifecycle.
     ProtocolError(String),
+    /// Process or pipe I/O failed.
     IoError(std::io::Error),
+    /// JSON serialization or deserialization failed.
     JsonError(serde_json::Error),
+    /// The outbound writer task is no longer accepting messages.
     ChannelError(Box<tokio::sync::mpsc::error::SendError<OutboundMessage>>),
+    /// The inbound reader task could not deliver a message.
     ChannelInboundError(String),
+    /// A server payload could not be interpreted as the requested result.
     ParseError(String),
+    /// An operation was attempted before the initialize handshake completed.
     NotInitialized,
 }
 
@@ -88,6 +111,7 @@ impl From<tokio::sync::mpsc::error::SendError<OutboundMessage>> for LspError {
 }
 
 #[derive(Debug)]
+/// JSON-RPC notification queued for the server writer.
 pub struct NotificationRequest {
     method: String,
     params: Value,
@@ -110,16 +134,22 @@ impl Display for NotificationRequest {
 }
 
 #[derive(Debug, Clone)]
+/// Correlated JSON-RPC request and its local timing metadata.
 pub struct Request {
+    /// Numeric JSON-RPC request identifier.
     pub id: i64,
+    /// LSP method name.
     pub method: String,
+    /// Method-specific JSON parameters.
     pub params: Value,
+    /// Local enqueue time used for timeout and latency accounting.
     pub timestamp: Instant,
 }
 
 static ID: AtomicUsize = AtomicUsize::new(1);
 
 impl Request {
+    /// Creates a request with the next process-wide correlation ID.
     pub fn new(method: &str, params: Value) -> Request {
         Request {
             id: next_id() as i64,
@@ -147,29 +177,43 @@ impl Display for Request {
 }
 
 #[derive(Debug, Clone)]
+/// Successful response paired with its originating request when known.
 pub struct ResponseMessage {
+    /// JSON-RPC request identifier.
     pub id: i64,
+    /// Method-specific result payload.
     pub result: Value,
+    /// Request metadata recovered from the pending-request table.
     pub request: Option<Request>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Request initiated by a language server toward Red.
 pub struct ServerRequest {
+    /// Server-selected JSON-RPC identifier, which may be numeric or textual.
     pub id: Value,
+    /// LSP method name.
     pub method: String,
+    /// Method-specific parameters.
     pub params: Value,
+    /// Managed client key that received the request.
     pub source: Option<String>,
 }
 
 #[derive(Debug)]
+/// Response Red sends for a server-initiated request.
 pub struct ServerResponse {
+    /// Identifier copied from the server request.
     pub id: Value,
+    /// Successful result, mutually exclusive with `error`.
     pub result: Option<Value>,
+    /// JSON-RPC error object, mutually exclusive with `result`.
     pub error: Option<Value>,
 }
 
 #[derive(Debug)]
 #[allow(unused)]
+/// Raw server notification not recognized by Red's typed notification set.
 pub struct Notification {
     method: String,
     params: Value,
@@ -185,9 +229,13 @@ pub struct ResponseError {
 }
 
 #[derive(Debug)]
+/// Message consumed by the asynchronous server writer.
 pub enum OutboundMessage {
+    /// Correlated request expecting a response.
     Request(Request),
+    /// Fire-and-forget notification.
     Notification(NotificationRequest),
+    /// Reply to a server-initiated request.
     Response(ServerResponse),
 }
 
@@ -204,20 +252,31 @@ impl Display for OutboundMessage {
 }
 
 #[derive(Debug)]
+/// Message delivered from an LSP reader task to the editor.
 pub enum InboundMessage {
+    /// Successful response to a Red-initiated request.
     Message(ResponseMessage),
+    /// Recognized typed notification.
     Notification(ParsedNotification),
+    /// Well-formed notification whose method Red does not interpret.
     UnknownNotification(Notification),
+    /// Request that requires an editor-owned response.
     ServerRequest(ServerRequest),
+    /// JSON-RPC error that could not be paired as a normal response.
     Error(ResponseError),
+    /// Error paired with a known Red request ID.
     RequestError { id: i64, error: LspError },
+    /// Transport or parsing failure not tied to one request.
     ProcessingError(LspError),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
+/// Server notifications that affect editor-owned state.
 pub enum ParsedNotification {
+    /// Diagnostics replacement for one text document.
     PublishDiagnostics(TextDocumentPublishDiagnostics),
+    /// Work-done or partial-result progress update.
     Progress(ProgressParams),
 }
 
@@ -235,23 +294,40 @@ fn parse_notification(
     Ok(None)
 }
 
+/// Allocates a process-wide JSON-RPC request identifier.
 pub fn next_id() -> usize {
     ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
 }
 
 #[async_trait::async_trait]
+/// Editor-facing abstraction over one or more language-server processes.
+///
+/// Methods accepting `x` and `y` receive Red character columns and zero-based
+/// lines; implementations own conversion to UTF-16 LSP [`Position`] values.
+/// Returned integers are request IDs whose results arrive through
+/// [`Self::recv_response`].
 pub trait LspClient: std::any::Any + Send {
+    /// Performs the LSP initialize/initialized handshake.
     async fn initialize(&mut self) -> Result<(), LspError>;
+    /// Opens a document and establishes its initial version.
     async fn did_open(&mut self, file: &str, contents: &str) -> Result<(), LspError>;
+    /// Publishes the current full document text as the next version.
     async fn did_change(&mut self, file: &str, contents: String) -> Result<(), LspError>;
+    /// Closes a document if this client tracks document lifecycles.
     async fn did_close(&mut self, _file: &str) -> Result<(), LspError> {
         Ok(())
     }
+    /// Notifies the server immediately before Red saves a document.
     async fn will_save(&mut self, file: &str) -> Result<(), LspError>;
+    /// Requests hover information at an editor position.
     async fn hover(&mut self, file: &str, x: usize, y: usize) -> Result<i64, LspError>;
+    /// Requests definition locations at an editor position.
     async fn goto_definition(&mut self, file: &str, x: usize, y: usize) -> Result<i64, LspError>;
+    /// Requests completion candidates at an editor position.
     async fn completion(&mut self, file: &str, x: usize, y: usize) -> Result<i64, LspError>;
+    /// Requests whole-document formatting with server defaults.
     async fn format_document(&mut self, file: &str) -> Result<i64, LspError>;
+    /// Requests whole-document formatting with explicit indentation options.
     async fn format_document_with_options(
         &mut self,
         file: &str,
@@ -260,14 +336,18 @@ pub trait LspClient: std::any::Any + Send {
     ) -> Result<i64, LspError> {
         self.format_document(file).await
     }
+    /// Requests the symbol hierarchy for a document.
     async fn document_symbols(&mut self, file: &str) -> Result<i64, LspError>;
+    /// Requests actions applicable to a range and its known diagnostics.
     async fn code_action(
         &mut self,
         file: &str,
         range: Range,
         diagnostics: Vec<Diagnostic>,
     ) -> Result<i64, LspError>;
+    /// Requests callable signature help at an editor position.
     async fn signature_help(&mut self, file: &str, x: usize, y: usize) -> Result<i64, LspError>;
+    /// Requests a workspace rename from an editor position.
     async fn rename(
         &mut self,
         file: &str,
@@ -275,12 +355,18 @@ pub trait LspClient: std::any::Any + Send {
         y: usize,
         new_name: &str,
     ) -> Result<i64, LspError>;
+    /// Requests document-local highlights related to an editor position.
     async fn document_highlight(&mut self, file: &str, x: usize, y: usize)
         -> Result<i64, LspError>;
+    /// Requests links embedded in a document.
     async fn document_link(&mut self, file: &str) -> Result<i64, LspError>;
+    /// Requests color literals and their ranges.
     async fn document_color(&mut self, file: &str) -> Result<i64, LspError>;
+    /// Requests foldable document ranges.
     async fn folding_range(&mut self, file: &str) -> Result<i64, LspError>;
+    /// Searches workspace symbols using this client's default workspace.
     async fn workspace_symbol(&mut self, query: &str) -> Result<i64, LspError>;
+    /// Searches workspace symbols using the workspace associated with `file`.
     async fn workspace_symbol_for_file(
         &mut self,
         _file: &str,
@@ -288,6 +374,7 @@ pub trait LspClient: std::any::Any + Send {
     ) -> Result<i64, LspError> {
         self.workspace_symbol(query).await
     }
+    /// Requests references to the symbol at an editor position.
     async fn references(
         &mut self,
         file: &str,
@@ -295,20 +382,27 @@ pub trait LspClient: std::any::Any + Send {
         y: usize,
         include_declaration: bool,
     ) -> Result<i64, LspError>;
+    /// Resolves call-hierarchy roots at an editor position.
     async fn call_hierarchy_prepare(
         &mut self,
         file: &str,
         x: usize,
         y: usize,
     ) -> Result<i64, LspError>;
+    /// Requests a complete semantic-token stream.
     async fn semantic_tokens_full(&mut self, file: &str) -> Result<i64, LspError>;
+    /// Requests inlay hints for an LSP range.
     async fn inlay_hint(&mut self, file: &str, range: Range) -> Result<i64, LspError>;
+    /// Sends an arbitrary request to this client.
+    ///
+    /// `force` bypasses capability gating used by known high-level requests.
     async fn send_request(
         &mut self,
         method: &str,
         params: Value,
         force: bool,
     ) -> Result<i64, LspError>;
+    /// Sends an arbitrary request through the client associated with `file`.
     async fn send_request_for_file(
         &mut self,
         _file: &str,
@@ -318,6 +412,7 @@ pub trait LspClient: std::any::Any + Send {
     ) -> Result<i64, LspError> {
         self.send_request(method, params, force).await
     }
+    /// Sends an arbitrary request through an explicitly named managed client.
     async fn send_request_for_source(
         &mut self,
         _source: &str,
@@ -327,6 +422,7 @@ pub trait LspClient: std::any::Any + Send {
     ) -> Result<i64, LspError> {
         self.send_request(method, params, force).await
     }
+    /// Sends an arbitrary notification, optionally bypassing lifecycle gating.
     async fn send_notification(
         &mut self,
         method: &str,
@@ -334,6 +430,7 @@ pub trait LspClient: std::any::Any + Send {
         force: bool,
     ) -> Result<(), LspError>;
 
+    /// Sends completion using an already converted LSP line and UTF-16 column.
     async fn request_completion(
         &mut self,
         file_uri: &str,
@@ -342,7 +439,9 @@ pub trait LspClient: std::any::Any + Send {
         trigger_character: Option<char>,
     ) -> Result<i64, LspError>;
 
-    /// Pull diagnostics if this capability is enabled, returns None otherwise
+    /// Pulls diagnostics when the server advertises support.
+    ///
+    /// Returns `None` when the capability is unavailable.
     async fn request_diagnostics(&mut self, file_uri: &str) -> Result<Option<i64>, LspError>;
 
     // TODO: Request code lens information if this capability is enabled, returns None otherwise
@@ -357,31 +456,39 @@ pub trait LspClient: std::any::Any + Send {
     // TODO: Request document symbol information if this capability is enabled, returns None otherwise
     // async fn request_document_symbol(&mut self, file_uri: &str) -> Result<Option<i64>, LspError>;
 
+    /// Receives the next inbound message and its managed client key, if any.
     async fn recv_response(&mut self)
         -> Result<Option<(InboundMessage, Option<String>)>, LspError>;
 
+    /// Returns capabilities negotiated by this client's primary server.
     fn get_server_capabilities(&self) -> Option<&ServerCapabilities>;
 
+    /// Returns capabilities for the managed client associated with `file`.
     fn server_capabilities_for_file(&self, _file: &str) -> Option<&ServerCapabilities> {
         self.get_server_capabilities()
     }
 
+    /// Reports whether the server associated with `file` supports formatting.
     fn supports_document_formatting(&self, _file: &str) -> bool {
         true
     }
 
+    /// Returns the most recently published LSP document version.
     fn document_version(&self, _file: &str) -> Option<i64> {
         None
     }
 
+    /// Returns the workspace root selected for `file`.
     fn workspace_root_for_file(&self, _file: &str) -> Option<PathBuf> {
         None
     }
 
+    /// Returns the workspace root associated with a server-initiated request.
     fn workspace_root_for_request(&self, _request: &ServerRequest) -> Option<PathBuf> {
         None
     }
 
+    /// Replies to a server `workspace/applyEdit` request.
     async fn respond_workspace_edit(
         &mut self,
         _request: &ServerRequest,
@@ -391,5 +498,6 @@ pub trait LspClient: std::any::Any + Send {
         Ok(())
     }
 
+    /// Performs graceful server shutdown and releases the transport.
     async fn shutdown(&mut self) -> Result<(), LspError>;
 }

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -1,3 +1,18 @@
+//! Hand-maintained LSP data-transfer objects plus Red-specific progress enrichment.
+//!
+//! Most types mirror JSON shapes from the Language Server Protocol and use protocol
+//! field names through Serde. Optional fields preserve the distinction between an absent
+//! capability and an explicit value. Numeric protocol enums validate unknown values
+//! instead of accepting arbitrary discriminants.
+//!
+//! [`Position::character`] is a zero-based UTF-16 code-unit offset. It must not be passed
+//! directly to editor or buffer APIs, even when ASCII input makes the number appear
+//! interchangeable with a grapheme or Unicode scalar index.
+//!
+//! This file is authored source rather than generated output. Red-specific fields such
+//! as [`ProgressParams::lsp_client`] are compatibility surface for bundled plugins and
+//! require the same serialization care as protocol fields.
+
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -651,7 +666,7 @@ impl WorkspaceFolder {
     }
 }
 
-/// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities
+/// <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities>
 #[derive(Debug, Clone, Serialize, Deserialize, Default, Builder)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientCapabilities {

--- a/src/lsp/workspace_edit.rs
+++ b/src/lsp/workspace_edit.rs
@@ -1,3 +1,17 @@
+//! Preparation and fail-closed application of multi-document LSP workspace edits.
+//!
+//! [`prepare_workspace_edit`] validates the complete ordered operation list before the
+//! editor mutates open buffers or filesystem resources. Targets must remain within the
+//! workspace, text must be valid and bounded UTF-8, expected revisions and versions must
+//! match, protected paths and unsupported change annotations fail closed, and total
+//! content is capped.
+//!
+//! Filesystem create, rename, and delete operations use handle-relative no-follow
+//! checks on supported platforms and record rollback state. If an operation fails, the
+//! implementation restores prior resources unless a concurrent external change would be
+//! overwritten. Buffer undo remains per document and does not include filesystem
+//! resource operations.
+
 use std::{
     collections::{HashMap, HashSet},
     fs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,11 @@
+//! Process entry point and top-level lifecycle selection for Red.
+//!
+//! Startup validates mutually exclusive utility modes before constructing editor state.
+//! Utility commands exit without entering the terminal, interactive runs own terminal
+//! setup and cleanup, and Unix detach mode splits ownership between a persistent core
+//! process and a replaceable terminal client. This module is responsible for choosing
+//! those lifecycles, not for implementing editor behavior within them.
+
 use std::{
     fs,
     io::{stdout, Write as _},

--- a/src/matchit.rs
+++ b/src/matchit.rs
@@ -1,3 +1,9 @@
+//! Configurable matching motions for brackets and language-specific token groups.
+//!
+//! Match discovery combines literal pairs with syntax-aware token groups configured per
+//! language. Returned positions use editor grapheme coordinates; tree-sitter byte spans
+//! are converted before crossing the module boundary.
+
 use regex::Regex;
 
 use crate::{

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -1,3 +1,13 @@
+//! Static validation of Husk calls against the machine-readable Red host API.
+//!
+//! [`HOST_API`] loads the embedded `host_api.json` schema, and the validator walks a
+//! parsed Husk AST to check action name, call kind, arity, and argument compatibility.
+//! This pass runs before activation so an invalid bundled or user plugin can be
+//! quarantined without executing host effects.
+//!
+//! Validation is deliberately conservative: a call that cannot be resolved safely is
+//! rejected rather than deferred to a dynamic runtime failure.
+
 use std::{collections::HashMap, ops::Range};
 
 use husk_ast::{

--- a/src/plugin/decoration.rs
+++ b/src/plugin/decoration.rs
@@ -1,3 +1,11 @@
+//! Namespaced inline decorations rendered against buffer lines.
+//!
+//! [`DecorationManager`] replaces one plugin namespace atomically and indexes accepted
+//! decorations by buffer and line for the renderer. Coordinates refer to buffer lines
+//! plus the anchor-specific character or display position documented by
+//! [`DecorationAnchor`]. Namespace replacement prevents stale decorations from surviving
+//! a plugin refresh.
+
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};

--- a/src/plugin/gutter.rs
+++ b/src/plugin/gutter.rs
@@ -1,3 +1,9 @@
+//! Namespaced signs rendered in the fixed-width editor gutter.
+//!
+//! [`GutterSignManager`] owns plugin sign sets and resolves collisions deterministically
+//! by priority. A refresh replaces a complete namespace; plugins should not assume that
+//! insertion order can preserve an older sign after the next update.
+
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};

--- a/src/plugin/location.rs
+++ b/src/plugin/location.rs
@@ -1,3 +1,10 @@
+//! Serialized plugin locations and explicit conversion at the editor navigation boundary.
+//!
+//! Plugin locations use zero-based lines and declare whether columns are UTF-8 bytes or
+//! UTF-16 code units. UTF-8 bytes remain the compatibility default. The editor validates
+//! boundaries before converting to its grapheme cursor; passing a scalar or display
+//! column under the default encoding can select the wrong text for non-ASCII input.
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/plugin/metadata.rs
+++ b/src/plugin/metadata.rs
@@ -1,3 +1,11 @@
+//! Optional plugin identity, dependency, compatibility, and capability metadata.
+//!
+//! Metadata is loaded before source activation so the registry can order dependencies
+//! and quarantine incompatible plugins without executing them. Missing metadata produces
+//! a minimal local description, while malformed supplied metadata is a quarantine error.
+//! Capability flags describe intent and discovery; process permissions remain an
+//! independently enforced configuration boundary.
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -14,7 +22,7 @@ pub struct PluginMetadata {
     /// Plugin description
     pub description: Option<String>,
 
-    /// Plugin author (name or name <email>)
+    /// Plugin author as a name or `name <email>` string.
     pub author: Option<String>,
 
     /// Plugin license

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,3 +1,15 @@
+//! Versioned Husk plugin platform and plugin-owned editor presentation resources.
+//!
+//! The registry owns discovery, compatibility, status, activation, and hot reload.
+//! [`Runtime`] owns the Husk VM and implements the Rust side of the host boundary.
+//! Feature modules model resources such as panels, overlays, gutter signs, decorations,
+//! workspaces, window bars, and permitted child processes; the editor remains the sole
+//! authority that applies their requested effects.
+//!
+//! `host_api.json` is the machine-readable compatibility contract. Rust request enums,
+//! semantic declarations, and prose documentation must remain consistent with that
+//! schema, but must not independently redefine its version.
+
 mod api;
 pub mod decoration;
 pub mod gutter;

--- a/src/plugin/overlay.rs
+++ b/src/plugin/overlay.rs
@@ -1,3 +1,10 @@
+//! Plugin-owned floating overlays positioned within the terminal viewport.
+//!
+//! [`OverlayManager`] stores complete overlay models by stable plugin-provided ID and
+//! resolves alignment against current terminal bounds during rendering. Creating an
+//! existing ID replaces its configuration; removal is idempotent from the caller's
+//! perspective.
+
 use std::collections::HashMap;
 
 use serde::Deserialize;

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -1,3 +1,14 @@
+//! Side-panel models, source-backed text conversations, focus, scrolling, and hit testing.
+//!
+//! [`PanelManager`] owns plugin panels by stable ID and computes how their requested
+//! widths reduce the editor viewport. Row panels contain selectable structured rows;
+//! text panels retain source blocks and derive wrapped rendered rows for the current
+//! width so streaming appends never destroy the authoritative text.
+//!
+//! Focus, composer drafts, tail-follow state, scroll offsets, and header hit regions are
+//! manager-owned UI state. A plugin may replace content but must use the same panel ID to
+//! preserve that lifecycle intentionally.
+
 use std::{collections::HashMap, time::Instant};
 
 use crossterm::event::{Event, KeyCode, KeyModifiers};

--- a/src/plugin/process.rs
+++ b/src/plugin/process.rs
@@ -1,3 +1,14 @@
+//! Permission-checked child-process lifecycle for bundled and user Husk plugins.
+//!
+//! [`ProcessManager`] starts only executables allowed for the requesting plugin, applies
+//! bounded output handling, strips unapproved environment variables, and returns events
+//! through polling instead of letting worker tasks mutate editor state. Process IDs are
+//! opaque capabilities owned by the creating plugin.
+//!
+//! A permitted executable is not a shell grant: arguments are passed directly and
+//! callers cannot use this API to expand shell syntax. Editor replacement uses a
+//! separate, narrowly scoped environment contract.
+
 use std::{
     collections::{HashMap, VecDeque},
     io::{BufRead, BufReader, Read, Write},

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -1,3 +1,15 @@
+//! Plugin discovery, dependency ordering, quarantine, command dispatch, and transactional reload.
+//!
+//! [`PluginRegistry`] is the lifecycle authority above the Husk [`Runtime`]. Plugins
+//! begin pending, become active only after metadata, compatibility, source, semantic, and
+//! activation checks, and otherwise enter a diagnostic [`PluginStatus`]. A required
+//! dependency failure cascades to active dependents.
+//!
+//! Hot reload stages replacement activation and teardown effects in the runtime. A
+//! successful reload commits them in lifecycle order; a failure leaves the previous VM,
+//! callbacks, commands, and state active and records a reload error. Callers should
+//! inspect status rather than assuming a changed source file became live.
+
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
@@ -10,6 +22,7 @@ use serde::Serialize;
 
 use super::{PluginMetadata, Runtime};
 
+/// Lifecycle authority for configured Husk plugins.
 pub struct PluginRegistry {
     plugins: Vec<(String, String)>,
     metadata: HashMap<String, PluginMetadata>,
@@ -19,6 +32,7 @@ pub struct PluginRegistry {
     last_hot_reload_poll: Instant,
 }
 
+/// Host API version used for plugin compatibility checks.
 pub const RED_HOST_API_VERSION: &str = "0.2.0";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,17 +43,28 @@ struct PluginModification {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "status")]
+/// Observable lifecycle state of a configured plugin.
 pub enum PluginStatus {
+    /// Registered but not yet considered for activation.
     Pending,
+    /// Loaded, activated, and eligible for callbacks.
     Active,
+    /// Previous version remains active because a staged reload failed.
     ActiveWithReloadError {
+        /// Source path that failed to replace the active version.
         path: String,
+        /// Parse, typecheck, activation, migration, or teardown failure.
         diagnostic: String,
     },
+    /// Explicitly disabled by configuration.
     Disabled,
+    /// Unloaded after a lifecycle or runtime failure.
     Quarantined {
+        /// Lifecycle phase that failed.
         stage: String,
+        /// Source or metadata path associated with the failure.
         path: String,
+        /// Human-readable failure detail.
         diagnostic: String,
     },
 }
@@ -51,6 +76,7 @@ impl Default for PluginRegistry {
 }
 
 impl PluginRegistry {
+    /// Creates an empty, uninitialized registry.
     pub fn new() -> Self {
         Self {
             plugins: Vec::new(),
@@ -62,6 +88,10 @@ impl PluginRegistry {
         }
     }
 
+    /// Registers a plugin source and eagerly reads adjacent metadata.
+    ///
+    /// Metadata failures quarantine the plugin immediately but do not abort
+    /// discovery of unrelated plugins.
     pub fn add(&mut self, name: &str, path: &str) {
         self.plugins.push((name.to_string(), path.to_string()));
         self.statuses
@@ -102,10 +132,12 @@ impl PluginRegistry {
     }
 
     #[must_use]
+    /// Returns current lifecycle status keyed by plugin name.
     pub fn statuses(&self) -> &HashMap<String, PluginStatus> {
         &self.statuses
     }
 
+    /// Activates plugins in dependency order and quarantines independent failures.
     pub async fn initialize(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
         let mut pending = self.plugins.clone();
         pending.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
@@ -257,6 +289,7 @@ impl PluginRegistry {
         );
     }
 
+    /// Executes a plugin command and quarantines its owner on callback failure.
     pub async fn execute(&mut self, runtime: &mut Runtime, command: &str) -> anyhow::Result<()> {
         let owner = runtime.command_plugin(command);
         if let Err(error) = runtime.execute_command(command).await {
@@ -274,6 +307,7 @@ impl PluginRegistry {
         Ok(())
     }
 
+    /// Broadcasts an event while isolating and quarantining per-plugin failures.
     pub async fn notify(
         &mut self,
         runtime: &mut Runtime,
@@ -293,6 +327,7 @@ impl PluginRegistry {
         Ok(())
     }
 
+    /// Sends an event only to one plugin and quarantines it on failure.
     pub async fn notify_plugin(
         &mut self,
         runtime: &mut Runtime,
@@ -313,6 +348,10 @@ impl PluginRegistry {
         Ok(())
     }
 
+    /// Resolves a one-shot plugin request and quarantines a failing callback.
+    ///
+    /// A callback failure still returns `true` because the request ID was
+    /// consumed and must not be retried.
     pub async fn resolve_request(
         &mut self,
         runtime: &mut Runtime,
@@ -346,6 +385,7 @@ impl PluginRegistry {
         }
     }
 
+    /// Invokes `before_exit` with the final editor snapshot after initialization.
     pub async fn before_exit(
         &self,
         runtime: &mut Runtime,
@@ -358,6 +398,7 @@ impl PluginRegistry {
         runtime.before_exit(serde_json::to_value(snapshot)?).await
     }
 
+    /// Runs plugin teardown and marks the registry uninitialized.
     pub async fn deactivate_all(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
         if !self.initialized {
             return Ok(());
@@ -368,6 +409,7 @@ impl PluginRegistry {
         Ok(())
     }
 
+    /// Transactionally reloads every enabled plugin in dependency order.
     pub async fn reload(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
         let selected = self
             .plugins
@@ -438,6 +480,9 @@ impl PluginRegistry {
         }
     }
 
+    /// Polls filesystem-backed sources and reloads changed plugins and dependents.
+    ///
+    /// Polling is internally rate-limited and ignores embedded plugin URIs.
     pub async fn poll_hot_reload(&mut self, runtime: &mut Runtime) {
         if self.last_hot_reload_poll.elapsed() < Duration::from_millis(250) {
             return;

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1,3 +1,17 @@
+//! Red-specific Husk VM host, request translation, snapshots, timers, and reload staging.
+//!
+//! [`Runtime`] wraps the Red-agnostic `husk::Vm` with a host that translates Husk calls
+//! into [`PluginRequest`] values. The editor consumes those
+//! requests and remains the sole mutator of buffers and UI state. Snapshot requests read
+//! editor-produced JSON captured at defined service points rather than borrowing editor
+//! state from the VM.
+//!
+//! Reload staging records host effects until the replacement has activated and the old
+//! plugin has torn down successfully. Committing reorders replacement effects ahead of
+//! teardown where required; rollback discards every staged request, log, and timer.
+//! Each callback also runs under an instruction budget so a plugin cannot monopolize the
+//! editor loop indefinitely.
+
 use std::{
     collections::HashMap,
     path::PathBuf,

--- a/src/plugin/timer_stats.rs
+++ b/src/plugin/timer_stats.rs
@@ -1,3 +1,10 @@
+//! Process-wide accounting for plugin-created timeouts and intervals.
+//!
+//! Statistics are diagnostic counters rather than timer ownership. The runtime updates
+//! them when resources are created or cleared, and shutdown may log a snapshot to expose
+//! leaked plugin timers. The global mutex assumes callbacks do not recursively request a
+//! statistics snapshot while holding it.
+
 use std::collections::HashMap;
 use std::sync::Mutex;
 

--- a/src/plugin/window_bar.rs
+++ b/src/plugin/window_bar.rs
@@ -1,3 +1,10 @@
+//! Plugin-defined semantic bars rendered above individual editor windows.
+//!
+//! [`WindowBarManager`] selects at most one bar for each stable window ID. Higher
+//! priority wins and the most recently created bar breaks ties. Segment clipping is
+//! display-width aware, preserves action hit regions for visible text, and resolves
+//! semantic theme styles before applying concrete overrides.
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -1,3 +1,10 @@
+//! Full-screen plugin workspace models and selection state.
+//!
+//! A [`WorkspaceModel`] is the plugin-owned snapshot of rows, sections, actions, and
+//! detail content. [`WorkspaceManager`] owns focus and the currently selected row while
+//! replacing models by stable workspace ID. Selection restoration is ID-based so
+//! reordering rows does not silently move focus to unrelated content.
+
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -1,3 +1,11 @@
+//! Best-effort persistence for command history, picker history, and plugin-owned values.
+//!
+//! Preferences are convenience state rather than recovery state: malformed or
+//! unreadable data loads as an empty store and is reported through the configured
+//! logger. File writes are owner-only and refuse unsafe symlink targets on supported
+//! platforms. An in-memory store gives tests and embedded callers identical mutation
+//! semantics without filesystem effects.
+
 use std::{
     collections::HashMap,
     fs,
@@ -12,6 +20,7 @@ const COMMAND_HISTORY_LIMIT: usize = 100;
 const PICKER_HISTORY_LIMIT: usize = 100;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// Serialized convenience state owned by [`PreferencesStore`].
 pub struct Preferences {
     #[serde(default)]
     command_history: Vec<String>,
@@ -22,12 +31,14 @@ pub struct Preferences {
 }
 
 #[derive(Debug, Clone)]
+/// Best-effort preferences persistence with an optional filesystem backing.
 pub struct PreferencesStore {
     path: Option<PathBuf>,
     preferences: Preferences,
 }
 
 impl PreferencesStore {
+    /// Creates a store whose mutations never touch the filesystem.
     pub fn in_memory() -> Self {
         Self {
             path: None,
@@ -35,6 +46,10 @@ impl PreferencesStore {
         }
     }
 
+    /// Loads preferences, falling back to empty state on any read or parse error.
+    ///
+    /// Failures are logged when a logger exists. Legacy plugin state is
+    /// imported opportunistically.
     pub fn load(path: impl AsRef<Path>) -> Self {
         let path = path.as_ref().to_path_buf();
         let preferences = load_preferences(&path).unwrap_or_else(|error| {
@@ -55,10 +70,12 @@ impl PreferencesStore {
         store
     }
 
+    /// Returns command-line history from oldest to newest.
     pub fn command_history(&self) -> &[String] {
         &self.preferences.command_history
     }
 
+    /// Returns history for a picker namespace from oldest to newest.
     pub fn picker_history(&self, key: &str) -> &[String] {
         self.preferences
             .picker_history
@@ -67,6 +84,9 @@ impl PreferencesStore {
             .unwrap_or(&[])
     }
 
+    /// Appends a non-empty command unless it duplicates the newest entry.
+    ///
+    /// History is bounded and a filesystem-backed store saves immediately.
     pub fn record_command(&mut self, command: &str) -> anyhow::Result<()> {
         if command.trim().is_empty() {
             return Ok(());
@@ -94,6 +114,7 @@ impl PreferencesStore {
         self.save()
     }
 
+    /// Appends a non-empty picker query within a bounded namespace history.
     pub fn record_picker_query(&mut self, key: &str, query: &str) -> anyhow::Result<()> {
         if key.trim().is_empty() || query.trim().is_empty() {
             return Ok(());
@@ -117,6 +138,7 @@ impl PreferencesStore {
         self.save()
     }
 
+    /// Removes and persists one picker history namespace.
     pub fn remove_picker_history(&mut self, key: &str) -> anyhow::Result<()> {
         if self.preferences.picker_history.remove(key).is_none() {
             return Ok(());
@@ -125,12 +147,14 @@ impl PreferencesStore {
         self.save()
     }
 
+    /// Reads a plugin-owned preference value.
     pub fn plugin_storage(&self, plugin: &str, key: &str) -> Option<&serde_json::Value> {
         self.preferences
             .plugin_storage
             .get(&plugin_storage_key(plugin, key))
     }
 
+    /// Sets and immediately persists a plugin-owned preference value.
     pub fn set_plugin_storage(
         &mut self,
         plugin: &str,
@@ -143,6 +167,9 @@ impl PreferencesStore {
         self.save()
     }
 
+    /// Persists owner-only JSON for filesystem-backed stores.
+    ///
+    /// In-memory stores treat saving as a successful no-op.
     pub fn save(&self) -> anyhow::Result<()> {
         let Some(path) = &self.path else {
             return Ok(());

--- a/src/self_check.rs
+++ b/src/self_check.rs
@@ -1,3 +1,10 @@
+//! Non-interactive validation of the embedded themes and bundled Husk plugin corpus.
+//!
+//! Self-check constructs production-equivalent plugin snapshots without entering raw
+//! terminal mode, activates every configured bundled plugin, and reports quarantine
+//! status. It is a packaging and release diagnostic; it does not inspect user-installed
+//! plugins or mutate user configuration.
+
 use crate::{
     assets,
     buffer::Buffer,

--- a/src/session.rs
+++ b/src/session.rs
@@ -22,6 +22,10 @@ use crate::{
     window::WindowManagerSnapshot,
 };
 
+/// Schema version written into every persisted [`SessionSnapshot`].
+///
+/// Readers reject snapshots with newer or otherwise unsupported versions
+/// rather than attempting a partial recovery.
 pub const SESSION_SCHEMA_VERSION: u32 = 2;
 const MAX_SESSION_DISK_CONTENT_BYTES: u64 = 8 * 1024 * 1024;
 const MAX_SESSION_SNAPSHOT_BYTES: u64 = 256 * 1024 * 1024;
@@ -61,29 +65,48 @@ pub(crate) struct SessionDiskFingerprint {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Complete editor-owned state needed to recover a crashed session.
+///
+/// This is a durable format, not an internal cache. New optional state must
+/// use Serde defaults so snapshots from earlier Red versions remain readable.
 pub struct SessionSnapshot {
+    /// On-disk schema version.
     pub version: u32,
+    /// Monotonically increasing write generation within this store.
     #[serde(default)]
     pub generation: u64,
+    /// Working directory in effect when the snapshot was captured.
     pub cwd: String,
+    /// Wall-clock capture time, in Unix epoch milliseconds.
     pub saved_at_ms: u64,
+    /// Buffers in editor index order.
     pub buffers: Vec<SessionBufferSnapshot>,
+    /// Index of the buffer that was active at capture time.
     pub current_buffer_index: usize,
+    /// Split tree, focused window, and per-window view state.
     pub window_layout: WindowManagerSnapshot,
+    /// Named editor registers.
     #[serde(default)]
     pub registers: HashMap<char, Content>,
+    /// Jump-list entries in traversal order.
     #[serde(default)]
     pub jumps: Vec<SessionJump>,
+    /// Current position in [`Self::jumps`].
     #[serde(default)]
     pub jump_index: usize,
+    /// Buffer-local marks.
     #[serde(default)]
     pub local_marks: Vec<SessionMark>,
+    /// Cross-buffer marks.
     #[serde(default)]
     pub global_marks: Vec<SessionMark>,
+    /// Editor-managed special marks.
     #[serde(default)]
     pub special_marks: Vec<SessionMark>,
+    /// Human-readable agent transcript retained across recovery.
     #[serde(default)]
     pub agent_transcript: Option<String>,
+    /// Pending agent proposal state, including review dispositions.
     #[serde(default)]
     pub agent_workspace: Option<ProposalWorkspaceSnapshot>,
     /// False means the transcript is archived context after recovery. Red never
@@ -93,51 +116,88 @@ pub struct SessionSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Recoverable state for one editor buffer.
+///
+/// Cursor coordinates use Red's character-column convention. `disk_contents`
+/// records the trusted disk base used for recovery divergence detection; it is
+/// intentionally distinct from the possibly dirty in-memory `contents`.
 pub struct SessionBufferSnapshot {
+    /// Stable buffer index referenced by windows, marks, and proposals.
     pub index: usize,
+    /// Canonical file path, or `None` for an unnamed buffer.
     pub path: Option<String>,
+    /// Full in-memory text at capture time.
     pub contents: String,
+    /// Whether the in-memory text differed from its saved state.
     pub dirty: bool,
+    /// Buffer revision used to correlate derived state.
     pub revision: u64,
+    /// Cursor character column.
     pub cursor_x: usize,
+    /// Zero-based cursor line.
     pub cursor_y: usize,
+    /// First buffer line visible in the viewport.
     pub viewport_top: usize,
+    /// Branching undo history associated with this text.
     pub undo_history: UndoHistory,
+    /// Disk text observed when the snapshot was captured.
     #[serde(default)]
     pub disk_contents: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// One jump-list destination persisted in a session snapshot.
 pub struct SessionJump {
+    /// Destination path, or `None` for an unnamed buffer.
     pub file: Option<String>,
+    /// Character column.
     pub x: usize,
+    /// Zero-based line.
     pub y: usize,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+/// Determines which side of an insertion a restored mark follows.
 pub enum SessionAnchorAffinity {
+    /// Keep the mark before text inserted exactly at its anchor.
     Left,
+    /// Move the mark after text inserted exactly at its anchor.
     Right,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Durable representation of an editor mark.
 pub struct SessionMark {
+    /// Register-like mark name.
     pub name: char,
+    /// Buffer index used when the mark was captured.
     pub buffer_index: usize,
+    /// File fallback for resolving the mark if buffer indices change.
     pub file: Option<String>,
+    /// Character offset used by edit-aware anchor restoration.
     pub char_index: usize,
+    /// Line-and-column fallback for older or degraded recovery paths.
     pub fallback: TextPosition,
+    /// Insertion-side behavior at the exact anchor.
     pub affinity: SessionAnchorAffinity,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Difference between a snapshot's disk base and the file now on disk.
 pub struct RecoveryDivergence {
+    /// File whose current contents no longer match the captured base.
     pub path: String,
+    /// Unified diff from the captured disk base to the current file.
     pub diff: String,
 }
 
 #[derive(Debug, Clone)]
+/// Crash-safe rotating store for session snapshots.
+///
+/// Writes use a synced temporary file and retain one last-known-good
+/// generation. Owner-scoped stores additionally confine access beneath a
+/// validated namespace directory.
 pub struct SessionStore {
     directory: PathBuf,
     namespace_root: Option<PathBuf>,
@@ -152,6 +212,7 @@ pub enum SnapshotFault {
 }
 
 impl SessionStore {
+    /// Creates a store rooted directly at `directory`.
     #[must_use]
     pub fn new(directory: impl Into<PathBuf>) -> Self {
         Self {
@@ -160,6 +221,10 @@ impl SessionStore {
         }
     }
 
+    /// Creates an owner-scoped store beneath `directory`.
+    ///
+    /// `owner` is restricted to a single safe path component. The root must
+    /// not be a symlink.
     pub fn for_owner(directory: impl AsRef<Path>, owner: &str) -> anyhow::Result<Self> {
         anyhow::ensure!(
             !owner.is_empty()
@@ -183,10 +248,15 @@ impl SessionStore {
         })
     }
 
+    /// Loads the preferred recoverable snapshot from the root and owner stores.
+    ///
+    /// Recoverable dirty or pending-proposal snapshots rank ahead of clean
+    /// snapshots, then capture time and generation break ties.
     pub fn load_latest(directory: impl AsRef<Path>) -> anyhow::Result<SessionSnapshot> {
         Self::load_latest_with_store(directory).map(|(_, snapshot)| snapshot)
     }
 
+    /// Loads the preferred snapshot together with the store that supplied it.
     pub fn load_latest_with_store(
         directory: impl AsRef<Path>,
     ) -> anyhow::Result<(Self, SessionSnapshot)> {
@@ -257,6 +327,7 @@ impl SessionStore {
     }
 
     #[must_use]
+    /// Returns the path reserved for the newest complete generation.
     pub fn latest_path(&self) -> PathBuf {
         self.directory.join("latest.json")
     }
@@ -270,6 +341,10 @@ impl SessionStore {
         format!("snapshot-{}-{id}.tmp", std::process::id())
     }
 
+    /// Loads and validates this store's newest usable generation.
+    ///
+    /// A missing or invalid `latest.json` falls back to `previous.json`.
+    /// Other I/O errors are surfaced rather than silently bypassed.
     pub fn load(&self) -> anyhow::Result<SessionSnapshot> {
         let validated = |path: &Path| {
             read_snapshot(path).and_then(|snapshot| {
@@ -293,6 +368,11 @@ impl SessionStore {
         }
     }
 
+    /// Atomically writes the next snapshot generation.
+    ///
+    /// The method updates `snapshot.version` and `snapshot.generation`, syncs
+    /// the temporary file, rotates the previous generation, and finally syncs
+    /// the containing directory.
     pub fn write(&self, snapshot: &mut SessionSnapshot) -> anyhow::Result<()> {
         self.write_with_fault(snapshot, SnapshotFault::None)
     }
@@ -1568,6 +1648,11 @@ fn open_or_create_session_child(parent: &File, name: &std::ffi::OsStr) -> io::Re
     Ok(unsafe { File::from_raw_fd(descriptor) })
 }
 
+/// Compares every file-backed snapshot buffer with its current disk contents.
+///
+/// Unreadable files are reported as divergences instead of being treated as
+/// empty or unchanged. The returned diffs are diagnostic; this function does
+/// not modify either disk or recovered buffer state.
 pub fn detect_disk_divergence(snapshot: &SessionSnapshot) -> Vec<RecoveryDivergence> {
     snapshot
         .buffers

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,10 +1,18 @@
+//! Debounced accumulation of file identifiers awaiting synchronization.
+//!
+//! [`SyncState`] coalesces duplicate changes until its quiet period elapses, then
+//! transfers the complete set to the caller. The caller owns delivery and retry;
+//! retrieving a ready set clears it from this state.
+
 use std::{
     collections::HashSet,
     time::{Duration, Instant},
 };
 
+/// Pending file changes and the quiet-period clock used to coalesce them.
 #[derive(Debug)]
 pub struct SyncState {
+    /// Deduplicated changed file identifiers, or `None` when no work is pending.
     pub changes: Option<HashSet<String>>,
 
     last_notification: Instant,
@@ -12,21 +20,27 @@ pub struct SyncState {
 }
 
 impl SyncState {
+    /// Creates an empty state with the default debounce delay.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Adds a file identifier and restarts the quiet period.
     pub fn notify_change(&mut self, file: impl ToString) {
         let changes = self.changes.get_or_insert_with(HashSet::new);
         changes.insert(file.to_string());
         self.last_notification = Instant::now();
     }
 
+    /// Returns whether the configured quiet period has elapsed.
     pub fn should_notify(&self) -> bool {
         let now = Instant::now();
         now.duration_since(self.last_notification) > self.debounce_delay
     }
 
+    /// Takes the pending set once the quiet period has elapsed.
+    ///
+    /// Calling this before the deadline preserves the set and returns `None`.
     pub fn get_changes(&mut self) -> Option<HashSet<String>> {
         if self.should_notify() {
             self.last_notification = Instant::now();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,5 +1,10 @@
-/// Test utilities for the Red editor
-/// This module provides test helpers without requiring feature flags
+//! Production-path test helpers for constructing and observing an editor.
+//!
+//! These helpers expose state needed by integration tests while routing actions and
+//! events through the same transaction, notification, plugin, and rendering seams used
+//! interactively. They are hidden from generated public documentation and are not a
+//! supported embedding API.
+
 use crate::editor::{Action, Editor, Mode};
 
 /// Extension trait for Editor that provides test-specific functionality

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,3 +1,11 @@
+//! Editor theme model, semantic style lookup, defaults, and VS Code theme import.
+//!
+//! A [`Theme`] contains the concrete styles used by the renderer and a semantic lookup
+//! surface used by plugins. [`ThemeStyleSpec`] resolves an ordered list of semantic
+//! foreground candidates before callers apply explicit style overrides. Parsing accepts
+//! comments through the VS Code adapter but produces the same internal model as bundled
+//! native themes.
+
 mod vscode;
 
 use std::collections::BTreeMap;

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -1,3 +1,9 @@
+//! Translation from VS Code color-theme JSON into Red's concrete [`Theme`].
+//!
+//! Import resolves workbench colors, token scopes, font styles, and fallback relationships
+//! without retaining the source JSON. Unknown source fields are ignored for compatibility;
+//! invalid colors or required structural values remain parse errors.
+
 use std::{
     collections::{BTreeMap, HashMap},
     fs,

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -1,3 +1,9 @@
+//! Completion-menu state, filtering, selection, documentation, and terminal rendering.
+//!
+//! [`CompletionUI`] owns a snapshot of LSP completion items and the selection derived
+//! from the current query. It produces actions for the editor to apply; accepting an
+//! item does not itself mutate a buffer.
+
 use std::cmp::min;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -1,3 +1,9 @@
+//! Type-erased wrapper around the currently active modal [`Component`].
+//!
+//! A dialog delegates drawing and input while preserving component-specific update hooks
+//! for pickers. The editor owns at most one dialog and decides whether unhandled input
+//! continues to the normal action pipeline.
+
 use crate::{
     editor::RenderBuffer,
     theme::{Style, Theme},

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -1,3 +1,10 @@
+//! Asynchronous workspace file discovery with ignore rules and bounded preview loading.
+//!
+//! [`FilePicker`] walks from the workspace root without blocking the editor loop, streams
+//! discovered paths into a picker, and reads previews on demand. Ignore files and hidden
+//! entries follow the configured walker policy; this feature is discovery UI rather than
+//! a security boundary for opening paths.
+
 use std::{
     path::{Path, PathBuf},
     sync::mpsc::{self, Receiver, TryRecvError},

--- a/src/ui/info.rs
+++ b/src/ui/info.rs
@@ -1,3 +1,8 @@
+//! Small informational dialog with width-aware wrapped text.
+//!
+//! [`Info`] is immutable apart from viewport sizing and returns ordinary close actions
+//! through the [`Component`] contract.
+
 use crate::{
     editor::{Editor, RenderBuffer},
     theme::{Style, Theme},

--- a/src/ui/input_prompt.rs
+++ b/src/ui/input_prompt.rs
@@ -1,3 +1,11 @@
+//! Single-line prompt component with optional masked rendering.
+//!
+//! [`InputPrompt`] owns text as Unicode graphemes for user-visible cursor motion and
+//! returns submission or cancellation actions to the editor. Sensitive prompts mask
+//! display and identify themselves through
+//! [`Component::is_sensitive_input`] so
+//! performance traces do not include their contents.
+
 use crossterm::event::{Event, KeyCode, KeyModifiers};
 
 use crate::{

--- a/src/ui/keymap_hints.rs
+++ b/src/ui/keymap_hints.rs
@@ -1,3 +1,9 @@
+//! Delayed, width-aware rendering of available continuations for pending key prefixes.
+//!
+//! Keymap hints are derived from effective configured mappings and command metadata. The
+//! renderer is purely presentational; prefix timing and key resolution remain editor
+//! responsibilities.
+
 use crate::{
     command_palette::KeymapHint,
     editor::RenderBuffer,

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -1,3 +1,8 @@
+//! Reusable selectable list primitive for compact modal components.
+//!
+//! [`List`] owns row selection and viewport scrolling while callers own item meaning and
+//! resulting editor actions. Row widths are clipped in terminal columns.
+
 use crate::{
     editor::RenderBuffer,
     theme::Style,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,11 @@
+//! Modal terminal UI components hosted above the editor and plugin surfaces.
+//!
+//! [`Component`] defines drawing, event handling, resizing, theme updates, cursor
+//! placement, and optional passthrough for one active dialog-like surface. Components
+//! return editor [`KeyAction`] values instead of mutating the
+//! editor directly. Sensitive components must report their input status so tracing and
+//! logging do not serialize secrets.
+
 mod agent_composer;
 mod completion;
 mod dialog;

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -1,3 +1,13 @@
+//! Structured fuzzy picker with query editing, history, previews, status, and live updates.
+//!
+//! [`Picker`] separates authoritative [`PickerItem`] identity and metadata from rendered
+//! rows. Filtering may be local or supplied by a live plugin callback; update IDs prevent
+//! responses for an older picker instance from mutating the active dialog.
+//!
+//! Query and cursor operations are grapheme-aware, while alignment and clipping use
+//! terminal display columns. Selection actions are returned to the editor or plugin
+//! owner and never applied directly by this module.
+
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -1,39 +1,82 @@
+//! Branch-preserving edit transactions, attribution, dirty-state revisions, and replay.
+//!
+//! One [`EditTransaction`] represents a logical undo step and contains ordered textual
+//! replacements plus cursor state before and after the change. [`UndoHistory`] retains
+//! sibling children when editing after an undo, so redo follows the selected branch
+//! rather than discarding alternate history.
+//!
+//! [`TextPosition::character`] is a zero-based Unicode scalar index within a line, not a
+//! UTF-8 byte, grapheme, terminal column, or LSP UTF-16 offset. Transactions record raw
+//! replacements but do not notify external consumers; the editor owns notification,
+//! anchor maintenance, rendering, and restoration around replay.
+
 use std::collections::{HashMap, HashSet};
 
 use crate::buffer::Buffer;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
+/// Identifies the subsystem responsible for one committed transaction.
 pub enum EditOrigin {
+    /// A change initiated directly by editor input or an explicit user command.
     User,
-    Agent { session_id: String, turn_id: String },
-    Plugin { name: String },
-    Lsp { server: String },
+    /// An accepted agent proposal attributed to its Codex session and turn.
+    Agent {
+        /// Codex conversation that produced the proposal.
+        session_id: String,
+        /// Turn within the conversation that produced the proposal.
+        turn_id: String,
+    },
+    /// A change requested by a named Husk plugin.
+    Plugin {
+        /// Registered plugin name.
+        name: String,
+    },
+    /// A change returned by a named language server.
+    Lsp {
+        /// Managed language-server key.
+        server: String,
+    },
 }
 
+/// Zero-based line and Unicode-scalar position used by the canonical edit boundary.
+///
+/// `character` is not a UTF-8 byte, user-perceived grapheme, terminal column, or UTF-16
+/// code-unit offset. Callers crossing one of those boundaries must convert explicitly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct TextPosition {
+    /// Zero-based logical line.
     pub line: usize,
+    /// Zero-based Unicode scalar index within `line`.
     pub character: usize,
 }
 
 impl TextPosition {
+    /// Creates a position from a line and Unicode scalar index.
     pub fn new(line: usize, character: usize) -> Self {
         Self { line, character }
     }
 }
 
+/// Half-open range in canonical buffer character coordinates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct TextRange {
+    /// Inclusive start position.
     pub start: TextPosition,
+    /// Exclusive end position.
     pub end: TextPosition,
 }
 
 impl TextRange {
+    /// Creates a half-open range without reordering its endpoints.
+    ///
+    /// Callers must supply `start <= end`; passing reversed endpoints will cause later
+    /// buffer conversion to clamp or reject the operation rather than selecting backward.
     pub fn new(start: TextPosition, end: TextPosition) -> Self {
         Self { start, end }
     }
 
+    /// Creates an empty range that inserts at `position`.
     pub fn insertion(position: TextPosition) -> Self {
         Self {
             start: position,
@@ -44,19 +87,29 @@ impl TextRange {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
+/// Serialized textual operation retained inside an edit transaction.
 pub enum TextEdit {
+    /// Replaces a half-open range and retains both images for replay and selective revert.
     Replace {
+        /// Canonical line and character range at original application time.
         range: TextRange,
+        /// Absolute Ropey character index at original application time.
         start_char: usize,
+        /// Text removed by the operation.
         old_text: String,
+        /// Text inserted by the operation.
         new_text: String,
     },
 }
 
+/// Concrete inverse replacement prepared for selective transaction reversion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RevertEdit {
+    /// Inclusive absolute character index in the current buffer.
     pub start_char: usize,
+    /// Exclusive absolute character index in the current buffer.
     pub end_char: usize,
+    /// Text that restores the selected transaction's pre-image.
     pub replacement: String,
 }
 
@@ -64,38 +117,60 @@ pub struct RevertEdit {
 /// the buffer's character coordinates immediately before that replacement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AppliedTextEdit {
+    /// Inclusive absolute character index before replay.
     pub start_char: usize,
+    /// Exclusive absolute character index before replay.
     pub end_char: usize,
+    /// Unicode scalar length of the inserted text.
     pub new_char_len: usize,
 }
 
+/// Cursor and viewport state restored around an undo-tree transaction.
+///
+/// `x` is an editor grapheme index, unlike [`TextPosition::character`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct CursorSnapshot {
+    /// Grapheme index within the cursor line.
     pub x: usize,
+    /// Zero-based buffer line.
     pub y: usize,
+    /// First buffer line visible in the originating window.
     pub vtop: usize,
 }
 
 impl CursorSnapshot {
+    /// Creates a cursor snapshot in editor coordinates.
     pub fn new(x: usize, y: usize, vtop: usize) -> Self {
         Self { x, y, vtop }
     }
 }
 
+/// One logical, attributed undo step and its cursor boundary.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EditTransaction {
+    /// Stable UUID used by history and selective-revert commands.
     pub id: String,
+    /// Best-effort Unix timestamp in milliseconds.
     pub timestamp_ms: u128,
+    /// Subsystem that initiated the change.
     pub origin: EditOrigin,
+    /// Human-readable action label.
     pub label: String,
+    /// Ordered replacements applied by the transaction.
     pub edits: Vec<TextEdit>,
+    /// Cursor state before the first replacement.
     pub before_cursor: CursorSnapshot,
+    /// Cursor state after the final replacement.
     pub after_cursor: CursorSnapshot,
     before_revision: u64,
     after_revision: u64,
 }
 
 impl EditTransaction {
+    /// Starts an empty transaction at the current history revision.
+    ///
+    /// The transaction is not part of history until at least one edit is recorded and
+    /// [`UndoHistory::commit_transaction`] succeeds.
     pub fn new(
         label: impl Into<String>,
         before_cursor: CursorSnapshot,
@@ -118,6 +193,7 @@ impl EditTransaction {
         }
     }
 
+    /// Returns whether the transaction contains no effective replacements.
     pub fn is_empty(&self) -> bool {
         self.edits.is_empty()
     }
@@ -130,19 +206,34 @@ struct UndoNode {
     children: Vec<usize>,
 }
 
+/// Read-only projection of one node used by undo-tree UI and diagnostics.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct UndoTreeEntry {
+    /// Internal node index within the projected tree.
     pub index: usize,
+    /// Parent node, or the virtual root when absent.
     pub parent: Option<usize>,
+    /// Child node indexes in creation order.
     pub children: Vec<usize>,
+    /// Whether this node is the history's current state.
     pub current: bool,
+    /// Stable transaction UUID.
     pub transaction_id: String,
+    /// Human-readable transaction label.
     pub label: String,
+    /// Attributed transaction origin.
     pub origin: EditOrigin,
+    /// Best-effort Unix timestamp in milliseconds.
     pub timestamp_ms: u128,
+    /// Recorded replacements in application order.
     pub edits: Vec<TextEdit>,
 }
 
+/// Buffer-local branching transaction history and saved-revision marker.
+///
+/// Mutation is single-owner through the editor. While a transaction is active,
+/// replacements are collected but the current revision does not advance; commit assigns
+/// one new revision to the entire logical change.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UndoHistory {
     nodes: Vec<UndoNode>,
@@ -171,10 +262,15 @@ impl Default for UndoHistory {
 }
 
 impl UndoHistory {
+    /// Begins a user transaction unless another transaction is already active.
     pub fn begin_transaction(&mut self, label: impl Into<String>, before_cursor: CursorSnapshot) {
         self.begin_transaction_with_origin(label, before_cursor, EditOrigin::User);
     }
 
+    /// Begins an attributed transaction unless another transaction is already active.
+    ///
+    /// Nested calls intentionally keep the first transaction's label, cursor, and origin.
+    /// A caller that assumes this replaces active metadata could misattribute later edits.
     pub fn begin_transaction_with_origin(
         &mut self,
         label: impl Into<String>,
@@ -192,6 +288,7 @@ impl UndoHistory {
     }
 
     #[must_use]
+    /// Returns the transaction at the current history node.
     pub fn latest_transaction(&self) -> Option<&EditTransaction> {
         self.current
             .and_then(|index| self.nodes.get(index))
@@ -199,6 +296,7 @@ impl UndoHistory {
     }
 
     #[must_use]
+    /// Returns a serializable projection of every retained undo branch.
     pub fn undo_tree(&self) -> Vec<UndoTreeEntry> {
         self.nodes
             .iter()
@@ -217,6 +315,11 @@ impl UndoHistory {
             .collect()
     }
 
+    /// Records one effective replacement in the active transaction.
+    ///
+    /// Equal old and new text is ignored. Calling this without an active transaction
+    /// records nothing, so production mutation must enter through the editor assertion
+    /// that guarantees a transaction exists.
     pub fn record_replace(
         &mut self,
         range: TextRange,
@@ -238,6 +341,10 @@ impl UndoHistory {
         }
     }
 
+    /// Commits the active non-empty transaction as a new child of the current node.
+    ///
+    /// Returns `true` only when history advanced. Empty transactions are discarded and
+    /// sibling branches remain available.
     pub fn commit_transaction(&mut self, after_cursor: CursorSnapshot) -> bool {
         let Some(mut transaction) = self.active_transaction.take() else {
             return false;
@@ -269,6 +376,7 @@ impl UndoHistory {
         true
     }
 
+    /// Drops the active transaction when it contains no replacements.
     pub fn cancel_transaction_if_empty(&mut self) {
         if self
             .active_transaction
@@ -279,14 +387,17 @@ impl UndoHistory {
         }
     }
 
+    /// Returns whether replacements are currently being collected.
     pub fn is_transaction_active(&self) -> bool {
         self.active_transaction.is_some()
     }
 
+    /// Marks the current history revision as the on-disk saved state.
     pub fn mark_saved(&mut self) {
         self.saved_revision = self.current_revision;
     }
 
+    /// Returns whether the selected history revision differs from the saved revision.
     pub fn is_dirty(&self) -> bool {
         self.current_revision != self.saved_revision
     }
@@ -437,14 +548,25 @@ impl UndoHistory {
         Ok(())
     }
 
+    /// Selects the next sibling branch available to a subsequent redo.
+    ///
+    /// Returns the selected one-based position and sibling count.
     pub fn select_next_branch(&mut self) -> Option<(usize, usize)> {
         self.select_branch(/*delta*/ 1)
     }
 
+    /// Selects the previous sibling branch available to a subsequent redo.
+    ///
+    /// Returns the selected one-based position and sibling count.
     pub fn select_previous_branch(&mut self) -> Option<(usize, usize)> {
         self.select_branch(/*delta*/ -1)
     }
 
+    /// Prepares inverse edits when a committed transaction still matches the current text.
+    ///
+    /// The method does not mutate the buffer. If later edits overlap the transaction's
+    /// post-image, it returns the current conflicting text so review UI can avoid
+    /// overwriting newer work.
     pub fn prepare_revert(
         &self,
         transaction_id: &str,
@@ -548,6 +670,10 @@ impl UndoHistory {
         parent.map_or(&self.root_children, |index| &self.nodes[index].children)
     }
 
+    /// Replays the current transaction backward and selects its parent.
+    ///
+    /// Returns the cursor to restore and concrete replacements for anchor maintenance.
+    /// External notifications and rendering remain the editor's responsibility.
     pub fn undo(&mut self, buffer: &mut Buffer) -> Option<(CursorSnapshot, Vec<AppliedTextEdit>)> {
         let index = self.current?;
         let transaction = &self.nodes[index].transaction;
@@ -576,6 +702,10 @@ impl UndoHistory {
         Some((cursor, applied_edits))
     }
 
+    /// Replays the selected child transaction and makes it current.
+    ///
+    /// Returns the cursor to restore and concrete replacements for anchor maintenance.
+    /// External notifications and rendering remain the editor's responsibility.
     pub fn redo(&mut self, buffer: &mut Buffer) -> Option<(CursorSnapshot, Vec<AppliedTextEdit>)> {
         let children = self.children_for(self.current);
         let selected = self

--- a/src/unicode_utils.rs
+++ b/src/unicode_utils.rs
@@ -1,3 +1,16 @@
+//! Explicit conversions among UTF-8 bytes, Unicode scalars, graphemes, and terminal columns.
+//!
+//! Red intentionally uses different coordinate systems at different boundaries:
+//! strings and parser spans use bytes, Ropey edits use scalar indices, the visible
+//! cursor uses grapheme indices, and layout uses display columns. Tab-aware helpers also
+//! require the starting column or configured tab width where expansion depends on
+//! context.
+//!
+//! Conversion functions clamp or return the nearest representable boundary as described
+//! by each API. Passing a value from the wrong coordinate system may work for ASCII and
+//! fail only for combining marks, CJK text, or emoji, so callers should never rely on
+//! coincident numeric values.
+
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthChar;
 use unicode_width::UnicodeWidthStr;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,9 @@
+//! Small path helpers shared by configuration, buffers, and workspace-aware features.
+//!
+//! User-home expansion is explicit and fallible. Workspace discovery prefers the Git
+//! root containing the current directory and falls back to the current directory, so it
+//! is a convenience boundary rather than a security boundary for untrusted paths.
+
 use std::{
     env,
     path::{Path, PathBuf},

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,3 +1,14 @@
+//! Split-tree ownership, stable window identity, viewport state, and terminal layout.
+//!
+//! [`WindowManager`] stores windows in a recursive [`Split`] tree. Tree-order indexes
+//! are transient navigation handles, while [`WindowId`] remains stable across sibling
+//! insertion and removal and is the correct identity for plugin resources. Layout
+//! propagates terminal bounds through split ratios and updates each leaf window.
+//!
+//! Window cursor `x` values are grapheme indices and vertical goals are terminal display
+//! columns. Buffer mutation and cursor validity remain editor responsibilities; this
+//! module only owns per-window presentation and split topology.
+
 use crate::editor::{CursorGoal, Point};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -19,11 +30,16 @@ impl WindowId {
     }
 }
 
+/// Spatial direction used for window navigation and split resizing.
 #[derive(Debug, Clone, Copy)]
 pub enum Direction {
+    /// Toward smaller terminal rows.
     Up,
+    /// Toward larger terminal rows.
     Down,
+    /// Toward smaller terminal columns.
     Left,
+    /// Toward larger terminal columns.
     Right,
 }
 
@@ -311,7 +327,9 @@ pub enum Split {
 
     /// A horizontal split (top/bottom)
     Horizontal {
+        /// Upper subtree.
         top: Box<Split>,
+        /// Lower subtree.
         bottom: Box<Split>,
         /// Position of the split (0.0 = top, 1.0 = bottom)
         ratio: f32,
@@ -319,37 +337,60 @@ pub enum Split {
 
     /// A vertical split (left/right)
     Vertical {
+        /// Left subtree.
         left: Box<Split>,
+        /// Right subtree.
         right: Box<Split>,
         /// Position of the split (0.0 = left, 1.0 = right)
         ratio: f32,
     },
 }
 
+/// Serializable split topology and per-leaf viewport state.
+///
+/// Stable window IDs are rebuilt on restore; `active_window_id` in the manager snapshot
+/// refers to tree order for backward compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SplitSnapshot {
+    /// One leaf displaying a saved buffer index.
     Window {
+        /// Buffer index in the snapshot's buffer table.
         #[serde(alias = "bufferIndex")]
         buffer_index: usize,
+        /// First visible buffer line.
         vtop: usize,
+        /// First visible display column in non-wrapping mode.
         vleft: usize,
+        /// Display columns skipped within a wrapped logical line.
         #[serde(default)]
         skipcol: usize,
+        /// Whether long lines wrap.
         #[serde(default = "default_wrap")]
         wrap: bool,
+        /// Grapheme cursor index.
         cx: usize,
+        /// Cursor row relative to `vtop`.
         cy: usize,
+        /// Legacy viewport x offset.
         vx: usize,
     },
+    /// Top-and-bottom child snapshots.
     Horizontal {
+        /// Relative portion assigned to the top subtree.
         ratio: f32,
+        /// Upper subtree.
         top: Box<SplitSnapshot>,
+        /// Lower subtree.
         bottom: Box<SplitSnapshot>,
     },
+    /// Left-and-right child snapshots.
     Vertical {
+        /// Relative portion assigned to the left subtree.
         ratio: f32,
+        /// Left subtree.
         left: Box<SplitSnapshot>,
+        /// Right subtree.
         right: Box<SplitSnapshot>,
     },
 }
@@ -358,10 +399,13 @@ fn default_wrap() -> bool {
     true
 }
 
+/// Serializable window tree plus the active tree-order index.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WindowManagerSnapshot {
+    /// Active window's tree-order index at capture time.
     #[serde(alias = "activeWindowId")]
     pub active_window_id: usize,
+    /// Complete saved split topology.
     pub root: SplitSnapshot,
 }
 
@@ -531,6 +575,7 @@ impl WindowManager {
         }
     }
 
+    /// Captures split topology and per-window viewport state.
     pub fn snapshot(&self) -> WindowManagerSnapshot {
         WindowManagerSnapshot {
             active_window_id: self.active_window_id,
@@ -538,6 +583,10 @@ impl WindowManager {
         }
     }
 
+    /// Restores a window manager after remapping saved buffer indexes.
+    ///
+    /// Returns `None` when every saved leaf refers to a buffer that was not restored.
+    /// Terminal geometry is recomputed rather than trusted from the snapshot.
     pub fn from_snapshot(
         snapshot: &WindowManagerSnapshot,
         terminal_size: (usize, usize),
@@ -691,6 +740,7 @@ impl WindowManager {
         self.resize_with_origin(Point::new(0, 0), terminal_size);
     }
 
+    /// Recomputes layout under an explicit terminal origin.
     pub fn resize_with_origin(&mut self, position: Point, terminal_size: (usize, usize)) {
         self.root.layout(
             position,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,7 @@
 # Integration Testing Plan for Red Editor
 
+> Current status: this document is a historical plan that predates the production-path `EditorHarness`, `EditorTestExt`, event simulation, detachable-session tests, mock LSP server, transaction coverage, and the present CI suite. Use `docs/EDIT_PIPELINE.md` for the authoritative action and mutation seams and `docs/DEBUGGING.md` for subsystem entry points. The remaining text is retained as design history, not as an implementation backlog.
+
 ## Current Status
 
 The test framework has been set up with:

--- a/tests/TESTING_PROPOSAL.md
+++ b/tests/TESTING_PROPOSAL.md
@@ -1,5 +1,7 @@
 # Proposal: Making Red Editor Testable
 
+> Historical proposal: the repository has since implemented test-only editor helpers, a reusable integration harness, production event and action entry points, mock LSP transport, and broad editing coverage. The code examples and privacy constraints below describe the state before that work and must not be copied as current APIs. See `docs/EDIT_PIPELINE.md`, `tests/common/editor_harness.rs`, and `src/test_utils.rs` for the maintained contract.
+
 ## Problem Statement
 
 The current editor architecture makes integration testing difficult:


### PR DESCRIPTION
## Why

Red's user-facing guides describe its edit pipeline, plugin lifecycle, agent safety model, recovery, and detachable sessions, but the source did not consistently state those contracts at the modules and types that enforce them. That made implementation ownership, coordinate systems, failure-closed behavior, and lifecycle boundaries difficult to recover during review. Existing rustdoc also contained malformed links and markup that ordinary CI did not reject.

## What Changed

- add responsibility, lifecycle, coordinate, ownership, and failure-behavior documentation across the editor core, LSP, Husk runtime, plugins, Codex integration, recovery, and detach protocol
- document every bundled Husk plugin's role and cleanup contract
- add `docs/DEBUGGING.md` with diagnostic commands, logs, performance tracing, and symptom-to-owner guidance
- mark superseded testing proposals as historical and link them to maintained implementation paths
- make the existing documentation CI job deny rustdoc warnings and run workspace doctests

This is a non-functional pass: it does not change runtime behavior, public names, serialization shapes, configuration defaults, or plugin semantics.

## How to Test

1. Run `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features --document-private-items`. Expected: documentation builds without broken-link, bare-URL, or markup warnings.
2. Run `python3 scripts/check_markdown_links.py`. Expected: all repository-relative documentation links resolve, including the new debugging guide.
3. Run `cargo test session::tests::corrupt_latest_never_replaces_the_last_known_good_snapshot --all-features`. Expected: the focused recovery failure path still passes, confirming the documentation pass did not alter snapshot behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --doc`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Markdown link checker self-test and repository check
- `git diff --check`
