### PR TITLE
fix(husk): remove deprecated toml document warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -2830,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2842,25 +2842,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3893,9 +3900,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.2"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4191c47f15cc3ec71fcb4913cb83d58def65dd3787610213c649283b5ce178"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ textwrap = "0.16"
 tempfile = "3.15.0"
 thiserror = "1.0"
 tokio = { version = "1.41.0", features = ["full"] }
-toml = "0.8.10"
+toml = "0.8.23"
 trash = "5.2.2"
 tree-sitter = "0.25"
 tree-sitter-bash = "0.25.1"

--- a/crates/husk-cli/Cargo.toml
+++ b/crates/husk-cli/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 sha2 = "0.10"
 tempfile = "3.15.0"
-toml_edit = "0.22.6"
+toml_edit = "0.22.27"
 wit-component = "0.251.0"
 wit-parser = "0.251.0"
 

--- a/crates/husk-cli/src/adapter_install.rs
+++ b/crates/husk-cli/src/adapter_install.rs
@@ -13,7 +13,7 @@ use husk::{
 use husk_extension::{BundleLimits, ExtensionBundle};
 use semver::Version;
 use sha2::{Digest, Sha256};
-use toml_edit::{Document, Item, Table, value};
+use toml_edit::{DocumentMut, Item, Table, value};
 
 pub(crate) struct AdapterIdentity {
     pub(crate) name: String,
@@ -239,7 +239,7 @@ fn updated_manifest_source(
     let manifest_source = fs::read_to_string(manifest_path)
         .with_context(|| format!("read `{}`", manifest_path.display()))?;
     let mut document = manifest_source
-        .parse::<Document>()
+        .parse::<DocumentMut>()
         .context("parse Husk.toml for editing")?;
     if !document.contains_key("extensions") {
         document.insert("extensions", Item::Table(Table::new()));

--- a/crates/husk-cli/src/lib.rs
+++ b/crates/husk-cli/src/lib.rs
@@ -1042,7 +1042,7 @@ fn cargo_package_checksum(
 ) -> anyhow::Result<Option<String>> {
     let source = std::str::from_utf8(lockfile).context("Cargo.lock is not UTF-8")?;
     let document = source
-        .parse::<toml_edit::Document>()
+        .parse::<toml_edit::DocumentMut>()
         .context("parse generated Cargo.lock")?;
     let packages = document
         .get("package")


### PR DESCRIPTION
`cargo install --path .` resolves a newer compatible `toml_edit` release where
`Document` is deprecated, so installing Red currently emits three deprecation
warnings from `husk-cli`.

This updates the TOML parsing callsites to use `DocumentMut` and aligns the
minimum `toml_edit` and `toml` versions plus the lockfile. Locked workspace
builds and fresh install resolution now compile against the same supported API.

## How to Test

1. Run `cargo install --path . --root "$(mktemp -d)"`.
   - Expected: `red` installs successfully without warnings about
     `toml_edit::Document`.
2. Run `cargo test -p husk-cli`.
   - Expected: all 47 tests pass, including adapter manifest install and
     rollback coverage.
3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
   - Expected: Clippy completes without warnings.
