### PR TITLE
fix(lsp): bound editor shutdown latency

### DIFF
--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -41,6 +41,11 @@ const MAX_LSP_HEADER_BYTES: usize = 16 * 1024;
 const MAX_LSP_STDERR_LINE_BYTES: usize = 64 * 1024;
 const MAX_PENDING_LSP_MESSAGES: usize = 512;
 const MAX_PENDING_LSP_BYTES: usize = 16 * 1024 * 1024;
+const SHUTDOWN_RESPONSE_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(windows)]
+const PROCESS_EXIT_GRACE: Duration = Duration::from_millis(100);
+#[cfg(not(windows))]
+const PROCESS_EXIT_GRACE: Duration = Duration::from_secs(5);
 
 /// Idle time after the last document change before diagnostics are
 /// requested. Typing produces one didChange per keystroke; requesting
@@ -1468,7 +1473,7 @@ impl LspClient for RealLspClient {
         let shutdown_id = self
             .send_request("shutdown", serde_json::Value::Null, true)
             .await?;
-        let response = tokio::time::timeout(Duration::from_secs(5), async {
+        let response = tokio::time::timeout(SHUTDOWN_RESPONSE_TIMEOUT, async {
             loop {
                 let Some(message) = self.response_rx.recv().await else {
                     return Err(LspError::ProtocolError(
@@ -1507,19 +1512,32 @@ impl LspClient for RealLspClient {
             return Ok(());
         };
 
-        // Create a timeout future
-        let timeout_future = tokio::time::sleep(std::time::Duration::from_secs(5));
+        let process_wait_started = Instant::now();
+        let timeout_future = tokio::time::sleep(PROCESS_EXIT_GRACE);
 
         // Wait for either timeout or process exit
         tokio::select! {
             _ = timeout_future => {
-                log!("[lsp] shutdown timeout reached, forcing exit");
-                // Kill the process if it hasn't exited
-                let _ = child.kill().await;
+                log!(
+                    "[lsp] {} did not exit within {:?}, forcing termination",
+                    self.config.command,
+                    PROCESS_EXIT_GRACE
+                );
+                if let Err(error) = child.start_kill() {
+                    log!("[lsp] failed to terminate {}: {}", self.config.command, error);
+                }
+                if let Err(error) = child.wait().await {
+                    log!("[lsp] error reaping {}: {}", self.config.command, error);
+                }
             }
             status = child.wait() => {
                 match status {
                     Ok(status) => {
+                        log!(
+                            "[lsp] {} exited naturally after {:?}",
+                            self.config.command,
+                            process_wait_started.elapsed()
+                        );
                         if !status.success() {
                             log!("[lsp] {} exited with status: {}", self.config.command, status);
                         }

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1523,11 +1523,15 @@ impl LspClient for RealLspClient {
                     self.config.command,
                     PROCESS_EXIT_GRACE
                 );
-                if let Err(error) = child.start_kill() {
-                    log!("[lsp] failed to terminate {}: {}", self.config.command, error);
-                }
-                if let Err(error) = child.wait().await {
-                    log!("[lsp] error reaping {}: {}", self.config.command, error);
+                match child.start_kill() {
+                    Ok(()) => {
+                        if let Err(error) = child.wait().await {
+                            log!("[lsp] error reaping {}: {}", self.config.command, error);
+                        }
+                    }
+                    Err(error) => {
+                        log!("[lsp] failed to terminate {}: {}", self.config.command, error);
+                    }
                 }
             }
             status = child.wait() => {

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -11,6 +11,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    future::Future,
     path::{Path, PathBuf},
 };
 
@@ -46,6 +47,18 @@ pub struct DocumentInfo {
 struct DocumentSelector {
     server_name: String,
     language_id: String,
+}
+
+async fn complete_shutdowns<I, F>(shutdowns: I) -> Result<(), LspError>
+where
+    I: IntoIterator<Item = F>,
+    F: Future<Output = Result<(), LspError>>,
+{
+    let results = futures::future::join_all(shutdowns).await;
+    for result in results {
+        result?;
+    }
+    Ok(())
 }
 
 /// Lazily starts and routes documents across configured language servers.
@@ -674,16 +687,20 @@ impl LspClient for LspManager {
     }
 
     async fn shutdown(&mut self) -> Result<(), LspError> {
-        for client in self.clients.values_mut() {
-            client.shutdown().await?;
-        }
-        Ok(())
+        complete_shutdowns(self.clients.values_mut().map(|client| client.shutdown())).await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
 
     use crate::{
         config::{LanguageDocumentConfig, LanguageServerConfig},
@@ -724,6 +741,49 @@ mod tests {
             initialization_options: None,
             workspace_name: None,
         }
+    }
+
+    #[tokio::test]
+    async fn shutdowns_are_driven_concurrently() {
+        let started = Arc::new(AtomicUsize::new(0));
+        let shutdowns = (0..2).map(|_| {
+            let started = Arc::clone(&started);
+            async move {
+                started.fetch_add(1, Ordering::SeqCst);
+                tokio::time::timeout(Duration::from_millis(100), async {
+                    while started.load(Ordering::SeqCst) < 2 {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .map_err(|_| {
+                    LspError::ProtocolError("shutdown futures ran sequentially".to_string())
+                })?;
+                Ok(())
+            }
+        });
+
+        complete_shutdowns(shutdowns).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_error_does_not_cancel_other_clients() {
+        let completed = Arc::new(AtomicBool::new(false));
+        let shutdowns = (0..2).map(|index| {
+            let completed = Arc::clone(&completed);
+            async move {
+                if index == 0 {
+                    Err(LspError::ProtocolError("expected failure".to_string()))
+                } else {
+                    tokio::task::yield_now().await;
+                    completed.store(true, Ordering::SeqCst);
+                    Ok(())
+                }
+            }
+        });
+
+        assert!(complete_shutdowns(shutdowns).await.is_err());
+        assert!(completed.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,12 +251,14 @@ async fn run() -> anyhow::Result<()> {
 
     let result = editor.run().await;
 
+    let cleanup_result = editor.cleanup();
+
     log!(" ===> after run, shutting down LSP");
     if let Err(e) = editor.lsp_mut().shutdown().await {
         log!("Error shutting down LSP: {}", e);
     }
 
-    editor.cleanup()?;
+    cleanup_result?;
     result?;
 
     Ok(())


### PR DESCRIPTION
Rust-analyzer can acknowledge the LSP shutdown handshake yet remain alive on Windows, leaving Red blocked in teardown for five seconds per workspace while the terminal still appears occupied.

This change restores the terminal as soon as the editor loop ends, limits the shutdown response wait to one second, and gives Windows language-server processes a 100 ms grace period before terminating and reaping them. Multiple LSP clients now shut down concurrently, and one client failure no longer prevents the remaining clients from being cleaned up.

In the deterministic Windows ConPTY reproduction, a 30-second rust-analyzer session improved from 5.075 seconds to 0.214 seconds from `:q` to process exit. A two-workspace run exited in 0.689 seconds without orphaned Red or rust-analyzer processes.

## How to Test

1. Run `cargo test --lib shutdowns_are_driven_concurrently`, `cargo test --lib shutdown_error_does_not_cancel_other_clients`, and `cargo test --lib shutdown_waits_for_the_response_before_sending_exit`; all should pass.
2. Run `cargo test --test lsp_lazy`; all 43 LSP integration tests should pass.
3. On Windows, open a Rust file in Red, leave rust-analyzer active for at least 30 seconds, then run `:q`; the terminal should restore immediately and Red should exit in roughly 0.2 seconds even when rust-analyzer does not exit naturally.
4. Open Rust files from multiple workspace roots and quit; teardown should remain bounded rather than adding a process timeout for each workspace.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Full-suite execution is currently blocked by the unrelated existing `plugin::runtime::tests::lsp_symbols_batches_pathological_document_symbol_results`, which also hangs when run in isolation.