### PR TITLE
fix(plugins): bound pathological callback workloads

### DIFF
--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -396,11 +396,13 @@ fn activity(event: Json) {
             title = red::string(update.kind, "Tool");
         }
         let rows = red::state("agent_activity_rows");
-        rows = red::push(rows, Json {
-            id: red::string(update.tool_call_id, ""),
-            title: title,
-            status: red::string(update.status, "in_progress"),
-        });
+        if red::len(rows) < 100 {
+            rows = red::push(rows, Json {
+                id: red::string(update.tool_call_id, ""),
+                title: title,
+                status: red::string(update.status, "in_progress"),
+            });
+        }
         red::state_set("agent_activity_rows", rows);
         render_activity();
         set_phase("tool", title);
@@ -1125,7 +1127,10 @@ fn refresh_proposals() {
 
 fn render_proposals(result: Json) {
     let rows = [];
-    for file in result.files {
+    let file_index = 0;
+    let truncated = false;
+    while file_index < red::len(result.files) && red::len(rows) < 499 {
+        let file = result.files[file_index];
         let status = " " + red::len(file.hunks) + " hunks";
         let status_style = muted_style();
         if file.conflict {
@@ -1143,14 +1148,20 @@ fn render_proposals(result: Json) {
             data: Json { session_id: file.session_id, path: file.path, hunk_id: "", conflict: file.conflict },
         });
         if file.conflict {
-            rows = red::push(rows, WorkspaceRow {
-                id: "conflict:" + file.session_id + ":" + file.path,
-                selectable: false,
-                depth: 1,
-                segments: [PanelSegment { text: file.message, style: warning_style() }],
-            });
+            if red::len(rows) < 499 {
+                rows = red::push(rows, WorkspaceRow {
+                    id: "conflict:" + file.session_id + ":" + file.path,
+                    selectable: false,
+                    depth: 1,
+                    segments: [PanelSegment { text: file.message, style: warning_style() }],
+                });
+            } else {
+                truncated = true;
+            }
         } else {
-            for hunk in file.hunks {
+            let hunk_index = 0;
+            while hunk_index < red::len(file.hunks) && red::len(rows) < 499 {
+                let hunk = file.hunks[hunk_index];
                 rows = red::push(rows, WorkspaceRow {
                     id: "hunk:" + file.session_id + ":" + hunk.id,
                     selectable: true,
@@ -1168,8 +1179,23 @@ fn render_proposals(result: Json) {
                         conflict: false,
                     },
                 });
+                hunk_index = hunk_index + 1;
+            }
+            if hunk_index < red::len(file.hunks) {
+                truncated = true;
             }
         }
+        file_index = file_index + 1;
+    }
+    if file_index < red::len(result.files) {
+        truncated = true;
+    }
+    if truncated {
+        rows = red::push(rows, WorkspaceRow {
+            id: "proposals-truncated",
+            selectable: false,
+            segments: [PanelSegment { text: "… review limited to 500 rows", style: muted_style() }],
+        });
     }
     if result.error != red::null() {
         rows = red::push(rows, WorkspaceRow {
@@ -1223,11 +1249,23 @@ fn show_proposal_detail(row: Json) {
         return;
     }
     let detail = [];
-    for line in red::split(row.data.old_text, "\n") {
-        detail = red::push(detail, [PanelSegment { text: "- " + line, style: warning_style() }]);
+    let old_lines = red::split(row.data.old_text, "\n");
+    let old_index = 0;
+    while old_index < red::len(old_lines) && red::len(detail) < 400 {
+        detail = red::push(detail, [PanelSegment { text: "- " + old_lines[old_index], style: warning_style() }]);
+        old_index = old_index + 1;
     }
-    for line in red::split(row.data.new_text, "\n") {
-        detail = red::push(detail, [PanelSegment { text: "+ " + line, style: success_style() }]);
+    let new_lines = red::split(row.data.new_text, "\n");
+    let new_index = 0;
+    while new_index < red::len(new_lines) && red::len(detail) < 400 {
+        detail = red::push(detail, [PanelSegment { text: "+ " + new_lines[new_index], style: success_style() }]);
+        new_index = new_index + 1;
+    }
+    if old_index < red::len(old_lines) || new_index < red::len(new_lines) {
+        detail = red::push(detail, [PanelSegment {
+            text: "… detail limited to 400 lines",
+            style: muted_style(),
+        }]);
     }
     red::state_set("agent_detail", detail);
     refresh_proposals();
@@ -1249,8 +1287,10 @@ fn proposals_ready(result: Json) {
         return;
     }
     let hunks = 0;
-    for file in result.files {
-        hunks = hunks + red::len(file.hunks);
+    let file_index = 0;
+    while file_index < red::len(result.files) && file_index < 500 {
+        hunks = hunks + red::len(result.files[file_index].hunks);
+        file_index = file_index + 1;
     }
     red::state_set("agent_proposal_notice", true);
     red::execute("Print", "Agent changes ready: " + files + " files, " + hunks + " hunks. Use :AgentReview to review before applying");
@@ -1279,7 +1319,9 @@ fn refresh_history() {
 
 fn render_history(result: Json) {
     let rows = [];
-    for entry in result.entries {
+    let index = 0;
+    while index < red::len(result.entries) && index < 500 {
+        let entry = result.entries[index];
         let origin = entry.origin.kind;
         if origin == "agent" {
             origin = "agent " + entry.origin.session_id + "/" + entry.origin.turn_id;
@@ -1295,6 +1337,14 @@ fn render_history(result: Json) {
             ],
             right_segments: [PanelSegment { text: origin, style: muted_style() }],
             data: Json { transaction_id: entry.transaction_id, edits: entry.edits },
+        });
+        index = index + 1;
+    }
+    if index < red::len(result.entries) {
+        rows = red::push(rows, WorkspaceRow {
+            id: "history-truncated",
+            selectable: false,
+            segments: [PanelSegment { text: "… history limited to 500 entries", style: muted_style() }],
         });
     }
     if red::len(rows) == 0 {

--- a/plugins/barbecue.hk
+++ b/plugins/barbecue.hk
@@ -272,12 +272,15 @@ fn symbols_for(window: Json) -> Json {
 }
 
 fn symbol_chain(window: Json) -> Json {
+    // Breadcrumb rendering runs once per window, so keep each callback's scan bounded.
     let symbols = symbols_for(window);
     let position = window_position(window);
     let leaf = red::null();
     let leaf_depth = -1;
     let containing = [];
-    for symbol in symbols {
+    let index = 0;
+    while index < red::len(symbols) && index < 512 {
+        let symbol = symbols[index];
         if contains_position(symbol.range, position) {
             containing = red::push(containing, symbol);
             if red::int(symbol.depth, 0) >= leaf_depth {
@@ -285,6 +288,7 @@ fn symbol_chain(window: Json) -> Json {
                 leaf_depth = red::int(symbol.depth, 0);
             }
         }
+        index = index + 1;
     }
     if leaf == red::null() {
         return [];
@@ -292,7 +296,7 @@ fn symbol_chain(window: Json) -> Json {
     let chain = [];
     let current = leaf;
     let steps = 0;
-    while current != red::null() && steps <= red::len(symbols) {
+    while current != red::null() && steps <= red::len(containing) {
         if contains_position(current.range, position) {
             chain = red::unshift(chain, current);
         }

--- a/plugins/buffer_picker.hk
+++ b/plugins/buffer_picker.hk
@@ -19,7 +19,9 @@ fn buffer_picker() {
 
 fn editor_info_loaded(info: Json) {
     let items = [];
-    for buffer in info.buffers {
+    let index = 0;
+    while index < red::len(info.buffers) && index < 500 {
+        let buffer = info.buffers[index];
         items = red::push(items, PickerItem {
             id: buffer.name,
             label: buffer.name,
@@ -28,11 +30,16 @@ fn editor_info_loaded(info: Json) {
                 name: buffer.name,
             },
         });
+        index = index + 1;
     }
 
+    let status = red::len(items) + " buffers";
+    if index < red::len(info.buffers) {
+        status = status + " (results truncated)";
+    }
     red::execute("OpenDynamicPicker", "Buffers", 701, items, PickerOptions {
         placeholder: "Filter buffers",
-        status: red::len(items) + " buffers",
+        status: status,
     });
 }
 

--- a/plugins/fidget.hk
+++ b/plugins/fidget.hk
@@ -82,15 +82,22 @@ fn progress(event: Json) {
         items = red::push(items, item);
     }
     if !found {
-        items = red::push(items, FidgetItem {
-            token: token,
-            group: group,
-            message: message,
-            title: title,
-            done: kind == "end",
-        });
+        // Refresh groups progress items quadratically; retain a small, useful ceiling.
+        if red::len(items) < 32 {
+            items = red::push(items, FidgetItem {
+                token: token,
+                group: group,
+                message: message,
+                title: title,
+                done: kind == "end",
+            });
+            found = true;
+        }
     }
     red::state_set("fidget_items", items);
+    if !found {
+        return;
+    }
     if kind == "end" {
         schedule_done(group, token);
         if !has_active() {

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -144,6 +144,7 @@ fn empty_state() -> Json {
         unstaged: [],
         untracked: [],
         conflicted: [],
+        truncated: false,
     };
 }
 
@@ -315,6 +316,9 @@ fn sign_windows_loaded(result: Json) {
     red::state_set("git_sign_jobs", []);
     let buffers = [];
     for window in result.windows {
+        if red::len(buffers) >= 8 {
+            return;
+        }
         let path = red::string(window.buffer_path, "");
         let buffer_index = red::int(window.buffer_index, -1);
         let key = path + ":" + buffer_index;
@@ -392,20 +396,26 @@ fn sign_diff_event(event: Json) {
     for job in red::state("git_sign_jobs") {
         if job.id == event.process_id {
             let signs = signs_from_patch(event.line, job.buffer_index, red::bool(job.staged, false));
+            let all_signs = red::state("git_signs");
             for sign in signs {
-                red::state_set("git_signs", red::push(red::state("git_signs"), sign));
+                if red::len(all_signs) >= 400 {
+                    break;
+                }
+                all_signs = red::push(all_signs, sign);
             }
-            red::execute("SetGutterSigns", "git-signs", red::state("git_signs"));
+            red::state_set("git_signs", all_signs);
+            red::execute("SetGutterSigns", "git-signs", all_signs);
             return;
         }
     }
 }
 
 fn signs_from_patch(patch: String, buffer_index: i32, staged: bool) -> Json {
+    // A large diff must not spend the whole plugin callback budget on gutter rows.
     let signs = [];
     let hunks = sign_hunks(patch);
     let index = 0;
-    while index < red::len(hunks) {
+    while index < red::len(hunks) && red::len(signs) < 200 {
         let hunk = hunks[index];
         let previous = red::null();
         let next = red::null();
@@ -417,7 +427,7 @@ fn signs_from_patch(patch: String, buffer_index: i32, staged: bool) -> Json {
             && (hunk.new_start == 0 || (previous != red::null() && hunk_change_end(previous) == hunk.new_start))
             && (next == red::null() || next.new_start != hunk.new_start + 1);
         let line = hunk.new_start;
-        while line <= change_end {
+        while line <= change_end && red::len(signs) < 200 {
             let sign_kind = kind;
             let changedelete = kind == "change"
                 && ((hunk.old_count > hunk.new_count && line == change_end)
@@ -434,7 +444,7 @@ fn signs_from_patch(patch: String, buffer_index: i32, staged: bool) -> Json {
         }
         if kind == "change" && hunk.new_count > hunk.old_count {
             line = change_end + 1;
-            while line < hunk.new_start + hunk.new_count {
+            while line < hunk.new_start + hunk.new_count && red::len(signs) < 200 {
                 signs = red::push(signs, git_sign(buffer_index, line - 1, "add", staged));
                 line = line + 1;
             }
@@ -446,7 +456,10 @@ fn signs_from_patch(patch: String, buffer_index: i32, staged: bool) -> Json {
 
 fn sign_hunks(patch: String) -> Json {
     let hunks = [];
-    for line in red::split(patch, "\n") {
+    let lines = red::split(patch, "\n");
+    let index = 0;
+    while index < red::len(lines) && index < 2000 && red::len(hunks) < 500 {
+        let line = lines[index];
         if red::starts_with(line, "@@ ") {
             let fields = red::split(line, " ");
             let old_range = red::split(red::slice(fields[1], 1), ",");
@@ -462,6 +475,7 @@ fn sign_hunks(patch: String) -> Json {
                 new_count: new_count,
             });
         }
+        index = index + 1;
     }
     return hunks;
 }
@@ -541,6 +555,7 @@ fn parse_status(output: String) -> Json {
     let state = empty_state();
     let records = red::split(output, red::char(0));
     let index = 0;
+    let entries = 0;
     while index < red::len(records) {
         let record = records[index];
         if red::starts_with(record, "# branch.oid ") {
@@ -556,13 +571,22 @@ fn parse_status(output: String) -> Json {
         } else if red::starts_with(record, "# stash ") {
             state.stash_count = red::int(red::slice(record, 8), 0);
         } else if red::starts_with(record, "? ") {
+            if entries >= 500 {
+                state.truncated = true;
+                return state;
+            }
             state.untracked = red::push(state.untracked, GitEntry {
                 path: red::slice(record, 2),
                 x: "?",
                 y: "?",
                 kind: "untracked",
             });
+            entries = entries + 1;
         } else if red::starts_with(record, "u ") {
+            if entries >= 500 {
+                state.truncated = true;
+                return state;
+            }
             let fields = red::split(record, " ");
             state.conflicted = red::push(state.conflicted, GitEntry {
                 path: join_fields(fields, 10),
@@ -570,6 +594,7 @@ fn parse_status(output: String) -> Json {
                 y: red::char_at(fields[1], 1),
                 kind: "conflicted",
             });
+            entries = entries + 1;
         } else if red::starts_with(record, "1 ") || red::starts_with(record, "2 ") {
             let fields = red::split(record, " ");
             let xy = fields[1];
@@ -591,10 +616,20 @@ fn parse_status(output: String) -> Json {
                 index = index + 1;
             }
             if entry.x != "." {
+                if entries >= 500 {
+                    state.truncated = true;
+                    return state;
+                }
                 state.staged = red::push(state.staged, entry);
+                entries = entries + 1;
             }
             if entry.y != "." {
+                if entries >= 500 {
+                    state.truncated = true;
+                    return state;
+                }
                 state.unstaged = red::push(state.unstaged, entry);
+                entries = entries + 1;
             }
         }
         index = index + 1;
@@ -635,6 +670,16 @@ fn render_dashboard() {
     rows = append_section(rows, "Staged", "staged", state.staged);
     rows = append_section(rows, "Unstaged", "unstaged", state.unstaged);
     rows = append_section(rows, "Untracked", "untracked", state.untracked);
+    if red::bool(state.truncated, false) {
+        rows = red::push(rows, WorkspaceRow {
+            id: "status-truncated",
+            selectable: false,
+            segments: [PanelSegment {
+                text: "… status limited to 500 entries",
+                style: muted_style(),
+            }],
+        });
+    }
     if red::len(rows) == 0 {
         rows = red::push(rows, WorkspaceRow {
             id: "clean",
@@ -1192,7 +1237,10 @@ fn capture_finished() {
 
 fn open_line_items(kind: String, title: String, output: String) {
     let items = [];
-    for line in red::split(output, "\n") {
+    let lines = red::split(output, "\n");
+    let index = 0;
+    while index < red::len(lines) && red::len(items) < 500 {
+        let line = lines[index];
         if red::trim(line) != "" {
             items = red::push(items, PickerItem {
                 id: line,
@@ -1201,6 +1249,7 @@ fn open_line_items(kind: String, title: String, output: String) {
                 data: Json { value: line },
             });
         }
+        index = index + 1;
     }
     items = red::push(items, PickerItem { id: "Cancel", label: "Cancel", kind: "Cancel" });
     open_items(kind, title, items);
@@ -1208,16 +1257,15 @@ fn open_line_items(kind: String, title: String, output: String) {
 
 fn open_detail_items(output: String) {
     let items = [];
-    let count = 0;
-    for line in red::split(output, "\n") {
-        if count < 500 {
-            items = red::push(items, PickerItem {
-                id: count,
-                label: line,
-                kind: "Text",
-            });
-            count = count + 1;
-        }
+    let lines = red::split(output, "\n");
+    let index = 0;
+    while index < red::len(lines) && index < 500 {
+        items = red::push(items, PickerItem {
+            id: index,
+            label: lines[index],
+            kind: "Text",
+        });
+        index = index + 1;
     }
     items = red::push(items, PickerItem { id: "Close", label: "Close", kind: "Close" });
     open_items("log-detail-view", "Commit details", items);
@@ -1225,7 +1273,10 @@ fn open_detail_items(output: String) {
 
 fn open_tag_push_items(output: String) {
     let items = [];
-    for line in red::split(output, "\n") {
+    let lines = red::split(output, "\n");
+    let index = 0;
+    while index < red::len(lines) && red::len(items) < 500 {
+        let line = lines[index];
         if red::trim(line) != "" {
             items = red::push(items, PickerItem {
                 id: line,
@@ -1234,6 +1285,7 @@ fn open_tag_push_items(output: String) {
                 data: Json { value: line },
             });
         }
+        index = index + 1;
     }
     items = red::push(items, PickerItem { id: "All tags", label: "All tags", kind: "GitTag" });
     items = red::push(items, PickerItem { id: "Cancel", label: "Cancel", kind: "Cancel" });
@@ -1302,7 +1354,10 @@ fn log_view() {
 
 fn open_worktree_items(output: String) {
     let items = [];
-    for line in red::split(output, "\n") {
+    let lines = red::split(output, "\n");
+    let index = 0;
+    while index < red::len(lines) && red::len(items) < 500 {
+        let line = lines[index];
         if red::starts_with(line, "worktree ") {
             let path = red::slice(line, 9);
             items = red::push(items, PickerItem {
@@ -1312,6 +1367,7 @@ fn open_worktree_items(output: String) {
                 data: Json { value: path },
             });
         }
+        index = index + 1;
     }
     items = red::push(items, PickerItem { id: "Cancel", label: "Cancel", kind: "Cancel" });
     open_items("worktrees", "Worktrees", items);
@@ -1337,7 +1393,10 @@ fn open_log_items(output: String) {
 
 fn start_rebase_plan(output: String) {
     let commits = [];
-    for line in red::split(output, "\n") {
+    let lines = red::split(output, "\n");
+    let index = 0;
+    while index < red::len(lines) && red::len(commits) < 500 {
+        let line = lines[index];
         if red::trim(line) != "" {
             let fields = red::split(line, "\t");
             commits = red::push(commits, RebaseCommit {
@@ -1345,6 +1404,7 @@ fn start_rebase_plan(output: String) {
                 subject: fields[1],
             });
         }
+        index = index + 1;
     }
     if red::len(commits) == 0 {
         return;

--- a/plugins/inlay_hints.hk
+++ b/plugins/inlay_hints.hk
@@ -110,15 +110,20 @@ fn render_if_ready() {
     }
 
     let layout = red::state("inlay_layout");
+    let hints_by_line = group_hints_by_line(result.hints, layout.rows);
     let seen = [];
     let decorations = [];
-    for row in layout.rows {
+    let row_index = 0;
+    while row_index < red::len(layout.rows) && row_index < 64 {
+        let row = layout.rows[row_index];
         if red::contains(seen, row.line) {
+            row_index = row_index + 1;
             continue;
         }
         seen = red::push(seen, row.line);
-        let text = line_hint_text(result.hints, row.line);
+        let text = line_hint_text(hints_for_line(hints_by_line, row.line));
         if text == "" {
+            row_index = row_index + 1;
             continue;
         }
         decorations = red::push(decorations, Decoration {
@@ -130,6 +135,7 @@ fn render_if_ready() {
             style: hint_style(red::state("inlay_info")),
             priority: 1001,
         });
+        row_index = row_index + 1;
     }
     if decorations != red::state("inlay_last_decorations") {
         red::state_set("inlay_last_decorations", decorations);
@@ -137,10 +143,55 @@ fn render_if_ready() {
     }
 }
 
-fn line_hint_text(hints: Json, line: i32) -> String {
+fn group_hints_by_line(hints: Json, rows: Json) -> Json {
+    // Bound both visible rows and hints per line before the insertion sort below.
+    let grouped = [];
+    let row_index = 0;
+    while row_index < red::len(rows) && red::len(grouped) < 64 {
+        let line = rows[row_index].line;
+        let found = false;
+        for group in grouped {
+            if group.line == line {
+                found = true;
+            }
+        }
+        if !found {
+            grouped = red::push(grouped, Json { line: line, hints: [] });
+        }
+        row_index = row_index + 1;
+    }
+    let index = 0;
+    while index < red::len(hints) && index < 256 {
+        let hint = hints[index];
+        let line = red::int(hint.position.line, -1);
+        let updated = [];
+        for group in grouped {
+            if group.line == line {
+                if red::len(group.hints) < 24 {
+                    group.hints = red::push(group.hints, hint);
+                }
+            }
+            updated = red::push(updated, group);
+        }
+        grouped = updated;
+        index = index + 1;
+    }
+    return grouped;
+}
+
+fn hints_for_line(grouped: Json, line: i32) -> Json {
+    for group in grouped {
+        if group.line == line {
+            return group.hints;
+        }
+    }
+    return [];
+}
+
+fn line_hint_text(hints: Json) -> String {
     let type_hints = [];
     let parameter_hints = [];
-    for hint in sorted_line_hints(hints, line) {
+    for hint in sorted_line_hints(hints) {
         let text = red::trim(label_text(hint.label));
         if red::int(hint.kind, 0) == 1 {
             if red::starts_with(text, ":") {
@@ -174,12 +225,9 @@ fn line_hint_text(hints: Json, line: i32) -> String {
     return result;
 }
 
-fn sorted_line_hints(hints: Json, line: i32) -> Json {
+fn sorted_line_hints(hints: Json) -> Json {
     let sorted = [];
     for hint in hints {
-        if red::int(hint.position.line, -1) != line {
-            continue;
-        }
         let inserted = false;
         let next = [];
         for current in sorted {

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -3,7 +3,7 @@
 // Picker rows retain serialized source locations and open them through the plugin
 // location contract, including explicit column encoding. Live workspace queries replace
 // results for the active picker instead of creating competing dialogs. Large symbol
-// responses are converted in cancellable timer batches so no callback monopolizes the
+// responses, including references, are converted in cancellable timer batches so no callback monopolizes the
 // Husk instruction budget; a final safety ceiling bounds pathological server responses.
 
 pub fn activate() {
@@ -14,7 +14,10 @@ pub fn activate() {
     red::state_set("lsp_symbol_batch_items", []);
     red::state_set("lsp_symbol_batch_index", 0);
     red::state_set("lsp_symbol_batch_picker", 0);
+    red::state_set("lsp_symbol_batch_kind", "");
     red::state_set("lsp_symbol_batch_workspace_only", false);
+    red::state_set("lsp_reference_file", "");
+    red::state_set("lsp_reference_position", red::null());
     red::request("GetConfig", icon_config_loaded, "plugin_config");
 
     red::add_command("LspDocumentSymbols", document_symbols, Json {
@@ -42,6 +45,7 @@ pub fn activate() {
     red::on("picker:query:202", workspace_query);
     red::on("picker:cancelled:201", cancel_symbol_batch);
     red::on("picker:cancelled:202", cancel_symbol_batch);
+    red::on("picker:cancelled:203", cancel_symbol_batch);
     red::on("timeout:callback", symbol_batch_timeout);
 }
 
@@ -87,6 +91,7 @@ fn workspace_query(query: Json) {
 }
 
 fn references() {
+    cancel_symbol_batch(red::null());
     red::request("References", show_references);
 }
 
@@ -148,7 +153,21 @@ fn start_symbol_batch(symbols: Json, workspace_only: bool, picker_id: i32) {
     red::state_set("lsp_symbol_batch_items", []);
     red::state_set("lsp_symbol_batch_index", 0);
     red::state_set("lsp_symbol_batch_picker", picker_id);
+    red::state_set("lsp_symbol_batch_kind", "symbols");
     red::state_set("lsp_symbol_batch_workspace_only", workspace_only);
+    schedule_symbol_batch();
+}
+
+fn start_reference_batch(result: Json) {
+    cancel_symbol_batch(red::null());
+    red::state_set("lsp_symbol_batch_symbols", result.references);
+    red::state_set("lsp_symbol_batch_items", []);
+    red::state_set("lsp_symbol_batch_index", 0);
+    red::state_set("lsp_symbol_batch_picker", 203);
+    red::state_set("lsp_symbol_batch_kind", "references");
+    red::state_set("lsp_symbol_batch_workspace_only", false);
+    red::state_set("lsp_reference_file", result.file);
+    red::state_set("lsp_reference_position", result.position);
     schedule_symbol_batch();
 }
 
@@ -166,12 +185,21 @@ fn symbol_batch_timeout(event: Json) {
     let items = red::state("lsp_symbol_batch_items");
     let index = red::int(red::state("lsp_symbol_batch_index"), 0);
     let picker_id = red::int(red::state("lsp_symbol_batch_picker"), 0);
+    let kind = red::string(red::state("lsp_symbol_batch_kind"), "symbols");
     let workspace_only = red::state_bool("lsp_symbol_batch_workspace_only");
     let processed = 0;
     while index < red::len(symbols) && index < 4096 && processed < 64 {
-        let symbol = symbols[index];
-        if !workspace_only || is_workspace_symbol_kind(symbol.kind_name) {
-            items = red::push(items, symbol_item(symbol));
+        let value = symbols[index];
+        if kind == "references" {
+            if !is_current_reference(
+                value,
+                red::string(red::state("lsp_reference_file"), ""),
+                red::state("lsp_reference_position")
+            ) {
+                items = red::push(items, reference_item(value));
+            }
+        } else if !workspace_only || is_workspace_symbol_kind(value.kind_name) {
+            items = red::push(items, symbol_item(value));
         }
         index = index + 1;
         processed = processed + 1;
@@ -181,16 +209,20 @@ fn symbol_batch_timeout(event: Json) {
     red::state_set("lsp_symbol_batch_index", index);
     red::execute("UpdatePickerItems", picker_id, items);
 
+    let noun = "symbols";
+    if kind == "references" {
+        noun = "references";
+    }
     if index < red::len(symbols) && index < 4096 {
-        red::execute("UpdatePickerStatus", picker_id, "Loading " + index + "/" + red::len(symbols) + " symbols");
+        red::execute("UpdatePickerStatus", picker_id, "Loading " + index + "/" + red::len(symbols) + " " + noun);
         schedule_symbol_batch();
         return;
     }
 
     if index < red::len(symbols) {
-        red::execute("UpdatePickerStatus", picker_id, red::len(items) + " symbols (results truncated)");
+        red::execute("UpdatePickerStatus", picker_id, red::len(items) + " " + noun + " (results truncated)");
     } else {
-        red::execute("UpdatePickerStatus", picker_id, red::len(items) + " symbols");
+        red::execute("UpdatePickerStatus", picker_id, red::len(items) + " " + noun);
     }
     clear_symbol_batch();
 }
@@ -209,7 +241,10 @@ fn clear_symbol_batch() {
     red::state_set("lsp_symbol_batch_items", []);
     red::state_set("lsp_symbol_batch_index", 0);
     red::state_set("lsp_symbol_batch_picker", 0);
+    red::state_set("lsp_symbol_batch_kind", "");
     red::state_set("lsp_symbol_batch_workspace_only", false);
+    red::state_set("lsp_reference_file", "");
+    red::state_set("lsp_reference_position", red::null());
 }
 
 fn deactivate() {
@@ -218,7 +253,17 @@ fn deactivate() {
 
 fn show_references(result: Json) {
     if !result.ok {
+        cancel_symbol_batch(red::null());
         red::execute("Print", "References unavailable: " + result.error);
+        return;
+    }
+
+    if red::len(result.references) > 64 {
+        start_reference_batch(result);
+        red::execute("OpenDynamicPicker", "References", 203, [], PickerOptions {
+            placeholder: "Filter references",
+            status: "Loading 0/" + red::len(result.references) + " references",
+        });
         return;
     }
 
@@ -294,6 +339,7 @@ fn open_symbol_selection(item: Json) {
 }
 
 fn open_reference_selection(item: Json) {
+    cancel_symbol_batch(red::null());
     open_reference(item.data.location);
 }
 

--- a/plugins/theme_browser.hk
+++ b/plugins/theme_browser.hk
@@ -59,13 +59,19 @@ fn open_picker_if_ready() {
     }
 
     let items = [];
-    for entry in entries {
-        items = red::push(items, theme_item(entry));
+    let index = 0;
+    while index < red::len(entries) && index < 500 {
+        items = red::push(items, theme_item(entries[index]));
+        index = index + 1;
     }
 
+    let status = red::len(items) + " themes";
+    if index < red::len(entries) {
+        status = status + " (results truncated)";
+    }
     red::execute("OpenDynamicPicker", "Themes", 601, items, PickerOptions {
         placeholder: "Filter themes",
-        status: red::len(items) + " themes",
+        status: status,
         initial_selection: red::string(red::state("theme_original"), ""),
         presentation: "compact",
     });

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1600,6 +1600,26 @@ mod tests {
         })
     }
 
+    fn sample_reference_payload_with_count(count: usize) -> serde_json::Value {
+        let references = (0..count)
+            .map(|index| {
+                serde_json::json!({
+                    "file": format!("src/reference_{index}.rs"),
+                    "range": {
+                        "start": { "line": index, "character": 1 },
+                        "end": { "line": index, "character": 4 }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!({
+            "ok": true,
+            "file": "src/main.rs",
+            "position": { "line": 0, "character": 0 },
+            "references": references,
+        })
+    }
+
     async fn pump_process_events(runtime: &mut Runtime) -> anyhow::Result<()> {
         for event in runtime.poll_process_events() {
             let Some(process_id) = event
@@ -3818,6 +3838,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bundled_agent_review_bounds_pathological_proposal_lists() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+
+        runtime.execute_command("AgentReview").await.unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::OpenWorkspace { id, .. } if id == "agent-review"
+        ));
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::AgentProposals { request_id, .. } => request_id,
+            _ => panic!("expected proposal review request"),
+        };
+        let files = (0..600)
+            .map(|index| {
+                serde_json::json!({
+                    "session_id": "session-1",
+                    "path": format!("/workspace/file_{index}.rs"),
+                    "conflict": false,
+                    "hunks": []
+                })
+            })
+            .collect::<Vec<_>>();
+
+        runtime
+            .resolve_request(request_id, serde_json::json!({ "files": files }))
+            .await
+            .unwrap();
+
+        let model = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::UpdateWorkspace { id, model } => {
+                assert_eq!(id, "agent-review");
+                model
+            }
+            _ => panic!("expected bounded proposal workspace update"),
+        };
+        assert_eq!(model.rows.len(), 500);
+        assert_eq!(model.rows.last().unwrap().id, "proposals-truncated");
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+    }
+
+    #[tokio::test]
     async fn bundled_agent_ignores_late_events_from_a_replaced_session() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
@@ -5450,6 +5517,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inlay_hints_bound_pathological_same_line_results() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        runtime.set_snapshot(
+            "editor_info",
+            serde_json::json!({
+                "theme": {
+                    "colors": {
+                        "editorInlayHint.typeForeground": "#c8c8c8",
+                        "editor.background": "#0a141e",
+                    },
+                    "gutter_style": { "fg": null },
+                }
+            }),
+        );
+        runtime.set_snapshot("viewport_layout", sample_indent_layout());
+        runtime
+            .load_plugin("inlay_hints", include_str!("../../plugins/inlay_hints.hk"))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::GetConfig { .. }
+        ));
+        let hints_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::InlayHints { request_id, .. } => request_id,
+            _ => panic!("expected inlay-hint request"),
+        };
+        let hints = (0..1_000)
+            .map(|index| {
+                serde_json::json!({
+                    "kind": 1,
+                    "position": { "line": 1, "character": index },
+                    "label": ": Type"
+                })
+            })
+            .collect::<Vec<_>>();
+
+        runtime
+            .resolve_request(
+                hints_request_id,
+                serde_json::json!({ "ok": true, "hints": hints }),
+            )
+            .await
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::SetDecorations { decorations, .. } => {
+                assert_eq!(decorations.len(), 1);
+                assert_eq!(decorations[0].line, 1);
+                assert_eq!(decorations[0].text.matches("Type").count(), 24);
+            }
+            _ => panic!("expected bounded inlay-hint decorations"),
+        }
+    }
+
+    #[tokio::test]
     async fn inlay_hints_ignore_stale_layout_and_render_configured_parameter_hints() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
@@ -5901,10 +6028,22 @@ mod tests {
         }
     }
 
+    #[cfg(not(windows))]
     #[tokio::test]
-    async fn git_dashboard_streams_porcelain_status_into_workspace() {
+    async fn git_dashboard_bounds_pathological_porcelain_status() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        for index in 0..600 {
+            fs::write(root.join(format!("untracked_{index}.txt")), "pending\n").unwrap();
+        }
 
         let mut runtime = Runtime::new_with_permissions(HashMap::from([(
             "git".to_string(),
@@ -5945,7 +6084,7 @@ mod tests {
         runtime
             .resolve_request(
                 cwd_request_id.expect("expected cwd request"),
-                serde_json::json!({ "value": "." }),
+                serde_json::json!({ "value": root.display().to_string() }),
             )
             .await
             .unwrap();
@@ -5991,7 +6130,10 @@ mod tests {
                     assert_eq!(id, "git-dashboard");
                     assert!(!model.header.is_empty());
                     assert!(!model.rows.is_empty());
-                    found = true;
+                    if model.rows.iter().any(|row| row.id == "status-truncated") {
+                        assert_eq!(model.rows.len(), 502);
+                        found = true;
+                    }
                 }
             }
             if found {
@@ -5999,7 +6141,7 @@ mod tests {
             }
             assert!(
                 Instant::now() < deadline,
-                "git dashboard did not update workspace"
+                "git dashboard did not render the bounded status"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -6019,7 +6161,10 @@ mod tests {
             .status()
             .unwrap()
             .success());
-        fs::write(&file, "before\n").unwrap();
+        let original = (0..600)
+            .map(|line| format!("before {line}\n"))
+            .collect::<String>();
+        fs::write(&file, original).unwrap();
         assert!(Command::new("git")
             .args(["add", "tracked.txt"])
             .current_dir(root)
@@ -6040,7 +6185,10 @@ mod tests {
             .status()
             .unwrap()
             .success());
-        fs::write(&file, "after\n").unwrap();
+        let modified = (0..600)
+            .map(|line| format!("after {line}\n"))
+            .collect::<String>();
+        fs::write(&file, modified).unwrap();
         assert!(Command::new("git")
             .args(["add", "tracked.txt"])
             .current_dir(root)
@@ -6165,7 +6313,7 @@ mod tests {
                 .process_manager
                 .active_process_count("git");
             if expected_sign_count > 0 && active_process_count == 0 {
-                assert_eq!(expected_sign_count, 1);
+                assert_eq!(expected_sign_count, 200);
                 break;
             }
             assert!(
@@ -7570,6 +7718,106 @@ mod tests {
             .await
             .unwrap();
         assert!(poll_timer_callbacks().is_empty());
+    }
+
+    #[tokio::test]
+    async fn lsp_symbols_batches_pathological_reference_results() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("lsp_symbols", include_str!("../../plugins/lsp_symbols.hk"))
+            .await
+            .unwrap();
+        let config_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetConfig { request_id, .. } => request_id,
+            _ => panic!("expected lsp_symbols config request"),
+        };
+        runtime
+            .resolve_request(
+                config_request_id,
+                serde_json::json!({
+                    "value": {
+                        "lsp_symbols": {
+                            "icons": {
+                                "enabled": true,
+                                "overrides": {}
+                            }
+                        }
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+        runtime.execute_command("LspReferences").await.unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::References {
+                request_id,
+                include_declaration,
+            } => {
+                assert!(include_declaration);
+                request_id
+            }
+            _ => panic!("expected references request"),
+        };
+        runtime
+            .resolve_request(request_id, sample_reference_payload_with_count(4_097))
+            .await
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenDynamicPicker {
+                id, items, options, ..
+            } => {
+                assert_eq!(id, 203);
+                assert!(items.is_empty());
+                assert_eq!(options.status.as_deref(), Some("Loading 0/4097 references"));
+            }
+            _ => panic!("expected empty references picker"),
+        }
+
+        let mut final_items = Vec::new();
+        let mut final_status = None;
+        for _ in 0..80 {
+            let callbacks = poll_timer_callbacks();
+            assert!(!callbacks.is_empty(), "expected a pending reference batch");
+            for callback in callbacks {
+                if let PluginRequest::TimeoutCallback { timer_id } = callback {
+                    runtime
+                        .notify(
+                            "timeout:callback",
+                            serde_json::json!({ "timer_id": timer_id }),
+                        )
+                        .await
+                        .unwrap();
+                }
+            }
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                match request {
+                    PluginRequest::UpdatePickerItems { id, items } => {
+                        assert_eq!(id, 203);
+                        final_items = items;
+                    }
+                    PluginRequest::UpdatePickerStatus { id, status } => {
+                        assert_eq!(id, 203);
+                        final_status = status;
+                    }
+                    _ => panic!("unexpected request while batching references"),
+                }
+            }
+            if final_items.len() == 4_096 {
+                break;
+            }
+        }
+
+        assert_eq!(final_items.len(), 4_096);
+        assert_eq!(final_items[4_095].label, "src/reference_4095.rs");
+        assert_eq!(
+            final_status.as_deref(),
+            Some("4096 references (results truncated)")
+        );
     }
 
     #[tokio::test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -7699,6 +7699,7 @@ mod tests {
             Some("4096 symbols (results truncated)")
         );
 
+        let timeout_count = PENDING_TIMEOUTS.lock().unwrap().len();
         runtime.execute_command("LspDocumentSymbols").await.unwrap();
         let request_id = match ACTION_DISPATCHER.recv_request() {
             PluginRequest::DocumentSymbols { request_id, .. } => request_id,
@@ -7712,12 +7713,13 @@ mod tests {
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::OpenDynamicPicker { id: 201, .. }
         ));
+        assert_eq!(PENDING_TIMEOUTS.lock().unwrap().len(), timeout_count + 1);
 
         runtime
             .notify("picker:cancelled:201", serde_json::Value::Null)
             .await
             .unwrap();
-        assert!(poll_timer_callbacks().is_empty());
+        assert_eq!(PENDING_TIMEOUTS.lock().unwrap().len(), timeout_count);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

PR #126 made large document-symbol results safe, but the follow-up plugin audit found the same Husk instruction-budget risk in references and several other bundled-plugin callbacks. Pathological LSP, Git, or agent payloads could still exhaust a callback and quarantine the affected plugin.

## What

- Reuse the cancellable 64-item symbol batching path for reference results, with the existing 4,096-result safety ceiling.
- Bound Git status/dashboard parsing, gutter diff scans, open-buffer sign jobs, and Git-backed picker construction; truncated status remains visible to the user.
- Bound inlay-hint grouping and per-line sorting, Barbecue symbol scans, agent proposal/history/detail rendering, buffer and theme pickers, and Fidget progress state.
- Add pathological runtime regressions for 4,097 references, 1,000 same-line inlay hints, 600 proposal files, 600 Git status entries, and a 600-line Git diff.

## How to Test

1. Run `cargo test lsp_symbols_ --all-features -- --test-threads=1`; the document-symbol and reference pickers should complete in timer batches, and the pathological reference test should stop at 4,096 items with a truncated status.
2. Run `cargo test git_ --all-features -- --test-threads=1`; the 600-entry status should render a truncation row, and the 600-line diff should emit the bounded staged gutter signs without quarantining the plugin.
3. Run `cargo test inlay_hints_ --all-features -- --test-threads=1`, `cargo test barbecue_handles_large_symbol_lists --all-features -- --test-threads=1`, and `cargo test bundled_agent_review_ --all-features -- --test-threads=1`; each pathological payload should render bounded output while normal interactions continue to work.

Full validation also passes with `cargo test --all-targets --all-features` and `cargo clippy --all-targets --all-features -- -D warnings`.