### PR TITLE
feat(husk): add full language server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -660,7 +666,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "futures-core",
  "libc",
@@ -748,7 +754,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -847,6 +853,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1139,6 +1154,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "husk-analysis"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "husk-ast",
+ "husk-lexer",
+ "husk-package",
+ "husk-parser",
+ "husk-runtime",
+ "husk-semantic",
+ "husk-types",
+ "tempfile",
+]
+
+[[package]]
 name = "husk-ast"
 version = "0.1.0"
 
@@ -1151,6 +1181,7 @@ dependencies = [
  "flate2",
  "husk",
  "husk-extension",
+ "husk-lsp",
  "nix",
  "reqwest",
  "semver",
@@ -1193,6 +1224,27 @@ dependencies = [
 [[package]]
 name = "husk-lexer"
 version = "0.1.0"
+
+[[package]]
+name = "husk-lsp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "husk-analysis",
+ "husk-ast",
+ "husk-extension",
+ "husk-lexer",
+ "husk-package",
+ "husk-runtime",
+ "husk-semantic",
+ "husk-types",
+ "husk-wasm",
+ "lsp-types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+]
 
 [[package]]
 name = "husk-package"
@@ -1655,6 +1707,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,7 +1789,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -1754,7 +1819,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -1766,7 +1831,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -1777,7 +1842,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1796,7 +1861,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1807,7 +1872,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1923,7 +1988,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1976,7 +2041,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -2208,7 +2273,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2337,7 +2402,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2458,6 +2523,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -2890,7 +2966,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -3304,7 +3380,7 @@ version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indexmap",
  "semver",
@@ -3317,7 +3393,7 @@ version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "indexmap",
  "semver",
 ]
@@ -3341,7 +3417,7 @@ checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
 dependencies = [
  "addr2line",
  "async-trait",
- "bitflags",
+ "bitflags 2.13.1",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -3535,7 +3611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80009f46991622814196d96fac6fc0a938f46b5cba737a8f4e21e24e5a03856f"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.1",
  "heck",
  "indexmap",
  "wit-parser",
@@ -3914,7 +3990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,14 @@ default-run = "red"
 members = [
     ".",
     "crates/husk",
+    "crates/husk-analysis",
     "crates/husk-ast",
     "crates/husk-cli",
     "crates/husk-diagnostics",
     "crates/husk-extension",
     "crates/husk-hir",
     "crates/husk-lexer",
+    "crates/husk-lsp",
     "crates/husk-parser",
     "crates/husk-package",
     "crates/husk-runtime",
@@ -32,12 +34,14 @@ license = "MIT"
 repository = "https://github.com/codersauce/red"
 
 [workspace.dependencies]
+husk-analysis = { version = "0.1.0", path = "crates/husk-analysis" }
 husk-ast = { version = "0.1.0", path = "crates/husk-ast" }
 husk-cli = { version = "0.1.0", path = "crates/husk-cli" }
 husk-diagnostics = { version = "0.1.0", path = "crates/husk-diagnostics" }
 husk-extension = { version = "0.1.0", path = "crates/husk-extension" }
 husk-hir = { version = "0.1.0", path = "crates/husk-hir" }
 husk-lexer = { version = "0.1.0", path = "crates/husk-lexer" }
+husk-lsp = { version = "0.1.0", path = "crates/husk-lsp" }
 husk-parser = { version = "0.1.0", path = "crates/husk-parser" }
 husk-package = { version = "0.1.0", path = "crates/husk-package" }
 husk-runtime = { version = "0.1.0", path = "crates/husk-runtime", default-features = false }

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ The current release includes:
   expanding Vim motion and editing compatibility
 - tree-sitter highlighting for Rust, Markdown, JavaScript, TypeScript/TSX,
   JSON, TOML, YAML, Python, Bash, PowerShell, Lua, and Husk
-- built-in LSP defaults for Rust, TypeScript/JavaScript, Python, Markdown, JSON,
-  TOML, YAML, and Lua
+- a first-party Husk language server plus built-in LSP defaults for Rust,
+  TypeScript/JavaScript, Python, Markdown, JSON, TOML, YAML, and Lua
 - command and keymap discovery, fuzzy files, buffer navigation, symbols,
   references, project search, and diagnostics
 - native Git gutter signs, hunk actions, and a full-screen workspace for
@@ -224,6 +224,7 @@ platform details.
 | Guide | Covers |
 | --- | --- |
 | [Getting started](docs/GETTING_STARTED.md) | Editing, keymaps, LSP, Git, CLI, and troubleshooting |
+| [Husk language server](docs/HUSK_LSP.md) | Husk editor features, external crates, configuration, and safety boundaries |
 | [Vim compatibility](docs/VIM_COMPATIBILITY.md) | Supported behavior and intentional differences |
 | [Agent workflow](docs/AGENT_WORKFLOW.md) | Codex prerequisites, review model, commands, and safety |
 | [Plugin system](docs/PLUGIN_SYSTEM.md) | Husk lifecycle, runtime architecture, and validation |

--- a/crates/husk-analysis/Cargo.toml
+++ b/crates/husk-analysis/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "husk-analysis"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Incremental source analysis for the Husk language"
+
+[dependencies]
+anyhow = "1.0.79"
+husk-ast.workspace = true
+husk-lexer.workspace = true
+husk-package.workspace = true
+husk-parser.workspace = true
+husk-runtime.workspace = true
+husk-semantic.workspace = true
+husk-types.workspace = true
+
+[dev-dependencies]
+tempfile = "3.15.0"

--- a/crates/husk-analysis/src/formatter.rs
+++ b/crates/husk-analysis/src/formatter.rs
@@ -1,0 +1,85 @@
+//! Conservative, lossless-line Husk formatting.
+
+use husk_lexer::{Lexer, TokenKind};
+
+/// Reindent brace-delimited source and remove trailing horizontal whitespace.
+///
+/// Token text and comments are otherwise preserved. This intentionally small
+/// formatter is safe for recovered syntax and is idempotent.
+#[must_use]
+pub fn format_source(source: &str, indent_width: usize) -> String {
+    let indent_width = indent_width.clamp(1, 16);
+    let tokens = Lexer::new(source)
+        .filter(|token| !matches!(token.kind, TokenKind::Eof))
+        .collect::<Vec<_>>();
+    let mut output = String::with_capacity(source.len().saturating_add(1));
+    let mut depth = 0usize;
+    let mut line_start = 0usize;
+
+    for line_with_ending in source.split_inclusive('\n') {
+        let has_newline = line_with_ending.ends_with('\n');
+        let line = line_with_ending
+            .strip_suffix('\n')
+            .unwrap_or(line_with_ending)
+            .strip_suffix('\r')
+            .unwrap_or_else(|| {
+                line_with_ending
+                    .strip_suffix('\n')
+                    .unwrap_or(line_with_ending)
+            });
+        let line_end = line_start + line.len();
+        let line_tokens = tokens
+            .iter()
+            .filter(|token| {
+                token.span.range.start >= line_start && token.span.range.start <= line_end
+            })
+            .collect::<Vec<_>>();
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            if has_newline {
+                output.push('\n');
+            }
+            line_start += line_with_ending.len();
+            continue;
+        }
+        let closes_first = line_tokens
+            .first()
+            .is_some_and(|token| matches!(token.kind, TokenKind::RBrace));
+        let line_depth = depth.saturating_sub(usize::from(closes_first));
+        if !trimmed.starts_with("#!") {
+            output.extend(std::iter::repeat_n(' ', line_depth * indent_width));
+        }
+        output.push_str(trimmed.trim_end());
+        if has_newline {
+            output.push('\n');
+        }
+
+        for token in line_tokens {
+            match token.kind {
+                TokenKind::LBrace => depth = depth.saturating_add(1),
+                TokenKind::RBrace => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+        line_start += line_with_ending.len();
+    }
+    if !source.is_empty() && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formatting_is_idempotent_and_preserves_comments_and_strings() {
+        let source = "fn main() {\nlet text = \"}\";   \n// keep me\nif true {\ntext;\n}\n}\n";
+        let expected = "fn main() {\n    let text = \"}\";\n    // keep me\n    if true {\n        text;\n    }\n}\n";
+        let formatted = format_source(source, 4);
+
+        assert_eq!(formatted, expected);
+        assert_eq!(format_source(&formatted, 4), expected);
+    }
+}

--- a/crates/husk-analysis/src/lib.rs
+++ b/crates/husk-analysis/src/lib.rs
@@ -1,0 +1,791 @@
+//! Incremental, editor-oriented analysis for Husk source.
+//!
+//! This crate deliberately stops before HIR lowering and execution. It accepts
+//! unsaved source revisions, retains recovered syntax, and exposes stable
+//! navigation data for protocol adapters such as `husk-lsp`.
+
+mod formatter;
+mod line_index;
+mod symbols;
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Context;
+use husk_ast::{File, Span};
+use husk_package::{PackageLimits, ResolvedPackage, discover_manifest};
+use husk_runtime::{module_declaration_ast, source_module_descriptors};
+use husk_semantic::{
+    HoverInfo, SemanticOptions, SemanticProfile, SemanticResult,
+    analyze_file_with_declarations_and_options,
+};
+use husk_types::ModuleDescriptor;
+
+pub use formatter::format_source;
+pub use line_index::{LineIndex, Position, PositionRange};
+pub use symbols::{Symbol, SymbolId, SymbolKind, SymbolOccurrence};
+
+const MAX_WORKSPACE_DOCUMENTS: usize = 256;
+const MAX_DOCUMENT_BYTES: usize = 1024 * 1024;
+
+/// Diagnostic severity independent of a transport protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticSeverity {
+    Error,
+    Warning,
+    Information,
+}
+
+/// One parser, semantic, package, or extension diagnostic.
+#[derive(Debug, Clone)]
+pub struct AnalysisDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub span: std::ops::Range<usize>,
+    pub severity: DiagnosticSeverity,
+    pub source: &'static str,
+}
+
+/// Immutable source and analysis products for one document revision.
+pub struct Document {
+    path: PathBuf,
+    module_path: Vec<String>,
+    version: i32,
+    text: Arc<str>,
+    syntax: File,
+    line_index: LineIndex,
+    semantic: SemanticResult,
+    diagnostics: Vec<AnalysisDiagnostic>,
+    symbols: Vec<Symbol>,
+    occurrences: Vec<SymbolOccurrence>,
+}
+
+impl Document {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn module_path(&self) -> &[String] {
+        &self.module_path
+    }
+
+    #[must_use]
+    pub fn version(&self) -> i32 {
+        self.version
+    }
+
+    #[must_use]
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    #[must_use]
+    pub fn syntax(&self) -> &File {
+        &self.syntax
+    }
+
+    #[must_use]
+    pub fn line_index(&self) -> &LineIndex {
+        &self.line_index
+    }
+
+    #[must_use]
+    pub fn semantic(&self) -> &SemanticResult {
+        &self.semantic
+    }
+
+    #[must_use]
+    pub fn diagnostics(&self) -> &[AnalysisDiagnostic] {
+        &self.diagnostics
+    }
+
+    #[must_use]
+    pub fn symbols(&self) -> &[Symbol] {
+        &self.symbols
+    }
+
+    #[must_use]
+    pub fn occurrences(&self) -> &[SymbolOccurrence] {
+        &self.occurrences
+    }
+
+    #[must_use]
+    pub fn byte_offset(&self, position: Position) -> Option<usize> {
+        self.line_index.byte_offset(&self.text, position)
+    }
+
+    #[must_use]
+    pub fn position_range(&self, range: &std::ops::Range<usize>) -> PositionRange {
+        self.line_index.range(&self.text, range)
+    }
+
+    #[must_use]
+    pub fn hover(&self, byte_offset: usize) -> Option<&HoverInfo> {
+        self.semantic
+            .hover_info
+            .iter()
+            .filter(|((start, end), _)| *start <= byte_offset && byte_offset <= *end)
+            .min_by_key(|((start, end), _)| end.saturating_sub(*start))
+            .map(|(_, hover)| hover)
+    }
+}
+
+/// Mutable analysis state for one LSP workspace.
+pub struct Workspace {
+    root: PathBuf,
+    profile: SemanticProfile,
+    cfg_flags: HashSet<String>,
+    declarations: Vec<File>,
+    trusted_declarations: Vec<File>,
+    external_modules: Vec<ModuleDescriptor>,
+    documents: BTreeMap<PathBuf, Document>,
+    package_diagnostics: Vec<AnalysisDiagnostic>,
+}
+
+impl Workspace {
+    /// Open a workspace and index its bounded Husk source set.
+    pub fn open(root: impl AsRef<Path>, profile: SemanticProfile) -> anyhow::Result<Self> {
+        let root = root
+            .as_ref()
+            .canonicalize()
+            .with_context(|| format!("resolve Husk workspace `{}`", root.as_ref().display()))?;
+        let mut workspace = Self {
+            root,
+            profile,
+            cfg_flags: HashSet::new(),
+            declarations: Vec::new(),
+            trusted_declarations: Vec::new(),
+            external_modules: Vec::new(),
+            documents: BTreeMap::new(),
+            package_diagnostics: Vec::new(),
+        };
+        workspace.refresh_disk()?;
+        Ok(workspace)
+    }
+
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    #[must_use]
+    pub fn profile(&self) -> SemanticProfile {
+        self.profile
+    }
+
+    pub fn set_profile(&mut self, profile: SemanticProfile) {
+        if self.profile != profile {
+            self.profile = profile;
+            self.reanalyze();
+        }
+    }
+
+    pub fn set_cfg_flags(&mut self, flags: impl IntoIterator<Item = String>) {
+        self.cfg_flags = flags.into_iter().collect();
+        self.reanalyze();
+    }
+
+    /// Replace the external typed module surface visible to every document.
+    pub fn set_external_modules(&mut self, modules: Vec<ModuleDescriptor>) -> anyhow::Result<()> {
+        let mut declarations = self.package_declarations().unwrap_or_default();
+        declarations.extend(self.trusted_declarations.iter().cloned());
+        for module in &modules {
+            module.validate()?;
+            declarations.push(module_declaration_ast(module)?);
+        }
+        self.external_modules = modules;
+        self.declarations = declarations;
+        self.reanalyze();
+        Ok(())
+    }
+
+    /// Replace trusted host declaration sources, such as Red's plugin API.
+    pub fn set_trusted_declaration_sources(
+        &mut self,
+        sources: impl IntoIterator<Item = String>,
+    ) -> anyhow::Result<()> {
+        let mut trusted = Vec::new();
+        for source in sources {
+            let parsed = husk_parser::parse_str(&source);
+            if !parsed.errors.is_empty() {
+                let messages = parsed
+                    .errors
+                    .iter()
+                    .map(|error| error.message.as_str())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                anyhow::bail!("trusted Husk declaration did not parse: {messages}");
+            }
+            trusted.push(
+                parsed
+                    .file
+                    .expect("the recovery parser always returns a Husk file"),
+            );
+        }
+        self.trusted_declarations = trusted;
+        let modules = self.external_modules.clone();
+        self.set_external_modules(modules)
+    }
+
+    #[must_use]
+    pub fn external_modules(&self) -> &[ModuleDescriptor] {
+        &self.external_modules
+    }
+
+    #[must_use]
+    pub fn package_diagnostics(&self) -> &[AnalysisDiagnostic] {
+        &self.package_diagnostics
+    }
+
+    #[must_use]
+    pub fn document(&self, path: impl AsRef<Path>) -> Option<&Document> {
+        self.documents.get(&normalize_path(path.as_ref()))
+    }
+
+    pub fn documents(&self) -> impl Iterator<Item = &Document> {
+        self.documents.values()
+    }
+
+    /// Insert or replace an unsaved source revision.
+    pub fn update(
+        &mut self,
+        path: impl AsRef<Path>,
+        version: i32,
+        text: impl Into<Arc<str>>,
+    ) -> anyhow::Result<&Document> {
+        let path = normalize_path(path.as_ref());
+        anyhow::ensure!(
+            path.starts_with(&self.root),
+            "Husk document `{}` is outside workspace `{}`",
+            path.display(),
+            self.root.display()
+        );
+        let text = text.into();
+        anyhow::ensure!(
+            text.len() <= MAX_DOCUMENT_BYTES,
+            "Husk document `{}` is {} bytes; maximum is {}",
+            path.display(),
+            text.len(),
+            MAX_DOCUMENT_BYTES
+        );
+        let module_path = self
+            .documents
+            .get(&path)
+            .map(|document| document.module_path.clone())
+            .unwrap_or_else(|| infer_module_path(&self.root, &path));
+        let document = analyze_document(
+            path.clone(),
+            module_path,
+            version,
+            text,
+            self.profile,
+            &self.cfg_flags,
+            &self.declarations,
+        );
+        self.documents.insert(path.clone(), document);
+        Ok(self
+            .documents
+            .get(&path)
+            .expect("document was inserted immediately above"))
+    }
+
+    /// Drop an in-memory revision and reload the on-disk source when present.
+    pub fn close(&mut self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        let path = normalize_path(path.as_ref());
+        if path.is_file() {
+            let bytes = fs::read(&path)
+                .with_context(|| format!("read Husk document `{}`", path.display()))?;
+            let text = String::from_utf8(bytes)
+                .with_context(|| format!("Husk document `{}` is not UTF-8", path.display()))?;
+            self.update(&path, 0, Arc::<str>::from(text))?;
+        } else {
+            self.documents.remove(&path);
+        }
+        Ok(())
+    }
+
+    /// Reload source and package declarations without changing open overlays.
+    pub fn refresh_disk(&mut self) -> anyhow::Result<()> {
+        self.package_diagnostics.clear();
+        let existing = self
+            .documents
+            .iter()
+            .filter(|(_, document)| document.version > 0)
+            .map(|(path, document)| (path.clone(), document.version, Arc::clone(&document.text)))
+            .collect::<Vec<_>>();
+        self.documents.clear();
+
+        match discover_manifest(&self.root) {
+            Ok(manifest) => match ResolvedPackage::open(&manifest, PackageLimits::default()) {
+                Ok(package) => {
+                    let source_descriptors = source_module_descriptors(&package)?;
+                    self.declarations = source_descriptors
+                        .iter()
+                        .map(module_declaration_ast)
+                        .collect::<anyhow::Result<Vec<_>>>()?;
+                    self.declarations
+                        .extend(self.trusted_declarations.iter().cloned());
+                    self.declarations.extend(
+                        self.external_modules
+                            .iter()
+                            .map(module_declaration_ast)
+                            .collect::<anyhow::Result<Vec<_>>>()?,
+                    );
+                    for module in package.modules {
+                        self.insert_disk_document(
+                            module.canonical_path,
+                            module.module_path,
+                            module.source,
+                        );
+                    }
+                }
+                Err(error) => {
+                    self.package_diagnostics.push(AnalysisDiagnostic {
+                        code: "HUSK-PKG0001".to_string(),
+                        message: error.to_string(),
+                        span: 0..0,
+                        severity: DiagnosticSeverity::Error,
+                        source: "husk-package",
+                    });
+                    self.load_loose_sources()?;
+                }
+            },
+            Err(_) => self.load_loose_sources()?,
+        }
+
+        for (path, version, text) in existing {
+            self.update(path, version, text)?;
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn symbol_at(&self, path: &Path, byte_offset: usize) -> Option<&Symbol> {
+        let document = self.document(path)?;
+        if let Some(symbol) = document
+            .symbols
+            .iter()
+            .filter(|symbol| symbol.span.start <= byte_offset && byte_offset <= symbol.span.end)
+            .min_by_key(|symbol| symbol.span.end.saturating_sub(symbol.span.start))
+        {
+            return Some(symbol);
+        }
+        let occurrence = document
+            .occurrences
+            .iter()
+            .filter(|occurrence| {
+                occurrence.span.start <= byte_offset && byte_offset <= occurrence.span.end
+            })
+            .min_by_key(|occurrence| occurrence.span.end.saturating_sub(occurrence.span.start))?;
+        self.symbol_by_id(&occurrence.id)
+    }
+
+    #[must_use]
+    pub fn symbol_by_id(&self, id: &SymbolId) -> Option<&Symbol> {
+        self.documents()
+            .flat_map(Document::symbols)
+            .find(|symbol| &symbol.id == id)
+    }
+
+    #[must_use]
+    pub fn definition(&self, id: &SymbolId) -> Option<(&Document, &Symbol)> {
+        self.documents().find_map(|document| {
+            document
+                .symbols
+                .iter()
+                .find(|symbol| &symbol.id == id)
+                .map(|symbol| (document, symbol))
+        })
+    }
+
+    #[must_use]
+    pub fn symbol_named(&self, name: &str) -> Option<(&Document, &Symbol)> {
+        self.documents().find_map(|document| {
+            document
+                .symbols
+                .iter()
+                .find(|symbol| symbol.name == name || symbol.qualified_name == name)
+                .map(|symbol| (document, symbol))
+        })
+    }
+
+    #[must_use]
+    pub fn references(&self, id: &SymbolId) -> Vec<&SymbolOccurrence> {
+        self.documents()
+            .flat_map(Document::occurrences)
+            .filter(|occurrence| &occurrence.id == id)
+            .collect()
+    }
+
+    #[must_use]
+    pub fn workspace_symbols(&self, query: &str) -> Vec<(&Path, &Symbol)> {
+        let query = query.to_ascii_lowercase();
+        let mut symbols = self
+            .documents()
+            .flat_map(|document| {
+                document.symbols.iter().filter_map(|symbol| {
+                    (query.is_empty()
+                        || symbol.name.to_ascii_lowercase().contains(&query)
+                        || symbol.qualified_name.to_ascii_lowercase().contains(&query))
+                    .then_some((document.path(), symbol))
+                })
+            })
+            .collect::<Vec<_>>();
+        symbols.sort_by(|left, right| {
+            left.1
+                .name
+                .cmp(&right.1.name)
+                .then_with(|| left.0.cmp(right.0))
+                .then_with(|| left.1.span.start.cmp(&right.1.span.start))
+        });
+        symbols
+    }
+
+    #[must_use]
+    pub fn completions(&self, path: &Path, prefix: &str) -> Vec<&Symbol> {
+        let prefix = prefix.to_ascii_lowercase();
+        let mut seen = HashSet::new();
+        let mut symbols = self
+            .documents()
+            .flat_map(Document::symbols)
+            .filter(|symbol| {
+                (prefix.is_empty() || symbol.name.to_ascii_lowercase().starts_with(&prefix))
+                    && seen.insert((symbol.name.clone(), symbol.kind, symbol.container.clone()))
+            })
+            .collect::<Vec<_>>();
+        symbols.sort_by(|left, right| {
+            let left_local = self
+                .document(path)
+                .is_some_and(|document| document.symbols.iter().any(|symbol| symbol.id == left.id));
+            let right_local = self.document(path).is_some_and(|document| {
+                document.symbols.iter().any(|symbol| symbol.id == right.id)
+            });
+            right_local
+                .cmp(&left_local)
+                .then_with(|| left.name.cmp(&right.name))
+        });
+        symbols
+    }
+
+    fn insert_disk_document(&mut self, path: PathBuf, module_path: Vec<String>, text: Arc<str>) {
+        let document = analyze_document(
+            path.clone(),
+            module_path,
+            0,
+            text,
+            self.profile,
+            &self.cfg_flags,
+            &self.declarations,
+        );
+        self.documents.insert(path, document);
+    }
+
+    fn load_loose_sources(&mut self) -> anyhow::Result<()> {
+        self.declarations.clear();
+        self.declarations
+            .extend(self.trusted_declarations.iter().cloned());
+        self.declarations.extend(
+            self.external_modules
+                .iter()
+                .map(module_declaration_ast)
+                .collect::<anyhow::Result<Vec<_>>>()?,
+        );
+        let mut paths = Vec::new();
+        collect_husk_files(&self.root, &mut paths)?;
+        paths.sort();
+        anyhow::ensure!(
+            paths.len() <= MAX_WORKSPACE_DOCUMENTS,
+            "Husk workspace contains {} source files; maximum is {}",
+            paths.len(),
+            MAX_WORKSPACE_DOCUMENTS
+        );
+        for path in paths {
+            let bytes = fs::read(&path)
+                .with_context(|| format!("read Husk document `{}`", path.display()))?;
+            anyhow::ensure!(
+                bytes.len() <= MAX_DOCUMENT_BYTES,
+                "Husk document `{}` is {} bytes; maximum is {}",
+                path.display(),
+                bytes.len(),
+                MAX_DOCUMENT_BYTES
+            );
+            let text = String::from_utf8(bytes)
+                .with_context(|| format!("Husk document `{}` is not UTF-8", path.display()))?;
+            self.insert_disk_document(
+                path.clone(),
+                infer_module_path(&self.root, &path),
+                Arc::from(text),
+            );
+        }
+        Ok(())
+    }
+
+    fn package_declarations(&self) -> anyhow::Result<Vec<File>> {
+        let Ok(manifest) = discover_manifest(&self.root) else {
+            return Ok(Vec::new());
+        };
+        let package = ResolvedPackage::open(manifest, PackageLimits::default())?;
+        source_module_descriptors(&package)?
+            .iter()
+            .map(module_declaration_ast)
+            .collect()
+    }
+
+    fn reanalyze(&mut self) {
+        let documents = std::mem::take(&mut self.documents);
+        self.documents = documents
+            .into_iter()
+            .map(|(path, document)| {
+                let analyzed = analyze_document(
+                    path.clone(),
+                    document.module_path,
+                    document.version,
+                    document.text,
+                    self.profile,
+                    &self.cfg_flags,
+                    &self.declarations,
+                );
+                (path, analyzed)
+            })
+            .collect();
+    }
+}
+
+fn analyze_document(
+    path: PathBuf,
+    module_path: Vec<String>,
+    version: i32,
+    text: Arc<str>,
+    profile: SemanticProfile,
+    cfg_flags: &HashSet<String>,
+    declarations: &[File],
+) -> Document {
+    let parsed = husk_parser::parse_str(&text);
+    let syntax = parsed
+        .file
+        .expect("the recovery parser always returns a Husk file");
+    let mut diagnostics = parsed
+        .errors
+        .into_iter()
+        .map(|error| AnalysisDiagnostic {
+            code: "HUSK-P0001".to_string(),
+            message: error.message,
+            span: error.span.range,
+            severity: DiagnosticSeverity::Error,
+            source: "husk-parser",
+        })
+        .collect::<Vec<_>>();
+    let semantic = analyze_file_with_declarations_and_options(
+        &syntax,
+        declarations,
+        SemanticOptions {
+            prelude: true,
+            cfg_flags: cfg_flags.clone(),
+            profile,
+            module_path: module_path.clone(),
+        },
+    );
+    diagnostics.extend(
+        semantic
+            .symbols
+            .errors
+            .iter()
+            .chain(&semantic.type_errors)
+            .map(|error| AnalysisDiagnostic {
+                code: "HUSK-T0001".to_string(),
+                message: error.message.clone(),
+                span: error.span.range.clone(),
+                severity: DiagnosticSeverity::Error,
+                source: "husk-semantic",
+            }),
+    );
+    diagnostics.sort_by(|left, right| {
+        left.span
+            .start
+            .cmp(&right.span.start)
+            .then_with(|| left.span.end.cmp(&right.span.end))
+            .then_with(|| left.message.cmp(&right.message))
+    });
+    diagnostics.dedup_by(|left, right| {
+        left.code == right.code && left.message == right.message && left.span == right.span
+    });
+    let (symbols, occurrences) =
+        symbols::extract_symbols(&path, &module_path, &text, &syntax, &semantic);
+    let line_index = LineIndex::new(&text);
+    Document {
+        path,
+        module_path,
+        version,
+        text,
+        syntax,
+        line_index,
+        semantic,
+        diagnostics,
+        symbols,
+        occurrences,
+    }
+}
+
+fn collect_husk_files(directory: &Path, output: &mut Vec<PathBuf>) -> anyhow::Result<()> {
+    let mut entries = fs::read_dir(directory)
+        .with_context(|| format!("read Husk workspace directory `{}`", directory.display()))?
+        .collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("inspect `{}`", path.display()))?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            let name = entry.file_name();
+            if matches!(
+                name.to_str(),
+                Some(".git" | ".husk" | "target" | "vendor" | "node_modules")
+            ) {
+                continue;
+            }
+            collect_husk_files(&path, output)?;
+        } else if file_type.is_file()
+            && path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| matches!(extension, "hk" | "husk"))
+        {
+            output.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn infer_module_path(root: &Path, path: &Path) -> Vec<String> {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let mut components = relative
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    if components
+        .first()
+        .is_some_and(|component| component == "src")
+    {
+        components.remove(0);
+    }
+    let Some(last) = components.last_mut() else {
+        return Vec::new();
+    };
+    if let Some((stem, _)) = last.rsplit_once('.') {
+        *last = stem.to_string();
+    }
+    if matches!(last.as_str(), "main" | "lib" | "mod") {
+        components.pop();
+    }
+    components
+}
+
+/// Create a span constrained to a source revision.
+#[must_use]
+pub fn bounded_span(span: &Span, source_len: usize) -> std::ops::Range<usize> {
+    span.range.start.min(source_len)..span.range.end.min(source_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use husk_types::{FunctionDescriptor, TypeDescriptor, Version};
+
+    use super::*;
+
+    #[test]
+    fn recovered_source_keeps_diagnostics_symbols_and_utf16_positions() {
+        let root = tempfile::tempdir().expect("create fixture directory");
+        let path = root.path().join("main.hk");
+        fs::write(
+            &path,
+            "fn greet(name: String) -> String { name }\nfn broken(",
+        )
+        .expect("write source fixture");
+        let workspace =
+            Workspace::open(root.path(), SemanticProfile::Native).expect("open workspace");
+        let document = workspace.document(&path).expect("fixture is indexed");
+
+        assert!(!document.diagnostics().is_empty());
+        assert!(
+            document
+                .symbols()
+                .iter()
+                .any(|symbol| symbol.name == "greet" && symbol.kind == SymbolKind::Function)
+        );
+    }
+
+    #[test]
+    fn unsaved_revisions_replace_disk_without_writing_it() {
+        let root = tempfile::tempdir().expect("create fixture directory");
+        let path = root.path().join("main.hk");
+        fs::write(&path, "fn before() {}\n").expect("write source fixture");
+        let mut workspace =
+            Workspace::open(root.path(), SemanticProfile::Native).expect("open workspace");
+        workspace
+            .update(&path, 7, Arc::<str>::from("fn after() {}\n"))
+            .expect("update overlay");
+
+        let document = workspace.document(&path).expect("fixture is indexed");
+        assert_eq!(document.version(), 7);
+        assert!(
+            document
+                .symbols()
+                .iter()
+                .any(|symbol| symbol.name == "after")
+        );
+        assert_eq!(
+            fs::read_to_string(&path).expect("read disk source"),
+            "fn before() {}\n"
+        );
+    }
+
+    #[test]
+    fn disk_refresh_preserves_external_module_declarations() {
+        let root = tempfile::tempdir().expect("create fixture directory");
+        let path = root.path().join("main.hk");
+        fs::write(&path, "fn main() { demo::answer(); }\n").expect("write source fixture");
+        let mut workspace =
+            Workspace::open(root.path(), SemanticProfile::Native).expect("open workspace");
+        let module = ModuleDescriptor::new(
+            "demo",
+            Version::new(1, 0, 0),
+            vec![
+                FunctionDescriptor::new("answer", Vec::new(), TypeDescriptor::Unit)
+                    .expect("create function descriptor"),
+            ],
+            Vec::new(),
+        )
+        .expect("create module descriptor");
+        workspace
+            .set_external_modules(vec![module])
+            .expect("register external module");
+        workspace.refresh_disk().expect("refresh disk state");
+
+        let document = workspace.document(&path).expect("fixture is indexed");
+        assert!(
+            document
+                .diagnostics()
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("demo")),
+            "{:?}",
+            document
+                .diagnostics()
+                .iter()
+                .map(|diagnostic| &diagnostic.message)
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/husk-analysis/src/line_index.rs
+++ b/crates/husk-analysis/src/line_index.rs
@@ -1,0 +1,160 @@
+//! UTF-8 byte offset and LSP UTF-16 position conversion.
+
+/// A zero-based line and UTF-16 code-unit position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Position {
+    pub line: u32,
+    pub character: u32,
+}
+
+/// A half-open source range expressed in LSP positions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PositionRange {
+    pub start: Position,
+    pub end: Position,
+}
+
+/// Line starts for one immutable source revision.
+#[derive(Debug, Clone)]
+pub struct LineIndex {
+    line_starts: Box<[usize]>,
+    text_len: usize,
+}
+
+impl LineIndex {
+    #[must_use]
+    pub fn new(text: &str) -> Self {
+        let mut line_starts = Vec::with_capacity(text.lines().count().saturating_add(1));
+        line_starts.push(0);
+        line_starts.extend(
+            text.bytes()
+                .enumerate()
+                .filter_map(|(index, byte)| (byte == b'\n').then_some(index + 1)),
+        );
+        Self {
+            line_starts: line_starts.into_boxed_slice(),
+            text_len: text.len(),
+        }
+    }
+
+    #[must_use]
+    pub fn position(&self, text: &str, byte: usize) -> Position {
+        let byte = byte.min(self.text_len);
+        let line = self.line_starts.partition_point(|start| *start <= byte) - 1;
+        let line_start = self.line_starts[line];
+        let character = text[line_start..byte]
+            .encode_utf16()
+            .count()
+            .try_into()
+            .unwrap_or(u32::MAX);
+        Position {
+            line: line.try_into().unwrap_or(u32::MAX),
+            character,
+        }
+    }
+
+    #[must_use]
+    pub fn byte_offset(&self, text: &str, position: Position) -> Option<usize> {
+        let line = usize::try_from(position.line).ok()?;
+        let line_start = *self.line_starts.get(line)?;
+        let line_end = self
+            .line_starts
+            .get(line + 1)
+            .copied()
+            .unwrap_or(self.text_len);
+        let mut content_end = line_end;
+        if text.as_bytes().get(content_end.saturating_sub(1)) == Some(&b'\n') {
+            content_end -= 1;
+        }
+        if text.as_bytes().get(content_end.saturating_sub(1)) == Some(&b'\r') {
+            content_end -= 1;
+        }
+        let line_text = &text[line_start..content_end];
+        let target = usize::try_from(position.character).ok()?;
+        let mut utf16_offset = 0;
+        for (byte, character) in line_text.char_indices() {
+            if utf16_offset == target {
+                return Some(line_start + byte);
+            }
+            utf16_offset += character.len_utf16();
+            if utf16_offset > target {
+                return None;
+            }
+        }
+        (utf16_offset == target).then_some(content_end)
+    }
+
+    #[must_use]
+    pub fn range(&self, text: &str, range: &std::ops::Range<usize>) -> PositionRange {
+        PositionRange {
+            start: self.position(text, range.start),
+            end: self.position(text, range.end),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_utf16_positions_without_splitting_scalars() {
+        let text = "a😀b\r\ncafé\n";
+        let index = LineIndex::new(text);
+
+        assert_eq!(
+            index.position(text, "a😀".len()),
+            Position {
+                line: 0,
+                character: 3,
+            }
+        );
+        assert_eq!(
+            index.byte_offset(
+                text,
+                Position {
+                    line: 0,
+                    character: 3,
+                },
+            ),
+            Some("a😀".len())
+        );
+        assert_eq!(
+            index.byte_offset(
+                text,
+                Position {
+                    line: 0,
+                    character: 2,
+                },
+            ),
+            None
+        );
+        assert_eq!(
+            index.byte_offset(
+                text,
+                Position {
+                    line: 0,
+                    character: 4,
+                },
+            ),
+            Some("a😀b".len())
+        );
+        assert_eq!(
+            index.byte_offset(
+                text,
+                Position {
+                    line: 0,
+                    character: 5,
+                },
+            ),
+            None
+        );
+        assert_eq!(
+            index.position(text, text.find("café").expect("fixture contains café")),
+            Position {
+                line: 1,
+                character: 0,
+            }
+        );
+    }
+}

--- a/crates/husk-analysis/src/symbols.rs
+++ b/crates/husk-analysis/src/symbols.rs
@@ -1,0 +1,813 @@
+//! Source symbol extraction shared by LSP features.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use husk_ast::{
+    EnumVariantFields, ExternItemKind, File, Ident, ImplItemKind, ItemKind, Pattern, PatternKind,
+    TypeExpr, TypeExprKind,
+};
+use husk_semantic::{ReferenceKind, SemanticResult};
+
+/// A language-level symbol category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SymbolKind {
+    Module,
+    Function,
+    Method,
+    Struct,
+    Field,
+    Enum,
+    Variant,
+    TypeAlias,
+    Trait,
+    Variable,
+    Parameter,
+    TypeParameter,
+    Property,
+    Constant,
+}
+
+/// A stable definition identity within one workspace snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SymbolId(pub String);
+
+/// A symbol definition suitable for navigation and completion.
+#[derive(Debug, Clone)]
+pub struct Symbol {
+    pub id: SymbolId,
+    pub name: String,
+    pub qualified_name: String,
+    pub kind: SymbolKind,
+    pub span: std::ops::Range<usize>,
+    pub full_span: std::ops::Range<usize>,
+    pub detail: String,
+    pub documentation: Option<String>,
+    pub container: Option<String>,
+    pub external: bool,
+}
+
+/// One definition or reference occurrence.
+#[derive(Debug, Clone)]
+pub struct SymbolOccurrence {
+    pub id: SymbolId,
+    pub path: std::path::PathBuf,
+    pub span: std::ops::Range<usize>,
+    pub is_definition: bool,
+}
+
+pub(crate) fn extract_symbols(
+    path: &Path,
+    module_path: &[String],
+    source: &str,
+    file: &File,
+    semantic: &SemanticResult,
+) -> (Vec<Symbol>, Vec<SymbolOccurrence>) {
+    let module = module_name(path, module_path);
+    let context = SymbolContext {
+        source,
+        module: &module,
+    };
+    let mut symbols = Vec::new();
+    let mut definition_ids = HashMap::<(String, SymbolKind), SymbolId>::new();
+
+    for item in &file.items {
+        match &item.kind {
+            ItemKind::Mod { name } => push_symbol(
+                &mut symbols,
+                &mut definition_ids,
+                &context,
+                name,
+                item.span.range.clone(),
+                SymbolKind::Module,
+                "module".to_string(),
+            ),
+            ItemKind::Fn {
+                name,
+                type_params,
+                params,
+                ret_type,
+                ..
+            } => {
+                push_symbol(
+                    &mut symbols,
+                    &mut definition_ids,
+                    &context,
+                    name,
+                    item.span.range.clone(),
+                    SymbolKind::Function,
+                    function_detail(
+                        &name.name,
+                        params.iter().map(|parameter| {
+                            (parameter.name.name.as_str(), type_name(&parameter.ty))
+                        }),
+                        ret_type.as_ref(),
+                    ),
+                );
+                for type_parameter in type_params {
+                    push_nested_symbol(
+                        &mut symbols,
+                        source,
+                        &module,
+                        &name.name,
+                        &type_parameter.name,
+                        SymbolKind::TypeParameter,
+                        "type parameter".to_string(),
+                    );
+                }
+                for parameter in params {
+                    push_nested_symbol(
+                        &mut symbols,
+                        source,
+                        &module,
+                        &name.name,
+                        &parameter.name,
+                        SymbolKind::Parameter,
+                        format!("{}: {}", parameter.name.name, type_name(&parameter.ty)),
+                    );
+                }
+            }
+            ItemKind::Struct {
+                name,
+                type_params,
+                fields,
+            } => {
+                push_symbol(
+                    &mut symbols,
+                    &mut definition_ids,
+                    &context,
+                    name,
+                    item.span.range.clone(),
+                    SymbolKind::Struct,
+                    format!("struct {}", name.name),
+                );
+                for parameter in type_params {
+                    push_nested_symbol(
+                        &mut symbols,
+                        source,
+                        &module,
+                        &name.name,
+                        parameter,
+                        SymbolKind::TypeParameter,
+                        "type parameter".to_string(),
+                    );
+                }
+                for field in fields {
+                    push_nested_symbol(
+                        &mut symbols,
+                        source,
+                        &module,
+                        &name.name,
+                        &field.name,
+                        SymbolKind::Field,
+                        format!("{}: {}", field.name.name, type_name(&field.ty)),
+                    );
+                }
+            }
+            ItemKind::Enum {
+                name,
+                type_params,
+                variants,
+            } => {
+                push_symbol(
+                    &mut symbols,
+                    &mut definition_ids,
+                    &context,
+                    name,
+                    item.span.range.clone(),
+                    SymbolKind::Enum,
+                    format!("enum {}", name.name),
+                );
+                for parameter in type_params {
+                    push_nested_symbol(
+                        &mut symbols,
+                        source,
+                        &module,
+                        &name.name,
+                        parameter,
+                        SymbolKind::TypeParameter,
+                        "type parameter".to_string(),
+                    );
+                }
+                for variant in variants {
+                    let detail = match &variant.fields {
+                        EnumVariantFields::Unit => {
+                            format!("{}::{}", name.name, variant.name.name)
+                        }
+                        EnumVariantFields::Tuple(types) => format!(
+                            "{}::{}({})",
+                            name.name,
+                            variant.name.name,
+                            types.iter().map(type_name).collect::<Vec<_>>().join(", ")
+                        ),
+                        EnumVariantFields::Struct(fields) => format!(
+                            "{}::{} {{ {} }}",
+                            name.name,
+                            variant.name.name,
+                            fields
+                                .iter()
+                                .map(|field| format!(
+                                    "{}: {}",
+                                    field.name.name,
+                                    type_name(&field.ty)
+                                ))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                    };
+                    push_nested_symbol(
+                        &mut symbols,
+                        source,
+                        &module,
+                        &name.name,
+                        &variant.name,
+                        SymbolKind::Variant,
+                        detail,
+                    );
+                }
+            }
+            ItemKind::TypeAlias { name, ty } => push_symbol(
+                &mut symbols,
+                &mut definition_ids,
+                &context,
+                name,
+                item.span.range.clone(),
+                SymbolKind::TypeAlias,
+                format!("type {} = {}", name.name, type_name(ty)),
+            ),
+            ItemKind::Trait(definition) => {
+                push_symbol(
+                    &mut symbols,
+                    &mut definition_ids,
+                    &context,
+                    &definition.name,
+                    item.span.range.clone(),
+                    SymbolKind::Trait,
+                    format!("trait {}", definition.name.name),
+                );
+                for trait_item in &definition.items {
+                    let husk_ast::TraitItemKind::Method(method) = &trait_item.kind;
+                    push_nested_symbol(
+                        &mut symbols,
+                        source,
+                        &module,
+                        &definition.name.name,
+                        &method.name,
+                        SymbolKind::Method,
+                        function_detail(
+                            &method.name.name,
+                            method.params.iter().map(|parameter| {
+                                (parameter.name.name.as_str(), type_name(&parameter.ty))
+                            }),
+                            method.ret_type.as_ref(),
+                        ),
+                    );
+                }
+            }
+            ItemKind::Impl(block) => {
+                let container = type_name(&block.self_ty);
+                for impl_item in &block.items {
+                    match &impl_item.kind {
+                        ImplItemKind::Method(method) => push_nested_symbol(
+                            &mut symbols,
+                            source,
+                            &module,
+                            &container,
+                            &method.name,
+                            SymbolKind::Method,
+                            function_detail(
+                                &method.name.name,
+                                method.params.iter().map(|parameter| {
+                                    (parameter.name.name.as_str(), type_name(&parameter.ty))
+                                }),
+                                method.ret_type.as_ref(),
+                            ),
+                        ),
+                        ImplItemKind::Property(property) => push_nested_symbol(
+                            &mut symbols,
+                            source,
+                            &module,
+                            &container,
+                            &property.name,
+                            SymbolKind::Property,
+                            format!("{}: {}", property.name.name, type_name(&property.ty)),
+                        ),
+                    }
+                }
+            }
+            ItemKind::ExternBlock { items, .. } => {
+                extract_extern_symbols(&mut symbols, &mut definition_ids, source, &module, items);
+            }
+            ItemKind::Use { .. } => {}
+        }
+    }
+
+    collect_local_definitions(path, &module, source, file, semantic, &mut symbols);
+    let mut occurrences = symbols
+        .iter()
+        .map(|symbol| SymbolOccurrence {
+            id: symbol.id.clone(),
+            path: path.to_path_buf(),
+            span: symbol.span.clone(),
+            is_definition: true,
+        })
+        .collect::<Vec<_>>();
+
+    for ((name, kind), references) in &semantic.references {
+        let symbol_kind = semantic_kind(*kind);
+        for reference in references {
+            if reference.span.range.end > source.len() {
+                continue;
+            }
+            let id = if *kind == ReferenceKind::Variable {
+                semantic
+                    .name_resolution
+                    .get(&(reference.span.range.start, reference.span.range.end))
+                    .map_or_else(
+                        || SymbolId(format!("{module}::local::{name}")),
+                        |resolved| SymbolId(format!("{module}::local::{resolved}")),
+                    )
+            } else {
+                definition_ids
+                    .get(&(name.clone(), symbol_kind))
+                    .cloned()
+                    .unwrap_or_else(|| SymbolId(format!("{module}::{symbol_kind:?}::{name}")))
+            };
+            if occurrences.iter().any(|occurrence| {
+                occurrence.id == id
+                    && occurrence.span == reference.span.range
+                    && occurrence.path == path
+            }) {
+                continue;
+            }
+            occurrences.push(SymbolOccurrence {
+                id,
+                path: path.to_path_buf(),
+                span: reference.span.range.clone(),
+                is_definition: false,
+            });
+        }
+    }
+
+    (symbols, occurrences)
+}
+
+struct SymbolContext<'a> {
+    source: &'a str,
+    module: &'a str,
+}
+
+fn push_symbol(
+    symbols: &mut Vec<Symbol>,
+    definition_ids: &mut HashMap<(String, SymbolKind), SymbolId>,
+    context: &SymbolContext<'_>,
+    ident: &Ident,
+    full_span: std::ops::Range<usize>,
+    kind: SymbolKind,
+    detail: String,
+) {
+    let qualified_name = ident.name.clone();
+    let id = SymbolId(format!("{}::{kind:?}::{qualified_name}", context.module));
+    definition_ids.insert((reference_name(kind, &qualified_name), kind), id.clone());
+    symbols.push(Symbol {
+        id,
+        name: ident.name.clone(),
+        qualified_name,
+        kind,
+        span: ident.span.range.clone(),
+        full_span,
+        detail,
+        documentation: documentation_before(context.source, ident.span.range.start),
+        container: None,
+        external: false,
+    });
+}
+
+fn push_nested_symbol(
+    symbols: &mut Vec<Symbol>,
+    source: &str,
+    module: &str,
+    container: &str,
+    ident: &Ident,
+    kind: SymbolKind,
+    detail: String,
+) {
+    let qualified_name = format!("{container}::{}", ident.name);
+    symbols.push(Symbol {
+        id: SymbolId(format!("{module}::{kind:?}::{qualified_name}")),
+        name: ident.name.clone(),
+        qualified_name,
+        kind,
+        span: ident.span.range.clone(),
+        full_span: ident.span.range.clone(),
+        detail,
+        documentation: documentation_before(source, ident.span.range.start),
+        container: Some(container.to_string()),
+        external: false,
+    });
+}
+
+fn extract_extern_symbols(
+    symbols: &mut Vec<Symbol>,
+    definition_ids: &mut HashMap<(String, SymbolKind), SymbolId>,
+    source: &str,
+    module: &str,
+    items: &[husk_ast::ExternItem],
+) {
+    let context = SymbolContext { source, module };
+    for item in items {
+        match &item.kind {
+            ExternItemKind::Fn {
+                name,
+                params,
+                ret_type,
+            } => push_symbol(
+                symbols,
+                definition_ids,
+                &context,
+                name,
+                item.span.range.clone(),
+                SymbolKind::Function,
+                function_detail(
+                    &name.name,
+                    params
+                        .iter()
+                        .map(|parameter| (parameter.name.name.as_str(), type_name(&parameter.ty))),
+                    ret_type.as_ref(),
+                ),
+            ),
+            ExternItemKind::Mod { binding, items, .. } => {
+                push_symbol(
+                    symbols,
+                    definition_ids,
+                    &context,
+                    binding,
+                    item.span.range.clone(),
+                    SymbolKind::Module,
+                    format!("extern module {}", binding.name),
+                );
+                for nested in items {
+                    let husk_ast::ModItemKind::Fn {
+                        name,
+                        params,
+                        ret_type,
+                    } = &nested.kind;
+                    push_nested_symbol(
+                        symbols,
+                        source,
+                        module,
+                        &binding.name,
+                        name,
+                        SymbolKind::Function,
+                        function_detail(
+                            &name.name,
+                            params.iter().map(|parameter| {
+                                (parameter.name.name.as_str(), type_name(&parameter.ty))
+                            }),
+                            ret_type.as_ref(),
+                        ),
+                    );
+                }
+            }
+            ExternItemKind::Struct { name, .. } => push_symbol(
+                symbols,
+                definition_ids,
+                &context,
+                name,
+                item.span.range.clone(),
+                SymbolKind::Struct,
+                format!("extern struct {}", name.name),
+            ),
+            ExternItemKind::Static { name, ty } | ExternItemKind::Const { name, ty } => {
+                push_symbol(
+                    symbols,
+                    definition_ids,
+                    &context,
+                    name,
+                    item.span.range.clone(),
+                    SymbolKind::Constant,
+                    format!("{}: {}", name.name, type_name(ty)),
+                );
+            }
+            ExternItemKind::Impl { self_ty, items, .. } => {
+                let container = type_name(self_ty);
+                for nested in items {
+                    match &nested.kind {
+                        ImplItemKind::Method(method) => push_nested_symbol(
+                            symbols,
+                            source,
+                            module,
+                            &container,
+                            &method.name,
+                            SymbolKind::Method,
+                            function_detail(
+                                &method.name.name,
+                                method.params.iter().map(|parameter| {
+                                    (parameter.name.name.as_str(), type_name(&parameter.ty))
+                                }),
+                                method.ret_type.as_ref(),
+                            ),
+                        ),
+                        ImplItemKind::Property(property) => push_nested_symbol(
+                            symbols,
+                            source,
+                            module,
+                            &container,
+                            &property.name,
+                            SymbolKind::Property,
+                            format!("{}: {}", property.name.name, type_name(&property.ty)),
+                        ),
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_local_definitions(
+    path: &Path,
+    module: &str,
+    source: &str,
+    file: &File,
+    semantic: &SemanticResult,
+    symbols: &mut Vec<Symbol>,
+) {
+    for item in &file.items {
+        let ItemKind::Fn { params, body, .. } = &item.kind else {
+            continue;
+        };
+        for parameter in params {
+            push_local_symbol(
+                path,
+                module,
+                source,
+                &parameter.name,
+                SymbolKind::Parameter,
+                semantic,
+                symbols,
+            );
+        }
+        visit_statements_for_bindings(path, module, source, body, semantic, symbols);
+    }
+}
+
+fn visit_statements_for_bindings(
+    path: &Path,
+    module: &str,
+    source: &str,
+    statements: &[husk_ast::Stmt],
+    semantic: &SemanticResult,
+    symbols: &mut Vec<Symbol>,
+) {
+    for statement in statements {
+        match &statement.kind {
+            husk_ast::StmtKind::Let {
+                pattern,
+                else_block,
+                ..
+            } => {
+                visit_pattern_bindings(path, module, source, pattern, semantic, symbols);
+                if let Some(block) = else_block {
+                    visit_statements_for_bindings(
+                        path,
+                        module,
+                        source,
+                        &block.stmts,
+                        semantic,
+                        symbols,
+                    );
+                }
+            }
+            husk_ast::StmtKind::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                visit_statements_for_bindings(
+                    path,
+                    module,
+                    source,
+                    &then_branch.stmts,
+                    semantic,
+                    symbols,
+                );
+                if let Some(branch) = else_branch {
+                    visit_statements_for_bindings(
+                        path,
+                        module,
+                        source,
+                        std::slice::from_ref(branch),
+                        semantic,
+                        symbols,
+                    );
+                }
+            }
+            husk_ast::StmtKind::While { body, .. }
+            | husk_ast::StmtKind::Loop { body }
+            | husk_ast::StmtKind::Block(body) => {
+                visit_statements_for_bindings(path, module, source, &body.stmts, semantic, symbols)
+            }
+            husk_ast::StmtKind::ForIn { binding, body, .. } => {
+                push_local_symbol(
+                    path,
+                    module,
+                    source,
+                    binding,
+                    SymbolKind::Variable,
+                    semantic,
+                    symbols,
+                );
+                visit_statements_for_bindings(path, module, source, &body.stmts, semantic, symbols);
+            }
+            husk_ast::StmtKind::IfLet {
+                pattern,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                visit_pattern_bindings(path, module, source, pattern, semantic, symbols);
+                visit_statements_for_bindings(
+                    path,
+                    module,
+                    source,
+                    &then_branch.stmts,
+                    semantic,
+                    symbols,
+                );
+                if let Some(branch) = else_branch {
+                    visit_statements_for_bindings(
+                        path,
+                        module,
+                        source,
+                        std::slice::from_ref(branch),
+                        semantic,
+                        symbols,
+                    );
+                }
+            }
+            husk_ast::StmtKind::Assign { .. }
+            | husk_ast::StmtKind::Expr(_)
+            | husk_ast::StmtKind::Semi(_)
+            | husk_ast::StmtKind::Return { .. }
+            | husk_ast::StmtKind::Break
+            | husk_ast::StmtKind::Continue => {}
+        }
+    }
+}
+
+fn visit_pattern_bindings(
+    path: &Path,
+    module: &str,
+    source: &str,
+    pattern: &Pattern,
+    semantic: &SemanticResult,
+    symbols: &mut Vec<Symbol>,
+) {
+    match &pattern.kind {
+        PatternKind::Binding(ident) => push_local_symbol(
+            path,
+            module,
+            source,
+            ident,
+            SymbolKind::Variable,
+            semantic,
+            symbols,
+        ),
+        PatternKind::EnumTuple { fields, .. } | PatternKind::Tuple { fields } => {
+            for field in fields {
+                visit_pattern_bindings(path, module, source, field, semantic, symbols);
+            }
+        }
+        PatternKind::EnumStruct { fields, .. } => {
+            for (_, field) in fields {
+                visit_pattern_bindings(path, module, source, field, semantic, symbols);
+            }
+        }
+        PatternKind::Wildcard | PatternKind::EnumUnit { .. } => {}
+    }
+}
+
+fn push_local_symbol(
+    _path: &Path,
+    module: &str,
+    source: &str,
+    ident: &Ident,
+    kind: SymbolKind,
+    semantic: &SemanticResult,
+    symbols: &mut Vec<Symbol>,
+) {
+    let resolved = semantic
+        .name_resolution
+        .get(&(ident.span.range.start, ident.span.range.end))
+        .cloned()
+        .unwrap_or_else(|| format!("{}@{}", ident.name, ident.span.range.start));
+    let id = SymbolId(format!("{module}::local::{resolved}"));
+    if symbols
+        .iter()
+        .any(|symbol| symbol.id == id && symbol.span == ident.span.range)
+    {
+        return;
+    }
+    symbols.push(Symbol {
+        id,
+        name: ident.name.clone(),
+        qualified_name: resolved,
+        kind,
+        span: ident.span.range.clone(),
+        full_span: ident.span.range.clone(),
+        detail: ident.name.clone(),
+        documentation: documentation_before(source, ident.span.range.start),
+        container: None,
+        external: false,
+    });
+}
+
+fn module_name(path: &Path, module_path: &[String]) -> String {
+    if module_path.is_empty() {
+        path.to_string_lossy().into_owned()
+    } else {
+        format!("crate::{}", module_path.join("::"))
+    }
+}
+
+fn semantic_kind(kind: ReferenceKind) -> SymbolKind {
+    match kind {
+        ReferenceKind::Function => SymbolKind::Function,
+        ReferenceKind::Struct => SymbolKind::Struct,
+        ReferenceKind::Enum => SymbolKind::Enum,
+        ReferenceKind::Variant => SymbolKind::Variant,
+        ReferenceKind::TypeAlias => SymbolKind::TypeAlias,
+        ReferenceKind::Trait => SymbolKind::Trait,
+        ReferenceKind::Variable => SymbolKind::Variable,
+        ReferenceKind::Field => SymbolKind::Field,
+    }
+}
+
+fn reference_name(kind: SymbolKind, qualified_name: &str) -> String {
+    match kind {
+        SymbolKind::Field => qualified_name.replace("::", "."),
+        SymbolKind::Variant => qualified_name.to_string(),
+        _ => qualified_name
+            .rsplit("::")
+            .next()
+            .unwrap_or(qualified_name)
+            .to_string(),
+    }
+}
+
+fn function_detail<'a>(
+    name: &str,
+    parameters: impl Iterator<Item = (&'a str, String)>,
+    ret_type: Option<&TypeExpr>,
+) -> String {
+    let parameters = parameters
+        .map(|(name, ty)| format!("{name}: {ty}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let result = ret_type.map_or_else(|| "()".to_string(), type_name);
+    format!("fn {name}({parameters}) -> {result}")
+}
+
+pub(crate) fn type_name(ty: &TypeExpr) -> String {
+    match &ty.kind {
+        TypeExprKind::Named(name) => name.name.clone(),
+        TypeExprKind::Generic { name, args } => format!(
+            "{}<{}>",
+            name.name,
+            args.iter().map(type_name).collect::<Vec<_>>().join(", ")
+        ),
+        TypeExprKind::Function { params, ret } => format!(
+            "fn({}) -> {}",
+            params.iter().map(type_name).collect::<Vec<_>>().join(", "),
+            type_name(ret)
+        ),
+        TypeExprKind::Array(element) => format!("[{}]", type_name(element)),
+        TypeExprKind::Tuple(elements) => format!(
+            "({})",
+            elements
+                .iter()
+                .map(type_name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        TypeExprKind::ImplTrait { trait_ty } => format!("impl {}", type_name(trait_ty)),
+    }
+}
+
+fn documentation_before(source: &str, offset: usize) -> Option<String> {
+    let prefix = &source[..offset.min(source.len())];
+    let mut lines = prefix.lines().rev();
+    let mut documentation = Vec::new();
+    for line in &mut lines {
+        let trimmed = line.trim();
+        if let Some(text) = trimmed.strip_prefix("///") {
+            documentation.push(text.trim().to_string());
+        } else if trimmed.is_empty() && documentation.is_empty() {
+            continue;
+        } else {
+            break;
+        }
+    }
+    documentation.reverse();
+    (!documentation.is_empty()).then(|| documentation.join("\n"))
+}

--- a/crates/husk-cli/Cargo.toml
+++ b/crates/husk-cli/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4.5.26", features = ["derive"] }
 flate2 = "1.0"
 husk = { path = "../husk" }
 husk-extension.workspace = true
+husk-lsp.workspace = true
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 semver = "1.0"
 serde = { version = "1.0.196", features = ["derive"] }

--- a/crates/husk-cli/src/generic_specialization.rs
+++ b/crates/husk-cli/src/generic_specialization.rs
@@ -225,6 +225,10 @@ pub(crate) fn apply_specializations(
             path: canonical.clone(),
             kind,
             signature: signature.to_string(),
+            documentation: Some(format!(
+                "Portable `{}` specialization for `serde_json::Value`.",
+                specialization.function()
+            )),
             compatibility: "compatible",
             reason: None,
             specialization: Some(canonical),

--- a/crates/husk-cli/src/lib.rs
+++ b/crates/husk-cli/src/lib.rs
@@ -83,6 +83,12 @@ enum Command {
         #[arg(long = "extension", value_name = "BUNDLE")]
         extensions: Vec<PathBuf>,
     },
+    /// Run the Husk language server.
+    Lsp {
+        /// Communicate with an editor over standard input and output.
+        #[arg(long)]
+        stdio: bool,
+    },
     /// Parse and type-check a Husk script.
     Check {
         /// Portable extension bundle to expose while checking.
@@ -320,6 +326,14 @@ fn execute(cli: Cli) -> anyhow::Result<ExitCode> {
             let stdin = io::stdin();
             let stdout = io::stdout();
             run_repl(&engine, stdin.lock(), stdout.lock(), interactive)
+        }
+        Command::Lsp { stdio } => {
+            anyhow::ensure!(
+                stdio,
+                "the Husk language server currently requires `--stdio`"
+            );
+            husk_lsp::run_stdio(husk_lsp::ServerOptions::default())?;
+            Ok(ExitCode::SUCCESS)
         }
         Command::Check {
             extensions,
@@ -916,6 +930,8 @@ struct ApiItemInspection {
     path: String,
     kind: &'static str,
     signature: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    documentation: Option<String>,
     compatibility: &'static str,
     reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1851,6 +1867,12 @@ fn classify_callable(
     owner_path: Option<&str>,
     resource_mappings: &ApiResourceMappings,
 ) -> ApiItemInspection {
+    let documentation = item
+        .get("docs")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|docs| !docs.is_empty())
+        .map(ToString::to_string);
     let Some(function) = item.pointer("/inner/function") else {
         return incompatible_api_item(path, default_kind, String::new(), "not a Rust function");
     };
@@ -1901,6 +1923,7 @@ fn classify_callable(
             path: path.to_string(),
             kind,
             signature,
+            documentation,
             compatibility: "specializable",
             reason: Some(
                 "generic Rust API requires a concrete --specialize instantiation".to_string(),
@@ -1948,6 +1971,7 @@ fn classify_callable(
             path: path.to_string(),
             kind,
             signature,
+            documentation,
             compatibility: "compatible",
             reason: None,
             specialization: None,
@@ -1967,6 +1991,7 @@ fn incompatible_api_item(
         path: path.to_string(),
         kind,
         signature,
+        documentation: None,
         compatibility: "incompatible",
         reason: Some(reason.to_string()),
         specialization: None,
@@ -3491,6 +3516,13 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
+
+    #[test]
+    fn parses_the_stdio_language_server_entrypoint() {
+        let cli = Cli::try_parse_from(["husk", "lsp", "--stdio"]).expect("parse LSP command");
+
+        assert!(matches!(cli.command, Command::Lsp { stdio: true }));
+    }
 
     #[test]
     fn derives_exact_component_exports_from_selected_wit_items() {

--- a/crates/husk-lsp/Cargo.toml
+++ b/crates/husk-lsp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "husk-lsp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Language Server Protocol implementation for Husk"
+
+[dependencies]
+anyhow = "1.0.79"
+husk-analysis.workspace = true
+husk-ast.workspace = true
+husk-extension.workspace = true
+husk-lexer.workspace = true
+husk-package.workspace = true
+husk-runtime = { workspace = true, features = ["wasm-extensions"] }
+husk-semantic.workspace = true
+husk-types.workspace = true
+husk-wasm.workspace = true
+lsp-types = "0.97.0"
+serde = { version = "1.0.196", features = ["derive"] }
+serde_json = "1.0.113"
+sha2 = "0.10"
+
+[[bin]]
+name = "husk-lsp"
+path = "src/main.rs"
+
+[dev-dependencies]
+tempfile = "3.15"

--- a/crates/husk-lsp/src/dependencies.rs
+++ b/crates/husk-lsp/src/dependencies.rs
@@ -1,0 +1,423 @@
+//! Read-only indexing for locked Husk extension adapters.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use husk_extension::{BundleLimits, ExtensionBundle};
+use husk_package::{LOCK_FILE, PackageLock, PackageManifest, discover_manifest};
+use husk_runtime::{WasmCompileOptions, WasmComponent, module_declaration_source};
+use husk_types::ModuleDescriptor;
+use sha2::{Digest, Sha256};
+
+pub(crate) struct DependencyIndex {
+    pub(crate) modules: Vec<ModuleDescriptor>,
+    pub(crate) stubs: Vec<(PathBuf, String)>,
+    pub(crate) diagnostics: Vec<String>,
+}
+
+pub(crate) fn index_dependencies(root: &Path) -> DependencyIndex {
+    let mut index = DependencyIndex {
+        modules: Vec::new(),
+        stubs: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    if let Err(error) = index_dependencies_inner(root, &mut index) {
+        index
+            .diagnostics
+            .push(format!("could not index Husk extensions: {error:#}"));
+    }
+    index
+}
+
+fn index_dependencies_inner(root: &Path, index: &mut DependencyIndex) -> anyhow::Result<()> {
+    let Ok(manifest_path) = discover_manifest(root) else {
+        return Ok(());
+    };
+    let package_root = manifest_path
+        .parent()
+        .context("Husk.toml has no parent directory")?;
+    let manifest_source = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read `{}`", manifest_path.display()))?;
+    let manifest = PackageManifest::parse(&manifest_source)?;
+    if manifest.extensions.is_empty() {
+        return Ok(());
+    }
+    let lock_path = package_root.join(LOCK_FILE);
+    let lock_source = fs::read_to_string(&lock_path).with_context(|| {
+        format!(
+            "read `{}`; run `red husk install --locked --offline`",
+            lock_path.display()
+        )
+    })?;
+    let lock = PackageLock::parse(&lock_source)?;
+    lock.validate_manifest(&manifest)?;
+
+    for (manifest_name, locked) in &lock.extensions {
+        let installed = package_root.join(&locked.source);
+        let artifact = locked
+            .artifact
+            .as_ref()
+            .map(|artifact| package_root.join(artifact));
+        let bundle_path = if installed.is_dir() {
+            installed
+        } else if artifact.as_ref().is_some_and(|artifact| artifact.is_dir()) {
+            artifact.expect("artifact existence was checked")
+        } else {
+            index.diagnostics.push(format!(
+                "extension `{manifest_name}` is not installed or vendored; run `red husk install --locked --offline`"
+            ));
+            continue;
+        };
+        let bundle = match ExtensionBundle::open(&bundle_path, BundleLimits::default()) {
+            Ok(bundle) => bundle,
+            Err(error) => {
+                index.diagnostics.push(format!(
+                    "extension `{manifest_name}` at `{}` is invalid: {error}",
+                    bundle_path.display()
+                ));
+                continue;
+            }
+        };
+        let digest = bundle.digest().to_string();
+        if digest != locked.sha256 {
+            index.diagnostics.push(format!(
+                "extension `{manifest_name}` digest is {digest}, expected {}",
+                locked.sha256
+            ));
+            continue;
+        }
+        let report_path = bundle.root().join("husk-adapter.json");
+        let report = match fs::read(&report_path) {
+            Ok(report)
+                if locked
+                    .report_sha256
+                    .as_ref()
+                    .is_none_or(|expected| hex_digest(&report) == *expected) =>
+            {
+                Some(report)
+            }
+            Ok(_) => {
+                index.diagnostics.push(format!(
+                    "extension `{manifest_name}` adapter report digest does not match Husk.lock"
+                ));
+                continue;
+            }
+            Err(error) if locked.report_sha256.is_some() => {
+                index.diagnostics.push(format!(
+                    "extension `{manifest_name}` adapter report is unavailable: {error}"
+                ));
+                continue;
+            }
+            Err(_) => None,
+        };
+        let component = match WasmComponent::from_bundle(&bundle, WasmCompileOptions::default()) {
+            Ok(component) => component,
+            Err(error) => {
+                index.diagnostics.push(format!(
+                    "extension `{manifest_name}` cannot be inspected: {error:#}"
+                ));
+                continue;
+            }
+        };
+        let mut descriptor = component.descriptor().clone();
+        if let Some(report) = report
+            && let Err(error) = enrich_documentation(&mut descriptor, &report)
+        {
+            index.diagnostics.push(format!(
+                "extension `{manifest_name}` adapter documentation is invalid: {error}"
+            ));
+        }
+        let declaration = module_declaration_source(&descriptor)?;
+        let stub_path = dependency_stub_path(package_root, &digest, descriptor.name.as_str());
+        write_stub(package_root, &stub_path, &declaration)?;
+        index.stubs.push((stub_path, declaration));
+        index.modules.push(descriptor);
+    }
+    index
+        .modules
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    index.stubs.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(())
+}
+
+fn dependency_stub_path(root: &Path, digest: &str, module: &str) -> PathBuf {
+    root.join(".husk")
+        .join("lsp")
+        .join(digest)
+        .join(format!("{module}.hk"))
+}
+
+fn write_stub(root: &Path, path: &Path, source: &str) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        path.starts_with(root),
+        "dependency stub `{}` escapes package root `{}`",
+        path.display(),
+        root.display()
+    );
+    let parent = path
+        .parent()
+        .context("dependency stub path has no parent directory")?;
+    let mut current = root.to_path_buf();
+    for component in parent
+        .strip_prefix(root)
+        .context("dependency stub parent escapes package root")?
+        .components()
+    {
+        current.push(component);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                anyhow::bail!(
+                    "dependency stub directory `{}` is a symlink",
+                    current.display()
+                );
+            }
+            Ok(metadata) => anyhow::ensure!(
+                metadata.is_dir(),
+                "dependency stub parent `{}` is not a directory",
+                current.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir(&current).with_context(|| {
+                    format!("create dependency stub directory `{}`", current.display())
+                })?;
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("inspect dependency stub directory `{}`", current.display())
+                });
+            }
+        }
+    }
+    if path.is_symlink() {
+        anyhow::bail!("dependency stub `{}` is a symlink", path.display());
+    }
+    if path.is_file() && fs::read_to_string(path).is_ok_and(|existing| existing == source) {
+        return Ok(());
+    }
+    fs::write(path, source).with_context(|| format!("write dependency stub `{}`", path.display()))
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn enrich_documentation(descriptor: &mut ModuleDescriptor, report: &[u8]) -> anyhow::Result<()> {
+    let report: serde_json::Value =
+        serde_json::from_slice(report).context("parse adapter report")?;
+    let items = report
+        .get("items")
+        .or_else(|| report.pointer("/public_api/items"))
+        .and_then(serde_json::Value::as_array)
+        .context("adapter report omitted its selected items")?;
+    let mut documentation = BTreeMap::<String, Option<String>>::new();
+    for item in items {
+        let Some(docs) = item
+            .get("documentation")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|docs| !docs.is_empty())
+        else {
+            continue;
+        };
+        let Some(wit) = item.get("wit") else {
+            continue;
+        };
+        let Some(declaration) = wit.get("declaration").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let member = declaration
+            .split_once(':')
+            .map_or_else(|| declaration.trim(), |(name, _)| name.trim());
+        let owner = wit
+            .get("owner_resource")
+            .and_then(serde_json::Value::as_str);
+        let raw_name = if member == "constructor" {
+            let Some(owner) = owner else {
+                continue;
+            };
+            format!("{owner}-new")
+        } else if let Some(owner) = owner {
+            format!("{owner}-{member}")
+        } else {
+            member.to_string()
+        };
+        let Ok(name) = husk_wasm::normalize_wit_name(&raw_name) else {
+            continue;
+        };
+        documentation
+            .entry(name)
+            .and_modify(|existing| *existing = None)
+            .or_insert_with(|| Some(docs.to_string()));
+    }
+    for function in descriptor.functions.iter_mut().chain(
+        descriptor
+            .interfaces
+            .iter_mut()
+            .flat_map(|interface| &mut interface.functions),
+    ) {
+        if let Some(Some(docs)) = documentation.get(&function.name) {
+            function.documentation = Some(docs.clone());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use husk_package::{
+        LockedCrateExtension, LockedExtension, PackageLock, installed_extension_path,
+        vendored_extension_path,
+    };
+    use husk_types::{FunctionDescriptor, TypeDescriptor, Version};
+    use serde_json::json;
+
+    use super::*;
+
+    const RESOURCE_COMPONENT: &str = include_str!("../../husk-wasm/tests/fixtures/resource.wat");
+
+    #[test]
+    fn stub_paths_are_digest_scoped_and_workspace_local() {
+        let root = Path::new("/workspace");
+        assert_eq!(
+            dependency_stub_path(root, "abc123", "serde_json"),
+            root.join(".husk/lsp/abc123/serde_json.hk")
+        );
+    }
+
+    #[test]
+    fn indexes_a_locked_crate_adapter_into_a_typed_navigation_stub() {
+        let package = tempfile::tempdir().expect("create package fixture");
+        let root = package.path();
+        fs::create_dir(root.join("src")).expect("create source directory");
+        fs::write(root.join("src/main.hk"), "fn main() {}\n").expect("write package source");
+        fs::write(
+            root.join("Husk.toml"),
+            "schema_version = 1\n\
+             [package]\n\
+             name = \"fixture\"\n\
+             version = \"0.1.0\"\n\
+             entry = \"src/main.hk\"\n\n\
+             [extensions.resource-fixture]\n\
+             crate = \"resource-fixture\"\n\
+             version = \"=1.0.0\"\n",
+        )
+        .expect("write package manifest");
+
+        let digest = hex_digest(RESOURCE_COMPONENT.as_bytes());
+        let source = installed_extension_path(&digest);
+        let bundle = root.join(&source);
+        fs::create_dir_all(&bundle).expect("create installed extension");
+        fs::write(
+            bundle.join("extension.toml"),
+            "schema_version = 1\n\
+             name = \"resource-fixture\"\n\
+             version = \"1.0.0\"\n\
+             module = \"resource_fixture\"\n\
+             artifact = \"component.wasm\"\n\
+             world = \"fixture:resource/factory\"\n\
+             minimum_husk = \"0.1.0\"\n",
+        )
+        .expect("write extension manifest");
+        fs::write(bundle.join("component.wasm"), RESOURCE_COMPONENT)
+            .expect("write component fixture");
+
+        let mut lock = PackageLock::empty("fixture".to_string(), Version::new(0, 1, 0));
+        lock.extensions = BTreeMap::from([(
+            "resource-fixture".to_string(),
+            LockedExtension {
+                module: "resource_fixture".to_string(),
+                version: Version::new(1, 0, 0),
+                source,
+                sha256: digest.clone(),
+                crate_source: Some(LockedCrateExtension {
+                    package: "resource-fixture".to_string(),
+                    version: Version::new(1, 0, 0),
+                    requirement: "=1.0.0".to_string(),
+                    features: Vec::new(),
+                    default_features: true,
+                    include: Vec::new(),
+                    specializations: Vec::new(),
+                    checksum: Some("fixture-checksum".to_string()),
+                }),
+                artifact: Some(vendored_extension_path(&digest)),
+                report_sha256: None,
+            },
+        )]);
+        fs::write(
+            root.join("Husk.lock"),
+            lock.to_toml().expect("serialize package lock"),
+        )
+        .expect("write package lock");
+
+        let index = index_dependencies(root);
+
+        assert!(index.diagnostics.is_empty(), "{:?}", index.diagnostics);
+        assert_eq!(index.modules.len(), 1);
+        assert_eq!(index.modules[0].name.as_str(), "resource_fixture");
+        assert_eq!(index.stubs.len(), 1);
+        assert!(
+            index.stubs[0].0.starts_with(
+                root.canonicalize()
+                    .expect("canonical package")
+                    .join(".husk/lsp")
+            )
+        );
+        assert!(index.stubs[0].1.contains("mod global resource_fixture"));
+        assert!(index.stubs[0].1.contains("fn new_item"));
+    }
+
+    #[test]
+    fn adapter_report_documentation_is_preserved_in_generated_stubs() {
+        let mut descriptor = ModuleDescriptor::new(
+            "sample",
+            Version::new(1, 0, 0),
+            vec![
+                FunctionDescriptor::new("parse_value", Vec::new(), TypeDescriptor::String)
+                    .expect("create function descriptor"),
+            ],
+            Vec::new(),
+        )
+        .expect("create module descriptor");
+        let report = serde_json::to_vec(&json!({
+            "items": [{
+                "documentation": "Parse one value.\n\nReturns owned data.",
+                "wit": {
+                    "owner_resource": null,
+                    "declaration": "parse-value: func() -> string;"
+                }
+            }]
+        }))
+        .expect("serialize adapter report");
+
+        enrich_documentation(&mut descriptor, &report).expect("enrich descriptor");
+        let declaration = module_declaration_source(&descriptor).expect("render declaration");
+
+        assert!(declaration.contains("/// Parse one value."));
+        assert!(declaration.contains("/// Returns owned data."));
+        assert!(declaration.contains("fn parse_value"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generated_stub_rejects_a_symlinked_cache_directory() {
+        use std::os::unix::fs::symlink;
+
+        let package = tempfile::tempdir().expect("create package");
+        let outside = tempfile::tempdir().expect("create outside directory");
+        symlink(outside.path(), package.path().join(".husk")).expect("create cache symlink");
+        let stub = package.path().join(".husk/lsp/digest/module.hk");
+
+        let error = write_stub(package.path(), &stub, "fn hidden() {}")
+            .expect_err("symlink must be rejected");
+
+        assert!(error.to_string().contains("symlink"), "{error:#}");
+        assert!(!outside.path().join("lsp/digest/module.hk").exists());
+    }
+}

--- a/crates/husk-lsp/src/lib.rs
+++ b/crates/husk-lsp/src/lib.rs
@@ -1,0 +1,8 @@
+//! Language Server Protocol support for Husk.
+
+mod dependencies;
+mod protocol;
+mod server;
+mod uri;
+
+pub use server::{ServerOptions, run_stdio};

--- a/crates/husk-lsp/src/main.rs
+++ b/crates/husk-lsp/src/main.rs
@@ -1,0 +1,9 @@
+fn main() -> std::process::ExitCode {
+    match husk_lsp::run_stdio(husk_lsp::ServerOptions::default()) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("husk-lsp: {error:#}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/husk-lsp/src/protocol.rs
+++ b/crates/husk-lsp/src/protocol.rs
@@ -1,0 +1,104 @@
+//! Bounded JSON-RPC framing for LSP stdio transport.
+
+use std::io::{BufRead, Write};
+
+use anyhow::Context;
+use serde_json::Value;
+
+const MAX_HEADER_BYTES: usize = 16 * 1024;
+const MAX_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
+
+pub(crate) fn read_message(reader: &mut impl BufRead) -> anyhow::Result<Option<Value>> {
+    let mut content_length = None;
+    let mut header_bytes = 0usize;
+    loop {
+        let mut line = String::new();
+        let read = reader.read_line(&mut line).context("read LSP header")?;
+        if read == 0 {
+            return if header_bytes == 0 {
+                Ok(None)
+            } else {
+                Err(anyhow::anyhow!("truncated LSP header"))
+            };
+        }
+        header_bytes = header_bytes.saturating_add(read);
+        anyhow::ensure!(
+            header_bytes <= MAX_HEADER_BYTES,
+            "LSP header exceeds {MAX_HEADER_BYTES} bytes"
+        );
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+        if let Some(value) = line
+            .trim_end_matches(['\r', '\n'])
+            .strip_prefix("Content-Length:")
+        {
+            anyhow::ensure!(content_length.is_none(), "duplicate Content-Length header");
+            content_length = Some(
+                value
+                    .trim()
+                    .parse::<usize>()
+                    .context("parse LSP Content-Length")?,
+            );
+        }
+    }
+    let length = content_length.context("LSP message omitted Content-Length")?;
+    anyhow::ensure!(
+        length <= MAX_MESSAGE_BYTES,
+        "LSP message is {length} bytes; maximum is {MAX_MESSAGE_BYTES}"
+    );
+    let mut body = vec![0; length];
+    reader
+        .read_exact(&mut body)
+        .context("read LSP message body")?;
+    serde_json::from_slice(&body)
+        .context("parse LSP JSON message")
+        .map(Some)
+}
+
+pub(crate) fn write_message(writer: &mut impl Write, message: &Value) -> anyhow::Result<()> {
+    let body = serde_json::to_vec(message).context("serialize LSP JSON message")?;
+    anyhow::ensure!(
+        body.len() <= MAX_MESSAGE_BYTES,
+        "LSP response is {} bytes; maximum is {MAX_MESSAGE_BYTES}",
+        body.len()
+    );
+    write!(writer, "Content-Length: {}\r\n\r\n", body.len())
+        .context("write LSP response header")?;
+    writer.write_all(&body).context("write LSP response body")?;
+    writer.flush().context("flush LSP response")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufReader, Cursor};
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn round_trips_a_framed_message() {
+        let expected = json!({"jsonrpc": "2.0", "id": 1, "method": "initialize"});
+        let mut output = Vec::new();
+        write_message(&mut output, &expected).expect("write message");
+        let mut reader = BufReader::new(Cursor::new(output));
+
+        assert_eq!(
+            read_message(&mut reader).expect("read message"),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_or_oversized_headers() {
+        let duplicate = b"Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}";
+        let mut reader = BufReader::new(Cursor::new(duplicate));
+        assert!(
+            read_message(&mut reader)
+                .expect_err("duplicate must fail")
+                .to_string()
+                .contains("duplicate")
+        );
+    }
+}

--- a/crates/husk-lsp/src/server.rs
+++ b/crates/husk-lsp/src/server.rs
@@ -1,0 +1,1639 @@
+//! Husk language-server state and request handlers.
+
+use std::collections::HashSet;
+use std::io::{BufReader, BufWriter};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Context;
+use husk_analysis::{
+    AnalysisDiagnostic, DiagnosticSeverity as AnalysisDiagnosticSeverity, Document,
+    Position as AnalysisPosition, Symbol, SymbolId, SymbolKind, Workspace, format_source,
+};
+use husk_ast::ItemKind;
+use husk_lexer::{KEYWORDS, Lexer, TokenKind};
+use husk_package::discover_manifest;
+use husk_semantic::SemanticProfile;
+use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+use serde_json::{Map, Value, json};
+
+use crate::dependencies::index_dependencies;
+use crate::protocol::{read_message, write_message};
+use crate::uri::{file_path, file_uri};
+
+const TOKEN_TYPES: &[&str] = &[
+    "namespace",
+    "type",
+    "enum",
+    "struct",
+    "typeParameter",
+    "parameter",
+    "variable",
+    "property",
+    "enumMember",
+    "function",
+    "method",
+    "keyword",
+    "string",
+    "number",
+    "operator",
+    "comment",
+];
+
+/// Host-selected defaults for a Husk language-server process.
+#[derive(Debug, Clone)]
+pub struct ServerOptions {
+    pub profile: SemanticProfile,
+    pub trusted_declarations: Vec<String>,
+}
+
+impl Default for ServerOptions {
+    fn default() -> Self {
+        Self {
+            profile: SemanticProfile::Native,
+            trusted_declarations: Vec::new(),
+        }
+    }
+}
+
+/// Run one Husk LSP session over process standard input and output.
+pub fn run_stdio(options: ServerOptions) -> anyhow::Result<()> {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut reader = BufReader::new(stdin.lock());
+    let mut writer = BufWriter::new(stdout.lock());
+    let mut server = Server::new(options);
+    while let Some(message) = read_message(&mut reader)? {
+        let responses = server.handle(message);
+        for response in responses {
+            write_message(&mut writer, &response)?;
+        }
+        if server.exited {
+            break;
+        }
+    }
+    Ok(())
+}
+
+struct Server {
+    options: ServerOptions,
+    workspace: Option<Workspace>,
+    shutdown_requested: bool,
+    exited: bool,
+    cancelled: HashSet<String>,
+    dependency_diagnostics: Vec<String>,
+}
+
+impl Server {
+    fn new(options: ServerOptions) -> Self {
+        Self {
+            options,
+            workspace: None,
+            shutdown_requested: false,
+            exited: false,
+            cancelled: HashSet::new(),
+            dependency_diagnostics: Vec::new(),
+        }
+    }
+
+    fn handle(&mut self, message: Value) -> Vec<Value> {
+        let Some(object) = message.as_object() else {
+            return vec![error_response(
+                Value::Null,
+                -32600,
+                "JSON-RPC message must be an object",
+            )];
+        };
+        let id = object.get("id").cloned();
+        let method = object.get("method").and_then(Value::as_str);
+        let params = object.get("params").cloned().unwrap_or(Value::Null);
+        match (id, method) {
+            (Some(id), Some(method)) => {
+                if self.cancelled.remove(&request_key(&id)) {
+                    return vec![error_response(id, -32800, "request cancelled")];
+                }
+                vec![match self.handle_request(method, params) {
+                    Ok(result) => success_response(id, result),
+                    Err(error) => error_response(id, -32603, &format!("{error:#}")),
+                }]
+            }
+            (None, Some(method)) => {
+                self.handle_notification(method, params)
+                    .unwrap_or_else(|error| {
+                        vec![notification(
+                            "window/logMessage",
+                            json!({"type": 1, "message": format!("{error:#}")}),
+                        )]
+                    })
+            }
+            (Some(id), None) => vec![error_response(
+                id,
+                -32600,
+                "JSON-RPC request omitted method",
+            )],
+            (None, None) => Vec::new(),
+        }
+    }
+
+    fn handle_request(&mut self, method: &str, params: Value) -> anyhow::Result<Value> {
+        if method != "initialize" && self.workspace.is_none() {
+            anyhow::bail!("Husk language server is not initialized");
+        }
+        match method {
+            "initialize" => self.initialize(params),
+            "shutdown" => {
+                self.shutdown_requested = true;
+                Ok(Value::Null)
+            }
+            "textDocument/diagnostic" => self.document_diagnostic(params),
+            "workspace/diagnostic" => Ok(json!({"items": []})),
+            "textDocument/completion" => self.completion(params),
+            "completionItem/resolve" => Ok(params),
+            "textDocument/hover" => self.hover(params),
+            "textDocument/signatureHelp" => self.signature_help(params),
+            "textDocument/definition"
+            | "textDocument/declaration"
+            | "textDocument/typeDefinition"
+            | "textDocument/implementation" => self.definition(params),
+            "textDocument/references" => self.references(params),
+            "textDocument/documentHighlight" => self.document_highlight(params),
+            "textDocument/prepareRename" => self.prepare_rename(params),
+            "textDocument/rename" => self.rename(params),
+            "textDocument/documentSymbol" => self.document_symbols(params),
+            "workspace/symbol" => self.workspace_symbols(params),
+            "textDocument/semanticTokens/full" => self.semantic_tokens(params),
+            "textDocument/inlayHint" => self.inlay_hints(params),
+            "textDocument/foldingRange" => self.folding_ranges(params),
+            "textDocument/selectionRange" => self.selection_ranges(params),
+            "textDocument/codeAction" => self.code_actions(params),
+            "textDocument/formatting" => self.format_document(params, false),
+            "textDocument/rangeFormatting" => self.format_document(params, true),
+            "textDocument/prepareCallHierarchy" => self.prepare_call_hierarchy(params),
+            "callHierarchy/incomingCalls" => self.incoming_calls(params),
+            "callHierarchy/outgoingCalls" => self.outgoing_calls(params),
+            "textDocument/documentLink" | "textDocument/colorPresentation" => Ok(json!([])),
+            _ => anyhow::bail!("unsupported LSP request `{method}`"),
+        }
+    }
+
+    fn handle_notification(&mut self, method: &str, params: Value) -> anyhow::Result<Vec<Value>> {
+        match method {
+            "initialized" => Ok(Vec::new()),
+            "exit" => {
+                self.exited = true;
+                Ok(Vec::new())
+            }
+            "$/cancelRequest" => {
+                if let Some(id) = params.get("id") {
+                    self.cancelled.insert(request_key(id));
+                }
+                Ok(Vec::new())
+            }
+            "textDocument/didOpen" => {
+                let item = params
+                    .get("textDocument")
+                    .context("didOpen omitted textDocument")?;
+                let uri = required_str(item, "uri")?;
+                let path = file_path(uri)?;
+                let version = item
+                    .get("version")
+                    .and_then(Value::as_i64)
+                    .and_then(|version| i32::try_from(version).ok())
+                    .unwrap_or(1);
+                let text = required_str(item, "text")?;
+                self.workspace_mut()?
+                    .update(&path, version, Arc::<str>::from(text))?;
+                Ok(vec![self.publish_diagnostics(&path)?])
+            }
+            "textDocument/didChange" => {
+                let document = params
+                    .get("textDocument")
+                    .context("didChange omitted textDocument")?;
+                let uri = required_str(document, "uri")?;
+                let path = file_path(uri)?;
+                let version = document
+                    .get("version")
+                    .and_then(Value::as_i64)
+                    .and_then(|version| i32::try_from(version).ok())
+                    .context("didChange omitted a valid document version")?;
+                let changes = params
+                    .get("contentChanges")
+                    .and_then(Value::as_array)
+                    .context("didChange omitted contentChanges")?;
+                self.apply_changes(&path, version, changes)?;
+                Ok(vec![self.publish_diagnostics(&path)?])
+            }
+            "textDocument/didClose" => {
+                let uri = text_document_uri(&params)?;
+                let path = file_path(uri)?;
+                self.workspace_mut()?.close(&path)?;
+                Ok(vec![notification(
+                    "textDocument/publishDiagnostics",
+                    json!({"uri": uri, "diagnostics": []}),
+                )])
+            }
+            "textDocument/didSave" | "workspace/didChangeWatchedFiles" => {
+                self.workspace_mut()?.refresh_disk()?;
+                Ok(Vec::new())
+            }
+            "workspace/didChangeConfiguration" => {
+                if let Some(profile) = params
+                    .pointer("/settings/husk/semanticProfile")
+                    .and_then(Value::as_str)
+                {
+                    self.workspace_mut()?.set_profile(parse_profile(profile)?);
+                }
+                if let Some(flags) = params
+                    .pointer("/settings/husk/cfgFlags")
+                    .and_then(Value::as_array)
+                {
+                    self.workspace_mut()?.set_cfg_flags(
+                        flags
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToString::to_string),
+                    );
+                }
+                Ok(Vec::new())
+            }
+            _ => Ok(Vec::new()),
+        }
+    }
+
+    fn initialize(&mut self, params: Value) -> anyhow::Result<Value> {
+        anyhow::ensure!(self.workspace.is_none(), "server is already initialized");
+        let root = workspace_root(&params)?;
+        let initialization = params
+            .get("initializationOptions")
+            .and_then(Value::as_object);
+        let explicit_profile = initialization
+            .and_then(|options| options.get("semanticProfile"))
+            .and_then(Value::as_str)
+            .map(parse_profile)
+            .transpose()?;
+        let loose_profile = initialization
+            .and_then(|options| options.get("looseSemanticProfile"))
+            .and_then(Value::as_str)
+            .map(parse_profile)
+            .transpose()?;
+        let profile = explicit_profile.unwrap_or_else(|| {
+            if discover_manifest(&root).is_ok() {
+                SemanticProfile::Native
+            } else {
+                loose_profile.unwrap_or(self.options.profile)
+            }
+        });
+        let mut workspace = Workspace::open(&root, profile)?;
+        let mut declarations = self.options.trusted_declarations.clone();
+        if let Some(extra) = initialization
+            .and_then(|options| options.get("declarations"))
+            .and_then(Value::as_array)
+        {
+            declarations.extend(
+                extra
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToString::to_string),
+            );
+        }
+        if !declarations.is_empty() {
+            workspace.set_trusted_declaration_sources(declarations)?;
+        }
+        let dependencies = index_dependencies(&root);
+        self.dependency_diagnostics = dependencies.diagnostics;
+        workspace.set_external_modules(dependencies.modules)?;
+        for (path, source) in dependencies.stubs {
+            workspace.update(path, 0, Arc::<str>::from(source))?;
+        }
+        self.workspace = Some(workspace);
+
+        Ok(json!({
+            "capabilities": {
+                "positionEncoding": "utf-16",
+                "textDocumentSync": {
+                    "openClose": true,
+                    "change": 2,
+                    "save": true
+                },
+                "diagnosticProvider": {
+                    "identifier": "husk",
+                    "interFileDependencies": true,
+                    "workspaceDiagnostics": false
+                },
+                "completionProvider": {
+                    "resolveProvider": true,
+                    "triggerCharacters": [".", ":", "<"]
+                },
+                "hoverProvider": true,
+                "signatureHelpProvider": {
+                    "triggerCharacters": ["(", ",", "<"],
+                    "retriggerCharacters": [","]
+                },
+                "definitionProvider": true,
+                "declarationProvider": true,
+                "typeDefinitionProvider": true,
+                "implementationProvider": true,
+                "referencesProvider": true,
+                "documentHighlightProvider": true,
+                "documentSymbolProvider": true,
+                "workspaceSymbolProvider": true,
+                "renameProvider": {"prepareProvider": true},
+                "semanticTokensProvider": {
+                    "legend": {
+                        "tokenTypes": TOKEN_TYPES,
+                        "tokenModifiers": ["declaration", "definition", "readonly", "static", "defaultLibrary"]
+                    },
+                    "full": true,
+                    "range": false
+                },
+                "inlayHintProvider": true,
+                "foldingRangeProvider": true,
+                "selectionRangeProvider": true,
+                "codeActionProvider": {
+                    "codeActionKinds": ["quickfix", "source.organizeImports"],
+                    "resolveProvider": false
+                },
+                "documentFormattingProvider": true,
+                "documentRangeFormattingProvider": true,
+                "callHierarchyProvider": true
+            },
+            "serverInfo": {
+                "name": "husk-lsp",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        }))
+    }
+
+    fn document_diagnostic(&self, params: Value) -> anyhow::Result<Value> {
+        let path = file_path(text_document_uri(&params)?)?;
+        let diagnostics = self.diagnostics_for_path(&path)?;
+        Ok(json!({
+            "kind": "full",
+            "items": diagnostics,
+        }))
+    }
+
+    fn completion(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let document = self.document(&path)?;
+        let (prefix, qualifier) = completion_context(document.text(), byte);
+        let mut items = self
+            .workspace()?
+            .completions(&path, &prefix)
+            .into_iter()
+            .filter(|symbol| {
+                qualifier.as_ref().is_none_or(|qualifier| {
+                    symbol.container.as_deref() == Some(qualifier)
+                        || symbol.qualified_name.starts_with(&format!("{qualifier}::"))
+                })
+            })
+            .map(completion_item)
+            .collect::<Vec<_>>();
+        if qualifier.is_none() {
+            items.extend(
+                KEYWORDS
+                    .iter()
+                    .filter(|keyword| keyword.starts_with(&prefix))
+                    .map(|keyword| {
+                        json!({
+                            "label": keyword,
+                            "kind": 14,
+                            "detail": "Husk keyword",
+                            "sortText": format!("9-{keyword}")
+                        })
+                    }),
+            );
+        }
+        Ok(json!({"isIncomplete": false, "items": items}))
+    }
+
+    fn hover(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let document = self.document(&path)?;
+        if let Some(hover) = document.hover(byte) {
+            let mut value = format!("```husk\n{}\n```", hover.signature);
+            if let Some(docs) = &hover.docs {
+                value.push_str("\n\n");
+                value.push_str(docs);
+            }
+            return Ok(json!({
+                "contents": {"kind": "markdown", "value": value}
+            }));
+        }
+        let Some((_, symbol)) = self.symbol_at(&path, byte) else {
+            return Ok(Value::Null);
+        };
+        let mut value = format!("```husk\n{}\n```", symbol.detail);
+        if let Some(documentation) = &symbol.documentation {
+            value.push_str("\n\n");
+            value.push_str(documentation);
+        }
+        Ok(json!({
+            "contents": {"kind": "markdown", "value": value},
+            "range": self.range(document, &symbol.span)
+        }))
+    }
+
+    fn signature_help(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let document = self.document(&path)?;
+        let Some((name, active_parameter)) = call_context(document.text(), byte) else {
+            return Ok(Value::Null);
+        };
+        let Some((_, symbol)) = self.workspace()?.symbol_named(&name) else {
+            return Ok(Value::Null);
+        };
+        let parameters = signature_parameters(&symbol.detail);
+        Ok(json!({
+            "signatures": [{
+                "label": symbol.detail,
+                "documentation": symbol.documentation.as_ref().map(|documentation| json!({
+                    "kind": "markdown",
+                    "value": documentation
+                })),
+                "parameters": parameters.iter().map(|parameter| json!({"label": parameter})).collect::<Vec<_>>(),
+                "activeParameter": active_parameter.min(parameters.len().saturating_sub(1))
+            }],
+            "activeSignature": 0,
+            "activeParameter": active_parameter.min(parameters.len().saturating_sub(1))
+        }))
+    }
+
+    fn definition(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let Some((definition_document, symbol)) = self.symbol_at(&path, byte) else {
+            return Ok(Value::Null);
+        };
+        location(definition_document, &symbol.span)
+    }
+
+    fn references(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let Some((_, symbol)) = self.symbol_at(&path, byte) else {
+            return Ok(json!([]));
+        };
+        let include_declaration = params
+            .pointer("/context/includeDeclaration")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let mut locations = Vec::new();
+        for occurrence in self.workspace()?.references(&symbol.id) {
+            if !include_declaration && occurrence.is_definition {
+                continue;
+            }
+            let document = self.document(&occurrence.path)?;
+            locations.push(location(document, &occurrence.span)?);
+        }
+        if locations.len() <= usize::from(include_declaration) {
+            locations.extend(self.textual_references(&symbol.name, include_declaration)?);
+            deduplicate_locations(&mut locations);
+        }
+        Ok(Value::Array(locations))
+    }
+
+    fn document_highlight(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let Some((_, symbol)) = self.symbol_at(&path, byte) else {
+            return Ok(json!([]));
+        };
+        let document = self.document(&path)?;
+        let mut highlights = self
+            .workspace()?
+            .references(&symbol.id)
+            .into_iter()
+            .filter(|occurrence| occurrence.path == path)
+            .map(|occurrence| {
+                json!({
+                    "range": self.range(document, &occurrence.span),
+                    "kind": if occurrence.is_definition { 3 } else { 2 }
+                })
+            })
+            .collect::<Vec<_>>();
+        if highlights.len() <= 1 {
+            highlights = word_occurrences(document.text(), &symbol.name)
+                .into_iter()
+                .map(|range| {
+                    json!({
+                        "range": self.range(document, &range),
+                        "kind": if range == symbol.span { 3 } else { 2 }
+                    })
+                })
+                .collect();
+        }
+        Ok(Value::Array(highlights))
+    }
+
+    fn prepare_rename(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let Some((document, symbol)) = self.symbol_at(&path, byte) else {
+            return Ok(Value::Null);
+        };
+        anyhow::ensure!(
+            !is_dependency_stub(document.path()),
+            "external dependency symbols are read-only"
+        );
+        Ok(json!({
+            "range": self.range(document, &symbol.span),
+            "placeholder": symbol.name
+        }))
+    }
+
+    fn rename(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let new_name = required_str(&params, "newName")?;
+        anyhow::ensure!(
+            husk_lexer::is_valid_identifier(new_name),
+            "`{new_name}` is not a valid Husk identifier"
+        );
+        let Some((definition_document, symbol)) = self.symbol_at(&path, byte) else {
+            return Ok(Value::Null);
+        };
+        anyhow::ensure!(
+            !is_dependency_stub(definition_document.path()),
+            "external dependency symbols are read-only"
+        );
+        let mut changes = Map::new();
+        for occurrence in self.workspace()?.references(&symbol.id) {
+            if is_dependency_stub(&occurrence.path) {
+                continue;
+            }
+            let document = self.document(&occurrence.path)?;
+            changes
+                .entry(file_uri(document.path())?)
+                .or_insert_with(|| Value::Array(Vec::new()))
+                .as_array_mut()
+                .expect("workspace edit entry is initialized as an array")
+                .push(json!({
+                    "range": self.range(document, &occurrence.span),
+                    "newText": new_name
+                }));
+        }
+        Ok(json!({"changes": changes}))
+    }
+
+    fn document_symbols(&self, params: Value) -> anyhow::Result<Value> {
+        let path = file_path(text_document_uri(&params)?)?;
+        let document = self.document(&path)?;
+        Ok(Value::Array(
+            document
+                .symbols()
+                .iter()
+                .filter(|symbol| {
+                    !matches!(
+                        symbol.kind,
+                        SymbolKind::Variable | SymbolKind::Parameter | SymbolKind::TypeParameter
+                    )
+                })
+                .map(|symbol| {
+                    json!({
+                        "name": symbol.name,
+                        "detail": symbol.detail,
+                        "kind": lsp_symbol_kind(symbol.kind),
+                        "range": self.range(document, &symbol.full_span),
+                        "selectionRange": self.range(document, &symbol.span)
+                    })
+                })
+                .collect(),
+        ))
+    }
+
+    fn workspace_symbols(&self, params: Value) -> anyhow::Result<Value> {
+        let query = params.get("query").and_then(Value::as_str).unwrap_or("");
+        let mut symbols = Vec::new();
+        for (path, symbol) in self.workspace()?.workspace_symbols(query) {
+            let document = self.document(path)?;
+            symbols.push(json!({
+                "name": symbol.name,
+                "kind": lsp_symbol_kind(symbol.kind),
+                "containerName": symbol.container,
+                "location": location(document, &symbol.span)?
+            }));
+        }
+        Ok(Value::Array(symbols))
+    }
+
+    fn semantic_tokens(&self, params: Value) -> anyhow::Result<Value> {
+        let path = file_path(text_document_uri(&params)?)?;
+        let document = self.document(&path)?;
+        let mut absolute = Vec::<(u32, u32, u32, u32, u32)>::new();
+        for token in Lexer::new(document.text()) {
+            if matches!(token.kind, TokenKind::Eof) || token.span.range.is_empty() {
+                continue;
+            }
+            let token_type = match &token.kind {
+                TokenKind::Keyword(_) => 11,
+                TokenKind::StringLiteral(_) => 12,
+                TokenKind::IntLiteral(_) | TokenKind::FloatLiteral(_) => 13,
+                TokenKind::Ident(_) => document
+                    .symbols()
+                    .iter()
+                    .find(|symbol| symbol.span == token.span.range)
+                    .map_or(6, |symbol| semantic_token_kind(symbol.kind)),
+                TokenKind::LParen
+                | TokenKind::RParen
+                | TokenKind::LBrace
+                | TokenKind::RBrace
+                | TokenKind::Comma
+                | TokenKind::Colon
+                | TokenKind::ColonColon
+                | TokenKind::Semicolon
+                | TokenKind::Dot
+                | TokenKind::LBracket
+                | TokenKind::RBracket
+                | TokenKind::Hash => continue,
+                _ => 14,
+            };
+            let range = document.position_range(&token.span.range);
+            if range.start.line != range.end.line {
+                continue;
+            }
+            absolute.push((
+                range.start.line,
+                range.start.character,
+                range.end.character.saturating_sub(range.start.character),
+                token_type,
+                0,
+            ));
+        }
+        absolute.sort_unstable();
+        let mut data = Vec::with_capacity(absolute.len() * 5);
+        let mut previous_line = 0;
+        let mut previous_start = 0;
+        for (line, start, length, token_type, modifiers) in absolute {
+            let delta_line = line.saturating_sub(previous_line);
+            let delta_start = if delta_line == 0 {
+                start.saturating_sub(previous_start)
+            } else {
+                start
+            };
+            data.extend([delta_line, delta_start, length, token_type, modifiers]);
+            previous_line = line;
+            previous_start = start;
+        }
+        Ok(json!({"data": data}))
+    }
+
+    fn inlay_hints(&self, params: Value) -> anyhow::Result<Value> {
+        let path = file_path(text_document_uri(&params)?)?;
+        let document = self.document(&path)?;
+        let hints = document
+            .symbols()
+            .iter()
+            .filter(|symbol| symbol.kind == SymbolKind::Variable)
+            .filter_map(|symbol| {
+                let hover = document.hover(symbol.span.start)?;
+                let (_, ty) = hover.signature.split_once(':')?;
+                Some(json!({
+                    "position": to_lsp_position(document.position_range(&symbol.span).end),
+                    "label": format!(": {}", ty.trim()),
+                    "kind": 1,
+                    "paddingLeft": false,
+                    "paddingRight": true
+                }))
+            })
+            .collect::<Vec<_>>();
+        Ok(Value::Array(hints))
+    }
+
+    fn folding_ranges(&self, params: Value) -> anyhow::Result<Value> {
+        let path = file_path(text_document_uri(&params)?)?;
+        let document = self.document(&path)?;
+        let ranges = document
+            .syntax()
+            .items
+            .iter()
+            .filter_map(|item| {
+                let range = document.position_range(&item.span.range);
+                (range.end.line > range.start.line).then(|| {
+                    json!({
+                        "startLine": range.start.line,
+                        "startCharacter": range.start.character,
+                        "endLine": range.end.line,
+                        "endCharacter": range.end.character,
+                        "kind": if matches!(item.kind, ItemKind::Use { .. }) { "imports" } else { "region" }
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(Value::Array(ranges))
+    }
+
+    fn selection_ranges(&self, params: Value) -> anyhow::Result<Value> {
+        let path = file_path(text_document_uri(&params)?)?;
+        let document = self.document(&path)?;
+        let positions = params
+            .get("positions")
+            .and_then(Value::as_array)
+            .context("selectionRange omitted positions")?;
+        let end = document
+            .position_range(&(document.text().len()..document.text().len()))
+            .end;
+        let document_range = json!({
+            "start": {"line": 0, "character": 0},
+            "end": to_lsp_position(end)
+        });
+        let mut selections = Vec::new();
+        for position in positions {
+            let position = parse_position(position)?;
+            let byte = document
+                .byte_offset(position)
+                .context("selection position is not a UTF-16 boundary")?;
+            let word = word_range(document.text(), byte).unwrap_or(byte..byte);
+            let line = line_range(document.text(), byte);
+            selections.push(json!({
+                "range": self.range(document, &word),
+                "parent": {
+                    "range": self.range(document, &line),
+                    "parent": {"range": document_range}
+                }
+            }));
+        }
+        Ok(Value::Array(selections))
+    }
+
+    fn code_actions(&self, params: Value) -> anyhow::Result<Value> {
+        let path = file_path(text_document_uri(&params)?)?;
+        let document = self.document(&path)?;
+        let uri = file_uri(document.path())?;
+        let mut actions = Vec::new();
+        if let Some(diagnostics) = params
+            .pointer("/context/diagnostics")
+            .and_then(Value::as_array)
+        {
+            for diagnostic in diagnostics {
+                let code = diagnostic.get("code").and_then(Value::as_str);
+                let message = diagnostic
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                if code == Some("HUSK-P0001")
+                    && (message.contains("`;`")
+                        || message.to_ascii_lowercase().contains("semicolon"))
+                    && let Some(end) = diagnostic.pointer("/range/end")
+                {
+                    actions.push(json!({
+                        "title": "Insert missing semicolon",
+                        "kind": "quickfix",
+                        "isPreferred": true,
+                        "diagnostics": [diagnostic],
+                        "edit": {
+                            "changes": {
+                                uri.clone(): [{
+                                    "range": {"start": end, "end": end},
+                                    "newText": ";"
+                                }]
+                            }
+                        }
+                    }));
+                }
+            }
+        }
+        if let Some((range, replacement)) = organize_imports(document) {
+            actions.push(json!({
+                "title": "Organize Husk imports",
+                "kind": "source.organizeImports",
+                "isPreferred": true,
+                "edit": {
+                    "changes": {
+                        uri: [{
+                            "range": self.range(document, &range),
+                            "newText": replacement
+                        }]
+                    }
+                }
+            }));
+        }
+        Ok(Value::Array(actions))
+    }
+
+    fn format_document(&self, params: Value, range_only: bool) -> anyhow::Result<Value> {
+        let path = file_path(text_document_uri(&params)?)?;
+        let document = self.document(&path)?;
+        let tab_size = params
+            .get("options")
+            .and_then(|options| options.get("tabSize"))
+            .and_then(Value::as_u64)
+            .and_then(|size| usize::try_from(size).ok())
+            .unwrap_or(4);
+        let formatted = format_source(document.text(), tab_size);
+        if formatted == document.text() {
+            return Ok(json!([]));
+        }
+        if range_only {
+            let requested = params
+                .get("range")
+                .context("rangeFormatting omitted range")?;
+            let start = parse_position(
+                requested
+                    .get("start")
+                    .context("format range omitted start")?,
+            )?;
+            let end = parse_position(requested.get("end").context("format range omitted end")?)?;
+            let last_line = if end.character == 0 && end.line > start.line {
+                end.line - 1
+            } else {
+                end.line
+            };
+            let original_range = complete_line_range(document, start.line, last_line)?;
+            let formatted_index = husk_analysis::LineIndex::new(&formatted);
+            let formatted_start = formatted_index
+                .byte_offset(
+                    &formatted,
+                    AnalysisPosition {
+                        line: start.line,
+                        character: 0,
+                    },
+                )
+                .context("formatted range starts outside document")?;
+            let formatted_end = formatted_line_end(&formatted, &formatted_index, last_line)?;
+            return Ok(json!([{
+                "range": self.range(document, &original_range),
+                "newText": &formatted[formatted_start..formatted_end]
+            }]));
+        }
+        Ok(json!([{
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": to_lsp_position(
+                    document.position_range(&(document.text().len()..document.text().len())).end
+                )
+            },
+            "newText": formatted
+        }]))
+    }
+
+    fn prepare_call_hierarchy(&self, params: Value) -> anyhow::Result<Value> {
+        let (path, byte) = self.document_position(&params)?;
+        let Some((document, symbol)) = self.symbol_at(&path, byte) else {
+            return Ok(json!([]));
+        };
+        if !matches!(symbol.kind, SymbolKind::Function | SymbolKind::Method) {
+            return Ok(json!([]));
+        }
+        Ok(Value::Array(vec![
+            self.call_hierarchy_item(document, symbol)?,
+        ]))
+    }
+
+    fn incoming_calls(&self, params: Value) -> anyhow::Result<Value> {
+        let target_id = call_hierarchy_symbol_id(&params)?;
+        let workspace = self.workspace()?;
+        let Some((_, target)) = workspace.definition(&target_id) else {
+            return Ok(json!([]));
+        };
+        let mut calls = Vec::new();
+        for document in workspace.documents() {
+            if is_dependency_stub(document.path()) {
+                continue;
+            }
+            for caller in document
+                .symbols()
+                .iter()
+                .filter(|symbol| matches!(symbol.kind, SymbolKind::Function | SymbolKind::Method))
+            {
+                let mut ranges = call_occurrences(document.text(), &caller.full_span, &target.name);
+                ranges.retain(|range| {
+                    workspace
+                        .symbol_at(document.path(), range.start)
+                        .is_none_or(|resolved| resolved.id == target.id)
+                });
+                if ranges.is_empty() {
+                    continue;
+                }
+                calls.push(json!({
+                    "from": self.call_hierarchy_item(document, caller)?,
+                    "fromRanges": ranges
+                        .iter()
+                        .map(|range| self.range(document, range))
+                        .collect::<Vec<_>>()
+                }));
+            }
+        }
+        Ok(Value::Array(calls))
+    }
+
+    fn outgoing_calls(&self, params: Value) -> anyhow::Result<Value> {
+        let caller_id = call_hierarchy_symbol_id(&params)?;
+        let workspace = self.workspace()?;
+        let Some((caller_document, caller)) = workspace.definition(&caller_id) else {
+            return Ok(json!([]));
+        };
+        let mut calls = Vec::new();
+        for target_document in workspace.documents() {
+            for target in target_document
+                .symbols()
+                .iter()
+                .filter(|symbol| matches!(symbol.kind, SymbolKind::Function | SymbolKind::Method))
+            {
+                let mut ranges =
+                    call_occurrences(caller_document.text(), &caller.full_span, &target.name);
+                ranges.retain(|range| {
+                    workspace
+                        .symbol_at(caller_document.path(), range.start)
+                        .is_none_or(|resolved| resolved.id == target.id)
+                });
+                if ranges.is_empty() {
+                    continue;
+                }
+                calls.push(json!({
+                    "to": self.call_hierarchy_item(target_document, target)?,
+                    "fromRanges": ranges
+                        .iter()
+                        .map(|range| self.range(caller_document, range))
+                        .collect::<Vec<_>>()
+                }));
+            }
+        }
+        Ok(Value::Array(calls))
+    }
+
+    fn call_hierarchy_item(&self, document: &Document, symbol: &Symbol) -> anyhow::Result<Value> {
+        Ok(json!({
+            "name": symbol.name,
+            "kind": lsp_symbol_kind(symbol.kind),
+            "uri": file_uri(document.path())?,
+            "range": self.range(document, &symbol.full_span),
+            "selectionRange": self.range(document, &symbol.span),
+            "detail": symbol.detail,
+            "data": {"symbolId": symbol.id.0}
+        }))
+    }
+
+    fn apply_changes(
+        &mut self,
+        path: &Path,
+        version: i32,
+        changes: &[Value],
+    ) -> anyhow::Result<()> {
+        let current = self.document(path)?;
+        if version <= current.version() {
+            return Ok(());
+        }
+        let mut text = current.text().to_string();
+        for change in changes {
+            let replacement = required_str(change, "text")?;
+            if let Some(range) = change.get("range") {
+                let start =
+                    parse_position(range.get("start").context("change range omitted start")?)?;
+                let end = parse_position(range.get("end").context("change range omitted end")?)?;
+                let index = husk_analysis::LineIndex::new(&text);
+                let start = index
+                    .byte_offset(&text, start)
+                    .context("change start splits a UTF-16 scalar")?;
+                let end = index
+                    .byte_offset(&text, end)
+                    .context("change end splits a UTF-16 scalar")?;
+                anyhow::ensure!(start <= end, "change range is reversed");
+                text.replace_range(start..end, replacement);
+            } else {
+                text.clear();
+                text.push_str(replacement);
+            }
+        }
+        self.workspace_mut()?
+            .update(path, version, Arc::<str>::from(text))?;
+        Ok(())
+    }
+
+    fn publish_diagnostics(&self, path: &Path) -> anyhow::Result<Value> {
+        Ok(notification(
+            "textDocument/publishDiagnostics",
+            json!({
+                "uri": file_uri(path)?,
+                "version": self.document(path)?.version(),
+                "diagnostics": self.diagnostics_for_path(path)?
+            }),
+        ))
+    }
+
+    fn diagnostics_for_path(&self, path: &Path) -> anyhow::Result<Vec<Diagnostic>> {
+        let document = self.document(path)?;
+        let mut diagnostics = document
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| to_lsp_diagnostic(document, diagnostic))
+            .collect::<Vec<_>>();
+        if !is_dependency_stub(path) {
+            diagnostics.extend(
+                self.workspace()?
+                    .package_diagnostics()
+                    .iter()
+                    .map(|diagnostic| to_lsp_diagnostic(document, diagnostic)),
+            );
+            diagnostics.extend(
+                self.dependency_diagnostics
+                    .iter()
+                    .map(|message| Diagnostic {
+                        range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                        severity: Some(DiagnosticSeverity::WARNING),
+                        code: Some(NumberOrString::String("HUSK-DEP0001".to_string())),
+                        code_description: None,
+                        source: Some("husk-lsp".to_string()),
+                        message: message.clone(),
+                        related_information: None,
+                        tags: None,
+                        data: None,
+                    }),
+            );
+        }
+        Ok(diagnostics)
+    }
+
+    fn document_position(&self, params: &Value) -> anyhow::Result<(PathBuf, usize)> {
+        let path = file_path(text_document_uri(params)?)?;
+        let position = parse_position(params.get("position").context("request omitted position")?)?;
+        let byte = self
+            .document(&path)?
+            .byte_offset(position)
+            .context("position splits a UTF-16 scalar or is outside the document")?;
+        Ok((path, byte))
+    }
+
+    fn symbol_at(&self, path: &Path, byte: usize) -> Option<(&Document, &Symbol)> {
+        let workspace = self.workspace.as_ref()?;
+        if let Some(symbol) = workspace.symbol_at(path, byte) {
+            return workspace.definition(&symbol.id);
+        }
+        let document = workspace.document(path)?;
+        let word = word_at(document.text(), byte)?;
+        let qualified =
+            qualifier_before(document.text(), byte).map(|qualifier| format!("{qualifier}::{word}"));
+        qualified
+            .as_deref()
+            .and_then(|qualified| workspace.symbol_named(qualified))
+            .or_else(|| workspace.symbol_named(word))
+    }
+
+    fn textual_references(
+        &self,
+        name: &str,
+        include_declaration: bool,
+    ) -> anyhow::Result<Vec<Value>> {
+        let mut locations = Vec::new();
+        for document in self.workspace()?.documents() {
+            if is_dependency_stub(document.path()) && !include_declaration {
+                continue;
+            }
+            for range in word_occurrences(document.text(), name) {
+                locations.push(location(document, &range)?);
+            }
+        }
+        Ok(locations)
+    }
+
+    fn workspace(&self) -> anyhow::Result<&Workspace> {
+        self.workspace
+            .as_ref()
+            .context("Husk language server is not initialized")
+    }
+
+    fn workspace_mut(&mut self) -> anyhow::Result<&mut Workspace> {
+        self.workspace
+            .as_mut()
+            .context("Husk language server is not initialized")
+    }
+
+    fn document(&self, path: &Path) -> anyhow::Result<&Document> {
+        self.workspace()?
+            .document(path)
+            .with_context(|| format!("Husk document `{}` is not indexed", path.display()))
+    }
+
+    fn range(&self, document: &Document, range: &std::ops::Range<usize>) -> Value {
+        let range = document.position_range(range);
+        json!({
+            "start": to_lsp_position(range.start),
+            "end": to_lsp_position(range.end)
+        })
+    }
+}
+
+fn workspace_root(params: &Value) -> anyhow::Result<PathBuf> {
+    if let Some(uri) = params
+        .get("workspaceFolders")
+        .and_then(Value::as_array)
+        .and_then(|folders| folders.first())
+        .and_then(|folder| folder.get("uri"))
+        .and_then(Value::as_str)
+    {
+        return file_path(uri);
+    }
+    if let Some(uri) = params.get("rootUri").and_then(Value::as_str) {
+        return file_path(uri);
+    }
+    if let Some(path) = params.get("rootPath").and_then(Value::as_str) {
+        return Ok(PathBuf::from(path));
+    }
+    std::env::current_dir().context("resolve default LSP workspace")
+}
+
+fn parse_profile(profile: &str) -> anyhow::Result<SemanticProfile> {
+    match profile {
+        "native" => Ok(SemanticProfile::Native),
+        "legacyJavaScript" | "legacy_javascript" | "red" => Ok(SemanticProfile::LegacyJavaScript),
+        _ => anyhow::bail!("unknown Husk semantic profile `{profile}`"),
+    }
+}
+
+fn text_document_uri(params: &Value) -> anyhow::Result<&str> {
+    params
+        .get("textDocument")
+        .and_then(|document| document.get("uri"))
+        .and_then(Value::as_str)
+        .context("request omitted textDocument.uri")
+}
+
+fn required_str<'a>(object: &'a Value, key: &str) -> anyhow::Result<&'a str> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .with_context(|| format!("request omitted string `{key}`"))
+}
+
+fn parse_position(value: &Value) -> anyhow::Result<AnalysisPosition> {
+    let line = value
+        .get("line")
+        .and_then(Value::as_u64)
+        .and_then(|line| u32::try_from(line).ok())
+        .context("position omitted a valid line")?;
+    let character = value
+        .get("character")
+        .and_then(Value::as_u64)
+        .and_then(|character| u32::try_from(character).ok())
+        .context("position omitted a valid character")?;
+    Ok(AnalysisPosition { line, character })
+}
+
+fn to_lsp_position(position: AnalysisPosition) -> Value {
+    json!({"line": position.line, "character": position.character})
+}
+
+fn to_lsp_diagnostic(document: &Document, diagnostic: &AnalysisDiagnostic) -> Diagnostic {
+    let range = document.position_range(&diagnostic.span);
+    Diagnostic {
+        range: Range::new(
+            Position::new(range.start.line, range.start.character),
+            Position::new(range.end.line, range.end.character),
+        ),
+        severity: Some(match diagnostic.severity {
+            AnalysisDiagnosticSeverity::Error => DiagnosticSeverity::ERROR,
+            AnalysisDiagnosticSeverity::Warning => DiagnosticSeverity::WARNING,
+            AnalysisDiagnosticSeverity::Information => DiagnosticSeverity::INFORMATION,
+        }),
+        code: Some(NumberOrString::String(diagnostic.code.clone())),
+        code_description: None,
+        source: Some(diagnostic.source.to_string()),
+        message: diagnostic.message.clone(),
+        related_information: None,
+        tags: None,
+        data: None,
+    }
+}
+
+fn completion_item(symbol: &Symbol) -> Value {
+    let function = matches!(symbol.kind, SymbolKind::Function | SymbolKind::Method);
+    let insert_text = function.then(|| format!("{}(${{1}})", symbol.name));
+    json!({
+        "label": symbol.name,
+        "kind": lsp_completion_kind(symbol.kind),
+        "detail": symbol.detail,
+        "documentation": symbol.documentation.as_ref().map(|documentation| json!({
+            "kind": "markdown",
+            "value": documentation
+        })),
+        "insertText": insert_text,
+        "insertTextFormat": if function { 2 } else { 1 },
+        "filterText": symbol.name,
+        "sortText": format!("1-{}", symbol.name),
+        "data": {"symbolId": symbol.id.0}
+    })
+}
+
+fn lsp_completion_kind(kind: SymbolKind) -> u32 {
+    match kind {
+        SymbolKind::Function => 3,
+        SymbolKind::Method => 2,
+        SymbolKind::Struct => 22,
+        SymbolKind::Enum => 13,
+        SymbolKind::Variant => 20,
+        SymbolKind::Field | SymbolKind::Property => 5,
+        SymbolKind::Module => 9,
+        SymbolKind::Variable | SymbolKind::Parameter => 6,
+        SymbolKind::Constant => 21,
+        SymbolKind::TypeParameter | SymbolKind::TypeAlias | SymbolKind::Trait => 25,
+    }
+}
+
+fn lsp_symbol_kind(kind: SymbolKind) -> u32 {
+    match kind {
+        SymbolKind::Module => 2,
+        SymbolKind::Function => 12,
+        SymbolKind::Method => 6,
+        SymbolKind::Struct => 23,
+        SymbolKind::Field => 8,
+        SymbolKind::Enum => 10,
+        SymbolKind::Variant => 22,
+        SymbolKind::TypeAlias => 5,
+        SymbolKind::Trait => 11,
+        SymbolKind::Variable | SymbolKind::Parameter => 13,
+        SymbolKind::TypeParameter => 26,
+        SymbolKind::Property => 7,
+        SymbolKind::Constant => 14,
+    }
+}
+
+fn semantic_token_kind(kind: SymbolKind) -> u32 {
+    match kind {
+        SymbolKind::Module => 0,
+        SymbolKind::TypeAlias | SymbolKind::Trait => 1,
+        SymbolKind::Enum => 2,
+        SymbolKind::Struct => 3,
+        SymbolKind::TypeParameter => 4,
+        SymbolKind::Parameter => 5,
+        SymbolKind::Variable | SymbolKind::Constant => 6,
+        SymbolKind::Field | SymbolKind::Property => 7,
+        SymbolKind::Variant => 8,
+        SymbolKind::Function => 9,
+        SymbolKind::Method => 10,
+    }
+}
+
+fn location(document: &Document, range: &std::ops::Range<usize>) -> anyhow::Result<Value> {
+    let range = document.position_range(range);
+    Ok(json!({
+        "uri": file_uri(document.path())?,
+        "range": {
+            "start": to_lsp_position(range.start),
+            "end": to_lsp_position(range.end)
+        }
+    }))
+}
+
+fn completion_context(source: &str, byte: usize) -> (String, Option<String>) {
+    let range = word_range(source, byte).unwrap_or(byte..byte);
+    let prefix = source[range.start..byte.min(range.end)].to_string();
+    let qualifier = qualifier_before(source, range.start).map(ToString::to_string);
+    (prefix, qualifier)
+}
+
+fn qualifier_before(source: &str, byte: usize) -> Option<&str> {
+    let prefix = source[..byte.min(source.len())].trim_end();
+    let before_separator = prefix.strip_suffix("::")?;
+    let start = before_separator
+        .char_indices()
+        .rev()
+        .find_map(|(index, character)| {
+            (!character.is_ascii_alphanumeric() && character != '_' && character != ':')
+                .then_some(index + character.len_utf8())
+        })
+        .unwrap_or(0);
+    let qualifier = before_separator[start..].trim_matches(':');
+    (!qualifier.is_empty()).then_some(qualifier)
+}
+
+fn word_at(source: &str, byte: usize) -> Option<&str> {
+    let range = word_range(source, byte)?;
+    source.get(range)
+}
+
+fn word_range(source: &str, byte: usize) -> Option<std::ops::Range<usize>> {
+    let byte = byte.min(source.len());
+    let mut start = byte;
+    while start > 0 {
+        let character = source[..start].chars().next_back()?;
+        if !character.is_ascii_alphanumeric() && character != '_' {
+            break;
+        }
+        start -= character.len_utf8();
+    }
+    let mut end = byte;
+    while end < source.len() {
+        let character = source[end..].chars().next()?;
+        if !character.is_ascii_alphanumeric() && character != '_' {
+            break;
+        }
+        end += character.len_utf8();
+    }
+    (start < end).then_some(start..end)
+}
+
+fn word_occurrences(source: &str, name: &str) -> Vec<std::ops::Range<usize>> {
+    source
+        .match_indices(name)
+        .filter_map(|(start, _)| {
+            let end = start + name.len();
+            let left = source[..start].chars().next_back();
+            let right = source[end..].chars().next();
+            let boundary = |character: Option<char>| {
+                character
+                    .is_none_or(|character| !character.is_ascii_alphanumeric() && character != '_')
+            };
+            (boundary(left) && boundary(right)).then_some(start..end)
+        })
+        .collect()
+}
+
+fn line_range(source: &str, byte: usize) -> std::ops::Range<usize> {
+    let byte = byte.min(source.len());
+    let start = source[..byte].rfind('\n').map_or(0, |index| index + 1);
+    let end = source[byte..]
+        .find('\n')
+        .map_or(source.len(), |index| byte + index);
+    start..end
+}
+
+fn complete_line_range(
+    document: &Document,
+    start_line: u32,
+    end_line: u32,
+) -> anyhow::Result<std::ops::Range<usize>> {
+    let start = document
+        .byte_offset(AnalysisPosition {
+            line: start_line,
+            character: 0,
+        })
+        .context("format range starts outside document")?;
+    let end = formatted_line_end(document.text(), document.line_index(), end_line)?;
+    Ok(start..end)
+}
+
+fn formatted_line_end(
+    source: &str,
+    index: &husk_analysis::LineIndex,
+    line: u32,
+) -> anyhow::Result<usize> {
+    index
+        .byte_offset(
+            source,
+            AnalysisPosition {
+                line: line.saturating_add(1),
+                character: 0,
+            },
+        )
+        .or_else(|| {
+            let last = index.position(source, source.len());
+            (line == last.line).then_some(source.len())
+        })
+        .context("format range ends outside document")
+}
+
+fn call_context(source: &str, byte: usize) -> Option<(String, usize)> {
+    let prefix = &source[..byte.min(source.len())];
+    let mut open_parens = Vec::new();
+    for token in Lexer::new(prefix) {
+        match token.kind {
+            TokenKind::LParen => open_parens.push(token.span.range.start),
+            TokenKind::RParen => {
+                open_parens.pop();
+            }
+            _ => {}
+        }
+    }
+    let open = open_parens.pop()?;
+    let name_end = open;
+    let name_range = word_range(source, name_end)?;
+    if name_range.end != name_end {
+        return None;
+    }
+    let arguments = &prefix[open + 1..];
+    let mut depth = 0usize;
+    let mut active = 0usize;
+    for token in Lexer::new(arguments) {
+        match token.kind {
+            TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => {
+                depth = depth.saturating_add(1);
+            }
+            TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => {
+                depth = depth.saturating_sub(1);
+            }
+            TokenKind::Comma if depth == 0 => active = active.saturating_add(1),
+            _ => {}
+        }
+    }
+    Some((source[name_range].to_string(), active))
+}
+
+fn call_hierarchy_symbol_id(params: &Value) -> anyhow::Result<SymbolId> {
+    params
+        .pointer("/item/data/symbolId")
+        .and_then(Value::as_str)
+        .map(|id| SymbolId(id.to_string()))
+        .context("call hierarchy item omitted its Husk symbol identity")
+}
+
+fn call_occurrences(
+    source: &str,
+    scope: &std::ops::Range<usize>,
+    name: &str,
+) -> Vec<std::ops::Range<usize>> {
+    let start = scope.start.min(source.len());
+    let end = scope.end.min(source.len());
+    if start >= end {
+        return Vec::new();
+    }
+    word_occurrences(&source[start..end], name)
+        .into_iter()
+        .filter_map(|range| {
+            let range = start + range.start..start + range.end;
+            let before = source[..range.start].trim_end();
+            let declaration = before.strip_suffix("fn").is_some_and(|prefix| {
+                prefix
+                    .chars()
+                    .next_back()
+                    .is_none_or(|character| !character.is_ascii_alphanumeric() && character != '_')
+            });
+            let after = source[range.end..end].trim_start();
+            (!declaration && (after.starts_with('(') || after.starts_with("::<"))).then_some(range)
+        })
+        .collect()
+}
+
+fn signature_parameters(signature: &str) -> Vec<String> {
+    let Some((_, after_open)) = signature.split_once('(') else {
+        return Vec::new();
+    };
+    let Some((parameters, _)) = after_open.rsplit_once(')') else {
+        return Vec::new();
+    };
+    parameters
+        .split(',')
+        .map(str::trim)
+        .filter(|parameter| !parameter.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn organize_imports(document: &Document) -> Option<(std::ops::Range<usize>, String)> {
+    let mut imports = document
+        .syntax()
+        .items
+        .iter()
+        .filter_map(|item| {
+            matches!(item.kind, ItemKind::Use { .. }).then_some(item.span.range.clone())
+        })
+        .collect::<Vec<_>>();
+    if imports.len() < 2 {
+        return None;
+    }
+    imports.sort_by_key(|range| range.start);
+    let start = imports.first()?.start;
+    let end = imports.last()?.end;
+    let mut lines = imports
+        .iter()
+        .filter_map(|range| document.text().get(range.clone()))
+        .map(str::trim)
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let original = lines.clone();
+    lines.sort();
+    lines.dedup();
+    if lines == original {
+        return None;
+    }
+    Some((start..end, format!("{}\n", lines.join("\n"))))
+}
+
+fn is_dependency_stub(path: &Path) -> bool {
+    path.components()
+        .collect::<Vec<_>>()
+        .windows(2)
+        .any(|components| {
+            components[0].as_os_str() == ".husk" && components[1].as_os_str() == "lsp"
+        })
+}
+
+fn deduplicate_locations(locations: &mut Vec<Value>) {
+    let mut seen = HashSet::new();
+    locations.retain(|location| {
+        serde_json::to_string(location).is_ok_and(|location| seen.insert(location))
+    });
+}
+
+fn request_key(id: &Value) -> String {
+    serde_json::to_string(id).unwrap_or_else(|_| "null".to_string())
+}
+
+fn success_response(id: Value, result: Value) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+fn error_response(id: Value, code: i32, message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {"code": code, "message": message}
+    })
+}
+
+fn notification(method: &str, params: Value) -> Value {
+    json!({"jsonrpc": "2.0", "method": method, "params": params})
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn completion_context_handles_flat_external_paths() {
+        assert_eq!(
+            completion_context("serde_json::from", "serde_json::from".len()),
+            ("from".to_string(), Some("serde_json".to_string()))
+        );
+    }
+
+    #[test]
+    fn word_search_requires_identifier_boundaries() {
+        assert_eq!(
+            word_occurrences("value value2 prevalue value", "value"),
+            vec![0..5, 22..27]
+        );
+    }
+
+    #[test]
+    fn call_context_counts_top_level_arguments() {
+        assert_eq!(
+            call_context("build(1, nested(2, 3), ", 23),
+            Some(("build".to_string(), 2))
+        );
+    }
+
+    #[test]
+    fn json_rpc_session_serves_editor_features_from_an_unsaved_revision() {
+        let root = tempfile::tempdir().expect("create LSP workspace");
+        let path = root.path().join("main.hk");
+        fs::write(&path, "fn stale() {}\n").expect("write on-disk fixture");
+        let root_uri = file_uri(root.path()).expect("encode workspace URI");
+        let uri = file_uri(&path).expect("encode document URI");
+        let source = "fn helper(value: i32) -> i32 { value }\nfn main() { hel }\n";
+        let mut server = Server::new(ServerOptions::default());
+
+        let initialized = server.handle(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"rootUri": root_uri}
+        }));
+        assert_eq!(
+            initialized[0].pointer("/result/capabilities/positionEncoding"),
+            Some(&json!("utf-16"))
+        );
+
+        let published = server.handle(json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "husk",
+                    "version": 7,
+                    "text": source
+                }
+            }
+        }));
+        assert_eq!(published[0].pointer("/params/version"), Some(&json!(7)));
+
+        let completion = server.handle(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/completion",
+            "params": {
+                "textDocument": {"uri": uri},
+                "position": {"line": 1, "character": 15}
+            }
+        }));
+        assert!(
+            completion[0]
+                .pointer("/result/items")
+                .and_then(Value::as_array)
+                .is_some_and(|items| {
+                    items
+                        .iter()
+                        .any(|item| item.get("label") == Some(&json!("helper")))
+                })
+        );
+
+        let hover = server.handle(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/hover",
+            "params": {
+                "textDocument": {"uri": uri},
+                "position": {"line": 0, "character": 4}
+            }
+        }));
+        assert!(
+            hover[0]
+                .pointer("/result/contents/value")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value.contains("fn helper(value: i32) -> i32"))
+        );
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("read disk fixture"),
+            "fn stale() {}\n",
+            "the LSP overlay must not modify the file"
+        );
+    }
+}

--- a/crates/husk-lsp/src/uri.rs
+++ b/crates/husk-lsp/src/uri.rs
@@ -1,0 +1,112 @@
+//! Strict file-URI conversion for Husk workspaces.
+
+use std::path::{Component, Path, PathBuf};
+
+pub(crate) fn file_path(uri: &str) -> anyhow::Result<PathBuf> {
+    let encoded = uri
+        .strip_prefix("file://")
+        .ok_or_else(|| anyhow::anyhow!("unsupported document URI `{uri}`"))?;
+    let encoded = encoded.strip_prefix("localhost").unwrap_or(encoded);
+    anyhow::ensure!(
+        encoded.starts_with('/'),
+        "unsupported file URI authority in `{uri}`"
+    );
+    let bytes = encoded.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        let hex = bytes
+            .get(index + 1..index + 3)
+            .and_then(|bytes| std::str::from_utf8(bytes).ok())
+            .ok_or_else(|| anyhow::anyhow!("invalid percent escape in `{uri}`"))?;
+        decoded.push(
+            u8::from_str_radix(hex, 16)
+                .map_err(|_| anyhow::anyhow!("invalid percent escape in `{uri}`"))?,
+        );
+        index += 3;
+    }
+    let path = String::from_utf8(decoded)
+        .map_err(|_| anyhow::anyhow!("file URI is not UTF-8: `{uri}`"))?;
+    #[cfg(windows)]
+    let path = path
+        .strip_prefix('/')
+        .filter(|path| path.as_bytes().get(1) == Some(&b':'))
+        .map(|path| path.replace('/', "\\"))
+        .unwrap_or(path);
+    normalize(Path::new(&path))
+}
+
+pub(crate) fn file_uri(path: &Path) -> anyhow::Result<String> {
+    let path = normalize(path)?;
+    let path = path.to_string_lossy();
+    #[cfg(windows)]
+    let path = {
+        let path = path.replace('\\', "/");
+        let path = path.strip_prefix("//?/").unwrap_or(&path).to_string();
+        anyhow::ensure!(
+            !path.starts_with("UNC/") && !path.starts_with("//"),
+            "UNC paths are not supported"
+        );
+        path
+    };
+    let mut uri = String::with_capacity(path.len().saturating_add(8));
+    uri.push_str("file://");
+    if !path.starts_with('/') {
+        uri.push('/');
+    }
+    for byte in path.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/' | b':') {
+            uri.push(char::from(byte));
+        } else {
+            const HEX: &[u8; 16] = b"0123456789ABCDEF";
+            uri.push('%');
+            uri.push(char::from(HEX[(byte >> 4) as usize]));
+            uri.push(char::from(HEX[(byte & 0x0f) as usize]));
+        }
+    }
+    Ok(uri)
+}
+
+fn normalize(path: &Path) -> anyhow::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                anyhow::ensure!(
+                    normalized.pop(),
+                    "path escapes filesystem root: `{}`",
+                    path.display()
+                );
+            }
+            Component::Normal(value) => normalized.push(value),
+        }
+    }
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_unicode_and_reserved_bytes() {
+        let path = std::env::temp_dir().join("café #1%.hk");
+        let uri = file_uri(&path).expect("encode URI");
+
+        assert!(uri.contains("caf%C3%A9%20%231%25.hk"));
+        assert_eq!(file_path(&uri).expect("decode URI"), path);
+    }
+}

--- a/crates/husk-runtime/src/lib.rs
+++ b/crates/husk-runtime/src/lib.rs
@@ -1182,7 +1182,13 @@ struct SourceInterfaceDescriptorBuilder {
     types: Vec<TypeDefinitionDescriptor>,
 }
 
-fn source_module_descriptors(package: &ResolvedPackage) -> anyhow::Result<Vec<ModuleDescriptor>> {
+/// Derive typed descriptors for every public source module in a resolved package.
+///
+/// Language tooling uses the same descriptors as runtime compilation so that
+/// cross-file analysis cannot drift from executable package semantics.
+pub fn source_module_descriptors(
+    package: &ResolvedPackage,
+) -> anyhow::Result<Vec<ModuleDescriptor>> {
     let mut named_types = HashMap::new();
     for module in package
         .modules
@@ -1472,7 +1478,8 @@ fn source_type_descriptor(
     }
 }
 
-fn module_declaration_ast(module: &ModuleDescriptor) -> anyhow::Result<File> {
+/// Render a typed module descriptor as a trusted Husk declaration source.
+pub fn module_declaration_source(module: &ModuleDescriptor) -> anyhow::Result<String> {
     let mut source = String::new();
     for definition in module.types.iter().chain(
         module
@@ -1486,6 +1493,7 @@ fn module_declaration_ast(module: &ModuleDescriptor) -> anyhow::Result<File> {
     if module_uses_json(module) {
         source.push_str("    struct Json;\n");
     }
+    push_doc_comments(&mut source, "    ", module.documentation.as_deref());
     source.push_str("    mod global ");
     source.push_str(module.name.as_str());
     source.push_str(" {\n");
@@ -1514,7 +1522,12 @@ fn module_declaration_ast(module: &ModuleDescriptor) -> anyhow::Result<File> {
         }
     }
     source.push_str("    }\n}\n");
+    Ok(source)
+}
 
+/// Parse a typed module descriptor into the declaration AST used by semantic analysis.
+pub fn module_declaration_ast(module: &ModuleDescriptor) -> anyhow::Result<File> {
+    let source = module_declaration_source(module)?;
     let parsed = husk_parser::parse_str(&source);
     if !parsed.errors.is_empty() {
         let messages = parsed
@@ -1591,6 +1604,7 @@ fn push_type_definition(source: &mut String, definition: &TypeDefinitionDescript
 }
 
 fn push_function_declaration(source: &mut String, function: &FunctionDescriptor) {
+    push_doc_comments(source, "        ", function.documentation.as_deref());
     source.push_str("        fn ");
     source.push_str(&function.name);
     source.push('(');
@@ -1605,6 +1619,21 @@ fn push_function_declaration(source: &mut String, function: &FunctionDescriptor)
     source.push_str(") -> ");
     push_type_declaration(source, &function.result);
     source.push_str(";\n");
+}
+
+fn push_doc_comments(source: &mut String, indent: &str, documentation: Option<&str>) {
+    let Some(documentation) = documentation else {
+        return;
+    };
+    for line in documentation.lines() {
+        source.push_str(indent);
+        source.push_str("///");
+        if !line.is_empty() {
+            source.push(' ');
+            source.push_str(line);
+        }
+        source.push('\n');
+    }
 }
 
 fn push_type_declaration(source: &mut String, ty: &TypeDescriptor) {

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -107,9 +107,12 @@ Patterns use Rust regular-expression syntax. `incsearch`, `hlsearch`,
 | `Space .` | Show code actions and quick fixes |
 | `Space r` | Rename the current symbol |
 
-Built-in server defaults cover Rust, TypeScript/JavaScript, Python, Markdown,
-JSON, TOML, YAML, and Lua. Each language server must be installed separately
-and available on `PATH`; servers start only after a matching file is opened.
+Husk's first-party server is included and starts for `.hk` and `.husk` files.
+Built-in defaults also cover Rust, TypeScript/JavaScript, Python, Markdown,
+JSON, TOML, YAML, and Lua; those external servers must be installed separately
+and available on `PATH`. Servers start only after a matching file is opened.
+See the [Husk language-server guide](HUSK_LSP.md) for its complete feature and
+external-crate contract.
 
 Add or override a server in `config.toml`:
 

--- a/docs/HUSK_IMPLEMENTATION_STATUS.md
+++ b/docs/HUSK_IMPLEMENTATION_STATUS.md
@@ -74,6 +74,7 @@ This is not yet a release-complete extraction. The main remaining work is:
 | Crate | Current responsibility |
 | --- | --- |
 | `husk` | Small documented facade that re-exports the public embedding API. |
+| `husk-analysis` | Recovered document analysis, UTF-16 positions, workspace symbols, references, and formatting. |
 | `husk-runtime` | Compiler orchestration, resolved HIR interpreter, heap, embedding ownership, limits, and an internal compatibility VM used by Red during migration. |
 | `husk-value` | Detached, backend-neutral host boundary values. |
 | `husk-types` | Validated module/type/function descriptors and stable hashes. |
@@ -81,7 +82,8 @@ This is not yet a release-complete extraction. The main remaining work is:
 | `husk-wasm` | Wasmtime Component inspection, descriptor derivation, dynamic calls, conversion, fuel, and store limits. |
 | `husk-package` | Bounded local `Husk.toml`, deterministic module graph, path and crate-backed extensions, and reproducible `Husk.lock`. |
 | `husk-hir` | Spanned executable HIR with stable per-function node and local IDs. |
-| `husk-cli` | `new`, `add`, `install`, `check`, `run`, `test`, `repl`, and extension bundle commands. |
+| `husk-lsp` | Bounded LSP transport, editor features, and verified locked-crate indexing. |
+| `husk-cli` | `new`, `add`, `install`, `check`, `run`, `test`, `repl`, `lsp`, and extension bundle commands. |
 | `husk-lexer`, `husk-ast`, `husk-parser`, `husk-semantic`, `husk-diagnostics` | Frontend and source-aware diagnostics. |
 
 The intended dependency direction is:
@@ -93,7 +95,9 @@ husk-extension ──> husk-package         └──> husk-wasm (optional featu
        │                  │
        └────────> husk-types <──────── husk-value
 
-husk-cli ──> husk facade
+husk-analysis ──> frontend/package/runtime crates
+husk-lsp ──> husk-analysis + package/extension/runtime crates
+husk-cli ──> husk facade + husk-lsp
 Red ──────> husk-runtime compatibility API (one VM per plugin)
 ```
 
@@ -194,6 +198,7 @@ No Husk crate depends on the Red root package.
 | P10-01 REPL | Mostly complete | Public item/statement/expression fragment parsers distinguish complete, incomplete, and invalid input. `ReplSession` preserves items, locals, heap, native/Wasm state, and rolls back script-owned state on runtime failure. `husk repl` implements only `:help`, `:reset`, and `:quit`. Diagnostics use one accumulated `<repl>` source rather than numbered synthetic source files. |
 | P10-02 test runner | Mostly complete | Package-wide discovery, filtering/listing, cfg, ignore, expected panic, isolated instances, and failure exit status work. Native `std` output is not captured and replayed only on failure. |
 | P10-03 diagnostics/docs | Partial | This status document and `HUSK_LANGUAGE_GUIDE.md` cover public workflows. Source-aware Husk call frames and module boundary context exist in important paths, but the complete diagnostic matrix and secret-redaction audit remain. |
+| P10-04 language server | Complete for the current language | `husk-analysis` and `husk-lsp` provide recovered unsaved analysis, UTF-16 incremental edits, diagnostics, completion, hover, signatures, navigation, references, rename, symbols, semantic tokens, hints, folding, selection, code actions, formatting, and call hierarchy. Locked crate adapters are indexed from verified installed or vendored Components without invoking Cargo or the network, and Red enables the server for `.hk` and `.husk` by default. |
 
 ### Phase 11 — optional native dynamic libraries
 
@@ -317,6 +322,8 @@ husk-package
 husk-wasm
 husk-runtime
 husk
+husk-analysis
+husk-lsp
 husk-cli
 ```
 

--- a/docs/HUSK_LANGUAGE_GUIDE.md
+++ b/docs/HUSK_LANGUAGE_GUIDE.md
@@ -1,10 +1,13 @@
 # Husk language and embedding guide
 
-This guide describes the interfaces implemented at the 2026-07-19 extraction
-checkpoint. For architecture rationale, see
+This guide describes the interfaces implemented through the 2026-07-24
+language-server checkpoint. For architecture rationale, see
 [HUSK_LANGUAGE_EXTRACTION_PLAN.md](HUSK_LANGUAGE_EXTRACTION_PLAN.md). For known
 gaps and exact remaining work, see
 [HUSK_IMPLEMENTATION_STATUS.md](HUSK_IMPLEMENTATION_STATUS.md).
+
+For editor setup, supported language features, and locked external-crate
+indexing, see [HUSK_LSP.md](HUSK_LSP.md).
 
 ## Build and run the CLI
 
@@ -602,11 +605,14 @@ The following are rejected by v1:
 - `s8`, `s16`, `u16`, `u32`, and `u64`;
 - `float32` and `char`;
 - maps and flags;
-- owned or borrowed resources;
 - futures, streams, async functions, and error contexts;
 - anonymous record/variant/enum types where nominal identity is required;
-- core-module, nested-component, resource, or other non-function exports in a
+- core-module, nested-component, or other unsupported component exports in a
   callable position.
+
+Named resources, owned handles, borrowed handles, constructors, methods, and
+resource-consuming calls are supported. Handles are instance-scoped and
+generation checked; borrowed resources cannot escape a component call.
 
 ### Capability behavior
 

--- a/docs/HUSK_LSP.md
+++ b/docs/HUSK_LSP.md
@@ -1,0 +1,109 @@
+# Husk language server
+
+Husk ships a first-party language server for `.hk` and `.husk` files. Red
+enables it by default; other editors can launch the same server with either:
+
+```shell
+husk lsp --stdio
+red husk lsp --stdio
+husk-lsp
+```
+
+All three entry points speak Language Server Protocol over standard input and
+output. Protocol logs and diagnostics never share standard output with framed
+messages.
+
+## Editor features
+
+The server analyzes the current unsaved document revision rather than requiring
+files to be saved or compiled. Positions and incremental edits use LSP UTF-16
+code units, including correct handling of non-BMP Unicode characters.
+
+| Area | Supported features |
+| --- | --- |
+| Feedback | Parser, type, package, and dependency diagnostics through push and pull diagnostics |
+| Authoring | Contextual completion, signature help, hover signatures and documentation, type inlay hints |
+| Navigation | Definition, declaration, type-definition and implementation lookup, references, document highlights |
+| Refactoring | Prepare rename, workspace rename, missing-semicolon quick fixes, organize imports |
+| Structure | Document and workspace symbols, folding ranges, selection ranges, incoming and outgoing call hierarchy |
+| Presentation | Full semantic tokens for declarations, references, keywords, literals, and operators |
+| Formatting | Whole-document and range formatting with client-selected indentation width |
+
+Recovered parser syntax remains available while a document is incomplete, so
+features that do not depend on the broken construct continue to work.
+Dependency stubs are intentionally read-only: navigation and hover can enter
+them, but rename never edits them.
+
+## Packages and external crates
+
+For a package with `Husk.toml`, the server uses native Husk semantics and the
+same public-module descriptors as package compilation. It indexes every source
+module in deterministic package order.
+
+Crate-backed extensions come exclusively from the verified package state:
+
+1. `Husk.toml` declares the crate adapter.
+2. `Husk.lock` pins its version, component digest, adapter selection, features,
+   and specializations.
+3. The installed `.husk/extensions/` bundle is preferred; the exact vendored
+   bundle is a read-only fallback.
+4. The component export surface becomes a typed Husk declaration under
+   `.husk/lsp/<component-digest>/<module>.hk`.
+5. Adapter report documentation is attached to matching functions for hover
+   and completion.
+
+Indexing validates the manifest/lock relationship, bundle metadata, component
+SHA-256, optional adapter-report SHA-256, component exports, type mappings, and
+deny-by-default capability policy. It does not invoke Cargo, resolve a crate,
+download anything, instantiate guest code, or execute an adapter. After a
+clone, prepare the exact offline state once:
+
+```shell
+red husk install --locked --offline
+```
+
+A missing, stale, or invalid adapter produces `HUSK-DEP0001` diagnostics while
+local source analysis continues. Generated stubs are content-addressed and are
+only rewritten when their content changes.
+
+## Red integration
+
+Red's embedded server definition launches `red husk lsp --stdio`, selects
+`Husk.toml` and then `.git` as workspace roots, and routes both supported file
+extensions to language ID `husk`.
+
+Real packages always use `SemanticProfile::Native`. Loose Husk files opened as
+Red plugins use the legacy JavaScript compatibility profile and receive Red's
+trusted host declarations, so `red::*`, `Json`, callback types, and editor host
+signatures participate in completion and type checking.
+
+The equivalent custom initialization options are:
+
+```json
+{
+  "semanticProfile": "native",
+  "looseSemanticProfile": "legacyJavaScript",
+  "declarations": ["optional trusted Husk declaration source"]
+}
+```
+
+`semanticProfile` explicitly selects a profile for every workspace.
+`looseSemanticProfile` is only used when no `Husk.toml` is discoverable.
+Clients can update `husk.semanticProfile` and `husk.cfgFlags` through
+`workspace/didChangeConfiguration`.
+
+## Boundaries
+
+- One process owns one workspace folder and at most 256 indexed Husk files.
+- Source files and overlays are bounded to 1 MiB each.
+- JSON-RPC headers are bounded to 16 KiB and messages to 16 MiB.
+- Only local `file:` URIs inside the selected workspace are accepted.
+- Symlinked package inputs, bundles, artifacts, and generated-stub targets fail
+  closed.
+- External dependency names are derived from verified component exports, not
+  from generated Rust source or Cargo metadata at edit time.
+
+The implementation is split between `husk-analysis`, which owns recovered
+syntax, semantics, overlays, UTF-16 indexing, symbols, and formatting, and
+`husk-lsp`, which owns bounded JSON-RPC transport, protocol capabilities,
+locked dependency indexing, and editor request handling.

--- a/scripts/check-husk-independence.sh
+++ b/scripts/check-husk-independence.sh
@@ -11,12 +11,14 @@ cp -R "$repository_root/tools/husk-standalone/smoke" "$temporary_root/smoke"
 
 for crate in \
     husk \
+    husk-analysis \
     husk-ast \
     husk-cli \
     husk-diagnostics \
     husk-extension \
     husk-hir \
     husk-lexer \
+    husk-lsp \
     husk-package \
     husk-parser \
     husk-runtime \

--- a/src/config.rs
+++ b/src/config.rs
@@ -669,6 +669,23 @@ pub fn default_language_servers() -> HashMap<String, LanguageServerConfig> {
             },
         ),
         (
+            "husk".to_string(),
+            LanguageServerConfig {
+                command: "red".to_string(),
+                args: vec!["husk".to_string(), "lsp".to_string(), "--stdio".to_string()],
+                language_id: String::new(),
+                file_extensions: Vec::new(),
+                documents: vec![document("husk", &["hk", "husk"])],
+                root_markers: vec!["Husk.toml".to_string(), ".git".to_string()],
+                env: HashMap::new(),
+                initialization_options: Some(json!({
+                    "looseSemanticProfile": "legacyJavaScript",
+                    "declarations": [crate::plugin::husk_lsp_declarations()]
+                })),
+                workspace_name: Some("husk".to_string()),
+            },
+        ),
+        (
             "typescript".to_string(),
             server(
                 "typescript-language-server",
@@ -2270,6 +2287,27 @@ theme = "theme/nightfox.json"
         assert_eq!(rust.language_id, "rust");
         assert_eq!(rust.file_extensions, vec!["rs"]);
         assert_eq!(typescript.command, "typescript-language-server");
+        let husk = config.lsp.servers.get("husk").unwrap();
+        assert_eq!(husk.command, "red");
+        assert_eq!(husk.args, vec!["husk", "lsp", "--stdio"]);
+        assert_eq!(husk.documents(), vec![document("husk", &["hk", "husk"])]);
+        assert_eq!(husk.root_markers, vec!["Husk.toml", ".git"]);
+        assert_eq!(
+            husk.initialization_options
+                .as_ref()
+                .and_then(|options| options.get("looseSemanticProfile")),
+            Some(&json!("legacyJavaScript"))
+        );
+        assert!(husk
+            .initialization_options
+            .as_ref()
+            .and_then(|options| options.get("declarations"))
+            .and_then(Value::as_array)
+            .is_some_and(
+                |declarations| declarations.iter().any(|declaration| declaration
+                    .as_str()
+                    .is_some_and(|source| source.contains("mod global red")))
+            ));
         assert!(config.lsp.servers.contains_key("markdown"));
         assert!(config.lsp.servers.contains_key("python"));
         assert!(config.lsp.servers.contains_key("json"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -671,7 +671,9 @@ pub fn default_language_servers() -> HashMap<String, LanguageServerConfig> {
         (
             "husk".to_string(),
             LanguageServerConfig {
-                command: "red".to_string(),
+                command: std::env::current_exe()
+                    .map(|path| path.to_string_lossy().into_owned())
+                    .unwrap_or_else(|_| "red".to_string()),
                 args: vec!["husk".to_string(), "lsp".to_string(), "--stdio".to_string()],
                 language_id: String::new(),
                 file_extensions: Vec::new(),
@@ -2288,7 +2290,13 @@ theme = "theme/nightfox.json"
         assert_eq!(rust.file_extensions, vec!["rs"]);
         assert_eq!(typescript.command, "typescript-language-server");
         let husk = config.lsp.servers.get("husk").unwrap();
-        assert_eq!(husk.command, "red");
+        assert_eq!(
+            husk.command,
+            std::env::current_exe()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        );
         assert_eq!(husk.args, vec!["husk", "lsp", "--stdio"]);
         assert_eq!(husk.documents(), vec![document("husk", &["hk", "husk"])]);
         assert_eq!(husk.root_markers, vec!["Husk.toml", ".git"]);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -6004,6 +6004,8 @@ impl Editor {
             Ok(None) => {}
             Err(err) => {
                 log!("ERROR: Lsp error: {err}");
+                self.last_error = Some(err.to_string());
+                needs_render = true;
             }
         }
 
@@ -9129,8 +9131,7 @@ impl Editor {
                 }
             }
             InboundMessage::ProcessingError(error_msg) => {
-                self.last_error = Some(error_msg.to_string());
-                None
+                Some(Action::Print(error_msg.to_string()))
             }
         }
     }
@@ -24064,6 +24065,21 @@ mod test {
     }
 
     #[test]
+    fn lsp_processing_error_produces_a_visible_print_action() {
+        let mut editor = test_editor(40, 10);
+        let message = InboundMessage::ProcessingError(crate::lsp::LspError::ServerError(
+            "husk lsp exited".to_string(),
+        ));
+
+        let action = editor.handle_lsp_message(&message, None);
+
+        assert!(matches!(
+            action,
+            Some(Action::Print(message)) if message.contains("husk lsp exited")
+        ));
+    }
+
+    #[test]
     fn empty_hover_array_is_ignored() {
         let mut editor = test_editor(40, 10);
         let message = InboundMessage::Message(ResponseMessage {
@@ -25615,7 +25631,7 @@ while True:
         assert!(editor.pending_lsp_format_saves.is_empty());
         assert!(editor.last_error.as_deref().is_some_and(|error| {
             error.contains("format-on-save unavailable; saved unformatted")
-                && error.contains("language server initialization has failed")
+                && error.contains("language server unavailable")
         }));
         let events = std::fs::read_to_string(events).unwrap();
         assert!(!events.contains("textDocument/formatting "));
@@ -25687,7 +25703,7 @@ while True:
             assert!(editor.pending_lsp_format_saves.is_empty());
             assert!(editor.last_error.as_deref().is_some_and(|error| {
                 error.contains("format-on-save unavailable; saved unformatted")
-                    && error.contains("language server initialization has failed")
+                    && error.contains("language server unavailable")
             }));
             let target_uri = crate::lsp::file_uri(&target).unwrap();
             let events = std::fs::read_to_string(events).unwrap();

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -11,9 +11,13 @@
 //! within the documented queue budgets.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     path::PathBuf,
     process::Stdio,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
     time::{Duration, Instant},
 };
 
@@ -39,6 +43,7 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_LSP_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MAX_LSP_HEADER_BYTES: usize = 16 * 1024;
 const MAX_LSP_STDERR_LINE_BYTES: usize = 64 * 1024;
+const MAX_LSP_STDERR_TAIL_LINES: usize = 8;
 const MAX_PENDING_LSP_MESSAGES: usize = 512;
 const MAX_PENDING_LSP_BYTES: usize = 16 * 1024 * 1024;
 const SHUTDOWN_RESPONSE_TIMEOUT: Duration = Duration::from_secs(1);
@@ -167,6 +172,39 @@ async fn spawn_lsp_process(
     Ok(command.spawn()?)
 }
 
+struct LspProcessMonitor {
+    stdout_closed: Arc<AtomicBool>,
+    stderr_closed: Arc<AtomicBool>,
+    stderr_tail: Arc<Mutex<VecDeque<String>>>,
+    failure_reported: bool,
+}
+
+impl LspProcessMonitor {
+    fn stderr_summary(&self) -> Option<String> {
+        let stderr_tail = self
+            .stderr_tail
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        stderr_tail
+            .iter()
+            .find(|line| {
+                let lower = line.to_ascii_lowercase();
+                lower.starts_with("error:")
+                    || lower.starts_with("fatal")
+                    || lower.contains("panicked")
+            })
+            .or_else(|| stderr_tail.back())
+            .cloned()
+    }
+}
+
+fn lsp_command_display(config: &LanguageServerConfig) -> String {
+    std::iter::once(config.command.as_str())
+        .chain(config.args.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 impl RealLspClient {
     #[cfg(test)]
     pub(super) fn with_test_channels(
@@ -184,12 +222,14 @@ impl RealLspClient {
             initialize_id: None,
             initialized: true,
             initialize_failed: false,
+            failure_reason: None,
             pending_messages: Vec::new(),
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             server_capabilities: None,
             pending_diagnostics: HashMap::new(),
             child: None,
+            process_monitor: None,
             config,
             workspace_root,
         }
@@ -206,6 +246,9 @@ impl RealLspClient {
 
         let (request_tx, mut request_rx) = mpsc::channel::<OutboundMessage>(512);
         let (response_tx, response_rx) = mpsc::channel::<InboundMessage>(512);
+        let stdout_closed = Arc::new(AtomicBool::new(false));
+        let stderr_closed = Arc::new(AtomicBool::new(false));
+        let stderr_tail = Arc::new(Mutex::new(VecDeque::new()));
 
         // Sends requests from the editor into LSP's stdin
         let rtx = response_tx.clone();
@@ -234,6 +277,7 @@ impl RealLspClient {
 
         // Sends responses from LSP's stdout to the editor
         let rtx = response_tx.clone();
+        let stdout_closed_task = Arc::clone(&stdout_closed);
         tokio::spawn(async move {
             let mut reader = BufReader::new(stdout);
 
@@ -254,11 +298,14 @@ impl RealLspClient {
                     break;
                 }
             }
+            stdout_closed_task.store(true, Ordering::Release);
         });
 
         // Language servers commonly write operational logs to stderr. Keep
         // those in the log file, and only surface panic/fatal-looking lines.
         let rtx = response_tx.clone();
+        let stderr_closed_task = Arc::clone(&stderr_closed);
+        let stderr_tail_task = Arc::clone(&stderr_tail);
         tokio::spawn(async move {
             let mut reader = BufReader::new(stderr);
             loop {
@@ -277,6 +324,13 @@ impl RealLspClient {
 
                 if !message.is_empty() {
                     log!("[lsp] incoming stderr: {:?}", message);
+                    let mut tail = stderr_tail_task
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    if tail.len() == MAX_LSP_STDERR_TAIL_LINES {
+                        tail.pop_front();
+                    }
+                    tail.push_back(message.clone());
                 }
 
                 if should_surface_server_stderr(&message) {
@@ -293,6 +347,7 @@ impl RealLspClient {
                     }
                 }
             }
+            stderr_closed_task.store(true, Ordering::Release);
         });
 
         Ok(RealLspClient {
@@ -307,9 +362,16 @@ impl RealLspClient {
             initialize_id: None,
             initialized: false,
             initialize_failed: false,
+            failure_reason: None,
             pending_diagnostics: HashMap::new(),
             server_capabilities: None,
             child: Some(child),
+            process_monitor: Some(LspProcessMonitor {
+                stdout_closed,
+                stderr_closed,
+                stderr_tail,
+                failure_reported: false,
+            }),
             config,
             workspace_root,
         })
@@ -541,6 +603,7 @@ pub struct RealLspClient {
     initialize_id: Option<i64>,
     initialized: bool,
     initialize_failed: bool,
+    failure_reason: Option<String>,
     pending_messages: Vec<OutboundMessage>,
     pending_message_bytes: usize,
     failed_pending_requests: Vec<(i64, String)>,
@@ -548,13 +611,25 @@ pub struct RealLspClient {
     /// Debounced diagnostics requests keyed by normalized document URI.
     pending_diagnostics: HashMap<String, Instant>,
     child: Option<tokio::process::Child>,
+    process_monitor: Option<LspProcessMonitor>,
     config: LanguageServerConfig,
     workspace_root: PathBuf,
 }
 
 impl RealLspClient {
-    fn fail_initialization(&mut self) {
+    fn fail_server(&mut self, reason: impl Into<String>) {
         self.initialize_failed = true;
+        self.initialized = false;
+        if self.failure_reason.is_none() {
+            self.failure_reason = Some(reason.into());
+        }
+        self.initialize_id = None;
+        self.failed_pending_requests.extend(
+            self.pending_responses
+                .drain()
+                .filter(|(_, request)| request.method != "initialize")
+                .map(|(id, request)| (id, request.method)),
+        );
         self.failed_pending_requests
             .extend(
                 self.pending_messages
@@ -565,23 +640,67 @@ impl RealLspClient {
                     }),
             );
         self.pending_message_bytes = 0;
+        self.pending_diagnostics.clear();
+    }
+
+    fn poll_process_failure(&mut self) -> Option<LspError> {
+        let monitor = self.process_monitor.as_mut()?;
+        if monitor.failure_reported {
+            return None;
+        }
+
+        let command = lsp_command_display(&self.config);
+        let status = match self.child.as_mut()?.try_wait() {
+            Ok(status) => status,
+            Err(error) => {
+                monitor.failure_reported = true;
+                return Some(LspError::IoError(error));
+            }
+        };
+
+        if let Some(status) = status {
+            if !monitor.stderr_closed.load(Ordering::Acquire) {
+                return None;
+            }
+            monitor.failure_reported = true;
+            let mut reason = format!("{command} exited unexpectedly with {status}");
+            if let Some(stderr) = monitor.stderr_summary() {
+                reason.push_str(": ");
+                reason.push_str(&stderr);
+            }
+            return Some(LspError::ServerError(reason));
+        }
+
+        if monitor.stdout_closed.load(Ordering::Acquire) {
+            monitor.failure_reported = true;
+            return Some(LspError::ProtocolError(format!(
+                "{command} closed its stdout stream unexpectedly"
+            )));
+        }
+
+        None
     }
 
     fn queue_pending(&mut self, message: OutboundMessage) -> Result<(), LspError> {
         if self.initialize_failed {
-            return Err(LspError::ProtocolError(
-                "language server initialization has failed".to_string(),
-            ));
+            let reason = self
+                .failure_reason
+                .as_deref()
+                .unwrap_or("language server initialization has failed");
+            return Err(LspError::ProtocolError(format!(
+                "language server unavailable: {reason}"
+            )));
         }
 
         let bytes = outbound_message_size(&message);
         let total = self.pending_message_bytes.saturating_add(bytes);
         if self.pending_messages.len() >= MAX_PENDING_LSP_MESSAGES || total > MAX_PENDING_LSP_BYTES
         {
-            self.fail_initialization();
-            return Err(LspError::ProtocolError(format!(
+            let error = LspError::ProtocolError(format!(
                 "language server did not initialize before its pending queue exceeded {MAX_PENDING_LSP_MESSAGES} messages or {MAX_PENDING_LSP_BYTES} bytes"
-            )));
+            ));
+            self.fail_server(error.to_string());
+            return Err(error);
         }
 
         self.pending_message_bytes = total;
@@ -730,6 +849,14 @@ impl LspClient for RealLspClient {
     ) -> Result<(), LspError> {
         log!("[lsp] send_notification: method={} force={force}", method);
 
+        if self.initialize_failed && !force {
+            log!(
+                "[lsp] skipping notification for unavailable server: {}",
+                method
+            );
+            return Ok(());
+        }
+
         let msg = OutboundMessage::Notification(NotificationRequest {
             method: method.to_string(),
             params,
@@ -802,13 +929,16 @@ impl LspClient for RealLspClient {
         &mut self,
     ) -> Result<Option<(InboundMessage, Option<String>)>, LspError> {
         if let Some((id, method)) = self.failed_pending_requests.pop() {
+            let reason = self
+                .failure_reason
+                .as_deref()
+                .unwrap_or("language server initialization or transport failed");
             return Ok(Some((
                 InboundMessage::RequestError {
                     id,
-                    error: LspError::ProtocolError(
-                        "language server initialization or transport failed before this request completed"
-                            .to_string(),
-                    ),
+                    error: LspError::ProtocolError(format!(
+                        "language server unavailable before this request completed: {reason}"
+                    )),
                 },
                 Some(method),
             )));
@@ -840,13 +970,19 @@ impl LspClient for RealLspClient {
 
         for id in timed_out {
             if let Some(request) = self.pending_responses.remove(&id) {
+                let elapsed = now.duration_since(request.timestamp);
                 if request.method == "initialize" {
-                    self.fail_initialization();
+                    let error = LspError::RequestTimeout(elapsed);
+                    self.fail_server(error.to_string());
+                    return Ok(Some((
+                        InboundMessage::ProcessingError(error),
+                        Some(request.method),
+                    )));
                 }
                 return Ok(Some((
                     InboundMessage::RequestError {
                         id,
-                        error: LspError::RequestTimeout(now.duration_since(request.timestamp)),
+                        error: LspError::RequestTimeout(elapsed),
                     },
                     Some(request.method),
                 )));
@@ -855,6 +991,11 @@ impl LspClient for RealLspClient {
 
         match self.response_rx.try_recv() {
             Ok(mut msg) => {
+                if matches!(msg, InboundMessage::ProcessingError(_)) {
+                    if let Some(error) = self.poll_process_failure() {
+                        msg = InboundMessage::ProcessingError(error);
+                    }
+                }
                 match &mut msg {
                     InboundMessage::Message(msg) => {
                         if let Some(req) = self.pending_responses.remove(&msg.id) {
@@ -865,8 +1006,19 @@ impl LspClient for RealLspClient {
                                 // Parse the initialize result
                                 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized
                                 let init_result: InitializeResult =
-                                    serde_json::from_value(msg.result.clone())
-                                        .map_err(LspError::JsonError)?;
+                                    match serde_json::from_value(msg.result.clone()) {
+                                        Ok(init_result) => init_result,
+                                        Err(error) => {
+                                            let error = LspError::ProtocolError(format!(
+                                                "invalid initialize response: {error}"
+                                            ));
+                                            self.fail_server(error.to_string());
+                                            return Ok(Some((
+                                                InboundMessage::ProcessingError(error),
+                                                Some(req.method),
+                                            )));
+                                        }
+                                    };
 
                                 // log!("[lsp] server capabilities: {:#?}", init_result.capabilities);
                                 self.server_capabilities = Some(init_result.capabilities);
@@ -923,7 +1075,15 @@ impl LspClient for RealLspClient {
 
                                 self.pending_responses.remove(&id);
                                 if method == "initialize" {
-                                    self.fail_initialization();
+                                    let error = LspError::ServerError(format!(
+                                        "language server rejected initialization: {}",
+                                        error.message
+                                    ));
+                                    self.fail_server(error.to_string());
+                                    return Ok(Some((
+                                        InboundMessage::ProcessingError(error),
+                                        Some(method),
+                                    )));
                                 }
 
                                 return Ok(Some((msg, Some(method))));
@@ -947,19 +1107,21 @@ impl LspClient for RealLspClient {
                     }
                     _ => {}
                 }
-                if matches!(msg, InboundMessage::ProcessingError(_)) {
-                    self.failed_pending_requests.extend(
-                        self.pending_responses
-                            .drain()
-                            .map(|(id, request)| (id, request.method)),
-                    );
-                    if !self.initialized {
-                        self.fail_initialization();
+                if let InboundMessage::ProcessingError(error) = &msg {
+                    if let Some(monitor) = self.process_monitor.as_mut() {
+                        monitor.failure_reported = true;
                     }
+                    self.fail_server(error.to_string());
                 }
                 Ok(Some((msg, None)))
             }
-            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Empty) => {
+                if let Some(error) = self.poll_process_failure() {
+                    self.fail_server(error.to_string());
+                    return Ok(Some((InboundMessage::ProcessingError(error), None)));
+                }
+                Ok(None)
+            }
             Err(err) => Err(LspError::ProtocolError(err.to_string())),
         }
     }
@@ -1470,6 +1632,44 @@ impl LspClient for RealLspClient {
     }
 
     async fn shutdown(&mut self) -> Result<(), LspError> {
+        if self.initialize_failed {
+            let Some(mut child) = self.child.take() else {
+                return Ok(());
+            };
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    log!(
+                        "[lsp] {} was already stopped during shutdown: {}",
+                        self.config.command,
+                        status
+                    );
+                }
+                Ok(None) => {
+                    log!(
+                        "[lsp] terminating unavailable language server: {}",
+                        self.config.command
+                    );
+                    if let Err(error) = child.start_kill() {
+                        log!(
+                            "[lsp] failed to terminate {}: {}",
+                            self.config.command,
+                            error
+                        );
+                    } else if let Err(error) = child.wait().await {
+                        log!("[lsp] error reaping {}: {}", self.config.command, error);
+                    }
+                }
+                Err(error) => {
+                    log!(
+                        "[lsp] failed to query {} during shutdown: {}",
+                        self.config.command,
+                        error
+                    );
+                }
+            }
+            return Ok(());
+        }
+
         let shutdown_id = self
             .send_request("shutdown", serde_json::Value::Null, true)
             .await?;
@@ -1629,6 +1829,78 @@ mod test {
         client.initialize().await.unwrap();
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exited_server_fails_initialization_with_stderr_and_preserves_editor_cleanup() {
+        let config = LanguageServerConfig {
+            command: "/bin/sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "printf 'error: husk lsp is unavailable\\n' >&2; exit 23".to_string(),
+            ],
+            language_id: "husk".to_string(),
+            file_extensions: vec!["hk".to_string()],
+            documents: Vec::new(),
+            root_markers: Vec::new(),
+            env: HashMap::new(),
+            initialization_options: None,
+            workspace_name: None,
+        };
+        let mut client = RealLspClient::start(config, std::env::current_dir().unwrap())
+            .await
+            .unwrap();
+        client.initialize().await.unwrap();
+        let request_id = client
+            .send_request("textDocument/documentSymbol", json!({}), false)
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let process_monitor = client
+                    .process_monitor
+                    .as_ref()
+                    .expect("real LSP client must monitor its child process");
+                if process_monitor.stdout_closed.load(Ordering::Acquire)
+                    && process_monitor.stderr_closed.load(Ordering::Acquire)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("exited language server pipes must close");
+
+        let (message, method) = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let Some(message) = client.recv_response().await.unwrap() {
+                    break message;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("exited language server must report its failure");
+        let InboundMessage::ProcessingError(error) = message else {
+            panic!("expected exited server to produce a processing error");
+        };
+        assert!(method.is_none());
+        assert!(error.to_string().contains("exit status: 23"));
+        assert!(error.to_string().contains("error: husk lsp is unavailable"));
+
+        let (message, method) = client.recv_response().await.unwrap().unwrap();
+        let InboundMessage::RequestError { id, error } = message else {
+            panic!("expected queued request to fail");
+        };
+        assert_eq!(id, request_id);
+        assert_eq!(method.as_deref(), Some("textDocument/documentSymbol"));
+        assert!(error.to_string().contains("error: husk lsp is unavailable"));
+
+        client.did_close("/tmp/unavailable.hk").await.unwrap();
+        client.shutdown().await.unwrap();
+    }
+
     #[tokio::test]
     async fn test_parse_publish_diagnostics() {
         let msg = std::fs::read_to_string("src/lsp/fixtures/publish-diagnostics.json").unwrap();
@@ -1687,8 +1959,10 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: None,
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -1860,8 +2134,10 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: None,
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -1931,8 +2207,10 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: None,
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -2033,8 +2311,10 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: None,
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -2091,8 +2371,10 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: None,
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -2149,8 +2431,10 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: None,
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -2187,6 +2471,74 @@ mod test {
     }
 
     #[tokio::test]
+    async fn invalid_initialize_response_fails_queued_requests_immediately() {
+        let (request_tx, _request_rx) = mpsc::channel(4);
+        let (response_tx, response_rx) = mpsc::channel(4);
+        let initialize = Request {
+            id: 800,
+            method: "initialize".to_string(),
+            params: json!({}),
+            timestamp: Instant::now(),
+        };
+        let mut client = RealLspClient {
+            request_tx,
+            response_rx,
+            files_versions: HashMap::new(),
+            files_content: HashMap::new(),
+            pending_responses: HashMap::from([(initialize.id, initialize)]),
+            initialize_id: Some(800),
+            initialized: false,
+            pending_diagnostics: HashMap::new(),
+            pending_messages: Vec::new(),
+            pending_message_bytes: 0,
+            failed_pending_requests: Vec::new(),
+            initialize_failed: false,
+            failure_reason: None,
+            server_capabilities: None,
+            child: None,
+            process_monitor: None,
+            config: default_language_servers()
+                .remove("rust")
+                .expect("default Rust LSP config must exist"),
+            workspace_root: std::env::current_dir().unwrap(),
+        };
+        let queued_id = client
+            .send_request("textDocument/documentSymbol", json!({}), false)
+            .await
+            .unwrap();
+        response_tx
+            .send(InboundMessage::Message(ResponseMessage {
+                id: 800,
+                result: json!({
+                    "capabilities": {
+                        "textDocumentSync": {
+                            "change": "incremental"
+                        }
+                    }
+                }),
+                request: None,
+            }))
+            .await
+            .unwrap();
+
+        let (message, method) = client.recv_response().await.unwrap().unwrap();
+        let InboundMessage::ProcessingError(error) = message else {
+            panic!("expected invalid initialize response to fail the server");
+        };
+        assert_eq!(method.as_deref(), Some("initialize"));
+        assert!(error.to_string().contains("invalid initialize response"));
+        assert!(client.initialize_failed);
+
+        let (message, method) = client.recv_response().await.unwrap().unwrap();
+        let InboundMessage::RequestError { id, error } = message else {
+            panic!("expected queued request to fail");
+        };
+        assert_eq!(id, queued_id);
+        assert_eq!(method.as_deref(), Some("textDocument/documentSymbol"));
+        assert!(error.to_string().contains("invalid initialize response"));
+    }
+
+    #[tokio::test]
     async fn failed_or_overflowed_initialization_fails_each_queued_request_and_bounds_memory() {
         let (request_tx, _request_rx) = mpsc::channel(1);
         let (_response_tx, response_rx) = mpsc::channel(1);
@@ -2203,8 +2555,10 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: None,
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -2232,9 +2586,7 @@ mod test {
         };
         assert_eq!(id, request_id);
         assert_eq!(method.as_deref(), Some("textDocument/formatting"));
-        assert!(error
-            .to_string()
-            .contains("initialization or transport failed"));
+        assert!(error.to_string().contains("pending queue exceeded"));
         assert!(client
             .send_request("textDocument/rename", json!({}), false)
             .await
@@ -2264,8 +2616,10 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: None,
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -2291,7 +2645,7 @@ mod test {
         };
         assert_eq!(id, 801);
         assert_eq!(method.as_deref(), Some("textDocument/formatting"));
-        assert!(error.to_string().contains("transport failed"));
+        assert!(error.to_string().contains("invalid stdout frame"));
     }
 
     #[tokio::test]
@@ -2320,6 +2674,7 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: Some(
                 serde_json::from_value(json!({
                     "diagnosticProvider": {
@@ -2330,6 +2685,7 @@ mod test {
                 .unwrap(),
             ),
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),
@@ -2372,10 +2728,12 @@ mod test {
             pending_message_bytes: 0,
             failed_pending_requests: Vec::new(),
             initialize_failed: false,
+            failure_reason: None,
             server_capabilities: Some(
                 serde_json::from_value(json!({ "textDocumentSync": 2 })).unwrap(),
             ),
             child: None,
+            process_monitor: None,
             config: default_language_servers()
                 .remove("rust")
                 .expect("default Rust LSP config must exist"),

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -427,7 +427,7 @@ pub struct TextDocumentSyncOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub will_save_wait_until: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub save: Option<SaveOptions>,
+    pub save: Option<TextDocumentSyncSaveOptions>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -448,6 +448,13 @@ impl From<TextDocumentSyncKind> for i32 {
     fn from(kind: TextDocumentSyncKind) -> i32 {
         kind as i32
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TextDocumentSyncSaveOptions {
+    Supported(bool),
+    Options(SaveOptions),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2052,5 +2059,26 @@ mod tests {
         assert_numeric_enum_rejects_unknown!(CompletionItemKind, 1);
         assert_numeric_enum_rejects_unknown!(PrepareSupportDefaultBehavior, 1);
         assert_numeric_enum_rejects_unknown!(InsertTextFormat, 1);
+    }
+
+    #[test]
+    fn text_document_sync_save_accepts_boolean_and_options() {
+        let supported: TextDocumentSyncOptions =
+            serde_json::from_value(serde_json::json!({ "save": true })).unwrap();
+        assert!(matches!(
+            supported.save,
+            Some(TextDocumentSyncSaveOptions::Supported(true))
+        ));
+
+        let options: TextDocumentSyncOptions = serde_json::from_value(serde_json::json!({
+            "save": { "includeText": true }
+        }))
+        .unwrap();
+        assert!(matches!(
+            options.save,
+            Some(TextDocumentSyncSaveOptions::Options(SaveOptions {
+                include_text: Some(true)
+            }))
+        ));
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -42,6 +42,10 @@ pub use runtime::{
     poll_timer_callbacks, CommandMetadata, ComposerHandle, PickerHandle, RegisteredPluginCommand,
     RequestId, Runtime,
 };
+
+pub(crate) fn husk_lsp_declarations() -> &'static str {
+    runtime::RED_HOST_DECLARATIONS
+}
 #[cfg(test)]
 pub(crate) use text_link::TextPanelFileLocation;
 pub(crate) use text_link::TextPanelLinkTarget;

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -115,7 +115,7 @@ impl ComposerHandle {
     }
 }
 
-const RED_HOST_DECLARATIONS: &str = r#"
+pub(super) const RED_HOST_DECLARATIONS: &str = r#"
 type Json = JsValue;
 struct PickerItem {
     id: String,

--- a/tools/husk-standalone/Cargo.toml
+++ b/tools/husk-standalone/Cargo.toml
@@ -1,12 +1,14 @@
 [workspace]
 members = [
     "crates/husk",
+    "crates/husk-analysis",
     "crates/husk-ast",
     "crates/husk-cli",
     "crates/husk-diagnostics",
     "crates/husk-extension",
     "crates/husk-hir",
     "crates/husk-lexer",
+    "crates/husk-lsp",
     "crates/husk-package",
     "crates/husk-parser",
     "crates/husk-runtime",
@@ -25,11 +27,13 @@ license = "MIT"
 repository = "https://github.com/codersauce/red"
 
 [workspace.dependencies]
+husk-analysis = { version = "0.1.0", path = "crates/husk-analysis" }
 husk-ast = { version = "0.1.0", path = "crates/husk-ast" }
 husk-diagnostics = { version = "0.1.0", path = "crates/husk-diagnostics" }
 husk-extension = { version = "0.1.0", path = "crates/husk-extension" }
 husk-hir = { version = "0.1.0", path = "crates/husk-hir" }
 husk-lexer = { version = "0.1.0", path = "crates/husk-lexer" }
+husk-lsp = { version = "0.1.0", path = "crates/husk-lsp" }
 husk-package = { version = "0.1.0", path = "crates/husk-package" }
 husk-parser = { version = "0.1.0", path = "crates/husk-parser" }
 husk-runtime = { version = "0.1.0", path = "crates/husk-runtime", default-features = false }


### PR DESCRIPTION
## Why

Husk files have syntax highlighting but no first-party semantic editor support. That leaves diagnostics, navigation, refactoring, and package-aware completion unavailable, especially for APIs supplied by external crate adapters.

## What changed

- add `husk-analysis`, a recovered-syntax workspace model with UTF-16 positions, package semantics, symbols, references, overlays, and conservative formatting
- add `husk-lsp`, a bounded stdio language server covering diagnostics, completion, hover, signatures, navigation, references, rename, symbols, semantic tokens, inlay hints, folding, selection ranges, code actions, formatting, and call hierarchy
- index external crate APIs only from lock-verified installed or vendored Component bundles, preserving adapter documentation in digest-scoped read-only navigation stubs without invoking Cargo, the network, or guest code
- expose `husk lsp --stdio` and configure Red to start it automatically for `.hk` and `.husk` files with Red's trusted host declarations
- document the feature/configuration contract and extend the Husk-only independence harness to cover the new crates

## How to Test

1. Run `cargo run -p husk-cli -- lsp --stdio`, initialize a workspace, and open an unsaved document containing a helper function. Completion and hover should resolve the helper using UTF-16 positions while the on-disk file remains unchanged.
2. Open a package with a locked, installed or vendored crate extension and request hover/definition on an exported API. Documentation should appear and definition should resolve to `.husk/lsp/<digest>/<module>.hk`. A mismatched bundle/report digest or symlinked cache directory should produce a dependency warning and must not index or write through the invalid path.
3. Run `cargo test -p husk-analysis -p husk-lsp -p husk-cli`; the analysis, JSON-RPC, external-adapter, CLI, and UTF-16 regression suites should pass.
4. Run `scripts/check-husk-independence.sh`; the copied Husk-only workspace should build and its standalone smoke program should run without the Red package.
