### PR TITLE
feat(neotree): add file management actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +291,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -1303,6 +1323,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2172,7 @@ dependencies = [
  "thiserror 1.0.57",
  "tokio",
  "toml",
+ "trash",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-javascript",
@@ -2869,6 +2914,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "5.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
+dependencies = [
+ "chrono",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows",
+]
+
+[[package]]
 name = "tree-sitter"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,6 +3131,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3529,10 +3598,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ tempfile = "3.15.0"
 thiserror = "1.0"
 tokio = { version = "1.41.0", features = ["full"] }
 toml = "0.8.10"
+trash = "5.2.2"
 tree-sitter = "0.25"
 tree-sitter-bash = "0.25.1"
 tree-sitter-javascript = "0.25.0"

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.3.0` is defined by
+Red host API version `0.4.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -22,6 +22,39 @@ literal host call absent from the canonical schema. Literal host calls also chec
 required/optional arity (`HUSK-A0002`) and obvious literal argument types
 (`HUSK-A0003`) against the machine-readable signature. `--no-typecheck` is an unsupported
 development escape hatch; compatibility guarantees do not apply while it is enabled.
+
+## Workspace file operations
+
+`FileOperation(callback: fn(Json), operation: Json)` applies a structured filesystem
+operation inside the active workspace. Supported `kind` values are `create`,
+`create_file`, `create_directory`, `rename`, `move`, `copy`, `delete`, `trash`,
+`restore`, `undo_trash`, and `stat`. Mutation paths must be workspace-relative; the host
+rejects absolute paths, parent traversal, workspace-root mutation, symlink escapes,
+self/descendant copies, and implicit overwrites.
+
+Create requests accept `path`; `create` treats a trailing slash as a directory and
+supports bounded Bash-style list and range brace expansion. Rename, move, and copy
+accept `source` and `destination`. Delete, trash, restore, and undo accept `paths:
+[String]`. Results contain `ok`, an optional `error`, and operation-specific path data.
+Trash restoration is available only on platforms whose system trash API exposes stable
+item identities.
+
+`FileOperation` was introduced in host API `0.4.0`.
+
+## Compact plugin dialogs
+
+`OpenInput(title: String, initial: String, handlers: ComposerHandlers)` opens the same
+compact, single-line input used by LSP rename. It submits through
+`ComposerHandlers.submitted` and cancels through `ComposerHandlers.cancelled`.
+
+`OpenConfirm(title: String, message: String, handlers: PickerHandlers)` opens a compact
+Accept/Cancel dialog. Cancel is selected by default; Left or `y` selects Accept, Right or
+`n` selects Cancel, Enter confirms the selection, and Escape cancels. Accept invokes
+`PickerHandlers.selected` with an item whose `id` is `accept`; cancellation invokes
+`PickerHandlers.cancelled`.
+
+Both calls were introduced in host API `0.4.0`, and their callback handles remain owned
+and released by the calling plugin.
 
 ## Command discovery metadata
 
@@ -62,8 +95,8 @@ picker. They do not use global `picker:*:<id>` subscriptions. Picker items and c
 payloads use the declared `PickerItem`, `PickerCancelled`, and `PickerActionEvent` records;
 the `PickerItem.data` field remains `Json` so a plugin can attach its own payload.
 
-`OpenPicker` was added in host API `0.3.0`. Plugins using it should declare
-`"red_api_version": "^0.3.0"`. The numeric-ID `OpenDynamicPicker` API remains
+`OpenPicker` was added in host API `0.3.0`. Plugins targeting this Red release should
+declare `"red_api_version": "^0.4.0"`. The numeric-ID `OpenDynamicPicker` API remains
 available for compatibility, but new plugins should not use it.
 
 ## Agent composer

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.3.0",
+  "api_version": "0.4.0",
   "changes": [
+    {
+      "version": "0.4.0",
+      "kind": "introduced",
+      "symbols": ["FileOperation", "OpenInput", "OpenConfirm"],
+      "migration_note": "docs/PLUGIN_API.md#workspace-file-operations"
+    },
     {
       "version": "0.3.0",
       "kind": "introduced",

--- a/examples/example-plugin/package.json
+++ b/examples/example-plugin/package.json
@@ -13,7 +13,7 @@
   "engines": {
     "red": ">=0.1.0"
   },
-  "red_api_version": "^0.3.0",
+  "red_api_version": "^0.4.0",
   "capabilities": {
     "commands": true,
     "events": true,

--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -1,9 +1,9 @@
-// Watched project tree panel with lazy directory expansion and Git status decoration.
+// Watched project tree panel with Neo-tree-style filesystem actions.
 //
 // Directory listings are authoritative snapshots supplied by Rust and may be truncated.
 // Reveal walks one path segment at a time, watchers follow the displayed root, and row
-// IDs are normalized project-relative paths. Deactivation stops watching and removes the
-// panel without changing files.
+// IDs are normalized project-relative paths. All mutations are performed by Red's
+// workspace-confined filesystem host API.
 
 pub fn activate() {
     red::add_command("NeoTree", neotree, Json {
@@ -26,6 +26,13 @@ pub fn activate() {
     red::state_set("status_index", Json {});
     red::state_set("cwd", ".");
     red::state_set("current_file", "");
+    red::state_set("selected", []);
+    red::state_set("clipboard", []);
+    red::state_set("trash_history", []);
+    red::state_set("pending_kind", "");
+    red::state_set("pending_paths", []);
+    red::state_set("paste_queue", []);
+    red::state_set("paste_index", 0);
     clear_reveal();
 }
 
@@ -82,6 +89,23 @@ fn panel_event(event: Json) {
         return;
     }
 
+    if event.action == "Ctrl-r" {
+        red::state_set("clipboard", []);
+        red::execute("Print", "Neo-tree clipboard cleared");
+        render();
+        return;
+    }
+
+    if event.action == "u" || event.action == "U" {
+        restore_last_trash();
+        return;
+    }
+
+    if event.action == "?" {
+        show_help();
+        return;
+    }
+
     let row = event.row;
     if row == red::null() {
         return;
@@ -104,6 +128,76 @@ fn panel_event(event: Json) {
         return;
     }
 
+    if event.action == "Tab" {
+        toggle_selection(row.path);
+        return;
+    }
+
+    if event.action == "a" {
+        open_create_prompt(row, false);
+        return;
+    }
+
+    if event.action == "A" {
+        open_create_prompt(row, true);
+        return;
+    }
+
+    if event.action == "d" {
+        confirm_removal("delete", selected_paths(row));
+        return;
+    }
+
+    if event.action == "T" {
+        confirm_removal("trash", selected_paths(row));
+        return;
+    }
+
+    if event.action == "i" {
+        red::request("FileOperation", stat_loaded, Json {
+            kind: "stat",
+            path: row.path,
+        });
+        return;
+    }
+
+    if event.action == "r" {
+        open_path_prompt("rename", "Rename", path_name(row.path), row.path, path_parent(row.path));
+        return;
+    }
+
+    if event.action == "b" {
+        let name = path_name(row.path);
+        open_path_prompt("basename", "Rename basename", basename(name), row.path, path_parent(row.path));
+        red::state_set("pending_extension", name_extension(name));
+        return;
+    }
+
+    if event.action == "c" || event.action == "m" {
+        let kind = "copy";
+        let title = "Copy to";
+        if event.action == "m" {
+            kind = "move";
+            title = "Move to";
+        }
+        open_path_prompt(kind, title, row.path, row.path, path_parent(row.path));
+        return;
+    }
+
+    if event.action == "y" || event.action == "x" {
+        let action = "copy";
+        if event.action == "x" {
+            action = "move";
+        }
+        update_clipboard(action, selected_paths(row));
+        return;
+    }
+
+    if event.action == "p" {
+        paste_clipboard(row);
+        return;
+    }
+
     if row.kind == "directory" && event.action == "expand" {
         expand_directory(row.path);
     }
@@ -111,6 +205,360 @@ fn panel_event(event: Json) {
     if row.kind == "directory" && event.action == "collapse" {
         collapse_directory(row.path);
     }
+}
+
+fn open_create_prompt(row: Json, directory: bool) {
+    let parent = row.path;
+    if row.kind != "directory" {
+        parent = path_parent(row.path);
+    }
+    if directory {
+        open_path_prompt("create_directory", "New directory", "", "", parent);
+    } else {
+        open_path_prompt("create", "New file or directory (trailing /)", "", "", parent);
+    }
+}
+
+fn open_path_prompt(kind: String, title: String, initial: String, source: String, parent: String) {
+    if source == "." {
+        red::execute("Print", "The workspace root cannot be modified");
+        return;
+    }
+    red::state_set("pending_kind", kind);
+    red::state_set("pending_source", source);
+    red::state_set("pending_parent", parent);
+    red::execute("OpenInput", title, initial, ComposerHandlers {
+        submitted: path_prompt_submitted,
+        cancelled: path_prompt_cancelled,
+    });
+}
+
+fn path_prompt_cancelled(event: ComposerCancelled) {
+    red::state_set("pending_kind", "");
+}
+
+fn path_prompt_submitted(value: String) {
+    let query = red::trim(value);
+    if query == "" {
+        return;
+    }
+
+    let kind = red::string(red::state("pending_kind"), "");
+    let source = red::string(red::state("pending_source"), "");
+    let parent = red::string(red::state("pending_parent"), ".");
+    if kind == "create" || kind == "create_directory" {
+        let create_kind = kind;
+        if kind == "create" && red::ends_with(query, "/") {
+            create_kind = "create_directory";
+        }
+        request_operation(Json {
+            kind: create_kind,
+            path: path_join(parent, query),
+        });
+        return;
+    }
+
+    let destination = query;
+    if kind == "rename" {
+        destination = path_join(parent, query);
+    } else if kind == "basename" {
+        destination = path_join(parent, query + red::string(red::state("pending_extension"), ""));
+    } else {
+        destination = workspace_path(query);
+    }
+    request_operation(Json {
+        kind: kind,
+        source: source,
+        destination: destination,
+    });
+}
+
+fn request_operation(operation: Json) {
+    red::request("FileOperation", operation_loaded, operation);
+}
+
+fn operation_loaded(result: Json) {
+    let kind = red::string(red::state("pending_kind"), "operation");
+    if !red::bool(result.ok, false) {
+        red::execute("Print", "Neo-tree " + kind + " failed: " + red::string(result.error, "unknown error"));
+        return;
+    }
+
+    if kind == "trash" && red::bool(result.undo_supported, false) {
+        red::state_set("trash_history", red::push(red::state("trash_history"), TrashBatch {
+            paths: red::state("pending_paths"),
+        }));
+    }
+    red::state_set("selected", []);
+    red::state_set("pending_kind", "");
+    red::execute("Print", "Neo-tree " + kind + " complete");
+    reset_tree();
+}
+
+fn selected_paths(row: Json) -> Json {
+    let paths = red::state("selected");
+    if red::len(paths) == 0 {
+        if row.path == "." {
+            red::execute("Print", "The workspace root cannot be modified");
+            return [];
+        }
+        return [row.path];
+    }
+    return paths;
+}
+
+fn toggle_selection(path: String) {
+    if path == "." {
+        return;
+    }
+    let selected = red::state("selected");
+    if red::contains(selected, path) {
+        selected = red::remove(selected, path);
+    } else {
+        selected = red::push(selected, path);
+    }
+    red::state_set("selected", selected);
+    render();
+}
+
+fn confirm_removal(kind: String, paths: Json) {
+    if red::len(paths) == 0 {
+        return;
+    }
+    red::state_set("pending_kind", kind);
+    red::state_set("pending_paths", paths);
+    let impact = "Move selected items to the system trash.";
+    if kind == "delete" {
+        impact = "Permanently delete selected items. This cannot be undone.";
+    }
+    red::execute("OpenConfirm", "Confirm " + kind, impact, PickerHandlers {
+        selected: removal_confirmed,
+        cancelled: removal_cancelled,
+    });
+}
+
+fn removal_cancelled(event: PickerCancelled) {
+    red::state_set("pending_kind", "");
+    red::state_set("pending_paths", []);
+}
+
+fn removal_confirmed(item: PickerItem) {
+    if item.id != "accept" {
+        red::state_set("pending_kind", "");
+        return;
+    }
+    request_operation(Json {
+        kind: red::string(red::state("pending_kind"), ""),
+        paths: red::state("pending_paths"),
+    });
+}
+
+fn restore_last_trash() {
+    let history = red::state("trash_history");
+    if red::len(history) == 0 {
+        red::execute("Print", "No trash operation is available to restore");
+        return;
+    }
+    let batch = history[red::len(history) - 1];
+    red::state_set("pending_kind", "restore");
+    red::state_set("pending_paths", batch.paths);
+    red::request("FileOperation", restore_loaded, Json {
+        kind: "undo_trash",
+        paths: batch.paths,
+    });
+}
+
+fn restore_loaded(result: Json) {
+    if !red::bool(result.ok, false) {
+        red::execute("Print", "Neo-tree restore failed: " + red::string(result.error, "unknown error"));
+        return;
+    }
+    let history = red::state("trash_history");
+    let remaining = [];
+    let index = 0;
+    while index < red::len(history) - 1 {
+        remaining = red::push(remaining, history[index]);
+        index = index + 1;
+    }
+    red::state_set("trash_history", remaining);
+    red::state_set("pending_kind", "");
+    red::execute("Print", "Neo-tree restore complete");
+    reset_tree();
+}
+
+fn update_clipboard(action: String, paths: Json) {
+    if red::len(paths) == 0 {
+        return;
+    }
+    let clipboard = [];
+    for entry in red::state("clipboard") {
+        if !red::contains(paths, entry.path) {
+            clipboard = red::push(clipboard, entry);
+        }
+    }
+    for path in paths {
+        clipboard = red::push(clipboard, ClipboardEntry {
+            path: path,
+            action: action,
+        });
+    }
+    red::state_set("clipboard", clipboard);
+    red::state_set("selected", []);
+    red::execute("Print", red::len(paths) + " item(s) marked to " + action);
+    render();
+}
+
+fn paste_clipboard(row: Json) {
+    let clipboard = red::state("clipboard");
+    if red::len(clipboard) == 0 {
+        red::execute("Print", "Neo-tree clipboard is empty");
+        return;
+    }
+    let destination = row.path;
+    if row.kind != "directory" {
+        destination = path_parent(row.path);
+    }
+    let queue = [];
+    for entry in clipboard {
+        queue = red::push(queue, PasteEntry {
+            source: entry.path,
+            destination: path_join(destination, path_name(entry.path)),
+            action: entry.action,
+        });
+    }
+    red::state_set("paste_queue", queue);
+    red::state_set("paste_index", 0);
+    run_next_paste();
+}
+
+fn run_next_paste() {
+    let queue = red::state("paste_queue");
+    let index = red::int(red::state("paste_index"), 0);
+    if index >= red::len(queue) {
+        red::state_set("clipboard", []);
+        red::execute("Print", "Neo-tree paste complete");
+        reset_tree();
+        return;
+    }
+    let entry = queue[index];
+    red::request("FileOperation", paste_loaded, Json {
+        kind: entry.action,
+        source: entry.source,
+        destination: entry.destination,
+    });
+}
+
+fn paste_loaded(result: Json) {
+    if !red::bool(result.ok, false) {
+        red::execute("Print", "Neo-tree paste stopped: " + red::string(result.error, "unknown error"));
+        reset_tree();
+        return;
+    }
+    let index = red::int(red::state("paste_index"), 0);
+    let entry = red::state("paste_queue")[index];
+    let clipboard = [];
+    for candidate in red::state("clipboard") {
+        if candidate.path != entry.source {
+            clipboard = red::push(clipboard, candidate);
+        }
+    }
+    red::state_set("clipboard", clipboard);
+    red::state_set("paste_index", index + 1);
+    run_next_paste();
+}
+
+fn stat_loaded(result: Json) {
+    if !red::bool(result.ok, false) {
+        red::execute("Print", "Neo-tree details failed: " + red::string(result.error, "unknown error"));
+        return;
+    }
+    red::execute("Print",
+        result.path + " · " + result.kind
+        + " · " + red::string(result.size, "0") + " bytes"
+        + " · readonly=" + red::string(result.readonly, "false")
+    );
+}
+
+fn show_help() {
+    red::execute("OpenPicker", "Neo-tree keys", [
+        PickerItem { id: "select", label: "Tab  toggle selection", kind: "Selection" },
+        PickerItem { id: "create", label: "a / A  create file / directory", kind: "Create" },
+        PickerItem { id: "rename", label: "r / b  rename / rename basename", kind: "Rename" },
+        PickerItem { id: "clipboard", label: "y / x / p / Ctrl-r  copy / cut / paste / clear", kind: "Clipboard" },
+        PickerItem { id: "direct", label: "c / m  copy / move to path", kind: "Move" },
+        PickerItem { id: "remove", label: "d / T / u / U  delete / trash / restore", kind: "Remove" },
+        PickerItem { id: "details", label: "i / R / ?  details / refresh / help", kind: "Other" },
+    ], PickerOptions {}, PickerHandlers {});
+}
+
+fn reset_tree() {
+    for watch in red::state("watches") {
+        red::execute("UnwatchDirectory", watch.id);
+    }
+    red::state_set("watches", []);
+    red::state_set("children", []);
+    red::state_set("expanded", ["."]);
+    clear_reveal();
+    request_directory(".");
+    request_git_status();
+}
+
+fn path_name(path: String) -> String {
+    let parts = red::split(normalize_path(path), "/");
+    return parts[red::len(parts) - 1];
+}
+
+fn path_parent(path: String) -> String {
+    let normalized = normalize_path(path);
+    let parts = red::split(normalized, "/");
+    if red::len(parts) <= 2 {
+        return ".";
+    }
+    let parent = ".";
+    let index = 1;
+    while index < red::len(parts) - 1 {
+        parent = parent + "/" + parts[index];
+        index = index + 1;
+    }
+    return parent;
+}
+
+fn path_join(parent: String, child: String) -> String {
+    let child = normalize_path(child);
+    if red::starts_with(child, "./") || red::starts_with(child, "/") {
+        return child;
+    }
+    if parent == "." {
+        return "./" + child;
+    }
+    return normalize_path(parent) + "/" + child;
+}
+
+fn workspace_path(path: String) -> String {
+    let path = normalize_path(path);
+    if red::starts_with(path, "./") || red::starts_with(path, "/") {
+        return path;
+    }
+    return "./" + path;
+}
+
+fn name_extension(name: String) -> String {
+    let parts = red::split(name, ".");
+    if red::len(parts) <= 1 {
+        return "";
+    }
+    if red::starts_with(name, ".") && red::len(parts) == 2 {
+        return "";
+    }
+    return "." + parts[red::len(parts) - 1];
+}
+
+fn basename(name: String) -> String {
+    let extension = name_extension(name);
+    if extension == "" {
+        return name;
+    }
+    return red::slice(name, 0, red::len(name) - red::len(extension));
 }
 
 fn reload_visible_tree() {
@@ -440,7 +888,12 @@ fn append_rows(path: String, ancestors: Json, rows: Json) -> Json {
         let is_directory = entry.kind == "directory";
         let expanded = is_directory && is_expanded(entry.path);
         let status = status_for_path(entry.path);
-        let segments = branch_prefix(ancestors, is_last);
+        let segments = [
+            segment(selection_marker(entry.path), ["list.highlightForeground"], true),
+        ];
+        for prefix in branch_prefix(ancestors, is_last) {
+            segments = red::push(segments, prefix);
+        }
         segments = red::push(segments, segment(entry_icon(entry.name, is_directory, expanded) + " ", entry_style_keys(status, is_directory), false));
         segments = red::push(segments, segment(entry.name, entry_style_keys(status, is_directory), false));
         rows = red::push(rows, PanelRow {
@@ -465,6 +918,21 @@ fn append_rows(path: String, ancestors: Json, rows: Json) -> Json {
         rows = red::push(rows, truncation_row("directory-limit:" + path, "… directory listing truncated"));
     }
     return rows;
+}
+
+fn selection_marker(path: String) -> String {
+    if red::contains(red::state("selected"), path) {
+        return "✓ ";
+    }
+    for entry in red::state("clipboard") {
+        if entry.path == path {
+            if entry.action == "move" {
+                return "✂ ";
+            }
+            return "⧉ ";
+        }
+    }
+    return "  ";
 }
 
 fn truncation_row(id: String, text: String) -> Json {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -97,9 +97,9 @@ use crate::{
     },
     theme::{parse_vscode_theme, parse_vscode_theme_contents, Style, Theme},
     ui::{
-        AgentComposer, CompletionUI, Component, FilePicker, HoverInfo, HoverInfoFormat, Info,
-        InputPrompt, LegacyPickerOptions, Picker, PickerItem, PickerOptions, PickerPreview,
-        PickerUpdate,
+        AgentComposer, CompletionUI, Component, Confirmation, FilePicker, HoverInfo,
+        HoverInfoFormat, Info, InputPrompt, LegacyPickerOptions, Picker, PickerItem, PickerOptions,
+        PickerPreview, PickerUpdate,
     },
     undo::{AppliedTextEdit, CursorSnapshot, EditOrigin, RevertEdit, TextPosition, TextRange},
     utils::{expand_user_path, get_workspace_path},
@@ -647,6 +647,12 @@ pub enum PluginRequest {
         query: String,
         history: Vec<String>,
     },
+    OpenCallbackInput {
+        owner: String,
+        handle: ComposerHandle,
+        title: String,
+        initial: String,
+    },
     OpenDynamicPicker {
         title: Option<String>,
         id: i32,
@@ -659,6 +665,12 @@ pub enum PluginRequest {
         title: Option<String>,
         items: Vec<PickerItem>,
         options: PickerOptions,
+    },
+    OpenCallbackConfirmation {
+        owner: String,
+        handle: PickerHandle,
+        title: String,
+        message: String,
     },
     UpdatePickerItems {
         id: i32,
@@ -907,6 +919,10 @@ pub enum PluginRequest {
         path: String,
         request_id: RequestId,
     },
+    FileOperation {
+        operation: Value,
+        request_id: RequestId,
+    },
     WatchDirectory {
         path: String,
         watch_id: i32,
@@ -940,8 +956,10 @@ impl PluginRequest {
             Self::OpenLocation { .. } => "OpenLocation",
             Self::OpenAgentComposer { .. } => "OpenAgentComposer",
             Self::OpenCallbackComposer { .. } => "OpenCallbackComposer",
+            Self::OpenCallbackInput { .. } => "OpenCallbackInput",
             Self::OpenDynamicPicker { .. } => "OpenDynamicPicker",
             Self::OpenCallbackPicker { .. } => "OpenCallbackPicker",
+            Self::OpenCallbackConfirmation { .. } => "OpenCallbackConfirmation",
             Self::UpdatePickerItems { .. } => "UpdatePickerItems",
             Self::UpdatePickerQuery { .. } => "UpdatePickerQuery",
             Self::UpdatePickerStatus { .. } => "UpdatePickerStatus",
@@ -1006,6 +1024,7 @@ impl PluginRequest {
             Self::CloseWindowBar { .. } => "CloseWindowBar",
             Self::ListDirectory { .. } => "ListDirectory",
             Self::GetGitStatus { .. } => "GetGitStatus",
+            Self::FileOperation { .. } => "FileOperation",
             Self::WatchDirectory { .. } => "WatchDirectory",
             Self::UnwatchDirectory { .. } => "UnwatchDirectory",
         }
@@ -6457,6 +6476,26 @@ impl Editor {
                     )));
                     needs_render = true;
                 }
+                PluginRequest::OpenCallbackInput {
+                    owner,
+                    handle,
+                    title,
+                    initial,
+                } => {
+                    if runtime.composer_plugin(handle).as_deref() != Some(owner.as_str()) {
+                        runtime.release_composer(handle);
+                        self.last_error = Some(
+                            "ignored an input whose callback owner no longer exists".to_string(),
+                        );
+                        needs_render = true;
+                        continue;
+                    }
+                    self.release_current_dialog_callbacks(runtime);
+                    self.current_dialog = Some(Box::new(InputPrompt::new_callback(
+                        self, title, initial, handle,
+                    )));
+                    needs_render = true;
+                }
                 PluginRequest::OpenDynamicPicker {
                     title,
                     id,
@@ -6496,6 +6535,27 @@ impl Editor {
                     }
                     self.release_current_dialog_callbacks(runtime);
                     self.current_dialog = Some(Box::new(picker));
+                    needs_render = true;
+                }
+                PluginRequest::OpenCallbackConfirmation {
+                    owner,
+                    handle,
+                    title,
+                    message,
+                } => {
+                    if runtime.picker_plugin(handle).as_deref() != Some(owner.as_str()) {
+                        runtime.release_picker(handle);
+                        self.last_error = Some(
+                            "ignored a confirmation whose callback owner no longer exists"
+                                .to_string(),
+                        );
+                        needs_render = true;
+                        continue;
+                    }
+                    self.release_current_dialog_callbacks(runtime);
+                    self.current_dialog = Some(Box::new(Confirmation::new_callback(
+                        self, title, message, handle,
+                    )));
                     needs_render = true;
                 }
                 PluginRequest::UpdatePickerItems { id, items } => {
@@ -7327,6 +7387,17 @@ impl Editor {
                     self.plugin_registry
                         .resolve_request(runtime, request_id, payload)
                         .await?;
+                }
+                PluginRequest::FileOperation {
+                    operation,
+                    request_id,
+                } => {
+                    let outcome = plugin::filesystem::apply_file_operation(&operation);
+                    self.reconcile_plugin_file_operation(&outcome).await?;
+                    self.plugin_registry
+                        .resolve_request(runtime, request_id, outcome.payload)
+                        .await?;
+                    needs_render = true;
                 }
                 PluginRequest::WatchDirectory {
                     path,
@@ -9382,15 +9453,27 @@ impl Editor {
                     }
                     KeyCode::Char('H') => "history",
                     KeyCode::Char('N') => "new",
-                    KeyCode::Char('a') => "composer_focus",
-                    KeyCode::Char('x') => "clear",
+                    KeyCode::Char('a') if !self.panel_manager.focused_row_panel() => {
+                        "composer_focus"
+                    }
+                    KeyCode::Char('x') if !self.panel_manager.focused_row_panel() => "clear",
                     KeyCode::Left | KeyCode::Char('h') => "collapse",
                     KeyCode::Right | KeyCode::Char('l') => "expand",
                     KeyCode::Enter => "activate",
                     KeyCode::Char(' ') => "toggle",
                     KeyCode::Char('q') => "close",
                     KeyCode::Char('R') => "refresh",
-                    _ => return None,
+                    _ => {
+                        if let Some(action) = self.panel_global_key_action(ev) {
+                            return Some(action);
+                        }
+                        let action = Self::key_string_for_event(ev)?;
+                        let panel_height = usize::from(self.size.1.saturating_sub(2));
+                        return self
+                            .panel_manager
+                            .handle_focused_key(&action, panel_height, usize::from(self.size.0))
+                            .and_then(Self::panel_event_key_action);
+                    }
                 };
 
                 let panel_height = usize::from(self.size.1.saturating_sub(2));
@@ -16102,6 +16185,55 @@ impl Editor {
             }
         }
         self.ensure_buffer_lsp_opened(buffer_index).await
+    }
+
+    async fn reconcile_plugin_file_operation(
+        &mut self,
+        outcome: &plugin::filesystem::FileOperationOutcome,
+    ) -> anyhow::Result<()> {
+        let mut identity_changes = Vec::new();
+        for index in 0..self.buffers.len() {
+            let Some(file) = self.buffers[index].file.clone() else {
+                continue;
+            };
+            let Ok(absolute) = Path::new(&file).absolutize() else {
+                continue;
+            };
+            let absolute = absolute.into_owned();
+            let previous_uri = self.buffers[index].uri()?.map(|uri| uri.to_string());
+
+            let renamed = outcome.renames.iter().find_map(|(source, destination)| {
+                absolute.strip_prefix(source).ok().map(|suffix| {
+                    if suffix.as_os_str().is_empty() {
+                        destination.clone()
+                    } else {
+                        destination.join(suffix)
+                    }
+                })
+            });
+            if let Some(destination) = renamed {
+                self.buffers[index].file = Some(destination.to_string_lossy().into_owned());
+                identity_changes.push((index, previous_uri));
+                continue;
+            }
+
+            if outcome
+                .removals
+                .iter()
+                .any(|removed| absolute == *removed || absolute.starts_with(removed))
+            {
+                self.buffers[index].file = None;
+                identity_changes.push((index, previous_uri));
+                self.last_error =
+                    Some("Removed file kept open as an unsaved scratch buffer".to_string());
+            }
+        }
+
+        for (index, previous_uri) in identity_changes {
+            self.sync_lsp_document_identity(previous_uri.as_deref(), index)
+                .await?;
+        }
+        Ok(())
     }
 
     fn apply_theme(&mut self, theme_name: &str, update_config: bool) -> anyhow::Result<()> {
@@ -23665,6 +23797,51 @@ mod test {
         let mut editor = Editor::with_size(lsp, 60, 12, config, Theme::default(), buffers).unwrap();
         editor.test_disable_terminal_output();
         editor
+    }
+
+    #[tokio::test]
+    async fn plugin_file_operations_reconcile_open_buffer_identity_without_losing_edits() {
+        let root = tempfile::tempdir().unwrap();
+        let old = root.path().join("old.rs");
+        let renamed = root.path().join("nested/renamed.rs");
+        let mut editor = lsp_test_editor(vec![Buffer::new(
+            Some(old.to_string_lossy().into_owned()),
+            "unsaved contents".to_string(),
+        )]);
+        editor.buffers[0].dirty = true;
+
+        editor
+            .reconcile_plugin_file_operation(&plugin::filesystem::FileOperationOutcome {
+                payload: Value::Null,
+                renames: vec![(old, renamed.clone())],
+                removals: Vec::new(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            editor.buffers[0].file.as_deref(),
+            Some(renamed.to_str().unwrap())
+        );
+        assert_eq!(editor.buffers[0].contents(), "unsaved contents");
+        assert!(editor.buffers[0].is_dirty());
+
+        editor
+            .reconcile_plugin_file_operation(&plugin::filesystem::FileOperationOutcome {
+                payload: Value::Null,
+                renames: Vec::new(),
+                removals: vec![renamed],
+            })
+            .await
+            .unwrap();
+
+        assert!(editor.buffers[0].file.is_none());
+        assert_eq!(editor.buffers[0].contents(), "unsaved contents");
+        assert!(editor.buffers[0].is_dirty());
+        assert_eq!(
+            editor.last_error.as_deref(),
+            Some("Removed file kept open as an unsaved scratch buffer")
+        );
     }
 
     fn lsp_edit(start: (usize, usize), end: (usize, usize), text: &str) -> LspTextEdit {

--- a/src/plugin/filesystem.rs
+++ b/src/plugin/filesystem.rs
@@ -1,0 +1,735 @@
+//! Workspace-confined filesystem operations exposed to trusted Red plugins.
+//!
+//! Paths are always interpreted relative to the editor workspace. Existing parent
+//! components are canonicalized before mutation to reject paths already redirected
+//! outside the workspace by a symlink.
+
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+    time::UNIX_EPOCH,
+};
+
+use anyhow::{anyhow, bail, Context};
+use serde_json::{json, Value};
+
+use crate::utils::get_workspace_path;
+
+const MAX_BRACE_EXPANSIONS: usize = 256;
+
+#[derive(Debug, Default)]
+pub struct FileOperationOutcome {
+    pub payload: Value,
+    pub renames: Vec<(PathBuf, PathBuf)>,
+    pub removals: Vec<PathBuf>,
+}
+
+pub fn apply_file_operation(operation: &Value) -> FileOperationOutcome {
+    match apply_file_operation_inner(operation) {
+        Ok(outcome) => outcome,
+        Err(error) => FileOperationOutcome {
+            payload: json!({
+                "ok": false,
+                "error": error.to_string(),
+            }),
+            ..FileOperationOutcome::default()
+        },
+    }
+}
+
+fn apply_file_operation_inner(operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    let root = get_workspace_path()
+        .canonicalize()
+        .context("workspace root is unavailable")?;
+    let kind = required_string(operation, "kind")?;
+    match kind {
+        "create" | "create_file" | "create_directory" => create(&root, kind, operation),
+        "rename" | "move" => rename_or_move(&root, operation),
+        "copy" => copy(&root, operation),
+        "delete" => delete(&root, operation),
+        "trash" => trash_paths(&root, operation),
+        "restore" | "undo_trash" => restore_paths(&root, operation),
+        "stat" => stat_path(&root, operation),
+        _ => bail!("unsupported file operation `{kind}`"),
+    }
+}
+
+fn create(root: &Path, kind: &str, operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    let pattern = required_string(operation, "path")?;
+    let expanded = expand_braces(pattern)?;
+    if expanded.is_empty() {
+        bail!("file name is empty");
+    }
+
+    let mut destinations = Vec::with_capacity(expanded.len());
+    for path in expanded {
+        let trailing_separator = path.ends_with('/') || path.ends_with('\\');
+        let path = path.trim_end_matches(['/', '\\']);
+        let destination = resolve_workspace_path(root, path)?;
+        refuse_root(root, &destination)?;
+        if destinations
+            .iter()
+            .any(|(existing, _)| existing == &destination)
+        {
+            bail!(
+                "{} appears more than once in the expanded path",
+                display_relative(root, &destination)
+            );
+        }
+        if fs::symlink_metadata(&destination).is_ok() {
+            bail!("{} already exists", display_relative(root, &destination));
+        }
+        let is_directory = kind == "create_directory" || (kind == "create" && trailing_separator);
+        destinations.push((destination, is_directory));
+    }
+
+    let mut created = Vec::with_capacity(destinations.len());
+    for (destination, is_directory) in destinations {
+        if is_directory {
+            fs::create_dir_all(&destination)
+                .with_context(|| format!("could not create {}", destination.display()))?;
+        } else {
+            let parent = destination
+                .parent()
+                .ok_or_else(|| anyhow!("file destination has no parent"))?;
+            fs::create_dir_all(parent)
+                .with_context(|| format!("could not create {}", parent.display()))?;
+            fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&destination)
+                .with_context(|| format!("could not create {}", destination.display()))?;
+        }
+        created.push(display_relative(root, &destination));
+    }
+
+    Ok(FileOperationOutcome {
+        payload: json!({
+            "ok": true,
+            "error": null,
+            "created": created,
+        }),
+        ..FileOperationOutcome::default()
+    })
+}
+
+fn rename_or_move(root: &Path, operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    let source = resolve_workspace_path(root, required_string(operation, "source")?)?;
+    let destination = resolve_workspace_path(root, required_string(operation, "destination")?)?;
+    refuse_root(root, &source)?;
+    refuse_root(root, &destination)?;
+    require_existing(&source)?;
+    require_unused(&destination)?;
+    refuse_descendant_destination(&source, &destination)?;
+
+    let parent = destination
+        .parent()
+        .ok_or_else(|| anyhow!("destination has no parent"))?;
+    fs::create_dir_all(parent).with_context(|| format!("could not create {}", parent.display()))?;
+    fs::rename(&source, &destination).with_context(|| {
+        format!(
+            "could not move {} to {}",
+            display_relative(root, &source),
+            display_relative(root, &destination)
+        )
+    })?;
+
+    Ok(FileOperationOutcome {
+        payload: json!({
+            "ok": true,
+            "error": null,
+            "source": display_relative(root, &source),
+            "destination": display_relative(root, &destination),
+        }),
+        renames: vec![(source, destination)],
+        removals: Vec::new(),
+    })
+}
+
+fn copy(root: &Path, operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    let source = resolve_workspace_path(root, required_string(operation, "source")?)?;
+    let destination = resolve_workspace_path(root, required_string(operation, "destination")?)?;
+    refuse_root(root, &destination)?;
+    require_existing(&source)?;
+    require_unused(&destination)?;
+    refuse_descendant_destination(&source, &destination)?;
+    if let Err(error) = copy_path(&source, &destination) {
+        if fs::symlink_metadata(&destination).is_ok() {
+            let _ = remove_path(&destination);
+        }
+        return Err(error).with_context(|| {
+            format!(
+                "could not copy {} to {}",
+                display_relative(root, &source),
+                display_relative(root, &destination)
+            )
+        });
+    }
+
+    Ok(FileOperationOutcome {
+        payload: json!({
+            "ok": true,
+            "error": null,
+            "source": display_relative(root, &source),
+            "destination": display_relative(root, &destination),
+        }),
+        ..FileOperationOutcome::default()
+    })
+}
+
+fn delete(root: &Path, operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    let paths = resolve_targets(root, operation)?;
+    for path in &paths {
+        refuse_root(root, path)?;
+        require_existing(path)?;
+    }
+    for path in &paths {
+        remove_path(path)?;
+    }
+
+    Ok(FileOperationOutcome {
+        payload: json!({
+            "ok": true,
+            "error": null,
+            "removed": relative_paths(root, &paths),
+        }),
+        removals: paths,
+        renames: Vec::new(),
+    })
+}
+
+fn trash_paths(root: &Path, operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    let paths = resolve_targets(root, operation)?;
+    for path in &paths {
+        refuse_root(root, path)?;
+        require_existing(path)?;
+    }
+    trash::delete_all(&paths).map_err(|error| anyhow!("could not move item to trash: {error}"))?;
+
+    Ok(FileOperationOutcome {
+        payload: json!({
+            "ok": true,
+            "error": null,
+            "removed": relative_paths(root, &paths),
+            "undo_supported": cfg!(any(
+                windows,
+                all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))
+            )),
+        }),
+        removals: paths,
+        renames: Vec::new(),
+    })
+}
+
+#[cfg(any(
+    windows,
+    all(
+        unix,
+        not(target_os = "macos"),
+        not(target_os = "ios"),
+        not(target_os = "android")
+    )
+))]
+fn restore_paths(root: &Path, operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    let wanted = resolve_targets(root, operation)?;
+    let wanted = wanted.into_iter().collect::<std::collections::HashSet<_>>();
+    let mut candidates = trash::os_limited::list()
+        .map_err(|error| anyhow!("could not inspect trash: {error}"))?
+        .into_iter()
+        .filter(|item| wanted.contains(&item.original_path()))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|item| item.time_deleted);
+
+    let mut selected = Vec::new();
+    for path in &wanted {
+        let item = candidates
+            .iter()
+            .rev()
+            .find(|item| item.original_path() == *path)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow!(
+                    "no matching trash item for {}",
+                    display_relative(root, path)
+                )
+            })?;
+        selected.push(item);
+    }
+    trash::os_limited::restore_all(selected)
+        .map_err(|error| anyhow!("could not restore trash item: {error}"))?;
+
+    Ok(FileOperationOutcome {
+        payload: json!({
+            "ok": true,
+            "error": null,
+            "restored": relative_paths(root, &wanted.into_iter().collect::<Vec<_>>()),
+        }),
+        ..FileOperationOutcome::default()
+    })
+}
+
+#[cfg(not(any(
+    windows,
+    all(
+        unix,
+        not(target_os = "macos"),
+        not(target_os = "ios"),
+        not(target_os = "android")
+    )
+)))]
+fn restore_paths(_root: &Path, _operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    bail!("restoring items from the system trash is not supported on this platform")
+}
+
+fn stat_path(root: &Path, operation: &Value) -> anyhow::Result<FileOperationOutcome> {
+    let path = resolve_workspace_path(root, required_string(operation, "path")?)?;
+    let metadata = fs::symlink_metadata(&path)
+        .with_context(|| format!("could not inspect {}", display_relative(root, &path)))?;
+    let kind = if metadata.file_type().is_symlink() {
+        "symlink"
+    } else if metadata.is_dir() {
+        "directory"
+    } else {
+        "file"
+    };
+    let modified_ms = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis());
+    let created_ms = metadata
+        .created()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis());
+
+    Ok(FileOperationOutcome {
+        payload: json!({
+            "ok": true,
+            "error": null,
+            "path": display_relative(root, &path),
+            "kind": kind,
+            "size": metadata.len(),
+            "readonly": metadata.permissions().readonly(),
+            "modified_ms": modified_ms,
+            "created_ms": created_ms,
+        }),
+        ..FileOperationOutcome::default()
+    })
+}
+
+fn required_string<'a>(value: &'a Value, key: &str) -> anyhow::Result<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow!("file operation requires `{key}`"))
+}
+
+fn resolve_targets(root: &Path, operation: &Value) -> anyhow::Result<Vec<PathBuf>> {
+    let raw = operation
+        .get("paths")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("file operation requires `paths`"))?;
+    if raw.is_empty() {
+        bail!("file operation requires at least one path");
+    }
+    let mut paths = raw
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| anyhow!("file operation paths must be strings"))
+                .and_then(|path| resolve_workspace_path(root, path))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    paths.sort();
+    paths.dedup();
+    let selected = paths.clone();
+    paths.retain(|path| {
+        !selected
+            .iter()
+            .any(|other| other != path && path.starts_with(other))
+    });
+    Ok(paths)
+}
+
+fn resolve_workspace_path(root: &Path, raw: &str) -> anyhow::Result<PathBuf> {
+    let raw_path = Path::new(raw);
+    if raw_path.is_absolute() {
+        bail!("absolute paths are not allowed");
+    }
+    let mut relative = PathBuf::new();
+    for component in raw_path.components() {
+        match component {
+            Component::Normal(component) => relative.push(component),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("path escapes the workspace")
+            }
+        }
+    }
+    if relative.as_os_str().is_empty() {
+        return Ok(root.to_path_buf());
+    }
+
+    let candidate = root.join(&relative);
+    let parent = candidate.parent().unwrap_or(root);
+    let mut existing = parent;
+    while !existing.exists() {
+        existing = existing
+            .parent()
+            .ok_or_else(|| anyhow!("path has no existing workspace ancestor"))?;
+    }
+    let canonical_parent = existing
+        .canonicalize()
+        .with_context(|| format!("could not resolve {}", existing.display()))?;
+    if !canonical_parent.starts_with(root) {
+        bail!("path resolves outside the workspace");
+    }
+    Ok(candidate)
+}
+
+fn refuse_root(root: &Path, path: &Path) -> anyhow::Result<()> {
+    if path == root {
+        bail!("the workspace root cannot be modified");
+    }
+    Ok(())
+}
+
+fn require_existing(path: &Path) -> anyhow::Result<()> {
+    fs::symlink_metadata(path)
+        .map(|_| ())
+        .with_context(|| format!("{} does not exist", path.display()))
+}
+
+fn require_unused(path: &Path) -> anyhow::Result<()> {
+    if fs::symlink_metadata(path).is_ok() {
+        bail!("{} already exists", path.display());
+    }
+    Ok(())
+}
+
+fn refuse_descendant_destination(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    if destination == source || destination.starts_with(source) {
+        bail!("cannot copy or move an item into itself");
+    }
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> anyhow::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn copy_path(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() {
+        let target = fs::read_link(source)?;
+        create_symlink(&target, destination, source.is_dir())?;
+        return Ok(());
+    }
+    if metadata.is_file() {
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(source, destination)?;
+        fs::set_permissions(destination, metadata.permissions())?;
+        return Ok(());
+    }
+
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        copy_path(&entry.path(), &destination.join(entry.file_name()))?;
+    }
+    fs::set_permissions(destination, metadata.permissions())?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, destination: &Path, _directory: bool) -> anyhow::Result<()> {
+    std::os::unix::fs::symlink(target, destination)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn create_symlink(target: &Path, destination: &Path, directory: bool) -> anyhow::Result<()> {
+    if directory {
+        std::os::windows::fs::symlink_dir(target, destination)?;
+    } else {
+        std::os::windows::fs::symlink_file(target, destination)?;
+    }
+    Ok(())
+}
+
+fn display_relative(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn relative_paths(root: &Path, paths: &[PathBuf]) -> Vec<String> {
+    paths
+        .iter()
+        .map(|path| display_relative(root, path))
+        .collect()
+}
+
+fn expand_braces(pattern: &str) -> anyhow::Result<Vec<String>> {
+    let mut expanded = vec![pattern.to_string()];
+    loop {
+        let mut changed = false;
+        let mut next = Vec::new();
+        for value in expanded {
+            let Some((start, end)) = first_brace_pair(&value)? else {
+                next.push(value);
+                continue;
+            };
+            changed = true;
+            let choices = brace_choices(&value[start + 1..end])?;
+            for choice in choices {
+                let mut item = String::new();
+                item.push_str(&value[..start]);
+                item.push_str(&choice);
+                item.push_str(&value[end + 1..]);
+                next.push(item);
+                if next.len() > MAX_BRACE_EXPANSIONS {
+                    bail!("brace expansion exceeds {MAX_BRACE_EXPANSIONS} paths");
+                }
+            }
+        }
+        if !changed {
+            return Ok(next);
+        }
+        expanded = next;
+    }
+}
+
+fn first_brace_pair(value: &str) -> anyhow::Result<Option<(usize, usize)>> {
+    let mut start = None;
+    let mut depth = 0usize;
+    for (index, character) in value.char_indices() {
+        match character {
+            '{' => {
+                if start.is_none() {
+                    start = Some(index);
+                }
+                depth += 1;
+            }
+            '}' if depth > 0 => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(start.map(|start| (start, index)));
+                }
+            }
+            '}' => bail!("brace expansion has an unmatched closing brace"),
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        bail!("brace expansion has an unmatched opening brace");
+    }
+    Ok(None)
+}
+
+fn brace_choices(contents: &str) -> anyhow::Result<Vec<String>> {
+    let parts = split_top_level(contents, ',');
+    if parts.len() > 1 {
+        return Ok(parts);
+    }
+    let range = split_top_level(contents, '.')
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    if range.len() == 2 || range.len() == 3 {
+        if let (Ok(start), Ok(end)) = (range[0].parse::<i64>(), range[1].parse::<i64>()) {
+            let step = range
+                .get(2)
+                .map(|value| value.parse::<i64>())
+                .transpose()?
+                .unwrap_or(if start <= end { 1 } else { -1 });
+            if step == 0 {
+                bail!("brace expansion step cannot be zero");
+            }
+            let width = range[0].len().max(range[1].len());
+            let mut values = Vec::new();
+            let mut current = start;
+            while (step > 0 && current <= end) || (step < 0 && current >= end) {
+                values.push(format!("{current:0width$}"));
+                current += step;
+                if values.len() > MAX_BRACE_EXPANSIONS {
+                    bail!("brace expansion exceeds {MAX_BRACE_EXPANSIONS} paths");
+                }
+            }
+            return Ok(values);
+        }
+        let start = range[0].chars().collect::<Vec<_>>();
+        let end = range[1].chars().collect::<Vec<_>>();
+        if start.len() == 1 && end.len() == 1 {
+            let start = start[0] as i64;
+            let end = end[0] as i64;
+            let step = range
+                .get(2)
+                .map(|value| value.parse::<i64>())
+                .transpose()?
+                .unwrap_or(if start <= end { 1 } else { -1 });
+            if step == 0 {
+                bail!("brace expansion step cannot be zero");
+            }
+            let mut values = Vec::new();
+            let mut current = start;
+            while (step > 0 && current <= end) || (step < 0 && current >= end) {
+                let character = char::from_u32(current as u32)
+                    .ok_or_else(|| anyhow!("invalid character range"))?;
+                values.push(character.to_string());
+                current += step;
+            }
+            return Ok(values);
+        }
+    }
+    Ok(vec![contents.to_string()])
+}
+
+fn split_top_level(value: &str, separator: char) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0usize;
+    for (index, character) in value.char_indices() {
+        match character {
+            '{' => depth += 1,
+            '}' => depth = depth.saturating_sub(1),
+            character if character == separator && depth == 0 => {
+                parts.push(value[start..index].to_string());
+                start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    parts.push(value[start..].to_string());
+    parts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_lists_ranges_steps_and_nested_braces() {
+        assert_eq!(expand_braces("file{,.bak}").unwrap(), ["file", "file.bak"]);
+        assert_eq!(
+            expand_braces("{a,b}/{00..02}.rs").unwrap(),
+            ["a/00.rs", "a/01.rs", "a/02.rs", "b/00.rs", "b/01.rs", "b/02.rs"]
+        );
+        assert_eq!(expand_braces("x{a..e..2}").unwrap(), ["xa", "xc", "xe"]);
+    }
+
+    #[test]
+    fn workspace_paths_reject_absolute_and_parent_components() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path().canonicalize().unwrap();
+        assert!(resolve_workspace_path(&root, "../outside").is_err());
+        assert!(resolve_workspace_path(&root, "/outside").is_err());
+        assert_eq!(
+            resolve_workspace_path(&root, "./src/main.rs").unwrap(),
+            root.join("src/main.rs")
+        );
+    }
+
+    #[test]
+    fn recursive_copy_preserves_files_and_rejects_existing_destinations() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let destination = root.path().join("destination");
+        fs::create_dir_all(source.join("nested")).unwrap();
+        fs::write(source.join("nested/file.txt"), "contents").unwrap();
+
+        copy_path(&source, &destination).unwrap();
+        assert_eq!(
+            fs::read_to_string(destination.join("nested/file.txt")).unwrap(),
+            "contents"
+        );
+    }
+
+    #[test]
+    fn create_move_copy_stat_and_delete_stay_within_the_workspace() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path().canonicalize().unwrap();
+
+        let created = create(&root, "create", &json!({ "path": "src/{one,two}.rs" })).unwrap();
+        assert_eq!(
+            created.payload["created"],
+            json!(["src/one.rs", "src/two.rs"])
+        );
+        create(
+            &root,
+            "create_directory",
+            &json!({ "path": "assets/icons" }),
+        )
+        .unwrap();
+        fs::write(root.join("src/one.rs"), "fn one() {}").unwrap();
+
+        copy(
+            &root,
+            &json!({
+                "source": "src",
+                "destination": "src-copy",
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            fs::read_to_string(root.join("src-copy/one.rs")).unwrap(),
+            "fn one() {}"
+        );
+
+        let moved = rename_or_move(
+            &root,
+            &json!({
+                "source": "src/two.rs",
+                "destination": "src/renamed.rs",
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            moved.payload["destination"],
+            serde_json::Value::String("src/renamed.rs".to_string())
+        );
+        assert_eq!(moved.renames.len(), 1);
+
+        let stat = stat_path(&root, &json!({ "path": "src/one.rs" })).unwrap();
+        assert_eq!(stat.payload["kind"], "file");
+        assert_eq!(stat.payload["size"], 11);
+
+        let removed = delete(
+            &root,
+            &json!({
+                "paths": ["src-copy/one.rs", "src-copy"],
+            }),
+        )
+        .unwrap();
+        assert_eq!(removed.payload["removed"], json!(["src-copy"]));
+        assert!(!root.join("src-copy").exists());
+        assert!(root.join("src/one.rs").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_paths_reject_children_of_symlinks_that_escape_the_root() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = root.path().canonicalize().unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.join("outside-link")).unwrap();
+
+        assert!(resolve_workspace_path(&root, "outside-link/escaped.txt").is_err());
+        assert_eq!(
+            resolve_workspace_path(&root, "outside-link").unwrap(),
+            root.join("outside-link")
+        );
+    }
+}

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.4.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },
@@ -33,6 +33,8 @@
     { "name": "ClearGutterSigns", "kind": "execute", "signature": "(namespace: String)", "introduced": "0.1.0" },
     { "name": "OpenPicker", "kind": "execute", "signature": "(title: String, items: [PickerItem], options: PickerOptions, handlers: PickerHandlers)", "introduced": "0.3.0" },
     { "name": "OpenComposer", "kind": "execute", "signature": "(title: String, query: String, history: [String], handlers: ComposerHandlers)", "introduced": "0.3.0" },
+    { "name": "OpenInput", "kind": "execute", "signature": "(title: String, initial: String, handlers: ComposerHandlers)", "introduced": "0.4.0" },
+    { "name": "OpenConfirm", "kind": "execute", "signature": "(title: String, message: String, handlers: PickerHandlers)", "introduced": "0.4.0" },
     { "name": "OpenDynamicPicker", "kind": "execute", "signature": "(title: String, id: i32, items: [PickerItem], options: PickerOptions)", "introduced": "0.1.0" },
     { "name": "OpenAgentComposer", "kind": "execute", "signature": "(title: String, id: i32, query: String, history: [String])", "introduced": "0.2.0" },
     { "name": "UpdatePickerItems", "kind": "execute", "signature": "(id: i32, items: [PickerItem])", "introduced": "0.1.0" },
@@ -99,6 +101,7 @@
     { "name": "CharIndexToDisplayColumn", "kind": "request", "signature": "(callback: fn(Json), x: i32, y: i32)", "introduced": "0.1.0" },
     { "name": "DisplayColumnToCharIndex", "kind": "request", "signature": "(callback: fn(Json), column: i32, y: i32)", "introduced": "0.1.0" },
     { "name": "ListDirectory", "kind": "request", "signature": "(callback: fn(Json), path: String)", "introduced": "0.1.0" },
-    { "name": "GetGitStatus", "kind": "request", "signature": "(callback: fn(Json), path: String)", "introduced": "0.1.0" }
+    { "name": "GetGitStatus", "kind": "request", "signature": "(callback: fn(Json), path: String)", "introduced": "0.1.0" },
+    { "name": "FileOperation", "kind": "request", "signature": "(callback: fn(Json), operation: Json)", "introduced": "0.4.0" }
   ]
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -12,6 +12,7 @@
 
 mod api;
 pub mod decoration;
+pub(crate) mod filesystem;
 pub mod gutter;
 pub mod location;
 pub(crate) mod markdown;

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -854,6 +854,12 @@ impl PanelManager {
             .is_some_and(|panel| panel.composer.is_some())
     }
 
+    pub fn focused_row_panel(&self) -> bool {
+        self.focused
+            .as_deref()
+            .is_some_and(|id| self.panels.contains_key(id))
+    }
+
     pub fn has_focused_panel(&self) -> bool {
         self.focused.is_some()
     }

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -32,7 +32,7 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.3.0";
+pub const RED_HOST_API_VERSION: &str = "0.4.0";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PluginModification {
@@ -1186,13 +1186,13 @@ mod tests {
     #[test]
     fn pre_one_minor_host_api_requirements_do_not_cross_minor_versions() {
         let mut metadata = PluginMetadata::minimal("composer-plugin".to_string());
-        metadata.red_api_version = Some("^0.3.0".to_string());
+        metadata.red_api_version = Some("^0.4.0".to_string());
         check_api_compatibility(&metadata).unwrap();
 
-        metadata.red_api_version = Some("^0.2.0".to_string());
+        metadata.red_api_version = Some("^0.3.0".to_string());
         let error = check_api_compatibility(&metadata).unwrap_err().to_string();
 
-        assert!(error.contains("^0.2.0"));
+        assert!(error.contains("^0.3.0"));
         assert!(error.contains(RED_HOST_API_VERSION));
         assert!(error.contains("docs/PLUGIN_API.md"));
     }
@@ -1404,7 +1404,7 @@ mod tests {
         ));
         assert_eq!(runtime.command_plugin("FutureCommand"), None);
 
-        fs::write(&metadata, r#"{"name":"future","red_api_version":"^0.3.0"}"#).unwrap();
+        fs::write(&metadata, r#"{"name":"future","red_api_version":"^0.4.0"}"#).unwrap();
         registry.reload(&mut runtime).await.unwrap();
 
         assert_eq!(
@@ -1657,7 +1657,7 @@ mod tests {
         .unwrap();
         fs::write(
             &metadata,
-            r#"{"name":"metadata","red_api_version":"^0.3.0"}"#,
+            r#"{"name":"metadata","red_api_version":"^0.4.0"}"#,
         )
         .unwrap();
         let mut registry = PluginRegistry::new();

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -848,6 +848,29 @@ impl RedHost {
                 });
                 return Ok(Value::Int(i64::from(handle.get())));
             }
+            "OpenConfirm" => {
+                let title = red_required_string(args, 0, "OpenConfirm")?.to_string();
+                let message = red_required_string(args, 1, "OpenConfirm")?.to_string();
+                let handlers = args
+                    .get(2)
+                    .ok_or_else(|| anyhow::anyhow!("OpenConfirm requires PickerHandlers"))
+                    .and_then(|value| red_picker_handlers(plugin, value, "OpenConfirm"))?;
+                let handle = self.policy_mut().allocate_picker_handle();
+                self.policy_mut().picker_handlers.insert(
+                    handle,
+                    PickerRegistration {
+                        plugin: plugin.to_string(),
+                        handlers,
+                    },
+                );
+                self.send_request(PluginRequest::OpenCallbackConfirmation {
+                    owner: plugin.to_string(),
+                    handle,
+                    title,
+                    message,
+                });
+                return Ok(Value::Int(i64::from(handle.get())));
+            }
             "OpenDynamicPicker" => {
                 let title = args.first().and_then(Value::as_str).map(str::to_string);
                 let id = args.get(1).and_then(value_to_i32).unwrap_or(1);
@@ -915,6 +938,29 @@ impl RedHost {
                     title,
                     query,
                     history,
+                });
+                return Ok(Value::Int(i64::from(handle.get())));
+            }
+            "OpenInput" => {
+                let title = red_required_string(args, 0, "OpenInput")?.to_string();
+                let initial = red_required_string(args, 1, "OpenInput")?.to_string();
+                let handlers = args
+                    .get(2)
+                    .ok_or_else(|| anyhow::anyhow!("OpenInput requires ComposerHandlers"))
+                    .and_then(|value| red_composer_handlers(plugin, value, "OpenInput"))?;
+                let handle = self.policy_mut().allocate_composer_handle();
+                self.policy_mut().composer_handlers.insert(
+                    handle,
+                    ComposerRegistration {
+                        plugin: plugin.to_string(),
+                        handlers,
+                    },
+                );
+                self.send_request(PluginRequest::OpenCallbackInput {
+                    owner: plugin.to_string(),
+                    handle,
+                    title,
+                    initial,
                 });
                 return Ok(Value::Int(i64::from(handle.get())));
             }
@@ -1494,6 +1540,13 @@ impl RedHost {
                     .and_then(Value::as_str)
                     .unwrap_or(".")
                     .to_string(),
+                request_id,
+            },
+            "FileOperation" => PluginRequest::FileOperation {
+                operation: args
+                    .first()
+                    .map(value_to_json)
+                    .unwrap_or(serde_json::Value::Null),
                 request_id,
             },
             other => anyhow::bail!("unsupported Red host request: {other}"),
@@ -8906,6 +8959,123 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn neotree_emits_create_and_multi_item_delete_file_operations() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("neotree", include_str!("../../plugins/neotree.hk"))
+            .await
+            .unwrap();
+
+        runtime
+            .notify(
+                "panel:event:neotree",
+                serde_json::json!({
+                    "action": "a",
+                    "row": { "path": "./src", "kind": "directory" },
+                }),
+            )
+            .await
+            .unwrap();
+        let create_handle = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackInput {
+                owner,
+                handle,
+                title,
+                initial,
+            } => {
+                assert_eq!(owner, "neotree");
+                assert_eq!(title, "New file or directory (trailing /)");
+                assert_eq!(initial, "");
+                handle
+            }
+            _ => panic!("expected Neo-tree create prompt"),
+        };
+        runtime
+            .notify_composer(
+                create_handle,
+                ComposerCallback::Submitted("generated/".to_string()),
+            )
+            .unwrap();
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::FileOperation {
+                operation,
+                request_id,
+            } => {
+                assert_eq!(
+                    operation,
+                    serde_json::json!({
+                        "kind": "create_directory",
+                        "path": "./src/generated",
+                    })
+                );
+                assert!(request_id.get() > 0);
+            }
+            _ => panic!("expected Neo-tree create file operation"),
+        }
+
+        for path in ["./src/one.rs", "./src/two.rs"] {
+            runtime
+                .notify(
+                    "panel:event:neotree",
+                    serde_json::json!({
+                        "action": "Tab",
+                        "row": { "path": path, "kind": "file" },
+                    }),
+                )
+                .await
+                .unwrap();
+        }
+        runtime
+            .notify(
+                "panel:event:neotree",
+                serde_json::json!({
+                    "action": "d",
+                    "row": { "path": "./src/two.rs", "kind": "file" },
+                }),
+            )
+            .await
+            .unwrap();
+        let delete_handle = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackConfirmation {
+                handle,
+                title,
+                message,
+                owner,
+            } => {
+                assert_eq!(owner, "neotree");
+                assert_eq!(title, "Confirm delete");
+                assert_eq!(
+                    message,
+                    "Permanently delete selected items. This cannot be undone."
+                );
+                handle
+            }
+            _ => panic!("expected Neo-tree delete confirmation"),
+        };
+        let accept = serde_json::from_value(serde_json::json!({
+            "id": "accept",
+            "label": "Accept",
+        }))
+        .unwrap();
+        runtime
+            .notify_picker(delete_handle, PickerCallback::Selected(accept))
+            .unwrap();
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::FileOperation { operation, .. } => {
+                assert_eq!(operation["kind"], "delete");
+                assert_eq!(
+                    operation["paths"],
+                    serde_json::json!(["./src/one.rs", "./src/two.rs"])
+                );
+            }
+            _ => panic!("expected Neo-tree delete file operation"),
+        }
+    }
+
+    #[tokio::test]
     async fn neotree_reveals_the_active_file_and_renders_git_status() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
@@ -9020,6 +9190,11 @@ mod tests {
             PluginRequest::UpdatePanel { id, rows } => {
                 assert_eq!(id, "neotree");
                 assert_eq!(rows[2].id, "./src/main.rs");
+                assert_eq!(rows[1].segments[0].text, "  ");
+                assert_eq!(rows[1].segments[1].text, "  ");
+                assert_eq!(rows[2].segments[0].text, "  ");
+                assert_eq!(rows[2].segments[1].text, "  ");
+                assert_eq!(rows[2].segments[2].text, "└ ");
             }
             _ => panic!("unexpected plugin request"),
         }

--- a/src/ui/confirmation.rs
+++ b/src/ui/confirmation.rs
@@ -1,0 +1,249 @@
+//! Compact, reusable Accept/Cancel confirmation dialog.
+
+use crossterm::event::{Event, KeyCode, KeyModifiers};
+use serde_json::Value;
+
+use crate::{
+    config::KeyAction,
+    editor::{Action, Editor, PickerCallback, RenderBuffer},
+    plugin::PickerHandle,
+    theme::{Style, Theme},
+    unicode_utils::{display_width, truncate_display_width},
+};
+
+use super::{
+    dialog::{BorderStyle, Dialog},
+    Component, PickerItem,
+};
+
+const ACCEPT_LABEL: &str = "[ Accept ]";
+const CANCEL_LABEL: &str = "[ Cancel ]";
+const BUTTON_GAP: usize = 2;
+
+/// A two-line confirmation surface that defaults to the safe Cancel action.
+pub struct Confirmation {
+    dialog: Dialog,
+    message: String,
+    accept_selected: bool,
+    callback_handle: PickerHandle,
+    style: Style,
+    theme: Theme,
+}
+
+impl Confirmation {
+    pub fn new_callback(
+        editor: &Editor,
+        title: impl Into<String>,
+        message: impl Into<String>,
+        callback_handle: PickerHandle,
+    ) -> Self {
+        let title = title.into();
+        let message = message.into();
+        let style = editor.theme.ui_style.dialog.clone();
+        let border_style = editor.theme.ui_style.dialog_border.clone();
+        let title_style = editor.theme.ui_style.dialog_title.clone();
+        let width = confirmation_width(editor.vwidth(), &message);
+        let x = editor.vwidth().saturating_sub(width + 2) / 2;
+        let y = editor.vheight().saturating_sub(4) / 2;
+        Self {
+            dialog: Dialog::new(
+                Some(title),
+                x,
+                y,
+                width,
+                2,
+                &style,
+                BorderStyle::Single,
+                &editor.theme,
+            )
+            .with_border_draw_style(&border_style)
+            .with_title_style(&title_style),
+            message,
+            accept_selected: false,
+            callback_handle,
+            style,
+            theme: editor.theme.clone(),
+        }
+    }
+
+    fn terminal_action(&self, accepted: bool) -> KeyAction {
+        let callback = if accepted {
+            PickerCallback::Selected(PickerItem {
+                id: "accept".to_string(),
+                icon: None,
+                label: "Accept".to_string(),
+                kind: Some("Proceed".to_string()),
+                annotation: None,
+                detail: None,
+                data: Value::Null,
+                matches: Vec::new(),
+                detail_matches: Vec::new(),
+                preview: None,
+            })
+        } else {
+            PickerCallback::Cancelled
+        };
+        KeyAction::Multiple(vec![
+            Action::NotifyPicker(self.callback_handle, Box::new(callback)),
+            Action::CloseDialog,
+        ])
+    }
+}
+
+impl Component for Confirmation {
+    fn picker_handle(&self) -> Option<PickerHandle> {
+        Some(self.callback_handle)
+    }
+
+    fn set_theme(&mut self, theme: &Theme) {
+        self.style = theme.ui_style.dialog.clone();
+        self.dialog.style = theme.ui_style.dialog.clone();
+        self.dialog.border_draw_style = theme.ui_style.dialog_border.clone();
+        self.dialog.title_style = theme.ui_style.dialog_title.clone();
+        self.dialog.theme = theme.clone();
+        self.theme = theme.clone();
+    }
+
+    fn resize(&mut self, viewport_width: usize, viewport_height: usize) -> bool {
+        self.dialog.width = confirmation_width(viewport_width, &self.message);
+        self.dialog.x = viewport_width.saturating_sub(self.dialog.width + 2) / 2;
+        self.dialog.y = viewport_height.saturating_sub(4) / 2;
+        true
+    }
+
+    fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.dialog.draw(buffer)?;
+        let message = truncate_display_width(&self.message, self.dialog.width);
+        buffer.set_text(self.dialog.x + 1, self.dialog.y + 1, &message, &self.style);
+
+        let buttons_width = display_width(ACCEPT_LABEL) + BUTTON_GAP + display_width(CANCEL_LABEL);
+        let button_x = self.dialog.x + 1 + self.dialog.width.saturating_sub(buttons_width) / 2;
+        let selected = self.theme.selected_style(
+            &self.style,
+            &self.theme.ui_style.picker_selected_item,
+            crate::theme::SelectionForegroundPriority::Selection,
+        );
+        buffer.set_text(
+            button_x,
+            self.dialog.y + 2,
+            ACCEPT_LABEL,
+            if self.accept_selected {
+                &selected
+            } else {
+                &self.style
+            },
+        );
+        buffer.set_text(
+            button_x + display_width(ACCEPT_LABEL) + BUTTON_GAP,
+            self.dialog.y + 2,
+            CANCEL_LABEL,
+            if self.accept_selected {
+                &self.style
+            } else {
+                &selected
+            },
+        );
+        Ok(())
+    }
+
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        let Event::Key(key) = event else {
+            return None;
+        };
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                Some(self.terminal_action(false))
+            }
+            (KeyCode::Left | KeyCode::BackTab, _) => {
+                self.accept_selected = true;
+                Some(KeyAction::Single(Action::ShowDialog))
+            }
+            (KeyCode::Right | KeyCode::Tab, _) => {
+                self.accept_selected = false;
+                Some(KeyAction::Single(Action::ShowDialog))
+            }
+            (KeyCode::Char('y' | 'Y'), _) => Some(self.terminal_action(true)),
+            (KeyCode::Char('n' | 'N'), _) => Some(self.terminal_action(false)),
+            (KeyCode::Enter, _) => Some(self.terminal_action(self.accept_selected)),
+            _ => None,
+        }
+    }
+}
+
+fn confirmation_width(viewport_width: usize, message: &str) -> usize {
+    let desired = display_width(message)
+        .max(display_width(ACCEPT_LABEL) + BUTTON_GAP + display_width(CANCEL_LABEL));
+    desired.min(60).min(viewport_width.saturating_sub(2)).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyEvent, KeyModifiers};
+
+    use super::*;
+    use crate::{buffer::Buffer, config::Config, lsp::LspManager};
+
+    fn editor() -> Editor {
+        let config = Config::default();
+        Editor::with_size(
+            Box::new(LspManager::new(config.lsp.clone())),
+            80,
+            20,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+        )
+        .unwrap()
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn confirmation_defaults_to_cancel_and_can_accept_from_the_keyboard() {
+        let editor = editor();
+        let handle = PickerHandle::from_raw(7);
+        let mut confirmation =
+            Confirmation::new_callback(&editor, "Delete file?", "This cannot be undone.", handle);
+
+        assert_eq!(
+            confirmation.handle_event(&key(KeyCode::Enter)),
+            Some(KeyAction::Multiple(vec![
+                Action::NotifyPicker(handle, Box::new(PickerCallback::Cancelled)),
+                Action::CloseDialog,
+            ]))
+        );
+
+        confirmation.handle_event(&key(KeyCode::Left));
+        assert!(matches!(
+            confirmation.handle_event(&key(KeyCode::Enter)),
+            Some(KeyAction::Multiple(actions))
+                if matches!(
+                    actions.first(),
+                    Some(Action::NotifyPicker(
+                        callback_handle,
+                        event,
+                    )) if *callback_handle == handle
+                        && matches!(event.as_ref(), PickerCallback::Selected(item) if item.id == "accept")
+                )
+        ));
+    }
+
+    #[test]
+    fn confirmation_stays_compact_and_clips_long_messages() {
+        let editor = editor();
+        let confirmation = Confirmation::new_callback(
+            &editor,
+            "Delete?",
+            "A very long explanation that should stay inside a compact dialog instead of becoming a picker.",
+            PickerHandle::from_raw(1),
+        );
+        let mut buffer = RenderBuffer::new(80, 20, &Style::default());
+
+        confirmation.draw(&mut buffer).unwrap();
+
+        assert_eq!(confirmation.dialog.height, 2);
+        assert!(confirmation.dialog.width <= 60);
+    }
+}

--- a/src/ui/input_prompt.rs
+++ b/src/ui/input_prompt.rs
@@ -10,7 +10,8 @@ use crossterm::event::{Event, KeyCode, KeyModifiers};
 
 use crate::{
     config::KeyAction,
-    editor::{Action, Editor, RenderBuffer},
+    editor::{Action, ComposerCallback, Editor, RenderBuffer},
+    plugin::ComposerHandle,
     theme::{Style, Theme},
     unicode_utils::{display_width, grapheme_len, grapheme_to_byte, truncate_display_width},
 };
@@ -31,6 +32,7 @@ pub struct InputPrompt {
     selected: bool,
     masked: bool,
     submit: SubmitAction,
+    callback_handle: Option<ComposerHandle>,
     style: Style,
     theme: Theme,
 }
@@ -68,6 +70,7 @@ impl InputPrompt {
             value,
             masked: false,
             submit: Box::new(submit),
+            callback_handle: None,
             style,
             theme: editor.theme.clone(),
         }
@@ -85,6 +88,21 @@ impl InputPrompt {
         prompt
     }
 
+    /// Builds a plugin-owned single-line prompt using the same callback lifecycle as
+    /// [`crate::ui::AgentComposer`].
+    pub fn new_callback(
+        editor: &Editor,
+        title: impl Into<String>,
+        initial: impl Into<String>,
+        handle: ComposerHandle,
+    ) -> Self {
+        let mut prompt = Self::new(editor, title, initial, move |value| {
+            Action::NotifyComposer(handle, Box::new(ComposerCallback::Submitted(value)))
+        });
+        prompt.callback_handle = Some(handle);
+        prompt
+    }
+
     fn insert(&mut self, text: &str) {
         let text = text.split(['\r', '\n']).next().unwrap_or_default();
         if self.selected {
@@ -99,6 +117,10 @@ impl InputPrompt {
 }
 
 impl Component for InputPrompt {
+    fn composer_handle(&self) -> Option<ComposerHandle> {
+        self.callback_handle
+    }
+
     fn set_theme(&mut self, theme: &Theme) {
         self.style = theme.ui_style.dialog.clone();
         self.dialog.style = theme.ui_style.dialog.clone();
@@ -143,17 +165,18 @@ impl Component for InputPrompt {
             }
             Event::Key(key) => match (key.code, key.modifiers) {
                 (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
-                    Some(KeyAction::Single(Action::CloseDialog))
+                    Some(self.cancel_action())
                 }
                 (KeyCode::Enter, _) => {
                     let value = self.value.trim().to_string();
                     if value.is_empty() {
-                        return Some(KeyAction::Single(Action::CloseDialog));
+                        return Some(self.cancel_action());
                     }
-                    Some(KeyAction::Multiple(vec![
-                        Action::CloseDialog,
-                        (self.submit)(value),
-                    ]))
+                    let submit = (self.submit)(value);
+                    if self.callback_handle.is_some() {
+                        return Some(KeyAction::Multiple(vec![submit, Action::CloseDialog]));
+                    }
+                    Some(KeyAction::Multiple(vec![Action::CloseDialog, submit]))
                 }
                 (KeyCode::Left, _) => {
                     self.selected = false;
@@ -221,6 +244,19 @@ impl Component for InputPrompt {
         };
         let x = self.dialog.x + 1 + offset;
         Some((x, self.dialog.y + 1))
+    }
+}
+
+impl InputPrompt {
+    fn cancel_action(&self) -> KeyAction {
+        if let Some(handle) = self.callback_handle {
+            KeyAction::Multiple(vec![
+                Action::NotifyComposer(handle, Box::new(ComposerCallback::Cancelled)),
+                Action::CloseDialog,
+            ])
+        } else {
+            KeyAction::Single(Action::CloseDialog)
+        }
     }
 }
 
@@ -322,6 +358,36 @@ mod tests {
         assert_eq!(
             prompt.handle_event(&key(KeyCode::Esc)),
             Some(KeyAction::Single(Action::CloseDialog))
+        );
+    }
+
+    #[test]
+    fn callback_input_uses_composer_lifecycle_and_preserves_a_trailing_slash() {
+        let editor = editor();
+        let handle = ComposerHandle::from_raw(9);
+        let mut prompt = InputPrompt::new_callback(&editor, "New path", "", handle);
+
+        prompt.handle_event(&Event::Paste("nested/".to_string()));
+
+        assert_eq!(prompt.composer_handle(), Some(handle));
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Enter)),
+            Some(KeyAction::Multiple(vec![
+                Action::NotifyComposer(
+                    handle,
+                    Box::new(ComposerCallback::Submitted("nested/".to_string()))
+                ),
+                Action::CloseDialog,
+            ]))
+        );
+
+        let mut cancelled = InputPrompt::new_callback(&editor, "New path", "", handle);
+        assert_eq!(
+            cancelled.handle_event(&key(KeyCode::Esc)),
+            Some(KeyAction::Multiple(vec![
+                Action::NotifyComposer(handle, Box::new(ComposerCallback::Cancelled)),
+                Action::CloseDialog,
+            ]))
         );
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@
 
 mod agent_composer;
 mod completion;
+mod confirmation;
 mod dialog;
 mod file_picker;
 mod hover_info;
@@ -20,6 +21,7 @@ mod picker;
 pub use agent_composer::AgentComposer;
 pub(crate) use agent_composer::{normalize_newlines, wrap_text};
 pub use completion::CompletionUI;
+pub use confirmation::Confirmation;
 use crossterm::event::{Event, KeyCode, MouseEvent, MouseEventKind};
 use dialog::Dialog;
 pub use file_picker::FilePicker;

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -4610,6 +4610,35 @@ fn focused_panel_allows_ctrl_e_neotree_toggle() {
 }
 
 #[test]
+fn focused_row_panel_forwards_file_operation_keys_to_its_plugin() {
+    let buffer = Buffer::new(None, "abcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    add_tree_panel(&mut harness);
+    assert!(harness.editor.test_focus_panel("tree"));
+
+    for (code, modifiers, expected) in [
+        (KeyCode::Char('a'), KeyModifiers::NONE, "a"),
+        (KeyCode::Char('x'), KeyModifiers::NONE, "x"),
+        (KeyCode::Tab, KeyModifiers::NONE, "Tab"),
+        (KeyCode::Char('r'), KeyModifiers::CONTROL, "Ctrl-r"),
+    ] {
+        let action = harness
+            .editor
+            .test_handle_event(Event::Key(KeyEvent::new(code, modifiers)))
+            .unwrap();
+        assert!(matches!(
+            action,
+            Some(KeyAction::Multiple(actions))
+                if actions.iter().any(|action| matches!(
+                    action,
+                    Action::NotifyPlugins(name, payload)
+                        if name == "panel:event:tree" && payload["action"] == expected
+                ))
+        ));
+    }
+}
+
+#[test]
 fn focused_agent_panel_keeps_leader_available_until_the_composer_is_focused() {
     let buffer = Buffer::new(None, "abcdef".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());


### PR DESCRIPTION
Neo-tree was limited to browsing and used a full-height picker for path entry, making routine file management awkward and destructive actions unclear.

This adds workspace-confined file operations to the plugin host and exposes them through the bundled Neo-tree:

- create files and directories, including trailing-slash directories and bounded brace expansion
- rename, rename basenames, copy, move, multi-select, cut/copy/paste, delete, system trash, supported trash restoration, and file details
- reuse the compact LSP-style input for paths and add a compact Accept/Cancel confirmation that defaults to Cancel
- keep open buffers and LSP document identities coherent when files move or are removed
- refresh the tree after mutations and keep child guide lines aligned with parent icons
- document the new APIs as Red host API 0.4.0

Filesystem mutations reject absolute paths, parent traversal, workspace-root changes, symlink escapes, self/descendant copies, and implicit overwrites.

## How to Test

1. Open a workspace, run `NeoTree`, focus a directory, press `a`, and enter `generated/`. A directory should be created and the tree should refresh with correctly aligned child guides.
2. Use `Tab` to select multiple entries, then exercise `y`/`x` and `p`, direct copy/move, rename, and file details. Open buffers should retain unsaved contents when their backing path is moved or deleted.
3. Press `d` or `T`. The compact confirmation should initially select Cancel; Enter or Escape must leave files untouched, while selecting Accept performs the operation.
4. Run `cargo test neotree --lib`, `cargo test plugin::filesystem::tests --lib`, `cargo test ui::input_prompt::tests --lib`, and `cargo test ui::confirmation::tests --lib`. All targeted tests should pass.
