### PR TITLE
feat(editor): add neovim-style comment operators

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -128,6 +128,38 @@ waiting = "steady_underscore"
 # language_id = "javascript"
 # file_extensions = ["js", "mjs", "cjs"]
 
+# Comment templates use Neovim's commentstring format. The single %s is
+# replaced with each selected line. Add or override languages and extensions
+# here without installing or starting a language server.
+[commenting.languages]
+bash = "# %s"
+c = "// %s"
+cc = "// %s"
+cpp = "// %s"
+css = "/* %s */"
+cxx = "// %s"
+go = "// %s"
+h = "// %s"
+hpp = "// %s"
+html = "<!-- %s -->"
+husk = "// %s"
+java = "// %s"
+javascript = "// %s"
+jsonc = "// %s"
+jsx = "// %s"
+lua = "-- %s"
+markdown = "<!-- %s -->"
+powershell = "# %s"
+python = "# %s"
+rust = "// %s"
+scss = "/* %s */"
+sql = "-- %s"
+toml = "# %s"
+tsx = "// %s"
+typescript = "// %s"
+xml = "<!-- %s -->"
+yaml = "# %s"
+
 [keys.insert]
 Enter = "InsertNewLine"
 Backspace = "DeletePreviousChar"
@@ -145,7 +177,7 @@ Esc = { EnterMode = "Normal" }
 "o" = [ { EnterMode = "Insert" }, "InsertLineBelowCursor" ]
 "O" = [ { EnterMode = "Insert" }, "InsertLineAtCursor" ]
 "G" = "MoveToBottom"
-"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd", "e" = "MoveToPreviousWordEnd", "E" = "MoveToPreviousBigWordEnd", "J" = { JoinLinesKeepSpaces = 2 }, "u" = { StartLowercaseOperator = 1 }, "U" = { StartUppercaseOperator = 1 }, "~" = { StartToggleCaseOperator = 1 }, "-" = "SelectPreviousUndoBranch", "+" = "SelectNextUndoBranch" }
+"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "c" = { StartCommentOperator = 1 }, "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd", "e" = "MoveToPreviousWordEnd", "E" = "MoveToPreviousBigWordEnd", "J" = { JoinLinesKeepSpaces = 2 }, "u" = { StartLowercaseOperator = 1 }, "U" = { StartUppercaseOperator = 1 }, "~" = { StartToggleCaseOperator = 1 }, "-" = "SelectPreviousUndoBranch", "+" = "SelectNextUndoBranch" }
 "u" = "Undo"
 "U" = "Redo"
 "Ctrl-r" = "Redo"
@@ -297,7 +329,7 @@ Esc = { EnterMode = "Normal" }
 "P" = [ "PasteBefore", { EnterMode = "Normal" } ]
 "I" = "InsertBlock"
 "J" = [ { JoinLines = 2 }, { EnterMode = "Normal" } ]
-"g" = { "J" = [ { JoinLinesKeepSpaces = 2 }, { EnterMode = "Normal" } ] }
+"g" = { "c" = [ "ToggleCommentSelection", { EnterMode = "Normal" } ], "J" = [ { JoinLinesKeepSpaces = 2 }, { EnterMode = "Normal" } ] }
 "u" = [ { TransformSelection = "Lower" }, { EnterMode = "Normal" } ]
 "U" = [ { TransformSelection = "Upper" }, { EnterMode = "Normal" } ]
 "~" = [ { TransformSelection = "Toggle" }, { EnterMode = "Normal" } ]

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -459,6 +459,15 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Action::Redo,
         ),
         builtin(
+            "edit.comment",
+            "Toggle line comments",
+            "Edit",
+            "Comment or uncomment the current line",
+            None,
+            &["comment", "uncomment", "toggle comment", "gcc"],
+            Action::ToggleCommentLines(1),
+        ),
+        builtin(
             "edit.repeat",
             "Repeat last change",
             "Edit",
@@ -896,6 +905,10 @@ fn action_label(action: &Action) -> String {
         Action::Quit(_) => "Quit".to_string(),
         Action::Undo => "Undo".to_string(),
         Action::Redo => "Redo".to_string(),
+        Action::StartCommentOperator(_) => "Comment with motion".to_string(),
+        Action::ToggleCommentLines(_) => "Toggle line comments".to_string(),
+        Action::ToggleCommentRange(_) => "Toggle range comments".to_string(),
+        Action::ToggleCommentSelection => "Toggle selected comments".to_string(),
         Action::RepeatLastChange => "Repeat last change".to_string(),
         Action::NextBuffer => "Next buffer".to_string(),
         Action::PreviousBuffer => "Previous buffer".to_string(),
@@ -1044,6 +1057,19 @@ mod tests {
             .unwrap();
         assert_eq!(save.colon.as_deref(), Some(":w"));
         assert!(save.aliases.iter().any(|alias| alias == ":write"));
+    }
+
+    #[test]
+    fn palette_lists_commenting_as_a_discoverable_edit_action() {
+        let entries = entries(&default_keys(), &[]);
+        let comment = entries
+            .iter()
+            .find(|entry| entry.id == "edit.comment")
+            .expect("comment action should appear in the command palette");
+
+        assert_eq!(comment.category, "Edit");
+        assert_eq!(comment.title, "Toggle line comments");
+        assert!(comment.aliases.iter().any(|alias| alias == "gcc"));
     }
 
     #[test]

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1,0 +1,194 @@
+//! Language-aware line commenting with Neovim-compatible range semantics.
+//!
+//! A comment template contains exactly one %s placeholder. Text before the
+//! placeholder is inserted before a line and text after it is inserted after a
+//! line, allowing the same implementation to handle line and wrapping comments.
+
+/// Validated left and right halves of a language-specific comment template.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommentSyntax {
+    left: String,
+    right: String,
+}
+
+impl CommentSyntax {
+    /// Parses a template containing exactly one placeholder and a real marker.
+    pub(crate) fn parse(template: &str) -> Option<Self> {
+        let (left, right) = template.split_once("%s")?;
+        if right.contains("%s") || (left.trim().is_empty() && right.trim().is_empty()) {
+            return None;
+        }
+
+        Some(Self {
+            left: left.to_string(),
+            right: right.to_string(),
+        })
+    }
+
+    /// Reports whether a nonblank line already has both comment markers.
+    pub(crate) fn is_commented(&self, line: &str) -> bool {
+        let line = line.trim();
+        if line.is_empty() {
+            return false;
+        }
+
+        line.strip_prefix(self.left.trim())
+            .is_some_and(|content| content.trim_end().ends_with(self.right.trim()))
+    }
+
+    /// Toggles the supplied lines as one range, preserving relative indentation.
+    pub(crate) fn toggle_lines(&self, lines: &[String]) -> Vec<String> {
+        let all_commented = lines
+            .iter()
+            .filter(|line| !line.trim().is_empty())
+            .all(|line| self.is_commented(line));
+
+        if all_commented {
+            return lines.iter().map(|line| self.uncomment_line(line)).collect();
+        }
+
+        let common_indent = lines
+            .iter()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| leading_whitespace(line))
+            .min_by_key(|indent| indent.len())
+            .unwrap_or_default();
+
+        lines
+            .iter()
+            .map(|line| {
+                if line.trim().is_empty() {
+                    return format!("{common_indent}{}{}", self.left.trim(), self.right.trim());
+                }
+
+                let content = line
+                    .get(common_indent.len()..)
+                    .unwrap_or_else(|| line.trim_start_matches(char::is_whitespace));
+                format!("{common_indent}{}{content}{}", self.left, self.right)
+            })
+            .collect()
+    }
+
+    fn uncomment_line(&self, line: &str) -> String {
+        let content = line.trim_start_matches(char::is_whitespace);
+        let indent = &line[..line.len() - content.len()];
+        let Some(content) = content
+            .strip_prefix(&self.left)
+            .or_else(|| content.strip_prefix(self.left.trim()))
+        else {
+            return line.to_string();
+        };
+
+        let (content, trailing) = if self.right.is_empty() {
+            (content, "")
+        } else {
+            let without_trailing = content.trim_end_matches(char::is_whitespace);
+            let trailing = &content[without_trailing.len()..];
+            let Some(content) = without_trailing
+                .strip_suffix(&self.right)
+                .or_else(|| without_trailing.strip_suffix(self.right.trim()))
+            else {
+                return line.to_string();
+            };
+            (content, trailing)
+        };
+
+        if content.trim().is_empty() {
+            return String::new();
+        }
+
+        format!("{indent}{content}{trailing}")
+    }
+}
+
+fn leading_whitespace(line: &str) -> &str {
+    let end = line
+        .find(|character: char| !character.is_whitespace())
+        .unwrap_or(line.len());
+    &line[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CommentSyntax;
+
+    fn toggle(template: &str, lines: &[&str]) -> Vec<String> {
+        let syntax = CommentSyntax::parse(template).expect("test template should be valid");
+        let lines = lines
+            .iter()
+            .map(|line| (*line).to_string())
+            .collect::<Vec<_>>();
+        syntax.toggle_lines(&lines)
+    }
+
+    #[test]
+    fn parses_line_and_wrapping_comment_templates() {
+        assert!(CommentSyntax::parse("// %s").is_some());
+        assert!(CommentSyntax::parse("# %s").is_some());
+        assert!(CommentSyntax::parse("<!-- %s -->").is_some());
+        assert!(CommentSyntax::parse("/* %s */").is_some());
+    }
+
+    #[test]
+    fn rejects_missing_duplicate_and_markerless_placeholders() {
+        assert!(CommentSyntax::parse("//").is_none());
+        assert!(CommentSyntax::parse("%s %s").is_none());
+        assert!(CommentSyntax::parse("%s").is_none());
+        assert!(CommentSyntax::parse("  %s  ").is_none());
+    }
+
+    #[test]
+    fn comments_at_the_least_indented_nonblank_line() {
+        assert_eq!(
+            toggle("// %s", &["    alpha", "      beta", "", "    gamma"]),
+            ["    // alpha", "    //   beta", "    //", "    // gamma"]
+        );
+    }
+
+    #[test]
+    fn uncomments_the_whole_range_when_all_nonblank_lines_are_commented() {
+        assert_eq!(
+            toggle("// %s", &["    // alpha", "    // beta", "    //"]),
+            ["    alpha", "    beta", ""]
+        );
+    }
+
+    #[test]
+    fn comments_the_whole_range_when_comment_state_is_mixed() {
+        assert_eq!(
+            toggle("// %s", &["    // alpha", "    beta"]),
+            ["    // // alpha", "    // beta"]
+        );
+    }
+
+    #[test]
+    fn leaves_a_blank_only_range_unchanged() {
+        assert_eq!(toggle("// %s", &["", "    ", "\t"]), ["", "    ", "\t"]);
+    }
+
+    #[test]
+    fn toggles_wrapping_comment_markers() {
+        assert_eq!(
+            toggle("<!-- %s -->", &["    <div>hello</div>"]),
+            ["    <!-- <div>hello</div> -->"]
+        );
+        assert_eq!(
+            toggle("<!-- %s -->", &["    <!-- <div>hello</div> -->"]),
+            ["    <div>hello</div>"]
+        );
+    }
+
+    #[test]
+    fn uncomments_markers_without_the_configured_padding() {
+        assert_eq!(toggle("// %s", &["    //alpha"]), ["    alpha"]);
+        assert_eq!(toggle("<!-- %s -->", &["    <!--hello-->"]), ["    hello"]);
+    }
+
+    #[test]
+    fn preserves_tabs_when_aligning_comment_markers() {
+        assert_eq!(
+            toggle("# %s", &["\talpha", "\t\tbeta"]),
+            ["\t# alpha", "\t# \tbeta"]
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,6 +209,9 @@ pub struct Config {
     /// Language-server routing and behavior.
     #[serde(default)]
     pub lsp: LspConfig,
+    /// Language-specific templates used by Vim-style line commenting.
+    #[serde(default)]
+    pub commenting: CommentingConfig,
     /// Matching-token navigation.
     #[serde(default)]
     pub matchit: MatchitConfig,
@@ -350,6 +353,58 @@ impl Default for ClipboardConfig {
             sync_on_paste: true,
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+/// Language-specific comment templates keyed by canonical language or extension.
+pub struct CommentingConfig {
+    /// Templates containing one placeholder for the original line contents.
+    #[serde(default = "default_comment_templates")]
+    pub languages: HashMap<String, String>,
+}
+
+impl Default for CommentingConfig {
+    fn default() -> Self {
+        Self {
+            languages: default_comment_templates(),
+        }
+    }
+}
+
+fn default_comment_templates() -> HashMap<String, String> {
+    [
+        ("bash", "# %s"),
+        ("c", "// %s"),
+        ("cc", "// %s"),
+        ("cpp", "// %s"),
+        ("css", "/* %s */"),
+        ("cxx", "// %s"),
+        ("go", "// %s"),
+        ("h", "// %s"),
+        ("hpp", "// %s"),
+        ("html", "<!-- %s -->"),
+        ("husk", "// %s"),
+        ("java", "// %s"),
+        ("javascript", "// %s"),
+        ("jsonc", "// %s"),
+        ("jsx", "// %s"),
+        ("lua", "-- %s"),
+        ("markdown", "<!-- %s -->"),
+        ("powershell", "# %s"),
+        ("python", "# %s"),
+        ("rust", "// %s"),
+        ("scss", "/* %s */"),
+        ("sql", "-- %s"),
+        ("toml", "# %s"),
+        ("tsx", "// %s"),
+        ("typescript", "// %s"),
+        ("xml", "<!-- %s -->"),
+        ("yaml", "# %s"),
+    ]
+    .into_iter()
+    .map(|(language, template)| (language.to_string(), template.to_string()))
+    .collect()
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -1138,6 +1193,7 @@ fn known_top_level_field(field: &str) -> bool {
             | "key_hints"
             | "clipboard"
             | "lsp"
+            | "commenting"
             | "matchit"
             | "disable_ai"
             | "agent"
@@ -1299,6 +1355,7 @@ fn known_schema_path(path: &[String]) -> bool {
         ["lsp", "servers", _, "env", _] | ["lsp", "servers", _, "initialization_options", ..] => {
             true
         }
+        ["commenting", "languages"] | ["commenting", "languages", _] => true,
         ["matchit", field] => matches!(*field, "enabled" | "pairs" | "languages"),
         ["matchit", "languages", _] | ["matchit", "languages", _, "groups"] => true,
         _ => false,
@@ -1741,6 +1798,7 @@ fn render_path(path: &[String]) -> String {
             Some("keys") => index >= 2,
             Some("plugins" | "plugin_permissions" | "plugin_config") => index >= 1,
             Some("lsp") if path.get(1).is_some_and(|part| part == "servers") => index >= 2,
+            Some("commenting") if path.get(1).is_some_and(|part| part == "languages") => index >= 2,
             Some("matchit") if path.get(1).is_some_and(|part| part == "languages") => index >= 2,
             _ => false,
         };
@@ -2496,6 +2554,84 @@ input_position = "left"
             g.get("%"),
             Some(&KeyAction::Single(Action::MatchitBackward))
         );
+    }
+
+    #[test]
+    fn default_config_maps_normal_and_visual_comment_operators() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        let Some(KeyAction::Nested(normal_g)) = config.keys.normal.get("g") else {
+            panic!("default config should map normal g to nested actions");
+        };
+        assert_eq!(
+            normal_g.get("c"),
+            Some(&KeyAction::Single(Action::StartCommentOperator(1)))
+        );
+
+        let Some(KeyAction::Nested(visual_g)) = config.keys.visual.get("g") else {
+            panic!("default config should map visual g to nested actions");
+        };
+        assert_eq!(
+            visual_g.get("c"),
+            Some(&KeyAction::Multiple(vec![
+                Action::ToggleCommentSelection,
+                Action::EnterMode(Mode::Normal),
+            ]))
+        );
+    }
+
+    #[test]
+    fn comment_configuration_defaults_cover_line_and_wrapping_comments() {
+        let config = Config::default();
+
+        assert_eq!(config.commenting.languages["rust"], "// %s");
+        assert_eq!(config.commenting.languages["python"], "# %s");
+        assert_eq!(config.commenting.languages["lua"], "-- %s");
+        assert_eq!(config.commenting.languages["html"], "<!-- %s -->");
+        assert_eq!(config.commenting.languages["css"], "/* %s */");
+        assert!(!config.commenting.languages.contains_key("json"));
+    }
+
+    #[test]
+    fn user_comment_templates_merge_without_discarding_language_defaults() {
+        let loaded = Config::load_user_toml(
+            "[commenting.languages]\nrust = \"/* %s */\"\ncustom = \"; %s\"\n",
+            Path::new("/tmp/config.toml"),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(loaded.config.commenting.languages["rust"], "/* %s */");
+        assert_eq!(loaded.config.commenting.languages["custom"], "; %s");
+        assert_eq!(loaded.config.commenting.languages["python"], "# %s");
+    }
+
+    #[test]
+    fn invalid_comment_template_type_recovers_independently() {
+        let loaded = Config::load_user_toml(
+            "[commenting.languages]\nrust = 42\npython = \"## %s\"\n",
+            Path::new("/tmp/config.toml"),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(loaded.config.commenting.languages["rust"], "// %s");
+        assert_eq!(loaded.config.commenting.languages["python"], "## %s");
+        assert!(loaded.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "CFG102" && diagnostic.path == r#"commenting.languages["rust"]"#
+        }));
+    }
+
+    #[test]
+    fn strict_overrides_accept_comment_template_paths() {
+        let loaded = Config::load_user_toml(
+            "",
+            Path::new("/tmp/config.toml"),
+            &["commenting.languages.rust = \"/* %s */\"".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(loaded.config.commenting.languages["rust"], "/* %s */");
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -76,6 +76,7 @@ use crate::{
     codex::{start_codex, CodexBridge, CodexCommand, CodexEvent, CodexProcessSpec},
     color::Color,
     command, command_palette,
+    comment::CommentSyntax,
     config::{Config, ConfigDiagnostic, ConfigDiagnosticSource, ConfigRecovery, KeyAction},
     dispatcher::Dispatcher,
     highlighter::Highlighter,
@@ -1287,6 +1288,10 @@ pub enum Action {
     JoinLines(u16),
     JoinLinesKeepSpaces(u16),
     ToggleCharCase(u16),
+    StartCommentOperator(u16),
+    ToggleCommentLines(u16),
+    ToggleCommentRange(TextRange),
+    ToggleCommentSelection,
     StartLowercaseOperator(u16),
     StartUppercaseOperator(u16),
     StartToggleCaseOperator(u16),
@@ -2515,6 +2520,7 @@ enum EditOperator {
     Delete,
     Change,
     Yank,
+    Comment,
     Lowercase,
     Uppercase,
     ToggleCase,
@@ -2523,6 +2529,7 @@ enum EditOperator {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PendingOperatorStep {
     Operator,
+    CommentTextObject,
     FindForward,
     TillForward,
     FindBackward,
@@ -2574,6 +2581,7 @@ impl EditOperator {
             EditOperator::Delete => "d",
             EditOperator::Change => "c",
             EditOperator::Yank => "y",
+            EditOperator::Comment => "gc",
             EditOperator::Lowercase => "gu",
             EditOperator::Uppercase => "gU",
             EditOperator::ToggleCase => "g~",
@@ -11286,6 +11294,9 @@ impl Editor {
                 'c' if pending.operator == EditOperator::Change => Some(KeyAction::Single(
                     Action::ChangeCurrentLines(pending.count()),
                 )),
+                'c' if pending.operator == EditOperator::Comment => Some(KeyAction::Single(
+                    Action::ToggleCommentLines(pending.count()),
+                )),
                 'y' if pending.operator == EditOperator::Yank => {
                     Some(KeyAction::Single(Action::YankCurrentLines(pending.count())))
                 }
@@ -11307,6 +11318,14 @@ impl Editor {
                         Some(self.current_line_range(pending.count(), false)),
                         "no text under cursor",
                     ),
+                'g' => {
+                    self.waiting_command = Some(format!("{}g", pending.operator.as_str()));
+                    self.pending_operator = Some(PendingOperator {
+                        step: PendingOperatorStep::CommentTextObject,
+                        ..pending
+                    });
+                    Some(KeyAction::None)
+                }
                 'w' => self.operator_action_for_range(
                     pending.operator,
                     self.word_motion_range(
@@ -11415,6 +11434,17 @@ impl Editor {
                 }
                 _ => self.pending_operator_invalid(),
             },
+            PendingOperatorStep::CommentTextObject => {
+                if c != 'c' {
+                    return self.pending_operator_invalid();
+                }
+                let range = self.comment_text_object_range();
+                self.operator_action_for_linewise_range(
+                    pending.operator,
+                    range,
+                    "comment block not found",
+                )
+            }
             PendingOperatorStep::FindForward => {
                 self.last_character_motion = Some((ForwardCharacterMotion::Find, c));
                 self.operator_action_for_range(
@@ -11485,6 +11515,7 @@ impl Editor {
             EditOperator::Delete => Action::DeleteTextRange(range),
             EditOperator::Change => Action::ChangeTextRange(range),
             EditOperator::Yank => Action::YankTextRange(range),
+            EditOperator::Comment => Action::ToggleCommentRange(range),
             EditOperator::Lowercase => Action::TransformTextRange {
                 range,
                 transform: CaseTransform::Lower,
@@ -11519,6 +11550,7 @@ impl Editor {
             EditOperator::Delete => Action::DeleteLinewiseRange(range),
             EditOperator::Change => Action::ChangeLinewiseRange(range),
             EditOperator::Yank => Action::YankLinewiseRange(range),
+            EditOperator::Comment => Action::ToggleCommentRange(range),
             EditOperator::Lowercase => Action::TransformTextRange {
                 range,
                 transform: CaseTransform::Lower,
@@ -12740,10 +12772,12 @@ impl Editor {
                 }
                 self.render(buffer)?;
             }
-            Action::StartLowercaseOperator(count)
+            Action::StartCommentOperator(count)
+            | Action::StartLowercaseOperator(count)
             | Action::StartUppercaseOperator(count)
             | Action::StartToggleCaseOperator(count) => {
                 let operator = match action {
+                    Action::StartCommentOperator(_) => EditOperator::Comment,
                     Action::StartLowercaseOperator(_) => EditOperator::Lowercase,
                     Action::StartUppercaseOperator(_) => EditOperator::Uppercase,
                     Action::StartToggleCaseOperator(_) => EditOperator::ToggleCase,
@@ -12751,6 +12785,38 @@ impl Editor {
                 };
                 self.pending_operator = Some(PendingOperator::new(operator, *count));
                 self.waiting_command = Some(operator.as_str().to_string());
+            }
+            Action::ToggleCommentLines(count) => {
+                let start_line = self.buffer_line();
+                let last_line = start_line
+                    .saturating_add(usize::from(count.saturating_sub(1)))
+                    .min(self.last_navigable_line());
+                if self.toggle_comment_lines(start_line, last_line) {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::ToggleCommentRange(range) => {
+                let start_line = range.start.line.min(self.last_navigable_line());
+                let last_line = if range.end.line > start_line && range.end.character == 0 {
+                    range.end.line.saturating_sub(1)
+                } else {
+                    range.end.line
+                }
+                .min(self.last_navigable_line());
+                if self.toggle_comment_lines(start_line, last_line) {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::ToggleCommentSelection => {
+                if let Some(selection) = self.selection {
+                    let (_, start_line, _, last_line) = selection.into();
+                    if self.toggle_comment_lines(start_line, last_line) {
+                        self.notify_change(runtime).await?;
+                    }
+                }
+                self.render(buffer)?;
             }
             Action::TransformTextRange { range, transform } => {
                 if self.transform_text_range(*range, *transform, "change case") {
@@ -16732,6 +16798,12 @@ impl Editor {
                     KeyAction::Single(Action::StartLowercaseOperator(_)) => {
                         KeyAction::Single(Action::StartLowercaseOperator(count))
                     }
+                    KeyAction::Single(Action::StartCommentOperator(_)) => {
+                        KeyAction::Single(Action::StartCommentOperator(count))
+                    }
+                    KeyAction::Single(Action::ToggleCommentLines(_)) => {
+                        KeyAction::Single(Action::ToggleCommentLines(count))
+                    }
                     KeyAction::Single(Action::StartUppercaseOperator(_)) => {
                         KeyAction::Single(Action::StartUppercaseOperator(count))
                     }
@@ -17012,6 +17084,101 @@ impl Editor {
             }
         }
         transformed
+    }
+
+    fn comment_syntax(&mut self) -> Option<CommentSyntax> {
+        let Some(language) = self.current_language_id() else {
+            self.last_error = Some("no comment syntax configured for unnamed buffer".to_string());
+            return None;
+        };
+        let extension = self.current_buffer().file_type();
+        let template = extension
+            .as_deref()
+            .and_then(|extension| self.config.commenting.languages.get(extension))
+            .or_else(|| self.config.commenting.languages.get(&language));
+        let Some(template) = template else {
+            self.last_error = Some(format!("no comment syntax configured for {language}"));
+            return None;
+        };
+        let Some(syntax) = CommentSyntax::parse(template) else {
+            self.last_error = Some(format!(
+                "invalid comment syntax configured for {language}: expected exactly one %s placeholder"
+            ));
+            return None;
+        };
+        Some(syntax)
+    }
+
+    fn comment_text_object_range(&mut self) -> Option<TextRange> {
+        let syntax = self.comment_syntax()?;
+        let current_line = self.buffer_line();
+        let is_commented_line = |line| {
+            self.current_buffer()
+                .get(line)
+                .is_some_and(|content| syntax.is_commented(trim_line_ending(&content)))
+        };
+        if !is_commented_line(current_line) {
+            return None;
+        }
+
+        let mut first_line = current_line;
+        while first_line > 0 && is_commented_line(first_line - 1) {
+            first_line -= 1;
+        }
+
+        let mut last_line = current_line;
+        let final_line = self.last_navigable_line();
+        while last_line < final_line && is_commented_line(last_line + 1) {
+            last_line += 1;
+        }
+
+        let end = if last_line < final_line {
+            TextPosition::new(last_line + 1, 0)
+        } else {
+            TextPosition::new(last_line, self.line_character_len(last_line))
+        };
+        Some(TextRange::new(TextPosition::new(first_line, 0), end))
+    }
+
+    fn toggle_comment_lines(&mut self, start_line: usize, last_line: usize) -> bool {
+        let Some(syntax) = self.comment_syntax() else {
+            return false;
+        };
+        let final_line = self.last_navigable_line();
+        let start_line = start_line.min(final_line);
+        let last_line = last_line.min(final_line);
+        if start_line > last_line {
+            return false;
+        }
+
+        let originals = (start_line..=last_line)
+            .filter_map(|line| self.current_buffer().get(line))
+            .map(|line| trim_line_ending(&line).to_string())
+            .collect::<Vec<_>>();
+        let replacements = syntax.toggle_lines(&originals);
+        let edits = originals
+            .iter()
+            .zip(replacements)
+            .enumerate()
+            .filter_map(|(offset, (original, replacement))| {
+                (original != &replacement).then_some((start_line + offset, replacement))
+            })
+            .collect::<Vec<_>>();
+        if edits.is_empty() {
+            return false;
+        }
+
+        self.begin_transaction("toggle comments");
+        for (line, replacement) in edits.into_iter().rev() {
+            let range = TextRange::new(
+                TextPosition::new(line, 0),
+                TextPosition::new(line, self.line_character_len(line)),
+            );
+            self.replace_range(range, &replacement);
+        }
+        self.move_to_text_position(TextPosition::new(start_line, 0));
+        self.commit_transaction(self.cursor_snapshot());
+        true
     }
 
     fn transform_text_range(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod codex;
 pub mod color;
 pub mod command;
 pub mod command_palette;
+mod comment;
 pub mod config;
 pub mod dispatcher;
 pub mod editor;

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -288,6 +288,274 @@ fn default_key_config() -> Config {
     toml::from_str(include_str!("../default_config.toml")).unwrap()
 }
 
+fn comment_harness(file: &str, contents: &str) -> EditorHarness {
+    let buffer = Buffer::new(Some(file.to_string()), contents.to_string());
+    EditorHarness::with_config(buffer, default_key_config())
+}
+
+#[tokio::test]
+async fn comment_gcc_toggles_the_current_line() {
+    let mut harness = comment_harness("main.rs", "    let value = 1;");
+
+    type_normal_keys(&mut harness, "gcc").await;
+    harness.assert_buffer_contents("    // let value = 1;");
+
+    type_normal_keys(&mut harness, "gcc").await;
+    harness.assert_buffer_contents("    let value = 1;");
+}
+
+#[tokio::test]
+async fn comment_gcc_honors_a_line_count() {
+    let mut harness = comment_harness("main.rs", "alpha\nbeta\ngamma\ndelta");
+
+    type_normal_keys(&mut harness, "3gcc").await;
+
+    harness.assert_buffer_contents("// alpha\n// beta\n// gamma\ndelta");
+}
+
+#[tokio::test]
+async fn comment_operator_covers_vertical_motions() {
+    let mut harness = comment_harness("main.rs", "alpha\nbeta\ngamma");
+
+    type_normal_keys(&mut harness, "gcj").await;
+
+    harness.assert_buffer_contents("// alpha\n// beta\ngamma");
+}
+
+#[tokio::test]
+async fn comment_operator_honors_a_motion_count() {
+    let mut harness = comment_harness("main.rs", "alpha\nbeta\ngamma\ndelta");
+
+    type_normal_keys(&mut harness, "gc2j").await;
+
+    harness.assert_buffer_contents("// alpha\n// beta\n// gamma\ndelta");
+}
+
+#[tokio::test]
+async fn comment_operator_covers_a_word_text_object_linewise() {
+    let mut harness = comment_harness("main.rs", "alpha beta\ngamma");
+
+    type_normal_keys(&mut harness, "gciw").await;
+
+    harness.assert_buffer_contents("// alpha beta\ngamma");
+}
+
+#[tokio::test]
+async fn comment_range_aligns_at_the_least_indented_nonblank_line() {
+    let mut harness = comment_harness("main.rs", "    alpha\n      beta\n\n    gamma");
+
+    type_normal_keys(&mut harness, "4gcc").await;
+
+    harness.assert_buffer_contents("    // alpha\n    //   beta\n    //\n    // gamma");
+}
+
+#[tokio::test]
+async fn comment_range_uncomments_only_when_every_nonblank_line_is_commented() {
+    let mut harness = comment_harness("main.rs", "    // alpha\n    // beta");
+
+    type_normal_keys(&mut harness, "2gcc").await;
+
+    harness.assert_buffer_contents("    alpha\n    beta");
+}
+
+#[tokio::test]
+async fn comment_range_comments_mixed_comment_states_together() {
+    let mut harness = comment_harness("main.rs", "    // alpha\n    beta");
+
+    type_normal_keys(&mut harness, "2gcc").await;
+
+    harness.assert_buffer_contents("    // // alpha\n    // beta");
+}
+
+#[tokio::test]
+async fn comment_characterwise_visual_selection_toggles_whole_lines() {
+    let mut harness = comment_harness("main.rs", "alpha\n  beta\ngamma");
+
+    type_normal_keys(&mut harness, "vjgc").await;
+
+    harness.assert_buffer_contents("// alpha\n//   beta\ngamma");
+    harness.assert_mode(Mode::Normal);
+}
+
+#[tokio::test]
+async fn comment_linewise_visual_selection_toggles_whole_lines() {
+    let mut harness = comment_harness("main.rs", "alpha\n  beta\ngamma");
+
+    type_normal_keys(&mut harness, "Vjgc").await;
+
+    harness.assert_buffer_contents("// alpha\n//   beta\ngamma");
+    harness.assert_mode(Mode::Normal);
+}
+
+#[tokio::test]
+async fn comment_blockwise_visual_selection_toggles_whole_lines() {
+    let mut harness = comment_harness("main.rs", "alpha\n  beta\ngamma");
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('v'),
+            KeyModifiers::CONTROL,
+        )))
+        .await
+        .unwrap();
+
+    type_normal_keys(&mut harness, "jgc").await;
+
+    harness.assert_buffer_contents("// alpha\n//   beta\ngamma");
+    harness.assert_mode(Mode::Normal);
+}
+
+#[tokio::test]
+async fn comment_templates_follow_the_active_language() {
+    for (file, contents, commented) in [
+        ("main.py", "    value = 1", "    # value = 1"),
+        ("main.lua", "    local value = 1", "    -- local value = 1"),
+        (
+            "index.html",
+            "    <div>hello</div>",
+            "    <!-- <div>hello</div> -->",
+        ),
+        ("site.css", "    color: red;", "    /* color: red; */"),
+        ("plugin.hk", "    let value = 1;", "    // let value = 1;"),
+    ] {
+        let mut harness = comment_harness(file, contents);
+
+        type_normal_keys(&mut harness, "gcc").await;
+        harness.assert_buffer_contents(commented);
+
+        type_normal_keys(&mut harness, "gcc").await;
+        harness.assert_buffer_contents(contents);
+    }
+}
+
+#[tokio::test]
+async fn comment_configuration_supports_language_overrides() {
+    let mut config = default_key_config();
+    config
+        .commenting
+        .languages
+        .insert("rust".to_string(), "/* %s */".to_string());
+    let buffer = Buffer::new(Some("main.rs".to_string()), "alpha".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    type_normal_keys(&mut harness, "gcc").await;
+
+    harness.assert_buffer_contents("/* alpha */");
+}
+
+#[tokio::test]
+async fn comment_configuration_prefers_extension_specific_overrides() {
+    let mut config = default_key_config();
+    config
+        .commenting
+        .languages
+        .insert("rs".to_string(), "/* %s */".to_string());
+    let buffer = Buffer::new(Some("main.rs".to_string()), "alpha".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    type_normal_keys(&mut harness, "gcc").await;
+
+    harness.assert_buffer_contents("/* alpha */");
+}
+
+#[tokio::test]
+async fn comment_operation_is_one_undoable_and_redoable_transaction() {
+    let mut harness = comment_harness("main.rs", "alpha\nbeta\ngamma");
+
+    type_normal_keys(&mut harness, "3gcc").await;
+    harness.assert_buffer_contents("// alpha\n// beta\n// gamma");
+
+    type_normal_keys(&mut harness, "u").await;
+    harness.assert_buffer_contents("alpha\nbeta\ngamma");
+
+    harness.execute_action(Action::Redo).await.unwrap();
+    harness.assert_buffer_contents("// alpha\n// beta\n// gamma");
+}
+
+#[tokio::test]
+async fn comment_gcc_is_repeatable_at_the_current_cursor() {
+    let mut harness = comment_harness("main.rs", "alpha\nbeta\ngamma");
+
+    type_normal_keys(&mut harness, "gccj.").await;
+
+    harness.assert_buffer_contents("// alpha\n// beta\ngamma");
+}
+
+#[tokio::test]
+async fn comment_text_object_uncomments_the_contiguous_comment_block() {
+    let mut harness = comment_harness("main.rs", "// alpha\n// beta\ngamma");
+
+    type_normal_keys(&mut harness, "gcgc").await;
+
+    harness.assert_buffer_contents("alpha\nbeta\ngamma");
+}
+
+#[tokio::test]
+async fn comment_text_object_can_be_deleted() {
+    let mut harness = comment_harness("main.rs", "// alpha\n// beta\ngamma");
+
+    type_normal_keys(&mut harness, "dgc").await;
+
+    harness.assert_buffer_contents("gamma");
+}
+
+#[tokio::test]
+async fn comment_operation_preserves_windows_line_endings() {
+    let mut harness = comment_harness("main.rs", "alpha\r\nbeta\r\n");
+
+    type_normal_keys(&mut harness, "2gcc").await;
+
+    harness.assert_buffer_contents("// alpha\r\n// beta\r\n");
+}
+
+#[tokio::test]
+async fn comment_unknown_language_leaves_the_buffer_unchanged() {
+    let mut harness = comment_harness("data.json", "{\"value\": 1}");
+
+    type_normal_keys(&mut harness, "gcc").await;
+
+    harness.assert_buffer_contents("{\"value\": 1}");
+    assert_eq!(
+        harness.last_error(),
+        Some("no comment syntax configured for json")
+    );
+    assert!(!harness.is_dirty());
+}
+
+#[tokio::test]
+async fn comment_unnamed_buffer_fails_without_changing_the_buffer() {
+    let buffer = Buffer::new(None, "alpha".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    type_normal_keys(&mut harness, "gcc").await;
+
+    harness.assert_buffer_contents("alpha");
+    assert_eq!(
+        harness.last_error(),
+        Some("no comment syntax configured for unnamed buffer")
+    );
+    assert!(!harness.is_dirty());
+}
+
+#[tokio::test]
+async fn comment_invalid_template_fails_without_changing_the_buffer() {
+    let mut config = default_key_config();
+    config
+        .commenting
+        .languages
+        .insert("rust".to_string(), "// missing placeholder".to_string());
+    let buffer = Buffer::new(Some("main.rs".to_string()), "alpha".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    type_normal_keys(&mut harness, "gcc").await;
+
+    harness.assert_buffer_contents("alpha");
+    assert_eq!(
+        harness.last_error(),
+        Some("invalid comment syntax configured for rust: expected exactly one %s placeholder")
+    );
+    assert!(!harness.is_dirty());
+}
+
 #[tokio::test]
 async fn dot_repeats_a_direct_change_at_the_current_cursor() {
     let buffer = Buffer::new(None, "abc\ndef".to_string());


### PR DESCRIPTION
## Why

Red does not yet offer the built-in Neovim-style comment operator, so users cannot toggle comments with familiar `gcc` and `gc{motion}` commands or apply them consistently to visual selections.

## What changed

- Add a real linewise comment operator supporting `gcc`, counts, motions, text objects, and contiguous comment blocks, including `3gcc`, `gcj`, `gc2j`, `gciw`, `gcgc`, and `dgc`.
- Support characterwise, linewise, and blockwise visual selections with `gc`, returning to normal mode afterward.
- Add configurable Neovim-style `%s` comment templates with defaults for 27 languages and support for language- and extension-specific overrides.
- Preserve common indentation, blank and mixed-comment ranges, Windows line endings, one-step undo and redo, and dot repeat.
- Expose line commenting in the command palette and add focused parser, configuration, and end-to-end editing regressions.

## How to Test

1. Open a Rust file with `RED_RUNTIME=. cargo run -- path/to/main.rs`. Press `gcc` twice and verify the current line is commented and then restored.
2. Test `3gcc`, `gcj`, `gc2j`, and `gciw`; verify the expected complete lines are toggled as a single undoable change.
3. Select multiple lines with `v`, `V`, or `Ctrl-v`, press `gc`, and verify the selected lines are toggled and the editor returns to normal mode.
4. Place the cursor inside consecutive commented lines and try `gcgc` and `dgc`; verify the complete contiguous comment block is toggled or deleted.
5. Press `gcc` in a JSON or unnamed buffer and verify the buffer remains unchanged with a clear missing-comment-syntax error.
6. Run `cargo test --test editing comment_` and verify all 22 commenting integration tests pass.