### PR TITLE
ci(actions): accelerate trusted test matrix with warp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             warp: warp-macos-latest-arm64-12x
           - standard: windows-latest
             warp: warp-windows-latest-x64-32x
-        rust: [stable, nightly]
+        rust: [stable]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,7 @@ jobs:
       ${{
         (
           github.event_name != 'pull_request' ||
-          contains(
-            fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-            github.event.pull_request.author_association
-          )
+          github.event.pull_request.head.repo.full_name == github.repository
         ) && matrix.platform.warp || matrix.platform.standard
       }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,28 @@ jobs:
         run: python3 scripts/readme_release.py --check
 
   test:
-    name: Test Suite
-    runs-on: ${{ matrix.os }}
+    name: Test Suite (${{ matrix.platform.standard }}, ${{ matrix.rust }})
+    runs-on: >-
+      ${{
+        (
+          github.event_name != 'pull_request' ||
+          contains(
+            fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+            github.event.pull_request.author_association
+          )
+        ) && matrix.platform.warp || matrix.platform.standard
+      }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        platform:
+          - standard: ubuntu-latest
+            warp: warp-ubuntu-latest-x64-32x
+          - standard: macos-latest
+            warp: warp-macos-latest-arm64-12x
+          - standard: windows-latest
+            warp: warp-windows-latest-x64-32x
         rust: [stable, nightly]
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,52 @@
+name: Nightly Rust
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Nightly Test Suite (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install --yes ripgrep
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-nightly-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test --all-targets --all-features --verbose
+
+      - name: Run tests (no default features)
+        run: cargo test --all-targets --no-default-features --verbose


### PR DESCRIPTION
The test matrix takes roughly 9-15 minutes per job on standard runners, and
running both stable and nightly doubles that cost on every change. Faster
runners should reduce the feedback loop for trusted changes without allowing
untrusted public-fork PRs to incur WarpBuild costs.

This routes the stable Test Suite jobs from pushes, manual runs, and
same-repository PR branches to WarpBuild. External fork PRs continue using the
standard GitHub-hosted runners. Nightly coverage moves out of the PR critical
path into one weekly Ubuntu job on a standard GitHub runner, which can also be
dispatched manually. Every test job has a 30-minute timeout.

## How to Test

1. Push to a same-repository PR branch and confirm the three stable Test Suite
   jobs start on the configured WarpBuild Linux 32x, macOS 12x, and Windows
   32x runners.
2. After merge, manually dispatch `Nightly Rust` and confirm its single nightly
   suite runs on standard `ubuntu-latest`.
3. For a PR whose head branch belongs to a fork, confirm the stable jobs select
   `ubuntu-latest`, `macos-latest`, and `windows-latest` instead.

Workflow syntax was validated locally with `actionlint`.
