### PR TITLE
feat(editor): highlight matching bracket pairs

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1745,6 +1745,9 @@ pub struct Editor {
     /// viewport-plus-margin slice.
     highlight_cache: HashMap<usize, ViewportHighlightEntry>,
 
+    /// Delimiter partners indexed only after the cursor lands on a configured bracket.
+    bracket_match_cache: Option<matchit::BracketMatchCache>,
+
     /// Memoized display layout, shared by the many per-frame layout queries.
     layout_cache: std::cell::RefCell<HashMap<LayoutCacheKey, std::sync::Arc<DisplayLayout>>>,
 
@@ -1784,6 +1787,9 @@ pub struct Editor {
 
     /// Last terminal cursor cell painted into the render buffer.
     last_rendered_cursor_position: Option<(usize, usize)>,
+
+    /// Terminal rows containing the previously rendered matching delimiter pair.
+    last_rendered_bracket_rows: Vec<usize>,
 
     /// Last rendered surface under the terminal-owned cursor.
     ///
@@ -2913,6 +2919,7 @@ impl Editor {
             plugin_registry,
             highlighter,
             highlight_cache: HashMap::new(),
+            bracket_match_cache: None,
             layout_cache: std::cell::RefCell::new(HashMap::new()),
             window_manager,
             stdout,
@@ -2925,6 +2932,7 @@ impl Editor {
             previous_render_buffer: None,
             force_full_redraw: false,
             last_rendered_cursor_position: None,
+            last_rendered_bracket_rows: Vec::new(),
             last_rendered_cursor_surface: None,
             defer_motion_render: false,
             deferred_motion_needs_full_render: false,
@@ -3128,7 +3136,10 @@ impl Editor {
             self.render(buffer)
         } else if self.can_render_cursor_motion_delta() {
             self.render_cursor_motion_delta(buffer)
-        } else if self.uses_synthetic_block_cursor() {
+        } else if self.uses_synthetic_block_cursor()
+            || !self.last_rendered_bracket_rows.is_empty()
+            || self.matching_bracket_positions().is_some()
+        {
             self.render_motion_frame(buffer)
         } else {
             self.draw_cursor_preserving_cursor_goal()
@@ -7643,7 +7654,10 @@ impl Editor {
             self.render(buffer)
         } else if self.can_render_cursor_motion_delta() {
             self.render_cursor_motion_delta(buffer)
-        } else if self.uses_synthetic_block_cursor() {
+        } else if self.uses_synthetic_block_cursor()
+            || !self.last_rendered_bracket_rows.is_empty()
+            || self.matching_bracket_positions().is_some()
+        {
             self.render_motion_frame(buffer)
         } else {
             self.draw_cursor_preserving_cursor_goal()
@@ -12114,6 +12128,7 @@ impl Editor {
             &Style::default(),
         );
         self.last_rendered_cursor_position = None;
+        self.last_rendered_bracket_rows.clear();
         self.last_rendered_cursor_surface = None;
     }
 
@@ -22155,6 +22170,27 @@ mod test {
         editor
     }
 
+    fn bracket_test_editor(contents: &str, width: usize, height: usize) -> Editor {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, contents.to_string());
+        let theme = Theme {
+            bracket_match_style: Some(Style {
+                bg: Some(Color::Rgb {
+                    r: 110,
+                    g: 90,
+                    b: 145,
+                }),
+                ..Style::default()
+            }),
+            ..Theme::default()
+        };
+        let mut editor =
+            Editor::with_size(lsp, width, height, config, theme, vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        editor
+    }
+
     fn splash_test_editor(width: usize, height: usize, config: Config) -> Editor {
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
         let buffer = Buffer::new(None, String::new());
@@ -22771,6 +22807,110 @@ mod test {
         assert_eq!(
             render_buffer.cells[row5].style.fg, styled,
             "upward delta render must keep highlighting"
+        );
+    }
+
+    #[test]
+    fn bracket_matching_highlights_multiline_partner_in_active_window() {
+        let mut editor = bracket_test_editor("if ready {\n    work();\n}", 40, 8);
+        editor.cx = 9;
+        let mut render_buffer = RenderBuffer::new(40, 8, &Style::default());
+
+        editor.render(&mut render_buffer).unwrap();
+
+        let window = editor.window_manager.active_window().unwrap();
+        let (partner_x, partner_y) = editor.buffer_to_window_coords(window, 0, 2).unwrap();
+        let partner_y = editor.window_to_terminal_y(window, partner_y);
+        let partner_x = editor.window_to_terminal_x(window, partner_x);
+        let partner = &render_buffer.cells[partner_y * render_buffer.width + partner_x];
+        let expected = editor.theme.selected_style(
+            &editor.theme.style,
+            &editor.theme.editor_bracket_match_style(),
+            crate::theme::SelectionForegroundPriority::Content,
+        );
+
+        assert_eq!(partner.c, '}');
+        assert_eq!(partner.style.bg, expected.bg);
+    }
+
+    #[test]
+    fn bracket_matching_respects_tabs_and_wrapped_lines() {
+        let mut editor = bracket_test_editor("\t[abcdefghijklmnopqrstuvwxyz0123456789]", 18, 8);
+        editor.cx = 1;
+        let mut render_buffer = RenderBuffer::new(18, 8, &Style::default());
+
+        editor.render(&mut render_buffer).unwrap();
+
+        let window = editor.window_manager.active_window().unwrap();
+        let closer = editor.current_buffer().get(0).unwrap().chars().count() - 1;
+        let (partner_x, partner_y) = editor.buffer_to_window_coords(window, closer, 0).unwrap();
+        let partner_y = editor.window_to_terminal_y(window, partner_y);
+        let partner_x = editor.window_to_terminal_x(window, partner_x);
+        let partner = &render_buffer.cells[partner_y * render_buffer.width + partner_x];
+
+        assert!(
+            partner_y > 0,
+            "the matching bracket should wrap onto another row"
+        );
+        assert_eq!(partner.c, ']');
+        assert_ne!(partner.style.bg, editor.theme.style.bg);
+    }
+
+    #[test]
+    fn cursor_motion_delta_clears_old_matching_bracket_rows() {
+        let mut editor = bracket_test_editor("{\n    value\n}", 30, 8);
+        let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+        editor.render(&mut render_buffer).unwrap();
+
+        let window = editor.window_manager.active_window().unwrap();
+        let (partner_x, partner_y) = editor.buffer_to_window_coords(window, 0, 2).unwrap();
+        let partner_y = editor.window_to_terminal_y(window, partner_y);
+        let partner_x = editor.window_to_terminal_x(window, partner_x);
+        let partner_index = partner_y * render_buffer.width + partner_x;
+        let highlighted = render_buffer.cells[partner_index].style.bg;
+        assert_ne!(highlighted, editor.theme.style.bg);
+
+        editor.cy = 1;
+        editor.cx = 4;
+        editor
+            .render_cursor_motion_delta(&mut render_buffer)
+            .unwrap();
+
+        assert_eq!(render_buffer.cells[partner_index].c, '}');
+        assert_eq!(
+            render_buffer.cells[partner_index].style.bg,
+            editor.theme.style.bg
+        );
+        assert!(editor.last_rendered_bracket_rows.is_empty());
+    }
+
+    #[test]
+    fn cursor_motion_delta_moves_matching_bracket_highlight_to_new_partner() {
+        let mut editor = bracket_test_editor("(\n)\n[\n]", 30, 8);
+        let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+        editor.render(&mut render_buffer).unwrap();
+
+        let window = editor.window_manager.active_window().unwrap();
+        let first = editor.buffer_to_window_coords(window, 0, 1).unwrap();
+        let second = editor.buffer_to_window_coords(window, 0, 3).unwrap();
+        let first_index = editor.window_to_terminal_y(window, first.1) * render_buffer.width
+            + editor.window_to_terminal_x(window, first.0);
+        let second_index = editor.window_to_terminal_y(window, second.1) * render_buffer.width
+            + editor.window_to_terminal_x(window, second.0);
+
+        editor.cy = 2;
+        editor.cx = 0;
+        editor
+            .render_cursor_motion_delta(&mut render_buffer)
+            .unwrap();
+
+        assert_eq!(
+            render_buffer.cells[first_index].style.bg,
+            editor.theme.style.bg
+        );
+        assert_ne!(
+            render_buffer.cells[second_index].style.bg,
+            editor.theme.style.bg
         );
     }
 

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -28,6 +28,7 @@ use crate::{
     plugin::DecorationAnchor,
     splash,
     theme::{SelectionForegroundPriority, Style},
+    undo::TextPosition,
     unicode_utils::{
         char_prefix, display_width, display_width_with_tabs, fit_display_width,
         grapheme_to_column_with_tabs, trim_line_ending, truncate_display_width,
@@ -387,13 +388,29 @@ impl Editor {
         self.sync_to_window();
 
         let new_cursor_position = self.render_cursor_position();
-        let mut rows = Vec::with_capacity(4);
+        let active_window_id = self.window_manager.active_window_id();
+        let matching_bracket_rows = self
+            .window_manager
+            .window_at_index(active_window_id)
+            .cloned()
+            .map(|window| {
+                self.matching_bracket_points(&window)
+                    .into_iter()
+                    .map(|point| point.y)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let mut rows = Vec::with_capacity(
+            4 + self.last_rendered_bracket_rows.len() + matching_bracket_rows.len(),
+        );
         if let Some((_, y)) = self.last_rendered_cursor_position {
             rows.push(y);
         }
         if let Some((_, y)) = new_cursor_position {
             rows.push(y);
         }
+        rows.extend(self.last_rendered_bracket_rows.iter().copied());
+        rows.extend(matching_bracket_rows.iter().copied());
 
         let status_y = (self.size.1 as usize).saturating_sub(2);
         let command_y = (self.size.1 as usize).saturating_sub(1);
@@ -409,7 +426,6 @@ impl Editor {
         rows.dedup();
 
         let snapshots = buffer.snapshot_rows(&rows);
-        let active_window_id = self.window_manager.active_window_id();
         self.render_window_rows(buffer, active_window_id, &rows)?;
         self.draw_statusline(buffer);
         self.draw_commandline(buffer);
@@ -420,6 +436,7 @@ impl Editor {
         self.render_diff(&changes)?;
         self.commit_render_buffer_changes(&changes);
         self.last_rendered_cursor_position = new_cursor_position;
+        self.last_rendered_bracket_rows = matching_bracket_rows;
         self.render_generation = self.render_generation.wrapping_add(1);
 
         Ok(())
@@ -449,6 +466,7 @@ impl Editor {
         self.render_gutter_rows_in_window(buffer, &window, window_id, &local_rows);
         self.render_main_content_rows_in_window(buffer, &window, &local_rows)?;
         self.render_line_highlight_rows_in_window(buffer, &window, &local_rows);
+        self.render_matching_brackets_in_window(buffer, &window, Some(terminal_rows));
 
         Ok(())
     }
@@ -1166,6 +1184,7 @@ impl Editor {
         }
 
         self.render_search_highlights_in_window(buffer, window)?;
+        self.render_matching_brackets_in_window(buffer, window, None);
 
         // Render selection last so its contrast guarantee is not overwritten by search highlights.
         if self.is_visual() && window.active {
@@ -1183,6 +1202,89 @@ impl Editor {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn matching_bracket_positions(&mut self) -> Option<[TextPosition; 2]> {
+        if !matches!(
+            self.mode,
+            Mode::Normal | Mode::Insert | Mode::Visual | Mode::VisualLine | Mode::VisualBlock
+        ) {
+            return None;
+        }
+
+        let cursor = self.cursor_text_position();
+        let buffer = self.buffer_manager.active_buffer()?;
+        let matching = crate::matchit::BracketMatchCache::matching_position(
+            &mut self.bracket_match_cache,
+            buffer,
+            cursor,
+            &self.config.matchit,
+        )?;
+
+        Some([cursor, matching])
+    }
+
+    fn matching_bracket_points(&mut self, window: &crate::window::Window) -> Vec<Point> {
+        if !window.active || self.current_dialog.is_some() {
+            return Vec::new();
+        }
+        let Some(positions) = self.matching_bracket_positions() else {
+            return Vec::new();
+        };
+
+        let mut points = Vec::with_capacity(positions.len());
+        for position in positions {
+            let Some(line) = self
+                .buffer_manager
+                .get(window.buffer_index)
+                .and_then(|buffer| buffer.get(position.line))
+            else {
+                continue;
+            };
+            let line = trim_line_ending(&line);
+            let tab_width = self.tab_width_for_buffer_index(window.buffer_index);
+            let start_col =
+                display_width_with_tabs(char_prefix(line, position.character), tab_width);
+            let end_col = display_width_with_tabs(
+                char_prefix(line, position.character.saturating_add(1)),
+                tab_width,
+            );
+            points.extend(self.display_col_range_points_in_window(
+                window,
+                position.line,
+                start_col,
+                end_col,
+            ));
+        }
+
+        points
+    }
+
+    fn render_matching_brackets_in_window(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        window: &crate::window::Window,
+        terminal_rows: Option<&[usize]>,
+    ) {
+        let mut points = self.matching_bracket_points(window);
+        if terminal_rows.is_none() {
+            self.last_rendered_bracket_rows = points.iter().map(|point| point.y).collect();
+            self.last_rendered_bracket_rows.sort_unstable();
+            self.last_rendered_bracket_rows.dedup();
+        }
+        if let Some(terminal_rows) = terminal_rows {
+            points.retain(|point| terminal_rows.contains(&point.y));
+        }
+        if points.is_empty() {
+            return;
+        }
+
+        buffer.apply_selection_for_points(
+            points,
+            &self.theme.editor_bracket_match_style(),
+            &self.theme,
+            SelectionForegroundPriority::Content,
+        );
     }
 
     fn render_search_highlights_in_window(

--- a/src/matchit.rs
+++ b/src/matchit.rs
@@ -4,12 +4,176 @@
 //! language. Returned positions use editor grapheme coordinates; tree-sitter byte spans
 //! are converted before crossing the module boundary.
 
+use std::collections::HashMap;
+
 use regex::Regex;
 
 use crate::{
+    buffer::{Buffer, BufferId},
     config::{MatchitConfig, MatchitLanguageConfig},
     undo::{TextPosition, TextRange},
 };
+
+/// Lazily indexes configured single-character delimiter pairs for one buffer revision.
+///
+/// The index walks the structurally shared rope directly instead of flattening the
+/// document or running the more expansive `%` motion tokenizer on every cursor move.
+#[derive(Debug)]
+pub(crate) struct BracketMatchCache {
+    buffer_id: BufferId,
+    revision: u64,
+    configured_pairs: Vec<[String; 2]>,
+    matches: HashMap<usize, usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BracketScanState {
+    Code,
+    SingleQuoted,
+    DoubleQuoted,
+    LineComment,
+    BlockComment,
+}
+
+impl BracketMatchCache {
+    /// Returns the partner only when the cursor is directly on a configured delimiter.
+    pub(crate) fn matching_position(
+        cache: &mut Option<Self>,
+        buffer: &Buffer,
+        cursor: TextPosition,
+        config: &MatchitConfig,
+    ) -> Option<TextPosition> {
+        let rope = buffer.contents_snapshot();
+        let cursor_index = buffer.position_to_char_idx(cursor);
+        let character = rope.get_char(cursor_index)?;
+        if !config.pairs.iter().any(|pair| {
+            single_character(&pair[0]) == Some(character)
+                || single_character(&pair[1]) == Some(character)
+        }) {
+            return None;
+        }
+
+        let cache_is_current = cache.as_ref().is_some_and(|entry| {
+            entry.buffer_id == buffer.id()
+                && entry.revision == buffer.revision()
+                && entry.configured_pairs == config.pairs
+        });
+        if !cache_is_current {
+            *cache = Some(Self::build(buffer, &rope, config));
+        }
+
+        cache
+            .as_ref()?
+            .matches
+            .get(&cursor_index)
+            .copied()
+            .map(|index| buffer.char_idx_to_position(index))
+    }
+
+    fn build(buffer: &Buffer, rope: &ropey::Rope, config: &MatchitConfig) -> Self {
+        let pairs = config
+            .pairs
+            .iter()
+            .filter_map(|pair| Some((single_character(&pair[0])?, single_character(&pair[1])?)))
+            .collect::<Vec<_>>();
+        let mut stacks = vec![Vec::<usize>::new(); pairs.len()];
+        let mut matches = HashMap::new();
+        let mut characters = rope.chars().enumerate().peekable();
+        let mut state = BracketScanState::Code;
+        let mut escaped = false;
+        let is_rust = buffer
+            .file
+            .as_deref()
+            .is_some_and(|file| file.ends_with(".rs"));
+
+        while let Some((index, character)) = characters.next() {
+            match state {
+                BracketScanState::LineComment => {
+                    if character == '\n' {
+                        state = BracketScanState::Code;
+                    }
+                }
+                BracketScanState::BlockComment => {
+                    if character == '*' && characters.peek().is_some_and(|(_, next)| *next == '/') {
+                        characters.next();
+                        state = BracketScanState::Code;
+                    }
+                }
+                BracketScanState::SingleQuoted | BracketScanState::DoubleQuoted => {
+                    let quote = if state == BracketScanState::SingleQuoted {
+                        '\''
+                    } else {
+                        '"'
+                    };
+                    if escaped {
+                        escaped = false;
+                    } else if character == '\\' {
+                        escaped = true;
+                    } else if character == quote {
+                        state = BracketScanState::Code;
+                    }
+                }
+                BracketScanState::Code => {
+                    if character == '/' {
+                        match characters.peek().map(|(_, next)| *next) {
+                            Some('/') => {
+                                characters.next();
+                                state = BracketScanState::LineComment;
+                                continue;
+                            }
+                            Some('*') => {
+                                characters.next();
+                                state = BracketScanState::BlockComment;
+                                continue;
+                            }
+                            _ => {}
+                        }
+                    }
+                    if character == '\'' {
+                        if is_rust
+                            && rope
+                                .get_char(index.saturating_add(1))
+                                .is_some_and(|next| next == '_' || next.is_alphabetic())
+                            && rope.get_char(index.saturating_add(2)) != Some('\'')
+                        {
+                            continue;
+                        }
+                        state = BracketScanState::SingleQuoted;
+                        continue;
+                    }
+                    if character == '"' {
+                        state = BracketScanState::DoubleQuoted;
+                        continue;
+                    }
+
+                    for (pair_index, (open, close)) in pairs.iter().copied().enumerate() {
+                        if character == open {
+                            stacks[pair_index].push(index);
+                        } else if character == close {
+                            if let Some(open_index) = stacks[pair_index].pop() {
+                                matches.insert(open_index, index);
+                                matches.insert(index, open_index);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            buffer_id: buffer.id(),
+            revision: buffer.revision(),
+            configured_pairs: config.pairs.clone(),
+            matches,
+        }
+    }
+}
+
+fn single_character(token: &str) -> Option<char> {
+    let mut characters = token.chars();
+    let character = characters.next()?;
+    characters.next().is_none().then_some(character)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MatchDirection {
@@ -630,4 +794,163 @@ fn advance_position(position: TextPosition) -> TextPosition {
 
 fn position_le(left: TextPosition, right: TextPosition) -> bool {
     (left.line, left.character) <= (right.line, right.character)
+}
+
+#[cfg(test)]
+mod bracket_match_tests {
+    use super::*;
+
+    fn position(contents: &str, needle: &str, occurrence: usize) -> TextPosition {
+        let byte = contents.match_indices(needle).nth(occurrence).unwrap().0;
+        let line = contents[..byte]
+            .chars()
+            .filter(|character| *character == '\n')
+            .count();
+        let character = contents[..byte]
+            .rsplit('\n')
+            .next()
+            .unwrap_or_default()
+            .chars()
+            .count();
+        TextPosition::new(line, character)
+    }
+
+    #[test]
+    fn configured_brackets_match_nested_pairs_in_both_directions() {
+        let contents = "fn outer() {\n    let value = [({})];\n}";
+        let buffer = Buffer::new(None, contents.to_string());
+        let config = MatchitConfig::default();
+        let mut cache = None;
+
+        for (open, close, open_occurrence, close_occurrence) in [
+            ("{", "}", 0, 1),
+            ("[", "]", 0, 0),
+            ("(", ")", 1, 1),
+            ("{", "}", 1, 0),
+        ] {
+            let opener = position(contents, open, open_occurrence);
+            let closer = position(contents, close, close_occurrence);
+            assert_eq!(
+                BracketMatchCache::matching_position(&mut cache, &buffer, opener, &config),
+                Some(closer)
+            );
+            assert_eq!(
+                BracketMatchCache::matching_position(&mut cache, &buffer, closer, &config),
+                Some(opener)
+            );
+        }
+    }
+
+    #[test]
+    fn bracket_matching_ignores_strings_and_comments() {
+        let contents = "{ \"}\" '\\'' // }\n /* } */ [ ] }";
+        let buffer = Buffer::new(None, contents.to_string());
+        let config = MatchitConfig::default();
+        let mut cache = None;
+        let opener = position(contents, "{", 0);
+        let closer = position(contents, "}", 3);
+
+        assert_eq!(
+            BracketMatchCache::matching_position(&mut cache, &buffer, opener, &config),
+            Some(closer)
+        );
+        for ignored in 0..3 {
+            assert_eq!(
+                BracketMatchCache::matching_position(
+                    &mut cache,
+                    &buffer,
+                    position(contents, "}", ignored),
+                    &config,
+                ),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn bracket_matching_requires_a_delimiter_under_the_cursor() {
+        let contents = "value (nested)";
+        let buffer = Buffer::new(None, contents.to_string());
+        let config = MatchitConfig::default();
+        let mut cache = None;
+
+        assert_eq!(
+            BracketMatchCache::matching_position(
+                &mut cache,
+                &buffer,
+                TextPosition::new(0, 0),
+                &config,
+            ),
+            None
+        );
+        assert!(
+            cache.is_none(),
+            "ordinary cursor motion must not index the buffer"
+        );
+    }
+
+    #[test]
+    fn bracket_matching_is_independent_of_advanced_matchit_navigation() {
+        let buffer = Buffer::new(None, "()".to_string());
+        let config = MatchitConfig {
+            enabled: false,
+            ..MatchitConfig::default()
+        };
+        let mut cache = None;
+
+        assert_eq!(
+            BracketMatchCache::matching_position(
+                &mut cache,
+                &buffer,
+                TextPosition::new(0, 0),
+                &config,
+            ),
+            Some(TextPosition::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn bracket_matching_rebuilds_after_the_buffer_changes() {
+        let mut buffer = Buffer::new(None, "()".to_string());
+        let config = MatchitConfig::default();
+        let mut cache = None;
+
+        assert_eq!(
+            BracketMatchCache::matching_position(
+                &mut cache,
+                &buffer,
+                TextPosition::new(0, 0),
+                &config,
+            ),
+            Some(TextPosition::new(0, 1))
+        );
+        buffer.set(0, "(())".to_string());
+        assert_eq!(
+            BracketMatchCache::matching_position(
+                &mut cache,
+                &buffer,
+                TextPosition::new(0, 0),
+                &config,
+            ),
+            Some(TextPosition::new(0, 3))
+        );
+    }
+
+    #[test]
+    fn rust_lifetimes_do_not_hide_later_matching_brackets() {
+        let contents = "fn borrow<'value>(text: &str) { text.len() }";
+        let buffer = Buffer::new(Some("borrow.rs".to_string()), contents.to_string());
+        let config = MatchitConfig::default();
+        let mut cache = None;
+
+        assert_eq!(
+            BracketMatchCache::matching_position(
+                &mut cache,
+                &buffer,
+                position(contents, "{", 0),
+                &config,
+            ),
+            Some(position(contents, "}", 0))
+        );
+    }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -39,6 +39,7 @@ pub struct Theme {
     pub ui_style: UiStyle,
     pub token_styles: Vec<TokenStyle>,
     pub line_highlight_style: Option<Style>,
+    pub bracket_match_style: Option<Style>,
     pub find_match_style: Option<Style>,
     pub find_match_highlight_style: Option<Style>,
     pub selection_style: Option<Style>,
@@ -86,6 +87,15 @@ impl Theme {
             }),
             ..Style::default()
         })
+    }
+
+    pub(crate) fn editor_bracket_match_style(&self) -> Style {
+        self.bracket_match_style
+            .clone()
+            .or_else(|| self.find_match_highlight_style.clone())
+            .or_else(|| self.find_match_style.clone())
+            .or_else(|| self.selection_style.clone())
+            .unwrap_or_else(|| self.editor_selection_style())
     }
 
     pub(crate) fn list_selection_style(&self) -> Style {
@@ -352,6 +362,7 @@ impl Default for Theme {
             ui_style: UiStyle::default(),
             token_styles: vec![],
             line_highlight_style: None,
+            bracket_match_style: None,
             find_match_style: None,
             find_match_highlight_style: None,
             selection_style: None,

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -110,6 +110,21 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
     let selection_style =
         vscode_theme.style_from("editor.selectionForeground", "editor.selectionBackground");
 
+    let bracket_match_style = vscode_theme
+        .style_from(
+            "editorBracketMatch.foreground",
+            "editorBracketMatch.background",
+        )
+        .map(|mut style| {
+            style.fg = style
+                .fg
+                .or_else(|| vscode_theme.color_from("editorBracketMatch.border"));
+            style
+        })
+        .or_else(|| {
+            vscode_theme.style_from("editorBracketMatch.border", "editorBracketMatch.background")
+        });
+
     let find_match_style = vscode_theme
         .colors
         .iter()
@@ -196,6 +211,7 @@ pub fn parse_vscode_theme_contents(contents: &str) -> anyhow::Result<Theme> {
         gutter_style,
         statusline_style,
         line_highlight_style,
+        bracket_match_style,
         find_match_style,
         find_match_highlight_style,
         selection_style,
@@ -696,6 +712,30 @@ mod test {
                 r: 62,
                 g: 87,
                 b: 103,
+            })
+        );
+    }
+
+    #[test]
+    fn test_bracket_match_style_uses_vscode_bracket_colors() {
+        let theme = parse_vscode_theme("./src/fixtures/mocha.json").unwrap();
+        let style = theme.bracket_match_style.unwrap();
+
+        assert_eq!(
+            style.bg,
+            Some(Color::Rgba {
+                r: 147,
+                g: 153,
+                b: 178,
+                a: 26,
+            })
+        );
+        assert_eq!(
+            style.fg,
+            Some(Color::Rgb {
+                r: 147,
+                g: 153,
+                b: 178,
             })
         );
     }

--- a/themes/red.json
+++ b/themes/red.json
@@ -6,6 +6,8 @@
     "editor.foreground": "#D8D8DE",
     "editor.lineHighlightBackground": "#16161B",
     "editor.selectionBackground": "#2B2B36",
+    "editorBracketMatch.background": "#34313D",
+    "editorBracketMatch.border": "#B4B4C0",
     "editor.findMatchBackground": "#5A3034",
     "editor.findMatchHighlightBackground": "#33262A",
     "editorCursor.foreground": "#E5484D",


### PR DESCRIPTION
## Why

Matching delimiters are difficult to follow in nested or multiline code when the editor provides no visual connection between the bracket under the cursor and its partner.

## What Changed

- Highlight configured matching bracket pairs in the active editor window, including nested and multiline delimiters.
- Lazily cache matches per buffer revision while ignoring strings, comments, and Rust lifetime annotations.
- Preserve tab-aware wrapping, split-window boundaries, incremental cursor redraws, and existing syntax contrast.
- Import VS Code bracket-match theme colors and add matching colors to the bundled Red theme.
- Cover matcher behavior, theme import, wrapped rendering, and stale-highlight cleanup with focused regression tests.

## How to Test

1. Run `cargo run -- path/to/file.rs`, place the cursor directly on each of `(`, `)`, `{`, `}`, `[`, and `]`, and confirm its matching delimiter is highlighted in both directions.
2. Try nested and multiline pairs, a line containing tabs that wraps, a bracket inside a string/comment, and a Rust lifetime such as `'value`; confirm only the real matching pair is highlighted.
3. Move the cursor off a multiline bracket or onto a different pair; confirm the previous partner highlight disappears immediately.
4. Run `cargo test --lib bracket_match` and `cargo test --lib matching_bracket`; expect all matcher, theme, wrapped-line, and cursor-redraw regressions to pass.
5. Run `cargo run --locked --release --example husk_cursor_bench -- --assert`; expect cursor callback p95 below the 4 ms budget (validated at 1.457 ms).