### PR TITLE
fix(theme): render consistent backgrounds

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1700,6 +1700,10 @@ pub struct Editor {
     /// renderer diff frames without cloning the entire render buffer.
     previous_render_buffer: Option<RenderBuffer>,
 
+    /// Forces the next full frame to repaint cells whose unresolved styles are
+    /// unchanged but whose theme-derived colors have changed.
+    force_full_redraw: bool,
+
     /// Last terminal cursor cell painted into the render buffer.
     last_rendered_cursor_position: Option<(usize, usize)>,
 
@@ -2852,6 +2856,7 @@ impl Editor {
             splash_shown: false,
             splash_dismissed: false,
             previous_render_buffer: None,
+            force_full_redraw: false,
             last_rendered_cursor_position: None,
             last_rendered_cursor_surface: None,
             defer_motion_render: false,
@@ -15879,6 +15884,7 @@ impl Editor {
         self.theme = theme;
         self.highlighter = highlighter;
         self.highlight_cache.clear();
+        self.force_full_redraw = true;
         self.completion_ui.set_theme(&self.theme);
         if let Some(dialog) = &mut self.current_dialog {
             dialog.set_theme(&self.theme);

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -212,6 +212,19 @@ impl Editor {
             *previous = RenderBuffer::new(buffer.width, buffer.height, &Style::default());
         }
 
+        if self.force_full_redraw {
+            return buffer
+                .cells
+                .iter()
+                .enumerate()
+                .map(|(position, cell)| Change {
+                    x: position % buffer.width,
+                    y: position / buffer.width,
+                    cell,
+                })
+                .collect();
+        }
+
         buffer.diff(previous)
     }
 
@@ -220,6 +233,7 @@ impl Editor {
             .as_mut()
             .expect("render buffer diff requires a previous frame")
             .apply_changes(changes);
+        self.force_full_redraw = false;
     }
 
     /// Renders the entire editor state to the terminal
@@ -2142,6 +2156,24 @@ mod tests {
         assert_eq!(cell(1, horizontal_y), '─');
         assert_eq!(cell(inner_x, horizontal_y), '┴');
         assert_eq!(cell(outer_x, horizontal_y), '┤');
+    }
+
+    #[test]
+    fn theme_change_repaints_cells_with_unchanged_unresolved_styles() {
+        let config = Config::default();
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let source = Buffer::new(None, String::new());
+        let mut editor =
+            Editor::with_size(lsp, 4, 2, config, Theme::default(), vec![source]).unwrap();
+        let buffer = RenderBuffer::new(4, 2, &Style::default());
+        editor.previous_render_buffer = Some(buffer.clone());
+        editor.force_full_redraw = true;
+
+        let changes = editor.render_buffer_changes(&buffer);
+
+        assert_eq!(changes.len(), buffer.width * buffer.height);
+        editor.commit_render_buffer_changes(&changes);
+        assert!(!editor.force_full_redraw);
     }
 
     #[test]

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -132,25 +132,25 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
 
     let statusline_style = vscode_theme.statusline_style(selection_style.as_ref());
 
-    let foreground_token_color = vscode_theme
-        .token_colors
-        .iter()
-        .filter(|tc| tc.scope.is_none())
-        .find(|tc| tc.settings.contains_key("foreground"));
-    let background_token_color = vscode_theme
-        .token_colors
-        .iter()
-        .filter(|tc| tc.scope.is_none())
-        .find(|tc| tc.settings.contains_key("background"));
-
-    let fg = match foreground_token_color {
-        Some(tc) => tc.settings.get("foreground"),
-        None => vscode_theme.colors.get("editor.foreground"),
+    // VS Code derives its default token rule from the workbench editor colors and
+    // ignores scope-less token rules when scoped highlighting rules are assembled.
+    // Keep accepting the legacy TextMate defaults only when the corresponding
+    // workbench color is absent so older standalone themes remain usable.
+    let scope_less_token_color = |component: &str| {
+        vscode_theme
+            .token_colors
+            .iter()
+            .filter(|tc| tc.scope.is_none())
+            .find_map(|tc| tc.settings.get(component))
     };
-    let bg = match background_token_color {
-        Some(tc) => tc.settings.get("background"),
-        None => vscode_theme.colors.get("editor.background"),
-    };
+    let fg = vscode_theme
+        .colors
+        .get("editor.foreground")
+        .or_else(|| scope_less_token_color("foreground"));
+    let bg = vscode_theme
+        .colors
+        .get("editor.background")
+        .or_else(|| scope_less_token_color("background"));
 
     let editor_style = Style {
         fg: fg
@@ -817,7 +817,97 @@ mod test {
 
     #[test]
     fn test_token_color_with_no_scope() {
-        parse_vscode_theme("src/fixtures/token-color-with-no-scope.json").unwrap();
+        let theme = parse_vscode_theme("src/fixtures/token-color-with-no-scope.json").unwrap();
+
+        assert_eq!(theme.style.fg, Some(parse_rgb("#d8dee9ff").unwrap()));
+        assert_eq!(theme.style.bg, Some(parse_rgb("#2e3440ff").unwrap()));
+    }
+
+    #[test]
+    fn test_editor_colors_override_scope_less_token_defaults() {
+        let theme = parse_vscode_theme_contents(
+            r##"
+            {
+                "name": "conflicting defaults",
+                "colors": {
+                    "editor.foreground": "#112233",
+                    "editor.background": "#f4f5f6"
+                },
+                "tokenColors": [
+                    {
+                        "settings": {
+                            "foreground": "#ffffff",
+                            "background": "#010203"
+                        }
+                    }
+                ]
+            }
+            "##,
+        )
+        .unwrap();
+
+        assert_eq!(theme.style.fg, Some(parse_rgb("#112233").unwrap()));
+        assert_eq!(theme.style.bg, Some(parse_rgb("#f4f5f6").unwrap()));
+    }
+
+    #[test]
+    fn test_bundled_conflicting_defaults_use_editor_colors() {
+        for (file, expected_fg, expected_bg) in [
+            ("themes/night-owl-light.json", "#403f53", "#FBFBFB"),
+            (
+                "themes/night-owl-light-no-italics.json",
+                "#403f53",
+                "#FBFBFB",
+            ),
+            ("themes/andromeda-bordered.json", "#D5CED9", "#262A33"),
+            (
+                "themes/andromeda-italic-bordered.json",
+                "#D5CED9",
+                "#262A33",
+            ),
+            ("themes/ayu-dark-bordered.json", "#bfbdb6", "#10141c"),
+            ("themes/ayu-light-bordered.json", "#5c6166", "#fcfcfc"),
+            ("themes/ayu-mirage-bordered.json", "#cccac2", "#242936"),
+            ("themes/community-material-theme.json", "#EEFFFF", "#263238"),
+            ("themes/winter-is-coming-light.json", "#236ebf", "#FFFFFF"),
+        ] {
+            let theme = parse_vscode_theme(file).unwrap();
+            assert_eq!(
+                theme.style.fg,
+                Some(parse_rgb(expected_fg).unwrap()),
+                "wrong editor foreground for {file}"
+            );
+            assert_eq!(
+                theme.style.bg,
+                Some(parse_rgb(expected_bg).unwrap()),
+                "wrong editor background for {file}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_fluoromachine_syntax_tokens_do_not_paint_background_tiles() {
+        let theme = parse_vscode_theme("themes/fluoromachine.json").unwrap();
+
+        for scope in [
+            "constant",
+            "constant.numeric",
+            "constant.language",
+            "entity.name.function",
+            "entity.name.function.member",
+            "support.type",
+            "keyword",
+            "keyword.control",
+            "keyword.operator",
+            "storage.type",
+            "entity.other.attribute-name",
+        ] {
+            assert_eq!(
+                theme.get_style(scope).and_then(|style| style.bg),
+                None,
+                "unexpected syntax background for {scope}"
+            );
+        }
     }
 
     #[test]

--- a/themes/fluoromachine.json
+++ b/themes/fluoromachine.json
@@ -17,8 +17,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#af6df9",
-        "background": "#2d273f"
+        "foreground": "#af6df9"
       },
       "name": "Constant",
       "scope": "constant"
@@ -26,8 +25,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#af6df9",
-        "background": "#2d273f"
+        "foreground": "#af6df9"
       },
       "name": "Number",
       "scope": "constant.numeric"
@@ -35,8 +33,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#af6df9",
-        "background": "#2d273f"
+        "foreground": "#af6df9"
       },
       "name": "Boolean",
       "scope": "constant.language"
@@ -65,8 +62,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#ffcc00",
-        "background": "#312b32"
+        "foreground": "#ffcc00"
       },
       "name": "Function",
       "scope": "entity.name.function"
@@ -74,8 +70,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#ffcc00",
-        "background": "#312b32"
+        "foreground": "#ffcc00"
       },
       "name": "@function.method",
       "scope": "entity.name.function.member"
@@ -90,8 +85,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#fc199a",
-        "background": "#31233a"
+        "foreground": "#fc199a"
       },
       "name": "@type.builtin",
       "scope": "support.type"
@@ -99,8 +93,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#fc199a",
-        "background": "#31233a"
+        "foreground": "#fc199a"
       },
       "name": "Keyword",
       "scope": "keyword"
@@ -108,8 +101,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#fc199a",
-        "background": "#31233a"
+        "foreground": "#fc199a"
       },
       "name": "Conditional",
       "scope": "keyword.control"
@@ -117,8 +109,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#fc199a",
-        "background": "#31233a"
+        "foreground": "#fc199a"
       },
       "name": "Operator",
       "scope": "keyword.operator"
@@ -126,8 +117,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#fc199a",
-        "background": "#31233a"
+        "foreground": "#fc199a"
       },
       "name": "StorageClass",
       "scope": "storage.type"
@@ -142,8 +132,7 @@
     {
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#fc199a",
-        "background": "#31233a"
+        "foreground": "#fc199a"
       },
       "name": "@attribute",
       "scope": "entity.other.attribute-name"


### PR DESCRIPTION
Some bundled VS Code themes displayed mismatched editor backgrounds because scope-less token defaults could override the workbench editor colors. Fluoromachine also defined backgrounds for ordinary syntax scopes, and live theme previews could leave cells painted with the previous theme because the renderer diffed unresolved styles.

This change:

- prefers `editor.foreground` and `editor.background`, retaining scope-less token colors only as fallbacks
- removes Fluoromachine's ordinary syntax-token background tiles
- forces one complete repaint after a theme change so hover previews cannot retain stale resolved backgrounds
- adds regression coverage for conflicting bundled defaults, Fluoromachine token styles, and theme-change repainting

## How to Test

1. Open the theme picker and hover between Night Owl Light, the bordered Ayu/Andromeda variants, and Rose Pine. The complete editor background should update immediately without stale rectangular regions.
2. Preview Fluoromachine and inspect constants, functions, keywords, and attributes. They should use their foreground/font styling without isolated background tiles.
3. Run `cargo test --all-features`; the full suite, including `theme_change_repaints_cells_with_unchanged_unresolved_styles`, should pass.
4. Run `cargo clippy --all-targets --all-features -- -D warnings`; it should complete without warnings.