### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Red are documented in this file.
 
+## [0.2.2](https://github.com/codersauce/red/compare/v0.2.1...v0.2.2)
+
+### Features
+
+- **picker:** Add semantic icons and colors ([#121](https://github.com/codersauce/red/issues/121)) ([833529b](https://github.com/codersauce/red/commit/833529b64b2a5b6d25b8f0923152d0f94b2e001f))
+- **lsp:** Render rich hover documentation ([#122](https://github.com/codersauce/red/issues/122)) ([326b10d](https://github.com/codersauce/red/commit/326b10db66186b16814b91084e76ecd4c44e49de))
+
+### Bug Fixes
+
+- **lsp:** Size and position hover dialogs ([#124](https://github.com/codersauce/red/issues/124)) ([39ade74](https://github.com/codersauce/red/commit/39ade74ffc373e3555878a1492551764f34aeac7))
+
+### Documentation
+
+- Document architecture and safety contracts ([#123](https://github.com/codersauce/red/issues/123)) ([0d4d649](https://github.com/codersauce/red/commit/0d4d649fae4ecbf6d53c9a38bd1952656aaf1926))
+
 ## [0.2.1](https://github.com/codersauce/red/compare/v0.2.0...v0.2.1)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "red"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 default-run = "red"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ files stay yours.
 [Documentation](#documentation) ·
 [Community](https://discord.gg/5PWvAUNRHU)
 
-<!-- current-release: 0.2.1 -->
+<!-- current-release: 0.2.2 -->
 The current documented release is
-[v0.2.1](https://github.com/codersauce/red/releases/tag/v0.2.1).
+[v0.2.2](https://github.com/codersauce/red/releases/tag/v0.2.2).
 
 ![Red editing its Rust rendering pipeline with the project tree open](docs/images/editor-overview.jpg)
 
@@ -55,7 +55,7 @@ The PowerShell installer verifies the release checksum, installs to
 To pin a release or choose another directory:
 
 ```shell
-RED_VERSION=0.2.1 RED_INSTALL_DIR="$HOME/bin" \
+RED_VERSION=0.2.2 RED_INSTALL_DIR="$HOME/bin" \
   sh -c "$(curl --proto '=https' --tlsv1.2 -fsSL https://getred.dev/install.sh)"
 ```
 


### PR DESCRIPTION
## Why

Prepare Red 0.2.2 with a reviewed version bump and a changelog generated from Git history.

## What changed

- Updated the package, lockfile, and README release versions.
- Prepended the generated release section to `CHANGELOG.md`.

## How to test

1. Confirm the package and README versions are `0.2.2` and match the
   requested release tag.
2. Review every generated changelog group and entry.
3. Confirm CI, including Clippy and the packaged runtime self-check, passes.

Merging this PR does not publish the release. After merge, create and push the annotated `v0.2.2` tag to start the release workflow.
