### PR TITLE
fix(editor): preserve YAML highlighting after edits

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3847,6 +3847,7 @@ impl Editor {
         };
         let revision = buffer.revision();
         let file = buffer.file.clone();
+        let requires_document_prefix = self.highlighter.requires_document_prefix(file.as_deref());
         let line_count = buffer.len();
         if vtop >= line_count {
             return Ok(Vec::new());
@@ -3872,11 +3873,15 @@ impl Editor {
             } else {
                 8
             };
-            let mut parse_start = vtop.saturating_sub(margin);
+            let mut parse_start = if requires_document_prefix {
+                0
+            } else {
+                vtop.saturating_sub(margin)
+            };
             let mut parse_end = (vtop + height + margin).min(line_count);
 
             if buffer.line_range_byte_len(parse_start, parse_end) > MAX_HIGHLIGHT_SLICE_BYTES {
-                parse_start = vtop;
+                parse_start = if requires_document_prefix { 0 } else { vtop };
                 parse_end = viewport_end;
                 if buffer.line_range_byte_len(parse_start, parse_end) > MAX_HIGHLIGHT_SLICE_BYTES {
                     self.highlight_cache.remove(&buffer_index);
@@ -22640,6 +22645,17 @@ mod test {
         editor
     }
 
+    fn yaml_test_editor(contents: String, width: usize, height: usize) -> Editor {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let theme = parse_vscode_theme("themes/mocha.json").unwrap();
+        let buffer = Buffer::new(Some("/tmp/red-highlight-test.yml".to_string()), contents);
+        let mut editor =
+            Editor::with_size(lsp, width, height, config, theme, vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        editor
+    }
+
     fn span_shape(spans: &[HighlightSpan]) -> Vec<(usize, usize, Style)> {
         spans
             .iter()
@@ -22674,6 +22690,90 @@ mod test {
         editor.current_buffer_mut().insert_str(0, 10, "// ");
         let after = editor.viewport_highlight_spans(0, 10, 20).unwrap();
         assert_ne!(span_shape(&before), span_shape(&after));
+    }
+
+    #[test]
+    fn yaml_highlighting_keeps_document_context_after_an_edit() {
+        let contents = r#"jobs:
+  test:
+    name: Test Suite
+    runs-on: >-
+      ${{
+        (
+          github.event_name != 'pull_request'
+        ) && matrix.platform.warp || matrix.platform.standard
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - standard: ubuntu-latest
+            warp: warp-ubuntu-latest-x64-32x
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run tests
+        run: cargo test
+"#
+        .to_string();
+        let (vtop, height) = (12, 10);
+        let mut editor = yaml_test_editor(contents, 120, height + 2);
+
+        editor
+            .viewport_highlight_spans(0, 0, editor.current_buffer().len())
+            .unwrap();
+        let before = editor.viewport_highlight_spans(0, vtop, height).unwrap();
+        assert!(!before.is_empty());
+
+        let edit_line = 17;
+        let edit_column = editor
+            .current_buffer()
+            .get(edit_line)
+            .unwrap()
+            .trim_end_matches(['\r', '\n'])
+            .chars()
+            .count();
+        editor
+            .current_buffer_mut()
+            .insert_str(edit_column, edit_line, " ");
+        let edited_contents = editor.current_buffer().contents();
+        let after = editor.viewport_highlight_spans(0, vtop, height).unwrap();
+
+        let mut fresh = yaml_test_editor(edited_contents, 120, height + 2);
+        fresh
+            .viewport_highlight_spans(0, 0, fresh.current_buffer().len())
+            .unwrap();
+        let expected = fresh.viewport_highlight_spans(0, vtop, height).unwrap();
+
+        assert!(!after.is_empty());
+        assert_eq!(span_shape(&after), span_shape(&expected));
+        assert_eq!(editor.highlight_cache[&0].start_line, 0);
+    }
+
+    #[test]
+    fn context_independent_highlighting_keeps_the_small_edit_margin() {
+        let (vtop, height) = (30, 20);
+        let mut editor = rust_test_editor(100, 120, height + 2);
+        editor.viewport_highlight_spans(0, vtop, height).unwrap();
+
+        editor.current_buffer_mut().insert_str(0, vtop, "// ");
+        editor.viewport_highlight_spans(0, vtop, height).unwrap();
+
+        assert_eq!(editor.highlight_cache[&0].start_line, vtop - 8);
+    }
+
+    #[test]
+    fn yaml_highlighting_skips_an_oversized_required_prefix() {
+        let contents = format!(
+            "root:\n  oversized: {}\n  visible: value\n",
+            "x".repeat(MAX_HIGHLIGHT_SLICE_BYTES)
+        );
+        let mut editor = yaml_test_editor(contents, 80, 3);
+
+        assert!(editor.viewport_highlight_spans(0, 2, 1).unwrap().is_empty());
+        assert!(!editor.highlight_cache.contains_key(&0));
     }
 
     #[test]

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -79,6 +79,16 @@ impl HuskStyles {
 
 const MAX_INJECTION_DEPTH: usize = 3;
 
+const YAML_ADDITIONAL_HIGHLIGHTS_QUERY: &str = r#"
+(escape_sequence) @escape
+
+[
+  (yaml_directive)
+  (tag_directive)
+  (reserved_directive)
+] @keyword.directive
+"#;
+
 impl Highlighter {
     pub fn new(theme: &Theme) -> anyhow::Result<Self> {
         let languages = language_definitions()
@@ -107,6 +117,14 @@ impl Highlighter {
     pub fn language_id_for_file(&self, file: Option<&str>) -> Option<&'static str> {
         let extension = file_extension(file?)?;
         self.language_id_for_extension(&extension)
+    }
+
+    /// Whether highlighting a file requires all text before the visible slice.
+    ///
+    /// YAML structure is indentation-sensitive, so parsing an arbitrary indented
+    /// viewport can lose the mapping and scalar context that determines its nodes.
+    pub(crate) fn requires_document_prefix(&self, file: Option<&str>) -> bool {
+        matches!(self.language_id_for_file(file), Some("yaml"))
     }
 
     pub fn language_id_for_extension(&self, extension: &str) -> Option<&'static str> {
@@ -186,21 +204,34 @@ impl Highlighter {
 
             let mut cursor = QueryCursor::new();
             let mut matches = cursor.matches(&highlighter.query, tree.root_node(), code.as_bytes());
+            let mut refinement_colors = Vec::new();
 
             while let Some(mat) = matches.next() {
                 for cap in mat.captures {
                     let node = cap.node;
                     let start = node.start_byte();
                     let end = node.end_byte();
+                    let capture_name = highlighter.query.capture_names()[cap.index as usize];
                     if let Some(style) = highlighter.capture_styles[cap.index as usize].as_ref() {
-                        colors.push(StyleInfo {
+                        let captured = StyleInfo {
                             start,
                             end,
                             style: style.clone(),
-                        });
+                        };
+                        if capture_refines_equal_range(capture_name) {
+                            refinement_colors.push(captured);
+                        } else {
+                            colors.push(captured);
+                        }
                     }
                 }
             }
+
+            // Query cursors return captures in syntax-tree order, which can put a
+            // broad scalar capture after a more specific capture over the same
+            // bytes. Keep semantic refinements later so the renderer's stable
+            // equal-range tie-break selects them.
+            colors.extend(refinement_colors);
 
             if depth < MAX_INJECTION_DEPTH {
                 if let Some(injection_query) = &highlighter.injection_query {
@@ -236,6 +267,14 @@ impl Highlighter {
         }
 
         Ok(colors)
+    }
+}
+
+fn capture_refines_equal_range(scope: &str) -> bool {
+    match scope {
+        "property" | "escape" | "string.escape" => true,
+        scope if scope.starts_with("keyword.directive") => true,
+        _ => false,
     }
 }
 
@@ -371,7 +410,10 @@ fn language_definitions() -> Vec<LanguageDefinition> {
             id: "yaml",
             extensions: &["yml", "yaml"],
             language: || tree_sitter_yaml::LANGUAGE.into(),
-            highlight_queries: &[tree_sitter_yaml::HIGHLIGHTS_QUERY],
+            highlight_queries: &[
+                tree_sitter_yaml::HIGHLIGHTS_QUERY,
+                YAML_ADDITIONAL_HIGHLIGHTS_QUERY,
+            ],
             injection_query: None,
         },
         LanguageDefinition {
@@ -753,6 +795,14 @@ mod tests {
         );
     }
 
+    fn effective_style_at(styles: &[StyleInfo], byte: usize) -> Option<&Style> {
+        styles
+            .iter()
+            .filter(|span| span.start <= byte && byte < span.end)
+            .map(|span| &span.style)
+            .next_back()
+    }
+
     #[test]
     fn resolves_language_by_file_extension() {
         let highlighter = highlighter();
@@ -794,6 +844,44 @@ mod tests {
             Some("husk")
         );
         assert_eq!(highlighter.language_id_for_file(Some("LICENSE")), None);
+    }
+
+    #[test]
+    fn yaml_requires_document_prefix_for_highlighting() {
+        let highlighter = highlighter();
+
+        assert!(highlighter.requires_document_prefix(Some("workflow.yml")));
+        assert!(highlighter.requires_document_prefix(Some("config.yaml")));
+        assert!(!highlighter.requires_document_prefix(Some("main.rs")));
+        assert!(!highlighter.requires_document_prefix(Some("README.md")));
+    }
+
+    #[test]
+    fn yaml_distinguishes_properties_values_escapes_and_directives() {
+        let theme = parse_vscode_theme("themes/red.json").unwrap();
+        let property = theme.get_style("property").unwrap();
+        let string = theme.get_style("string").unwrap();
+        let escape = theme.get_style("escape").unwrap();
+        let directive = theme.get_style("keyword.directive").unwrap();
+        assert_ne!(property.fg, string.fg);
+
+        let mut highlighter = Highlighter::new(&theme).unwrap();
+        let code = "%YAML 1.2\n---\nname: example\nescaped: \"line\\n\"\n";
+        let styles = highlighter.highlight("yaml", code).unwrap();
+
+        assert_eq!(
+            effective_style_at(&styles, code.find("name").unwrap()),
+            Some(&property)
+        );
+        assert_eq!(
+            effective_style_at(&styles, code.find("example").unwrap()),
+            Some(&string)
+        );
+        assert_eq!(
+            effective_style_at(&styles, code.find("\\n").unwrap()),
+            Some(&escape)
+        );
+        assert_eq!(effective_style_at(&styles, 0), Some(&directive));
     }
 
     #[test]

--- a/src/theme/vscode.rs
+++ b/src/theme/vscode.rs
@@ -550,10 +550,34 @@ fn parse_color_value(value: &Value) -> anyhow::Result<Color> {
 }
 
 fn translate_scope(vscode_scope: String) -> String {
+    if vscode_scope
+        .split_whitespace()
+        .any(is_textmate_property_scope)
+    {
+        return "property".to_string();
+    }
+
     SYNTAX_HIGHLIGHTING_MAP
         .get(&vscode_scope.as_str())
         .map(|s| s.to_string())
         .unwrap_or(vscode_scope)
+}
+
+fn is_textmate_property_scope(scope: &str) -> bool {
+    scope == "property"
+        || scope == "entity.name.tag.yaml"
+        || scope == "meta.property-name"
+        || scope_is_or_has_suffix(scope, "support.type.property-name")
+        || scope_is_or_has_suffix(scope, "punctuation.support.type.property-name")
+        || scope_is_or_has_suffix(scope, "variable.other.member")
+        || scope_is_or_has_suffix(scope, "variable.other.property")
+}
+
+fn scope_is_or_has_suffix(scope: &str, base: &str) -> bool {
+    scope == base
+        || scope
+            .strip_prefix(base)
+            .is_some_and(|suffix| suffix.starts_with('.'))
 }
 
 #[derive(Deserialize, Debug)]
@@ -1022,6 +1046,22 @@ mod test {
 
         assert!(theme.get_style("tag").is_some());
         assert!(theme.get_style("attribute").is_some());
+    }
+
+    #[test]
+    fn test_textmate_property_scopes_map_to_tree_sitter_property_capture() {
+        for scope in [
+            "support.type.property-name.yaml",
+            "punctuation.support.type.property-name.json",
+            "source.yaml entity.name.tag.yaml",
+            "source.json meta.structure.dictionary.json support.type.property-name.json",
+            "variable.other.member",
+            "variable.other.property.ts",
+        ] {
+            assert_eq!(translate_scope(scope.to_string()), "property", "{scope}");
+        }
+
+        assert_eq!(translate_scope("entity.name.tag".to_string()), "tag");
     }
 
     #[test]

--- a/themes/red.json
+++ b/themes/red.json
@@ -150,6 +150,16 @@
       "settings": { "foreground": "#D8D8DE" }
     },
     {
+      "scope": [
+        "property",
+        "support.type.property-name",
+        "entity.name.tag.yaml",
+        "variable.other.member",
+        "variable.other.property"
+      ],
+      "settings": { "foreground": "#8FA8C8" }
+    },
+    {
       "scope": ["variable.parameter"],
       "settings": { "foreground": "#C8C8D2", "fontStyle": "italic" }
     },


### PR DESCRIPTION
YAML highlighting could lose its structural context after an edit because viewport reparsing started only a few lines above the visible region. In indentation-sensitive files, that slice can begin inside a nested mapping or folded scalar, causing valid captures to disappear. YAML property captures also lacked reliable VS Code theme resolution, leaving keys and string values visually indistinguishable.

This change:

- reparses YAML from the document prefix while preserving the existing highlight-size bound and the smaller edit margin for context-independent languages;
- maps TextMate property scopes to the tree-sitter `property` capture and ensures semantic refinements win equal-range capture ties;
- adds distinct YAML key styling to the bundled Red theme, plus escape and directive captures;
- covers post-edit context, oversized prefixes, non-YAML margins, property scope translation, and key/value styling with regression tests.

## How to Test

1. Run `cargo run -- .github/workflows/ci.yml`, move to the nested steps around line 70, and edit a YAML value. Syntax highlighting should remain intact after the edit, with keys blue and string values brown in the Red theme.
2. Run `cargo test yaml_highlighting --lib`. The post-edit parse should match a fresh full-context parse, while a required prefix over the highlight byte limit should safely produce no cached spans.
3. Run `cargo test yaml_distinguishes_properties_values_escapes_and_directives --lib`. Keys, scalar values, escapes, and directives should resolve to their intended distinct styles.