### PR TITLE
feat(git): make the dashboard interactive and responsive

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -181,7 +181,10 @@ uses your existing SSH agent or Git credential helper.
 
 The diff pane wraps long lines by default. Press `Tab` or `Ctrl-w w` to move
 between the file list and diff; `Ctrl-w h` and `Ctrl-w l` focus a pane
-directly. In the diff, `j`/`k`, `Ctrl-u`/`Ctrl-d`, `Ctrl-b`/`Ctrl-f`, and
+directly. Wide terminals show the panes side by side; narrower terminals stack
+the file list above the full-width diff, falling back to one focused pane only
+when there is not enough height for both. In the diff, `j`/`k`,
+`Ctrl-u`/`Ctrl-d`, `Ctrl-b`/`Ctrl-f`, and
 `[h`/`]h` provide line, page, and hunk navigation. `W` toggles wrapping; when
 wrapping is off, `h`/`l`, the arrow keys, and `0`/`$` scroll horizontally.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -179,6 +179,17 @@ adaptive diff pane. It also exposes synchronization, branch, remote, tag,
 stash, worktree, log, reset, and interactive-rebase actions. Authentication
 uses your existing SSH agent or Git credential helper.
 
+The diff pane wraps long lines by default. Press `Tab` or `Ctrl-w w` to move
+between the file list and diff; `Ctrl-w h` and `Ctrl-w l` focus a pane
+directly. In the diff, `j`/`k`, `Ctrl-u`/`Ctrl-d`, `Ctrl-b`/`Ctrl-f`, and
+`[h`/`]h` provide line, page, and hunk navigation. `W` toggles wrapping; when
+wrapping is off, `h`/`l`, the arrow keys, and `0`/`$` scroll horizontally.
+
+Use `v` to select changed lines. Lowercase `s`, `u`, and `x` stage, unstage,
+or discard the current changed line or selection; uppercase `S`, `U`, and `X`
+apply the same operation to the current hunk. Destructive actions remain
+confirmation-gated.
+
 ## Agent workflow
 
 Install and authenticate Codex separately, then press `Space A` from Normal or

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -44,6 +44,7 @@ python3 scripts/detach_bench.py 50 120 120 1536
 python3 scripts/interaction_bench.py typing
 python3 scripts/interaction_bench.py search --query self
 python3 scripts/interaction_bench.py picker --query src/editor.rs
+python3 scripts/git_workspace_bench.py --files 80 --presses 120
 ```
 
 The detach driver creates an isolated config and Unicode-heavy buffer, disables LSP,
@@ -54,6 +55,11 @@ event/render percentiles, terminal output, and log volume while typing alternati
 editing an incremental search query, or repeatedly filtering a picker with a file preview. Use
 `--file`, `--root`, `--rows`, `--cols`, and `--config-override` to exercise large repositories,
 single-line files, wrapping, and other representative layouts. For example:
+
+The Git workspace driver creates an isolated repository with many modified Rust files, rapidly
+moves through the file list, then repeats the same motion in the diff pane. It reports frame and
+plugin-callback percentiles and fails if selection churn starts more than two subprocesses, core
+diff navigation starts any subprocess, or the Git plugin exceeds its process budget.
 
 ```shell
 python3 scripts/interaction_bench.py picker \

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -284,8 +284,8 @@ fn status_event(event: Json) {
     }
     if event["type"] == "stdout" {
         red::state_set("git_state", parse_status(event.line));
+        refresh_selected_detail(false);
         render_dashboard();
-        refresh_selected_detail();
         red::request("GetWindows", sign_windows_loaded);
         let safe_sync_pending = red::state_bool("git_safe_sync_pending");
         if red::state_bool("git_dashboard_open") || safe_sync_pending {
@@ -309,7 +309,7 @@ fn status_event(event: Json) {
     }
 }
 
-fn refresh_selected_detail() {
+fn refresh_selected_detail(render_loading: bool) {
     if !red::state_bool("git_dashboard_open") {
         return;
     }
@@ -321,7 +321,7 @@ fn refresh_selected_detail() {
                 let entry = state[section][0];
                 show_detail(WorkspaceRow {
                     data: Json { section: section, path: entry.path, entry: entry },
-                });
+                }, render_loading);
                 return;
             }
         }
@@ -333,7 +333,7 @@ fn refresh_selected_detail() {
             if entry.path == path {
                 show_detail(WorkspaceRow {
                     data: Json { section: preferred_section, path: path, entry: entry },
-                });
+                }, render_loading);
                 return;
             }
         }
@@ -346,14 +346,14 @@ fn refresh_selected_detail() {
             if entry.path == path {
                 show_detail(WorkspaceRow {
                     data: Json { section: section, path: path, entry: entry },
-                });
+                }, render_loading);
                 return;
             }
         }
     }
     red::state_set("git_detail_document", red::null());
     red::state_set("git_detail", [[PanelSegment { text: "The selected file has no remaining changes.", style: success_style() }]]);
-    render_dashboard();
+    if render_loading { render_dashboard(); }
 }
 
 fn sign_windows_loaded(result: Json) {
@@ -759,16 +759,18 @@ fn append_section(rows: Json, title: String, section: String, entries: Json) -> 
         selectable: false,
         segments: [PanelSegment { text: title + "  " + red::len(entries), style: heading_style() }],
     });
+    let status_style = section_style(section);
+    let secondary_style = muted_style();
     for entry in entries {
         rows = red::push(rows, WorkspaceRow {
             id: section + ":" + entry.path,
             selectable: true,
             depth: 1,
             path: entry.path,
-            segments: entry_path_segments(entry),
+            segments: entry_path_segments(entry, secondary_style),
             right_segments: [PanelSegment {
                 text: status_label(entry),
-                style: section_style(section),
+                style: status_style,
             }],
             data: Json { section: section, path: entry.path, entry: entry },
         });
@@ -776,29 +778,30 @@ fn append_section(rows: Json, title: String, section: String, entries: Json) -> 
     return rows;
 }
 
-fn entry_path_segments(entry: Json) -> Json {
+fn entry_path_segments(entry: Json, secondary_style: Json) -> Json {
     let parts = red::split(entry.path, "/");
     let filename = entry.path;
     let parent = "";
-    if red::len(parts) > 0 {
-        filename = red::string(parts[red::len(parts) - 1], entry.path);
+    let part_count = red::len(parts);
+    if part_count > 0 {
+        filename = parts[part_count - 1];
         let index = 0;
-        while index + 1 < red::len(parts) {
+        while index + 1 < part_count {
             if parent != "" { parent = parent + "/"; }
-            parent = parent + red::string(parts[index], "");
+            parent = parent + parts[index];
             index = index + 1;
         }
     }
     let segments = [
-        PanelSegment { text: filename, style: normal_style() },
+        PanelSegment { text: filename },
     ];
     if parent != "" {
-        segments = red::push(segments, PanelSegment { text: "  " + parent, style: muted_style() });
+        segments = red::push(segments, PanelSegment { text: "  " + parent, style: secondary_style });
     }
     if entry.kind == "renamed" && entry.original_path != red::null() {
         segments = red::push(segments, PanelSegment {
             text: "  ← " + red::string(entry.original_path, ""),
-            style: muted_style(),
+            style: secondary_style,
         });
     }
     return segments;
@@ -853,7 +856,7 @@ fn workspace_event(event: Json) {
         event.action == "mouse_down" ||
         event.action == "mouse_click"
     ) {
-        show_detail(row);
+        show_detail(row, true);
         return;
     }
     if event.action == "prefix" ||
@@ -955,11 +958,11 @@ fn workspace_event(event: Json) {
     }
 }
 
-fn show_detail(row: Json) {
+fn show_detail(row: Json, render_loading: bool) {
     if row == red::null() || row.data.path == red::null() {
         red::state_set("git_detail", [[PanelSegment { text: "Select a change to inspect its diff.", style: muted_style() }]]);
         red::state_set("git_detail_document", red::null());
-        render_dashboard();
+        if render_loading { render_dashboard(); }
         return;
     }
     let args = ["diff"];
@@ -987,7 +990,7 @@ fn show_detail(row: Json) {
     });
     red::state_set("git_detail_process", process_id);
     red::on("process:" + process_id, detail_event);
-    render_dashboard();
+    if render_loading { render_dashboard(); }
 }
 
 fn detail_event(event: Json) {

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -15,7 +15,7 @@ pub fn activate() {
         description: "Inspect and manage workspace changes",
         aliases: ["source control", "status"],
     });
-    red::add_command("GitRefresh", refresh, Json {
+    red::add_command("GitRefresh", force_refresh, Json {
         title: "Refresh Git status",
         category: "Git",
         description: "Refresh workspace Git information",
@@ -73,6 +73,10 @@ pub fn activate() {
     red::on("filesystem:changed:1502", git_directory_changed);
     red::state_set("git_dashboard_open", false);
     red::state_set("git_process", "");
+    red::state_set("git_status_initialized", false);
+    red::state_set("git_status_output", "");
+    red::state_set("git_refresh_forced", true);
+    red::state_set("git_idle_polls", 0);
     red::state_set("git_refresh_timer", "");
     red::state_set("git_poll_timer", "");
     red::state_set("git_watch_path", "");
@@ -113,14 +117,19 @@ pub fn activate() {
     red::state_set("git_capture_kind", "");
     red::state_set("git_capture_output", "");
     red::state_set("git_operation", "");
-    red::state_set("git_operation_process", "");
-    red::state_set("git_operation_kind", "");
+    red::state_set("git_operation_jobs", []);
+    red::state_set("git_operation_candidate", "");
     red::state_set("git_detail", [[PanelSegment { text: "Select a change to inspect its diff.", style: normal_style() }]]);
     red::state_set("git_detail_document", red::null());
     red::state_set("git_detail_process", "");
     red::state_set("git_detail_output", "");
+    red::state_set("git_detail_pending_output", "");
     red::state_set("git_detail_path", "");
     red::state_set("git_detail_section", "");
+    red::state_set("git_detail_rendered_path", "");
+    red::state_set("git_detail_rendered_section", "");
+    red::state_set("git_detail_timer", "");
+    red::state_set("git_pending_detail_row", red::null());
     red::state_set("git_safe_sync_pending", false);
     red::state_set("git_confirm_mode", "");
     red::state_set("git_confirm_args", []);
@@ -161,11 +170,18 @@ fn dashboard() {
         detail_ratio: 58,
         min_two_pane_width: 96,
         detail_wrap: true,
+        notify_detail_navigation: false,
     });
-    refresh();
+    force_refresh();
 }
 
 fn close_dashboard() {
+    cancel_detail_timer();
+    let detail_process = red::string(red::state("git_detail_process"), "");
+    if detail_process != "" {
+        red::execute("KillProcess", detail_process);
+        red::state_set("git_detail_process", "");
+    }
     red::state_set("git_dashboard_open", false);
     red::execute("CloseWorkspace", "git-dashboard");
 }
@@ -175,10 +191,11 @@ fn schedule_poll() {
 }
 
 fn git_directory_changed(event: Json) {
-    refresh();
+    force_refresh();
 }
 
 fn schedule_refresh(event: Json) {
+    red::state_set("git_refresh_forced", true);
     let timer = red::string(red::state("git_refresh_timer"), "");
     if timer != "" {
         red::execute("CancelTimeout", timer);
@@ -187,6 +204,13 @@ fn schedule_refresh(event: Json) {
 }
 
 fn timeout_callback(event: Json) {
+    if event.timer_id == red::state("git_detail_timer") {
+        red::state_set("git_detail_timer", "");
+        let row = red::state("git_pending_detail_row");
+        red::state_set("git_pending_detail_row", red::null());
+        show_detail(row, true);
+        return;
+    }
     if event.timer_id == red::state("git_refresh_timer") {
         red::state_set("git_refresh_timer", "");
         refresh();
@@ -197,6 +221,11 @@ fn timeout_callback(event: Json) {
         refresh();
         schedule_poll();
     }
+}
+
+fn force_refresh() {
+    red::state_set("git_refresh_forced", true);
+    refresh();
 }
 
 fn refresh() {
@@ -283,12 +312,38 @@ fn status_event(event: Json) {
         return;
     }
     if event["type"] == "stdout" {
-        red::state_set("git_state", parse_status(event.line));
-        refresh_selected_detail(false);
-        render_dashboard();
-        red::request("GetWindows", sign_windows_loaded);
+        let output = red::string(event.line, "");
+        let initialized = red::state_bool("git_status_initialized");
+        let changed = !initialized || output != red::string(red::state("git_status_output"), "");
+        let forced = red::state_bool("git_refresh_forced");
+        red::state_set("git_status_initialized", true);
+        red::state_set("git_refresh_forced", false);
+        if changed {
+            red::state_set("git_status_output", output);
+            red::state_set("git_state", parse_status(output));
+        }
+        let refresh_detail = changed || forced;
+        if refresh_detail {
+            red::state_set("git_idle_polls", 0);
+        } else {
+            let idle_polls = red::int(red::state("git_idle_polls"), 0) + 1;
+            red::state_set("git_idle_polls", idle_polls);
+            if idle_polls >= 6 {
+                red::state_set("git_idle_polls", 0);
+                refresh_detail = true;
+            }
+        }
+        if refresh_detail {
+            refresh_selected_detail(false);
+        }
         let safe_sync_pending = red::state_bool("git_safe_sync_pending");
-        if red::state_bool("git_dashboard_open") || safe_sync_pending {
+        if changed {
+            render_dashboard();
+        }
+        if changed || forced {
+            red::request("GetWindows", sign_windows_loaded);
+        }
+        if changed && (red::state_bool("git_dashboard_open") || safe_sync_pending) {
             detect_operation();
         }
         if safe_sync_pending {
@@ -366,66 +421,103 @@ fn sign_windows_loaded(result: Json) {
     red::state_set("git_signs", []);
     red::state_set("git_sign_jobs", []);
     let buffers = [];
+    let seen = [];
     for window in result.windows {
         if red::len(buffers) >= 8 {
-            return;
+            break;
         }
         let path = red::string(window.buffer_path, "");
         let buffer_index = red::int(window.buffer_index, -1);
         let key = path + ":" + buffer_index;
-        if path == "" || buffer_index < 0 || red::contains(buffers, key) {
+        if path == "" || buffer_index < 0 || red::contains(seen, key) {
             continue;
         }
-        buffers = red::push(buffers, key);
-        spawn_sign_diff(path, buffer_index, false);
-        spawn_sign_diff(path, buffer_index, true);
+        seen = red::push(seen, key);
+        buffers = red::push(buffers, SignBuffer {
+            path: sign_repository_path(path),
+            buffer_index: buffer_index,
+        });
+    }
+    if red::len(buffers) > 0 {
+        spawn_sign_diff(buffers, false);
+        spawn_sign_diff(buffers, true);
     }
 }
 
 fn detect_operation() {
-    red::state_set("git_operation", "");
-    check_operation("merge", ["rev-parse", "-q", "--verify", "MERGE_HEAD"]);
+    for job in red::state("git_operation_jobs") {
+        red::execute("KillProcess", job.id);
+    }
+    red::state_set("git_operation_jobs", []);
+    red::state_set("git_operation_candidate", "");
+    spawn_operation_check("merge", ["rev-parse", "-q", "--verify", "MERGE_HEAD"]);
+    spawn_operation_check("cherry-pick", ["rev-parse", "-q", "--verify", "CHERRY_PICK_HEAD"]);
+    spawn_operation_check("revert", ["rev-parse", "-q", "--verify", "REVERT_HEAD"]);
+    spawn_operation_check("rebase", ["rebase", "--show-current-patch"]);
 }
 
-fn check_operation(kind: String, args: Json) {
-    red::state_set("git_operation_kind", kind);
+fn spawn_operation_check(kind: String, args: Json) {
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
         args: args,
         cwd: red::string(red::state("git_root"), "."),
     });
-    red::state_set("git_operation_process", process_id);
+    red::state_set("git_operation_jobs", red::push(
+        red::state("git_operation_jobs"),
+        OperationJob { id: process_id, kind: kind }
+    ));
     red::on("process:" + process_id, operation_check_event);
 }
 
 fn operation_check_event(event: Json) {
-    if event.process_id != red::state("git_operation_process") || event["type"] != "exit" {
+    if event["type"] != "exit" {
         return;
     }
-    let kind = red::string(red::state("git_operation_kind"), "");
+    let remaining = [];
+    let kind = "";
+    for job in red::state("git_operation_jobs") {
+        if job.id == event.process_id {
+            kind = red::string(job.kind, "");
+        } else {
+            remaining = red::push(remaining, job);
+        }
+    }
+    if kind == "" { return; }
+    red::state_set("git_operation_jobs", remaining);
     if red::int(event.code, 1) == 0 {
-        red::state_set("git_operation", kind);
-        render_dashboard();
-        return;
+        let candidate = red::string(red::state("git_operation_candidate"), "");
+        if candidate == "" || operation_rank(kind) < operation_rank(candidate) {
+            red::state_set("git_operation_candidate", kind);
+        }
     }
-    if kind == "merge" {
-        check_operation("cherry-pick", ["rev-parse", "-q", "--verify", "CHERRY_PICK_HEAD"]);
-    } else if kind == "cherry-pick" {
-        check_operation("revert", ["rev-parse", "-q", "--verify", "REVERT_HEAD"]);
-    } else if kind == "revert" {
-        check_operation("rebase", ["rebase", "--show-current-patch"]);
+    if red::len(remaining) == 0 {
+        let operation = red::string(red::state("git_operation_candidate"), "");
+        if operation != red::string(red::state("git_operation"), "") {
+            red::state_set("git_operation", operation);
+            render_dashboard();
+        }
     }
 }
 
-fn spawn_sign_diff(path: String, buffer_index: i32, staged: bool) {
-    let args = ["diff"];
+fn operation_rank(kind: String) -> i32 {
+    if kind == "merge" { return 0; }
+    if kind == "cherry-pick" { return 1; }
+    if kind == "revert" { return 2; }
+    return 3;
+}
+
+fn spawn_sign_diff(buffers: Json, staged: bool) {
+    let args = ["-c", "core.quotePath=false", "diff"];
     if staged {
         args = red::push(args, "--cached");
     }
     args = red::push(args, "--no-ext-diff");
+    args = red::push(args, "--no-prefix");
     args = red::push(args, "--unified=0");
     args = red::push(args, "--");
-    args = red::push(args, path);
+    for buffer in buffers {
+        args = red::push(args, buffer.path);
+    }
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
         args: args,
@@ -434,7 +526,7 @@ fn spawn_sign_diff(path: String, buffer_index: i32, staged: bool) {
     });
     red::state_set("git_sign_jobs", red::push(red::state("git_sign_jobs"), SignJob {
         id: process_id,
-        buffer_index: buffer_index,
+        buffers: buffers,
         staged: staged,
     }));
     red::on("process:" + process_id, sign_diff_event);
@@ -446,7 +538,7 @@ fn sign_diff_event(event: Json) {
     }
     for job in red::state("git_sign_jobs") {
         if job.id == event.process_id {
-            let signs = signs_from_patch(event.line, job.buffer_index, red::bool(job.staged, false));
+            let signs = signs_from_multi_patch(event.line, job.buffers, red::bool(job.staged, false));
             let all_signs = red::state("git_signs");
             for sign in signs {
                 if red::len(all_signs) >= 400 {
@@ -461,24 +553,89 @@ fn sign_diff_event(event: Json) {
     }
 }
 
-fn signs_from_patch(patch: String, buffer_index: i32, staged: bool) -> Json {
-    // A large diff must not spend the whole plugin callback budget on gutter rows.
-    let signs = [];
-    let hunks = sign_hunks(patch);
+fn signs_from_multi_patch(patch: String, buffers: Json, staged: bool) -> Json {
+    let hunks = [];
+    let buffer_index = -1;
+    let lines = red::split(patch, "\n");
     let index = 0;
-    while index < red::len(hunks) && red::len(signs) < 200 {
+    while index < red::len(lines) && index < 12000 && red::len(hunks) < 1000 {
+        let line = lines[index];
+        if red::starts_with(line, "diff --git ") {
+            buffer_index = sign_buffer_for_header(line, buffers);
+        } else if buffer_index >= 0 && red::starts_with(line, "@@ ") {
+            hunks = red::push(hunks, sign_hunk(line, buffer_index));
+        }
+        index = index + 1;
+    }
+    return signs_from_hunks(hunks, staged);
+}
+
+fn sign_buffer_for_header(header: String, buffers: Json) -> i32 {
+    for buffer in buffers {
+        let path = red::string(buffer.path, "");
+        if header == "diff --git " + path + " " + path ||
+            header == "diff --git \"" + path + "\" \"" + path + "\"" {
+            return red::int(buffer.buffer_index, -1);
+        }
+    }
+    // Renames have distinct old/new names, so match the destination field.
+    for buffer in buffers {
+        let path = red::string(buffer.path, "");
+        if red::ends_with(header, " " + path) || red::ends_with(header, " \"" + path + "\"") {
+            return red::int(buffer.buffer_index, -1);
+        }
+    }
+    return -1;
+}
+
+fn sign_repository_path(path: String) -> String {
+    let selected_path = "";
+    let state = red::state("git_state");
+    for section in ["conflicted", "staged", "unstaged", "untracked"] {
+        for entry in state[section] {
+            let candidate = red::string(entry.path, "");
+            if candidate != "" &&
+                (path == candidate || red::ends_with(path, "/" + candidate)) &&
+                red::len(candidate) > red::len(selected_path) {
+                selected_path = candidate;
+            }
+        }
+    }
+    if selected_path != "" { return selected_path; }
+    return repository_path(path);
+}
+
+fn signs_from_hunks(hunks: Json, staged: bool) -> Json {
+    let signs = [];
+    let appearances = sign_appearances(staged);
+    let current_buffer = -1;
+    let buffer_signs = 0;
+    let index = 0;
+    while index < red::len(hunks) && red::len(signs) < 400 {
         let hunk = hunks[index];
+        if hunk.buffer_index != current_buffer {
+            current_buffer = hunk.buffer_index;
+            buffer_signs = 0;
+        }
+        if buffer_signs >= 200 {
+            index = index + 1;
+            continue;
+        }
         let previous = red::null();
         let next = red::null();
-        if index > 0 { previous = hunks[index - 1]; }
-        if index + 1 < red::len(hunks) { next = hunks[index + 1]; }
+        if index > 0 && hunks[index - 1].buffer_index == current_buffer {
+            previous = hunks[index - 1];
+        }
+        if index + 1 < red::len(hunks) && hunks[index + 1].buffer_index == current_buffer {
+            next = hunks[index + 1];
+        }
         let kind = hunk_kind(hunk);
         let change_end = hunk_change_end(hunk);
         let topdelete = kind == "delete"
             && (hunk.new_start == 0 || (previous != red::null() && hunk_change_end(previous) == hunk.new_start))
             && (next == red::null() || next.new_start != hunk.new_start + 1);
         let line = hunk.new_start;
-        while line <= change_end && red::len(signs) < 200 {
+        while line <= change_end && buffer_signs < 200 && red::len(signs) < 400 {
             let sign_kind = kind;
             let changedelete = kind == "change"
                 && ((hunk.old_count > hunk.new_count && line == change_end)
@@ -490,13 +647,28 @@ fn signs_from_patch(patch: String, buffer_index: i32, staged: bool) -> Json {
             }
             let one_based = line;
             if topdelete { one_based = one_based + 1; }
-            signs = red::push(signs, git_sign(buffer_index, one_based - 1, sign_kind, staged));
+            signs = red::push(signs, git_sign(
+                current_buffer,
+                one_based - 1,
+                sign_kind,
+                staged,
+                appearances
+            ));
+            buffer_signs = buffer_signs + 1;
             line = line + 1;
         }
         if kind == "change" && hunk.new_count > hunk.old_count {
             line = change_end + 1;
-            while line < hunk.new_start + hunk.new_count && red::len(signs) < 200 {
-                signs = red::push(signs, git_sign(buffer_index, line - 1, "add", staged));
+            while line < hunk.new_start + hunk.new_count &&
+                buffer_signs < 200 && red::len(signs) < 400 {
+                signs = red::push(signs, git_sign(
+                    current_buffer,
+                    line - 1,
+                    "add",
+                    staged,
+                    appearances
+                ));
+                buffer_signs = buffer_signs + 1;
                 line = line + 1;
             }
         }
@@ -505,30 +677,21 @@ fn signs_from_patch(patch: String, buffer_index: i32, staged: bool) -> Json {
     return signs;
 }
 
-fn sign_hunks(patch: String) -> Json {
-    let hunks = [];
-    let lines = red::split(patch, "\n");
-    let index = 0;
-    while index < red::len(lines) && index < 2000 && red::len(hunks) < 500 {
-        let line = lines[index];
-        if red::starts_with(line, "@@ ") {
-            let fields = red::split(line, " ");
-            let old_range = red::split(red::slice(fields[1], 1), ",");
-            let new_range = red::split(red::slice(fields[2], 1), ",");
-            let old_count = 1;
-            let new_count = 1;
-            if red::len(old_range) > 1 { old_count = red::int(old_range[1], 1); }
-            if red::len(new_range) > 1 { new_count = red::int(new_range[1], 1); }
-            hunks = red::push(hunks, SignHunk {
-                old_start: red::int(old_range[0], 1),
-                old_count: old_count,
-                new_start: red::int(new_range[0], 1),
-                new_count: new_count,
-            });
-        }
-        index = index + 1;
-    }
-    return hunks;
+fn sign_hunk(line: String, buffer_index: i32) -> Json {
+    let fields = red::split(line, " ");
+    let old_range = red::split(red::slice(fields[1], 1), ",");
+    let new_range = red::split(red::slice(fields[2], 1), ",");
+    let old_count = 1;
+    let new_count = 1;
+    if red::len(old_range) > 1 { old_count = red::int(old_range[1], 1); }
+    if red::len(new_range) > 1 { new_count = red::int(new_range[1], 1); }
+    return SignHunk {
+        buffer_index: buffer_index,
+        old_start: red::int(old_range[0], 1),
+        old_count: old_count,
+        new_start: red::int(new_range[0], 1),
+        new_count: new_count,
+    };
 }
 
 fn hunk_kind(hunk: Json) -> String {
@@ -546,15 +709,35 @@ fn hunk_change_end(hunk: Json) -> i32 {
     return hunk.new_start + count - 1;
 }
 
-fn git_sign(buffer_index: i32, line: i32, kind: String, staged: bool) -> Json {
+fn git_sign(
+    buffer_index: i32,
+    line: i32,
+    kind: String,
+    staged: bool,
+    appearances: Json
+) -> Json {
     let safe_line = line;
     if safe_line < 0 { safe_line = 0; }
+    let appearance = appearances[kind];
     return GutterSign {
         buffer_index: buffer_index,
         line: safe_line,
-        text: sign_glyph(kind, staged),
+        text: appearance.text,
         priority: staged_priority(staged),
-        style: sign_style(kind, staged),
+        style: appearance.style,
+    };
+}
+
+fn sign_appearances(staged: bool) -> Json {
+    return SignAppearances {
+        add: SignAppearance { text: sign_glyph("add", staged), style: sign_style("add", staged) },
+        change: SignAppearance { text: sign_glyph("change", staged), style: sign_style("change", staged) },
+        delete: SignAppearance { text: sign_glyph("delete", staged), style: sign_style("delete", staged) },
+        topdelete: SignAppearance { text: sign_glyph("topdelete", staged), style: sign_style("topdelete", staged) },
+        changedelete: SignAppearance {
+            text: sign_glyph("changedelete", staged),
+            style: sign_style("changedelete", staged),
+        },
     };
 }
 
@@ -856,7 +1039,7 @@ fn workspace_event(event: Json) {
         event.action == "mouse_down" ||
         event.action == "mouse_click"
     ) {
-        show_detail(row, true);
+        schedule_detail(row);
         return;
     }
     if event.action == "prefix" ||
@@ -888,7 +1071,7 @@ fn workspace_event(event: Json) {
         return;
     }
     if event.action == "r" {
-        refresh();
+        force_refresh();
         return;
     }
     if event.action == "$" {
@@ -958,6 +1141,29 @@ fn workspace_event(event: Json) {
     }
 }
 
+fn cancel_detail_timer() {
+    let timer = red::string(red::state("git_detail_timer"), "");
+    if timer != "" {
+        red::execute("CancelTimeout", timer);
+    }
+    red::state_set("git_detail_timer", "");
+    red::state_set("git_pending_detail_row", red::null());
+}
+
+fn schedule_detail(row: Json) {
+    cancel_detail_timer();
+    if row == red::null() || row.data.path == red::null() {
+        show_detail(row, true);
+        return;
+    }
+    if row.data.path == red::state("git_detail_path") &&
+        row.data.section == red::state("git_detail_section") {
+        return;
+    }
+    red::state_set("git_pending_detail_row", row);
+    red::state_set("git_detail_timer", red::execute("SetTimeout", 60));
+}
+
 fn show_detail(row: Json, render_loading: bool) {
     if row == red::null() || row.data.path == red::null() {
         red::state_set("git_detail", [[PanelSegment { text: "Select a change to inspect its diff.", style: muted_style() }]]);
@@ -977,9 +1183,12 @@ fn show_detail(row: Json, render_loading: bool) {
     if previous != "" {
         red::execute("KillProcess", previous);
     }
-    red::state_set("git_detail", [[PanelSegment { text: "Loading diff…", style: muted_style() }]]);
-    red::state_set("git_detail_document", red::null());
-    red::state_set("git_detail_output", "");
+    if render_loading {
+        red::state_set("git_detail", [[PanelSegment { text: "Loading diff…", style: muted_style() }]]);
+        red::state_set("git_detail_document", red::null());
+        red::state_set("git_detail_output", "");
+    }
+    red::state_set("git_detail_pending_output", "");
     red::state_set("git_detail_path", row.data.path);
     red::state_set("git_detail_section", row.data.section);
     let process_id = red::execute("SpawnProcess", Process {
@@ -999,8 +1208,8 @@ fn detail_event(event: Json) {
     }
     if event["type"] == "stdout" {
         red::state_set(
-            "git_detail_output",
-            red::string(red::state("git_detail_output"), "") + event.line
+            "git_detail_pending_output",
+            red::string(red::state("git_detail_pending_output"), "") + event.line
         );
         return;
     }
@@ -1008,7 +1217,17 @@ fn detail_event(event: Json) {
         return;
     }
     red::state_set("git_detail_process", "");
-    let output = red::string(red::state("git_detail_output"), "");
+    let output = red::string(red::state("git_detail_pending_output"), "");
+    let path = red::string(red::state("git_detail_path"), "");
+    let section = red::string(red::state("git_detail_section"), "");
+    if output == red::string(red::state("git_detail_output"), "") &&
+        path == red::string(red::state("git_detail_rendered_path"), "") &&
+        section == red::string(red::state("git_detail_rendered_section"), "") {
+        return;
+    }
+    red::state_set("git_detail_output", output);
+    red::state_set("git_detail_rendered_path", path);
+    red::state_set("git_detail_rendered_section", section);
     if output == "" {
         red::state_set("git_detail", [[PanelSegment { text: "No textual diff available.", style: muted_style() }]]);
         red::state_set("git_detail_document", red::null());
@@ -1017,8 +1236,8 @@ fn detail_event(event: Json) {
             "git_detail_document",
             detail_document(
                 output,
-                red::string(red::state("git_detail_path"), ""),
-                red::string(red::state("git_detail_section"), "")
+                path,
+                section
             )
         );
         red::state_set("git_detail", []);
@@ -1422,7 +1641,7 @@ fn confirmation_selected(item: PickerItem) {
 
 fn action_finished(event: Json) {
     if event["type"] == "exit" {
-        refresh();
+        force_refresh();
     }
 }
 
@@ -2344,7 +2563,7 @@ fn commit_finished(event: Json) {
     }
     if red::int(event.code, 1) == 0 {
         red::state_set("git_commit_retry_text", "");
-        refresh();
+        force_refresh();
         return;
     }
     red::request("GetEditorState", commit_snapshot_loaded);
@@ -2774,6 +2993,11 @@ fn apply_hunk_check_finished(event: Json) {
 }
 
 fn deactivate() {
+    cancel_detail_timer();
+    for job in red::state("git_operation_jobs") {
+        red::execute("KillProcess", job.id);
+    }
+    red::state_set("git_operation_jobs", []);
     let refresh_timer = red::string(red::state("git_refresh_timer"), "");
     if refresh_timer != "" {
         red::execute("CancelTimeout", refresh_timer);

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -116,10 +116,18 @@ pub fn activate() {
     red::state_set("git_operation_process", "");
     red::state_set("git_operation_kind", "");
     red::state_set("git_detail", [[PanelSegment { text: "Select a change to inspect its diff.", style: normal_style() }]]);
+    red::state_set("git_detail_document", red::null());
+    red::state_set("git_detail_process", "");
+    red::state_set("git_detail_output", "");
+    red::state_set("git_detail_path", "");
+    red::state_set("git_detail_section", "");
     red::state_set("git_safe_sync_pending", false);
     red::state_set("git_confirm_mode", "");
     red::state_set("git_confirm_args", []);
     red::state_set("git_pending_commit_message", "");
+    red::state_set("git_apply_check_process", "");
+    red::state_set("git_apply_check_action", "");
+    red::state_set("git_apply_check_patch", "");
     red::request("GetConfig", git_cwd_loaded, "cwd");
     red::request("GetConfig", git_config_loaded);
     red::request("GetEditorInfo", git_info_loaded);
@@ -152,6 +160,7 @@ fn dashboard() {
         title: "Git",
         detail_ratio: 58,
         min_two_pane_width: 96,
+        detail_wrap: true,
     });
     refresh();
 }
@@ -276,6 +285,7 @@ fn status_event(event: Json) {
     if event["type"] == "stdout" {
         red::state_set("git_state", parse_status(event.line));
         render_dashboard();
+        refresh_selected_detail();
         red::request("GetWindows", sign_windows_loaded);
         let safe_sync_pending = red::state_bool("git_safe_sync_pending");
         if red::state_bool("git_dashboard_open") || safe_sync_pending {
@@ -297,6 +307,53 @@ fn status_event(event: Json) {
             render_error("git status exited with " + red::int(event.code, 0));
         }
     }
+}
+
+fn refresh_selected_detail() {
+    if !red::state_bool("git_dashboard_open") {
+        return;
+    }
+    let path = red::string(red::state("git_detail_path"), "");
+    let state = red::state("git_state");
+    if path == "" {
+        for section in ["conflicted", "staged", "unstaged", "untracked"] {
+            if red::len(state[section]) > 0 {
+                let entry = state[section][0];
+                show_detail(WorkspaceRow {
+                    data: Json { section: section, path: entry.path, entry: entry },
+                });
+                return;
+            }
+        }
+        return;
+    }
+    let preferred_section = red::string(red::state("git_detail_section"), "");
+    if preferred_section != "" {
+        for entry in state[preferred_section] {
+            if entry.path == path {
+                show_detail(WorkspaceRow {
+                    data: Json { section: preferred_section, path: path, entry: entry },
+                });
+                return;
+            }
+        }
+    }
+    for section in ["conflicted", "staged", "unstaged", "untracked"] {
+        if section == preferred_section {
+            continue;
+        }
+        for entry in state[section] {
+            if entry.path == path {
+                show_detail(WorkspaceRow {
+                    data: Json { section: section, path: path, entry: entry },
+                });
+                return;
+            }
+        }
+    }
+    red::state_set("git_detail_document", red::null());
+    red::state_set("git_detail", [[PanelSegment { text: "The selected file has no remaining changes.", style: success_style() }]]);
+    render_dashboard();
 }
 
 fn sign_windows_loaded(result: Json) {
@@ -685,8 +742,9 @@ fn render_dashboard() {
         header: header_segments(state),
         rows: rows,
         detail: red::state("git_detail"),
+        detail_document: red::state("git_detail_document"),
         footer: [PanelSegment {
-            text: "s stage  u unstage  x discard  c commit  y sync  b branch  t tag  z stash  w worktree  l log  i rebase  ? help  q close",
+            text: "Tab/Ctrl-w w focus  j/k scroll  [h/]h hunks  W wrap  v select  s/u/x line  S/U/X hunk  Enter open  ? help  q close",
             style: muted_style(),
         }],
     });
@@ -706,14 +764,44 @@ fn append_section(rows: Json, title: String, section: String, entries: Json) -> 
             id: section + ":" + entry.path,
             selectable: true,
             depth: 1,
-            segments: [
-                PanelSegment { text: status_label(entry) + " ", style: section_style(section) },
-                PanelSegment { text: entry.path, style: normal_style() },
-            ],
+            path: entry.path,
+            segments: entry_path_segments(entry),
+            right_segments: [PanelSegment {
+                text: status_label(entry),
+                style: section_style(section),
+            }],
             data: Json { section: section, path: entry.path, entry: entry },
         });
     }
     return rows;
+}
+
+fn entry_path_segments(entry: Json) -> Json {
+    let parts = red::split(entry.path, "/");
+    let filename = entry.path;
+    let parent = "";
+    if red::len(parts) > 0 {
+        filename = red::string(parts[red::len(parts) - 1], entry.path);
+        let index = 0;
+        while index + 1 < red::len(parts) {
+            if parent != "" { parent = parent + "/"; }
+            parent = parent + red::string(parts[index], "");
+            index = index + 1;
+        }
+    }
+    let segments = [
+        PanelSegment { text: filename, style: normal_style() },
+    ];
+    if parent != "" {
+        segments = red::push(segments, PanelSegment { text: "  " + parent, style: muted_style() });
+    }
+    if entry.kind == "renamed" && entry.original_path != red::null() {
+        segments = red::push(segments, PanelSegment {
+            text: "  ← " + red::string(entry.original_path, ""),
+            style: muted_style(),
+        });
+    }
+    return segments;
 }
 
 fn header_segments(state: Json) -> Json {
@@ -752,8 +840,44 @@ fn status_label(entry: Json) -> String {
 
 fn workspace_event(event: Json) {
     let row = event.row;
-    if event.action == "up" || event.action == "down" || event.action == "page_up" || event.action == "page_down" {
+    if event.focus == "rows" && (
+        event.action == "up" ||
+        event.action == "down" ||
+        event.action == "page_up" ||
+        event.action == "page_down" ||
+        event.action == "half_page_up" ||
+        event.action == "half_page_down" ||
+        event.action == "first" ||
+        event.action == "last" ||
+        event.action == "mouse_up" ||
+        event.action == "mouse_down" ||
+        event.action == "mouse_click"
+    ) {
         show_detail(row);
+        return;
+    }
+    if event.action == "prefix" ||
+        event.action == "noop" ||
+        event.action == "focus_next" ||
+        event.action == "focus_previous" ||
+        event.action == "focus_rows" ||
+        event.action == "focus_detail" ||
+        event.action == "left" ||
+        event.action == "right" ||
+        event.action == "horizontal_start" ||
+        event.action == "horizontal_end" ||
+        event.action == "toggle_wrap" ||
+        event.action == "visual" ||
+        event.action == "cancel_selection" ||
+        event.action == "previous_hunk" ||
+        event.action == "next_hunk" {
+        return;
+    }
+    if event.focus == "detail" && (
+        event.action == "mouse_up" || event.action == "mouse_down" ||
+        event.action == "mouse_left" || event.action == "mouse_right" ||
+        event.action == "mouse_click"
+    ) {
         return;
     }
     if event.action == "q" || event.action == "escape" {
@@ -768,6 +892,16 @@ fn workspace_event(event: Json) {
         command_log();
         return;
     }
+    if event.action == "activate" && event.focus == "detail" && event.detail_line != red::null() {
+        let target_line = red::int(event.detail_line.new_line, red::int(event.detail_line.old_line, 1));
+        red::execute("OpenLocation", Location {
+            path: red::string(red::state("git_root"), ".") + "/" + event.detail_line.data.path,
+            line: target_line - 1,
+            column: 0,
+        });
+        close_dashboard();
+        return;
+    }
     if event.action == "activate" && row != red::null() && row.data.path != red::null() {
         red::execute("OpenLocation", Location {
             path: red::string(red::state("git_root"), ".") + "/" + row.data.path,
@@ -777,7 +911,12 @@ fn workspace_event(event: Json) {
         close_dashboard();
         return;
     }
-    if event.action == "s" {
+    if event.focus == "detail" && (
+        event.action == "s" || event.action == "u" || event.action == "x" ||
+        event.action == "S" || event.action == "U" || event.action == "X"
+    ) {
+        run_detail_action(event);
+    } else if event.action == "s" {
         run_row_action(row, "add");
     } else if event.action == "u" {
         run_row_action(row, "restore-staged");
@@ -819,6 +958,7 @@ fn workspace_event(event: Json) {
 fn show_detail(row: Json) {
     if row == red::null() || row.data.path == red::null() {
         red::state_set("git_detail", [[PanelSegment { text: "Select a change to inspect its diff.", style: muted_style() }]]);
+        red::state_set("git_detail_document", red::null());
         render_dashboard();
         return;
     }
@@ -830,7 +970,152 @@ fn show_detail(row: Json) {
     args = red::push(args, "--color=never");
     args = red::push(args, "--");
     args = red::push(args, row.data.path);
-    capture_git("detail", args);
+    let previous = red::string(red::state("git_detail_process"), "");
+    if previous != "" {
+        red::execute("KillProcess", previous);
+    }
+    red::state_set("git_detail", [[PanelSegment { text: "Loading diff…", style: muted_style() }]]);
+    red::state_set("git_detail_document", red::null());
+    red::state_set("git_detail_output", "");
+    red::state_set("git_detail_path", row.data.path);
+    red::state_set("git_detail_section", row.data.section);
+    let process_id = red::execute("SpawnProcess", Process {
+        command: "git",
+        args: args,
+        raw_output: true,
+        cwd: red::string(red::state("git_root"), "."),
+    });
+    red::state_set("git_detail_process", process_id);
+    red::on("process:" + process_id, detail_event);
+    render_dashboard();
+}
+
+fn detail_event(event: Json) {
+    if event.process_id != red::state("git_detail_process") {
+        return;
+    }
+    if event["type"] == "stdout" {
+        red::state_set(
+            "git_detail_output",
+            red::string(red::state("git_detail_output"), "") + event.line
+        );
+        return;
+    }
+    if event["type"] != "exit" {
+        return;
+    }
+    red::state_set("git_detail_process", "");
+    let output = red::string(red::state("git_detail_output"), "");
+    if output == "" {
+        red::state_set("git_detail", [[PanelSegment { text: "No textual diff available.", style: muted_style() }]]);
+        red::state_set("git_detail_document", red::null());
+    } else {
+        red::state_set(
+            "git_detail_document",
+            detail_document(
+                output,
+                red::string(red::state("git_detail_path"), ""),
+                red::string(red::state("git_detail_section"), "")
+            )
+        );
+        red::state_set("git_detail", []);
+    }
+    render_dashboard();
+}
+
+fn detail_document(output: String, path: String, section: String) -> Json {
+    let lines = [];
+    let old_line = 0;
+    let new_line = 0;
+    let hunk_index = 0;
+    let hunk_id = red::null();
+    let patch_index = 0;
+    for raw in red::split(output, "\n") {
+        if patch_index >= 1000 {
+            return WorkspaceDocument { path: path, lines: lines };
+        }
+        if red::starts_with(raw, "@@ ") {
+            hunk_index = hunk_index + 1;
+            hunk_id = path + ":" + hunk_index;
+            let fields = red::split(raw, " ");
+            old_line = diff_range_start(fields[1]);
+            new_line = diff_range_start(fields[2]);
+            lines = red::push(lines, WorkspaceDocumentLine {
+                id: hunk_id + ":header",
+                text: raw,
+                kind: "hunk",
+                hunk_id: hunk_id,
+                data: Json {
+                    path: path,
+                    section: section,
+                    patch_index: patch_index,
+                    hunk_id: hunk_id,
+                },
+            });
+        } else if red::starts_with(raw, "+") && !red::starts_with(raw, "+++") {
+            lines = red::push(lines, diff_document_line(
+                raw, "added", red::null(), new_line, path, section, hunk_id, patch_index
+            ));
+            new_line = new_line + 1;
+        } else if red::starts_with(raw, "-") && !red::starts_with(raw, "---") {
+            lines = red::push(lines, diff_document_line(
+                raw, "removed", old_line, red::null(), path, section, hunk_id, patch_index
+            ));
+            old_line = old_line + 1;
+        } else if red::starts_with(raw, " ") && hunk_id != red::null() {
+            lines = red::push(lines, diff_document_line(
+                raw, "context", old_line, new_line, path, section, hunk_id, patch_index
+            ));
+            old_line = old_line + 1;
+            new_line = new_line + 1;
+        } else {
+            lines = red::push(lines, WorkspaceDocumentLine {
+                id: path + ":meta:" + patch_index,
+                text: raw,
+                kind: "meta",
+                hunk_id: hunk_id,
+                data: Json {
+                    path: path,
+                    section: section,
+                    patch_index: patch_index,
+                    hunk_id: hunk_id,
+                },
+            });
+        }
+        patch_index = patch_index + 1;
+    }
+    return WorkspaceDocument { path: path, lines: lines };
+}
+
+fn diff_range_start(field: String) -> i32 {
+    let range = red::split(red::slice(field, 1), ",");
+    return red::int(range[0], 0);
+}
+
+fn diff_document_line(
+    raw: String,
+    kind: String,
+    old_line: Json,
+    new_line: Json,
+    path: String,
+    section: String,
+    hunk_id: Json,
+    patch_index: i32
+) -> Json {
+    return WorkspaceDocumentLine {
+        id: path + ":" + patch_index,
+        text: red::slice(raw, 1),
+        kind: kind,
+        old_line: old_line,
+        new_line: new_line,
+        hunk_id: hunk_id,
+        data: Json {
+            path: path,
+            section: section,
+            patch_index: patch_index,
+            hunk_id: hunk_id,
+        },
+    };
 }
 
 fn detail_lines(output: String) -> Json {
@@ -877,6 +1162,208 @@ fn run_row_action(row: Json, action: String) {
         cwd: red::string(red::state("git_root"), "."),
     });
     red::on("process:" + process_id, action_finished);
+}
+
+fn run_detail_action(event: Json) {
+    let line = event.detail_line;
+    if line == red::null() || line.data == red::null() {
+        return;
+    }
+    let action = event.action;
+    let hunk_action = action == "S" || action == "U" || action == "X";
+    let normalized = red::lower(action);
+    let section = red::string(line.data.section, "");
+    if normalized == "s" && section != "unstaged" && section != "untracked" {
+        red::execute("Print", "Stage actions require an unstaged change");
+        return;
+    }
+    if normalized == "u" && section != "staged" {
+        red::execute("Print", "Unstage actions require a staged change");
+        return;
+    }
+    if normalized == "x" && section != "unstaged" {
+        red::execute("Print", "Discard actions require an unstaged tracked change");
+        return;
+    }
+    let patch = red::string(red::state("git_detail_output"), "");
+    let selected = "";
+    if hunk_action {
+        selected = patch_for_dashboard_hunk(patch, red::string(line.hunk_id, ""));
+    } else {
+        if line.kind != "added" && line.kind != "removed" && event.detail_selection == red::null() {
+            red::execute("Print", "Select an added or removed line");
+            return;
+        }
+        let start_index = red::int(line.data.patch_index, 0);
+        let end_index = start_index;
+        if event.detail_selection != red::null() {
+            let document = red::state("git_detail_document");
+            let first = red::int(event.detail_selection[0], event.detail_index);
+            let last = red::int(event.detail_selection[1], event.detail_index);
+            if first >= 0 && last < red::len(document.lines) {
+                start_index = red::int(document.lines[first].data.patch_index, start_index);
+                end_index = red::int(document.lines[last].data.patch_index, end_index);
+            }
+        }
+        selected = patch_for_dashboard_range(patch, start_index, end_index);
+    }
+    if selected == "" {
+        red::execute("Print", "No applicable Git change selected");
+        return;
+    }
+    if normalized == "x" {
+        red::state_set("git_hunk_patch", selected);
+        red::execute("OpenDynamicPicker", "Discard selected changes", 490, [
+            PickerItem { id: "cancel", label: "Cancel", kind: "Cancel" },
+            PickerItem { id: "proceed", label: "Proceed", kind: "Destructive" },
+        ], PickerOptions { status: red::string(line.data.path, "") + " · this cannot be undone by Red" });
+    } else if normalized == "s" {
+        apply_hunk("stage", selected);
+    } else {
+        apply_hunk("unstage", selected);
+    }
+}
+
+fn patch_for_dashboard_hunk(patch: String, selected_id: String) -> String {
+    if selected_id == "" {
+        return "";
+    }
+    let header = [];
+    let selected = [];
+    let current = [];
+    let hunk_index = 0;
+    let path = red::string(red::state("git_detail_path"), "");
+    for line in red::split(patch, "\n") {
+        if red::starts_with(line, "@@ ") {
+            if red::len(current) > 0 && path + ":" + hunk_index == selected_id {
+                selected = current;
+            }
+            hunk_index = hunk_index + 1;
+            current = [line];
+        } else if red::len(current) > 0 {
+            current = red::push(current, line);
+        } else {
+            header = red::push(header, line);
+        }
+    }
+    if red::len(current) > 0 && path + ":" + hunk_index == selected_id {
+        selected = current;
+    }
+    if red::len(selected) == 0 {
+        return "";
+    }
+    for line in selected {
+        header = red::push(header, line);
+    }
+    return red::join(header, "\n");
+}
+
+fn patch_for_dashboard_range(patch: String, start_index: i32, end_index: i32) -> String {
+    let first = start_index;
+    let last = end_index;
+    if last < first {
+        let swap = first;
+        first = last;
+        last = swap;
+    }
+    let common_header = [];
+    let selected_hunks = [];
+    let current = [];
+    let current_start = 0;
+    let old_start = 0;
+    let new_start = 0;
+    let patch_index = 0;
+    for line in red::split(patch, "\n") {
+        if red::starts_with(line, "@@ ") {
+            if red::len(current) > 0 {
+                let selected = dashboard_selected_hunk(
+                    current, current_start, old_start, new_start, first, last
+                );
+                if selected != "" {
+                    selected_hunks = red::push(selected_hunks, selected);
+                }
+            }
+            current = [line];
+            current_start = patch_index;
+            let fields = red::split(line, " ");
+            old_start = range_start(fields[1]);
+            new_start = range_start(fields[2]);
+        } else if red::len(current) > 0 {
+            current = red::push(current, line);
+        } else {
+            common_header = red::push(common_header, line);
+        }
+        patch_index = patch_index + 1;
+    }
+    if red::len(current) > 0 {
+        let selected = dashboard_selected_hunk(
+            current, current_start, old_start, new_start, first, last
+        );
+        if selected != "" {
+            selected_hunks = red::push(selected_hunks, selected);
+        }
+    }
+    if red::len(selected_hunks) == 0 {
+        return "";
+    }
+    let result = red::join(common_header, "\n");
+    for hunk in selected_hunks {
+        if result != "" { result = result + "\n"; }
+        result = result + hunk;
+    }
+    return result;
+}
+
+fn dashboard_selected_hunk(
+    lines: Json,
+    patch_start: i32,
+    old_start: i32,
+    new_start: i32,
+    selected_start: i32,
+    selected_end: i32
+) -> String {
+    let output = [];
+    let has_change = false;
+    let index = 1;
+    while index < red::len(lines) {
+        let line = red::string(lines[index], "");
+        let global_index = patch_start + index;
+        if red::starts_with(line, "+") {
+            if global_index >= selected_start && global_index <= selected_end {
+                output = red::push(output, line);
+                has_change = true;
+            }
+        } else if red::starts_with(line, "-") {
+            if global_index >= selected_start && global_index <= selected_end {
+                output = red::push(output, line);
+                has_change = true;
+            } else {
+                output = red::push(output, " " + red::slice(line, 1));
+            }
+        } else {
+            output = red::push(output, line);
+        }
+        index = index + 1;
+    }
+    if !has_change {
+        return "";
+    }
+    let old_count = 0;
+    let new_count = 0;
+    for line in output {
+        let text = red::string(line, "");
+        if red::starts_with(text, " ") || red::starts_with(text, "-") {
+            old_count = old_count + 1;
+        }
+        if red::starts_with(text, " ") || red::starts_with(text, "+") {
+            new_count = new_count + 1;
+        }
+    }
+    let result = "@@ -" + old_start + "," + old_count + " +" + new_start + "," + new_count + " @@";
+    for line in output {
+        result = result + "\n" + red::string(line, "");
+    }
+    return result;
 }
 
 fn confirm_git(title: String, impact: String, args: Json) {
@@ -1005,6 +1492,13 @@ fn help_menu() {
         PickerItem { id: "s", label: "s stage", kind: "Staged" },
         PickerItem { id: "u", label: "u unstage", kind: "Action" },
         PickerItem { id: "x", label: "x discard", kind: "Destructive" },
+        PickerItem { id: "focus", label: "Tab / Ctrl-w w switch Files and Diff", kind: "Action" },
+        PickerItem { id: "direction", label: "Ctrl-w h / l focus Files or Diff", kind: "Action" },
+        PickerItem { id: "scroll", label: "Ctrl-u/d half page · Ctrl-b/f full page", kind: "Action" },
+        PickerItem { id: "hunks", label: "[h / ]h previous or next hunk", kind: "Action" },
+        PickerItem { id: "wrap", label: "W toggle diff wrapping", kind: "Action" },
+        PickerItem { id: "select", label: "v select diff lines", kind: "Action" },
+        PickerItem { id: "partial", label: "s/u/x line or range · S/U/X hunk", kind: "Staged" },
         PickerItem { id: "c", label: "c commit", kind: "GitCommit" },
         PickerItem { id: "f", label: "f fetch", kind: "Action" },
         PickerItem { id: "p", label: "p push", kind: "Action" },
@@ -2225,6 +2719,25 @@ fn selected_hunk(lines: Json, old_start: i32, new_start: i32, start_line: i32, e
 }
 
 fn apply_hunk(action: String, patch: String) {
+    let previous = red::string(red::state("git_apply_check_process"), "");
+    if previous != "" {
+        red::execute("KillProcess", previous);
+    }
+    red::state_set("git_apply_check_action", action);
+    red::state_set("git_apply_check_patch", patch);
+    let args = apply_hunk_args(action);
+    args = red::push(args, "--check");
+    let process_id = red::execute("SpawnProcess", Process {
+        command: "git",
+        args: args,
+        stdin: patch + "\n",
+        cwd: red::string(red::state("git_root"), "."),
+    });
+    red::state_set("git_apply_check_process", process_id);
+    red::on("process:" + process_id, apply_hunk_check_finished);
+}
+
+fn apply_hunk_args(action: String) -> Json {
     let args = ["apply"];
     if action == "stage" || action == "unstage" {
         args = red::push(args, "--cached");
@@ -2234,9 +2747,23 @@ fn apply_hunk(action: String, patch: String) {
     }
     args = red::push(args, "--unidiff-zero");
     args = red::push(args, "-");
+    return args;
+}
+
+fn apply_hunk_check_finished(event: Json) {
+    if event.process_id != red::state("git_apply_check_process") || event["type"] != "exit" {
+        return;
+    }
+    red::state_set("git_apply_check_process", "");
+    if red::int(event.code, 1) != 0 {
+        red::execute("Print", "Git rejected the selected patch; refresh and try again");
+        return;
+    }
+    let action = red::string(red::state("git_apply_check_action"), "");
+    let patch = red::string(red::state("git_apply_check_patch"), "");
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
-        args: args,
+        args: apply_hunk_args(action),
         stdin: patch + "\n",
         cwd: red::string(red::state("git_root"), "."),
     });

--- a/scripts/git_workspace_bench.py
+++ b/scripts/git_workspace_bench.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Measure Git workspace row churn and core-owned diff navigation in a PTY.
+
+Build first with `cargo build --locked --release`, then run:
+    python3 scripts/git_workspace_bench.py --files 80 --presses 120
+"""
+
+import argparse
+from collections import defaultdict
+import fcntl
+import os
+from pathlib import Path
+import pty
+import re
+import struct
+import subprocess
+import tempfile
+import termios
+import threading
+import time
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BIN = ROOT / "target" / "release" / "red"
+TIMING = re.compile(r"\[PERF\] (\S+)(?: (.*?))?: (\d+)us")
+
+
+def percentile(samples, value):
+    return samples[(len(samples) - 1) * value // 100]
+
+
+def run_git(root, *args):
+    subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def make_repository(root, files):
+    run_git(root, "init", "-q")
+    for index in range(files):
+        (root / f"file_{index:03}.rs").write_text(
+            f"fn value_{index}() -> usize {{ {index} }}\n", encoding="utf-8"
+        )
+    run_git(root, "add", ".")
+    run_git(
+        root,
+        "-c",
+        "user.name=Red Bench",
+        "-c",
+        "user.email=red-bench@example.test",
+        "commit",
+        "-qm",
+        "baseline",
+    )
+    for index in range(files):
+        (root / f"file_{index:03}.rs").write_text(
+            f"fn value_{index}() -> usize {{ {index} + 1 }}\n", encoding="utf-8"
+        )
+
+
+def timing_report(log, begin, end):
+    active = False
+    samples = defaultdict(list)
+    for line in log.read_text(encoding="utf-8", errors="replace").splitlines():
+        if begin in line:
+            active = True
+            continue
+        if end in line:
+            active = False
+            continue
+        if not active:
+            continue
+        match = TIMING.search(line)
+        if not match:
+            continue
+        label, detail, micros = match.group(1), match.group(2) or "", int(match.group(3))
+        if label in ("notify", "drain"):
+            label = f"{label} {detail.split()[0]}"
+        samples[label].append(micros)
+    return samples
+
+
+def process_count(samples):
+    return sum(label.startswith("notify process:") for label in samples)
+
+
+def print_samples(title, samples, invocations):
+    print(f"\n=== {title}: git invocations={invocations} ===")
+    print(f"{'label':<45} {'n':>6} {'p50 us':>10} {'p95 us':>10} {'max us':>10}")
+    for label, values in sorted(samples.items(), key=lambda item: -sum(item[1])):
+        values.sort()
+        print(
+            f"{label:<45} {len(values):>6} {percentile(values, 50):>10} "
+            f"{percentile(values, 95):>10} {values[-1]:>10}"
+        )
+
+
+def run(args):
+    if not BIN.exists():
+        raise SystemExit("build the release binary first: cargo build --locked --release")
+    with tempfile.TemporaryDirectory(prefix="red-git-workspace-perf-") as temp_name:
+        temp = Path(temp_name)
+        repository = temp / "repository"
+        repository.mkdir()
+        make_repository(repository, args.files)
+        config_home = temp / "config"
+        config_dir = config_home / "red"
+        config_dir.mkdir(parents=True)
+        log = temp / "red.log"
+        (config_dir / "config.toml").write_text(f'log_file = "{log}"\n', encoding="utf-8")
+
+        master, slave = pty.openpty()
+        fcntl.ioctl(
+            slave,
+            termios.TIOCSWINSZ,
+            struct.pack("HHHH", args.rows, args.cols, 0, 0),
+        )
+        process = subprocess.Popen(
+            [
+                str(BIN),
+                "--root",
+                str(repository),
+                "--config-override",
+                "lsp.enabled = false",
+                str(repository / "file_000.rs"),
+            ],
+            stdin=slave,
+            stdout=slave,
+            stderr=subprocess.DEVNULL,
+            env=dict(
+                os.environ,
+                RED_PERF="trace",
+                XDG_CONFIG_HOME=str(config_home),
+            ),
+            close_fds=True,
+        )
+        os.close(slave)
+
+        def drain():
+            while True:
+                try:
+                    if not os.read(master, 1 << 20):
+                        return
+                except OSError:
+                    return
+
+        threading.Thread(target=drain, daemon=True).start()
+        try:
+            deadline = time.monotonic() + 12
+            while time.monotonic() < deadline:
+                if log.exists() and "[PERF] startup:interactive:" in log.read_text(
+                    encoding="utf-8", errors="replace"
+                ):
+                    break
+                if process.poll() is not None:
+                    raise RuntimeError("editor exited before first paint")
+                time.sleep(0.02)
+            else:
+                raise RuntimeError("editor did not reach first paint")
+
+            os.write(master, b":GitDashboard\r")
+            time.sleep(1.2)
+            with log.open("a", encoding="utf-8") as stream:
+                stream.write("[GIT BENCH] rows begin\n")
+            for _ in range(args.presses):
+                os.write(master, b"j")
+                time.sleep(args.delay_ms / 1000)
+            time.sleep(0.3)
+            with log.open("a", encoding="utf-8") as stream:
+                stream.write("[GIT BENCH] rows end\n")
+            row_samples = timing_report(
+                log, "[GIT BENCH] rows begin", "[GIT BENCH] rows end"
+            )
+            row_processes = process_count(row_samples)
+
+            os.write(master, b"\t")
+            time.sleep(0.1)
+            with log.open("a", encoding="utf-8") as stream:
+                stream.write("[GIT BENCH] detail begin\n")
+            for _ in range(args.presses):
+                os.write(master, b"j")
+                time.sleep(args.delay_ms / 1000)
+            time.sleep(0.2)
+            with log.open("a", encoding="utf-8") as stream:
+                stream.write("[GIT BENCH] detail end\n")
+            detail_samples = timing_report(
+                log, "[GIT BENCH] detail begin", "[GIT BENCH] detail end"
+            )
+            detail_processes = process_count(detail_samples)
+
+            contents = log.read_text(encoding="utf-8", errors="replace")
+            if "maximum of 16 active processes" in contents or "quarantined plugin `git`" in contents:
+                raise RuntimeError("Git plugin exceeded its process budget or was quarantined")
+            print_samples(
+                "file-list churn",
+                row_samples,
+                row_processes,
+            )
+            print_samples(
+                "diff navigation",
+                detail_samples,
+                detail_processes,
+            )
+            if row_processes > 2:
+                raise RuntimeError(f"row churn spawned {row_processes} Git processes; expected <= 2")
+            if detail_processes != 0:
+                raise RuntimeError(f"core-owned diff navigation spawned {detail_processes} Git processes")
+        finally:
+            if process.poll() is None:
+                os.write(master, b"q")
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=3)
+            os.close(master)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--files", type=int, default=80)
+    parser.add_argument("--presses", type=int, default=120)
+    parser.add_argument("--delay-ms", type=float, default=2)
+    parser.add_argument("--rows", type=int, default=30)
+    parser.add_argument("--cols", type=int, default=100)
+    args = parser.parse_args()
+    if args.files < 2 or args.presses < 1 or args.delay_ms < 0:
+        parser.error("files >= 2, presses >= 1, and delay-ms >= 0 are required")
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9253,11 +9253,17 @@ impl Editor {
             return None;
         };
         let id = event.workspace_id.clone();
+        let notify_plugin = event.notify_plugin;
         serde_json::to_value(event).ok().map(|payload| {
-            KeyAction::Multiple(vec![
-                Action::NotifyPlugins(format!("workspace:event:{id}"), payload),
-                Action::Refresh,
-            ])
+            let mut actions = Vec::with_capacity(2);
+            if notify_plugin {
+                actions.push(Action::NotifyPlugins(
+                    format!("workspace:event:{id}"),
+                    payload,
+                ));
+            }
+            actions.push(Action::Refresh);
+            KeyAction::Multiple(actions)
         })
     }
 
@@ -16112,6 +16118,7 @@ impl Editor {
         self.theme = theme;
         self.highlighter = highlighter;
         self.highlight_cache.clear();
+        self.workspace_manager.update_theme(&self.theme);
         self.force_full_redraw = true;
         self.completion_ui.set_theme(&self.theme);
         if let Some(dialog) = &mut self.current_dialog {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7273,7 +7273,7 @@ impl Editor {
                     needs_render = true;
                 }
                 PluginRequest::UpdateWorkspace { id, model } => {
-                    if self.workspace_manager.update(&id, model) {
+                    if self.workspace_manager.update(&id, model, &self.theme) {
                         needs_render = true;
                     }
                 }
@@ -9204,24 +9204,54 @@ impl Editor {
     }
 
     fn handle_workspace_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
-        let Event::Key(event) = ev else {
+        let event = if let Event::Mouse(event) = ev {
+            let horizontal = event.modifiers.contains(KeyModifiers::SHIFT);
+            let action = match event.kind {
+                MouseEventKind::ScrollUp if horizontal => "mouse_left",
+                MouseEventKind::ScrollDown if horizontal => "mouse_right",
+                MouseEventKind::ScrollUp => "mouse_up",
+                MouseEventKind::ScrollDown => "mouse_down",
+                MouseEventKind::Down(MouseButton::Left) => "mouse_click",
+                _ => return None,
+            };
+            self.workspace_manager.handle_mouse(
+                action,
+                event.column as usize,
+                event.row as usize,
+                self.size.1 as usize,
+                self.size.0 as usize,
+            )?
+        } else if let Event::Key(event) = ev {
+            let control = event.modifiers.contains(KeyModifiers::CONTROL);
+            let action = match event.code {
+                KeyCode::Char('w') if control => "ctrl_w".to_string(),
+                KeyCode::Char('u') if control => "half_page_up".to_string(),
+                KeyCode::Char('d') if control => "half_page_down".to_string(),
+                KeyCode::Char('b') if control => "page_up".to_string(),
+                KeyCode::Char('f') if control => "page_down".to_string(),
+                KeyCode::Up | KeyCode::Char('k') => "up".to_string(),
+                KeyCode::Down | KeyCode::Char('j') => "down".to_string(),
+                KeyCode::Left => "left".to_string(),
+                KeyCode::Right => "right".to_string(),
+                KeyCode::Home => "first".to_string(),
+                KeyCode::End => "last".to_string(),
+                KeyCode::PageUp => "page_up".to_string(),
+                KeyCode::PageDown => "page_down".to_string(),
+                KeyCode::Enter => "activate".to_string(),
+                KeyCode::Esc => "escape".to_string(),
+                KeyCode::Tab => "toggle".to_string(),
+                KeyCode::BackTab => "back_toggle".to_string(),
+                KeyCode::Char(c) => c.to_string(),
+                _ => return None,
+            };
+            self.workspace_manager.handle_action(
+                action,
+                self.size.1 as usize,
+                self.size.0 as usize,
+            )?
+        } else {
             return None;
         };
-        let action = match event.code {
-            KeyCode::Up | KeyCode::Char('k') => "up".to_string(),
-            KeyCode::Down | KeyCode::Char('j') => "down".to_string(),
-            KeyCode::PageUp => "page_up".to_string(),
-            KeyCode::PageDown => "page_down".to_string(),
-            KeyCode::Enter => "activate".to_string(),
-            KeyCode::Esc => "escape".to_string(),
-            KeyCode::Tab => "toggle".to_string(),
-            KeyCode::BackTab => "back_toggle".to_string(),
-            KeyCode::Char(c) => c.to_string(),
-            _ => return None,
-        };
-        let event = self
-            .workspace_manager
-            .handle_action(action, self.size.1 as usize)?;
         let id = event.workspace_id.clone();
         serde_json::to_value(event).ok().map(|payload| {
             KeyAction::Multiple(vec![

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -266,7 +266,8 @@ impl Editor {
         self.render_ui_chrome(buffer)?;
         // A modal workspace replaces editor chrome but remains below dialogs
         // and overlays so prompts and transient menus stay interactive.
-        self.workspace_manager.render(buffer, &self.theme.style);
+        self.workspace_manager
+            .render(buffer, &self.theme, self.picker_icons());
         self.render_dialog(buffer)?;
 
         // Render all plugins

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -48,4 +48,7 @@ pub use window_bar::{
     RenderedWindowBar, WindowBarConfig, WindowBarEdge, WindowBarHitRegion, WindowBarManager,
     WindowBarOverflow, WindowBarSegment, WindowBarSemanticStyle, WindowBarStyle,
 };
-pub use workspace::{WorkspaceConfig, WorkspaceManager, WorkspaceModel, WorkspaceRow};
+pub use workspace::{
+    WorkspaceConfig, WorkspaceDocument, WorkspaceDocumentLine, WorkspaceManager, WorkspaceModel,
+    WorkspaceRow,
+};

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -7887,12 +7887,177 @@ mod tests {
 
     #[cfg(not(windows))]
     #[tokio::test]
+    async fn git_dashboard_debounces_rapid_detail_selection_to_one_process() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        for name in ["first.rs", "second.rs"] {
+            fs::write(root.join(name), "fn before() {}\n").unwrap();
+        }
+        assert!(Command::new("git")
+            .args(["add", "."])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "-c",
+                "user.name=Red Test",
+                "-c",
+                "user.email=red@example.test",
+                "commit",
+                "-qm",
+                "initial",
+            ])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(root.join("first.rs"), "fn first() {}\n").unwrap();
+        fs::write(root.join("second.rs"), "fn second() {}\n").unwrap();
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut rows = None;
+        let (first, second) = loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                match request {
+                    PluginRequest::GetWindows { request_id } => {
+                        runtime
+                            .resolve_request(request_id, serde_json::json!({ "windows": [] }))
+                            .await
+                            .unwrap();
+                    }
+                    PluginRequest::UpdateWorkspace { model, .. }
+                        if model.detail_document.is_some() =>
+                    {
+                        let first = model
+                            .rows
+                            .iter()
+                            .find(|row| row.id == "unstaged:first.rs")
+                            .cloned();
+                        let second = model
+                            .rows
+                            .iter()
+                            .find(|row| row.id == "unstaged:second.rs")
+                            .cloned();
+                        if let (Some(first), Some(second)) = (first, second) {
+                            rows = Some((first, second));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(rows) = rows.as_ref() {
+                if runtime
+                    .inner
+                    .lock()
+                    .unwrap()
+                    .host
+                    .process_manager
+                    .active_process_count("git")
+                    == 0
+                {
+                    break rows.clone();
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "initial Git detail did not settle"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+
+        for index in 0..40 {
+            let row = if index % 2 == 0 { &first } else { &second };
+            runtime
+                .notify(
+                    "workspace:event:git-dashboard",
+                    serde_json::json!({ "action": "down", "focus": "rows", "row": row }),
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            runtime
+                .inner
+                .lock()
+                .unwrap()
+                .host
+                .process_manager
+                .active_process_count("git"),
+            0,
+            "selection changes should wait for the debounce window"
+        );
+
+        tokio::time::sleep(Duration::from_millis(70)).await;
+        let callbacks = poll_timer_callbacks();
+        assert!(
+            !callbacks.is_empty(),
+            "the final detail timer should remain"
+        );
+        for callback in callbacks {
+            if let PluginRequest::TimeoutCallback { timer_id } = callback {
+                runtime
+                    .notify(
+                        "timeout:callback",
+                        serde_json::json!({ "timer_id": timer_id }),
+                    )
+                    .await
+                    .unwrap();
+            }
+        }
+        assert_eq!(
+            runtime
+                .inner
+                .lock()
+                .unwrap()
+                .host
+                .process_manager
+                .active_process_count("git"),
+            1,
+            "the debounce callback should spawn one detail process"
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut selected_path = None;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::UpdateWorkspace { model, .. } = request {
+                    selected_path = model.detail_document.map(|document| document.path);
+                }
+            }
+            if selected_path.as_deref() == Some("second.rs") {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "debounced Git detail did not render"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
     async fn git_signs_deduplicate_split_windows_and_apply_staged_configuration() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
         let repository = tempfile::tempdir().unwrap();
         let root = repository.path();
         let file = root.join("tracked.txt");
+        let second_file = root.join("second.txt");
         assert!(Command::new("git")
             .args(["init", "-q"])
             .current_dir(root)
@@ -7903,8 +8068,9 @@ mod tests {
             .map(|line| format!("before {line}\n"))
             .collect::<String>();
         fs::write(&file, original).unwrap();
+        fs::write(&second_file, "before\n").unwrap();
         assert!(Command::new("git")
-            .args(["add", "tracked.txt"])
+            .args(["add", "."])
             .current_dir(root)
             .status()
             .unwrap()
@@ -7927,8 +8093,9 @@ mod tests {
             .map(|line| format!("after {line}\n"))
             .collect::<String>();
         fs::write(&file, modified).unwrap();
+        fs::write(&second_file, "after\n").unwrap();
         assert!(Command::new("git")
-            .args(["add", "tracked.txt"])
+            .args(["add", "."])
             .current_dir(root)
             .status()
             .unwrap()
@@ -8006,6 +8173,7 @@ mod tests {
 
         let deadline = Instant::now() + Duration::from_secs(5);
         let mut expected_sign_count = 0;
+        let mut saw_second_sign = false;
         loop {
             pump_process_events(&mut runtime).await.unwrap();
             while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
@@ -8025,6 +8193,11 @@ mod tests {
                                             "buffer_path": file.display().to_string(),
                                             "buffer_index": 7,
                                             "active": false
+                                        },
+                                        {
+                                            "buffer_path": second_file.display().to_string(),
+                                            "buffer_index": 8,
+                                            "active": false
                                         }
                                     ]
                                 }),
@@ -8039,6 +8212,9 @@ mod tests {
                                 sign.buffer_index == 7 && sign.text == "!" && sign.priority == 5
                             })
                             .count();
+                        saw_second_sign = signs.iter().any(|sign| {
+                            sign.buffer_index == 8 && sign.text == "!" && sign.priority == 5
+                        });
                     }
                     _ => {}
                 }
@@ -8050,7 +8226,7 @@ mod tests {
                 .host
                 .process_manager
                 .active_process_count("git");
-            if expected_sign_count > 0 && active_process_count == 0 {
+            if expected_sign_count > 0 && saw_second_sign && active_process_count == 0 {
                 assert_eq!(expected_sign_count, 200);
                 break;
             }

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -3144,6 +3144,67 @@ mod tests {
         }
     }
 
+    #[cfg(not(windows))]
+    async fn load_git_runtime(root: &Path) -> Runtime {
+        let mut runtime = Runtime::new_with_permissions(HashMap::from([(
+            "git".to_string(),
+            PluginPermissions {
+                process: vec!["git".to_string()],
+            },
+        )]));
+        runtime
+            .load_plugin("git", include_str!("../../plugins/git.hk"))
+            .await
+            .unwrap();
+        let mut cwd_request_id = None;
+        let mut config_request_id = None;
+        let mut info_request_id = None;
+        for _ in 0..3 {
+            match ACTION_DISPATCHER.recv_request() {
+                PluginRequest::GetConfig { request_id, key } if key.as_deref() == Some("cwd") => {
+                    cwd_request_id = Some(request_id);
+                }
+                PluginRequest::GetConfig {
+                    request_id,
+                    key: None,
+                } => config_request_id = Some(request_id),
+                PluginRequest::EditorInfo(request_id) => info_request_id = Some(request_id),
+                _ => panic!("unexpected Git plugin startup request"),
+            }
+        }
+        runtime
+            .resolve_request(
+                cwd_request_id.unwrap(),
+                serde_json::json!({ "value": root.display().to_string() }),
+            )
+            .await
+            .unwrap();
+        runtime
+            .resolve_request(
+                config_request_id.unwrap(),
+                serde_json::json!({ "value": { "executable": "red", "plugin_config": {} } }),
+            )
+            .await
+            .unwrap();
+        runtime
+            .resolve_request(
+                info_request_id.unwrap(),
+                serde_json::json!({
+                    "theme": {
+                        "style": { "fg": null, "bg": null, "bold": false, "italic": false },
+                        "ui_style": {
+                            "muted": { "fg": null, "bg": null, "bold": false, "italic": false },
+                            "popup_title": { "fg": null, "bg": null, "bold": false, "italic": false }
+                        },
+                        "colors": {}
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+        runtime
+    }
+
     #[tokio::test]
     async fn cancelled_timeout_never_reaches_the_editor_queue() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
@@ -7692,6 +7753,136 @@ mod tests {
             }
             _ => panic!("expected callback-backed command log"),
         }
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_dashboard_renders_structured_diff_and_stages_one_selected_line() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        let file = root.join("tracked.rs");
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(&file, "one\ntwo\nthree\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "tracked.rs"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "-c",
+                "user.name=Red Test",
+                "-c",
+                "user.email=red@example.test",
+                "commit",
+                "-qm",
+                "initial",
+            ])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(&file, "ONE\ntwo\nTHREE\n").unwrap();
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let selected_row = loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut selected = None;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::UpdateWorkspace { model, .. } = request {
+                    selected = model
+                        .rows
+                        .into_iter()
+                        .find(|row| row.id == "unstaged:tracked.rs");
+                }
+            }
+            if let Some(row) = selected {
+                break row;
+            }
+            assert!(Instant::now() < deadline, "Git status row did not appear");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({
+                    "action": "down",
+                    "focus": "rows",
+                    "row": selected_row,
+                }),
+            )
+            .await
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let selected_line = loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut selected = None;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::UpdateWorkspace { model, .. } = request {
+                    selected = model.detail_document.and_then(|document| {
+                        document
+                            .lines
+                            .into_iter()
+                            .find(|line| line.kind == "added" && line.text == "ONE")
+                    });
+                }
+            }
+            if let Some(line) = selected {
+                break line;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "structured Git diff did not appear"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({
+                    "action": "s",
+                    "focus": "detail",
+                    "detail_index": 0,
+                    "detail_line": selected_line,
+                    "detail_selection": null,
+                    "row": selected_row,
+                }),
+            )
+            .await
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let staged = loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            while ACTION_DISPATCHER.try_recv_request().is_some() {}
+            let staged = Command::new("git")
+                .args(["show", ":tracked.rs"])
+                .current_dir(root)
+                .output()
+                .unwrap();
+            let contents = String::from_utf8(staged.stdout).unwrap();
+            if contents.contains("ONE") {
+                break contents;
+            }
+            assert!(Instant::now() < deadline, "selected line was not staged");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert!(staged.contains("ONE"));
+        assert!(!staged.contains("THREE"));
+        assert_eq!(fs::read_to_string(file).unwrap(), "ONE\ntwo\nTHREE\n");
     }
 
     #[cfg(not(windows))]

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -35,6 +35,11 @@ pub struct WorkspaceConfig {
     /// Whether structured detail documents wrap long lines initially.
     #[serde(default = "default_detail_wrap")]
     pub detail_wrap: bool,
+    /// Whether navigation handled entirely by the detail pane is also sent to
+    /// the owning plugin. Plugins only need this when they implement custom
+    /// navigation behavior; line operations are always delivered.
+    #[serde(default = "default_notify_detail_navigation")]
+    pub notify_detail_navigation: bool,
 }
 
 fn default_detail_ratio() -> u8 {
@@ -53,6 +58,10 @@ fn default_detail_wrap() -> bool {
     true
 }
 
+fn default_notify_detail_navigation() -> bool {
+    true
+}
+
 impl Default for WorkspaceConfig {
     fn default() -> Self {
         Self {
@@ -61,6 +70,7 @@ impl Default for WorkspaceConfig {
             min_two_pane_width: default_min_two_pane_width(),
             min_stacked_height: default_min_stacked_height(),
             detail_wrap: default_detail_wrap(),
+            notify_detail_navigation: default_notify_detail_navigation(),
         }
     }
 }
@@ -82,7 +92,7 @@ pub struct WorkspaceModel {
     pub footer: Vec<PanelSegment>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct WorkspaceDocument {
     #[serde(default)]
@@ -91,7 +101,7 @@ pub struct WorkspaceDocument {
     pub lines: Vec<WorkspaceDocumentLine>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct WorkspaceDocumentLine {
     pub id: String,
@@ -308,6 +318,10 @@ pub struct WorkspaceEvent {
     pub detail_line: Option<WorkspaceDocumentLine>,
     pub detail_selection: Option<[usize; 2]>,
     pub detail_wrap: bool,
+    /// Core-only delivery policy used by the editor and omitted from the
+    /// plugin payload.
+    #[serde(skip)]
+    pub notify_plugin: bool,
 }
 
 #[derive(Debug)]
@@ -385,7 +399,9 @@ impl PluginWorkspace {
                     .map_or(0, |document| document.lines.len().saturating_sub(1)),
             )
         });
-        self.detail_highlights = highlight_document(model.detail_document.as_ref(), theme);
+        if self.model.detail_document != model.detail_document {
+            self.detail_highlights = highlight_document(model.detail_document.as_ref(), theme);
+        }
         self.model = model;
         self.selected = selected;
         self.scroll = self.scroll.min(self.selected);
@@ -430,6 +446,8 @@ impl PluginWorkspace {
                 anchor.max(self.detail_cursor),
             ]
         });
+        let notify_plugin = self.config.notify_detail_navigation
+            || !is_core_detail_interaction(self.focus, action.as_str());
         WorkspaceEvent {
             workspace_id: self.id.clone(),
             action,
@@ -440,6 +458,7 @@ impl PluginWorkspace {
             detail_line,
             detail_selection,
             detail_wrap: self.detail_wrap,
+            notify_plugin,
         }
     }
 
@@ -704,6 +723,44 @@ impl PluginWorkspace {
     }
 }
 
+fn is_core_detail_interaction(focus: WorkspaceFocus, action: &str) -> bool {
+    matches!(
+        action,
+        "prefix"
+            | "noop"
+            | "toggle"
+            | "back_toggle"
+            | "focus_next"
+            | "focus_previous"
+            | "focus_rows"
+            | "focus_detail"
+    ) || (focus == WorkspaceFocus::Detail
+        && matches!(
+            action,
+            "up" | "down"
+                | "half_page_up"
+                | "half_page_down"
+                | "page_up"
+                | "page_down"
+                | "first"
+                | "last"
+                | "previous_hunk"
+                | "next_hunk"
+                | "visual"
+                | "cancel_selection"
+                | "toggle_wrap"
+                | "left"
+                | "right"
+                | "horizontal_start"
+                | "horizontal_end"
+                | "mouse_up"
+                | "mouse_down"
+                | "mouse_left"
+                | "mouse_right"
+                | "mouse_click"
+        ))
+}
+
 #[derive(Debug, Default)]
 pub struct WorkspaceManager {
     active: Option<PluginWorkspace>,
@@ -732,6 +789,13 @@ impl WorkspaceManager {
             true
         } else {
             false
+        }
+    }
+
+    pub fn update_theme(&mut self, theme: &Theme) {
+        if let Some(workspace) = self.active.as_mut() {
+            workspace.detail_highlights =
+                highlight_document(workspace.model.detail_document.as_ref(), theme);
         }
     }
 
@@ -1497,6 +1561,45 @@ mod tests {
         let event = manager.handle_action("h".to_string(), 20, 100).unwrap();
         assert_eq!(event.action, "focus_rows");
         assert_eq!(event.focus, WorkspaceFocus::Rows);
+    }
+
+    #[test]
+    fn core_owned_detail_navigation_skips_plugin_callbacks_but_keeps_operations() {
+        let mut manager = WorkspaceManager::default();
+        manager.open(
+            "git".to_string(),
+            WorkspaceConfig {
+                notify_detail_navigation: false,
+                ..WorkspaceConfig::default()
+            },
+        );
+        manager.update("git", model_with_document(), &Theme::default());
+
+        let focus = manager
+            .handle_action("toggle".to_string(), 20, 100)
+            .unwrap();
+        assert!(!focus.notify_plugin);
+        let movement = manager.handle_action("down".to_string(), 20, 100).unwrap();
+        assert!(!movement.notify_plugin);
+        assert!(
+            manager
+                .handle_action("s".to_string(), 20, 100)
+                .unwrap()
+                .notify_plugin
+        );
+
+        manager.handle_action("ctrl_w".to_string(), 20, 100);
+        manager.handle_action("h".to_string(), 20, 100);
+        assert!(
+            manager
+                .handle_action("down".to_string(), 20, 100)
+                .unwrap()
+                .notify_plugin
+        );
+        assert!(serde_json::to_value(movement)
+            .unwrap()
+            .get("notify_plugin")
+            .is_none());
     }
 
     #[test]

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -29,6 +29,9 @@ pub struct WorkspaceConfig {
     pub detail_ratio: u8,
     #[serde(default = "default_min_two_pane_width")]
     pub min_two_pane_width: usize,
+    /// Minimum terminal height that can show rows above detail in a stacked layout.
+    #[serde(default = "default_min_stacked_height")]
+    pub min_stacked_height: usize,
     /// Whether structured detail documents wrap long lines initially.
     #[serde(default = "default_detail_wrap")]
     pub detail_wrap: bool,
@@ -42,6 +45,10 @@ fn default_min_two_pane_width() -> usize {
     100
 }
 
+fn default_min_stacked_height() -> usize {
+    16
+}
+
 fn default_detail_wrap() -> bool {
     true
 }
@@ -52,6 +59,7 @@ impl Default for WorkspaceConfig {
             title: String::new(),
             detail_ratio: default_detail_ratio(),
             min_two_pane_width: default_min_two_pane_width(),
+            min_stacked_height: default_min_stacked_height(),
             detail_wrap: default_detail_wrap(),
         }
     }
@@ -107,6 +115,167 @@ pub enum WorkspaceFocus {
     #[default]
     Rows,
     Detail,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WorkspaceRect {
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+}
+
+impl WorkspaceRect {
+    fn contains(self, column: usize, row: usize) -> bool {
+        column >= self.x
+            && column < self.x.saturating_add(self.width)
+            && row >= self.y
+            && row < self.y.saturating_add(self.height)
+    }
+
+    fn content_height(self) -> usize {
+        self.height.saturating_sub(1)
+    }
+
+    fn content_offset(self, row: usize) -> Option<usize> {
+        let content_y = self.y.saturating_add(1);
+        (row >= content_y && row < self.y.saturating_add(self.height))
+            .then_some(row.saturating_sub(content_y))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkspaceSeparator {
+    Columns(WorkspaceRect),
+    Stacked(WorkspaceRect),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkspaceLayoutMode {
+    Columns,
+    Stacked,
+    Focused,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WorkspaceLayout {
+    mode: WorkspaceLayoutMode,
+    rows: Option<WorkspaceRect>,
+    detail: Option<WorkspaceRect>,
+    separator: Option<WorkspaceSeparator>,
+}
+
+impl WorkspaceLayout {
+    fn calculate(workspace: &PluginWorkspace, height: usize, width: usize) -> Self {
+        let body = WorkspaceRect {
+            x: 0,
+            y: 2,
+            width,
+            height: height.saturating_sub(3),
+        };
+        if width >= workspace.config.min_two_pane_width {
+            let maximum_rows_width = width.saturating_sub(21).max(20);
+            let rows_width = width
+                .saturating_mul(100usize.saturating_sub(workspace.config.detail_ratio as usize))
+                / 100;
+            let rows_width = rows_width.clamp(20, maximum_rows_width).min(width);
+            let separator = WorkspaceRect {
+                x: rows_width,
+                y: body.y,
+                width: usize::from(rows_width < width),
+                height: body.height,
+            };
+            let detail_x = rows_width.saturating_add(separator.width);
+            return Self {
+                mode: WorkspaceLayoutMode::Columns,
+                rows: Some(WorkspaceRect {
+                    width: rows_width,
+                    ..body
+                }),
+                detail: Some(WorkspaceRect {
+                    x: detail_x,
+                    width: width.saturating_sub(detail_x),
+                    ..body
+                }),
+                separator: Some(WorkspaceSeparator::Columns(separator)),
+            };
+        }
+
+        if height >= workspace.config.min_stacked_height && body.height >= 13 {
+            let pane_height = body.height.saturating_sub(1);
+            let maximum_rows_height = pane_height.saturating_sub(6);
+            let rows_height = pane_height
+                .saturating_mul(35)
+                .saturating_div(100)
+                .clamp(6, 11)
+                .min(maximum_rows_height);
+            let separator_y = body.y.saturating_add(rows_height);
+            let detail_y = separator_y.saturating_add(1);
+            return Self {
+                mode: WorkspaceLayoutMode::Stacked,
+                rows: Some(WorkspaceRect {
+                    height: rows_height,
+                    ..body
+                }),
+                detail: Some(WorkspaceRect {
+                    y: detail_y,
+                    height: body.height.saturating_sub(rows_height).saturating_sub(1),
+                    ..body
+                }),
+                separator: Some(WorkspaceSeparator::Stacked(WorkspaceRect {
+                    y: separator_y,
+                    height: 1,
+                    ..body
+                })),
+            };
+        }
+
+        Self {
+            mode: WorkspaceLayoutMode::Focused,
+            rows: (workspace.focus == WorkspaceFocus::Rows).then_some(body),
+            detail: (workspace.focus == WorkspaceFocus::Detail).then_some(body),
+            separator: None,
+        }
+    }
+
+    fn pane(self, focus: WorkspaceFocus) -> Option<WorkspaceRect> {
+        match focus {
+            WorkspaceFocus::Rows => self.rows,
+            WorkspaceFocus::Detail => self.detail,
+        }
+    }
+
+    fn visible_rows(self, focus: WorkspaceFocus) -> usize {
+        self.pane(focus)
+            .map_or(1, WorkspaceRect::content_height)
+            .max(1)
+    }
+
+    fn detail_code_width(self) -> usize {
+        self.detail
+            .map_or(1, |rect| rect.width.saturating_sub(14).max(1))
+    }
+
+    fn focus_at(self, column: usize, row: usize) -> Option<WorkspaceFocus> {
+        if self.mode == WorkspaceLayoutMode::Focused {
+            return self
+                .rows
+                .filter(|rect| rect.contains(column, row))
+                .map(|_| WorkspaceFocus::Rows)
+                .or_else(|| {
+                    self.detail
+                        .filter(|rect| rect.contains(column, row))
+                        .map(|_| WorkspaceFocus::Detail)
+                });
+        }
+        if self.rows.is_some_and(|rect| rect.contains(column, row)) {
+            Some(WorkspaceFocus::Rows)
+        } else if self.detail.is_some_and(|rect| rect.contains(column, row)) {
+            Some(WorkspaceFocus::Detail)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -318,19 +487,13 @@ impl PluginWorkspace {
         }
     }
 
-    fn ensure_detail_cursor_visible(&mut self, height: usize, width: usize) {
-        let visible_rows = height.saturating_sub(5).max(1);
+    fn ensure_detail_cursor_visible(&mut self, layout: WorkspaceLayout) {
+        let visible_rows = layout.visible_rows(WorkspaceFocus::Detail);
         if self.detail_cursor < self.detail_scroll {
             self.detail_scroll = self.detail_cursor;
             return;
         }
-        let two_pane = width >= self.config.min_two_pane_width;
-        let left_width = if two_pane {
-            width.saturating_mul(100usize.saturating_sub(self.config.detail_ratio as usize)) / 100
-        } else {
-            0
-        };
-        let code_width = width.saturating_sub(left_width).saturating_sub(15).max(1);
+        let code_width = layout.detail_code_width();
         let Some(document) = self.model.detail_document.as_ref() else {
             return;
         };
@@ -392,7 +555,8 @@ impl PluginWorkspace {
     }
 
     fn handle_action(&mut self, mut action: String, height: usize, width: usize) -> WorkspaceEvent {
-        let visible_rows = height.saturating_sub(5).max(1);
+        let layout = WorkspaceLayout::calculate(self, height, width);
+        let visible_rows = layout.visible_rows(self.focus);
 
         if let Some(prefix) = self.key_prefix.take() {
             action = match (prefix.as_str(), action.as_str()) {
@@ -529,12 +693,12 @@ impl PluginWorkspace {
                             .max()
                     })
                     .unwrap_or_default();
-                self.detail_horizontal = max_width.saturating_sub(width / 2);
+                self.detail_horizontal = max_width.saturating_sub(layout.detail_code_width());
             }
             _ => {}
         }
         if self.focus == WorkspaceFocus::Detail {
-            self.ensure_detail_cursor_visible(height, width);
+            self.ensure_detail_cursor_visible(WorkspaceLayout::calculate(self, height, width));
         }
         self.event(action)
     }
@@ -594,23 +758,11 @@ impl WorkspaceManager {
         width: usize,
     ) -> Option<WorkspaceEvent> {
         let workspace = self.active.as_mut()?;
-        let two_pane = width >= workspace.config.min_two_pane_width;
-        let left_width = if two_pane {
-            width.saturating_mul(100usize.saturating_sub(workspace.config.detail_ratio as usize))
-                / 100
-        } else {
-            width
+        let layout = WorkspaceLayout::calculate(workspace, height, width);
+        if let Some(focus) = layout.focus_at(column, row) {
+            workspace.focus = focus;
         }
-        .max(20)
-        .min(width);
-        if two_pane {
-            workspace.focus = if column <= left_width {
-                WorkspaceFocus::Rows
-            } else {
-                WorkspaceFocus::Detail
-            };
-        }
-        let visible_rows = height.saturating_sub(5).max(1);
+        let visible_rows = layout.visible_rows(workspace.focus);
         match action {
             "mouse_up" => match workspace.focus {
                 WorkspaceFocus::Rows => workspace.move_selection(-3, visible_rows),
@@ -628,10 +780,9 @@ impl WorkspaceManager {
             {
                 workspace.detail_horizontal = workspace.detail_horizontal.saturating_add(4);
             }
-            "mouse_click" if row >= 3 => {
-                let offset = row - 3;
-                match workspace.focus {
-                    WorkspaceFocus::Rows => {
+            "mouse_click" => match workspace.focus {
+                WorkspaceFocus::Rows => {
+                    if let Some(offset) = layout.rows.and_then(|rect| rect.content_offset(row)) {
                         let candidate = workspace.scroll.saturating_add(offset);
                         if workspace
                             .model
@@ -642,16 +793,19 @@ impl WorkspaceManager {
                             workspace.selected = candidate;
                         }
                     }
-                    WorkspaceFocus::Detail => {
-                        let detail_x = if two_pane { left_width + 1 } else { 0 };
-                        let detail_width = width.saturating_sub(detail_x);
-                        let code_width = detail_width.saturating_sub(14).max(1);
-                        workspace.detail_cursor =
-                            workspace.detail_line_at_visual_offset(offset, code_width);
+                }
+                WorkspaceFocus::Detail => {
+                    if let Some(offset) = layout.detail.and_then(|rect| rect.content_offset(row)) {
+                        workspace.detail_cursor = workspace
+                            .detail_line_at_visual_offset(offset, layout.detail_code_width());
                     }
                 }
-            }
+            },
             _ => {}
+        }
+        if workspace.focus == WorkspaceFocus::Detail {
+            workspace
+                .ensure_detail_cursor_visible(WorkspaceLayout::calculate(workspace, height, width));
         }
         Some(workspace.event(action.to_string()))
     }
@@ -684,47 +838,37 @@ impl WorkspaceManager {
             false,
         );
 
-        let body_top = 2;
-        let body_height = buffer.height.saturating_sub(3);
-        let two_pane = buffer.width >= workspace.config.min_two_pane_width;
-        let left_width = if two_pane {
-            buffer
-                .width
-                .saturating_mul(100usize.saturating_sub(workspace.config.detail_ratio as usize))
-                / 100
-        } else {
-            buffer.width
-        };
-        let left_width = left_width.max(20).min(buffer.width);
-        let show_rows = two_pane || workspace.focus == WorkspaceFocus::Rows;
-        let show_detail = two_pane || workspace.focus == WorkspaceFocus::Detail;
-
-        if show_rows {
+        let layout = WorkspaceLayout::calculate(workspace, buffer.height, buffer.width);
+        if let Some(rect) = layout.rows {
             render_row_pane(
                 buffer,
                 workspace,
                 theme,
                 icons,
-                (0, left_width, body_top, body_height),
+                (rect.x, rect.width, rect.y, rect.height),
             );
         }
 
-        if two_pane && left_width < buffer.width {
-            for y in body_top..buffer.height.saturating_sub(1) {
-                buffer.set_text(left_width, y, "│", editor_style);
+        match layout.separator {
+            Some(WorkspaceSeparator::Columns(rect)) => {
+                for y in rect.y..rect.y.saturating_add(rect.height) {
+                    buffer.set_text(rect.x, y, "│", editor_style);
+                }
             }
+            Some(WorkspaceSeparator::Stacked(rect)) => {
+                buffer.set_text(rect.x, rect.y, &"─".repeat(rect.width), editor_style);
+            }
+            None => {}
         }
-        if show_detail {
-            let detail_x = if two_pane { left_width + 1 } else { 0 };
-            let detail_width = buffer.width.saturating_sub(detail_x);
+        if let Some(rect) = layout.detail {
             render_detail_pane(
                 buffer,
                 workspace,
                 theme,
-                detail_x,
-                detail_width,
-                body_top,
-                body_height,
+                rect.x,
+                rect.width,
+                rect.y,
+                rect.height,
             );
         }
 
@@ -1373,6 +1517,81 @@ mod tests {
         let detail = buffer_text(&buffer);
         assert!(detail.contains("Diff  wrap"));
         assert!(detail.contains("let first = true"));
+    }
+
+    #[test]
+    fn responsive_layout_uses_columns_stacking_and_focused_fallback() {
+        let theme = Theme::default();
+        let mut workspace = PluginWorkspace::new("git".to_string(), WorkspaceConfig::default());
+        workspace.update(model_with_document(), &theme);
+
+        let columns = WorkspaceLayout::calculate(&workspace, 24, 100);
+        assert_eq!(columns.mode, WorkspaceLayoutMode::Columns);
+        assert!(columns.rows.is_some_and(|rect| rect.width < 100));
+        assert!(columns.detail.is_some_and(|rect| rect.width < 100));
+        assert!(matches!(
+            columns.separator,
+            Some(WorkspaceSeparator::Columns(_))
+        ));
+
+        let stacked = WorkspaceLayout::calculate(&workspace, 24, 99);
+        assert_eq!(stacked.mode, WorkspaceLayoutMode::Stacked);
+        assert_eq!(stacked.rows.map(|rect| rect.width), Some(99));
+        assert_eq!(stacked.detail.map(|rect| rect.width), Some(99));
+        assert!(stacked.rows.unwrap().y < stacked.detail.unwrap().y);
+        assert!(matches!(
+            stacked.separator,
+            Some(WorkspaceSeparator::Stacked(_))
+        ));
+
+        let focused = WorkspaceLayout::calculate(&workspace, 15, 80);
+        assert_eq!(focused.mode, WorkspaceLayoutMode::Focused);
+        assert!(focused.rows.is_some());
+        assert!(focused.detail.is_none());
+    }
+
+    #[test]
+    fn stacked_workspace_renders_both_panes_and_mouse_focuses_each() {
+        let theme = Theme::default();
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update(
+            "git",
+            WorkspaceModel {
+                rows: vec![row("first", true), row("second", true)],
+                detail_document: Some(document()),
+                ..WorkspaceModel::default()
+            },
+            &theme,
+        );
+        let mut buffer = RenderBuffer::new(80, 24, &theme.style);
+
+        manager.render(&mut buffer, &theme, PickerIconsConfig::default());
+
+        let rendered = buffer_text(&buffer);
+        assert!(rendered.contains("Changes"));
+        assert!(rendered.contains("Diff  wrap"));
+        assert!(rendered.contains("let first = true"));
+        let layout = WorkspaceLayout::calculate(manager.active.as_ref().unwrap(), 24, 80);
+        let rows = layout.rows.unwrap();
+        let detail = layout.detail.unwrap();
+        let separator = match layout.separator.unwrap() {
+            WorkspaceSeparator::Stacked(rect) => rect,
+            WorkspaceSeparator::Columns(_) => panic!("expected a stacked separator"),
+        };
+        assert_eq!(buffer.cells[separator.y * buffer.width].text, "─");
+
+        let event = manager
+            .handle_mouse("mouse_click", 1, rows.y + 2, 24, 80)
+            .unwrap();
+        assert_eq!(event.focus, WorkspaceFocus::Rows);
+        assert_eq!(event.row.unwrap().id, "second");
+
+        let event = manager
+            .handle_mouse("mouse_click", 20, detail.y + 4, 24, 80)
+            .unwrap();
+        assert_eq!(event.focus, WorkspaceFocus::Detail);
+        assert_eq!(event.detail_index, 3);
     }
 
     #[test]

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -677,11 +677,10 @@ impl WorkspaceManager {
         );
         render_segments(
             buffer,
-            1,
-            1,
-            buffer.width - 2,
+            (1, 1, buffer.width - 2),
             &workspace.model.header,
             editor_style,
+            theme,
             false,
         );
 
@@ -731,11 +730,10 @@ impl WorkspaceManager {
 
         render_segments(
             buffer,
-            1,
-            buffer.height - 1,
-            buffer.width - 2,
+            (1, buffer.height - 1, buffer.width - 2),
             &workspace.model.footer,
             editor_style,
+            theme,
             false,
         );
     }
@@ -859,17 +857,23 @@ fn render_row_pane(
                 if icons.color {
                     icon_style.fg = picker_file_icon_color(path).or(icon_style.fg);
                 }
+                if selected {
+                    icon_style = theme.ensure_text_contrast(&icon_style);
+                }
                 buffer.set_text(content_x, y, &fit_display_width(icon, 2), &icon_style);
                 content_x += 3;
             }
         }
         render_segments(
             buffer,
-            content_x,
-            y,
-            width.saturating_sub(content_x.saturating_sub(x) + 1),
+            (
+                content_x,
+                y,
+                width.saturating_sub(content_x.saturating_sub(x) + 1),
+            ),
             &row.segments,
             &row_style,
+            theme,
             selected,
         );
         let right_width = row
@@ -880,11 +884,10 @@ fn render_row_pane(
         if right_width > 0 && right_width + 1 < width {
             render_segments(
                 buffer,
-                x + width.saturating_sub(right_width + 1),
-                y,
-                right_width,
+                (x + width.saturating_sub(right_width + 1), y, right_width),
                 &row.right_segments,
                 &row_style,
+                theme,
                 selected,
             );
         }
@@ -932,11 +935,10 @@ fn render_detail_pane(
         {
             render_segments(
                 buffer,
-                x + 1,
-                content_top + index,
-                width.saturating_sub(2),
+                (x + 1, content_top + index, width.saturating_sub(2)),
                 line,
                 &theme.style,
+                theme,
                 false,
             );
         }
@@ -1185,13 +1187,13 @@ fn diff_foreground(kind: &str, theme: &Theme) -> Option<Color> {
 
 fn render_segments(
     buffer: &mut RenderBuffer,
-    mut x: usize,
-    y: usize,
-    width: usize,
+    rect: (usize, usize, usize),
     segments: &[PanelSegment],
     editor_style: &Style,
+    theme: &Theme,
     selected: bool,
 ) {
+    let (mut x, y, width) = rect;
     let end = x.saturating_add(width).min(buffer.width);
     for segment in segments {
         if x >= end {
@@ -1209,6 +1211,7 @@ fn render_segments(
             // must take precedence, otherwise each text segment punches a
             // dark hole through the selection background.
             style.bg = editor_style.bg;
+            style = theme.ensure_text_contrast(&style);
             style.bold = true;
         }
         buffer.set_text(x, y, &text, &style);
@@ -1375,12 +1378,30 @@ mod tests {
     #[test]
     fn selected_row_background_wins_over_segment_backgrounds() {
         let theme = crate::theme::parse_vscode_theme("src/fixtures/mocha.json").unwrap();
+        let selected_background = theme
+            .selected_style(
+                &theme.style,
+                &theme.list_selection_style(),
+                SelectionForegroundPriority::Selection,
+            )
+            .bg;
         let mut selected_row = row("file", true);
-        selected_row.segments = vec![PanelSegment {
-            text: "main.rs".to_string(),
-            style: Some(theme.style.clone()),
-            semantic: None,
-        }];
+        selected_row.segments = vec![
+            PanelSegment {
+                text: "main.rs".to_string(),
+                style: Some(theme.style.clone()),
+                semantic: None,
+            },
+            PanelSegment {
+                text: " src".to_string(),
+                style: Some(Style {
+                    fg: selected_background,
+                    bg: theme.style.bg,
+                    ..Style::default()
+                }),
+                semantic: None,
+            },
+        ];
         selected_row.right_segments = vec![PanelSegment {
             text: "~".to_string(),
             style: Some(theme.style.clone()),
@@ -1400,13 +1421,7 @@ mod tests {
 
         manager.render(&mut buffer, &theme, PickerIconsConfig::default());
 
-        let expected = theme
-            .selected_style(
-                &theme.style,
-                &theme.list_selection_style(),
-                SelectionForegroundPriority::Selection,
-            )
-            .bg;
+        let expected = selected_background;
         let selected_screen_row = 3;
         assert_eq!(
             buffer.cells[selected_screen_row * buffer.width + 1]
@@ -1419,6 +1434,11 @@ mod tests {
                 .style
                 .bg,
             expected
+        );
+        let path_cell = &buffer.cells[selected_screen_row * buffer.width + 8];
+        assert!(
+            crate::color::contrast_ratio(path_cell.style.fg.unwrap(), path_cell.style.bg.unwrap())
+                >= crate::theme::MINIMUM_SELECTION_TEXT_CONTRAST
         );
     }
 

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -6,10 +6,15 @@
 //! reordering rows does not silently move focus to unrelated content.
 
 use serde::{Deserialize, Serialize};
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
+    color::Color,
+    config::PickerIconsConfig,
     editor::render_buffer::RenderBuffer,
-    theme::Style,
+    highlighter::Highlighter,
+    theme::{SelectionForegroundPriority, Style, Theme},
+    ui::{picker_file_icon, picker_file_icon_color},
     unicode_utils::{display_width, fit_display_width, truncate_display_width},
 };
 
@@ -24,6 +29,9 @@ pub struct WorkspaceConfig {
     pub detail_ratio: u8,
     #[serde(default = "default_min_two_pane_width")]
     pub min_two_pane_width: usize,
+    /// Whether structured detail documents wrap long lines initially.
+    #[serde(default = "default_detail_wrap")]
+    pub detail_wrap: bool,
 }
 
 fn default_detail_ratio() -> u8 {
@@ -34,12 +42,17 @@ fn default_min_two_pane_width() -> usize {
     100
 }
 
+fn default_detail_wrap() -> bool {
+    true
+}
+
 impl Default for WorkspaceConfig {
     fn default() -> Self {
         Self {
             title: String::new(),
             detail_ratio: default_detail_ratio(),
             min_two_pane_width: default_min_two_pane_width(),
+            detail_wrap: default_detail_wrap(),
         }
     }
 }
@@ -53,8 +66,47 @@ pub struct WorkspaceModel {
     pub rows: Vec<WorkspaceRow>,
     #[serde(default)]
     pub detail: Vec<Vec<PanelSegment>>,
+    /// Optional focusable document. Legacy `detail` lines remain supported for
+    /// workspaces that only need a passive preview.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail_document: Option<WorkspaceDocument>,
     #[serde(default)]
     pub footer: Vec<PanelSegment>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct WorkspaceDocument {
+    #[serde(default)]
+    pub path: String,
+    #[serde(default)]
+    pub lines: Vec<WorkspaceDocumentLine>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct WorkspaceDocumentLine {
+    pub id: String,
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub old_line: Option<usize>,
+    #[serde(default)]
+    pub new_line: Option<usize>,
+    #[serde(default)]
+    pub hunk_id: Option<String>,
+    #[serde(default)]
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceFocus {
+    #[default]
+    Rows,
+    Detail,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,6 +117,8 @@ pub struct WorkspaceRow {
     pub selectable: bool,
     #[serde(default)]
     pub depth: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
     #[serde(default)]
     pub segments: Vec<PanelSegment>,
     #[serde(default)]
@@ -80,6 +134,11 @@ pub struct WorkspaceEvent {
     pub action: String,
     pub selected_index: usize,
     pub row: Option<WorkspaceRow>,
+    pub focus: WorkspaceFocus,
+    pub detail_index: usize,
+    pub detail_line: Option<WorkspaceDocumentLine>,
+    pub detail_selection: Option<[usize; 2]>,
+    pub detail_wrap: bool,
 }
 
 #[derive(Debug)]
@@ -89,20 +148,37 @@ pub struct PluginWorkspace {
     model: WorkspaceModel,
     selected: usize,
     scroll: usize,
+    focus: WorkspaceFocus,
+    detail_cursor: usize,
+    detail_scroll: usize,
+    detail_horizontal: usize,
+    detail_wrap: bool,
+    detail_selection_anchor: Option<usize>,
+    key_prefix: Option<String>,
+    detail_highlights: Vec<Vec<crate::editor::StyleInfo>>,
 }
 
 impl PluginWorkspace {
     fn new(id: String, config: WorkspaceConfig) -> Self {
+        let detail_wrap = config.detail_wrap;
         Self {
             id,
             config,
             model: WorkspaceModel::default(),
             selected: 0,
             scroll: 0,
+            focus: WorkspaceFocus::Rows,
+            detail_cursor: 0,
+            detail_scroll: 0,
+            detail_horizontal: 0,
+            detail_wrap,
+            detail_selection_anchor: None,
+            key_prefix: None,
+            detail_highlights: Vec::new(),
         }
     }
 
-    fn update(&mut self, model: WorkspaceModel) {
+    fn update(&mut self, model: WorkspaceModel, theme: &Theme) {
         let selected_id = self
             .model
             .rows
@@ -112,9 +188,39 @@ impl PluginWorkspace {
             .and_then(|id| model.rows.iter().position(|row| row.id == id))
             .or_else(|| model.rows.iter().position(|row| row.selectable))
             .unwrap_or(0);
+        let detail_id = self
+            .model
+            .detail_document
+            .as_ref()
+            .and_then(|document| document.lines.get(self.detail_cursor))
+            .map(|line| line.id.as_str());
+        let restored_detail = detail_id.and_then(|id| {
+            model
+                .detail_document
+                .as_ref()?
+                .lines
+                .iter()
+                .position(|line| line.id == id)
+        });
+        let first_change = model.detail_document.as_ref().and_then(|document| {
+            document
+                .lines
+                .iter()
+                .position(|line| matches!(line.kind.as_str(), "added" | "removed"))
+        });
+        self.detail_cursor = restored_detail.or(first_change).unwrap_or_else(|| {
+            self.detail_cursor.min(
+                model
+                    .detail_document
+                    .as_ref()
+                    .map_or(0, |document| document.lines.len().saturating_sub(1)),
+            )
+        });
+        self.detail_highlights = highlight_document(model.detail_document.as_ref(), theme);
         self.model = model;
         self.selected = selected;
         self.scroll = self.scroll.min(self.selected);
+        self.detail_scroll = self.detail_scroll.min(self.detail_cursor);
     }
 
     fn move_selection(&mut self, delta: isize, visible_rows: usize) {
@@ -143,12 +249,294 @@ impl PluginWorkspace {
     }
 
     fn event(&self, action: String) -> WorkspaceEvent {
+        let detail_line = self
+            .model
+            .detail_document
+            .as_ref()
+            .and_then(|document| document.lines.get(self.detail_cursor))
+            .cloned();
+        let detail_selection = self.detail_selection_anchor.map(|anchor| {
+            [
+                anchor.min(self.detail_cursor),
+                anchor.max(self.detail_cursor),
+            ]
+        });
         WorkspaceEvent {
             workspace_id: self.id.clone(),
             action,
             selected_index: self.selected,
             row: self.model.rows.get(self.selected).cloned(),
+            focus: self.focus,
+            detail_index: self.detail_cursor,
+            detail_line,
+            detail_selection,
+            detail_wrap: self.detail_wrap,
         }
+    }
+
+    fn detail_len(&self) -> usize {
+        self.model
+            .detail_document
+            .as_ref()
+            .map_or(0, |document| document.lines.len())
+    }
+
+    fn detail_line_at_visual_offset(&self, offset: usize, code_width: usize) -> usize {
+        let Some(document) = self.model.detail_document.as_ref() else {
+            return 0;
+        };
+        let mut remaining = offset;
+        for (index, line) in document.lines.iter().enumerate().skip(self.detail_scroll) {
+            let visual_rows = if self.detail_wrap {
+                display_width(&line.text).max(1).div_ceil(code_width.max(1))
+            } else {
+                1
+            };
+            if remaining < visual_rows {
+                return index;
+            }
+            remaining = remaining.saturating_sub(visual_rows);
+        }
+        document.lines.len().saturating_sub(1)
+    }
+
+    fn move_detail(&mut self, delta: isize, visible_rows: usize) {
+        let len = self.detail_len();
+        if len == 0 {
+            return;
+        }
+        self.detail_cursor = self
+            .detail_cursor
+            .saturating_add_signed(delta)
+            .min(len.saturating_sub(1));
+        if self.detail_cursor < self.detail_scroll {
+            self.detail_scroll = self.detail_cursor;
+        } else if self.detail_cursor >= self.detail_scroll + visible_rows.max(1) {
+            self.detail_scroll = self
+                .detail_cursor
+                .saturating_sub(visible_rows.saturating_sub(1));
+        }
+    }
+
+    fn ensure_detail_cursor_visible(&mut self, height: usize, width: usize) {
+        let visible_rows = height.saturating_sub(5).max(1);
+        if self.detail_cursor < self.detail_scroll {
+            self.detail_scroll = self.detail_cursor;
+            return;
+        }
+        let two_pane = width >= self.config.min_two_pane_width;
+        let left_width = if two_pane {
+            width.saturating_mul(100usize.saturating_sub(self.config.detail_ratio as usize)) / 100
+        } else {
+            0
+        };
+        let code_width = width.saturating_sub(left_width).saturating_sub(15).max(1);
+        let Some(document) = self.model.detail_document.as_ref() else {
+            return;
+        };
+        let occupied = document
+            .lines
+            .iter()
+            .skip(self.detail_scroll)
+            .take(self.detail_cursor.saturating_sub(self.detail_scroll) + 1)
+            .map(|line| {
+                if self.detail_wrap {
+                    display_width(&line.text).max(1).div_ceil(code_width)
+                } else {
+                    1
+                }
+            })
+            .sum::<usize>();
+        if occupied > visible_rows {
+            self.detail_scroll = self.detail_cursor;
+        }
+    }
+
+    fn move_to_hunk(&mut self, forward: bool, visible_rows: usize) {
+        let Some(document) = self.model.detail_document.as_ref() else {
+            return;
+        };
+        let current = document
+            .lines
+            .get(self.detail_cursor)
+            .and_then(|line| line.hunk_id.as_deref());
+        let target = if forward {
+            document
+                .lines
+                .iter()
+                .enumerate()
+                .skip(self.detail_cursor.saturating_add(1))
+                .find(|(_, line)| {
+                    line.hunk_id
+                        .as_deref()
+                        .is_some_and(|id| Some(id) != current)
+                })
+                .map(|(index, _)| index)
+        } else {
+            document
+                .lines
+                .iter()
+                .enumerate()
+                .take(self.detail_cursor)
+                .rev()
+                .find(|(_, line)| {
+                    line.hunk_id
+                        .as_deref()
+                        .is_some_and(|id| Some(id) != current)
+                })
+                .map(|(index, _)| index)
+        };
+        if let Some(target) = target {
+            self.move_detail(target as isize - self.detail_cursor as isize, visible_rows);
+        }
+    }
+
+    fn handle_action(&mut self, mut action: String, height: usize, width: usize) -> WorkspaceEvent {
+        let visible_rows = height.saturating_sub(5).max(1);
+
+        if let Some(prefix) = self.key_prefix.take() {
+            action = match (prefix.as_str(), action.as_str()) {
+                ("ctrl_w", "w" | "ctrl_w") => "focus_next",
+                ("ctrl_w", "W" | "p") => "focus_previous",
+                ("ctrl_w", "h") => "focus_rows",
+                ("ctrl_w", "l") => "focus_detail",
+                ("ctrl_w", "c" | "q") => "escape",
+                ("g", "g") => "first",
+                ("[", "h") => "previous_hunk",
+                ("]", "h") => "next_hunk",
+                _ => "noop",
+            }
+            .to_string();
+        } else if matches!(action.as_str(), "ctrl_w" | "g" | "[" | "]") {
+            self.key_prefix = Some(action);
+            return self.event("prefix".to_string());
+        }
+
+        if action == "escape" && self.detail_selection_anchor.is_some() {
+            action = "cancel_selection".to_string();
+        } else if self.focus == WorkspaceFocus::Detail {
+            action = match action.as_str() {
+                "h" => "left",
+                "l" => "right",
+                "0" if !self.detail_wrap => "horizontal_start",
+                "$" if !self.detail_wrap => "horizontal_end",
+                "W" => "toggle_wrap",
+                "v" => "visual",
+                other => other,
+            }
+            .to_string();
+        }
+
+        match action.as_str() {
+            "toggle" | "back_toggle" | "focus_next" | "focus_previous" => {
+                if self.model.detail_document.is_some() {
+                    self.focus = match self.focus {
+                        WorkspaceFocus::Rows => WorkspaceFocus::Detail,
+                        WorkspaceFocus::Detail => WorkspaceFocus::Rows,
+                    };
+                }
+            }
+            "focus_rows" => self.focus = WorkspaceFocus::Rows,
+            "focus_detail" if self.model.detail_document.is_some() => {
+                self.focus = WorkspaceFocus::Detail;
+            }
+            "up" => match self.focus {
+                WorkspaceFocus::Rows => self.move_selection(-1, visible_rows),
+                WorkspaceFocus::Detail => self.move_detail(-1, visible_rows),
+            },
+            "down" => match self.focus {
+                WorkspaceFocus::Rows => self.move_selection(1, visible_rows),
+                WorkspaceFocus::Detail => self.move_detail(1, visible_rows),
+            },
+            "half_page_up" => match self.focus {
+                WorkspaceFocus::Rows => {
+                    self.move_selection(-((visible_rows / 2).max(1) as isize), visible_rows)
+                }
+                WorkspaceFocus::Detail => {
+                    self.move_detail(-((visible_rows / 2).max(1) as isize), visible_rows)
+                }
+            },
+            "half_page_down" => match self.focus {
+                WorkspaceFocus::Rows => {
+                    self.move_selection((visible_rows / 2).max(1) as isize, visible_rows)
+                }
+                WorkspaceFocus::Detail => {
+                    self.move_detail((visible_rows / 2).max(1) as isize, visible_rows)
+                }
+            },
+            "page_up" => match self.focus {
+                WorkspaceFocus::Rows => self.move_selection(-(visible_rows as isize), visible_rows),
+                WorkspaceFocus::Detail => self.move_detail(-(visible_rows as isize), visible_rows),
+            },
+            "page_down" => match self.focus {
+                WorkspaceFocus::Rows => self.move_selection(visible_rows as isize, visible_rows),
+                WorkspaceFocus::Detail => self.move_detail(visible_rows as isize, visible_rows),
+            },
+            "first" => match self.focus {
+                WorkspaceFocus::Rows => {
+                    self.move_selection(-(self.selected as isize), visible_rows)
+                }
+                WorkspaceFocus::Detail => {
+                    self.move_detail(-(self.detail_cursor as isize), visible_rows)
+                }
+            },
+            "last" => match self.focus {
+                WorkspaceFocus::Rows => {
+                    self.move_selection(self.model.rows.len() as isize, visible_rows)
+                }
+                WorkspaceFocus::Detail => {
+                    self.move_detail(self.detail_len() as isize, visible_rows)
+                }
+            },
+            "previous_hunk" if self.focus == WorkspaceFocus::Detail => {
+                self.move_to_hunk(false, visible_rows)
+            }
+            "next_hunk" if self.focus == WorkspaceFocus::Detail => {
+                self.move_to_hunk(true, visible_rows)
+            }
+            "visual" if self.focus == WorkspaceFocus::Detail => {
+                self.detail_selection_anchor = match self.detail_selection_anchor {
+                    Some(_) => None,
+                    None => Some(self.detail_cursor),
+                };
+            }
+            "cancel_selection" => self.detail_selection_anchor = None,
+            "toggle_wrap" if self.focus == WorkspaceFocus::Detail => {
+                self.detail_wrap = !self.detail_wrap;
+                if self.detail_wrap {
+                    self.detail_horizontal = 0;
+                }
+            }
+            "left" if self.focus == WorkspaceFocus::Detail && !self.detail_wrap => {
+                self.detail_horizontal = self.detail_horizontal.saturating_sub(4);
+            }
+            "right" if self.focus == WorkspaceFocus::Detail && !self.detail_wrap => {
+                self.detail_horizontal = self.detail_horizontal.saturating_add(4);
+            }
+            "horizontal_start" if self.focus == WorkspaceFocus::Detail => {
+                self.detail_horizontal = 0;
+            }
+            "horizontal_end" if self.focus == WorkspaceFocus::Detail && !self.detail_wrap => {
+                let max_width = self
+                    .model
+                    .detail_document
+                    .as_ref()
+                    .and_then(|document| {
+                        document
+                            .lines
+                            .iter()
+                            .map(|line| display_width(&line.text))
+                            .max()
+                    })
+                    .unwrap_or_default();
+                self.detail_horizontal = max_width.saturating_sub(width / 2);
+            }
+            _ => {}
+        }
+        if self.focus == WorkspaceFocus::Detail {
+            self.ensure_detail_cursor_visible(height, width);
+        }
+        self.event(action)
     }
 }
 
@@ -162,11 +550,11 @@ impl WorkspaceManager {
         self.active = Some(PluginWorkspace::new(id, config));
     }
 
-    pub fn update(&mut self, id: &str, model: WorkspaceModel) -> bool {
+    pub fn update(&mut self, id: &str, model: WorkspaceModel, theme: &Theme) -> bool {
         let Some(workspace) = self.active.as_mut().filter(|workspace| workspace.id == id) else {
             return false;
         };
-        workspace.update(model);
+        workspace.update(model, theme);
         true
     }
 
@@ -187,23 +575,92 @@ impl WorkspaceManager {
         self.active.is_some()
     }
 
-    pub fn handle_action(&mut self, action: String, height: usize) -> Option<WorkspaceEvent> {
+    pub fn handle_action(
+        &mut self,
+        action: String,
+        height: usize,
+        width: usize,
+    ) -> Option<WorkspaceEvent> {
         let workspace = self.active.as_mut()?;
-        let visible_rows = height.saturating_sub(4);
-        match action.as_str() {
-            "up" => workspace.move_selection(-1, visible_rows),
-            "down" => workspace.move_selection(1, visible_rows),
-            "page_up" => workspace.move_selection(-(visible_rows as isize), visible_rows),
-            "page_down" => workspace.move_selection(visible_rows as isize, visible_rows),
-            _ => {}
-        }
-        Some(workspace.event(action))
+        Some(workspace.handle_action(action, height, width))
     }
 
-    pub fn render(&self, buffer: &mut RenderBuffer, editor_style: &Style) {
+    pub fn handle_mouse(
+        &mut self,
+        action: &str,
+        column: usize,
+        row: usize,
+        height: usize,
+        width: usize,
+    ) -> Option<WorkspaceEvent> {
+        let workspace = self.active.as_mut()?;
+        let two_pane = width >= workspace.config.min_two_pane_width;
+        let left_width = if two_pane {
+            width.saturating_mul(100usize.saturating_sub(workspace.config.detail_ratio as usize))
+                / 100
+        } else {
+            width
+        }
+        .max(20)
+        .min(width);
+        if two_pane {
+            workspace.focus = if column <= left_width {
+                WorkspaceFocus::Rows
+            } else {
+                WorkspaceFocus::Detail
+            };
+        }
+        let visible_rows = height.saturating_sub(5).max(1);
+        match action {
+            "mouse_up" => match workspace.focus {
+                WorkspaceFocus::Rows => workspace.move_selection(-3, visible_rows),
+                WorkspaceFocus::Detail => workspace.move_detail(-3, visible_rows),
+            },
+            "mouse_down" => match workspace.focus {
+                WorkspaceFocus::Rows => workspace.move_selection(3, visible_rows),
+                WorkspaceFocus::Detail => workspace.move_detail(3, visible_rows),
+            },
+            "mouse_left" if workspace.focus == WorkspaceFocus::Detail && !workspace.detail_wrap => {
+                workspace.detail_horizontal = workspace.detail_horizontal.saturating_sub(4);
+            }
+            "mouse_right"
+                if workspace.focus == WorkspaceFocus::Detail && !workspace.detail_wrap =>
+            {
+                workspace.detail_horizontal = workspace.detail_horizontal.saturating_add(4);
+            }
+            "mouse_click" if row >= 3 => {
+                let offset = row - 3;
+                match workspace.focus {
+                    WorkspaceFocus::Rows => {
+                        let candidate = workspace.scroll.saturating_add(offset);
+                        if workspace
+                            .model
+                            .rows
+                            .get(candidate)
+                            .is_some_and(|row| row.selectable)
+                        {
+                            workspace.selected = candidate;
+                        }
+                    }
+                    WorkspaceFocus::Detail => {
+                        let detail_x = if two_pane { left_width + 1 } else { 0 };
+                        let detail_width = width.saturating_sub(detail_x);
+                        let code_width = detail_width.saturating_sub(14).max(1);
+                        workspace.detail_cursor =
+                            workspace.detail_line_at_visual_offset(offset, code_width);
+                    }
+                }
+            }
+            _ => {}
+        }
+        Some(workspace.event(action.to_string()))
+    }
+
+    pub fn render(&self, buffer: &mut RenderBuffer, theme: &Theme, icons: PickerIconsConfig) {
         let Some(workspace) = &self.active else {
             return;
         };
+        let editor_style = &theme.style;
         for y in 0..buffer.height {
             buffer.set_text(0, y, &" ".repeat(buffer.width), editor_style);
         }
@@ -240,69 +697,36 @@ impl WorkspaceManager {
             buffer.width
         };
         let left_width = left_width.max(20).min(buffer.width);
+        let show_rows = two_pane || workspace.focus == WorkspaceFocus::Rows;
+        let show_detail = two_pane || workspace.focus == WorkspaceFocus::Detail;
 
-        for (screen_row, row) in workspace
-            .model
-            .rows
-            .iter()
-            .skip(workspace.scroll)
-            .take(body_height)
-            .enumerate()
-        {
-            let y = body_top + screen_row;
-            let selected = workspace.scroll + screen_row == workspace.selected && row.selectable;
-            let x = 1 + row.depth.saturating_mul(2);
-            render_segments(
+        if show_rows {
+            render_row_pane(
                 buffer,
-                x,
-                y,
-                left_width.saturating_sub(x + 1),
-                &row.segments,
-                editor_style,
-                selected,
+                workspace,
+                theme,
+                icons,
+                (0, left_width, body_top, body_height),
             );
-            let right_width = row
-                .right_segments
-                .iter()
-                .map(|segment| display_width(&segment.text))
-                .sum::<usize>();
-            if right_width > 0 && right_width + 1 < left_width {
-                render_segments(
-                    buffer,
-                    left_width.saturating_sub(right_width + 1),
-                    y,
-                    right_width,
-                    &row.right_segments,
-                    editor_style,
-                    selected,
-                );
-            }
-            if selected {
-                let marker_style = row
-                    .segments
-                    .first()
-                    .and_then(|segment| segment.style.as_ref())
-                    .unwrap_or(editor_style);
-                buffer.set_text(0, y, "›", marker_style);
-            }
         }
 
         if two_pane && left_width < buffer.width {
             for y in body_top..buffer.height.saturating_sub(1) {
                 buffer.set_text(left_width, y, "│", editor_style);
             }
-            let detail_x = left_width + 2;
-            for (index, line) in workspace.model.detail.iter().take(body_height).enumerate() {
-                render_segments(
-                    buffer,
-                    detail_x,
-                    body_top + index,
-                    buffer.width.saturating_sub(detail_x + 1),
-                    line,
-                    editor_style,
-                    false,
-                );
-            }
+        }
+        if show_detail {
+            let detail_x = if two_pane { left_width + 1 } else { 0 };
+            let detail_width = buffer.width.saturating_sub(detail_x);
+            render_detail_pane(
+                buffer,
+                workspace,
+                theme,
+                detail_x,
+                detail_width,
+                body_top,
+                body_height,
+            );
         }
 
         render_segments(
@@ -315,6 +739,448 @@ impl WorkspaceManager {
             false,
         );
     }
+}
+
+fn highlight_document(
+    document: Option<&WorkspaceDocument>,
+    theme: &Theme,
+) -> Vec<Vec<crate::editor::StyleInfo>> {
+    let Some(document) = document else {
+        return Vec::new();
+    };
+    let Some(mut highlighter) = Highlighter::new(theme).ok() else {
+        return (0..document.lines.len()).map(|_| Vec::new()).collect();
+    };
+
+    // A unified diff interleaves two different programs. Feeding removed and
+    // added lines to one parser makes replacements (especially multiline ones)
+    // corrupt the syntax state for everything that follows. Parse an old-file
+    // and new-file projection independently, then use the matching side for
+    // each displayed line.
+    let old = highlight_document_projection(document, &mut highlighter, false);
+    let new = highlight_document_projection(document, &mut highlighter, true);
+    document
+        .lines
+        .iter()
+        .zip(old.into_iter().zip(new))
+        .map(|(line, (old_spans, new_spans))| match line.kind.as_str() {
+            "removed" => old_spans,
+            "added" | "context" => new_spans,
+            _ => Vec::new(),
+        })
+        .collect()
+}
+
+fn highlight_document_projection(
+    document: &WorkspaceDocument,
+    highlighter: &mut Highlighter,
+    new_side: bool,
+) -> Vec<Vec<crate::editor::StyleInfo>> {
+    let source_lines = document
+        .lines
+        .iter()
+        .map(|line| match (line.kind.as_str(), new_side) {
+            ("context", _) | ("added", true) | ("removed", false) => line.text.as_str(),
+            _ => "",
+        })
+        .collect::<Vec<_>>();
+    let source = source_lines.join("\n");
+    let spans = highlighter
+        .highlight_for_file(Some(&document.path), &source)
+        .unwrap_or_default();
+    let mut result = (0..document.lines.len())
+        .map(|_| Vec::new())
+        .collect::<Vec<_>>();
+    let mut line_start = 0;
+    for (index, text) in source_lines.iter().enumerate() {
+        let line_end = line_start + text.len();
+        for span in spans
+            .iter()
+            .filter(|span| span.start < line_end && span.end > line_start)
+        {
+            result[index].push(crate::editor::StyleInfo {
+                start: span.start.saturating_sub(line_start),
+                end: span.end.min(line_end).saturating_sub(line_start),
+                style: span.style.clone(),
+            });
+        }
+        line_start = line_end.saturating_add(1);
+    }
+    result
+}
+
+fn render_row_pane(
+    buffer: &mut RenderBuffer,
+    workspace: &PluginWorkspace,
+    theme: &Theme,
+    icons: PickerIconsConfig,
+    rect: (usize, usize, usize, usize),
+) {
+    let (x, width, top, height) = rect;
+    if width == 0 || height == 0 {
+        return;
+    }
+    let active = workspace.focus == WorkspaceFocus::Rows;
+    let mut title_style = theme.ui_style.popup_title.clone();
+    title_style.bold = active;
+    buffer.set_text(
+        x + 1,
+        top,
+        if active { "› Changes" } else { "  Changes" },
+        &title_style,
+    );
+    let content_top = top + 1;
+    let content_height = height.saturating_sub(1);
+    for (screen_row, row) in workspace
+        .model
+        .rows
+        .iter()
+        .skip(workspace.scroll)
+        .take(content_height)
+        .enumerate()
+    {
+        let y = content_top + screen_row;
+        let selected = workspace.scroll + screen_row == workspace.selected && row.selectable;
+        let row_style = if selected && active {
+            theme.selected_style(
+                &theme.style,
+                &theme.list_selection_style(),
+                SelectionForegroundPriority::Selection,
+            )
+        } else {
+            theme.style.clone()
+        };
+        buffer.set_text(x, y, &fit_display_width("", width), &row_style);
+        let mut content_x = x + 1 + row.depth.saturating_mul(2);
+        if let Some(path) = row.path.as_deref() {
+            let icon = picker_file_icon(path, icons.style);
+            if !icon.is_empty() {
+                let mut icon_style = row_style.clone();
+                if icons.color {
+                    icon_style.fg = picker_file_icon_color(path).or(icon_style.fg);
+                }
+                buffer.set_text(content_x, y, &fit_display_width(icon, 2), &icon_style);
+                content_x += 3;
+            }
+        }
+        render_segments(
+            buffer,
+            content_x,
+            y,
+            width.saturating_sub(content_x.saturating_sub(x) + 1),
+            &row.segments,
+            &row_style,
+            selected,
+        );
+        let right_width = row
+            .right_segments
+            .iter()
+            .map(|segment| display_width(&segment.text))
+            .sum::<usize>();
+        if right_width > 0 && right_width + 1 < width {
+            render_segments(
+                buffer,
+                x + width.saturating_sub(right_width + 1),
+                y,
+                right_width,
+                &row.right_segments,
+                &row_style,
+                selected,
+            );
+        }
+        if selected {
+            buffer.set_text(x, y, if active { "›" } else { "·" }, &row_style);
+        }
+    }
+}
+
+fn render_detail_pane(
+    buffer: &mut RenderBuffer,
+    workspace: &PluginWorkspace,
+    theme: &Theme,
+    x: usize,
+    width: usize,
+    top: usize,
+    height: usize,
+) {
+    if width < 4 || height == 0 {
+        return;
+    }
+    let active = workspace.focus == WorkspaceFocus::Detail;
+    let mut title_style = theme.ui_style.popup_title.clone();
+    title_style.bold = active;
+    let wrap_label = if workspace.detail_wrap {
+        "wrap"
+    } else {
+        "nowrap"
+    };
+    let title = if active {
+        format!(" › Diff  {wrap_label}")
+    } else {
+        format!("   Diff  {wrap_label}")
+    };
+    buffer.set_text(x, top, &truncate_display_width(&title, width), &title_style);
+    let content_top = top + 1;
+    let content_height = height.saturating_sub(1);
+    let Some(document) = workspace.model.detail_document.as_ref() else {
+        for (index, line) in workspace
+            .model
+            .detail
+            .iter()
+            .take(content_height)
+            .enumerate()
+        {
+            render_segments(
+                buffer,
+                x + 1,
+                content_top + index,
+                width.saturating_sub(2),
+                line,
+                &theme.style,
+                false,
+            );
+        }
+        return;
+    };
+
+    let gutter_width = 13.min(width.saturating_sub(1));
+    let code_width = width.saturating_sub(gutter_width + 1).max(1);
+    let selection = workspace.detail_selection_anchor.map(|anchor| {
+        (
+            anchor.min(workspace.detail_cursor),
+            anchor.max(workspace.detail_cursor),
+        )
+    });
+    let mut screen_row = 0;
+    for (line_index, line) in document
+        .lines
+        .iter()
+        .enumerate()
+        .skip(workspace.detail_scroll)
+    {
+        if screen_row >= content_height {
+            break;
+        }
+        let segments = if workspace.detail_wrap {
+            wrapped_slices(&line.text, code_width)
+        } else {
+            vec![display_slice(
+                &line.text,
+                workspace.detail_horizontal,
+                code_width,
+            )]
+        };
+        for (segment_index, segment) in segments.into_iter().enumerate() {
+            if screen_row >= content_height {
+                break;
+            }
+            let y = content_top + screen_row;
+            let selected =
+                selection.is_some_and(|(start, end)| line_index >= start && line_index <= end);
+            let cursor = active && line_index == workspace.detail_cursor;
+            let mut line_style = diff_line_style(&line.kind, theme);
+            if selected {
+                line_style = theme.selected_style(
+                    &line_style,
+                    &theme.editor_selection_style(),
+                    SelectionForegroundPriority::Content,
+                );
+            } else if cursor {
+                let cursor_style = Style {
+                    bg: theme
+                        .line_highlight_style
+                        .as_ref()
+                        .and_then(|style| style.bg)
+                        .or(theme.ui_style.picker_selected_item.bg),
+                    ..Style::default()
+                };
+                line_style = theme.selected_style(
+                    &line_style,
+                    &cursor_style,
+                    SelectionForegroundPriority::Content,
+                );
+            }
+            buffer.set_text(x, y, &fit_display_width("", width), &line_style);
+            if segment_index == 0 {
+                let marker = match line.kind.as_str() {
+                    "added" => "+",
+                    "removed" => "−",
+                    "hunk" => "@",
+                    _ => " ",
+                };
+                let gutter = format!(
+                    "{:>4} {:>4} {marker} ",
+                    line.old_line.map_or(String::new(), |line| line.to_string()),
+                    line.new_line.map_or(String::new(), |line| line.to_string()),
+                );
+                let mut gutter_style = line_style.clone();
+                gutter_style.fg = diff_foreground(&line.kind, theme).or(gutter_style.fg);
+                buffer.set_text(
+                    x,
+                    y,
+                    &truncate_display_width(&gutter, gutter_width),
+                    &gutter_style,
+                );
+            }
+            let code_x = x + gutter_width;
+            buffer.set_text(
+                code_x,
+                y,
+                &fit_display_width(&segment.text, code_width),
+                &line_style,
+            );
+            render_syntax_overlays(
+                buffer,
+                (code_x, y, code_width),
+                &line.text,
+                &segment,
+                workspace
+                    .detail_highlights
+                    .get(line_index)
+                    .map_or(&[], Vec::as_slice),
+                &line_style,
+            );
+            screen_row += 1;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DisplaySlice {
+    text: String,
+    byte_start: usize,
+    byte_end: usize,
+}
+
+fn wrapped_slices(text: &str, width: usize) -> Vec<DisplaySlice> {
+    if text.is_empty() {
+        return vec![DisplaySlice {
+            text: String::new(),
+            byte_start: 0,
+            byte_end: 0,
+        }];
+    }
+    let mut result = Vec::new();
+    let mut column = 0;
+    while column < display_width(text) {
+        let slice = display_slice(text, column, width.max(1));
+        if slice.byte_start == slice.byte_end {
+            break;
+        }
+        column += display_width(&slice.text).max(1);
+        result.push(slice);
+    }
+    result
+}
+
+fn display_slice(text: &str, start_column: usize, width: usize) -> DisplaySlice {
+    let mut column = 0;
+    let mut byte_start = text.len();
+    let mut byte_end = text.len();
+    let mut output = String::new();
+    for (start, grapheme) in text.grapheme_indices(true) {
+        let grapheme_width = display_width(grapheme);
+        let end_column = column + grapheme_width;
+        if end_column <= start_column {
+            column = end_column;
+            continue;
+        }
+        if byte_start == text.len() {
+            byte_start = start;
+        }
+        if display_width(&output) + grapheme_width > width {
+            break;
+        }
+        output.push_str(grapheme);
+        byte_end = start + grapheme.len();
+        column = end_column;
+    }
+    if byte_start == text.len() {
+        byte_start = text.len();
+        byte_end = text.len();
+    }
+    DisplaySlice {
+        text: output,
+        byte_start,
+        byte_end,
+    }
+}
+
+fn render_syntax_overlays(
+    buffer: &mut RenderBuffer,
+    rect: (usize, usize, usize),
+    text: &str,
+    visible: &DisplaySlice,
+    spans: &[crate::editor::StyleInfo],
+    line_style: &Style,
+) {
+    let (x, y, width) = rect;
+    for span in spans {
+        let start = span.start.max(visible.byte_start).min(visible.byte_end);
+        let end = span.end.min(visible.byte_end).max(start);
+        if start >= end || !text.is_char_boundary(start) || !text.is_char_boundary(end) {
+            continue;
+        }
+        let offset = display_width(&text[visible.byte_start..start]);
+        if offset >= width {
+            continue;
+        }
+        let highlighted = truncate_display_width(&text[start..end], width - offset);
+        let style = span.style.fallback_bg(line_style);
+        buffer.set_text(x + offset, y, &highlighted, &style);
+    }
+}
+
+fn diff_line_style(kind: &str, theme: &Theme) -> Style {
+    let mut style = theme.style.clone();
+    style.bg = match kind {
+        "added" => diff_background(
+            theme,
+            "diffEditor.insertedLineBackground",
+            "gitDecoration.addedResourceForeground",
+        ),
+        "removed" => diff_background(
+            theme,
+            "diffEditor.removedLineBackground",
+            "gitDecoration.deletedResourceForeground",
+        ),
+        "hunk" => theme
+            .colors
+            .get("diffEditor.diagonalFill")
+            .copied()
+            .or_else(|| {
+                theme
+                    .line_highlight_style
+                    .as_ref()
+                    .and_then(|style| style.bg)
+            }),
+        _ => style.bg,
+    };
+    style
+}
+
+fn diff_background(theme: &Theme, preferred: &str, fallback: &str) -> Option<Color> {
+    theme.colors.get(preferred).copied().or_else(|| {
+        theme
+            .colors
+            .get(fallback)
+            .copied()
+            .map(|color| match color {
+                Color::Rgb { r, g, b } | Color::Rgba { r, g, b, .. } => {
+                    Color::Rgba { r, g, b, a: 38 }
+                }
+            })
+    })
+}
+
+fn diff_foreground(kind: &str, theme: &Theme) -> Option<Color> {
+    let key = match kind {
+        "added" => "gitDecoration.addedResourceForeground",
+        "removed" => "gitDecoration.deletedResourceForeground",
+        "hunk" => "gitDecoration.modifiedResourceForeground",
+        _ => return None,
+    };
+    theme.colors.get(key).copied()
 }
 
 fn render_segments(
@@ -338,6 +1204,11 @@ fn render_segments(
             .unwrap_or_else(|| editor_style.clone())
             .fallback_bg(editor_style);
         if selected {
+            // Segment styles commonly carry the editor background so they can
+            // render correctly on an unselected row. The selected row fill
+            // must take precedence, otherwise each text segment punches a
+            // dark hole through the selection background.
+            style.bg = editor_style.bg;
             style.bold = true;
         }
         buffer.set_text(x, y, &text, &style);
@@ -352,11 +1223,71 @@ fn render_segments(
 mod tests {
     use super::*;
 
+    fn document() -> WorkspaceDocument {
+        WorkspaceDocument {
+            path: "src/main.rs".to_string(),
+            lines: vec![
+                WorkspaceDocumentLine {
+                    id: "h1-header".to_string(),
+                    text: "@@ -1 +1 @@".to_string(),
+                    kind: "hunk".to_string(),
+                    hunk_id: Some("h1".to_string()),
+                    ..WorkspaceDocumentLine::default()
+                },
+                WorkspaceDocumentLine {
+                    id: "h1-add".to_string(),
+                    text: "let first = true;".to_string(),
+                    kind: "added".to_string(),
+                    new_line: Some(1),
+                    hunk_id: Some("h1".to_string()),
+                    ..WorkspaceDocumentLine::default()
+                },
+                WorkspaceDocumentLine {
+                    id: "h2-header".to_string(),
+                    text: "@@ -8 +8 @@".to_string(),
+                    kind: "hunk".to_string(),
+                    hunk_id: Some("h2".to_string()),
+                    ..WorkspaceDocumentLine::default()
+                },
+                WorkspaceDocumentLine {
+                    id: "h2-remove".to_string(),
+                    text: "let second = false;".to_string(),
+                    kind: "removed".to_string(),
+                    old_line: Some(8),
+                    hunk_id: Some("h2".to_string()),
+                    ..WorkspaceDocumentLine::default()
+                },
+            ],
+        }
+    }
+
+    fn model_with_document() -> WorkspaceModel {
+        WorkspaceModel {
+            rows: vec![row("file", true)],
+            detail_document: Some(document()),
+            ..WorkspaceModel::default()
+        }
+    }
+
+    fn buffer_text(buffer: &RenderBuffer) -> String {
+        buffer
+            .cells
+            .chunks(buffer.width)
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.text.as_str())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     fn row(id: &str, selectable: bool) -> WorkspaceRow {
         WorkspaceRow {
             id: id.to_string(),
             selectable,
             depth: 0,
+            path: None,
             segments: vec![],
             right_segments: vec![],
             data: serde_json::Value::Null,
@@ -373,8 +1304,9 @@ mod tests {
                 rows: vec![row("heading", false), row("a", true), row("b", true)],
                 ..WorkspaceModel::default()
             },
+            &Theme::default(),
         );
-        let event = manager.handle_action("down".to_string(), 20).unwrap();
+        let event = manager.handle_action("down".to_string(), 20, 100).unwrap();
         assert_eq!(event.row.unwrap().id, "b");
         manager.update(
             "git",
@@ -382,8 +1314,136 @@ mod tests {
                 rows: vec![row("b", true), row("c", true)],
                 ..WorkspaceModel::default()
             },
+            &Theme::default(),
         );
-        let event = manager.handle_action("noop".to_string(), 20).unwrap();
+        let event = manager.handle_action("noop".to_string(), 20, 100).unwrap();
         assert_eq!(event.row.unwrap().id, "b");
+    }
+
+    #[test]
+    fn detail_focus_supports_tab_ctrl_w_hunks_ranges_and_wrap_toggle() {
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update("git", model_with_document(), &Theme::default());
+
+        let event = manager
+            .handle_action("toggle".to_string(), 20, 100)
+            .unwrap();
+        assert_eq!(event.focus, WorkspaceFocus::Detail);
+        assert!(event.detail_wrap);
+
+        let event = manager.handle_action("]".to_string(), 20, 100).unwrap();
+        assert_eq!(event.action, "prefix");
+        let event = manager.handle_action("h".to_string(), 20, 100).unwrap();
+        assert_eq!(event.action, "next_hunk");
+        assert_eq!(event.detail_line.unwrap().hunk_id.as_deref(), Some("h2"));
+
+        manager.handle_action("visual".to_string(), 20, 100);
+        let event = manager.handle_action("up".to_string(), 20, 100).unwrap();
+        assert_eq!(event.detail_selection, Some([1, 2]));
+
+        let event = manager
+            .handle_action("toggle_wrap".to_string(), 20, 100)
+            .unwrap();
+        assert!(!event.detail_wrap);
+        manager.handle_action("ctrl_w".to_string(), 20, 100);
+        let event = manager.handle_action("h".to_string(), 20, 100).unwrap();
+        assert_eq!(event.action, "focus_rows");
+        assert_eq!(event.focus, WorkspaceFocus::Rows);
+    }
+
+    #[test]
+    fn narrow_workspace_switches_between_full_width_rows_and_diff() {
+        let theme = Theme::default();
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update("git", model_with_document(), &theme);
+        let mut buffer = RenderBuffer::new(80, 12, &theme.style);
+
+        manager.render(&mut buffer, &theme, PickerIconsConfig::default());
+        let rows = buffer_text(&buffer);
+        assert!(rows.contains("Changes"));
+        assert!(!rows.contains("let first = true"));
+
+        manager.handle_action("toggle".to_string(), 12, 80);
+        manager.render(&mut buffer, &theme, PickerIconsConfig::default());
+        let detail = buffer_text(&buffer);
+        assert!(detail.contains("Diff  wrap"));
+        assert!(detail.contains("let first = true"));
+    }
+
+    #[test]
+    fn selected_row_background_wins_over_segment_backgrounds() {
+        let theme = crate::theme::parse_vscode_theme("src/fixtures/mocha.json").unwrap();
+        let mut selected_row = row("file", true);
+        selected_row.segments = vec![PanelSegment {
+            text: "main.rs".to_string(),
+            style: Some(theme.style.clone()),
+            semantic: None,
+        }];
+        selected_row.right_segments = vec![PanelSegment {
+            text: "~".to_string(),
+            style: Some(theme.style.clone()),
+            semantic: None,
+        }];
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update(
+            "git",
+            WorkspaceModel {
+                rows: vec![selected_row],
+                ..WorkspaceModel::default()
+            },
+            &theme,
+        );
+        let mut buffer = RenderBuffer::new(100, 12, &theme.style);
+
+        manager.render(&mut buffer, &theme, PickerIconsConfig::default());
+
+        let expected = theme
+            .selected_style(
+                &theme.style,
+                &theme.list_selection_style(),
+                SelectionForegroundPriority::Selection,
+            )
+            .bg;
+        let selected_screen_row = 3;
+        assert_eq!(
+            buffer.cells[selected_screen_row * buffer.width + 1]
+                .style
+                .bg,
+            expected
+        );
+        assert_eq!(
+            buffer.cells[selected_screen_row * buffer.width + 38]
+                .style
+                .bg,
+            expected
+        );
+    }
+
+    #[test]
+    fn diff_lines_compose_theme_backgrounds_with_syntax_foregrounds() {
+        let theme = crate::theme::parse_vscode_theme("src/fixtures/mocha.json").unwrap();
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update("git", model_with_document(), &theme);
+        manager.handle_action("toggle".to_string(), 12, 80);
+        manager.handle_action("down".to_string(), 12, 80);
+        let mut buffer = RenderBuffer::new(80, 12, &theme.style);
+
+        manager.render(&mut buffer, &theme, PickerIconsConfig::default());
+
+        let added_row = &buffer.cells[4 * buffer.width..5 * buffer.width];
+        let expected_background = theme
+            .colors
+            .get("diffEditor.insertedLineBackground")
+            .copied();
+        assert!(added_row
+            .iter()
+            .any(|cell| cell.style.bg == expected_background));
+        assert!(added_row
+            .iter()
+            .any(|cell| cell.style.fg.is_some() && cell.style.fg != theme.style.fg));
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -28,6 +28,7 @@ pub use info::Info;
 pub use input_prompt::InputPrompt;
 pub(crate) use keymap_hints::draw_keymap_hints;
 use list::List;
+pub(crate) use picker::{picker_file_icon, picker_file_icon_color};
 pub use picker::{
     LegacyPickerOptions, Picker, PickerIcon, PickerItem, PickerOptions, PickerPresentation,
     PickerPreview, PickerUpdate,

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -2072,7 +2072,7 @@ fn item_file_path(item: &PickerItem) -> Option<&str> {
     }
 }
 
-fn picker_file_icon(path: &str, style: PickerIconStyle) -> &'static str {
+pub(crate) fn picker_file_icon(path: &str, style: PickerIconStyle) -> &'static str {
     let extension = picker_file_extension(path);
     match style {
         PickerIconStyle::Unicode => match extension {
@@ -2118,7 +2118,7 @@ fn picker_file_icon(path: &str, style: PickerIconStyle) -> &'static str {
     }
 }
 
-fn picker_file_icon_color(path: &str) -> Option<Color> {
+pub(crate) fn picker_file_icon_color(path: &str) -> Option<Color> {
     picker_file_devicon(path)
         .1
         .map(|(r, g, b)| Color::Rgb { r, g, b })


### PR DESCRIPTION
The Git dashboard previously rendered a mostly passive preview: the file list and diff could not share focus, long lines had no wrapping controls, diff styling was limited, and rapid navigation could exhaust the plugin process budget.

This change turns the dashboard into an interactive source-control workspace:

- adds file icons, semantic status colors, selection-contrast safeguards, syntax-highlighted structured diffs, and added/removed line backgrounds
- supports `Tab`/`Shift-Tab` and `Ctrl-w` window motions, keyboard and mouse scrolling, hunk navigation, visual line ranges, wrap-by-default, and horizontal navigation in nowrap mode
- allows stage, unstage, and discard operations on lines, ranges, and hunks, with patch validation and confirmation for destructive actions
- adapts wide layouts to columns, narrow layouts to stacked panes, and very short terminals to a focused single pane
- debounces and caches detail refreshes, batches sign updates, suppresses core-only plugin callbacks, and bounds idle work
- adds `scripts/git_workspace_bench.py` plus regression tests for partial staging, responsive layout, contrast, syntax highlighting, multi-buffer signs, and process storms

## How to Test

1. In a repository with staged and unstaged Rust changes, run `:GitDashboard`.
2. Verify wide terminals use side-by-side panes and narrow terminals stack them. Use `Tab`, `Shift-Tab`, and `Ctrl-w h/l/w` to move focus.
3. In the diff, verify syntax colors and added/removed backgrounds. Use `j/k`, `Ctrl-u/d`, `Ctrl-b/f`, and `[h`/`]h`; press `W` to toggle wrapping and verify horizontal movement works when wrapping is off.
4. Select a changed line or visual range and stage/unstage with `s`/`u`; use the uppercase variants for a hunk. Confirm only the intended patch changes, and verify discard still asks for confirmation.
5. Resize to an 80-column terminal and use mouse scroll/click in both panes. Confirm the selected filename and path remain readable and focus follows the clicked pane.
6. Run `python3 scripts/git_workspace_bench.py --files 80 --presses 120`. Expect no more than two Git invocations during file-list churn, zero during diff navigation, and no plugin quarantine.

Automated validation completed with `cargo test --all-targets --all-features --no-fail-fast` and `cargo clippy --all-targets --all-features -- -D warnings`.
