### PR TITLE
fix(lsp): handle large symbol results

### DIFF
--- a/plugins/barbecue.hk
+++ b/plugins/barbecue.hk
@@ -2,7 +2,8 @@
 //
 // Refreshes are coalesced through one timeout so cursor and window event bursts do not
 // repeatedly query LSP. Window IDs, rather than tree-order indexes, own rendered bars;
-// deactivate cancels pending work and removes the plugin's chrome.
+// symbol ancestry is resolved from the small set of ranges containing the cursor; deactivate
+// cancels pending work and removes the plugin's chrome.
 
 pub fn activate() {
     red::on("editor:ready", refresh);
@@ -275,10 +276,14 @@ fn symbol_chain(window: Json) -> Json {
     let position = window_position(window);
     let leaf = red::null();
     let leaf_depth = -1;
+    let containing = [];
     for symbol in symbols {
-        if contains_position(symbol.range, position) && red::int(symbol.depth, 0) >= leaf_depth {
-            leaf = symbol;
-            leaf_depth = red::int(symbol.depth, 0);
+        if contains_position(symbol.range, position) {
+            containing = red::push(containing, symbol);
+            if red::int(symbol.depth, 0) >= leaf_depth {
+                leaf = symbol;
+                leaf_depth = red::int(symbol.depth, 0);
+            }
         }
     }
     if leaf == red::null() {
@@ -286,18 +291,18 @@ fn symbol_chain(window: Json) -> Json {
     }
     let chain = [];
     let current = leaf;
-    for step in red::range(red::len(symbols) + 1) {
-        if current != red::null() {
-            if contains_position(current.range, position) {
-                chain = red::unshift(chain, current);
-            }
-            let parent_id = red::string(current.parent_id, "");
-            if parent_id == "" {
-                current = red::null();
-            } else {
-                current = symbol_by_id(symbols, parent_id);
-            }
+    let steps = 0;
+    while current != red::null() && steps <= red::len(symbols) {
+        if contains_position(current.range, position) {
+            chain = red::unshift(chain, current);
         }
+        let parent_id = red::string(current.parent_id, "");
+        if parent_id == "" {
+            current = red::null();
+        } else {
+            current = symbol_by_id(containing, parent_id);
+        }
+        steps = steps + 1;
     }
     return chain;
 }

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -2,11 +2,19 @@
 //
 // Picker rows retain serialized source locations and open them through the plugin
 // location contract, including explicit column encoding. Live workspace queries replace
-// results for the active picker instead of creating competing dialogs.
+// results for the active picker instead of creating competing dialogs. Large symbol
+// responses are converted in cancellable timer batches so no callback monopolizes the
+// Husk instruction budget; a final safety ceiling bounds pathological server responses.
 
 pub fn activate() {
     red::state_set("lsp_symbol_icons_enabled", true);
     red::state_set("lsp_symbol_icon_overrides", Json {});
+    red::state_set("lsp_symbol_batch_timer", "");
+    red::state_set("lsp_symbol_batch_symbols", []);
+    red::state_set("lsp_symbol_batch_items", []);
+    red::state_set("lsp_symbol_batch_index", 0);
+    red::state_set("lsp_symbol_batch_picker", 0);
+    red::state_set("lsp_symbol_batch_workspace_only", false);
     red::request("GetConfig", icon_config_loaded, "plugin_config");
 
     red::add_command("LspDocumentSymbols", document_symbols, Json {
@@ -32,6 +40,9 @@ pub fn activate() {
     red::on("picker:selected:202", open_symbol_selection);
     red::on("picker:selected:203", open_reference_selection);
     red::on("picker:query:202", workspace_query);
+    red::on("picker:cancelled:201", cancel_symbol_batch);
+    red::on("picker:cancelled:202", cancel_symbol_batch);
+    red::on("timeout:callback", symbol_batch_timeout);
 }
 
 fn icon_config_loaded(event: Json) {
@@ -57,10 +68,12 @@ fn symbol_icon(kind: String) -> Json {
 }
 
 fn document_symbols() {
+    cancel_symbol_batch(red::null());
     red::request("DocumentSymbols", show_document_symbols);
 }
 
 fn workspace_symbols() {
+    cancel_symbol_batch(red::null());
     red::execute("OpenDynamicPicker", "Workspace Symbols", 202, [], PickerOptions {
         external_filter: true,
         placeholder: "Type to search workspace symbols",
@@ -79,34 +92,128 @@ fn references() {
 
 fn show_document_symbols(result: Json) {
     if !result.ok {
+        cancel_symbol_batch(red::null());
         red::execute("Print", "Document symbols unavailable: " + result.error);
         return;
     }
 
-    let items = symbol_items(result.symbols, false);
-    let count = red::len(items);
+    let count = red::len(result.symbols);
     if count == 0 {
         red::execute("Print", "No document symbols found");
         return;
     }
 
-    red::execute("OpenDynamicPicker", "Document Symbols", 201, items, PickerOptions {
+    if count <= 64 {
+        let items = symbol_items(result.symbols, false);
+        red::execute("OpenDynamicPicker", "Document Symbols", 201, items, PickerOptions {
+            placeholder: "Filter document symbols",
+            status: red::len(items) + " symbols",
+        });
+        return;
+    }
+
+    start_symbol_batch(result.symbols, false, 201);
+    red::execute("OpenDynamicPicker", "Document Symbols", 201, [], PickerOptions {
         placeholder: "Filter document symbols",
-        status: count + " symbols",
+        status: "Loading 0/" + count + " symbols",
     });
 }
 
 fn update_workspace_symbols(result: Json) {
     if !result.ok {
+        cancel_symbol_batch(red::null());
         red::execute("UpdatePickerItems", 202, []);
         red::execute("UpdatePickerStatus", 202, "Workspace symbols unavailable: " + result.error);
         return;
     }
 
+    let total = red::len(result.symbols);
+    if total > 64 {
+        start_symbol_batch(result.symbols, true, 202);
+        red::execute("UpdatePickerItems", 202, []);
+        red::execute("UpdatePickerStatus", 202, "Loading 0/" + total + " symbols");
+        return;
+    }
+
+    cancel_symbol_batch(red::null());
     let items = symbol_items(result.symbols, true);
     let count = red::len(items);
     red::execute("UpdatePickerItems", 202, items);
     red::execute("UpdatePickerStatus", 202, count + " symbols");
+}
+
+fn start_symbol_batch(symbols: Json, workspace_only: bool, picker_id: i32) {
+    cancel_symbol_batch(red::null());
+    red::state_set("lsp_symbol_batch_symbols", symbols);
+    red::state_set("lsp_symbol_batch_items", []);
+    red::state_set("lsp_symbol_batch_index", 0);
+    red::state_set("lsp_symbol_batch_picker", picker_id);
+    red::state_set("lsp_symbol_batch_workspace_only", workspace_only);
+    schedule_symbol_batch();
+}
+
+fn schedule_symbol_batch() {
+    red::state_set("lsp_symbol_batch_timer", red::execute("SetTimeout", 0));
+}
+
+fn symbol_batch_timeout(event: Json) {
+    if event.timer_id != red::state("lsp_symbol_batch_timer") {
+        return;
+    }
+    red::state_set("lsp_symbol_batch_timer", "");
+
+    let symbols = red::state("lsp_symbol_batch_symbols");
+    let items = red::state("lsp_symbol_batch_items");
+    let index = red::int(red::state("lsp_symbol_batch_index"), 0);
+    let picker_id = red::int(red::state("lsp_symbol_batch_picker"), 0);
+    let workspace_only = red::state_bool("lsp_symbol_batch_workspace_only");
+    let processed = 0;
+    while index < red::len(symbols) && index < 4096 && processed < 64 {
+        let symbol = symbols[index];
+        if !workspace_only || is_workspace_symbol_kind(symbol.kind_name) {
+            items = red::push(items, symbol_item(symbol));
+        }
+        index = index + 1;
+        processed = processed + 1;
+    }
+
+    red::state_set("lsp_symbol_batch_items", items);
+    red::state_set("lsp_symbol_batch_index", index);
+    red::execute("UpdatePickerItems", picker_id, items);
+
+    if index < red::len(symbols) && index < 4096 {
+        red::execute("UpdatePickerStatus", picker_id, "Loading " + index + "/" + red::len(symbols) + " symbols");
+        schedule_symbol_batch();
+        return;
+    }
+
+    if index < red::len(symbols) {
+        red::execute("UpdatePickerStatus", picker_id, red::len(items) + " symbols (results truncated)");
+    } else {
+        red::execute("UpdatePickerStatus", picker_id, red::len(items) + " symbols");
+    }
+    clear_symbol_batch();
+}
+
+fn cancel_symbol_batch(event: Json) {
+    let timer = red::string(red::state("lsp_symbol_batch_timer"), "");
+    if timer != "" {
+        red::execute("CancelTimeout", timer);
+    }
+    clear_symbol_batch();
+}
+
+fn clear_symbol_batch() {
+    red::state_set("lsp_symbol_batch_timer", "");
+    red::state_set("lsp_symbol_batch_symbols", []);
+    red::state_set("lsp_symbol_batch_items", []);
+    red::state_set("lsp_symbol_batch_index", 0);
+    red::state_set("lsp_symbol_batch_picker", 0);
+    red::state_set("lsp_symbol_batch_workspace_only", false);
+}
+
+fn deactivate() {
+    cancel_symbol_batch(red::null());
 }
 
 fn show_references(result: Json) {
@@ -182,6 +289,7 @@ fn reference_item(location: Json) -> Json {
 }
 
 fn open_symbol_selection(item: Json) {
+    cancel_symbol_batch(red::null());
     open_symbol(item.data.symbol);
 }
 

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1573,6 +1573,33 @@ mod tests {
         })
     }
 
+    fn sample_symbol_payload_with_count(count: usize) -> serde_json::Value {
+        let symbols = (0..count)
+            .map(|index| {
+                serde_json::json!({
+                    "name": format!("symbol_{index}"),
+                    "detail": "fn()",
+                    "kind": 12,
+                    "kind_name": "Function",
+                    "file": "src/editor.rs",
+                    "range": {
+                        "start": { "line": index, "character": 0 },
+                        "end": { "line": index, "character": 10 }
+                    },
+                    "selection_range": {
+                        "start": { "line": index, "character": 3 },
+                        "end": { "line": index, "character": 9 }
+                    },
+                    "depth": 0
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!({
+            "ok": true,
+            "symbols": symbols,
+        })
+    }
+
     async fn pump_process_events(runtime: &mut Runtime) -> anyhow::Result<()> {
         for event in runtime.poll_process_events() {
             let Some(process_id) = event
@@ -5697,7 +5724,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn barbecue_renders_breadcrumbs_and_opens_symbol_action() {
+    async fn barbecue_handles_large_symbol_lists_and_opens_symbol_action() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
 
@@ -5781,6 +5808,54 @@ mod tests {
         let symbol_request_id = symbol_request_id.expect("expected symbol request");
         assert_eq!(symbol_request_count, 1);
 
+        let symbols = (0..1_000)
+            .map(|index| {
+                let (id, name, parent_id, depth, start_line, end_line) = if index == 5 {
+                    (
+                        "outer".to_string(),
+                        "outer".to_string(),
+                        serde_json::Value::Null,
+                        0,
+                        5,
+                        8,
+                    )
+                } else if index == 6 {
+                    (
+                        "inner".to_string(),
+                        "inner".to_string(),
+                        serde_json::json!("outer"),
+                        1,
+                        6,
+                        7,
+                    )
+                } else {
+                    (
+                        format!("symbol-{index}"),
+                        format!("symbol_{index}"),
+                        serde_json::Value::Null,
+                        0,
+                        index,
+                        index + 1,
+                    )
+                };
+                serde_json::json!({
+                    "id": id,
+                    "parent_id": parent_id,
+                    "name": name,
+                    "kind_name": "Function",
+                    "file": "/repo/plugins/example.rs",
+                    "depth": depth,
+                    "range": {
+                        "start": { "line": start_line, "character": 0 },
+                        "end": { "line": end_line, "character": 0 }
+                    },
+                    "selection_range": {
+                        "start": { "line": start_line, "character": 0 },
+                        "end": { "line": start_line, "character": 5 }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
         runtime
             .resolve_request(
                 symbol_request_id,
@@ -5789,33 +5864,21 @@ mod tests {
                     "file": "/repo/plugins/example.rs",
                     "buffer_index": 2,
                     "revision": 4,
-                    "symbols": [{
-                        "id": "inner",
-                        "parent_id": null,
-                        "name": "inner",
-                        "kind_name": "Function",
-                        "file": "/repo/plugins/example.rs",
-                        "range": {
-                            "start": { "line": 5, "character": 0 },
-                            "end": { "line": 8, "character": 0 }
-                        },
-                        "selection_range": {
-                            "start": { "line": 5, "character": 11 },
-                            "end": { "line": 5, "character": 16 }
-                        }
-                    }]
+                    "symbols": symbols,
                 }),
             )
             .await
             .unwrap();
 
-        let mut saw_symbol = false;
+        let mut saw_outer = false;
+        let mut saw_inner = false;
         while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
             if let PluginRequest::UpdateWindowBar { segments, .. } = request {
-                saw_symbol |= segments.iter().any(|segment| segment.text == "󰊕 inner");
+                saw_outer |= segments.iter().any(|segment| segment.text == "󰊕 outer");
+                saw_inner |= segments.iter().any(|segment| segment.text == "󰊕 inner");
             }
         }
-        assert!(saw_symbol);
+        assert!(saw_outer && saw_inner);
 
         runtime
             .notify(
@@ -5827,8 +5890,8 @@ mod tests {
         match ACTION_DISPATCHER.recv_request() {
             PluginRequest::OpenLocation { location, .. } => {
                 assert_eq!(location.path, "/repo/plugins/example.rs");
-                assert_eq!(location.line, 5);
-                assert_eq!(location.column, 11);
+                assert_eq!(location.line, 6);
+                assert_eq!(location.column, 0);
                 assert_eq!(
                     location.column_encoding,
                     crate::plugin::LocationColumnEncoding::Utf16
@@ -7393,6 +7456,120 @@ mod tests {
             }
             _ => panic!("unexpected plugin request"),
         }
+    }
+
+    #[tokio::test]
+    async fn lsp_symbols_batches_pathological_document_symbol_results() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("lsp_symbols", include_str!("../../plugins/lsp_symbols.hk"))
+            .await
+            .unwrap();
+        let config_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetConfig { request_id, .. } => request_id,
+            _ => panic!("expected lsp_symbols config request"),
+        };
+        runtime
+            .resolve_request(
+                config_request_id,
+                serde_json::json!({
+                    "value": {
+                        "lsp_symbols": {
+                            "icons": {
+                                "enabled": true,
+                                "overrides": {}
+                            }
+                        }
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+        runtime.execute_command("LspDocumentSymbols").await.unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::DocumentSymbols { request_id, .. } => request_id,
+            _ => panic!("expected document-symbol request"),
+        };
+        runtime
+            .resolve_request(request_id, sample_symbol_payload_with_count(4_097))
+            .await
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenDynamicPicker {
+                id, items, options, ..
+            } => {
+                assert_eq!(id, 201);
+                assert!(items.is_empty());
+                assert_eq!(options.status.as_deref(), Some("Loading 0/4097 symbols"));
+            }
+            _ => panic!("expected empty document-symbol picker"),
+        }
+
+        let mut final_items = Vec::new();
+        let mut final_status = None;
+        for _ in 0..80 {
+            let callbacks = poll_timer_callbacks();
+            assert!(!callbacks.is_empty(), "expected a pending symbol batch");
+            for callback in callbacks {
+                if let PluginRequest::TimeoutCallback { timer_id } = callback {
+                    runtime
+                        .notify(
+                            "timeout:callback",
+                            serde_json::json!({ "timer_id": timer_id }),
+                        )
+                        .await
+                        .unwrap();
+                }
+            }
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                match request {
+                    PluginRequest::UpdatePickerItems { id, items } => {
+                        assert_eq!(id, 201);
+                        final_items = items;
+                    }
+                    PluginRequest::UpdatePickerStatus { id, status } => {
+                        assert_eq!(id, 201);
+                        final_status = status;
+                    }
+                    _ => panic!("unexpected request while batching document symbols"),
+                }
+            }
+            if final_items.len() == 4_096 {
+                break;
+            }
+        }
+
+        assert_eq!(final_items.len(), 4_096);
+        assert_eq!(final_items[4_095].label, "symbol_4095");
+        assert_eq!(
+            final_status.as_deref(),
+            Some("4096 symbols (results truncated)")
+        );
+
+        runtime.execute_command("LspDocumentSymbols").await.unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::DocumentSymbols { request_id, .. } => request_id,
+            _ => panic!("expected another document-symbol request"),
+        };
+        runtime
+            .resolve_request(request_id, sample_symbol_payload_with_count(65))
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::OpenDynamicPicker { id: 201, .. }
+        ));
+
+        runtime
+            .notify("picker:cancelled:201", serde_json::Value::Null)
+            .await
+            .unwrap();
+        assert!(poll_timer_callbacks().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

`Ctrl-t` could stop working on large files because `lsp_symbols` converted the complete document-symbol response in one Husk callback. Files such as `src/editor.rs` can return hundreds of symbols, exhausting the 100,000-instruction callback budget and quarantining the plugin. Barbecue could hit the same limit while repeatedly walking the full symbol list to build breadcrumbs.

## What Changed

- convert large document- and workspace-symbol responses in cancellable 64-item timer batches while updating picker progress
- preserve the immediate path for small responses and cap pathological responses at 4,096 items with an explicit truncated status
- cancel pending symbol work when a picker closes, a new request starts, a symbol is selected, or the plugin deactivates
- restrict Barbecue parent lookups to symbols whose ranges contain the cursor and stop ancestry traversal at the root
- cover a 4,097-symbol picker response and a 1,000-symbol nested breadcrumb response with regression tests

## How to Test

1. Open a large Rust file such as `src/editor.rs` and press `Ctrl-t`. Expect the Document Symbols picker to open immediately, populate incrementally, and remain usable without quarantining `lsp_symbols`.
2. Close the picker while it is loading, then press `Ctrl-t` again. Expect the previous batch to be cancelled and the new picker to load normally.
3. With Barbecue enabled, move through nested symbols in a large file and activate a breadcrumb. Expect the complete ancestor chain and navigation to work without exhausting the plugin budget.
4. Run `cargo test lsp_symbols_ --all-features -- --test-threads=1` and `cargo test barbecue_handles_large_symbol_lists_and_opens_symbol_action --all-features -- --test-threads=1`. Expect all focused regressions to pass.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`