### PR TITLE
fix(lsp): prevent pathological batching hangs

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Test the Husk runtime and plugin bridge
         run: |
           cargo test --all-features -p red husk
+          cargo test --all-features -p red plugin::runtime::tests::lsp_symbols_
           cargo test --all-features -p husk -p husk-ast -p husk-diagnostics -p husk-lexer -p husk-parser -p husk-semantic -p husk-types
 
       - name: Validate example plugin metadata

--- a/crates/husk-runtime/src/lib.rs
+++ b/crates/husk-runtime/src/lib.rs
@@ -1786,6 +1786,7 @@ struct RuntimeHeap {
     slots: Vec<HeapSlot>,
     free: Vec<u32>,
     live_objects: usize,
+    live_closures: usize,
     live_bytes: usize,
     max_objects: usize,
     max_bytes: usize,
@@ -1797,6 +1798,7 @@ impl Default for RuntimeHeap {
             slots: Vec::new(),
             free: Vec::new(),
             live_objects: 0,
+            live_closures: 0,
             live_bytes: 0,
             max_objects: 1_000_000,
             max_bytes: 64 * 1024 * 1024,
@@ -1864,6 +1866,7 @@ impl RuntimeHeap {
         closure: ClosureObject,
     ) -> anyhow::Result<FunctionHandle> {
         let handle = self.allocate(HeapObject::Closure(Box::new(closure)))?;
+        self.live_closures += 1;
         Ok(FunctionHandle {
             instance_generation,
             slot: handle.slot,
@@ -2035,12 +2038,14 @@ impl RuntimeHeap {
                 slot.marked = false;
                 continue;
             }
+            let is_closure = matches!(slot.object, Some(HeapObject::Closure(_)));
             let object_bytes = slot.object.as_ref().map_or(0, heap_object_size);
             slot.object = None;
             slot.generation = slot.generation.wrapping_add(1).max(1);
             self.free
                 .push(u32::try_from(index).expect("allocated heap indices fit in u32"));
             self.live_objects = self.live_objects.saturating_sub(1);
+            self.live_closures = self.live_closures.saturating_sub(usize::from(is_closure));
             self.live_bytes = self.live_bytes.saturating_sub(object_bytes);
         }
     }
@@ -3608,6 +3613,14 @@ impl Vm {
         result: Option<&Value>,
     ) {
         if finished.owned_cells.is_empty() {
+            return;
+        }
+        // Cells can escape a completed frame only through a closure capture.
+        // Avoid walking large, closure-free parent values on every helper call.
+        if self.heap.live_closures == 0 {
+            for handle in &finished.owned_cells {
+                self.heap.free_cell(*handle);
+            }
             return;
         }
         let mut function_roots = self.rooted_functions.iter().copied().collect::<Vec<_>>();
@@ -6833,6 +6846,7 @@ mod tests {
             // immediately. The orphaned closure is swept before the next
             // top-level call.
             assert_eq!(vm.heap.live_objects, 1);
+            assert_eq!(vm.heap.live_closures, 1);
         }
     }
 
@@ -6858,6 +6872,7 @@ mod tests {
         assert!(matches!(closure, Value::Closure(_)));
         vm.call_export("handles", "noop", Vec::new(), &mut host)
             .unwrap();
+        assert_eq!(vm.heap.live_closures, 0);
         let error = vm
             .call_export("handles", "invoke", vec![closure], &mut host)
             .unwrap_err()

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -214,7 +214,7 @@ fn symbol_batch_timeout(event: Json) {
     red::state_set("lsp_symbol_batch_timer", "");
 
     let symbols = red::state("lsp_symbol_batch_symbols");
-    let items = red::state("lsp_symbol_batch_items");
+    let batch = [];
     let index = red::int(red::state("lsp_symbol_batch_index"), 0);
     let handle = red::state("lsp_symbol_batch_picker");
     if handle == red::null() || handle != red::state("lsp_symbol_picker") {
@@ -232,15 +232,17 @@ fn symbol_batch_timeout(event: Json) {
                 red::string(red::state("lsp_reference_file"), ""),
                 red::state("lsp_reference_position")
             ) {
-                items = red::push(items, reference_item(value));
+                batch = red::push(batch, reference_item(value));
             }
         } else if !workspace_only || is_workspace_symbol_kind(value.kind_name) {
-            items = red::push(items, symbol_item(value));
+            batch = red::push(batch, symbol_item(value));
         }
         index = index + 1;
         processed = processed + 1;
     }
 
+    // Keep the growing result out of helper-call frames and extend it once per batch.
+    let items = red::extend(red::state("lsp_symbol_batch_items"), batch);
     red::state_set("lsp_symbol_batch_items", items);
     red::state_set("lsp_symbol_batch_index", index);
     red::execute("UpdatePickerItems", handle, items);

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -160,6 +160,7 @@ extern "red" {
         fn state_set();
         fn state() -> JsValue;
         fn push() -> JsValue;
+        fn extend() -> JsValue;
         fn unshift() -> JsValue;
         fn contains() -> bool;
         fn remove() -> JsValue;
@@ -1670,6 +1671,12 @@ impl RedHost {
             "red::push" => {
                 let mut values = red_required_value_array(args, 0, path)?;
                 Arc::make_mut(&mut values).push(args.get(1).cloned().unwrap_or(Value::Null));
+                Ok(Value::Array(values))
+            }
+            "red::extend" => {
+                let mut values = red_required_value_array(args, 0, path)?;
+                let additional = red_required_value_array(args, 1, path)?;
+                Arc::make_mut(&mut values).extend(additional.iter().cloned());
                 Ok(Value::Array(values))
             }
             "red::unshift" => {
@@ -3326,6 +3333,37 @@ mod tests {
             }
             _ => panic!("unexpected plugin request"),
         }
+    }
+
+    #[test]
+    fn host_array_extend_appends_json_values_without_mutating_the_source() {
+        let mut host = RedHost::new(HashMap::new());
+        let source = Value::Array(Arc::new(vec![Value::Int(1), Value::Int(2)]));
+
+        let extended = host
+            .call_module(
+                "array-test",
+                "red::extend",
+                &[
+                    source.clone(),
+                    Value::Json(serde_json::json!([{ "value": 3 }, { "value": 4 }])),
+                ],
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(source.to_json(), serde_json::json!([1, 2]));
+        assert_eq!(
+            extended.to_json(),
+            serde_json::json!([1, 2, { "value": 3 }, { "value": 4 }])
+        );
+
+        let error = host
+            .call_module("array-test", "red::extend", &[source, Value::Null])
+            .unwrap()
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("argument 1 must be an array"), "{error}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Large document-symbol and reference responses could keep the LSP picker busy for over a minute. Although callbacks were already capped at 64 entries, each helper call recursively scanned the full response during frame cleanup and repeatedly copied the growing picker array, making pathological responses effectively hang.

This keeps each callback bounded by accumulating a small batch and extending the picker results once, adds the corresponding `red::extend` host API, and lets Husk release completed frames without a full reachability walk when no closures can capture their cells. Closure accounting and array-extension regressions are covered, and plugin CI now runs the production LSP-symbol tests explicitly.

## How to Test

1. Run the two pathological-response regressions:

   ```sh
   cargo test --all-features -p red --lib plugin::runtime::tests::lsp_symbols_batches_pathological_document_symbol_results -- --exact --nocapture
   cargo test --all-features -p red --lib plugin::runtime::tests::lsp_symbols_batches_pathological_reference_results -- --exact --nocapture
   ```

   Both should complete promptly and preserve the result cap, picker updates, and cancellation behavior; locally they complete in about 5.5s and 3.4s instead of exceeding 60s.

2. Exercise the full LSP plugin and runtime regressions:

   ```sh
   cargo test --all-features -p red plugin::runtime::tests::lsp_symbols_
   cargo test --all-features -p husk-runtime
   cargo test --all-features -p husk --test embedding_api
   ```

   All tests should pass, including closure cleanup, stale-handle rejection, and invalid-array handling.

Validated with the full workspace test suite, `cargo clippy --all-targets --all-features -- -D warnings`, formatting checks, and `cargo run --all-features -- --self-check`.