### PR TITLE
fix(agent): honor required codex hooks

### DIFF
--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -50,7 +50,9 @@ Every Codex thread is started with:
 - `approvalPolicy = "never"`
 - no execution environments
 - configured MCP servers disabled
-- apps, connectors, plugins, orchestrator MCP, notifications, and hooks disabled
+- apps, connectors, plugins, orchestrator MCP, and notifications disabled
+- hooks disabled unless the managed Codex policy requires them; when required,
+  Codex may also load trusted user, workspace, or plugin hooks
 - Red's bounded dynamic tools and reviewable-edit instructions
 
 Native command, file-change, and permission escalation requests are denied.

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -319,10 +319,6 @@ async fn run<H: CodexToolHost>(
         .arg("features.plugins=false")
         .arg("-c")
         .arg("features.remote_plugin=false")
-        .arg("-c")
-        .arg("features.hooks=false")
-        .arg("-c")
-        .arg("features.codex_hooks=false")
         .envs(&spec.environment)
         .current_dir(&spec.current_dir)
         .stdin(Stdio::piped())
@@ -731,8 +727,8 @@ async fn handle_response(
             )
             .await?;
         }
-        Pending::Requirements { cwd, config } => {
-            if !requirements_are_safe(&message) {
+        Pending::Requirements { cwd, mut config } => {
+            let Some(hooks_enabled) = required_hooks_mode(&message) else {
                 events
                     .send(CodexEvent::Failed {
                         session_id: None,
@@ -742,7 +738,8 @@ async fn handle_response(
                     .await
                     .ok();
                 return Ok(());
-            }
+            };
+            config["features"]["hooks"] = json!(hooks_enabled);
             let id = rpc_id(next_id);
             pending.insert(id.clone(), Pending::Start { cwd: cwd.clone() });
             write_message(
@@ -1131,33 +1128,42 @@ fn restricted_config(response: &Value) -> Option<Value> {
             "plugins": false,
             "remote_plugin": false,
             "skill_mcp_dependency_install": false,
-            "hooks": false,
-            "codex_hooks": false
+            "hooks": false
         },
         "orchestrator": {"mcp": {"enabled": false}},
         "notify": []
     }))
 }
 
-fn requirements_are_safe(response: &Value) -> bool {
-    let Some(features) = response
-        .pointer("/result/requirements/featureRequirements")
-        .and_then(Value::as_object)
-    else {
-        return response
-            .pointer("/result/requirements")
-            .is_none_or(Value::is_null);
+/// Returns whether hooks must be enabled while rejecting other required
+/// extension features that could escape Red's review boundary.
+fn required_hooks_mode(response: &Value) -> Option<bool> {
+    let Some(requirements) = response.pointer("/result/requirements") else {
+        return Some(false);
     };
-    [
+    if requirements.is_null() {
+        return Some(false);
+    }
+    let features = response
+        .pointer("/result/requirements/featureRequirements")
+        .and_then(Value::as_object)?;
+    if [
         "apps",
         "connectors",
         "plugins",
         "skill_mcp_dependency_install",
-        "hooks",
-        "codex_hooks",
     ]
     .iter()
-    .all(|name| features.get(*name).and_then(Value::as_bool) != Some(true))
+    .any(|name| features.get(*name).and_then(Value::as_bool) == Some(true))
+    {
+        return None;
+    }
+
+    Some(
+        ["hooks", "codex_hooks"]
+            .iter()
+            .any(|name| features.get(*name).and_then(Value::as_bool) == Some(true)),
+    )
 }
 
 fn tool_definitions() -> Value {
@@ -1372,5 +1378,68 @@ mod tests {
         std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         assert!(find_executable(command.to_str().unwrap()).is_none());
+    }
+
+    #[test]
+    fn required_hooks_mode_allows_managed_only_hooks() {
+        for feature in ["hooks", "codex_hooks"] {
+            let response = json!({
+                "result": {
+                    "requirements": {
+                        "allowManagedHooksOnly": true,
+                        "featureRequirements": {(feature): true}
+                    }
+                }
+            });
+
+            assert_eq!(required_hooks_mode(&response), Some(true));
+        }
+    }
+
+    #[test]
+    fn required_hooks_mode_allows_hooks_without_managed_only_enforcement() {
+        for managed_only in [Value::Null, json!(false)] {
+            let response = json!({
+                "result": {
+                    "requirements": {
+                        "allowManagedHooksOnly": managed_only,
+                        "featureRequirements": {"hooks": true}
+                    }
+                }
+            });
+
+            assert_eq!(required_hooks_mode(&response), Some(true));
+        }
+    }
+
+    #[test]
+    fn required_hooks_mode_rejects_other_required_extensions() {
+        for feature in [
+            "apps",
+            "connectors",
+            "plugins",
+            "skill_mcp_dependency_install",
+        ] {
+            let response = json!({
+                "result": {
+                    "requirements": {
+                        "allowManagedHooksOnly": true,
+                        "featureRequirements": {(feature): true}
+                    }
+                }
+            });
+
+            assert_eq!(required_hooks_mode(&response), None);
+        }
+    }
+
+    #[test]
+    fn required_hooks_mode_disables_hooks_without_requirements() {
+        for response in [
+            json!({"result": {"requirements": null}}),
+            json!({"result": {}}),
+        ] {
+            assert_eq!(required_hooks_mode(&response), Some(false));
+        }
     }
 }

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -42,7 +42,10 @@ fn mock_codex(directory: &std::path::Path) -> std::path::PathBuf {
     std::fs::write(
         &path,
         r#"#!/usr/bin/env python3
-import json, sys
+import json, os, sys
+
+assert "features.hooks=false" not in sys.argv
+assert "features.codex_hooks=false" not in sys.argv
 
 def send(value):
     print(json.dumps(value), flush=True)
@@ -60,11 +63,15 @@ for line in sys.stdin:
     elif method == "config/read":
         send({"id": ident, "result": {"config": {"mcp_servers": {}}, "origins": {}}})
     elif method == "configRequirements/read":
-        send({"id": ident, "result": {"requirements": None}})
+        requirements = json.loads(os.environ.get("RED_MOCK_REQUIREMENTS", "null"))
+        send({"id": ident, "result": {"requirements": requirements}})
     elif method == "thread/start":
         assert message["params"]["sandbox"] == "read-only"
         assert message["params"]["approvalPolicy"] == "never"
         assert len(message["params"]["dynamicTools"]) == 9
+        expected_hooks = os.environ.get("RED_MOCK_EXPECT_HOOKS") == "true"
+        assert message["params"]["config"]["features"]["hooks"] is expected_hooks
+        assert "codex_hooks" not in message["params"]["config"]["features"]
         send({"id": ident, "result": {"thread": {"id": "thread-red"}}})
     elif method == "turn/start":
         text = message["params"]["input"][0]["text"]
@@ -150,6 +157,51 @@ async fn direct_app_server_streams_and_routes_writes_to_the_host() {
         vec![("src/main.rs".to_string(), "proposed\n".to_string())]
     );
 
+    drop(bridge);
+    task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn direct_app_server_starts_with_required_hooks() {
+    let directory = tempfile::tempdir().unwrap();
+    let codex = mock_codex(directory.path());
+    let host = RecordingHost {
+        writes: Arc::new(Mutex::new(Vec::new())),
+    };
+    let mut spec = CodexProcessSpec::new(codex, directory.path());
+    spec.environment.insert(
+        "RED_MOCK_REQUIREMENTS".into(),
+        json!({
+            "allowManagedHooksOnly": null,
+            "featureRequirements": {"hooks": true}
+        })
+        .to_string()
+        .into(),
+    );
+    spec.environment
+        .insert("RED_MOCK_EXPECT_HOOKS".into(), "true".into());
+    let (mut bridge, task) = start_codex(spec, host, NonZeroUsize::new(32).unwrap()).unwrap();
+
+    bridge
+        .send(CodexCommand::NewSession {
+            cwd: directory.path().to_path_buf(),
+        })
+        .await
+        .unwrap();
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if let Some(event) = bridge.try_recv() {
+                break event;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        matches!(event, CodexEvent::SessionCreated { session_id } if session_id == "thread-red")
+    );
     drop(bridge);
     task.await.unwrap().unwrap();
 }


### PR DESCRIPTION
Managed Codex environments can require lifecycle hooks (for example, the managed PushPatrol `PreToolUse` hook). Red currently launches the app-server with both `features.hooks=false` and the legacy `features.codex_hooks=false` alias, then rejects any hook requirement. This prevents `thread/start`, leaves the saved prompt in the Retry Codex picker, and makes the Agent pane unusable even when Codex authentication and the read-only sandbox are valid.

This change honors a required hook feature while keeping Red's remaining reviewable-edit restrictions intact:

- remove the contradictory process-level hook overrides and use the canonical `hooks` feature in the restricted thread configuration;
- accept either hook feature name from `configRequirements/read`, while continuing to reject required apps, connectors, plugins, and skill MCP dependency installation;
- document that a required hook feature may also load trusted user, workspace, or plugin hooks;
- add unit and app-server regressions for required hooks, the legacy alias, null/false managed-only policy, extension rejection, and the no-requirements path.

## How to Test

1. Run the focused automated coverage:

   ```bash
   cargo test --locked --lib required_hooks_mode
   cargo test --locked --test codex_app_server
   cargo clippy --locked --all-targets --all-features -- -D warnings
   ```

   Expected: all four hook-mode unit cases and both app-server integration tests pass with no Clippy warnings.

2. In an environment whose `configRequirements/read` reports `featureRequirements.hooks = true` and `allowManagedHooksOnly = null`, start Red, press `Space A`, and submit a prompt.

   Expected: Red creates the Agent session and sends `thread/start` with `config.features.hooks = true`; it no longer shows `Managed Codex requirements prevent a reviewable session`.

3. Repeat without managed hook requirements.

   Expected: the Agent still starts with `config.features.hooks = false`, preserving the existing no-hooks behavior.
