### PR TITLE
feat(husk): add generic specialization and grouped imports

### DIFF
--- a/crates/husk-cli/src/adapter_build.rs
+++ b/crates/husk-cli/src/adapter_build.rs
@@ -9,9 +9,10 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use std::collections::{HashMap, HashSet, VecDeque};
+
 use anyhow::Context;
-#[cfg(target_os = "linux")]
-use nix::sys::resource::{Resource, setrlimit};
 #[cfg(unix)]
 use nix::{
     sys::signal::{Signal, killpg},
@@ -532,6 +533,7 @@ fn configure_environment(
     command
         .current_dir(build)
         .env_clear()
+        .env("CARGO_BUILD_JOBS", "1")
         .env("CARGO_HOME", cargo_home)
         .env("CARGO_INCREMENTAL", "0")
         .env("CARGO_NET_OFFLINE", (!allow_network).to_string())
@@ -541,6 +543,29 @@ fn configure_environment(
         .env("RUSTC", &toolchain.rustc)
         .env("SOURCE_DATE_EPOCH", "1")
         .env("TMPDIR", build.join("tmp"));
+
+    #[cfg(target_os = "macos")]
+    configure_macos_toolchain(command);
+}
+
+#[cfg(target_os = "macos")]
+fn configure_macos_toolchain(command: &mut Command) {
+    let sdk = env::var_os("SDKROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"));
+    if sdk.is_dir() {
+        command.env("SDKROOT", sdk);
+    }
+
+    // The `/usr/bin/cc` shim invokes xcrun, whose global cache is intentionally
+    // outside the adapter sandbox. Invoke the installed compiler directly.
+    let clang = Path::new("/Library/Developer/CommandLineTools/usr/bin/clang");
+    if clang.is_file() {
+        command
+            .env("CC", clang)
+            .env("CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER", clang)
+            .env("CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER", clang);
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -679,19 +704,10 @@ fn run_bounded(
     let stderr_path = directory.join("command.stderr");
     let stdout = File::create(&stdout_path).context("create bounded command stdout")?;
     let stderr = File::create(&stderr_path).context("create bounded command stderr")?;
-    let baseline = user_resource_usage()?;
-    let process_ceiling = baseline.processes.saturating_add(options.max_processes);
     command
         .process_group(0)
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
-    // SAFETY: the closure only performs the async-signal-safe setrlimit syscall.
-    unsafe {
-        command.pre_exec(move || {
-            set_process_ceiling(process_ceiling)?;
-            Ok(())
-        });
-    }
     let mut child = command
         .spawn()
         .with_context(|| format!("{description}: launch process"))?;
@@ -711,19 +727,22 @@ fn run_bounded(
                 options.max_output_bytes
             );
         }
-        let usage = user_resource_usage()?;
-        if usage.resident_bytes
-            > baseline
-                .resident_bytes
-                .saturating_add(options.max_memory_bytes)
-        {
+        let usage = match process_tree_resource_usage(child.id()) {
+            Ok(usage) => usage,
+            Err(error) => {
+                terminate(&mut child);
+                return Err(error)
+                    .with_context(|| format!("{description}: inspect build process tree"));
+            }
+        };
+        if usage.resident_bytes > options.max_memory_bytes {
             terminate(&mut child);
             anyhow::bail!(
                 "{description} exceeded the {} byte aggregate resident memory limit",
                 options.max_memory_bytes
             );
         }
-        if usage.processes > baseline.processes.saturating_add(options.max_processes) {
+        if usage.processes > options.max_processes {
             terminate(&mut child);
             anyhow::bail!(
                 "{description} exceeded the {} process limit",
@@ -820,65 +839,106 @@ fn run_bounded_windows(
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-struct UserResourceUsage {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProcessSnapshot {
+    pid: u32,
+    parent_pid: u32,
+    process_group: u32,
+    resident_bytes: u64,
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ProcessTreeResourceUsage {
     processes: u64,
     resident_bytes: u64,
 }
 
-#[cfg(target_os = "linux")]
-fn user_resource_usage() -> anyhow::Result<UserResourceUsage> {
-    // SAFETY: getuid has no preconditions.
-    let user = unsafe { nix::libc::getuid() }.to_string();
-    let mut tasks = 0u64;
-    let mut resident_bytes = 0u64;
-    for entry in fs::read_dir("/proc").context("inspect Linux process table")? {
-        let entry = entry.context("read Linux process table entry")?;
-        if !entry
-            .file_name()
-            .to_string_lossy()
-            .bytes()
-            .all(|byte| byte.is_ascii_digit())
-        {
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn process_tree_resource_usage(root_pid: u32) -> anyhow::Result<ProcessTreeResourceUsage> {
+    let snapshots = process_snapshots()?;
+    Ok(measure_process_tree(root_pid, &snapshots))
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn measure_process_tree(root_pid: u32, snapshots: &[ProcessSnapshot]) -> ProcessTreeResourceUsage {
+    let mut children: HashMap<u32, Vec<&ProcessSnapshot>> = HashMap::new();
+    let mut pending = VecDeque::new();
+    for snapshot in snapshots {
+        children
+            .entry(snapshot.parent_pid)
+            .or_default()
+            .push(snapshot);
+        if snapshot.pid == root_pid || snapshot.process_group == root_pid {
+            pending.push_back(snapshot);
+        }
+    }
+
+    let mut visited = HashSet::new();
+    let mut usage = ProcessTreeResourceUsage::default();
+    while let Some(snapshot) = pending.pop_front() {
+        if !visited.insert(snapshot.pid) {
             continue;
         }
+        usage.processes = usage.processes.saturating_add(1);
+        usage.resident_bytes = usage.resident_bytes.saturating_add(snapshot.resident_bytes);
+        if let Some(descendants) = children.get(&snapshot.pid) {
+            pending.extend(descendants.iter().copied());
+        }
+    }
+    usage
+}
+
+#[cfg(target_os = "linux")]
+fn process_snapshots() -> anyhow::Result<Vec<ProcessSnapshot>> {
+    let mut snapshots = Vec::new();
+    for entry in fs::read_dir("/proc").context("inspect Linux process table")? {
+        let entry = entry.context("read Linux process table entry")?;
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        let stat = match fs::read_to_string(entry.path().join("stat")) {
+            Ok(stat) => stat,
+            Err(_) => continue,
+        };
+        let Some((parent_pid, process_group)) = linux_process_identity(&stat) else {
+            continue;
+        };
         let status = match fs::read_to_string(entry.path().join("status")) {
             Ok(status) => status,
             Err(_) => continue,
         };
-        let owned = status
+        let resident_bytes = status
             .lines()
-            .find_map(|line| line.strip_prefix("Uid:"))
-            .and_then(|uids| uids.split_whitespace().next())
-            == Some(user.as_str());
-        if owned {
-            for line in status.lines() {
-                if let Some(value) = line.strip_prefix("Threads:") {
-                    tasks = tasks.saturating_add(value.trim().parse::<u64>().unwrap_or(1));
-                } else if let Some(value) = line.strip_prefix("VmRSS:") {
-                    let kibibytes = value
-                        .split_whitespace()
-                        .next()
-                        .and_then(|value| value.parse::<u64>().ok())
-                        .unwrap_or(0);
-                    resident_bytes = resident_bytes.saturating_add(kibibytes.saturating_mul(1024));
-                }
-            }
-        }
+            .find_map(|line| line.strip_prefix("VmRSS:"))
+            .and_then(|value| value.split_whitespace().next())
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0)
+            .saturating_mul(1024);
+        snapshots.push(ProcessSnapshot {
+            pid,
+            parent_pid,
+            process_group,
+            resident_bytes,
+        });
     }
-    Ok(UserResourceUsage {
-        processes: tasks,
-        resident_bytes,
-    })
+    Ok(snapshots)
 }
 
-#[cfg(target_os = "linux")]
-fn set_process_ceiling(process_ceiling: u64) -> std::io::Result<()> {
-    setrlimit(Resource::RLIMIT_NPROC, process_ceiling, process_ceiling)
-        .map_err(std::io::Error::other)
+#[cfg(any(target_os = "linux", test))]
+fn linux_process_identity(stat: &str) -> Option<(u32, u32)> {
+    // Linux permits spaces and parentheses in `comm`, so split after the last
+    // closing parenthesis before reading state, parent PID, and process group.
+    let (_, fields) = stat.rsplit_once(')')?;
+    let mut fields = fields.split_whitespace();
+    fields.next()?;
+    let parent_pid = fields.next()?.parse().ok()?;
+    let process_group = fields.next()?.parse().ok()?;
+    Some((parent_pid, process_group))
 }
 
 #[cfg(target_os = "macos")]
-fn user_resource_usage() -> anyhow::Result<UserResourceUsage> {
+fn process_snapshots() -> anyhow::Result<Vec<ProcessSnapshot>> {
     const PROC_UID_ONLY: u32 = 4;
     // SAFETY: getuid has no preconditions.
     let uid = unsafe { nix::libc::getuid() };
@@ -899,16 +959,15 @@ fn user_resource_usage() -> anyhow::Result<UserResourceUsage> {
     anyhow::ensure!(bytes >= 0, "read macOS process table");
     pids.truncate(usize::try_from(bytes).unwrap_or(0) / pid_size);
 
-    let mut processes = 0u64;
-    let mut resident_bytes = 0u64;
+    let mut snapshots = Vec::with_capacity(pids.len());
     for pid in pids.into_iter().filter(|pid| *pid > 0) {
-        let mut task = std::mem::MaybeUninit::<nix::libc::proc_taskinfo>::uninit();
+        let mut task = std::mem::MaybeUninit::<nix::libc::proc_taskallinfo>::uninit();
         let task_size = i32::try_from(std::mem::size_of_val(&task)).unwrap_or(i32::MAX);
-        // SAFETY: `task` points to writable storage for one proc_taskinfo.
+        // SAFETY: `task` points to writable storage for one proc_taskallinfo.
         let read = unsafe {
             nix::libc::proc_pidinfo(
                 pid,
-                nix::libc::PROC_PIDTASKINFO,
+                nix::libc::PROC_PIDTASKALLINFO,
                 0,
                 task.as_mut_ptr().cast(),
                 task_size,
@@ -917,29 +976,15 @@ fn user_resource_usage() -> anyhow::Result<UserResourceUsage> {
         if read == task_size {
             // SAFETY: proc_pidinfo initialized the complete structure.
             let task = unsafe { task.assume_init() };
-            processes = processes.saturating_add(1);
-            resident_bytes = resident_bytes.saturating_add(task.pti_resident_size);
+            snapshots.push(ProcessSnapshot {
+                pid: task.pbsd.pbi_pid,
+                parent_pid: task.pbsd.pbi_ppid,
+                process_group: task.pbsd.pbi_pgid,
+                resident_bytes: task.ptinfo.pti_resident_size,
+            });
         }
     }
-    Ok(UserResourceUsage {
-        processes,
-        resident_bytes,
-    })
-}
-
-#[cfg(target_os = "macos")]
-fn set_process_ceiling(process_ceiling: u64) -> std::io::Result<()> {
-    let limit = nix::libc::rlimit {
-        rlim_cur: process_ceiling,
-        rlim_max: process_ceiling,
-    };
-    // SAFETY: `limit` is a valid rlimit value and setrlimit does not retain it.
-    let status = unsafe { nix::libc::setrlimit(nix::libc::RLIMIT_NPROC, &limit) };
-    if status == 0 {
-        Ok(())
-    } else {
-        Err(std::io::Error::last_os_error())
-    }
+    Ok(snapshots)
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -992,10 +1037,173 @@ fn display_status(status: ExitStatus) -> String {
     )
 }
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
 mod tests {
     use super::*;
 
+    fn snapshot(
+        pid: u32,
+        parent_pid: u32,
+        process_group: u32,
+        resident_bytes: u64,
+    ) -> ProcessSnapshot {
+        ProcessSnapshot {
+            pid,
+            parent_pid,
+            process_group,
+            resident_bytes,
+        }
+    }
+
+    fn bounded_test_options(max_processes: u64) -> BuildOptions {
+        BuildOptions {
+            allow_network: false,
+            timeout: Duration::from_secs(5),
+            max_output_bytes: 1024,
+            max_memory_bytes: 64 * 1024 * 1024,
+            max_processes,
+        }
+    }
+
+    struct BackgroundProcess(std::process::Child);
+
+    impl BackgroundProcess {
+        fn spawn() -> Self {
+            let child = Command::new("/bin/sleep")
+                .arg("5")
+                .process_group(0)
+                .spawn()
+                .expect("start isolated background process");
+            Self(child)
+        }
+    }
+
+    impl Drop for BackgroundProcess {
+        fn drop(&mut self) {
+            terminate(&mut self.0);
+        }
+    }
+
+    #[test]
+    fn process_tree_excludes_unrelated_user_processes_and_resident_memory() {
+        let snapshots = [
+            snapshot(91, 1, 91, u64::MAX),
+            snapshot(43, 42, 42, 30),
+            snapshot(42, 1, 42, 20),
+            snapshot(92, 91, 91, u64::MAX),
+        ];
+
+        assert_eq!(
+            measure_process_tree(42, &snapshots),
+            ProcessTreeResourceUsage {
+                processes: 2,
+                resident_bytes: 50,
+            }
+        );
+    }
+
+    #[test]
+    fn process_tree_includes_descendants_that_create_a_new_process_group() {
+        let snapshots = [
+            snapshot(44, 43, 43, 40),
+            snapshot(43, 42, 43, 30),
+            snapshot(42, 1, 42, 20),
+            snapshot(99, 1, 99, 1_000_000),
+        ];
+
+        assert_eq!(
+            measure_process_tree(42, &snapshots),
+            ProcessTreeResourceUsage {
+                processes: 3,
+                resident_bytes: 90,
+            }
+        );
+    }
+
+    #[test]
+    fn process_tree_keeps_tracking_reparented_members_of_the_build_group() {
+        let snapshots = [snapshot(43, 1, 42, 30), snapshot(42, 1, 42, 20)];
+
+        assert_eq!(
+            measure_process_tree(42, &snapshots),
+            ProcessTreeResourceUsage {
+                processes: 2,
+                resident_bytes: 50,
+            }
+        );
+    }
+
+    #[test]
+    fn bounded_build_ignores_unrelated_processes_owned_by_the_same_user() {
+        let _first_unrelated_process = BackgroundProcess::spawn();
+        let _second_unrelated_process = BackgroundProcess::spawn();
+        let directory = tempfile::tempdir().unwrap();
+        let mut command = Command::new("/bin/sleep");
+        command.arg("0.1");
+
+        run_bounded(
+            &mut command,
+            directory.path(),
+            &bounded_test_options(1),
+            "run process-tree isolation fixture",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn bounded_build_rejects_extra_processes_in_its_own_tree() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "/bin/sleep 5 & wait"]);
+
+        let error = run_bounded(
+            &mut command,
+            directory.path(),
+            &bounded_test_options(1),
+            "run process limit fixture",
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("process limit"), "{error:#}");
+    }
+
+    #[test]
+    fn bounded_build_rejects_memory_used_by_its_own_process_tree() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut command = Command::new("/bin/sleep");
+        command.arg("1");
+        let options = BuildOptions {
+            max_memory_bytes: 1,
+            ..bounded_test_options(1)
+        };
+
+        let error = run_bounded(
+            &mut command,
+            directory.path(),
+            &options,
+            "run memory limit fixture",
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("memory limit"), "{error:#}");
+    }
+
+    #[test]
+    fn linux_process_identity_handles_spaces_and_parentheses_in_command_names() {
+        assert_eq!(
+            linux_process_identity("42 (cargo (build script)) S 12 34 56"),
+            Some((12, 34))
+        );
+    }
+
+    #[test]
+    fn linux_process_identity_rejects_malformed_process_table_entries() {
+        for stat in ["", "42 cargo S 12 34", "42 (cargo) S", "42 (cargo) S x 34"] {
+            assert!(linux_process_identity(stat).is_none(), "{stat}");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
     #[test]
     fn sandbox_profile_denies_network_and_limits_writes_to_build_root() {
         let profile = sandbox_profile(

--- a/crates/husk-cli/src/adapter_install.rs
+++ b/crates/husk-cli/src/adapter_install.rs
@@ -73,6 +73,7 @@ pub(crate) fn install(
             version: identity.version.clone(),
             source: relative_bundle.clone(),
             sha256: digest.clone(),
+            report_sha256: Some(hex_digest(report)),
             crate_source: Some(LockedCrateExtension {
                 package: source.declaration.package.clone(),
                 version: identity.version.clone(),
@@ -80,6 +81,7 @@ pub(crate) fn install(
                 features: source.declaration.features.clone(),
                 default_features: source.declaration.default_features,
                 include: source.declaration.include.clone(),
+                specializations: source.declaration.specializations.clone(),
                 checksum: source.checksum.clone(),
             }),
             artifact: Some(vendored_bundle.clone()),
@@ -273,6 +275,15 @@ fn updated_manifest_source(
             .collect::<toml_edit::Array>();
         extension.insert("include", value(include));
     }
+    if !source.specializations.is_empty() {
+        let specializations = source
+            .specializations
+            .iter()
+            .cloned()
+            .map(toml_edit::Value::from)
+            .collect::<toml_edit::Array>();
+        extension.insert("specializations", value(specializations));
+    }
     extensions.insert(name, Item::Table(extension));
     Ok(document.to_string())
 }
@@ -426,7 +437,7 @@ fn package_lock_from_source(source: &str) -> anyhow::Result<PackageLock> {
     PackageLock::parse(source).context("parse Husk.lock")
 }
 
-fn hex_digest(component: &[u8]) -> String {
+pub(crate) fn hex_digest(component: &[u8]) -> String {
     let digest = Sha256::digest(component);
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
@@ -473,6 +484,7 @@ mod tests {
                 features: vec!["fast".to_string()],
                 default_features: false,
                 include: vec!["sample_crate::run".to_string()],
+                specializations: vec!["sample_crate::run<sample_crate::Payload>".to_string()],
             },
             checksum: Some("crate-checksum".to_string()),
         }
@@ -500,6 +512,10 @@ mod tests {
         assert!(manifest.contains("[extensions.sample-crate]"), "{manifest}");
         assert!(manifest.contains("crate = \"sample-crate\""), "{manifest}");
         assert!(manifest.contains("version = \"^1.2\""), "{manifest}");
+        assert!(
+            manifest.contains("sample_crate::run<sample_crate::Payload>"),
+            "{manifest}"
+        );
         assert!(!manifest.contains(&installed.digest), "{manifest}");
         assert!(
             directory
@@ -511,6 +527,11 @@ mod tests {
         let lock = fs::read_to_string(directory.path().join("Husk.lock")).unwrap();
         assert!(lock.contains("[extensions.sample-crate]"), "{lock}");
         assert!(lock.contains(&installed.digest), "{lock}");
+        assert!(lock.contains("report_sha256"), "{lock}");
+        assert!(
+            lock.contains("sample_crate::run<sample_crate::Payload>"),
+            "{lock}"
+        );
         let package =
             ResolvedPackage::open(directory.path().join("Husk.toml"), PackageLimits::default())
                 .unwrap();
@@ -636,6 +657,45 @@ mod tests {
             .unwrap(),
             original_component
         );
+    }
+
+    #[test]
+    fn install_rejects_a_tampered_adapter_report_without_replacing_working_state() {
+        let directory = package();
+        let installed = install(
+            &directory.path().join("Husk.toml"),
+            &identity(),
+            b"verified component",
+            b"{\"selection\":\"automatic\"}\n",
+            &source(),
+            false,
+        )
+        .unwrap();
+        let installed_report_path = directory
+            .path()
+            .join(&installed.bundle)
+            .join("husk-adapter.json");
+        let original_report = fs::read(&installed_report_path).unwrap();
+        let vendored_report = directory
+            .path()
+            .join("vendor/husk")
+            .join(format!("{}.huskext/husk-adapter.json", installed.digest));
+        fs::write(vendored_report, b"{\"selection\":\"tampered\"}\n").unwrap();
+
+        let error = crate::package_install::install(
+            &directory.path().join("Husk.toml"),
+            &crate::package_install::InstallOptions {
+                locked: true,
+                offline: true,
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("adapter selection report"),
+            "{error:#}"
+        );
+        assert_eq!(fs::read(installed_report_path).unwrap(), original_report);
     }
 
     #[test]

--- a/crates/husk-cli/src/generic_specialization.rs
+++ b/crates/husk-cli/src/generic_specialization.rs
@@ -1,0 +1,558 @@
+use std::fmt;
+
+use anyhow::{Context, bail};
+
+use crate::{
+    AdapterCallableInspection, AdapterResourceInspection, ApiItemInspection, PublicApiInspection,
+    WitCallableInspection,
+};
+
+const MAX_SPECIALIZATION_BYTES: usize = 4096;
+const MAX_TYPE_DEPTH: usize = 16;
+const SERDE_JSON_VALUE_PROFILE: &str = "serde_json/value@1";
+const SERDE_JSON_VALUE_SPECIALIZATIONS: [&str; 3] = [
+    "serde_json::from_str<serde_json::Value>",
+    "serde_json::to_string<serde_json::Value>",
+    "serde_json::to_string_pretty<serde_json::Value>",
+];
+
+/// One finite, ahead-of-time instantiation of a public Rust function.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct GenericSpecialization {
+    function: String,
+    type_arguments: Vec<SpecializationType>,
+}
+
+/// A validated Rust type that may appear in an adapter specialization.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct SpecializationType {
+    path: String,
+    arguments: Vec<Self>,
+}
+
+impl GenericSpecialization {
+    pub(crate) fn parse(source: &str) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            !source.is_empty() && source.len() <= MAX_SPECIALIZATION_BYTES,
+            "generic specialization must contain between 1 and {MAX_SPECIALIZATION_BYTES} bytes"
+        );
+        let mut parser = SpecializationParser::new(source);
+        let function = parser.parse_path().context("parse generic function path")?;
+        if parser.consume_str("::") {
+            anyhow::ensure!(
+                parser.peek() == Some('<'),
+                "expected `<` after the specialization turbofish"
+            );
+        }
+        let type_arguments = parser
+            .parse_type_arguments(0)
+            .context("parse generic type arguments")?;
+        parser.skip_whitespace();
+        anyhow::ensure!(
+            parser.is_finished(),
+            "unexpected trailing specialization input"
+        );
+        anyhow::ensure!(
+            !type_arguments.is_empty(),
+            "generic specialization must include at least one concrete type"
+        );
+        Ok(Self {
+            function,
+            type_arguments,
+        })
+    }
+
+    pub(crate) fn function(&self) -> &str {
+        &self.function
+    }
+
+    pub(crate) fn type_arguments(&self) -> &[SpecializationType] {
+        &self.type_arguments
+    }
+
+    pub(crate) fn canonical(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl fmt::Display for GenericSpecialization {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}<", self.function)?;
+        for (index, argument) in self.type_arguments.iter().enumerate() {
+            if index > 0 {
+                formatter.write_str(", ")?;
+            }
+            write!(formatter, "{argument}")?;
+        }
+        formatter.write_str(">")
+    }
+}
+
+impl SpecializationType {
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub(crate) fn arguments(&self) -> &[Self] {
+        &self.arguments
+    }
+}
+
+impl fmt::Display for SpecializationType {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.path)?;
+        if !self.arguments.is_empty() {
+            formatter.write_str("<")?;
+            for (index, argument) in self.arguments.iter().enumerate() {
+                if index > 0 {
+                    formatter.write_str(", ")?;
+                }
+                write!(formatter, "{argument}")?;
+            }
+            formatter.write_str(">")?;
+        }
+        Ok(())
+    }
+}
+
+/// Parse and canonicalize user input before it reaches generated Rust source.
+pub(crate) fn parse_specializations(
+    sources: &[String],
+) -> anyhow::Result<Vec<GenericSpecialization>> {
+    let mut specializations = sources
+        .iter()
+        .map(|source| {
+            GenericSpecialization::parse(source)
+                .with_context(|| format!("invalid generic specialization `{source}`"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    specializations.sort();
+    for pair in specializations.windows(2) {
+        anyhow::ensure!(
+            pair[0] != pair[1],
+            "duplicate generic specialization `{}`",
+            pair[0]
+        );
+    }
+    Ok(specializations)
+}
+
+/// Resolve user selections and provide a versioned, reproducible default.
+pub(crate) fn select_specializations(
+    crate_name: &str,
+    crate_version: &str,
+    requested: &[String],
+) -> anyhow::Result<Vec<GenericSpecialization>> {
+    let version = semver::Version::parse(crate_version)
+        .with_context(|| format!("invalid inspected crate version `{crate_version}`"))?;
+    let defaults = if requested.is_empty() && crate_name == "serde_json" && version.major == 1 {
+        SERDE_JSON_VALUE_SPECIALIZATIONS
+            .iter()
+            .map(|specialization| (*specialization).to_string())
+            .collect::<Vec<_>>()
+    } else {
+        requested.to_vec()
+    };
+    let specializations = parse_specializations(&defaults)?;
+    let crate_path = crate_name.replace('-', "_");
+    for specialization in &specializations {
+        anyhow::ensure!(
+            specialization
+                .function()
+                .strip_prefix(&crate_path)
+                .is_some_and(|suffix| suffix.starts_with("::")),
+            "generic specialization `{specialization}` does not belong to crate `{crate_name}`"
+        );
+    }
+    Ok(specializations)
+}
+
+/// Materialize validated Rust instantiations as portable, concrete WIT exports.
+pub(crate) fn apply_specializations(
+    public_api: &mut PublicApiInspection,
+    crate_name: &str,
+    crate_version: &str,
+    specializations: &[GenericSpecialization],
+) -> anyhow::Result<Option<String>> {
+    if specializations.is_empty() {
+        return Ok(None);
+    }
+    let version = semver::Version::parse(crate_version)
+        .with_context(|| format!("invalid inspected crate version `{crate_version}`"))?;
+    anyhow::ensure!(
+        crate_name == "serde_json" && version.major == 1,
+        "crate `{crate_name}` does not yet provide a portable lowering profile for generic specializations"
+    );
+
+    let mut items = Vec::with_capacity(specializations.len());
+    for specialization in specializations {
+        anyhow::ensure!(
+            specialization.type_arguments().len() == 1
+                && specialization.type_arguments()[0].path() == "serde_json::Value"
+                && specialization.type_arguments()[0].arguments().is_empty(),
+            "the `{SERDE_JSON_VALUE_PROFILE}` profile requires the concrete type `serde_json::Value`; got `{specialization}`"
+        );
+        let (kind, owner_resource, declaration, implementation, signature) = match specialization
+            .function()
+        {
+            "serde_json::from_str" => (
+                "function",
+                None,
+                "from-str-value: func(input: string) -> result<value, string>;",
+                "fn from_str_value(input: String) -> Result<Value, String> {\n    inspected::from_str::<inspected::Value>(&input)\n        .map(|value| Value::new(AdapterValue(value)))\n        .map_err(|error| error.to_string())\n}",
+                "fn serde_json::from_str<serde_json::Value>(input: &str) -> Result<serde_json::Value, serde_json::Error>",
+            ),
+            "serde_json::to_string" => (
+                "method",
+                Some("value"),
+                "to-string: func() -> result<string, string>;",
+                "fn to_string(&self) -> Result<String, String> {\n    inspected::to_string::<inspected::Value>(&self.0)\n        .map_err(|error| error.to_string())\n}",
+                "fn serde_json::to_string<serde_json::Value>(value: &serde_json::Value) -> Result<String, serde_json::Error>",
+            ),
+            "serde_json::to_string_pretty" => (
+                "method",
+                Some("value"),
+                "to-string-pretty: func() -> result<string, string>;",
+                "fn to_string_pretty(&self) -> Result<String, String> {\n    inspected::to_string_pretty::<inspected::Value>(&self.0)\n        .map_err(|error| error.to_string())\n}",
+                "fn serde_json::to_string_pretty<serde_json::Value>(value: &serde_json::Value) -> Result<String, serde_json::Error>",
+            ),
+            function => anyhow::bail!(
+                "the `{SERDE_JSON_VALUE_PROFILE}` profile has no portable lowering for `{function}`"
+            ),
+        };
+        let canonical = specialization.canonical();
+        items.push(ApiItemInspection {
+            path: canonical.clone(),
+            kind,
+            signature: signature.to_string(),
+            compatibility: "compatible",
+            reason: None,
+            specialization: Some(canonical),
+            wit: Some(WitCallableInspection {
+                owner_resource: owner_resource.map(str::to_string),
+                declaration: declaration.to_string(),
+                resources: vec!["value".to_string()],
+                resource_types: vec![AdapterResourceInspection {
+                    wit_name: "value".to_string(),
+                    rust_path: "serde_json::Value".to_string(),
+                }],
+                adapter: Some(AdapterCallableInspection {
+                    implementation: implementation.to_string(),
+                }),
+            }),
+        });
+    }
+
+    if public_api.status != "available" {
+        public_api.status = "available";
+        public_api.source = Some(format!("built-in {SERDE_JSON_VALUE_PROFILE} profile"));
+        public_api.unavailable_reason = None;
+    }
+    if !public_api
+        .resources
+        .iter()
+        .any(|resource| resource == "serde_json::Value")
+    {
+        public_api.resources.push("serde_json::Value".to_string());
+        public_api.resources.sort();
+    }
+    public_api.items.extend(items);
+    public_api
+        .items
+        .sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    public_api.compatible_items = public_api
+        .items
+        .iter()
+        .filter(|item| item.compatibility == "compatible")
+        .count();
+    public_api.specializable_items = public_api
+        .items
+        .iter()
+        .filter(|item| item.compatibility == "specializable")
+        .count();
+    public_api.incompatible_items =
+        public_api.items.len() - public_api.compatible_items - public_api.specializable_items;
+    Ok(Some(SERDE_JSON_VALUE_PROFILE.to_string()))
+}
+
+struct SpecializationParser<'a> {
+    source: &'a str,
+    position: usize,
+}
+
+impl<'a> SpecializationParser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            position: 0,
+        }
+    }
+
+    fn is_finished(&self) -> bool {
+        self.position == self.source.len()
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.source[self.position..].chars().next()
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.peek().is_some_and(char::is_whitespace) {
+            self.position += self.peek().map_or(0, char::len_utf8);
+        }
+    }
+
+    fn consume_str(&mut self, expected: &str) -> bool {
+        self.skip_whitespace();
+        if self.source[self.position..].starts_with(expected) {
+            self.position += expected.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn parse_identifier(&mut self) -> anyhow::Result<String> {
+        self.skip_whitespace();
+        let start = self.position;
+        let Some(first) = self.peek() else {
+            bail!("expected a Rust identifier");
+        };
+        anyhow::ensure!(
+            first == '_' || first.is_ascii_alphabetic(),
+            "expected a Rust identifier"
+        );
+        self.position += first.len_utf8();
+        while self
+            .peek()
+            .is_some_and(|character| character == '_' || character.is_ascii_alphanumeric())
+        {
+            self.position += 1;
+        }
+        Ok(self.source[start..self.position].to_string())
+    }
+
+    fn parse_path(&mut self) -> anyhow::Result<String> {
+        let mut path = self.parse_identifier()?;
+        loop {
+            let saved = self.position;
+            if !self.consume_str("::") {
+                break;
+            }
+            self.skip_whitespace();
+            if self.peek() == Some('<') {
+                self.position = saved;
+                break;
+            }
+            let next = self.parse_identifier()?;
+            path.push_str("::");
+            path.push_str(&next);
+        }
+        Ok(path)
+    }
+
+    fn parse_type_arguments(&mut self, depth: usize) -> anyhow::Result<Vec<SpecializationType>> {
+        anyhow::ensure!(
+            depth < MAX_TYPE_DEPTH,
+            "generic specialization exceeds the maximum type depth of {MAX_TYPE_DEPTH}"
+        );
+        anyhow::ensure!(self.consume_str("<"), "expected concrete type arguments");
+        let mut arguments = Vec::new();
+        loop {
+            self.skip_whitespace();
+            anyhow::ensure!(self.peek() != Some('>'), "empty type argument");
+            let path = self.parse_path()?;
+            let nested = if self.peek_after_whitespace() == Some('<') {
+                self.parse_type_arguments(depth + 1)?
+            } else {
+                Vec::new()
+            };
+            arguments.push(SpecializationType {
+                path,
+                arguments: nested,
+            });
+            if self.consume_str(">") {
+                break;
+            }
+            anyhow::ensure!(
+                self.consume_str(","),
+                "expected `,` or `>` in type arguments"
+            );
+        }
+        Ok(arguments)
+    }
+
+    fn peek_after_whitespace(&mut self) -> Option<char> {
+        self.skip_whitespace();
+        self.peek()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GenericSpecialization, SERDE_JSON_VALUE_PROFILE, apply_specializations,
+        parse_specializations, select_specializations,
+    };
+
+    #[test]
+    fn parses_and_canonicalizes_qualified_generic_specializations() {
+        let specialization =
+            GenericSpecialization::parse("serde_json::from_str::<serde_json::Value>").unwrap();
+
+        assert_eq!(specialization.function(), "serde_json::from_str");
+        assert_eq!(
+            specialization.type_arguments()[0].path(),
+            "serde_json::Value"
+        );
+        assert_eq!(
+            specialization.canonical(),
+            "serde_json::from_str<serde_json::Value>"
+        );
+    }
+
+    #[test]
+    fn preserves_nested_concrete_type_arguments() {
+        let specialization =
+            GenericSpecialization::parse("example::decode<Result<Vec<String>, example::Error>>")
+                .unwrap();
+
+        assert_eq!(
+            specialization.canonical(),
+            "example::decode<Result<Vec<String>, example::Error>>"
+        );
+        assert_eq!(specialization.type_arguments()[0].arguments().len(), 2);
+    }
+
+    #[test]
+    fn rejects_source_injection_and_incomplete_type_arguments() {
+        for source in [
+            "serde_json::from_str",
+            "serde_json::from_str<>",
+            "serde_json::from_str<Value>; panic!()",
+            "serde_json::from_str<&Value>",
+            "serde_json::from_str<Value,>",
+        ] {
+            assert!(GenericSpecialization::parse(source).is_err(), "{source}");
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_canonical_specializations() {
+        let error = parse_specializations(&[
+            "serde_json::from_str<serde_json::Value>".to_string(),
+            "serde_json::from_str::<serde_json::Value>".to_string(),
+        ])
+        .unwrap_err();
+
+        assert!(error.to_string().contains("duplicate"), "{error:#}");
+    }
+
+    #[test]
+    fn automatically_selects_the_versioned_serde_json_value_profile() {
+        let specializations = select_specializations("serde_json", "1.0.151", &[]).unwrap();
+
+        assert_eq!(
+            specializations
+                .iter()
+                .map(GenericSpecialization::canonical)
+                .collect::<Vec<_>>(),
+            [
+                "serde_json::from_str<serde_json::Value>",
+                "serde_json::to_string<serde_json::Value>",
+                "serde_json::to_string_pretty<serde_json::Value>",
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_specializations_from_a_different_crate() {
+        let error = select_specializations(
+            "serde_json",
+            "1.0.151",
+            &["another_crate::decode<serde_json::Value>".to_string()],
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("does not belong"), "{error:#}");
+    }
+
+    #[test]
+    fn rejects_unversioned_or_unsupported_serde_json_lowerings() {
+        let specializations =
+            parse_specializations(&["serde_json::from_str<serde_json::Map>".to_string()]).unwrap();
+        let mut public_api = crate::unavailable_public_api("fixture has no Rustdoc cache");
+        let error =
+            apply_specializations(&mut public_api, "serde_json", "1.0.151", &specializations)
+                .unwrap_err();
+
+        assert!(error.to_string().contains("serde_json::Value"), "{error:#}");
+        assert_eq!(public_api.status, "unavailable");
+    }
+
+    #[test]
+    fn serde_json_profile_generates_valid_wit_and_concrete_guest_code() {
+        let specializations = select_specializations("serde_json", "1.0.151", &[]).unwrap();
+        let mut public_api = crate::unavailable_public_api("fixture has no Rustdoc cache");
+        let profile =
+            apply_specializations(&mut public_api, "serde_json", "1.0.151", &specializations)
+                .unwrap();
+
+        assert_eq!(profile.as_deref(), Some(SERDE_JSON_VALUE_PROFILE));
+        assert_eq!(public_api.status, "available");
+        assert_eq!(public_api.compatible_items, 3);
+        assert_eq!(public_api.resources, ["serde_json::Value"]);
+
+        let inspection = crate::CrateInspection {
+            name: "serde_json".to_string(),
+            version: "1.0.151".to_string(),
+            source: "registry+https://github.com/rust-lang/crates.io-index".to_string(),
+            rust_version: None,
+            license: None,
+            repository: None,
+            enabled_features: vec!["std".to_string(), "preserve_order".to_string()],
+            available_features: vec!["std".to_string(), "preserve_order".to_string()],
+            targets: Vec::new(),
+            has_library: true,
+            has_build_script: false,
+            native_links: None,
+            readiness: "ready-for-adapter-design",
+            blockers: Vec::new(),
+            warnings: Vec::new(),
+            next_step: "generate adapter",
+            specialization_profile: profile,
+            specializations: specializations
+                .iter()
+                .map(GenericSpecialization::canonical)
+                .collect(),
+            public_api,
+        };
+        let generated = crate::render_adapter_package(&inspection, &[]).unwrap();
+
+        wit_parser::Resolve::default()
+            .push_str("serde-json.wit", &generated.wit)
+            .unwrap();
+        assert!(generated.wit.contains("resource value {"));
+        assert!(
+            generated
+                .wit
+                .contains("from-str-value: func(input: string)")
+        );
+        assert!(generated.wit.contains("to-string-pretty: func()"));
+        assert!(
+            generated
+                .source
+                .contains("inspected::from_str::<inspected::Value>(&input)")
+        );
+        assert!(
+            generated
+                .source
+                .contains("inspected::to_string_pretty::<inspected::Value>(&self.0)")
+        );
+        assert!(generated.manifest.contains("\"preserve_order\""));
+        let report: serde_json::Value = serde_json::from_str(&generated.report).unwrap();
+        assert_eq!(report["specialization_profile"], SERDE_JSON_VALUE_PROFILE);
+        assert_eq!(report["specializations"].as_array().unwrap().len(), 3);
+        assert_eq!(report["items"].as_array().unwrap().len(), 3);
+    }
+}

--- a/crates/husk-cli/src/lib.rs
+++ b/crates/husk-cli/src/lib.rs
@@ -1,5 +1,6 @@
 mod adapter_build;
 mod adapter_install;
+mod generic_specialization;
 mod package_install;
 mod package_new;
 
@@ -16,6 +17,7 @@ use std::{
 
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
+use generic_specialization::GenericSpecialization;
 use husk::{
     CallContext, CompiledModule, Engine, MainArguments, MainResult, NativeError, NativeModule,
     OwnedValue, PackageLimits, ReplOutcome, ResolvedPackage, TestExpectation, Version,
@@ -224,6 +226,9 @@ struct CrateRequest {
     /// Cargo features to enable.
     #[arg(long, value_delimiter = ',')]
     features: Vec<String>,
+    /// Instantiate a public generic Rust function with concrete types.
+    #[arg(long = "specialize", value_name = "FUNCTION<T>")]
+    specializations: Vec<String>,
     /// Disable the crate's default feature set.
     #[arg(long)]
     no_default_features: bool,
@@ -579,10 +584,14 @@ fn execute_extension(command: ExtensionCommand) -> anyhow::Result<ExitCode> {
             }
             for interface in &descriptor.interfaces {
                 for function in &interface.functions {
-                    println!(
-                        "export: {}::{}::{}",
-                        descriptor.name, interface.name, function.name
-                    );
+                    if interface.name == descriptor.name.as_str() {
+                        println!("export: {}::{}", descriptor.name, function.name);
+                    } else {
+                        println!(
+                            "export: {}::{}::{}",
+                            descriptor.name, interface.name, function.name
+                        );
+                    }
                 }
             }
             Ok(ExitCode::SUCCESS)
@@ -882,6 +891,10 @@ struct CrateInspection {
     blockers: Vec<String>,
     warnings: Vec<String>,
     next_step: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    specialization_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    specializations: Vec<String>,
     public_api: PublicApiInspection,
 }
 
@@ -893,6 +906,7 @@ struct PublicApiInspection {
     unavailable_reason: Option<String>,
     resources: Vec<String>,
     compatible_items: usize,
+    specializable_items: usize,
     incompatible_items: usize,
     items: Vec<ApiItemInspection>,
 }
@@ -904,6 +918,8 @@ struct ApiItemInspection {
     signature: String,
     compatibility: &'static str,
     reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    specialization: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     wit: Option<WitCallableInspection>,
 }
@@ -957,14 +973,23 @@ fn execute_add(
     let mut include = includes.to_vec();
     include.sort();
     include.dedup();
+    let report = inspect_crate(CrateInspectOptions {
+        crate_name: request.crate_name.clone(),
+        version: request.version.clone(),
+        features: request.features.clone(),
+        specializations: request.specializations.clone(),
+        no_default_features: request.no_default_features,
+        path: request.path.clone(),
+        offline,
+    })?;
     let source = husk::CrateExtensionSource {
         package: request.crate_name.clone(),
         version: request.version.clone().unwrap_or_else(|| "*".to_string()),
         features,
         default_features: !request.no_default_features,
         include,
+        specializations: report.specializations.clone(),
     };
-    let report = inspect_crate(request.into())?;
     let generated = tempfile::tempdir().context("create temporary adapter workspace")?;
     let adapter = generated.path().join("adapter");
     write_adapter_package(&report, includes, &adapter)?;
@@ -1143,6 +1168,7 @@ struct CrateInspectOptions {
     crate_name: String,
     version: Option<String>,
     features: Vec<String>,
+    specializations: Vec<String>,
     no_default_features: bool,
     path: Option<PathBuf>,
     offline: bool,
@@ -1154,6 +1180,7 @@ impl From<CrateRequest> for CrateInspectOptions {
             crate_name: request.crate_name,
             version: request.version,
             features: request.features,
+            specializations: request.specializations,
             no_default_features: request.no_default_features,
             path: request.path,
             offline: request.offline,
@@ -1293,10 +1320,21 @@ fn inspect_crate(options: CrateInspectOptions) -> anyhow::Result<CrateInspection
             "the crate links native library `{links}`; portable wasm compatibility is unproven"
         ));
     }
-    let public_api = inspect_public_api(package, options.offline, options.path.is_some());
+    let mut public_api = inspect_public_api(package, options.offline, options.path.is_some());
     if let Some(reason) = &public_api.unavailable_reason {
         warnings.push(format!("public API analysis is unavailable: {reason}"));
     }
+    let specializations = generic_specialization::select_specializations(
+        &package.name,
+        &package.version,
+        &options.specializations,
+    )?;
+    let specialization_profile = generic_specialization::apply_specializations(
+        &mut public_api,
+        &package.name,
+        &package.version,
+        &specializations,
+    )?;
     let api_analyzed = public_api.status == "available";
 
     Ok(CrateInspection {
@@ -1329,6 +1367,11 @@ fn inspect_crate(options: CrateInspectOptions) -> anyhow::Result<CrateInspection
         } else {
             "extract and classify the crate's public Rust API"
         },
+        specialization_profile,
+        specializations: specializations
+            .iter()
+            .map(GenericSpecialization::canonical)
+            .collect(),
         public_api,
     })
 }
@@ -1440,6 +1483,7 @@ fn unavailable_public_api(reason: &str) -> PublicApiInspection {
         unavailable_reason: Some(reason.to_string()),
         resources: Vec::new(),
         compatible_items: 0,
+        specializable_items: 0,
         incompatible_items: 0,
         items: Vec::new(),
     }
@@ -1576,7 +1620,11 @@ fn analyze_rustdoc_json(
         .iter()
         .filter(|item| item.compatibility == "compatible")
         .count();
-    let incompatible_items = items.len() - compatible_items;
+    let specializable_items = items
+        .iter()
+        .filter(|item| item.compatibility == "specializable")
+        .count();
+    let incompatible_items = items.len() - compatible_items - specializable_items;
 
     Ok(PublicApiInspection {
         status: "available",
@@ -1587,6 +1635,7 @@ fn analyze_rustdoc_json(
         unavailable_reason: None,
         resources: resources.into_iter().collect(),
         compatible_items,
+        specializable_items,
         incompatible_items,
         items,
     })
@@ -1848,12 +1897,17 @@ fn classify_callable(
         .and_then(serde_json::Value::as_array)
         .is_some_and(|params| !params.is_empty())
     {
-        return incompatible_api_item(
-            path,
+        return ApiItemInspection {
+            path: path.to_string(),
             kind,
             signature,
-            "generic or lifetime parameters are not supported",
-        );
+            compatibility: "specializable",
+            reason: Some(
+                "generic Rust API requires a concrete --specialize instantiation".to_string(),
+            ),
+            specialization: None,
+            wit: None,
+        };
     }
     for input in inputs {
         let Some(parts) = input.as_array() else {
@@ -1896,6 +1950,7 @@ fn classify_callable(
             signature,
             compatibility: "compatible",
             reason: None,
+            specialization: None,
             wit: Some(wit),
         },
         Err(reason) => incompatible_api_item(path, kind, signature, &reason),
@@ -1914,6 +1969,7 @@ fn incompatible_api_item(
         signature,
         compatibility: "incompatible",
         reason: Some(reason.to_string()),
+        specialization: None,
         wit: None,
     }
 }
@@ -2750,12 +2806,22 @@ fn print_crate_inspection(report: &CrateInspection) {
     for warning in &report.warnings {
         println!("warning: {warning}");
     }
+    if let Some(profile) = &report.specialization_profile {
+        println!("specialization-profile: {profile}");
+    }
+    for specialization in &report.specializations {
+        println!("specialization: {specialization}");
+    }
     println!("public-api: {}", report.public_api.status);
     if let Some(source) = &report.public_api.source {
         println!("public-api-source: {source}");
         println!(
             "compatible-api-items: {}",
             report.public_api.compatible_items
+        );
+        println!(
+            "specializable-api-items: {}",
+            report.public_api.specializable_items
         );
         println!(
             "incompatible-api-items: {}",
@@ -2913,10 +2979,12 @@ fn render_adapter_package(
             .items
             .iter()
             .filter(|item| {
-                item.wit
-                    .as_ref()
-                    .and_then(|mapping| mapping.adapter.as_ref())
-                    .is_some()
+                (report.specialization_profile.is_none() || item.specialization.is_some())
+                    && item
+                        .wit
+                        .as_ref()
+                        .and_then(|mapping| mapping.adapter.as_ref())
+                        .is_some()
             })
             .collect::<Vec<_>>();
         selected.sort_unstable_by(|left, right| left.path.cmp(&right.path));
@@ -3078,6 +3146,8 @@ fn render_adapter_package(
         "crate": report.name,
         "version": report.version,
         "features": report.enabled_features,
+        "specialization_profile": report.specialization_profile,
+        "specializations": report.specializations,
         "selection": if includes.is_empty() { "automatic" } else { "explicit" },
         "items": selected,
         "skipped": skipped,
@@ -3524,6 +3594,7 @@ mod tests {
             crate_name: "inspect-me".to_string(),
             version: None,
             features: Vec::new(),
+            specializations: Vec::new(),
             no_default_features: false,
             path: Some(crate_directory.path().to_path_buf()),
             offline: true,
@@ -3676,7 +3747,8 @@ mod tests {
             ["any_crate::OpenError", "any_crate::Widget"]
         );
         assert_eq!(report.compatible_items, 2);
-        assert_eq!(report.incompatible_items, 1);
+        assert_eq!(report.specializable_items, 1);
+        assert_eq!(report.incompatible_items, 0);
         assert!(report.items.iter().any(|item| {
             item.path == "any_crate::Widget::open"
                 && item.kind == "constructor"
@@ -3730,7 +3802,7 @@ world any-crate-adapter {
         assert!(
             error
                 .to_string()
-                .contains("generic or lifetime parameters are not supported"),
+                .contains("requires a concrete --specialize instantiation"),
             "{error:#}"
         );
 
@@ -3751,6 +3823,8 @@ world any-crate-adapter {
             blockers: Vec::new(),
             warnings: Vec::new(),
             next_step: "generate adapter",
+            specialization_profile: None,
+            specializations: Vec::new(),
             public_api: report,
         };
         let package = render_adapter_package(

--- a/crates/husk-cli/src/package_install.rs
+++ b/crates/husk-cli/src/package_install.rs
@@ -78,6 +78,9 @@ pub(crate) fn install(
             "vendored extension `{name}` declares package `{}`",
             source.manifest().name
         );
+        if let Some(expected) = &locked.report_sha256 {
+            verify_adapter_report(&artifact, name, expected)?;
+        }
         let destination = staged_extensions.join(format!("{}.huskext", locked.sha256));
         copy_adapter_bundle(&artifact, &destination)?;
         let installed = ExtensionBundle::open(&destination, BundleLimits::default())
@@ -86,11 +89,42 @@ pub(crate) fn install(
             installed.digest().to_string() == locked.sha256,
             "staged extension `{name}` changed during installation"
         );
+        if let Some(expected) = &locked.report_sha256 {
+            verify_adapter_report(&destination, name, expected)?;
+        }
         extension_count += 1;
     }
 
     publish_extensions(root, manifest_path, &staged_extensions)?;
     Ok(InstallOutput { extension_count })
+}
+
+fn verify_adapter_report(bundle: &Path, name: &str, expected: &str) -> anyhow::Result<()> {
+    const MAX_ADAPTER_REPORT_BYTES: u64 = 16 * 1024 * 1024;
+
+    let report_path = bundle.join("husk-adapter.json");
+    let metadata = fs::symlink_metadata(&report_path)
+        .with_context(|| format!("inspect extension `{name}` adapter selection report"))?;
+    anyhow::ensure!(
+        metadata.is_file() && !metadata.file_type().is_symlink(),
+        "extension `{name}` adapter selection report is not a regular file"
+    );
+    anyhow::ensure!(
+        metadata.len() <= MAX_ADAPTER_REPORT_BYTES,
+        "extension `{name}` adapter selection report exceeds the 16 MiB install limit"
+    );
+    let report = fs::read(&report_path)
+        .with_context(|| format!("read extension `{name}` adapter selection report"))?;
+    anyhow::ensure!(
+        report.len() as u64 <= MAX_ADAPTER_REPORT_BYTES,
+        "extension `{name}` adapter selection report exceeds the 16 MiB install limit"
+    );
+    let actual = crate::adapter_install::hex_digest(&report);
+    anyhow::ensure!(
+        actual == expected,
+        "extension `{name}` adapter selection report has digest {actual}, expected {expected}"
+    );
+    Ok(())
 }
 
 fn publish_extensions(

--- a/crates/husk-cli/tests/cli.rs
+++ b/crates/husk-cli/tests/cli.rs
@@ -155,7 +155,30 @@ const MATH_COMPONENT: &str = r#"
             (canon lift (core func $i "add"))))
 "#;
 
+const SAME_NAMED_MATH_COMPONENT: &str = r#"
+    (component
+        (core module $m
+            (func (export "add") (param i32 i32) (result i32)
+                local.get 0 local.get 1 i32.add))
+        (core instance $i (instantiate $m))
+        (func $add
+            (param "left" s32)
+            (param "right" s32)
+            (result s32)
+            (canon lift (core func $i "add")))
+        (instance $math
+            (export "add" (func $add)))
+        (export "example:math/math@1.0.0" (instance $math)))
+"#;
+
 fn write_extension_source(directory: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+    write_extension_source_with_component(directory, MATH_COMPONENT)
+}
+
+fn write_extension_source_with_component(
+    directory: &TempDir,
+    component_source: &str,
+) -> (std::path::PathBuf, std::path::PathBuf) {
     let manifest = directory.path().join("math.toml");
     let component = directory.path().join("math.wasm");
     fs::write(
@@ -174,7 +197,7 @@ fn write_extension_source(directory: &TempDir) -> (std::path::PathBuf, std::path
         "#,
     )
     .unwrap();
-    fs::write(&component, MATH_COMPONENT).unwrap();
+    fs::write(&component, component_source).unwrap();
     (manifest, component)
 }
 
@@ -217,6 +240,63 @@ fn extension_pack_inspect_and_run_work_end_to_end() {
         .output()
         .unwrap();
     assert_eq!(run.status.code(), Some(42), "{run:?}");
+}
+
+#[test]
+fn extension_inspection_and_execution_flatten_same_named_interfaces() {
+    let directory = TempDir::new().unwrap();
+    let (manifest, component) =
+        write_extension_source_with_component(&directory, SAME_NAMED_MATH_COMPONENT);
+    let bundle = directory.path().join("math.huskext");
+    let pack = Command::new(env!("CARGO_BIN_EXE_husk"))
+        .args(["extension", "pack", "--manifest"])
+        .arg(&manifest)
+        .arg("--component")
+        .arg(&component)
+        .arg("--output")
+        .arg(&bundle)
+        .output()
+        .unwrap();
+    assert!(pack.status.success(), "{pack:?}");
+
+    let inspect = Command::new(env!("CARGO_BIN_EXE_husk"))
+        .args(["extension", "inspect"])
+        .arg(&bundle)
+        .output()
+        .unwrap();
+    assert!(inspect.status.success(), "{inspect:?}");
+    let stdout = String::from_utf8(inspect.stdout).unwrap();
+    assert!(stdout.lines().any(|line| line == "export: math::add"));
+    assert!(!stdout.lines().any(|line| line == "export: math::math::add"));
+
+    let script = directory.path().join("script.hk");
+    fs::write(
+        &script,
+        "use math::{add};\nfn main() -> i32 { add(20, 22) }",
+    )
+    .unwrap();
+    let run = Command::new(env!("CARGO_BIN_EXE_husk"))
+        .arg("run")
+        .arg("--extension")
+        .arg(&bundle)
+        .arg(&script)
+        .output()
+        .unwrap();
+    assert_eq!(run.status.code(), Some(42), "{run:?}");
+
+    fs::write(
+        &script,
+        "use math::math::add;\nfn main() -> i32 { add(20, 22) }",
+    )
+    .unwrap();
+    let duplicated = Command::new(env!("CARGO_BIN_EXE_husk"))
+        .arg("run")
+        .arg("--extension")
+        .arg(&bundle)
+        .arg(&script)
+        .output()
+        .unwrap();
+    assert!(!duplicated.status.success(), "{duplicated:?}");
 }
 
 fn write_package(directory: &TempDir) {

--- a/crates/husk-package/src/lib.rs
+++ b/crates/husk-package/src/lib.rs
@@ -89,6 +89,9 @@ pub struct CrateExtensionSource {
     pub default_features: bool,
     #[serde(default)]
     pub include: Vec<String>,
+    /// Canonical, ahead-of-time Rust generic instantiations for this adapter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub specializations: Vec<String>,
 }
 
 const fn default_true() -> bool {
@@ -134,6 +137,17 @@ impl PackageManifest {
                             ),
                         });
                     }
+                    if extension
+                        .specializations
+                        .iter()
+                        .any(|specialization| specialization.is_empty())
+                    {
+                        return Err(PackageError::InvalidManifest {
+                            message: format!(
+                                "crate extension `{name}` contains an empty generic specialization"
+                            ),
+                        });
+                    }
                 }
             }
         }
@@ -157,6 +171,7 @@ pub struct ResolvedExtension {
     pub bundle: ExtensionBundle,
     pub crate_source: Option<LockedCrateExtension>,
     pub artifact: Option<PathBuf>,
+    pub report_sha256: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -246,8 +261,8 @@ impl ResolvedPackage {
 
         let mut extensions = Vec::new();
         for (name, declaration) in &manifest.extensions {
-            let (source, crate_source, artifact) = match declaration {
-                ExtensionSource::Path(extension) => (extension.path.clone(), None, None),
+            let (source, crate_source, artifact, report_sha256) = match declaration {
+                ExtensionSource::Path(extension) => (extension.path.clone(), None, None, None),
                 ExtensionSource::Crate(_) => {
                     let locked_extension = locked
                         .as_ref()
@@ -261,6 +276,7 @@ impl ResolvedPackage {
                         locked_extension.source.clone(),
                         locked_extension.crate_source.clone(),
                         locked_extension.artifact.clone(),
+                        locked_extension.report_sha256.clone(),
                     )
                 }
             };
@@ -295,6 +311,7 @@ impl ResolvedPackage {
                 bundle,
                 crate_source,
                 artifact,
+                report_sha256,
             });
         }
         extensions.sort_unstable_by(|left, right| left.manifest_name.cmp(&right.manifest_name));
@@ -396,6 +413,9 @@ pub struct LockedExtension {
     pub crate_source: Option<LockedCrateExtension>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact: Option<PathBuf>,
+    /// SHA-256 of the exact adapter selection and specialization report.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub report_sha256: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -409,6 +429,8 @@ pub struct LockedCrateExtension {
     pub default_features: bool,
     #[serde(default)]
     pub include: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub specializations: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checksum: Option<String>,
 }
@@ -433,6 +455,7 @@ impl PackageLock {
                             sha256: extension.bundle.digest().to_string(),
                             crate_source: extension.crate_source.clone(),
                             artifact: extension.artifact.clone(),
+                            report_sha256: extension.report_sha256.clone(),
                         },
                     )
                 })
@@ -504,6 +527,7 @@ impl PackageLock {
                         || crate_source.features != extension.features
                         || crate_source.default_features != extension.default_features
                         || crate_source.include != extension.include
+                        || crate_source.specializations != extension.specializations
                         || locked.source != expected_source
                         || locked.artifact.is_none()
                     {

--- a/crates/husk-package/tests/package.rs
+++ b/crates/husk-package/tests/package.rs
@@ -1,6 +1,9 @@
 use std::fs;
 
-use husk_package::{LOCK_FILE, PackageError, PackageLimits, ResolvedPackage, discover_manifest};
+use husk_package::{
+    LOCK_FILE, PackageError, PackageLimits, PackageLock, PackageManifest, ResolvedPackage,
+    discover_manifest,
+};
 use tempfile::TempDir;
 
 fn package(manifest_extensions: &str) -> TempDir {
@@ -195,4 +198,96 @@ fn lock_reads_use_the_package_specific_limit() {
 
     let error = resolved.enforce_lock().unwrap_err().to_string();
     assert!(error.contains("maximum is 4"), "{error}");
+}
+
+#[test]
+fn crate_lock_rejects_changed_generic_specializations() {
+    let manifest = PackageManifest::parse(
+        r#"
+        schema_version = 1
+
+        [package]
+        name = "example"
+        version = "0.1.0"
+        entry = "src/main.hk"
+
+        [extensions.serde_json]
+        crate = "serde_json"
+        version = "^1"
+        specializations = ["serde_json::from_str<serde_json::Value>"]
+        "#,
+    )
+    .unwrap();
+    let lock = PackageLock::parse(
+        r#"
+        schema_version = 1
+
+        [package]
+        name = "example"
+        version = "0.1.0"
+
+        [extensions.serde_json]
+        module = "serde_json"
+        version = "1.0.151"
+        source = ".husk/extensions/fixture-digest.huskext"
+        sha256 = "fixture-digest"
+        artifact = "vendor/husk/fixture-digest.huskext"
+        report_sha256 = "fixture-report-digest"
+
+        [extensions.serde_json.crate]
+        package = "serde_json"
+        version = "1.0.151"
+        requirement = "^1"
+        default_features = true
+        specializations = ["serde_json::to_string<serde_json::Value>"]
+        "#,
+    )
+    .unwrap();
+
+    let error = lock.validate_manifest(&manifest).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("differs between Husk.toml and Husk.lock"),
+        "{error}"
+    );
+}
+
+#[test]
+fn existing_locks_without_specialization_or_report_provenance_remain_readable() {
+    let lock = PackageLock::parse(
+        r#"
+        schema_version = 1
+
+        [package]
+        name = "example"
+        version = "0.1.0"
+
+        [extensions.serde_json]
+        module = "serde_json"
+        version = "1.0.151"
+        source = ".husk/extensions/fixture-digest.huskext"
+        sha256 = "fixture-digest"
+        artifact = "vendor/husk/fixture-digest.huskext"
+
+        [extensions.serde_json.crate]
+        package = "serde_json"
+        version = "1.0.151"
+        requirement = "^1"
+        default_features = true
+        "#,
+    )
+    .unwrap();
+
+    let extension = &lock.extensions["serde_json"];
+    assert!(extension.report_sha256.is_none());
+    assert!(
+        extension
+            .crate_source
+            .as_ref()
+            .unwrap()
+            .specializations
+            .is_empty()
+    );
 }

--- a/crates/husk-runtime/src/lib.rs
+++ b/crates/husk-runtime/src/lib.rs
@@ -2355,24 +2355,40 @@ fn runtime_type_name(ty: &TypeExpr) -> anyhow::Result<String> {
 }
 
 fn collect_function_imports(file: &File, module_path: &[String]) -> HashMap<String, String> {
-    file.items
-        .iter()
-        .filter_map(|item| {
-            let ItemKind::Use {
-                path,
-                kind: husk_ast::UseKind::Item,
-            } = &item.kind
-            else {
-                return None;
-            };
-            let alias = path.last()?.name.clone();
-            let segments = path
-                .iter()
-                .map(|segment| segment.name.clone())
-                .collect::<Vec<_>>();
-            normalize_source_path(&segments, module_path).map(|path| (alias, path))
-        })
-        .collect()
+    let mut imports = HashMap::new();
+
+    for item in &file.items {
+        let ItemKind::Use { path, kind } = &item.kind else {
+            continue;
+        };
+
+        let mut segments = path
+            .iter()
+            .map(|segment| segment.name.clone())
+            .collect::<Vec<_>>();
+
+        match kind {
+            husk_ast::UseKind::Item => {
+                if let (Some(alias), Some(path)) =
+                    (path.last(), normalize_source_path(&segments, module_path))
+                {
+                    imports.insert(alias.name.clone(), path);
+                }
+            }
+            husk_ast::UseKind::Variants(items) => {
+                for item in items {
+                    segments.push(item.name.clone());
+                    if let Some(path) = normalize_source_path(&segments, module_path) {
+                        imports.insert(item.name.clone(), path);
+                    }
+                    segments.pop();
+                }
+            }
+            husk_ast::UseKind::Glob => {}
+        }
+    }
+
+    imports
 }
 
 fn normalize_source_path(segments: &[String], module_path: &[String]) -> Option<String> {
@@ -2450,26 +2466,36 @@ fn finalize_function_table(
     let mut module_paths = Vec::new();
     for module in modules {
         for function in &module.functions {
-            module_paths.push(format!("{}::{}", module.name, function.name));
+            let path = format!("{}::{}", module.name, function.name);
+            module_paths.push((path.clone(), path));
         }
         for interface in &module.interfaces {
             for function in &interface.functions {
-                module_paths.push(format!(
-                    "{}::{}::{}",
-                    module.name, interface.name, function.name
-                ));
+                let target = format!("{}::{}::{}", module.name, interface.name, function.name);
+                let path = if interface.name == module.name.as_str() {
+                    format!("{}::{}", module.name, function.name)
+                } else {
+                    target.clone()
+                };
+                module_paths.push((path, target));
             }
         }
     }
     module_paths.sort_unstable();
-    module_paths.dedup();
+    for paths in module_paths.windows(2) {
+        anyhow::ensure!(
+            paths[0].0 != paths[1].0,
+            "duplicate Husk module-function path `{}` targets both `{}` and `{}`",
+            paths[0].0,
+            paths[0].1,
+            paths[1].1
+        );
+    }
     let mut module_functions = HashMap::with_capacity(module_paths.len());
     let mut module_ids = HashMap::with_capacity(module_paths.len());
-    for path in module_paths {
+    for (path, target) in module_paths {
         let id = ModuleFunctionId::from_raw(stable_callable_id("module", &path));
-        if let Some(previous) =
-            module_functions.insert(id, ModuleFunctionTarget { path: path.clone() })
-        {
+        if let Some(previous) = module_functions.insert(id, ModuleFunctionTarget { path: target }) {
             anyhow::bail!(
                 "stable Husk module-function ID collision between `{}` and `{path}`",
                 previous.path
@@ -6465,6 +6491,30 @@ mod tests {
 
     impl Host for TestHost {
         fn log(&mut self, _message: &str) {}
+    }
+
+    #[test]
+    fn same_named_interface_rejects_colliding_root_function() {
+        let function = FunctionDescriptor::new("add", Vec::new(), TypeDescriptor::I32).unwrap();
+        let interface = InterfaceDescriptor::new("math", vec![function.clone()]).unwrap();
+        let module = ModuleDescriptor::new(
+            "math",
+            Version::new(1, 0, 0),
+            vec![function],
+            vec![interface],
+        )
+        .unwrap();
+
+        let error = finalize_function_table(HashMap::new(), &[module], SemanticProfile::Native)
+            .err()
+            .unwrap();
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate Husk module-function path `math::add`"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/husk-semantic/src/lib.rs
+++ b/crates/husk-semantic/src/lib.rs
@@ -1468,9 +1468,21 @@ impl TypeChecker {
     }
 
     fn process_item_import(&mut self, path: &[Ident], kind: &husk_ast::UseKind) {
-        if !matches!(kind, husk_ast::UseKind::Item) {
-            return;
+        match kind {
+            husk_ast::UseKind::Item => self.import_module_function(path),
+            husk_ast::UseKind::Variants(items) => {
+                let mut item_path = path.to_vec();
+                for item in items {
+                    item_path.push(item.clone());
+                    self.import_module_function(&item_path);
+                    item_path.pop();
+                }
+            }
+            husk_ast::UseKind::Glob => {}
         }
+    }
+
+    fn import_module_function(&mut self, path: &[Ident]) {
         let Some(alias) = path.last() else {
             return;
         };
@@ -7134,6 +7146,36 @@ fn main() {
         );
         let file = parsed.file.expect("parser produced no AST");
         let result = analyze_file(&file);
+        assert!(
+            result.symbols.errors.is_empty() && result.type_errors.is_empty(),
+            "semantic errors: symbols={:?}, types={:?}",
+            result.symbols.errors,
+            result.type_errors
+        );
+    }
+
+    #[test]
+    fn grouped_enum_variant_imports_remain_available() {
+        let source = r#"
+            use Option::{None, Some};
+
+            fn main() -> i32 {
+                let value: Option<i32> = Some(42);
+                match value {
+                    Some(value) => value,
+                    None => 0,
+                }
+            }
+        "#;
+        let parsed = parse_str(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let file = parsed.file.expect("parser produced no AST");
+        let result = analyze_file(&file);
+
         assert!(
             result.symbols.errors.is_empty() && result.type_errors.is_empty(),
             "semantic errors: symbols={:?}, types={:?}",

--- a/crates/husk/tests/package_embedding.rs
+++ b/crates/husk/tests/package_embedding.rs
@@ -76,6 +76,23 @@ fn package_compiles_once_and_dispatches_across_relative_and_absolute_modules() {
 }
 
 #[test]
+fn grouped_source_module_imports_resolve_and_dispatch_each_function() {
+    let directory = write_package(
+        "mod util;\nuse crate::util::{answer, offset};\nfn main() -> i32 { answer() + offset() }",
+        &[(
+            "util.hk",
+            "pub fn answer() -> i32 { 40 }\npub fn offset() -> i32 { 2 }",
+        )],
+    );
+    let package = resolve(directory.path());
+    let engine = Engine::<()>::builder().build().unwrap();
+    let compiled = engine.compile_package(&package).unwrap();
+    let mut instance = engine.instantiate(compiled, ()).unwrap();
+
+    assert_eq!(instance.call("main", &[]).unwrap(), OwnedValue::I64(42));
+}
+
+#[test]
 fn private_functions_do_not_cross_source_module_boundaries() {
     let directory = write_package(
         "mod util;\nfn main() -> i32 { util::secret() }",

--- a/crates/husk/tests/wasm_extension.rs
+++ b/crates/husk/tests/wasm_extension.rs
@@ -18,7 +18,153 @@ const MATH_COMPONENT: &str = r#"
         (export "example:math/api@1.0.0" (instance $api)))
 "#;
 
+const SAME_NAMED_MATH_COMPONENT: &str = r#"
+    (component
+        (core module $m
+            (func (export "add") (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                i32.add)
+            (func (export "subtract") (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                i32.sub))
+        (core instance $i (instantiate $m))
+        (func $add
+            (param "left" s32)
+            (param "right" s32)
+            (result s32)
+            (canon lift (core func $i "add")))
+        (func $subtract
+            (param "left" s32)
+            (param "right" s32)
+            (result s32)
+            (canon lift (core func $i "subtract")))
+        (instance $math
+            (export "add" (func $add))
+            (export "subtract" (func $subtract)))
+        (export "example:math/math@1.0.0" (instance $math)))
+"#;
+
 const RESOURCE_COMPONENT: &str = include_str!("../../husk-wasm/tests/fixtures/resource.wat");
+
+fn same_named_interface_engine() -> Engine<()> {
+    let component = WasmComponent::compile_bytes(
+        "math",
+        Version::new(1, 0, 0),
+        SAME_NAMED_MATH_COMPONENT.as_bytes(),
+        WasmCompileOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(component.descriptor().interfaces[0].name, "math");
+
+    Engine::<()>::builder()
+        .register_wasm_component(component)
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn same_named_component_interface_dispatches_from_module_root() {
+    let engine = same_named_interface_engine();
+    let compiled = engine
+        .compile_source("main", "main.hk", "fn main() -> i32 { math::add(20, 22) }")
+        .unwrap();
+    let mut instance = engine.instantiate(compiled, ()).unwrap();
+
+    assert_eq!(instance.call("main", &[]).unwrap(), OwnedValue::I64(42));
+}
+
+#[test]
+fn same_named_component_interface_supports_individual_function_imports() {
+    let engine = same_named_interface_engine();
+    let compiled = engine
+        .compile_source(
+            "main",
+            "main.hk",
+            "use math::add;\nfn main() -> i32 { add(20, 22) }",
+        )
+        .unwrap();
+    let mut instance = engine.instantiate(compiled, ()).unwrap();
+
+    assert_eq!(instance.call("main", &[]).unwrap(), OwnedValue::I64(42));
+}
+
+#[test]
+fn same_named_component_interface_supports_grouped_function_imports() {
+    let engine = same_named_interface_engine();
+    let compiled = engine
+        .compile_source(
+            "main",
+            "main.hk",
+            "use math::{add, subtract};\nfn main() -> i32 { add(subtract(44, 2), 0) }",
+        )
+        .unwrap();
+    let mut instance = engine.instantiate(compiled, ()).unwrap();
+
+    assert_eq!(instance.call("main", &[]).unwrap(), OwnedValue::I64(42));
+}
+
+#[test]
+fn same_named_component_interface_rejects_duplicated_module_paths() {
+    let engine = same_named_interface_engine();
+
+    assert!(
+        engine
+            .compile_source(
+                "main",
+                "main.hk",
+                "fn main() -> i32 { math::math::add(20, 22) }",
+            )
+            .is_err()
+    );
+    assert!(
+        engine
+            .compile_source(
+                "main",
+                "main.hk",
+                "use math::math::add;\nfn main() -> i32 { add(20, 22) }",
+            )
+            .is_err()
+    );
+}
+
+#[test]
+fn same_named_resource_interface_dispatches_from_module_root() {
+    let component = WasmComponent::compile_bytes(
+        "factory",
+        Version::new(1, 0, 0),
+        RESOURCE_COMPONENT.as_bytes(),
+        WasmCompileOptions::default(),
+    )
+    .unwrap();
+    let engine = Engine::<()>::builder()
+        .register_wasm_component(component)
+        .unwrap()
+        .build()
+        .unwrap();
+    let compiled = engine
+        .compile_source(
+            "main",
+            "main.hk",
+            r#"
+                use factory::{consume_item, item_value, new_item};
+
+                fn main() -> i32 {
+                    let item = new_item();
+                    let value = item_value(item);
+                    consume_item(item);
+                    value
+                }
+            "#,
+        )
+        .unwrap();
+    let mut instance = engine.instantiate(compiled, ()).unwrap();
+
+    assert_eq!(instance.call("main", &[]).unwrap(), OwnedValue::I64(100));
+}
 
 #[test]
 fn component_descriptor_typechecks_and_dispatches_through_engine() {

--- a/docs/HUSK_LANGUAGE_EXTRACTION_PLAN.md
+++ b/docs/HUSK_LANGUAGE_EXTRACTION_PLAN.md
@@ -390,8 +390,11 @@ source is parsed and no `RED_HOST_DECLARATIONS` equivalent exists.
 
 Module construction rejects duplicate names, invalid identifiers, unsupported
 types, normalized interface/function collisions, and conflicting versions
-before any script is compiled. Root functions use `module::function`; functions
-inside a WIT-style interface use `module::interface::function`.
+before any script is compiled. Root functions use `module::function`. A
+WIT-style interface with the same name as its module also exposes its functions
+as `module::function`; its repeated interface name is an internal Component
+detail, not a public Husk namespace. Distinct WIT-style interfaces continue to
+use `module::interface::function`.
 
 ### Typed Rust adapters
 

--- a/docs/HUSK_LANGUAGE_GUIDE.md
+++ b/docs/HUSK_LANGUAGE_GUIDE.md
@@ -241,6 +241,75 @@ version = "*"
 under `vendor/husk/`, and installs it under `.husk/extensions/`. Commit the
 manifest, lock file, and vendored bundle; do not commit `.husk/`.
 
+Generic Rust functions are not component exports by themselves: Husk must
+instantiate them with concrete Rust types while building the adapter. For
+`serde_json` 1.x, Husk automatically selects a versioned `serde_json::Value`
+profile:
+
+```shell
+red husk new json-example
+cd json-example
+red husk add serde_json --features preserve_order
+```
+
+The generated adapter provides parsing, compact serialization, and pretty
+serialization. `preserve_order` stays enabled inside the WebAssembly guest, so
+JSON object keys retain their input order. The selected instantiations are
+recorded in `Husk.toml` and `Husk.lock`:
+
+```toml
+[extensions.serde_json]
+crate = "serde_json"
+version = "*"
+features = ["preserve_order"]
+specializations = [
+  "serde_json::from_str<serde_json::Value>",
+  "serde_json::to_string<serde_json::Value>",
+  "serde_json::to_string_pretty<serde_json::Value>",
+]
+```
+
+A crate-backed extension exposes its adapter functions directly under the
+declared extension module. An internal Component interface with the same name
+does not add another Husk path segment. Import the specialized adapter
+functions individually or as a group from `src/main.hk`:
+
+```husk
+use serde_json::{
+    from_str_value,
+    value_to_string,
+    value_to_string_pretty,
+};
+
+fn main() -> Result<(), String> {
+    let value = from_str_value("{\"z\":1,\"a\":2}")?;
+    std::println(value_to_string(value)?);
+    std::println(value_to_string_pretty(value)?);
+    Ok(())
+}
+```
+
+Individual imports such as `use serde_json::from_str_value;` are also valid.
+The duplicated `serde_json::serde_json::from_str_value` path is not a public
+Husk export. Distinct, explicitly named interfaces remain qualified, such as
+`regex::api::is_match`.
+
+Run the locked package with `red husk run --locked .`. For an explicitly
+selected profile operation, repeat `--specialize` as needed:
+
+```shell
+red husk add serde_json \
+  --specialize 'serde_json::from_str<serde_json::Value>' \
+  --specialize 'serde_json::to_string<serde_json::Value>'
+```
+
+Only supported, versioned concrete lowerings are accepted; arbitrary generic
+Rust APIs are reported as `specializable` and are not silently exported.
+
+Adapter build process and memory limits apply only to the adapter's own
+process tree. Unrelated applications and background processes do not consume
+the adapter's resource budget.
+
 After cloning a package, recreate its installed state without Cargo or network
 access:
 
@@ -249,9 +318,11 @@ red husk install --locked --offline
 red husk run --locked .
 ```
 
-Installation verifies the locked digest and bundle metadata, stages the full
-extension set, atomically replaces `.husk/extensions/`, and removes stale
-installed bundles. Path-based extensions under `vendor/` remain supported.
+Installation verifies the locked component digest, adapter-report digest, and
+bundle metadata, stages the full extension set, atomically replaces
+`.husk/extensions/`, and removes stale installed bundles. Path-based extensions
+under `vendor/` and older locks without an adapter-report digest remain
+supported.
 
 ## Tests
 


### PR DESCRIPTION
## Why

Generic Rust functions cannot cross a WebAssembly Component boundary without choosing concrete types. As a result, Husk could not expose serde_json's parsing and serialization APIs as portable crate adapters, while same-named component interfaces leaked a duplicated module segment into public imports.

## What changed

- Parse and canonicalize bounded, concrete `--specialize` selections; reject duplicate, malformed, cross-crate, and unsupported instantiations.
- Automatically provide a versioned `serde_json::Value` profile for parsing, compact serialization, and pretty serialization, while retaining crate features such as `preserve_order`.
- Record selected specializations and the adapter-report digest in package and lockfile metadata; verify vendored reports during locked, offline installation and retain compatibility with existing lockfiles.
- Expose same-named component interfaces directly as `module::function` and support individual and grouped imports without accepting duplicated public paths.
- Apply adapter process and memory limits to the actual build process tree so unrelated user processes cannot exhaust the sandbox.
- Add specialization, manifest, provenance, resource-limit, CLI, source-module, and WebAssembly regressions; document the JSON workflow.

## How to Test

1. From the feature worktree, select an isolated Cargo target and create a disposable example without installing Husk:

   ```bash
   export CARGO_TARGET_DIR="${TMPDIR:-/tmp}/red-husk-generic-specialization-target"
   example_dir="$(mktemp -d "${TMPDIR:-/tmp}/husk-json-example-XXXXXX")"

   cargo run -p husk-cli --bin husk -- new --name json-example "$example_dir"
   cargo run -p husk-cli --bin husk -- add serde_json \
     --features preserve_order \
     --package "$example_dir"
   ```

2. Replace the example's `src/main.hk` with:

   ```husk
   use serde_json::{
       from_str_value,
       value_to_string,
       value_to_string_pretty,
   };

   fn main() -> Result<(), String> {
       let value = from_str_value("{\"z\":4,\"a\":\"b\"}")?;
       std::println(value_to_string(value)?);
       std::println(value_to_string_pretty(value)?);
       Ok(())
   }
   ```

   Run the locked package:

   ```bash
   cargo run -p husk-cli --bin husk -- run --locked "$example_dir"
   ```

   Expect compact and pretty-printed JSON, with `z` preceding `a` in both outputs.

3. Change the import to `use serde_json::serde_json::from_str_value;` and rerun the package. Expect compilation to fail: the duplicated interface path is not public.

4. Run the focused positive and negative regressions:

   ```bash
   cargo test -p husk-cli generic_specialization
   cargo test -p husk-cli extension_inspection_and_execution_flatten_same_named_interfaces
   cargo test -p husk-package
   cargo test -p husk --test wasm_extension --test package_embedding
   ```

   These also verify specialization changes and tampered adapter reports are rejected and explicitly named interfaces remain qualified.