### PR TITLE
fix(editor): report failed searches

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10313,6 +10313,20 @@ impl Editor {
         self.last_error = None;
     }
 
+    fn finish_search_with_error(&mut self, session: SearchSession, error: String) {
+        self.restore_search_origin(&session.origin, session.origin_vtop);
+        self.search_term = session.draft;
+        self.search_direction = session.direction;
+        self.search_highlights_suppressed = false;
+        self.active_search = None;
+        self.mode = Mode::Normal;
+        self.last_error = Some(error);
+    }
+
+    fn pattern_not_found_message(pattern: &str) -> String {
+        format!("Pattern not found: {pattern}")
+    }
+
     fn active_search_text(&self) -> Option<&str> {
         self.active_search
             .as_ref()
@@ -10374,7 +10388,7 @@ impl Editor {
             self.render(buffer)?;
             return Ok(true);
         } else {
-            self.last_error = Some(format!("pattern not found: {pattern}"));
+            self.last_error = Some(Self::pattern_not_found_message(&pattern));
             self.render(buffer)?;
         }
 
@@ -14394,8 +14408,7 @@ impl Editor {
                     let matches = match self.search_matches(&session.draft) {
                         Ok(matches) => matches,
                         Err(err) => {
-                            self.restore_search_origin(&session.origin, session.origin_vtop);
-                            self.last_error = Some(err.to_string());
+                            self.finish_search_with_error(session, err.to_string());
                             self.render(buffer)?;
                             return Ok(false);
                         }
@@ -14406,8 +14419,8 @@ impl Editor {
                         session.direction,
                         self.config.search.wrapscan,
                     ) else {
-                        self.restore_search_origin(&session.origin, session.origin_vtop);
-                        self.last_error = Some(format!("pattern not found: {}", session.draft));
+                        let error = Self::pattern_not_found_message(&session.draft);
+                        self.finish_search_with_error(session, error);
                         self.render(buffer)?;
                         return Ok(false);
                     };

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -762,6 +762,99 @@ async fn search_enter_commits_preview_and_n_repeats_direction() {
 }
 
 #[tokio::test]
+async fn search_enter_without_match_exits_and_reports_error() {
+    let mut harness = EditorHarness::with_content("alpha\nbeta");
+    harness
+        .execute_action(Action::SetCursor(0, 1))
+        .await
+        .unwrap();
+
+    harness
+        .execute_action(Action::EnterSearch(SearchDirection::Forward))
+        .await
+        .unwrap();
+    type_normal_keys(&mut harness, "missing").await;
+    harness.assert_mode(Mode::Search);
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_cursor_at(0, 1);
+    assert!(harness
+        .commandline_row()
+        .starts_with("Pattern not found: missing"));
+}
+
+#[tokio::test]
+async fn failed_search_becomes_the_most_recent_search() {
+    let mut harness = EditorHarness::with_content("alpha\nbeta\nalpha");
+
+    harness
+        .execute_action(Action::EnterSearch(SearchDirection::Forward))
+        .await
+        .unwrap();
+    type_normal_keys(&mut harness, "alpha").await;
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+    harness.assert_cursor_at(0, 2);
+
+    harness
+        .execute_action(Action::EnterSearch(SearchDirection::Forward))
+        .await
+        .unwrap();
+    type_normal_keys(&mut harness, "missing").await;
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::RepeatSearch).await.unwrap();
+
+    harness.assert_cursor_at(0, 2);
+    assert!(harness
+        .commandline_row()
+        .starts_with("Pattern not found: missing"));
+}
+
+#[tokio::test]
+async fn invalid_search_pattern_exits_and_reports_error() {
+    let mut harness = EditorHarness::with_content("alpha\nbeta");
+
+    harness
+        .execute_action(Action::EnterSearch(SearchDirection::Forward))
+        .await
+        .unwrap();
+    type_normal_keys(&mut harness, "[").await;
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_cursor_at(0, 0);
+    assert!(harness
+        .commandline_row()
+        .starts_with("invalid search pattern:"));
+}
+
+#[tokio::test]
 async fn backward_search_previews_previous_match() {
     let mut harness = EditorHarness::with_content("alpha\nbeta\nalpha\nbeta\nalpha");
     harness


### PR DESCRIPTION
Submitting a `/` or `?` search with no matches currently leaves Red in Search mode. Because the active prompt takes precedence over command-line errors, pressing Enter appears to do nothing.

This change completes failed search submissions by restoring the original cursor and viewport, returning to Normal mode, and displaying the search error. The submitted pattern and direction remain the latest search so `n` and `N` retain Vim-compatible repeat behavior. Invalid regular expressions follow the same terminal transition and expose their existing validation error.

## How to Test

1. Open a document, enter `/definitely-missing`, and press Enter. Verify Red returns to Normal mode, restores the search origin, and shows `Pattern not found: definitely-missing`.
2. Complete a successful search, submit a missing pattern, then press `n`. Verify Red repeats the missing pattern instead of returning to the previous successful search.
3. Enter an invalid pattern such as `/[` and press Enter. Verify Red exits Search mode and displays the invalid-pattern error.

Automated coverage: `cargo test --test movement search_`
