### PR TITLE
fix(logging): use a cross-platform default path

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -35,10 +35,10 @@ sidescrolloff = 0
 # disappears on the first edit, file open, or window split.
 splash = true
 
-# The full path to the log file. If the log file is not present, red will
-# create it. If the log file is present, red will append to it.
-# This setting is optional, if not present, red will not log anything.
-log_file = "/tmp/red.log"
+# Path to the log file. Relative paths are resolved from Red's config
+# directory. If the log file is not present, Red will create it; if it is
+# present, Red will append to it.
+log_file = "red.log"
 
 # Built-in plugins are enabled through the [plugins] table below. Add plugin
 # names here to disable defaults without copying or editing bundled plugin files.

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -8,7 +8,10 @@ Run `red --check-config` before debugging downstream behavior. It prints every r
 
 Run `red --runtime-files` when a plugin or theme is absent or unexpectedly old. Resolution order is user configuration, `RED_RUNTIME`, then embedded assets. The listing marks shadowed sources, so a user copy or development runtime can be identified without guessing which bytes were loaded.
 
-The default log is `/tmp/red.log`. A configured `log_file` replaces that destination. Failure to open the configured path becomes a configuration diagnostic and disables logging rather than preventing startup.
+The default log is `red.log` in Red's configuration directory. Relative
+`log_file` values resolve from that directory, while absolute and `~/...`
+paths remain supported. Failure to open the configured path becomes a
+configuration diagnostic and disables logging rather than preventing startup.
 
 ## Input, editing, undo, and rendering
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -291,8 +291,9 @@ Use `red --help` for the complete generated command-line reference.
 
 ## Troubleshooting
 
-Red logs to `/tmp/red.log` by default. Override `log_file` in your config when
-another location is preferable.
+Red logs to `red.log` in its configuration directory by default. Relative
+`log_file` values are resolved from that directory; absolute paths and `~/...`
+paths are also supported.
 
 - **LSP is not working:** confirm the language server is installed and on
   `PATH`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2735,7 +2735,7 @@ groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
         );
         let permissions = config.plugin_permissions.get("project_search").unwrap();
         assert_eq!(permissions.process, vec!["rg".to_string()]);
-        assert_eq!(config.log_file.as_deref(), Some("/tmp/red.log"));
+        assert_eq!(config.log_file.as_deref(), Some("red.log"));
     }
 
     #[test]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -10,6 +10,7 @@ use std::{
     fmt,
     fs::{File, OpenOptions},
     io::Write,
+    path::Path,
     sync::Mutex,
     time::SystemTime,
 };
@@ -51,7 +52,7 @@ pub struct Logger {
 }
 
 impl Logger {
-    pub fn try_new(file: &str) -> std::io::Result<Self> {
+    pub fn try_new(file: impl AsRef<Path>) -> std::io::Result<Self> {
         let file = OpenOptions::new()
             .create(true)
             .append(true) // implies .write(true)
@@ -63,7 +64,7 @@ impl Logger {
         })
     }
 
-    pub fn new(file: &str) -> Self {
+    pub fn new(file: impl AsRef<Path>) -> Self {
         Self::try_new(file).expect("log file opens fine")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::{
     fs,
     io::{stdout, Write as _},
     panic,
+    path::{Path, PathBuf},
 };
 
 #[cfg(unix)]
@@ -36,6 +37,7 @@ use red::onboarding;
 use red::preferences::PreferencesStore;
 use red::session::SessionStore;
 use red::theme::{parse_vscode_theme, parse_vscode_theme_contents, Theme};
+use red::utils::expand_user_path;
 use red::{log, run_self_check, LOGGER};
 
 #[cfg(unix)]
@@ -666,21 +668,30 @@ fn finalize_runtime_config(
         }
     };
 
-    let logger = match loaded.config.log_file.as_deref() {
-        Some(path) => match Logger::try_new(path) {
-            Ok(logger) => Some(logger),
-            Err(error) => {
-                loaded.add_runtime_diagnostic(
-                    "CFG303",
-                    ConfigDiagnosticSeverity::Error,
-                    &["log_file".to_string()],
-                    format!("configured log file could not be opened: {error}"),
-                    "disabled logging",
-                );
-                loaded.config.log_file = None;
-                None
+    let logger = match loaded.config.log_file.clone() {
+        Some(configured_path) => {
+            match resolve_log_path(&config_dir, &configured_path).and_then(|path| {
+                Logger::try_new(&path)
+                    .map(|logger| (path, logger))
+                    .map_err(anyhow::Error::from)
+            }) {
+                Ok((path, logger)) => {
+                    loaded.config.log_file = Some(path.to_string_lossy().into_owned());
+                    Some(logger)
+                }
+                Err(error) => {
+                    loaded.add_runtime_diagnostic(
+                        "CFG303",
+                        ConfigDiagnosticSeverity::Error,
+                        &["log_file".to_string()],
+                        format!("configured log file could not be opened: {error}"),
+                        "disabled logging",
+                    );
+                    loaded.config.log_file = None;
+                    None
+                }
             }
-        },
+        }
         None => None,
     };
 
@@ -694,6 +705,15 @@ fn finalize_runtime_config(
     }
 
     Ok((loaded, theme, logger))
+}
+
+fn resolve_log_path(config_dir: &Path, configured_path: &str) -> anyhow::Result<PathBuf> {
+    let path = expand_user_path(configured_path)?;
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(config_dir.join(path))
+    }
 }
 
 #[cfg(test)]
@@ -723,6 +743,26 @@ mod tests {
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "CFG303"));
+    }
+
+    #[test]
+    fn relative_log_paths_resolve_from_the_config_directory() {
+        let config_dir = Path::new("config-root");
+
+        assert_eq!(
+            resolve_log_path(config_dir, "logs/red.log").unwrap(),
+            config_dir.join("logs").join("red.log")
+        );
+    }
+
+    #[test]
+    fn absolute_log_paths_are_preserved() {
+        let absolute = std::env::current_dir().unwrap().join("red.log");
+
+        assert_eq!(
+            resolve_log_path(Path::new("ignored"), &absolute.to_string_lossy()).unwrap(),
+            absolute
+        );
     }
 
     #[test]


### PR DESCRIPTION
On Windows, Red's embedded `/tmp/red.log` default cannot be opened, which produces `CFG303` and disables logging. That makes runtime failures—including language-server diagnostics—unnecessarily difficult to investigate.

This change uses `red.log` relative to Red's configuration directory as the cross-platform default. Startup now expands `~/...` values, preserves absolute paths, resolves relative paths from the config directory, and stores the resolved path so `ViewLogs` opens the same file the logger writes. The logger accepts `Path` values directly, and the user and debugging documentation now describe the effective behavior.

## How to Test

1. On Windows, launch Red without a `log_file` override. Confirm startup does not report `CFG303` and that `red.log` is created under Red's configuration directory.
2. Configure an absolute `log_file` path and confirm Red writes to that exact location. Configure a path whose parent does not exist and confirm Red reports `CFG303`, disables logging, and continues startup.
3. Run `cargo test log_paths --all-features -- --nocapture` and confirm the relative- and absolute-path resolution tests pass.