### PR TITLE
feat(git): extract native husk core

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -46,7 +46,10 @@ jobs:
         run: |
           cargo test --all-features -p red husk
           cargo test --all-features -p red plugin::runtime::tests::lsp_symbols_
-          cargo test --all-features -p husk -p husk-ast -p husk-diagnostics -p husk-lexer -p husk-parser -p husk-semantic -p husk-types
+          cargo test --all-features -p red plugin::runtime::tests::git_
+          cargo test --all-features -p red plugin::runtime::tests::embedded_git_core_
+          cargo test --all-features -p husk -p husk-ast -p husk-diagnostics -p husk-lexer -p husk-package -p husk-parser -p husk-semantic -p husk-types
+          cargo run --all-features -p husk-cli -- test --locked plugins/git_core
 
       - name: Validate example plugin metadata
         run: python3 -m json.tool examples/example-plugin/package.json > /dev/null

--- a/crates/husk-package/src/lib.rs
+++ b/crates/husk-package/src/lib.rs
@@ -329,6 +329,77 @@ impl ResolvedPackage {
         })
     }
 
+    /// Resolve a pure package whose sources are embedded in the host binary.
+    ///
+    /// `files` are package-relative paths paired with UTF-8 source. The same
+    /// module layout, ambiguity, size, and module-count rules as filesystem
+    /// packages apply. Embedded packages cannot declare extensions because
+    /// their bundles and lock provenance cannot be verified without a
+    /// filesystem root.
+    pub fn from_sources(
+        display_root: impl Into<PathBuf>,
+        manifest_source: &str,
+        files: &[(&str, &str)],
+        limits: PackageLimits,
+    ) -> Result<Self, PackageError> {
+        let display_root = display_root.into();
+        let manifest_path = display_root.join(MANIFEST_FILE);
+        let manifest_bytes = u64::try_from(manifest_source.len()).unwrap_or(u64::MAX);
+        if manifest_bytes > limits.max_manifest_bytes {
+            return Err(PackageError::TooLarge {
+                path: manifest_path,
+                actual: manifest_bytes,
+                maximum: limits.max_manifest_bytes,
+            });
+        }
+
+        let manifest = PackageManifest::parse(manifest_source)?;
+        if !manifest.extensions.is_empty() {
+            return Err(PackageError::InvalidManifest {
+                message: "embedded packages cannot declare extensions".to_string(),
+            });
+        }
+
+        let mut sources = BTreeMap::new();
+        for (path, source) in files {
+            let path = PathBuf::from(path);
+            validate_local_path(&path, "embedded source")?;
+            if sources
+                .insert(path.clone(), Arc::<str>::from(*source))
+                .is_some()
+            {
+                return Err(PackageError::InvalidManifest {
+                    message: format!("duplicate embedded source `{}`", path.display()),
+                });
+            }
+        }
+
+        let entry = manifest.package.entry.clone();
+        if !sources.contains_key(&entry) {
+            return Err(PackageError::NotFile(display_root.join(entry)));
+        }
+        let source_root = display_root.join(entry.parent().unwrap_or(Path::new("")));
+        let mut resolver =
+            EmbeddedModuleResolver::new(display_root.clone(), source_root.clone(), sources, limits);
+        resolver.resolve(Vec::new(), entry)?;
+        let modules = resolver.finish();
+        let lock = PackageLock::empty(
+            manifest.package.name.clone(),
+            manifest.package.version.clone(),
+        );
+
+        Ok(Self {
+            root: display_root,
+            source_root,
+            manifest_path,
+            manifest,
+            modules,
+            extensions: Vec::new(),
+            lock,
+            limits,
+        })
+    }
+
     pub fn enforce_lock(&self) -> Result<(), PackageError> {
         let path = self.root.join(LOCK_FILE);
         reject_symlink(&path)?;
@@ -595,6 +666,144 @@ struct ModuleResolver {
     modules: BTreeMap<Vec<String>, SourceModule>,
     canonical_owners: HashMap<PathBuf, Vec<String>>,
     stack: Vec<(Vec<String>, PathBuf)>,
+}
+
+struct EmbeddedModuleResolver {
+    display_root: PathBuf,
+    source_root: PathBuf,
+    sources: BTreeMap<PathBuf, Arc<str>>,
+    limits: PackageLimits,
+    modules: BTreeMap<Vec<String>, SourceModule>,
+}
+
+impl EmbeddedModuleResolver {
+    fn new(
+        display_root: PathBuf,
+        source_root: PathBuf,
+        sources: BTreeMap<PathBuf, Arc<str>>,
+        limits: PackageLimits,
+    ) -> Self {
+        Self {
+            display_root,
+            source_root,
+            sources,
+            limits,
+            modules: BTreeMap::new(),
+        }
+    }
+
+    fn resolve(
+        &mut self,
+        module_path: Vec<String>,
+        source_path: PathBuf,
+    ) -> Result<(), PackageError> {
+        if self.modules.len() >= self.limits.max_modules {
+            return Err(PackageError::TooManyModules {
+                maximum: self.limits.max_modules,
+            });
+        }
+        let canonical_path = self.display_root.join(&source_path);
+        if self.modules.contains_key(&module_path) {
+            let module = display_module(&module_path);
+            return Err(PackageError::DuplicateModuleFile {
+                path: canonical_path,
+                first: module.clone(),
+                second: module,
+            });
+        }
+        let source = self
+            .sources
+            .get(&source_path)
+            .cloned()
+            .ok_or_else(|| PackageError::NotFile(canonical_path.clone()))?;
+        let source_bytes = u64::try_from(source.len()).unwrap_or(u64::MAX);
+        if source_bytes > self.limits.max_source_bytes {
+            return Err(PackageError::TooLarge {
+                path: canonical_path,
+                actual: source_bytes,
+                maximum: self.limits.max_source_bytes,
+            });
+        }
+        let parsed = husk_parser::parse_str(&source);
+        if !parsed.errors.is_empty() {
+            return Err(PackageError::Parse {
+                path: canonical_path,
+                errors: parsed
+                    .errors
+                    .into_iter()
+                    .map(|error| {
+                        format!(
+                            "{} at {}..{}",
+                            error.message, error.span.range.start, error.span.range.end
+                        )
+                    })
+                    .collect(),
+            });
+        }
+        let mut syntax = parsed.file.expect("parser returns a file");
+        let display_path = canonical_path
+            .strip_prefix(&self.source_root)
+            .unwrap_or(&canonical_path)
+            .to_path_buf();
+        let ast_path = Arc::<str>::from(display_path.to_string_lossy().as_ref());
+        for item in &mut syntax.items {
+            item.set_file_path(Arc::clone(&ast_path));
+        }
+        let child_names = syntax
+            .items
+            .iter()
+            .filter_map(|item| match &item.kind {
+                ItemKind::Mod { name } => Some(name.name.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        self.modules.insert(
+            module_path.clone(),
+            SourceModule {
+                module_path: module_path.clone(),
+                canonical_path,
+                display_path,
+                source,
+                syntax,
+            },
+        );
+
+        let child_base = module_child_base(&source_path, module_path.is_empty());
+        for child_name in child_names {
+            let flat = child_base.join(format!("{child_name}.hk"));
+            let nested = child_base.join(&child_name).join("mod.hk");
+            let selected = match (
+                self.sources.contains_key(&flat),
+                self.sources.contains_key(&nested),
+            ) {
+                (true, false) => flat,
+                (false, true) => nested,
+                (true, true) => {
+                    return Err(PackageError::AmbiguousModule {
+                        module: child_name,
+                        flat: self.display_root.join(flat),
+                        nested: self.display_root.join(nested),
+                    });
+                }
+                (false, false) => {
+                    return Err(PackageError::MissingModule {
+                        module: child_name,
+                        flat: self.display_root.join(flat),
+                        nested: self.display_root.join(nested),
+                    });
+                }
+            };
+            let mut child_path = module_path.clone();
+            child_path.push(child_name);
+            self.resolve(child_path, selected)?;
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> Vec<SourceModule> {
+        self.modules.into_values().collect()
+    }
 }
 
 impl ModuleResolver {

--- a/crates/husk-package/tests/package.rs
+++ b/crates/husk-package/tests/package.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::PathBuf};
 
 use husk_package::{
     LOCK_FILE, PackageError, PackageLimits, PackageLock, PackageManifest, ResolvedPackage,
@@ -63,6 +63,144 @@ fn resolves_flat_and_nested_modules_in_stable_order() {
     assert_eq!(
         discover_manifest(directory.path().join("src/util/nested/mod.hk")).unwrap(),
         directory.path().join("Husk.toml").canonicalize().unwrap()
+    );
+}
+
+#[test]
+fn resolves_embedded_modules_in_stable_order() {
+    let manifest = r#"
+        schema_version = 1
+
+        [package]
+        name = "embedded-example"
+        version = "0.1.0"
+        entry = "src/main.hk"
+    "#;
+    let resolved = ResolvedPackage::from_sources(
+        "embedded/example",
+        manifest,
+        &[
+            (
+                "src/main.hk",
+                "mod util;\nfn main() -> i32 { util::answer() }",
+            ),
+            (
+                "src/util.hk",
+                "mod nested;\npub fn answer() -> i32 { nested::value() }",
+            ),
+            ("src/util/nested/mod.hk", "pub fn value() -> i32 { 42 }"),
+        ],
+        PackageLimits::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolved
+            .modules
+            .iter()
+            .map(|module| module.module_path.join("::"))
+            .collect::<Vec<_>>(),
+        vec!["", "util", "util::nested"]
+    );
+    assert_eq!(resolved.modules[0].display_path, PathBuf::from("main.hk"));
+    assert_eq!(
+        resolved.modules[2].display_path,
+        PathBuf::from("util/nested/mod.hk")
+    );
+}
+
+#[test]
+fn embedded_modules_reject_ambiguous_missing_duplicate_and_extension_inputs() {
+    let manifest = r#"
+        schema_version = 1
+
+        [package]
+        name = "embedded-example"
+        version = "0.1.0"
+        entry = "src/main.hk"
+    "#;
+    let missing = ResolvedPackage::from_sources(
+        "embedded/example",
+        manifest,
+        &[("src/main.hk", "mod util;")],
+        PackageLimits::default(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(missing.contains("expected exactly one"), "{missing}");
+
+    let ambiguous = ResolvedPackage::from_sources(
+        "embedded/example",
+        manifest,
+        &[
+            ("src/main.hk", "mod util;"),
+            ("src/util.hk", "pub fn answer() {}"),
+            ("src/util/mod.hk", "pub fn answer() {}"),
+        ],
+        PackageLimits::default(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(ambiguous.contains("ambiguous"), "{ambiguous}");
+
+    let duplicate = ResolvedPackage::from_sources(
+        "embedded/example",
+        manifest,
+        &[
+            ("src/main.hk", "fn main() {}"),
+            ("src/main.hk", "fn other() {}"),
+        ],
+        PackageLimits::default(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        duplicate.contains("duplicate embedded source"),
+        "{duplicate}"
+    );
+
+    let duplicate_module = ResolvedPackage::from_sources(
+        "embedded/example",
+        manifest,
+        &[
+            ("src/main.hk", "mod util;\nmod util;"),
+            ("src/util.hk", "pub fn answer() {}"),
+        ],
+        PackageLimits::default(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        duplicate_module.contains("resolves as both"),
+        "{duplicate_module}"
+    );
+
+    let escaping = ResolvedPackage::from_sources(
+        "embedded/example",
+        manifest,
+        &[("../src/main.hk", "fn main() {}")],
+        PackageLimits::default(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        escaping.contains("must be a normalized relative path"),
+        "{escaping}"
+    );
+
+    let extension_manifest =
+        format!("{manifest}\n[extensions.regex]\npath = \"vendor/regex.huskext\"\n");
+    let extension = ResolvedPackage::from_sources(
+        "embedded/example",
+        &extension_manifest,
+        &[("src/main.hk", "fn main() {}")],
+        PackageLimits::default(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        extension.contains("embedded packages cannot declare extensions"),
+        "{extension}"
     );
 }
 

--- a/docs/HUSK_LANGUAGE_GUIDE.md
+++ b/docs/HUSK_LANGUAGE_GUIDE.md
@@ -138,8 +138,8 @@ Parser/tooling callers can separately use
 
 ## Local packages
 
-A package is filesystem-only. It has no registry, URL dependency, or version
-solver.
+CLI package loading is filesystem-only. It has no registry, URL dependency, or
+version solver.
 
 Example layout:
 
@@ -230,6 +230,30 @@ husk test --locked calculator
 ```
 
 `--locked` rejects a missing or changed lock file.
+
+Embedders can resolve a pure, multi-file package directly from bundled source
+strings without relying on a runtime filesystem layout:
+
+```rust
+use husk::{PackageLimits, ResolvedPackage};
+
+let package = ResolvedPackage::from_sources(
+    "embedded/calculator",
+    include_str!("../calculator/Husk.toml"),
+    &[
+        ("src/main.hk", include_str!("../calculator/src/main.hk")),
+        ("src/math.hk", include_str!("../calculator/src/math.hk")),
+    ],
+    PackageLimits::default(),
+)?;
+# drop(package);
+# Ok::<(), anyhow::Error>(())
+```
+
+The source paths are package-relative, use the same deterministic `mod`
+resolution and size limits as filesystem packages, and reject missing,
+ambiguous, duplicate, or escaping inputs. Embedded packages are pure: extension
+declarations are rejected.
 
 Crate-backed extensions are declarations rather than paths into generated
 state:

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -133,6 +133,14 @@ the Codex/proposal UI (`agent`). The
 [README plugin overview](../README.md#plugins-and-themes) is the concise
 capability inventory; the bundled `.hk` sources are working examples.
 
+The Git plugin keeps its event, picker, and permissioned-process shell in
+`plugins/git.hk`, while its status model, diff and hunk parsing, selection
+logic, and Git argument construction live in the native, multi-file
+`plugins/git_core` Husk package. Red embeds those pure sources and exposes a
+small internal bridge to the compatibility shell, so installed builds do not
+depend on a checkout-relative source path. The bridge is bundled-plugin
+implementation detail, not a public plugin API.
+
 `buffer:changed`, cursor, mode, viewport, file, theme, window, LSP, timer, picker, composer, panel, process, filesystem, workspace, and agent events are emitted by the production runtime. Subscribe only to the events a plugin needs and debounce expensive work.
 
 ## Validation
@@ -141,6 +149,7 @@ Run:
 
 ```shell
 cargo test --workspace
+cargo run -p husk-cli -- test --locked plugins/git_core
 cargo clippy --all-targets --all-features -- -D warnings
 cargo run -- --self-check
 cargo run -- --runtime-files

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -235,14 +235,7 @@ fn refresh() {
     }
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
-        args: [
-            "status",
-            "--porcelain=v2",
-            "--branch",
-            "--show-stash",
-            "-z",
-            "--untracked-files=all",
-        ],
+        args: red::git_core("status_args"),
         env: Json {
             GIT_PAGER: "cat",
             GIT_TERMINAL_PROMPT: "0",
@@ -507,20 +500,13 @@ fn operation_rank(kind: String) -> i32 {
 }
 
 fn spawn_sign_diff(buffers: Json, staged: bool) {
-    let args = ["-c", "core.quotePath=false", "diff"];
-    if staged {
-        args = red::push(args, "--cached");
-    }
-    args = red::push(args, "--no-ext-diff");
-    args = red::push(args, "--no-prefix");
-    args = red::push(args, "--unified=0");
-    args = red::push(args, "--");
+    let paths = [];
     for buffer in buffers {
-        args = red::push(args, buffer.path);
+        paths = red::push(paths, buffer.path);
     }
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
-        args: args,
+        args: red::git_core("sign_diff_args", staged, paths),
         raw_output: true,
         cwd: red::string(red::state("git_root"), "."),
     });
@@ -554,38 +540,8 @@ fn sign_diff_event(event: Json) {
 }
 
 fn signs_from_multi_patch(patch: String, buffers: Json, staged: bool) -> Json {
-    let hunks = [];
-    let buffer_index = -1;
-    let lines = red::split(patch, "\n");
-    let index = 0;
-    while index < red::len(lines) && index < 12000 && red::len(hunks) < 1000 {
-        let line = lines[index];
-        if red::starts_with(line, "diff --git ") {
-            buffer_index = sign_buffer_for_header(line, buffers);
-        } else if buffer_index >= 0 && red::starts_with(line, "@@ ") {
-            hunks = red::push(hunks, sign_hunk(line, buffer_index));
-        }
-        index = index + 1;
-    }
+    let hunks = red::git_core("sign_hunks", patch, buffers);
     return signs_from_hunks(hunks, staged);
-}
-
-fn sign_buffer_for_header(header: String, buffers: Json) -> i32 {
-    for buffer in buffers {
-        let path = red::string(buffer.path, "");
-        if header == "diff --git " + path + " " + path ||
-            header == "diff --git \"" + path + "\" \"" + path + "\"" {
-            return red::int(buffer.buffer_index, -1);
-        }
-    }
-    // Renames have distinct old/new names, so match the destination field.
-    for buffer in buffers {
-        let path = red::string(buffer.path, "");
-        if red::ends_with(header, " " + path) || red::ends_with(header, " \"" + path + "\"") {
-            return red::int(buffer.buffer_index, -1);
-        }
-    }
-    return -1;
 }
 
 fn sign_repository_path(path: String) -> String {
@@ -675,23 +631,6 @@ fn signs_from_hunks(hunks: Json, staged: bool) -> Json {
         index = index + 1;
     }
     return signs;
-}
-
-fn sign_hunk(line: String, buffer_index: i32) -> Json {
-    let fields = red::split(line, " ");
-    let old_range = red::split(red::slice(fields[1], 1), ",");
-    let new_range = red::split(red::slice(fields[2], 1), ",");
-    let old_count = 1;
-    let new_count = 1;
-    if red::len(old_range) > 1 { old_count = red::int(old_range[1], 1); }
-    if red::len(new_range) > 1 { new_count = red::int(new_range[1], 1); }
-    return SignHunk {
-        buffer_index: buffer_index,
-        old_start: red::int(old_range[0], 1),
-        old_count: old_count,
-        new_start: red::int(new_range[0], 1),
-        new_count: new_count,
-    };
 }
 
 fn hunk_kind(hunk: Json) -> String {
@@ -786,102 +725,7 @@ fn sign_style(kind: String, staged: bool) -> Json {
 }
 
 fn parse_status(output: String) -> Json {
-    let state = empty_state();
-    let records = red::split(output, red::char(0));
-    let index = 0;
-    let entries = 0;
-    while index < red::len(records) {
-        let record = records[index];
-        if red::starts_with(record, "# branch.oid ") {
-            state.oid = red::slice(record, 13);
-        } else if red::starts_with(record, "# branch.head ") {
-            state.head = red::slice(record, 14);
-        } else if red::starts_with(record, "# branch.upstream ") {
-            state.upstream = red::slice(record, 18);
-        } else if red::starts_with(record, "# branch.ab ") {
-            let parts = red::split(red::slice(record, 12), " ");
-            state.ahead = red::int(red::slice(parts[0], 1), 0);
-            state.behind = red::int(red::slice(parts[1], 1), 0);
-        } else if red::starts_with(record, "# stash ") {
-            state.stash_count = red::int(red::slice(record, 8), 0);
-        } else if red::starts_with(record, "? ") {
-            if entries >= 500 {
-                state.truncated = true;
-                return state;
-            }
-            state.untracked = red::push(state.untracked, GitEntry {
-                path: red::slice(record, 2),
-                x: "?",
-                y: "?",
-                kind: "untracked",
-            });
-            entries = entries + 1;
-        } else if red::starts_with(record, "u ") {
-            if entries >= 500 {
-                state.truncated = true;
-                return state;
-            }
-            let fields = red::split(record, " ");
-            state.conflicted = red::push(state.conflicted, GitEntry {
-                path: join_fields(fields, 10),
-                x: red::char_at(fields[1], 0),
-                y: red::char_at(fields[1], 1),
-                kind: "conflicted",
-            });
-            entries = entries + 1;
-        } else if red::starts_with(record, "1 ") || red::starts_with(record, "2 ") {
-            let fields = red::split(record, " ");
-            let xy = fields[1];
-            let path_index = 8;
-            let kind = "changed";
-            if red::starts_with(record, "2 ") {
-                path_index = 9;
-                kind = "renamed";
-            }
-            let entry = GitEntry {
-                path: join_fields(fields, path_index),
-                original_path: red::null(),
-                x: red::char_at(xy, 0),
-                y: red::char_at(xy, 1),
-                kind: kind,
-            };
-            if kind == "renamed" && index + 1 < red::len(records) {
-                entry.original_path = records[index + 1];
-                index = index + 1;
-            }
-            if entry.x != "." {
-                if entries >= 500 {
-                    state.truncated = true;
-                    return state;
-                }
-                state.staged = red::push(state.staged, entry);
-                entries = entries + 1;
-            }
-            if entry.y != "." {
-                if entries >= 500 {
-                    state.truncated = true;
-                    return state;
-                }
-                state.unstaged = red::push(state.unstaged, entry);
-                entries = entries + 1;
-            }
-        }
-        index = index + 1;
-    }
-    return state;
-}
-
-fn join_fields(fields: Json, start: i32) -> String {
-    let result = "";
-    let index = start;
-    while index < red::len(fields) {
-        if result != "" {
-            result = result + " ";
-        }
-        result = result + red::string(fields[index], "");
-        index = index + 1;
-    }
-    return result;
+    return red::git_core("parse_status", output);
 }
 
 fn render_dashboard() {
@@ -1171,14 +1015,6 @@ fn show_detail(row: Json, render_loading: bool) {
         if render_loading { render_dashboard(); }
         return;
     }
-    let args = ["diff"];
-    if row.data.section == "staged" {
-        args = red::push(args, "--cached");
-    }
-    args = red::push(args, "--no-ext-diff");
-    args = red::push(args, "--color=never");
-    args = red::push(args, "--");
-    args = red::push(args, row.data.path);
     let previous = red::string(red::state("git_detail_process"), "");
     if previous != "" {
         red::execute("KillProcess", previous);
@@ -1193,7 +1029,7 @@ fn show_detail(row: Json, render_loading: bool) {
     red::state_set("git_detail_section", row.data.section);
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
-        args: args,
+        args: red::git_core("detail_diff_args", row.data.section, row.data.path),
         raw_output: true,
         cwd: red::string(red::state("git_root"), "."),
     });
@@ -1246,98 +1082,7 @@ fn detail_event(event: Json) {
 }
 
 fn detail_document(output: String, path: String, section: String) -> Json {
-    let lines = [];
-    let old_line = 0;
-    let new_line = 0;
-    let hunk_index = 0;
-    let hunk_id = red::null();
-    let patch_index = 0;
-    for raw in red::split(output, "\n") {
-        if patch_index >= 1000 {
-            return WorkspaceDocument { path: path, lines: lines };
-        }
-        if red::starts_with(raw, "@@ ") {
-            hunk_index = hunk_index + 1;
-            hunk_id = path + ":" + hunk_index;
-            let fields = red::split(raw, " ");
-            old_line = diff_range_start(fields[1]);
-            new_line = diff_range_start(fields[2]);
-            lines = red::push(lines, WorkspaceDocumentLine {
-                id: hunk_id + ":header",
-                text: raw,
-                kind: "hunk",
-                hunk_id: hunk_id,
-                data: Json {
-                    path: path,
-                    section: section,
-                    patch_index: patch_index,
-                    hunk_id: hunk_id,
-                },
-            });
-        } else if red::starts_with(raw, "+") && !red::starts_with(raw, "+++") {
-            lines = red::push(lines, diff_document_line(
-                raw, "added", red::null(), new_line, path, section, hunk_id, patch_index
-            ));
-            new_line = new_line + 1;
-        } else if red::starts_with(raw, "-") && !red::starts_with(raw, "---") {
-            lines = red::push(lines, diff_document_line(
-                raw, "removed", old_line, red::null(), path, section, hunk_id, patch_index
-            ));
-            old_line = old_line + 1;
-        } else if red::starts_with(raw, " ") && hunk_id != red::null() {
-            lines = red::push(lines, diff_document_line(
-                raw, "context", old_line, new_line, path, section, hunk_id, patch_index
-            ));
-            old_line = old_line + 1;
-            new_line = new_line + 1;
-        } else {
-            lines = red::push(lines, WorkspaceDocumentLine {
-                id: path + ":meta:" + patch_index,
-                text: raw,
-                kind: "meta",
-                hunk_id: hunk_id,
-                data: Json {
-                    path: path,
-                    section: section,
-                    patch_index: patch_index,
-                    hunk_id: hunk_id,
-                },
-            });
-        }
-        patch_index = patch_index + 1;
-    }
-    return WorkspaceDocument { path: path, lines: lines };
-}
-
-fn diff_range_start(field: String) -> i32 {
-    let range = red::split(red::slice(field, 1), ",");
-    return red::int(range[0], 0);
-}
-
-fn diff_document_line(
-    raw: String,
-    kind: String,
-    old_line: Json,
-    new_line: Json,
-    path: String,
-    section: String,
-    hunk_id: Json,
-    patch_index: i32
-) -> Json {
-    return WorkspaceDocumentLine {
-        id: path + ":" + patch_index,
-        text: red::slice(raw, 1),
-        kind: kind,
-        old_line: old_line,
-        new_line: new_line,
-        hunk_id: hunk_id,
-        data: Json {
-            path: path,
-            section: section,
-            patch_index: patch_index,
-            hunk_id: hunk_id,
-        },
-    };
+    return red::git_core("detail_document", output, path, section);
 }
 
 fn detail_lines(output: String) -> Json {
@@ -1447,145 +1192,12 @@ fn run_detail_action(event: Json) {
 }
 
 fn patch_for_dashboard_hunk(patch: String, selected_id: String) -> String {
-    if selected_id == "" {
-        return "";
-    }
-    let header = [];
-    let selected = [];
-    let current = [];
-    let hunk_index = 0;
     let path = red::string(red::state("git_detail_path"), "");
-    for line in red::split(patch, "\n") {
-        if red::starts_with(line, "@@ ") {
-            if red::len(current) > 0 && path + ":" + hunk_index == selected_id {
-                selected = current;
-            }
-            hunk_index = hunk_index + 1;
-            current = [line];
-        } else if red::len(current) > 0 {
-            current = red::push(current, line);
-        } else {
-            header = red::push(header, line);
-        }
-    }
-    if red::len(current) > 0 && path + ":" + hunk_index == selected_id {
-        selected = current;
-    }
-    if red::len(selected) == 0 {
-        return "";
-    }
-    for line in selected {
-        header = red::push(header, line);
-    }
-    return red::join(header, "\n");
+    return red::string(red::git_core("dashboard_hunk", patch, path, selected_id), "");
 }
 
 fn patch_for_dashboard_range(patch: String, start_index: i32, end_index: i32) -> String {
-    let first = start_index;
-    let last = end_index;
-    if last < first {
-        let swap = first;
-        first = last;
-        last = swap;
-    }
-    let common_header = [];
-    let selected_hunks = [];
-    let current = [];
-    let current_start = 0;
-    let old_start = 0;
-    let new_start = 0;
-    let patch_index = 0;
-    for line in red::split(patch, "\n") {
-        if red::starts_with(line, "@@ ") {
-            if red::len(current) > 0 {
-                let selected = dashboard_selected_hunk(
-                    current, current_start, old_start, new_start, first, last
-                );
-                if selected != "" {
-                    selected_hunks = red::push(selected_hunks, selected);
-                }
-            }
-            current = [line];
-            current_start = patch_index;
-            let fields = red::split(line, " ");
-            old_start = range_start(fields[1]);
-            new_start = range_start(fields[2]);
-        } else if red::len(current) > 0 {
-            current = red::push(current, line);
-        } else {
-            common_header = red::push(common_header, line);
-        }
-        patch_index = patch_index + 1;
-    }
-    if red::len(current) > 0 {
-        let selected = dashboard_selected_hunk(
-            current, current_start, old_start, new_start, first, last
-        );
-        if selected != "" {
-            selected_hunks = red::push(selected_hunks, selected);
-        }
-    }
-    if red::len(selected_hunks) == 0 {
-        return "";
-    }
-    let result = red::join(common_header, "\n");
-    for hunk in selected_hunks {
-        if result != "" { result = result + "\n"; }
-        result = result + hunk;
-    }
-    return result;
-}
-
-fn dashboard_selected_hunk(
-    lines: Json,
-    patch_start: i32,
-    old_start: i32,
-    new_start: i32,
-    selected_start: i32,
-    selected_end: i32
-) -> String {
-    let output = [];
-    let has_change = false;
-    let index = 1;
-    while index < red::len(lines) {
-        let line = red::string(lines[index], "");
-        let global_index = patch_start + index;
-        if red::starts_with(line, "+") {
-            if global_index >= selected_start && global_index <= selected_end {
-                output = red::push(output, line);
-                has_change = true;
-            }
-        } else if red::starts_with(line, "-") {
-            if global_index >= selected_start && global_index <= selected_end {
-                output = red::push(output, line);
-                has_change = true;
-            } else {
-                output = red::push(output, " " + red::slice(line, 1));
-            }
-        } else {
-            output = red::push(output, line);
-        }
-        index = index + 1;
-    }
-    if !has_change {
-        return "";
-    }
-    let old_count = 0;
-    let new_count = 0;
-    for line in output {
-        let text = red::string(line, "");
-        if red::starts_with(text, " ") || red::starts_with(text, "-") {
-            old_count = old_count + 1;
-        }
-        if red::starts_with(text, " ") || red::starts_with(text, "+") {
-            new_count = new_count + 1;
-        }
-    }
-    let result = "@@ -" + old_start + "," + old_count + " +" + new_start + "," + new_count + " @@";
-    for line in output {
-        result = result + "\n" + red::string(line, "");
-    }
-    return result;
+    return red::string(red::git_core("dashboard_range", patch, start_index, end_index), "");
 }
 
 fn confirm_git(title: String, impact: String, args: Json) {
@@ -2536,20 +2148,9 @@ fn finish_commit_scratch(submit: bool, text: String) {
 }
 
 fn run_commit(mode: String, message: String) {
-    let args = ["commit"];
-    if mode == "amend" || mode == "--amend" {
-        args = red::push(args, "--amend");
-    }
-    if mode == "--amend" {
-        args = red::push(args, "--no-edit");
-    } else {
-        args = red::push(args, "--cleanup=strip");
-        args = red::push(args, "-F");
-        args = red::push(args, "-");
-    }
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
-        args: args,
+        args: red::git_core("commit_args", mode),
         stdin: message + "\n",
         cwd: red::string(red::state("git_root"), "."),
     });
@@ -2617,21 +2218,13 @@ fn hunk_buffer_text(event: Json) {
 fn spawn_hunk_diff(action: String) {
     red::state_set("git_hunk_unsaved", false);
     red::state_set("git_hunk_patch", "");
-    let args = ["diff"];
-    if action == "unstage" {
-        args = red::push(args, "--cached");
-    }
-    args = red::push(args, "--no-ext-diff");
-    if action == "next" || action == "previous" {
-        args = red::push(args, "--unified=0");
-    } else {
-        args = red::push(args, "--unified=3");
-    }
-    args = red::push(args, "--");
-    args = red::push(args, red::string(red::state("git_hunk_path"), ""));
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
-        args: args,
+        args: red::git_core(
+            "hunk_diff_args",
+            action,
+            red::string(red::state("git_hunk_path"), "")
+        ),
         raw_output: true,
         cwd: red::string(red::state("git_root"), "."),
     });
@@ -2664,19 +2257,7 @@ fn hunk_diff_event(event: Json) {
 }
 
 fn normalize_unsaved_patch(patch: String, path: String) -> String {
-    let lines = [];
-    for line in red::split(patch, "\n") {
-        let normalized = line;
-        if red::starts_with(line, "diff --git ") {
-            normalized = "diff --git a/" + path + " b/" + path;
-        } else if red::starts_with(line, "--- ") {
-            normalized = "--- a/" + path;
-        } else if red::starts_with(line, "+++ ") {
-            normalized = "+++ b/" + path;
-        }
-        lines = red::push(lines, normalized);
-    }
-    return red::join(lines, "\n");
+    return red::string(red::git_core("normalize_unsaved", patch, path), "");
 }
 
 fn hunk_selection_loaded(selection: Json) {
@@ -2764,180 +2345,15 @@ fn print_hunk_boundary(forward: bool) {
 }
 
 fn hunk_starts(patch: String) -> Json {
-    let starts = [];
-    for line in red::split(patch, "\n") {
-        if red::starts_with(line, "@@ ") {
-            starts = red::push(starts, hunk_start(line));
-        }
-    }
-    return starts;
-}
-
-fn hunk_start(header: String) -> i32 {
-    let fields = red::split(header, " ");
-    let plus = fields[2];
-    let range = red::split(red::slice(plus, 1), ",");
-    return red::int(range[0], 1) - 1;
+    return red::git_core("hunk_starts", patch);
 }
 
 fn patch_for_hunk(patch: String, cursor_line: i32) -> String {
-    let header = [];
-    let selected = [];
-    let current = [];
-    let current_start = -1;
-    let current_end = -1;
-    for line in red::split(patch, "\n") {
-        if red::starts_with(line, "@@ ") {
-            if current_start >= 0 && cursor_line >= current_start && cursor_line <= current_end {
-                selected = current;
-            }
-            current = [line];
-            current_start = hunk_start(line);
-            let fields = red::split(line, " ");
-            let range = red::split(red::slice(fields[2], 1), ",");
-            let count = 1;
-            if red::len(range) > 1 {
-                count = red::int(range[1], 1);
-            }
-            current_end = current_start + count - 1;
-        } else if current_start >= 0 {
-            current = red::push(current, line);
-        } else {
-            header = red::push(header, line);
-        }
-    }
-    if current_start >= 0 && cursor_line >= current_start && cursor_line <= current_end {
-        selected = current;
-    }
-    if red::len(selected) == 0 {
-        return "";
-    }
-    for line in selected {
-        header = red::push(header, line);
-    }
-    return red::join(header, "\n");
+    return red::string(red::git_core("editor_hunk", patch, cursor_line), "");
 }
 
 fn patch_for_line_range(patch: String, start_line: i32, end_line: i32) -> String {
-    let common_header = [];
-    let selected_hunks = [];
-    let current = [];
-    let old_start = 0;
-    let new_start = 0;
-    for line in red::split(patch, "\n") {
-        if red::starts_with(line, "@@ ") {
-            if red::len(current) > 0 {
-                let selected = selected_hunk(current, old_start, new_start, start_line, end_line);
-                if selected != "" {
-                    selected_hunks = red::push(selected_hunks, selected);
-                }
-            }
-            current = [line];
-            let fields = red::split(line, " ");
-            old_start = range_start(fields[1]);
-            new_start = range_start(fields[2]);
-        } else if red::len(current) > 0 {
-            current = red::push(current, line);
-        } else {
-            common_header = red::push(common_header, line);
-        }
-    }
-    if red::len(current) > 0 {
-        let selected = selected_hunk(current, old_start, new_start, start_line, end_line);
-        if selected != "" {
-            selected_hunks = red::push(selected_hunks, selected);
-        }
-    }
-    if red::len(selected_hunks) == 0 {
-        return "";
-    }
-    let result = red::join(common_header, "\n");
-    for hunk in selected_hunks {
-        if result != "" {
-            result = result + "\n";
-        }
-        result = result + hunk;
-    }
-    return result;
-}
-
-fn range_start(field: String) -> i32 {
-    let range = red::split(red::slice(field, 1), ",");
-    return red::int(range[0], 1);
-}
-
-fn selected_hunk(lines: Json, old_start: i32, new_start: i32, start_line: i32, end_line: i32) -> String {
-    let output = [];
-    let new_line = new_start - 1;
-    let index = 1;
-    while index < red::len(lines) {
-        let line = red::string(lines[index], "");
-        if !red::starts_with(line, "+") && !red::starts_with(line, "-") {
-            output = red::push(output, line);
-            if red::starts_with(line, " ") {
-                new_line = new_line + 1;
-            }
-            index = index + 1;
-            continue;
-        }
-        let removed = [];
-        while index < red::len(lines) && red::starts_with(red::string(lines[index], ""), "-") {
-            removed = red::push(removed, lines[index]);
-            index = index + 1;
-        }
-        let addition_start = new_line;
-        let added = [];
-        while index < red::len(lines) && red::starts_with(red::string(lines[index], ""), "+") {
-            added = red::push(added, lines[index]);
-            new_line = new_line + 1;
-            index = index + 1;
-        }
-        let addition_end = addition_start;
-        if red::len(added) > 0 {
-            addition_end = addition_start + red::len(added) - 1;
-        }
-        let selected = false;
-        if red::len(added) > 0 {
-            selected = addition_start <= end_line && addition_end >= start_line;
-        } else {
-            selected = addition_start >= start_line && addition_start <= end_line + 1;
-        }
-        if selected {
-            for removed_line in removed {
-                output = red::push(output, removed_line);
-            }
-            for added_line in added {
-                output = red::push(output, added_line);
-            }
-        } else {
-            for removed_line in removed {
-                output = red::push(output, " " + red::slice(red::string(removed_line, ""), 1));
-            }
-        }
-    }
-    let has_change = false;
-    let old_count = 0;
-    let new_count = 0;
-    for line in output {
-        let text = red::string(line, "");
-        if red::starts_with(text, "+") || red::starts_with(text, "-") {
-            has_change = true;
-        }
-        if red::starts_with(text, " ") || red::starts_with(text, "-") {
-            old_count = old_count + 1;
-        }
-        if red::starts_with(text, " ") || red::starts_with(text, "+") {
-            new_count = new_count + 1;
-        }
-    }
-    if !has_change {
-        return "";
-    }
-    let result = "@@ -" + old_start + "," + old_count + " +" + new_start + "," + new_count + " @@";
-    for line in output {
-        result = result + "\n" + red::string(line, "");
-    }
-    return result;
+    return red::string(red::git_core("editor_range", patch, start_line, end_line), "");
 }
 
 fn apply_hunk(action: String, patch: String) {
@@ -2960,16 +2376,7 @@ fn apply_hunk(action: String, patch: String) {
 }
 
 fn apply_hunk_args(action: String) -> Json {
-    let args = ["apply"];
-    if action == "stage" || action == "unstage" {
-        args = red::push(args, "--cached");
-    }
-    if action == "unstage" || action == "reset" {
-        args = red::push(args, "--reverse");
-    }
-    args = red::push(args, "--unidiff-zero");
-    args = red::push(args, "-");
-    return args;
+    return red::git_core("apply_hunk_args", action);
 }
 
 fn apply_hunk_check_finished(event: Json) {

--- a/plugins/git_core/Husk.lock
+++ b/plugins/git_core/Husk.lock
@@ -1,0 +1,5 @@
+schema_version = 1
+
+[package]
+name = "red-git-core"
+version = "0.1.0"

--- a/plugins/git_core/Husk.toml
+++ b/plugins/git_core/Husk.toml
@@ -1,0 +1,6 @@
+schema_version = 1
+
+[package]
+name = "red-git-core"
+version = "0.1.0"
+entry = "src/main.hk"

--- a/plugins/git_core/src/commands.hk
+++ b/plugins/git_core/src/commands.hk
@@ -1,0 +1,187 @@
+// Typed command construction for operations where an invalid combination can
+// change repository history or the working tree.
+
+enum ApplyTarget {
+    Stage,
+    Unstage,
+    Reset,
+}
+
+enum DiffTarget {
+    Worktree,
+    Index,
+}
+
+enum HunkView {
+    Navigation,
+    Selection,
+}
+
+enum CommitMode {
+    Create,
+    Amend,
+    AmendNoEdit,
+}
+
+pub fn status_args() -> [String] {
+    [
+        "status",
+        "--porcelain=v2",
+        "--branch",
+        "--show-stash",
+        "-z",
+        "--untracked-files=all",
+    ]
+}
+
+pub fn sign_diff_args(staged: bool, paths: [String]) -> [String] {
+    let mut args = ["-c", "core.quotePath=false", "diff"];
+    if staged {
+        args.push("--cached");
+    }
+    args.push("--no-ext-diff");
+    args.push("--no-prefix");
+    args.push("--unified=0");
+    args.push("--");
+    for path in paths {
+        args.push(path);
+    }
+    args
+}
+
+pub fn detail_diff_args(section: String, path: String) -> [String] {
+    let target = diff_target(section);
+    let mut args = ["diff"];
+    match target {
+        DiffTarget::Index => args.push("--cached"),
+        DiffTarget::Worktree => {},
+    };
+    args.push("--no-ext-diff");
+    args.push("--color=never");
+    args.push("--");
+    args.push(path);
+    args
+}
+
+pub fn hunk_diff_args(action: String, path: String) -> [String] {
+    let target = diff_target(action);
+    let view = hunk_view(action);
+    let mut args = ["diff"];
+    match target {
+        DiffTarget::Index => args.push("--cached"),
+        DiffTarget::Worktree => {},
+    };
+    args.push("--no-ext-diff");
+    match view {
+        HunkView::Navigation => args.push("--unified=0"),
+        HunkView::Selection => args.push("--unified=3"),
+    };
+    args.push("--");
+    args.push(path);
+    args
+}
+
+pub fn commit_args(mode: String) -> [String] {
+    let mode = commit_mode(mode);
+    let mut args = ["commit"];
+    let mut no_edit = false;
+    match mode {
+        CommitMode::Create => {},
+        CommitMode::Amend => args.push("--amend"),
+        CommitMode::AmendNoEdit => {
+            args.push("--amend");
+            args.push("--no-edit");
+            no_edit = true;
+        },
+    };
+    if no_edit {
+        return args;
+    }
+    args.push("--cleanup=strip");
+    args.push("-F");
+    args.push("-");
+    args
+}
+
+pub fn apply_hunk_args(action: String) -> [String] {
+    if action != "stage" && action != "unstage" && action != "reset" {
+        return [];
+    }
+    let target = apply_target(action);
+    let mut args = ["apply"];
+
+    match target {
+        ApplyTarget::Stage => args.push("--cached"),
+        ApplyTarget::Unstage => {
+            args.push("--cached");
+            args.push("--reverse");
+        },
+        ApplyTarget::Reset => args.push("--reverse"),
+    };
+    args.push("--unidiff-zero");
+    args.push("-");
+    args
+}
+
+fn apply_target(action: String) -> ApplyTarget {
+    if action == "stage" {
+        return ApplyTarget::Stage;
+    }
+    if action == "unstage" {
+        return ApplyTarget::Unstage;
+    }
+    if action == "reset" {
+        return ApplyTarget::Reset;
+    }
+    ApplyTarget::Reset
+}
+
+fn diff_target(value: String) -> DiffTarget {
+    if value == "staged" || value == "unstage" {
+        return DiffTarget::Index;
+    }
+    DiffTarget::Worktree
+}
+
+fn hunk_view(action: String) -> HunkView {
+    if action == "next" || action == "previous" {
+        return HunkView::Navigation;
+    }
+    HunkView::Selection
+}
+
+fn commit_mode(mode: String) -> CommitMode {
+    if mode == "--amend" {
+        return CommitMode::AmendNoEdit;
+    }
+    if mode == "amend" {
+        return CommitMode::Amend;
+    }
+    CommitMode::Create
+}
+
+#[test]
+fn builds_explicit_apply_modes() {
+    assert(apply_hunk_args("stage").join(" ") == "apply --cached --unidiff-zero -");
+    assert(apply_hunk_args("unstage").join(" ") == "apply --cached --reverse --unidiff-zero -");
+    assert(apply_hunk_args("reset").join(" ") == "apply --reverse --unidiff-zero -");
+    assert(apply_hunk_args("unknown").len() == 0);
+}
+
+#[test]
+fn builds_bounded_noninteractive_status_and_diff_commands() {
+    assert(status_args().join(" ") == "status --porcelain=v2 --branch --show-stash -z --untracked-files=all");
+    assert(sign_diff_args(false, ["src/a.rs"]).join(" ") == "-c core.quotePath=false diff --no-ext-diff --no-prefix --unified=0 -- src/a.rs");
+    assert(sign_diff_args(true, ["src/a.rs", "src/b.rs"]).join(" ") == "-c core.quotePath=false diff --cached --no-ext-diff --no-prefix --unified=0 -- src/a.rs src/b.rs");
+    assert(detail_diff_args("staged", "src/a.rs").join(" ") == "diff --cached --no-ext-diff --color=never -- src/a.rs");
+    assert(detail_diff_args("unstaged", "src/a.rs").join(" ") == "diff --no-ext-diff --color=never -- src/a.rs");
+}
+
+#[test]
+fn builds_navigation_selection_and_commit_modes_explicitly() {
+    assert(hunk_diff_args("next", "src/a.rs").join(" ") == "diff --no-ext-diff --unified=0 -- src/a.rs");
+    assert(hunk_diff_args("unstage", "src/a.rs").join(" ") == "diff --cached --no-ext-diff --unified=3 -- src/a.rs");
+    assert(commit_args("create").join(" ") == "commit --cleanup=strip -F -");
+    assert(commit_args("amend").join(" ") == "commit --amend --cleanup=strip -F -");
+    assert(commit_args("--amend").join(" ") == "commit --amend --no-edit");
+}

--- a/plugins/git_core/src/main.hk
+++ b/plugins/git_core/src/main.hk
@@ -1,0 +1,3 @@
+mod commands;
+mod patch;
+mod status;

--- a/plugins/git_core/src/patch.hk
+++ b/plugins/git_core/src/patch.hk
@@ -1,0 +1,713 @@
+// One typed unified-diff model feeds signs, workspace detail, hunk navigation,
+// and line/hunk selection. Raw text is retained so metadata and uncommon diff
+// lines round-trip without loss.
+
+pub enum DiffLineKind {
+    Context,
+    Added,
+    Removed,
+    NoNewlineMarker,
+    Metadata,
+}
+
+pub struct DiffLine {
+    raw: String,
+    kind: DiffLineKind,
+    patch_index: i32,
+}
+
+pub struct LineRange {
+    start: i32,
+    count: i32,
+}
+
+pub struct Hunk {
+    header: String,
+    old: LineRange,
+    new: LineRange,
+    patch_index: i32,
+    lines: [DiffLine],
+}
+
+pub struct FilePatch {
+    header: [String],
+    hunks: [Hunk],
+}
+
+pub struct Patch {
+    prefix: [String],
+    files: [FilePatch],
+}
+
+pub struct SignBuffer {
+    path: String,
+    buffer_index: i32,
+}
+
+pub struct SignHunk {
+    buffer_index: i32,
+    old_start: i32,
+    old_count: i32,
+    new_start: i32,
+    new_count: i32,
+}
+
+pub struct WorkspaceLineData {
+    path: String,
+    section: String,
+    patch_index: i32,
+    hunk_id: Option<String>,
+}
+
+pub struct WorkspaceDocumentLine {
+    id: String,
+    text: String,
+    kind: String,
+    old_line: Option<i32>,
+    new_line: Option<i32>,
+    hunk_id: Option<String>,
+    data: WorkspaceLineData,
+}
+
+pub struct WorkspaceDocument {
+    path: String,
+    lines: [WorkspaceDocumentLine],
+}
+
+fn parse_patch(text: String) -> Patch {
+    let mut prefix = [];
+    let mut files = [];
+    let mut header = [];
+    let mut hunks = [];
+    let mut hunk_header = "";
+    let mut hunk_lines = [];
+    let mut old = LineRange { start: 0, count: 0 };
+    let mut new = LineRange { start: 0, count: 0 };
+    let mut hunk_index = 0;
+    let mut in_file = false;
+    let mut index = 0;
+
+    for raw in text.split("\n") {
+        if index >= 12000 {
+            break;
+        }
+        if raw.starts_with("diff --git ") {
+            if hunk_header != "" {
+                hunks.push(Hunk {
+                    header: hunk_header,
+                    old: old,
+                    new: new,
+                    patch_index: hunk_index,
+                    lines: hunk_lines,
+                });
+                hunk_header = "";
+                hunk_lines = [];
+            }
+            if in_file {
+                files.push(FilePatch { header: header, hunks: hunks });
+                header = [];
+                hunks = [];
+            }
+            in_file = true;
+            header.push(raw);
+        } else if raw.starts_with("@@ ") {
+            if hunk_header != "" {
+                hunks.push(Hunk {
+                    header: hunk_header,
+                    old: old,
+                    new: new,
+                    patch_index: hunk_index,
+                    lines: hunk_lines,
+                });
+                hunk_lines = [];
+            }
+            if !in_file {
+                in_file = true;
+                header = prefix;
+                prefix = [];
+            }
+            let ranges = hunk_ranges(raw);
+            old = ranges.0;
+            new = ranges.1;
+            hunk_header = raw;
+            hunk_index = index;
+        } else if hunk_header != "" {
+            hunk_lines.push(DiffLine {
+                raw: raw,
+                kind: line_kind(raw),
+                patch_index: index,
+            });
+        } else if in_file {
+            header.push(raw);
+        } else {
+            prefix.push(raw);
+        }
+        index += 1;
+    }
+
+    if hunk_header != "" {
+        hunks.push(Hunk {
+            header: hunk_header,
+            old: old,
+            new: new,
+            patch_index: hunk_index,
+            lines: hunk_lines,
+        });
+    }
+    if in_file {
+        files.push(FilePatch { header: header, hunks: hunks });
+    }
+    Patch { prefix: prefix, files: files }
+}
+
+fn hunk_ranges(header: String) -> (LineRange, LineRange) {
+    let fields = header.split(" ");
+    if fields.len() < 3 {
+        return (LineRange { start: 0, count: 0 }, LineRange { start: 0, count: 0 });
+    }
+    (parse_range(fields[1]), parse_range(fields[2]))
+}
+
+fn parse_range(field: String) -> LineRange {
+    if field.len() < 2 {
+        return LineRange { start: 0, count: 0 };
+    }
+    let fields = field.slice(1, field.len()).split(",");
+    let start = parse_number(fields[0]);
+    let mut count = 1;
+    if fields.len() > 1 {
+        count = parse_number(fields[1]);
+    }
+    LineRange { start: start, count: count }
+}
+
+fn parse_number(value: String) -> i32 {
+    let mut result = 0;
+    for character in value {
+        if character >= "0" && character <= "9" {
+            let value = digit(character);
+            if result > 214748364 || (result == 214748364 && value > 7) {
+                return 2147483647;
+            }
+            result = result * 10 + value;
+        }
+    }
+    result
+}
+
+fn digit(value: String) -> i32 {
+    if value == "0" { return 0; }
+    if value == "1" { return 1; }
+    if value == "2" { return 2; }
+    if value == "3" { return 3; }
+    if value == "4" { return 4; }
+    if value == "5" { return 5; }
+    if value == "6" { return 6; }
+    if value == "7" { return 7; }
+    if value == "8" { return 8; }
+    9
+}
+
+fn line_kind(raw: String) -> DiffLineKind {
+    if raw.starts_with("+") && !raw.starts_with("+++") {
+        return DiffLineKind::Added;
+    }
+    if raw.starts_with("-") && !raw.starts_with("---") {
+        return DiffLineKind::Removed;
+    }
+    if raw.starts_with(" ") {
+        return DiffLineKind::Context;
+    }
+    if raw.starts_with("\\ No newline at end of file") {
+        return DiffLineKind::NoNewlineMarker;
+    }
+    DiffLineKind::Metadata
+}
+
+pub fn sign_hunks(text: String, buffers: [SignBuffer]) -> [SignHunk] {
+    let patch = parse_patch(text);
+    let mut result = [];
+
+    for file in patch.files {
+        if result.len() >= 1000 {
+            break;
+        }
+        if file.header.len() == 0 {
+            continue;
+        }
+        let buffer_index = buffer_for_header(file.header[0], buffers);
+        if buffer_index < 0 {
+            continue;
+        }
+        for hunk in file.hunks {
+            if result.len() >= 1000 {
+                break;
+            }
+            result.push(SignHunk {
+                buffer_index: buffer_index,
+                old_start: hunk.old.start,
+                old_count: hunk.old.count,
+                new_start: hunk.new.start,
+                new_count: hunk.new.count,
+            });
+        }
+    }
+    result
+}
+
+fn buffer_for_header(header: String, buffers: [SignBuffer]) -> i32 {
+    for buffer in buffers {
+        let path = buffer.path;
+        if header == "diff --git " + path + " " + path ||
+            header == "diff --git \"" + path + "\" \"" + path + "\"" {
+            return buffer.buffer_index;
+        }
+    }
+    for buffer in buffers {
+        let path = buffer.path;
+        if header.ends_with(" " + path) || header.ends_with(" \"" + path + "\"") {
+            return buffer.buffer_index;
+        }
+    }
+    -1
+}
+
+pub fn detail_document(text: String, path: String, section: String) -> WorkspaceDocument {
+    let patch = parse_patch(text);
+    let mut lines = [];
+    let mut hunk_number = 0;
+
+    for raw in patch.prefix {
+        if lines.len() >= 1000 { break; }
+        lines.push(document_meta(raw, path, section, lines.len()));
+    }
+    for file in patch.files {
+        for raw in file.header {
+            if lines.len() >= 1000 { break; }
+            lines.push(document_meta(raw, path, section, lines.len()));
+        }
+        for hunk in file.hunks {
+            if lines.len() >= 1000 { break; }
+            hunk_number += 1;
+            let hunk_id = path + ":" + hunk_number;
+            let header_data = WorkspaceLineData {
+                path: path,
+                section: section,
+                patch_index: hunk.patch_index,
+                hunk_id: Some(hunk_id),
+            };
+            lines.push(WorkspaceDocumentLine {
+                id: hunk_id + ":header",
+                text: hunk.header,
+                kind: "hunk",
+                old_line: None,
+                new_line: None,
+                hunk_id: Some(hunk_id),
+                data: header_data,
+            });
+            let mut old_line = hunk.old.start;
+            let mut new_line = hunk.new.start;
+            for line in hunk.lines {
+                if lines.len() >= 1000 { break; }
+                let mut kind = "meta";
+                let mut text = line.raw;
+                let mut old_value = None;
+                let mut new_value = None;
+                match line.kind {
+                    DiffLineKind::Added => {
+                        kind = "added";
+                        text = line.raw.slice(1, line.raw.len());
+                        new_value = Some(new_line);
+                        new_line += 1;
+                    },
+                    DiffLineKind::Removed => {
+                        kind = "removed";
+                        text = line.raw.slice(1, line.raw.len());
+                        old_value = Some(old_line);
+                        old_line += 1;
+                    },
+                    DiffLineKind::Context => {
+                        kind = "context";
+                        text = line.raw.slice(1, line.raw.len());
+                        old_value = Some(old_line);
+                        new_value = Some(new_line);
+                        old_line += 1;
+                        new_line += 1;
+                    },
+                    DiffLineKind::NoNewlineMarker => {},
+                    DiffLineKind::Metadata => {},
+                };
+                lines.push(WorkspaceDocumentLine {
+                    id: path + ":" + line.patch_index,
+                    text: text,
+                    kind: kind,
+                    old_line: old_value,
+                    new_line: new_value,
+                    hunk_id: Some(hunk_id),
+                    data: WorkspaceLineData {
+                        path: path,
+                        section: section,
+                        patch_index: line.patch_index,
+                        hunk_id: Some(hunk_id),
+                    },
+                });
+            }
+        }
+    }
+    WorkspaceDocument { path: path, lines: lines }
+}
+
+fn document_meta(raw: String, path: String, section: String, index: i32) -> WorkspaceDocumentLine {
+    WorkspaceDocumentLine {
+        id: path + ":meta:" + index,
+        text: raw,
+        kind: "meta",
+        old_line: None,
+        new_line: None,
+        hunk_id: None,
+        data: WorkspaceLineData {
+            path: path,
+            section: section,
+            patch_index: index,
+            hunk_id: None,
+        },
+    }
+}
+
+pub fn dashboard_hunk(text: String, path: String, selected_id: String) -> String {
+    if selected_id == "" {
+        return "";
+    }
+    let patch = parse_patch(text);
+    let mut hunk_number = 0;
+    let mut output = patch.prefix;
+
+    for file in patch.files {
+        for raw in file.header {
+            output.push(raw);
+        }
+        for hunk in file.hunks {
+            hunk_number += 1;
+            if path + ":" + hunk_number == selected_id {
+                output.push(hunk.header);
+                for line in hunk.lines {
+                    output.push(line.raw);
+                }
+                return output.join("\n");
+            }
+        }
+    }
+    ""
+}
+
+pub fn dashboard_range(text: String, start_index: i32, end_index: i32) -> String {
+    let mut first = start_index;
+    let mut last = end_index;
+    if last < first {
+        let swap = first;
+        first = last;
+        last = swap;
+    }
+    let patch = parse_patch(text);
+    let mut output = patch.prefix;
+    let mut found = false;
+
+    for file in patch.files {
+        let mut selected = [];
+        for hunk in file.hunks {
+            let selection = dashboard_selected_hunk(hunk, first, last);
+            if selection != "" {
+                selected.push(selection);
+            }
+        }
+        if selected.len() > 0 {
+            found = true;
+            for raw in file.header {
+                output.push(raw);
+            }
+            for hunk in selected {
+                output.push(hunk);
+            }
+        }
+    }
+    if !found {
+        return "";
+    }
+    output.join("\n")
+}
+
+fn dashboard_selected_hunk(hunk: Hunk, first: i32, last: i32) -> String {
+    let mut output = [];
+    let mut changed = false;
+    for line in hunk.lines {
+        let selected = line.patch_index >= first && line.patch_index <= last;
+        match line.kind {
+            DiffLineKind::Added => {
+                if selected {
+                    output.push(line.raw);
+                    changed = true;
+                }
+            },
+            DiffLineKind::Removed => {
+                if selected {
+                    output.push(line.raw);
+                    changed = true;
+                } else {
+                    output.push(" " + line.raw.slice(1, line.raw.len()));
+                }
+            },
+            DiffLineKind::Context => {
+                output.push(line.raw);
+            },
+            DiffLineKind::NoNewlineMarker => {
+                output.push(line.raw);
+            },
+            DiffLineKind::Metadata => {
+                output.push(line.raw);
+            },
+        };
+    }
+    if !changed {
+        return "";
+    }
+    serialize_selected_hunk(hunk.old.start, hunk.new.start, output)
+}
+
+pub fn hunk_starts(text: String) -> [i32] {
+    let patch = parse_patch(text);
+    let mut starts = [];
+    for file in patch.files {
+        for hunk in file.hunks {
+            starts.push(hunk.new.start - 1);
+        }
+    }
+    starts
+}
+
+pub fn editor_hunk(text: String, cursor_line: i32) -> String {
+    let patch = parse_patch(text);
+    let mut output = patch.prefix;
+    for file in patch.files {
+        for raw in file.header {
+            output.push(raw);
+        }
+        for hunk in file.hunks {
+            let start = hunk.new.start - 1;
+            let end = start + hunk.new.count - 1;
+            if cursor_line >= start && cursor_line <= end {
+                output.push(hunk.header);
+                for line in hunk.lines {
+                    output.push(line.raw);
+                }
+                return output.join("\n");
+            }
+        }
+    }
+    ""
+}
+
+pub fn editor_range(text: String, start_line: i32, end_line: i32) -> String {
+    let patch = parse_patch(text);
+    let mut output = patch.prefix;
+    let mut found = false;
+
+    for file in patch.files {
+        let mut selected = [];
+        for hunk in file.hunks {
+            let result = editor_selected_hunk(hunk, start_line, end_line);
+            if result != "" {
+                selected.push(result);
+            }
+        }
+        if selected.len() > 0 {
+            found = true;
+            for raw in file.header {
+                output.push(raw);
+            }
+            for hunk in selected {
+                output.push(hunk);
+            }
+        }
+    }
+    if !found {
+        return "";
+    }
+    output.join("\n")
+}
+
+fn editor_selected_hunk(hunk: Hunk, start_line: i32, end_line: i32) -> String {
+    let mut output = [];
+    let mut new_line = hunk.new.start - 1;
+    let lines = hunk.lines;
+    let mut index = 0;
+
+    while index < lines.len() {
+        let current = lines[index];
+        let mut is_change = false;
+        match current.kind {
+            DiffLineKind::Added => {
+                is_change = true;
+            },
+            DiffLineKind::Removed => {
+                is_change = true;
+            },
+            DiffLineKind::Context => {},
+            DiffLineKind::NoNewlineMarker => {},
+            DiffLineKind::Metadata => {},
+        };
+        if !is_change {
+            output.push(current.raw);
+            if current.raw.starts_with(" ") {
+                new_line += 1;
+            }
+            index += 1;
+            continue;
+        }
+
+        let mut removed: [String] = [];
+        while index < lines.len() && lines[index].raw.starts_with("-") {
+            removed.push(lines[index].raw);
+            index += 1;
+        }
+        let addition_start = new_line;
+        let mut added: [String] = [];
+        while index < lines.len() && lines[index].raw.starts_with("+") {
+            added.push(lines[index].raw);
+            new_line += 1;
+            index += 1;
+        }
+        let mut addition_end = addition_start;
+        if added.len() > 0 {
+            addition_end = addition_start + added.len() - 1;
+        }
+        let mut selected = addition_start >= start_line && addition_start <= end_line + 1;
+        if added.len() > 0 {
+            selected = addition_start <= end_line && addition_end >= start_line;
+        }
+        if selected {
+            for raw in removed { output.push(raw); }
+            for raw in added { output.push(raw); }
+        } else {
+            for raw in removed {
+                output.push(" " + raw.slice(1, raw.len()));
+            }
+        }
+    }
+    serialize_selected_hunk(hunk.old.start, hunk.new.start, output)
+}
+
+fn serialize_selected_hunk(old_start: i32, new_start: i32, lines: [String]) -> String {
+    let mut old_count = 0;
+    let mut new_count = 0;
+    let mut changed = false;
+    for raw in lines {
+        if raw.starts_with("+") {
+            new_count += 1;
+            changed = true;
+        } else if raw.starts_with("-") {
+            old_count += 1;
+            changed = true;
+        } else if raw.starts_with(" ") {
+            old_count += 1;
+            new_count += 1;
+        }
+    }
+    if !changed {
+        return "";
+    }
+    let mut output = ["@@ -" + old_start + "," + old_count + " +" + new_start + "," + new_count + " @@"];
+    for raw in lines {
+        output.push(raw);
+    }
+    output.join("\n")
+}
+
+pub fn normalize_unsaved(text: String, path: String) -> String {
+    let patch = parse_patch(text);
+    let mut output = patch.prefix;
+    for file in patch.files {
+        for raw in file.header {
+            if raw.starts_with("diff --git ") {
+                output.push("diff --git a/" + path + " b/" + path);
+            } else if raw.starts_with("--- ") {
+                output.push("--- a/" + path);
+            } else if raw.starts_with("+++ ") {
+                output.push("+++ b/" + path);
+            } else {
+                output.push(raw);
+            }
+        }
+        for hunk in file.hunks {
+            output.push(hunk.header);
+            for line in hunk.lines {
+                output.push(line.raw);
+            }
+        }
+    }
+    output.join("\n")
+}
+
+#[test]
+fn parses_multi_file_hunks_and_matches_renamed_destination_buffers() {
+    let text = "diff --git tracked.rs tracked.rs\n--- tracked.rs\n+++ tracked.rs\n@@ -2,2 +2,3 @@\n-old\n+new\n+extra\n context\ndiff --git old name.rs new name.rs\n--- old name.rs\n+++ new name.rs\n@@ -8 +8 @@\n-before\n+after";
+    let hunks = sign_hunks(text, [
+        SignBuffer { path: "tracked.rs", buffer_index: 4 },
+        SignBuffer { path: "new name.rs", buffer_index: 8 },
+    ]);
+
+    assert(hunks.len() == 2);
+    assert(hunks[0].buffer_index == 4);
+    assert(hunks[0].old_start == 2);
+    assert(hunks[0].old_count == 2);
+    assert(hunks[0].new_count == 3);
+    assert(hunks[1].buffer_index == 8);
+}
+
+#[test]
+fn renders_structured_detail_and_selects_one_dashboard_line() {
+    let text = "diff --git a/tracked.rs b/tracked.rs\n--- a/tracked.rs\n+++ b/tracked.rs\n@@ -1,3 +1,3 @@\n-one\n+ONE\n two\n-three\n+THREE\n\\ No newline at end of file";
+    let document = detail_document(text, "tracked.rs", "unstaged");
+
+    assert(document.lines.len() == 10);
+    assert(document.lines[3].kind == "hunk");
+    assert(document.lines[4].kind == "removed");
+    assert(document.lines[5].kind == "added");
+    assert(document.lines[5].data.patch_index == 5);
+    let selected = dashboard_range(text, 4, 5);
+    assert(selected.includes("-one\n+ONE"));
+    assert(!selected.includes("-three"));
+    assert(!selected.includes("+THREE"));
+}
+
+#[test]
+fn selects_editor_hunks_and_preserves_unselected_removed_context() {
+    let text = "diff --git a/tracked.rs b/tracked.rs\n--- a/tracked.rs\n+++ b/tracked.rs\n@@ -1,3 +1,3 @@\n-one\n+ONE\n two\n-three\n+THREE\n@@ -8 +8 @@\n-old\n+new";
+    let starts = hunk_starts(text);
+    assert(starts.len() == 2);
+    assert(starts[0] == 0);
+    assert(starts[1] == 7);
+    assert(editor_hunk(text, 7).includes("-old\n+new"));
+    let selected = editor_range(text, 0, 0);
+    assert(selected.includes("-one\n+ONE"));
+    assert(selected.includes(" three"));
+    assert(!selected.includes("+THREE"));
+}
+
+#[test]
+fn normalizes_unsaved_patch_paths_without_rewriting_content() {
+    let text = "diff --git /private/tmp/file -\n--- /private/tmp/file\n+++ -\n@@ -1 +1 @@\n-before\n+after";
+    let normalized = normalize_unsaved(text, "src/file.rs");
+    assert(normalized.includes("diff --git a/src/file.rs b/src/file.rs"));
+    assert(normalized.includes("--- a/src/file.rs"));
+    assert(normalized.includes("+++ b/src/file.rs"));
+    assert(normalized.includes("-before\n+after"));
+}
+
+#[test]
+fn saturates_pathological_diff_range_values() {
+    let text = "diff --git a.rs a.rs\n@@ -999999999999999999999,1 +999999999999999999999,1 @@\n-old\n+new";
+    let hunks = sign_hunks(text, [SignBuffer { path: "a.rs", buffer_index: 1 }]);
+    assert(hunks.len() == 1);
+    assert(hunks[0].old_start == 2147483647);
+    assert(hunks[0].new_start == 2147483647);
+}

--- a/plugins/git_core/src/status.hk
+++ b/plugins/git_core/src/status.hk
@@ -1,0 +1,384 @@
+// Typed porcelain-v2 status parsing. The compatibility view is created only at
+// the Red boundary; all parsing and classification uses the native model.
+
+struct RepoPath {
+    value: String,
+}
+
+enum ChangeKind {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+    Copied,
+    TypeChanged,
+    Updated,
+    Unknown,
+}
+
+enum Change {
+    Tracked {
+        path: RepoPath,
+        original_path: Option<RepoPath>,
+        index: Option<ChangeKind>,
+        worktree: Option<ChangeKind>,
+        renamed: bool,
+    },
+    Untracked {
+        path: RepoPath,
+    },
+    Conflicted {
+        path: RepoPath,
+        index: Option<ChangeKind>,
+        worktree: Option<ChangeKind>,
+    },
+}
+
+struct BranchStatus {
+    head: Option<String>,
+    oid: Option<String>,
+    upstream: Option<String>,
+    ahead: i32,
+    behind: i32,
+    stash_count: i32,
+}
+
+struct GitStatus {
+    branch: BranchStatus,
+    changes: [Change],
+    truncated: bool,
+}
+
+pub struct GitEntry {
+    path: String,
+    original_path: Option<String>,
+    x: String,
+    y: String,
+    kind: String,
+}
+
+pub struct GitState {
+    head: String,
+    oid: String,
+    upstream: String,
+    ahead: i32,
+    behind: i32,
+    stash_count: i32,
+    staged: [GitEntry],
+    unstaged: [GitEntry],
+    untracked: [GitEntry],
+    conflicted: [GitEntry],
+    truncated: bool,
+}
+
+pub fn parse_status(output: String) -> GitState {
+    status_view(parse_porcelain(output, 500))
+}
+
+fn parse_porcelain(output: String, limit: i32) -> GitStatus {
+    let mut branch = BranchStatus {
+        head: None,
+        oid: None,
+        upstream: None,
+        ahead: 0,
+        behind: 0,
+        stash_count: 0,
+    };
+    let mut changes = [];
+    let mut truncated = false;
+    let records = output.split("\0");
+    let mut index = 0;
+    let mut visible_slots = 0;
+
+    while index < records.len() {
+        let record = records[index];
+        if record.starts_with("# branch.oid ") {
+            branch.oid = Some(record.slice(13, record.len()));
+        } else if record.starts_with("# branch.head ") {
+            branch.head = Some(record.slice(14, record.len()));
+        } else if record.starts_with("# branch.upstream ") {
+            branch.upstream = Some(record.slice(18, record.len()));
+        } else if record.starts_with("# branch.ab ") {
+            let fields = record.slice(12, record.len()).split(" ");
+            if fields.len() >= 2 {
+                branch.ahead = parse_count(fields[0]);
+                branch.behind = parse_count(fields[1]);
+            }
+        } else if record.starts_with("# stash ") {
+            branch.stash_count = parse_count(record.slice(8, record.len()));
+        } else if record.starts_with("? ") {
+            if visible_slots >= limit {
+                truncated = true;
+                break;
+            }
+            changes.push(Change::Untracked {
+                path: RepoPath { value: record.slice(2, record.len()) },
+            });
+            visible_slots += 1;
+        } else if record.starts_with("u ") {
+            if visible_slots >= limit {
+                truncated = true;
+                break;
+            }
+            let fields = record.split(" ");
+            if fields.len() >= 11 {
+                let xy = fields[1];
+                changes.push(Change::Conflicted {
+                    path: RepoPath { value: join_fields(fields, 10) },
+                    index: parse_change(xy.char_at(0)),
+                    worktree: parse_change(xy.char_at(1)),
+                });
+                visible_slots += 1;
+            }
+        } else if record.starts_with("1 ") || record.starts_with("2 ") {
+            let fields = record.split(" ");
+            let renamed = record.starts_with("2 ");
+            let mut path_index = 8;
+            if renamed {
+                path_index = 9;
+            }
+            if fields.len() > path_index {
+                let xy = fields[1];
+                let mut original_path = None;
+                if renamed && index + 1 < records.len() {
+                    original_path = Some(RepoPath { value: records[index + 1] });
+                    index += 1;
+                }
+                let index_change = parse_change(xy.char_at(0));
+                let mut worktree_change = parse_change(xy.char_at(1));
+                let mut slots = 0;
+                if let Some(_) = index_change {
+                    slots += 1;
+                }
+                if let Some(_) = worktree_change {
+                    slots += 1;
+                }
+                if visible_slots + slots > limit {
+                    truncated = true;
+                    if let Some(_) = index_change {
+                        worktree_change = None;
+                        slots = 1;
+                    } else {
+                        break;
+                    }
+                }
+                changes.push(Change::Tracked {
+                    path: RepoPath { value: join_fields(fields, path_index) },
+                    original_path: original_path,
+                    index: index_change,
+                    worktree: worktree_change,
+                    renamed: renamed,
+                });
+                visible_slots += slots;
+                if truncated {
+                    break;
+                }
+            }
+        }
+        index += 1;
+    }
+    GitStatus {
+        branch: branch,
+        changes: changes,
+        truncated: truncated,
+    }
+}
+
+fn status_view(status: GitStatus) -> GitState {
+    let mut staged = [];
+    let mut unstaged = [];
+    let mut untracked = [];
+    let mut conflicted = [];
+
+    for change in status.changes {
+        match change {
+            Change::Tracked { path, original_path, index, worktree, renamed } => {
+                let mut original = None;
+                if let Some(value) = original_path {
+                    original = Some(value.value);
+                }
+                let mut kind = "changed";
+                if renamed {
+                    kind = "renamed";
+                }
+                let x = change_code(index);
+                let y = change_code(worktree);
+                let entry = GitEntry {
+                    path: path.value,
+                    original_path: original,
+                    x: x,
+                    y: y,
+                    kind: kind,
+                };
+                if x != "." {
+                    staged.push(entry);
+                }
+                if y != "." {
+                    unstaged.push(entry);
+                }
+            },
+            Change::Untracked { path } => untracked.push(GitEntry {
+                path: path.value,
+                original_path: None,
+                x: "?",
+                y: "?",
+                kind: "untracked",
+            }),
+            Change::Conflicted { path, index, worktree } => conflicted.push(GitEntry {
+                path: path.value,
+                original_path: None,
+                x: change_code(index),
+                y: change_code(worktree),
+                kind: "conflicted",
+            }),
+        }
+    }
+
+    let mut head = "";
+    if let Some(value) = status.branch.head {
+        head = value;
+    }
+    let mut oid = "";
+    if let Some(value) = status.branch.oid {
+        oid = value;
+    }
+    let mut upstream = "";
+    if let Some(value) = status.branch.upstream {
+        upstream = value;
+    }
+    GitState {
+        head: head,
+        oid: oid,
+        upstream: upstream,
+        ahead: status.branch.ahead,
+        behind: status.branch.behind,
+        stash_count: status.branch.stash_count,
+        staged: staged,
+        unstaged: unstaged,
+        untracked: untracked,
+        conflicted: conflicted,
+        truncated: status.truncated,
+    }
+}
+
+fn parse_change(value: String) -> Option<ChangeKind> {
+    if value == "." {
+        return None;
+    }
+    if value == "A" {
+        return Some(ChangeKind::Added);
+    }
+    if value == "M" {
+        return Some(ChangeKind::Modified);
+    }
+    if value == "D" {
+        return Some(ChangeKind::Deleted);
+    }
+    if value == "R" {
+        return Some(ChangeKind::Renamed);
+    }
+    if value == "C" {
+        return Some(ChangeKind::Copied);
+    }
+    if value == "T" {
+        return Some(ChangeKind::TypeChanged);
+    }
+    if value == "U" {
+        return Some(ChangeKind::Updated);
+    }
+    Some(ChangeKind::Unknown)
+}
+
+fn change_code(value: Option<ChangeKind>) -> String {
+    let Some(kind) = value else {
+        return ".";
+    };
+    match kind {
+        ChangeKind::Added => "A",
+        ChangeKind::Modified => "M",
+        ChangeKind::Deleted => "D",
+        ChangeKind::Renamed => "R",
+        ChangeKind::Copied => "C",
+        ChangeKind::TypeChanged => "T",
+        ChangeKind::Updated => "U",
+        ChangeKind::Unknown => "?",
+    }
+}
+
+fn parse_count(value: String) -> i32 {
+    let mut count = 0;
+    for character in value {
+        if character >= "0" && character <= "9" {
+            let value = digit(character);
+            if count > 214748364 || (count == 214748364 && value > 7) {
+                return 2147483647;
+            }
+            count = count * 10 + value;
+        }
+    }
+    count
+}
+
+fn digit(value: String) -> i32 {
+    if value == "0" { return 0; }
+    if value == "1" { return 1; }
+    if value == "2" { return 2; }
+    if value == "3" { return 3; }
+    if value == "4" { return 4; }
+    if value == "5" { return 5; }
+    if value == "6" { return 6; }
+    if value == "7" { return 7; }
+    if value == "8" { return 8; }
+    9
+}
+
+fn join_fields(fields: [String], start: i32) -> String {
+    fields.slice(start, fields.len()).join(" ")
+}
+
+#[test]
+fn parses_branch_changed_renamed_untracked_and_conflicted_records() {
+    let output = "# branch.oid abcdef\0# branch.head feature/native\0# branch.upstream origin/main\0# branch.ab +2 -3\0# stash 4\01 M. N... 100644 100644 100644 abc def src/changed file.rs\02 RM N... 100644 100644 100644 abc def R100 src/new name.rs\0src/old name.rs\0? notes/todo.txt\0u UU N... 100644 100644 100644 100644 abc def ghi src/conflict.rs\0";
+    assert_msg(change_code(parse_change("M")) == "M", "modified code did not round trip");
+    let parsed = parse_porcelain(output, 500);
+    assert_msg(parsed.changes.len() == 4, format("changes={}", parsed.changes.len()));
+    let state = status_view(parsed);
+
+    assert(state.head == "feature/native");
+    assert(state.upstream == "origin/main");
+    assert(state.ahead == 2);
+    assert(state.behind == 3);
+    assert(state.stash_count == 4);
+    assert_msg(state.staged.len() == 2, format("staged={}", state.staged.len()));
+    assert(state.unstaged.len() == 1);
+    assert(state.staged[1].kind == "renamed");
+    assert(state.staged[1].path == "src/new name.rs");
+    assert(state.staged[0].original_path == None);
+    assert(state.staged[1].original_path == Some("src/old name.rs"));
+    assert(state.untracked[0].path == "notes/todo.txt");
+    assert(state.untracked[0].original_path == None);
+    assert(state.conflicted[0].path == "src/conflict.rs");
+}
+
+#[test]
+fn bounds_status_by_visible_slots_not_distinct_paths() {
+    let output = "1 MM N... 100644 100644 100644 abc def one.rs\01 MM N... 100644 100644 100644 abc def two.rs\0? three.rs\0";
+    let status = parse_porcelain(output, 4);
+    let view = status_view(status);
+
+    assert(view.truncated);
+    assert_msg(view.staged.len() == 2, format("bounded staged={}", view.staged.len()));
+    assert(view.unstaged.len() == 2);
+    assert(view.untracked.len() == 0);
+}
+
+#[test]
+fn keeps_the_last_available_index_slot_when_a_tracked_path_spans_both_sections() {
+    let output = "? one.rs\01 MM N... 100644 100644 100644 abc def two.rs\0";
+    let view = status_view(parse_porcelain(output, 2));
+
+    assert(view.truncated);
+    assert(view.untracked.len() == 1);
+    assert(view.staged.len() == 1);
+    assert(view.unstaged.len() == 0);
+}

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -22,7 +22,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use husk_runtime::{Callback, CompileOptions, CompiledProgram, Host, SemanticProfile, Value};
+use husk_runtime::{
+    Callback, CompileOptions, CompiledProgram, Host, PackageLimits, ResolvedPackage,
+    SemanticProfile, Value,
+};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -56,6 +59,7 @@ lazy_static::lazy_static! {
 
 const PLUGIN_INSTRUCTION_BUDGET: usize = 100_000;
 static NEXT_PLUGIN_VM_GENERATION: AtomicU64 = AtomicU64::new(1);
+static GIT_CORE_PROGRAM: OnceLock<Result<CompiledProgram, String>> = OnceLock::new();
 
 /// User-facing metadata attached to a registered Red plugin command.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -188,6 +192,7 @@ extern "red" {
         fn char() -> String;
         fn null() -> JsValue;
         fn parse_json() -> JsValue;
+        fn git_core() -> JsValue;
     }
 }
 "#;
@@ -224,6 +229,7 @@ struct RedHost {
     staged_effects: Option<Vec<StagedHostEffect>>,
     staged_replacement_start: Option<usize>,
     staged_teardown_start: Option<usize>,
+    git_core: Option<husk_runtime::Vm>,
 }
 
 #[derive(Debug, Clone)]
@@ -408,6 +414,7 @@ impl RedHost {
             staged_effects: None,
             staged_replacement_start: None,
             staged_teardown_start: None,
+            git_core: None,
         }
     }
 
@@ -1901,8 +1908,145 @@ impl RedHost {
                     .map(Value::Json)
                     .unwrap_or(Value::Unit))
             }
+            "red::git_core" => {
+                let operation = red_required_string(args, 0, path)?;
+                self.call_git_core(operation, &args[1..])
+            }
             _ => anyhow::bail!("unknown Red host function `{path}`"),
         })())
+    }
+
+    fn call_git_core(&mut self, operation: &str, args: &[Value]) -> anyhow::Result<Value> {
+        let function = match operation {
+            "parse_status" => "status::parse_status",
+            "sign_hunks" => "patch::sign_hunks",
+            "detail_document" => "patch::detail_document",
+            "dashboard_hunk" => "patch::dashboard_hunk",
+            "dashboard_range" => "patch::dashboard_range",
+            "hunk_starts" => "patch::hunk_starts",
+            "editor_hunk" => "patch::editor_hunk",
+            "editor_range" => "patch::editor_range",
+            "normalize_unsaved" => "patch::normalize_unsaved",
+            "apply_hunk_args" => "commands::apply_hunk_args",
+            "status_args" => "commands::status_args",
+            "sign_diff_args" => "commands::sign_diff_args",
+            "detail_diff_args" => "commands::detail_diff_args",
+            "hunk_diff_args" => "commands::hunk_diff_args",
+            "commit_args" => "commands::commit_args",
+            _ => anyhow::bail!("unknown Git core operation `{operation}`"),
+        };
+
+        if self.git_core.is_none() {
+            let program = git_core_program()?;
+            let mut vm = new_plugin_vm();
+            let mut host = GitCoreHost;
+            vm.load_compiled_plugin("red-git-core", program, &mut host)?;
+            self.git_core = Some(vm);
+        }
+        let vm = self
+            .git_core
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Git core VM did not initialize"))?;
+        let mut host = GitCoreHost;
+        let result = vm.call_export("red-git-core", function, args.to_vec(), &mut host)?;
+        Ok(normalize_git_core_value(result))
+    }
+}
+
+struct GitCoreHost;
+
+impl Host for GitCoreHost {
+    fn log(&mut self, _message: &str) {}
+}
+
+fn git_core_program() -> anyhow::Result<CompiledProgram> {
+    let compiled = GIT_CORE_PROGRAM.get_or_init(|| {
+        let package = ResolvedPackage::from_sources(
+            "plugins/git_core",
+            include_str!("../../plugins/git_core/Husk.toml"),
+            &[
+                (
+                    "src/main.hk",
+                    include_str!("../../plugins/git_core/src/main.hk"),
+                ),
+                (
+                    "src/status.hk",
+                    include_str!("../../plugins/git_core/src/status.hk"),
+                ),
+                (
+                    "src/patch.hk",
+                    include_str!("../../plugins/git_core/src/patch.hk"),
+                ),
+                (
+                    "src/commands.hk",
+                    include_str!("../../plugins/git_core/src/commands.hk"),
+                ),
+            ],
+            PackageLimits::default(),
+        )
+        .map_err(|error| format!("failed to resolve embedded Git core: {error}"))?;
+        CompiledProgram::compile_package(&package, &CompileOptions::default())
+            .map_err(|error| format!("failed to compile embedded Git core: {error}"))
+    });
+    compiled
+        .as_ref()
+        .cloned()
+        .map_err(|error| anyhow::anyhow!("{error}"))
+}
+
+fn normalize_git_core_value(value: Value) -> Value {
+    match value {
+        Value::Variant {
+            type_name,
+            case,
+            fields,
+        } if type_name == "Option" => match (case.as_str(), fields.as_slice()) {
+            ("None", []) => Value::Null,
+            ("Some", [value]) => normalize_git_core_value(value.clone()),
+            _ => Value::Null,
+        },
+        Value::Array(values) => Value::Array(Arc::new(
+            values
+                .iter()
+                .cloned()
+                .map(normalize_git_core_value)
+                .collect(),
+        )),
+        Value::Tuple(values) => Value::Tuple(Arc::new(
+            values
+                .iter()
+                .cloned()
+                .map(normalize_git_core_value)
+                .collect(),
+        )),
+        Value::Object(fields) => Value::Object(Arc::new(
+            fields
+                .iter()
+                .map(|(name, value)| (name.clone(), normalize_git_core_value(value.clone())))
+                .collect(),
+        )),
+        Value::Struct { fields, .. } => Value::Object(Arc::new(
+            fields
+                .iter()
+                .map(|(name, value)| (name.clone(), normalize_git_core_value(value.clone())))
+                .collect(),
+        )),
+        Value::Variant {
+            type_name,
+            case,
+            fields,
+        } => Value::Variant {
+            type_name,
+            case,
+            fields: Arc::new(
+                fields
+                    .iter()
+                    .cloned()
+                    .map(normalize_git_core_value)
+                    .collect(),
+            ),
+        },
+        value => value,
     }
 }
 
@@ -3266,6 +3410,53 @@ mod tests {
             .await
             .unwrap();
         runtime
+    }
+
+    #[test]
+    fn embedded_git_core_compiles_as_a_native_multi_file_package_and_normalizes_options() {
+        let program = git_core_program().unwrap();
+        assert_eq!(program.semantic_profile(), SemanticProfile::Native);
+        assert_eq!(program.source_map().sources().len(), 4);
+        assert_eq!(program.module_semantic_results().len(), 4);
+
+        let mut host = RedHost::new(HashMap::new());
+        let status = host
+            .call_git_core(
+                "parse_status",
+                &[Value::String(
+                    "# branch.head native\0? src/new file.rs\0".to_string(),
+                )],
+            )
+            .unwrap()
+            .to_json();
+        assert_eq!(status["head"], "native");
+        assert_eq!(status["untracked"][0]["path"], "src/new file.rs");
+        assert!(status["untracked"][0]["original_path"].is_null());
+
+        let document = host
+            .call_git_core(
+                "detail_document",
+                &[
+                    Value::String(
+                        "diff --git a/file.rs b/file.rs\n--- a/file.rs\n+++ b/file.rs\n@@ -1 +1 @@\n-old\n+new"
+                            .to_string(),
+                    ),
+                    Value::String("file.rs".to_string()),
+                    Value::String("unstaged".to_string()),
+                ],
+            )
+            .unwrap()
+            .to_json();
+        assert!(document["lines"][3]["old_line"].is_null());
+        assert_eq!(document["lines"][4]["old_line"], 1);
+        assert!(document["lines"][4]["new_line"].is_null());
+        assert_eq!(document["lines"][5]["new_line"], 1);
+
+        let error = host.call_git_core("not_an_operation", &[]).unwrap_err();
+        assert!(
+            error.to_string().contains("unknown Git core operation"),
+            "{error}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

The bundled Git plugin had several independent, stringly typed implementations of porcelain-status parsing, unified-diff parsing, hunk selection, and Git argument construction. Keeping those algorithms inside the legacy compatibility script made behavior difficult to reason about and duplicated bounds and reconstruction logic across dashboard, gutter, and editor workflows.

## What Changed

- Add the native multi-file `plugins/git_core` Husk package with typed status/change models, one bounded patch/hunk representation, explicit command modes, and focused native tests for renames, conflicts, truncation, line selection, no-newline markers, and pathological range values.
- Replace roughly 600 lines of duplicated logic in `plugins/git.hk` with a narrow in-process bridge while retaining its event, picker, state, and permissioned-process shell. Native `Option` and struct values are normalized at that boundary so existing plugin behavior is preserved.
- Add `ResolvedPackage::from_sources` for deterministic, bounded, pure embedded packages; reject missing, ambiguous, duplicate, escaping, oversized, and extension-bearing inputs. The Git sources are embedded with `include_str!`, so installed builds remain relocatable.
- Extend the plugin-check workflow and Husk/plugin documentation with the new package, resolver, and production-path checks.

## How to Test

Run the native package and resolver tests:

```sh
cargo run --all-features -p husk-cli -- test --locked plugins/git_core
cargo test --all-features -p husk-package
```

Expected: all native Git-core tests pass, including multi-file/rename mapping, staged and unstaged hunk selection, status truncation, invalid apply actions, and saturated diff ranges; embedded-package rejection cases pass.

Exercise the production Git bridge and bundled runtime:

```sh
cargo test --all-features -p red --lib plugin::runtime::tests::git_
cargo test --all-features -p red --lib plugin::runtime::tests::embedded_git_core_
cargo clippy --all-targets --all-features -- -D warnings
cargo run --all-features -- --self-check
```

Expected: the six Git dashboard/gutter/hunk regressions and native-profile bridge test pass, Clippy is clean, and self-check reports `plugin git: active` followed by `red self-check ok`.

The full workspace/all-targets run also passed after excluding the two pre-existing pathological LSP-symbol tests (`lsp_symbols_batches_pathological_document_symbol_results` and `lsp_symbols_batches_pathological_reference_results`), which reproduce independently on untouched `master`; they are unrelated to this change.
