### PR TITLE
feat(editor): add buffer-local syntax command

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -165,6 +165,7 @@ Enter Command mode with `:` or `;`.
 | `:sp [file]` / `:vs [file]` | Open a horizontal or vertical split |
 | `:close` / `:only` | Close the window or keep only the current window |
 | `:wrap` / `:nowrap` | Enable or disable wrapping |
+| `:syntax [language]` / `:syn [language]` / `:ft [language]` | Choose buffer-local syntax; use `auto` to reset or `off` to disable |
 | `:join [count]` / `:join! [count]` | Join with normalized or preserved spacing |
 | `:commands` | Open the command palette |
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -51,6 +51,18 @@ pub struct SearchMatch {
     pub end_y: usize,
 }
 
+/// Buffer-local syntax-highlighting selection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum SyntaxSelection {
+    /// Detect syntax from the buffer's file name.
+    #[default]
+    Auto,
+    /// Disable syntax highlighting.
+    Off,
+    /// Highlight using the selected canonical language identifier.
+    Language(String),
+}
+
 /// Buffer represents an editable text buffer, which may be associated with a file.
 /// It maintains the text content as a rope data structure for efficient editing operations.
 #[derive(Debug)]
@@ -78,6 +90,9 @@ pub struct Buffer {
 
     /// Monotonic content revision used by render caches.
     revision: u64,
+
+    /// Buffer-local syntax-highlighting selection.
+    syntax_selection: SyntaxSelection,
 }
 
 impl Buffer {
@@ -98,6 +113,7 @@ impl Buffer {
             vtop: 0,
             undo_history: UndoHistory::default(),
             revision: 0,
+            syntax_selection: SyntaxSelection::Auto,
         }
     }
 
@@ -195,6 +211,16 @@ impl Buffer {
                 .next_back()
                 .map(|ext| ext.to_string().to_lowercase())
         })
+    }
+
+    /// Returns the buffer-local syntax-highlighting selection.
+    pub fn syntax_selection(&self) -> &SyntaxSelection {
+        &self.syntax_selection
+    }
+
+    /// Sets the buffer-local syntax-highlighting selection without changing the text.
+    pub fn set_syntax_selection(&mut self, selection: SyntaxSelection) {
+        self.syntax_selection = selection;
     }
 
     /// Gets the full contents of the buffer as a single string
@@ -1148,6 +1174,25 @@ mod test {
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
 
+    #[test]
+    fn syntax_selection_is_buffer_local_and_does_not_change_revision() {
+        let mut buffer = Buffer::new(Some("notes.txt".to_string()), "fn main() {}".to_string());
+        let revision = buffer.revision();
+
+        assert_eq!(buffer.syntax_selection(), &SyntaxSelection::Auto);
+
+        buffer.set_syntax_selection(SyntaxSelection::Language("rust".to_string()));
+        assert_eq!(
+            buffer.syntax_selection(),
+            &SyntaxSelection::Language("rust".to_string())
+        );
+        assert_eq!(buffer.revision(), revision);
+        assert!(!buffer.is_dirty());
+
+        buffer.set_syntax_selection(SyntaxSelection::Off);
+        assert_eq!(buffer.syntax_selection(), &SyntaxSelection::Off);
+        assert_eq!(buffer.revision(), revision);
+    }
     fn unique_temp_dir(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("red-{name}-{}", uuid::Uuid::new_v4()))
     }

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -35,6 +35,9 @@ pub(crate) const BUILTIN_COLON_COMMANDS: &[&str] = &[
     "nohlsearch",
     "wrap",
     "nowrap",
+    "syntax",
+    "syn",
+    "ft",
     "config-diagnostics",
 ];
 
@@ -547,6 +550,15 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Some(":nowrap"),
             &[],
             Action::SetWrap(false),
+        ),
+        builtin(
+            "view.syntax",
+            "Set syntax",
+            "View",
+            "Choose syntax highlighting for the current buffer",
+            Some(":syntax"),
+            &[":syn", ":ft", "filetype", "language"],
+            Action::OpenSyntaxPicker,
         ),
         builtin(
             "window.split_horizontal",
@@ -1070,6 +1082,22 @@ mod tests {
         assert_eq!(comment.category, "Edit");
         assert_eq!(comment.title, "Toggle line comments");
         assert!(comment.aliases.iter().any(|alias| alias == "gcc"));
+    }
+
+    #[test]
+    fn palette_lists_syntax_selection_with_colon_aliases() {
+        let entries = entries(&default_keys(), &[]);
+        let syntax = entries
+            .iter()
+            .find(|entry| entry.id == "view.syntax")
+            .expect("syntax action should appear in the command palette");
+
+        assert_eq!(syntax.category, "View");
+        assert_eq!(syntax.title, "Set syntax");
+        assert_eq!(syntax.colon.as_deref(), Some(":syntax"));
+        assert!(syntax.aliases.iter().any(|alias| alias == ":syn"));
+        assert!(syntax.aliases.iter().any(|alias| alias == ":ft"));
+        assert_eq!(syntax.action, Action::OpenSyntaxPicker);
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -71,7 +71,7 @@ use crate::{
     agent_workspace::{
         ProposalDisposition, ProposalToolHost, ProposalWorkspace, StagedProposalAcceptance,
     },
-    buffer::{Buffer, BufferId, SearchMatch},
+    buffer::{Buffer, BufferId, SearchMatch, SyntaxSelection},
     clipboard::{ClipboardProvider, DisabledClipboardProvider, NativeClipboardProvider},
     codex::{start_codex, CodexBridge, CodexCommand, CodexEvent, CodexProcessSpec},
     color::Color,
@@ -1345,6 +1345,8 @@ pub enum Action {
     DeleteBuffer(bool),
     FilePicker,
     CommandPalette,
+    OpenSyntaxPicker,
+    SetSyntax(String),
     ConfigDiagnostics,
     ShowDialog,
     CloseDialog,
@@ -1546,6 +1548,7 @@ pub struct HighlightSpan {
 struct ViewportHighlightEntry {
     revision: u64,
     file: Option<String>,
+    language_id: Option<&'static str>,
     /// First buffer line included in the parse.
     start_line: usize,
     /// Byte offset of each parsed line within the parsed text, plus a final
@@ -3840,13 +3843,28 @@ impl Editor {
         self.highlighter.highlight_for_file(file, code)
     }
 
-    fn highlight_spans(
+    fn highlight_spans_for_language(
         &mut self,
-        file: Option<&str>,
+        language_id: Option<&str>,
         code: &str,
     ) -> anyhow::Result<Vec<HighlightSpan>> {
-        self.highlight(file, code)
+        let Some(language_id) = language_id else {
+            return Ok(Vec::new());
+        };
+        self.highlighter
+            .highlight(language_id, code)
             .map(style_info_to_highlight_spans)
+    }
+
+    fn highlight_language_id_for_buffer_index(&self, buffer_index: usize) -> Option<&'static str> {
+        let buffer = self.buffer_manager.get(buffer_index)?;
+        match buffer.syntax_selection() {
+            SyntaxSelection::Auto => self
+                .highlighter
+                .language_id_for_file(buffer.file.as_deref()),
+            SyntaxSelection::Off => None,
+            SyntaxSelection::Language(language) => self.highlighter.language_id_for_name(language),
+        }
     }
 
     /// Returns highlight spans positioned relative to the viewport text
@@ -3867,7 +3885,8 @@ impl Editor {
         };
         let revision = buffer.revision();
         let file = buffer.file.clone();
-        let requires_document_prefix = self.highlighter.requires_document_prefix(file.as_deref());
+        let language_id = self.highlight_language_id_for_buffer_index(buffer_index);
+        let requires_document_prefix = self.highlighter.requires_document_prefix(language_id);
         let line_count = buffer.len();
         if vtop >= line_count {
             return Ok(Vec::new());
@@ -3875,8 +3894,9 @@ impl Editor {
         let viewport_end = (vtop + height).min(line_count);
 
         let cached = self.highlight_cache.get(&buffer_index);
-        let same_document =
-            cached.is_some_and(|entry| entry.revision == revision && entry.file == file);
+        let same_document = cached.is_some_and(|entry| {
+            entry.revision == revision && entry.file == file && entry.language_id == language_id
+        });
         let covered = same_document
             && cached.is_some_and(|entry| {
                 let parse_end = entry.start_line + entry.line_offsets.len().saturating_sub(1);
@@ -3919,7 +3939,7 @@ impl Editor {
             }
             line_offsets.push(text.len());
 
-            let spans = self.highlight_spans(file.as_deref(), &text)?;
+            let spans = self.highlight_spans_for_language(language_id, &text)?;
             if self.highlight_cache.len() >= 32 {
                 self.highlight_cache.clear();
             }
@@ -3928,6 +3948,7 @@ impl Editor {
                 ViewportHighlightEntry {
                     revision,
                     file,
+                    language_id,
                     start_line: parse_start,
                     line_offsets,
                     spans,
@@ -3962,11 +3983,12 @@ impl Editor {
 
     fn draw_line(&mut self, buffer: &mut RenderBuffer) {
         let line = self.viewport_line(self.cy).unwrap_or_default();
-        let file = self.current_buffer().file.clone();
+        let language_id =
+            self.highlight_language_id_for_buffer_index(self.buffer_manager.active_index());
         let style_info = if line.len() > MAX_HIGHLIGHT_SLICE_BYTES {
             Vec::new()
         } else {
-            self.highlight_spans(file.as_deref(), &line)
+            self.highlight_spans_for_language(language_id, &line)
                 .unwrap_or_default()
         };
         let default_style = self.theme.style.clone();
@@ -9922,6 +9944,18 @@ impl Editor {
             }];
         }
 
+        if matches!(name, "syntax" | "syn" | "ft") {
+            let mut arguments = arguments.split_whitespace();
+            let Some(syntax) = arguments.next() else {
+                return vec![Action::OpenSyntaxPicker];
+            };
+            if arguments.next().is_some() {
+                self.last_error = Some("usage: syntax [language|auto|off]".to_string());
+                return Vec::new();
+            }
+            return vec![Action::SetSyntax(syntax.to_string())];
+        }
+
         let parsed = command::parse(command_palette::BUILTIN_COLON_COMMANDS, cmd);
 
         let Some(parsed) = parsed else {
@@ -10463,7 +10497,14 @@ impl Editor {
         )
     }
 
-    fn command_completion_context(command: &str) -> Option<CommandCompletionContext> {
+    fn command_accepts_syntax_completion(command: &str) -> bool {
+        matches!(command.trim_end_matches('!'), "syntax" | "syn" | "ft")
+    }
+
+    fn command_completion_context(
+        command: &str,
+        accepts_completion: fn(&str) -> bool,
+    ) -> Option<CommandCompletionContext> {
         let command_start = command
             .char_indices()
             .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index))?;
@@ -10473,7 +10514,7 @@ impl Editor {
             .find_map(|(index, ch)| ch.is_whitespace().then_some(command_start + index))
             .unwrap_or(command.len());
         let command_name = &command[command_start..command_end];
-        if !Self::command_accepts_file_completion(command_name) {
+        if !accepts_completion(command_name) {
             return None;
         }
 
@@ -10608,38 +10649,61 @@ impl Editor {
             }
         }
 
-        let (context, candidates) =
-            if let Some(context) = Self::command_completion_context(&self.command) {
-                let candidates = Self::path_completion_candidates(&context.fragment)
-                    .into_iter()
-                    .map(|candidate| candidate.replacement)
-                    .collect::<Vec<_>>();
-                (context, candidates)
+        let (context, candidates) = if let Some(context) =
+            Self::command_completion_context(&self.command, Self::command_accepts_file_completion)
+        {
+            let candidates = Self::path_completion_candidates(&context.fragment)
+                .into_iter()
+                .map(|candidate| candidate.replacement)
+                .collect::<Vec<_>>();
+            (context, candidates)
+        } else if let Some(context) =
+            Self::command_completion_context(&self.command, Self::command_accepts_syntax_completion)
+        {
+            let fragment = context.fragment.to_ascii_lowercase();
+            let mut candidates = if fragment.chars().any(char::is_whitespace) {
+                Vec::new()
             } else {
-                let command_start = self
-                    .command
-                    .char_indices()
-                    .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index))
-                    .unwrap_or(self.command.len());
-                let fragment = &self.command[command_start..];
-                if fragment.is_empty() || fragment.chars().any(char::is_whitespace) {
-                    self.command_completion = None;
-                    return;
-                }
-                let candidates = command_palette::colon_completion_names(plugin_commands)
+                ["auto", "off"]
                     .into_iter()
-                    .filter(|command| command.starts_with(fragment))
-                    .collect::<Vec<_>>();
-                (
-                    CommandCompletionContext {
-                        replacement_start: command_start,
-                        replacement_end: self.command.len(),
-                        fragment: fragment.to_string(),
-                        needs_leading_space: false,
-                    },
-                    candidates,
-                )
+                    .filter(|language| language.starts_with(&fragment))
+                    .map(str::to_string)
+                    .chain(
+                        self.highlighter
+                            .matching_language_ids(&fragment)
+                            .into_iter()
+                            .map(str::to_string),
+                    )
+                    .collect::<Vec<_>>()
             };
+            candidates.sort_unstable();
+            candidates.dedup();
+            (context, candidates)
+        } else {
+            let command_start = self
+                .command
+                .char_indices()
+                .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index))
+                .unwrap_or(self.command.len());
+            let fragment = &self.command[command_start..];
+            if fragment.is_empty() || fragment.chars().any(char::is_whitespace) {
+                self.command_completion = None;
+                return;
+            }
+            let candidates = command_palette::colon_completion_names(plugin_commands)
+                .into_iter()
+                .filter(|command| command.starts_with(fragment))
+                .collect::<Vec<_>>();
+            (
+                CommandCompletionContext {
+                    replacement_start: command_start,
+                    replacement_end: self.command.len(),
+                    fragment: fragment.to_string(),
+                    needs_leading_space: false,
+                },
+                candidates,
+            )
+        };
         if candidates.is_empty() {
             self.command_completion = None;
             return;
@@ -12019,6 +12083,10 @@ impl Editor {
     }
 
     fn current_language_id(&self) -> Option<String> {
+        if let SyntaxSelection::Language(language) = self.current_buffer().syntax_selection() {
+            return Some(language.clone());
+        }
+
         self.highlighter
             .language_id_for_file(self.current_buffer().file.as_deref())
             .map(str::to_string)
@@ -14631,6 +14699,49 @@ impl Editor {
                 self.current_dialog = Some(Box::new(picker));
                 self.render(buffer)?;
             }
+            Action::OpenSyntaxPicker => {
+                let items = ["auto", "off"]
+                    .into_iter()
+                    .chain(self.highlighter.language_ids())
+                    .map(str::to_string)
+                    .collect();
+                let picker = Picker::builder()
+                    .title("Syntax")
+                    .items(items)
+                    .placeholder("Select a syntax or choose auto/off")
+                    .select_action(Action::SetSyntax)
+                    .build(self);
+                self.release_current_dialog_callbacks(runtime);
+                self.current_dialog = Some(Box::new(picker));
+                self.render(buffer)?;
+            }
+            Action::SetSyntax(syntax) => {
+                let syntax = syntax.trim();
+                let (selection, label) = match syntax.to_ascii_lowercase().as_str() {
+                    "auto" => (SyntaxSelection::Auto, "auto"),
+                    "off" => (SyntaxSelection::Off, "off"),
+                    _ => {
+                        let Some(language_id) = self.highlighter.language_id_for_name(syntax)
+                        else {
+                            self.last_error =
+                                Some(format!("unknown syntax {syntax:?} (try :syntax)"));
+                            self.render(buffer)?;
+                            return Ok(false);
+                        };
+                        (
+                            SyntaxSelection::Language(language_id.to_string()),
+                            language_id,
+                        )
+                    }
+                };
+                self.current_buffer_mut().set_syntax_selection(selection);
+                self.highlight_cache
+                    .remove(&self.buffer_manager.active_index());
+                self.bracket_match_cache = None;
+                self.force_full_redraw = true;
+                self.last_error = Some(format!("syntax: {label}"));
+                self.render(buffer)?;
+            }
             Action::ConfigDiagnostics => {
                 self.release_current_dialog_callbacks(runtime);
                 self.open_config_diagnostics();
@@ -17175,10 +17286,21 @@ impl Editor {
             return None;
         };
         let extension = self.current_buffer().file_type();
-        let template = extension
-            .as_deref()
-            .and_then(|extension| self.config.commenting.languages.get(extension))
-            .or_else(|| self.config.commenting.languages.get(&language));
+        let template = if matches!(
+            self.current_buffer().syntax_selection(),
+            SyntaxSelection::Language(_)
+        ) {
+            self.config.commenting.languages.get(&language).or_else(|| {
+                extension
+                    .as_deref()
+                    .and_then(|extension| self.config.commenting.languages.get(extension))
+            })
+        } else {
+            extension
+                .as_deref()
+                .and_then(|extension| self.config.commenting.languages.get(extension))
+                .or_else(|| self.config.commenting.languages.get(&language))
+        };
         let Some(template) = template else {
             self.last_error = Some(format!("no comment syntax configured for {language}"));
             return None;
@@ -20990,6 +21112,55 @@ mod test {
     }
 
     #[tokio::test]
+    async fn syntax_picker_opens_from_colon_command_and_applies_selected_language() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 14);
+        editor.buffer_manager.replace_buffers(vec![Buffer::new(
+            Some("notes.txt".to_string()),
+            "fn main() {}".to_string(),
+        )]);
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 14, &Style::default());
+        let mut runtime = Runtime::new();
+
+        enter_colon_command(&mut editor, &mut buffer, &mut runtime, "syntax").await;
+
+        let frame = render_text_rows(&buffer).join("\n");
+        assert!(editor.current_dialog.is_some());
+        assert!(frame.contains("Syntax"));
+        assert!(frame.contains("auto"));
+        assert!(frame.contains("off"));
+
+        editor
+            .process_editor_event(
+                Event::Paste("rust".to_string()),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert!(render_text_rows(&buffer).join("\n").contains("rust"));
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert!(editor.current_dialog.is_none());
+        assert_eq!(
+            editor.current_buffer().syntax_selection(),
+            &SyntaxSelection::Language("rust".to_string())
+        );
+        assert_eq!(editor.last_error.as_deref(), Some("syntax: rust"));
+    }
+
+    #[tokio::test]
     async fn command_palette_searches_and_runs_a_registered_plugin_command() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_plugin_requests();
@@ -22810,6 +22981,30 @@ mod test {
     }
 
     #[test]
+    fn viewport_highlight_cache_follows_buffer_syntax_selection() {
+        let mut editor = rust_test_editor(100, 120, 22);
+        editor.current_buffer_mut().file = Some("notes.txt".to_string());
+
+        let automatic = editor.viewport_highlight_spans(0, 10, 20).unwrap();
+        assert!(automatic.is_empty());
+        assert_eq!(editor.highlight_cache[&0].language_id, None);
+
+        editor
+            .current_buffer_mut()
+            .set_syntax_selection(SyntaxSelection::Language("rust".to_string()));
+        let forced = editor.viewport_highlight_spans(0, 10, 20).unwrap();
+        assert!(!forced.is_empty());
+        assert_eq!(editor.highlight_cache[&0].language_id, Some("rust"));
+
+        editor
+            .current_buffer_mut()
+            .set_syntax_selection(SyntaxSelection::Off);
+        let disabled = editor.viewport_highlight_spans(0, 10, 20).unwrap();
+        assert!(disabled.is_empty());
+        assert_eq!(editor.highlight_cache[&0].language_id, None);
+    }
+
+    #[test]
     fn yaml_highlighting_keeps_document_context_after_an_edit() {
         let contents = r#"jobs:
   test:
@@ -22866,6 +23061,24 @@ mod test {
 
         assert!(!after.is_empty());
         assert_eq!(span_shape(&after), span_shape(&expected));
+        assert_eq!(editor.highlight_cache[&0].start_line, 0);
+    }
+
+    #[test]
+    fn forced_yaml_highlighting_keeps_required_document_prefix() {
+        let contents = (0..80)
+            .map(|line| format!("  key_{line}: value_{line}\n"))
+            .collect::<String>();
+        let mut editor = yaml_test_editor(format!("root:\n{contents}"), 120, 22);
+        editor.current_buffer_mut().file = Some("notes.txt".to_string());
+        editor
+            .current_buffer_mut()
+            .set_syntax_selection(SyntaxSelection::Language("yaml".to_string()));
+
+        let spans = editor.viewport_highlight_spans(0, 30, 20).unwrap();
+
+        assert!(!spans.is_empty());
+        assert_eq!(editor.highlight_cache[&0].language_id, Some("yaml"));
         assert_eq!(editor.highlight_cache[&0].start_line, 0);
     }
 

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -79,6 +79,37 @@ impl HuskStyles {
 
 const MAX_INJECTION_DEPTH: usize = 3;
 
+const LANGUAGE_NAMES: &[(&str, &str)] = &[
+    ("rs", "rust"),
+    ("rust", "rust"),
+    ("js", "javascript"),
+    ("javascript", "javascript"),
+    ("mjs", "javascript"),
+    ("cjs", "javascript"),
+    ("jsx", "jsx"),
+    ("ts", "typescript"),
+    ("typescript", "typescript"),
+    ("tsx", "tsx"),
+    ("json", "json"),
+    ("toml", "toml"),
+    ("yaml", "yaml"),
+    ("yml", "yaml"),
+    ("py", "python"),
+    ("python", "python"),
+    ("md", "markdown"),
+    ("markdown", "markdown"),
+    ("bash", "bash"),
+    ("sh", "bash"),
+    ("shell", "bash"),
+    ("zsh", "bash"),
+    ("powershell", "powershell"),
+    ("pwsh", "powershell"),
+    ("ps1", "powershell"),
+    ("lua", "lua"),
+    ("hk", "husk"),
+    ("husk", "husk"),
+];
+
 const YAML_ADDITIONAL_HIGHLIGHTS_QUERY: &str = r#"
 (escape_sequence) @escape
 
@@ -119,12 +150,12 @@ impl Highlighter {
         self.language_id_for_extension(&extension)
     }
 
-    /// Whether highlighting a file requires all text before the visible slice.
+    /// Whether highlighting a language requires all text before the visible slice.
     ///
     /// YAML structure is indentation-sensitive, so parsing an arbitrary indented
     /// viewport can lose the mapping and scalar context that determines its nodes.
-    pub(crate) fn requires_document_prefix(&self, file: Option<&str>) -> bool {
-        matches!(self.language_id_for_file(file), Some("yaml"))
+    pub(crate) fn requires_document_prefix(&self, language_id: Option<&str>) -> bool {
+        matches!(language_id, Some("yaml"))
     }
 
     pub fn language_id_for_extension(&self, extension: &str) -> Option<&'static str> {
@@ -134,6 +165,39 @@ impl Highlighter {
 
     pub fn language_id_for_name(&self, name: &str) -> Option<&'static str> {
         language_id_for_name(name).or_else(|| self.language_id_for_extension(name))
+    }
+
+    /// Returns the bundled canonical language identifiers in display order.
+    pub fn language_ids(&self) -> Vec<&'static str> {
+        let mut language_ids = self.languages.keys().copied().collect::<Vec<_>>();
+        language_ids.sort_unstable();
+        language_ids
+    }
+
+    /// Returns canonical language identifiers matching a name or extension prefix.
+    pub fn matching_language_ids(&self, prefix: &str) -> Vec<&'static str> {
+        let prefix = prefix.trim_start_matches('.').to_ascii_lowercase();
+        let mut language_ids = self
+            .languages
+            .keys()
+            .copied()
+            .filter(|language| language.starts_with(&prefix))
+            .chain(
+                self.extensions
+                    .iter()
+                    .filter(|(extension, _)| extension.starts_with(&prefix))
+                    .map(|(_, language)| *language),
+            )
+            .chain(
+                LANGUAGE_NAMES
+                    .iter()
+                    .filter(|(name, _)| name.starts_with(&prefix))
+                    .map(|(_, language)| *language),
+            )
+            .collect::<Vec<_>>();
+        language_ids.sort_unstable();
+        language_ids.dedup();
+        language_ids
     }
 
     pub fn highlight_for_file(
@@ -323,23 +387,10 @@ fn language_id_for_name(name: &str) -> Option<&'static str> {
     let name = name.trim().to_ascii_lowercase();
     let name = name.split_whitespace().next().unwrap_or_default();
 
-    match name {
-        "rs" | "rust" => Some("rust"),
-        "js" | "javascript" | "mjs" | "cjs" => Some("javascript"),
-        "jsx" => Some("jsx"),
-        "ts" | "typescript" => Some("typescript"),
-        "tsx" => Some("tsx"),
-        "json" => Some("json"),
-        "toml" => Some("toml"),
-        "yaml" | "yml" => Some("yaml"),
-        "py" | "python" => Some("python"),
-        "md" | "markdown" => Some("markdown"),
-        "bash" | "sh" | "shell" | "zsh" => Some("bash"),
-        "powershell" | "pwsh" | "ps1" => Some("powershell"),
-        "lua" => Some("lua"),
-        "hk" | "husk" => Some("husk"),
-        _ => None,
-    }
+    LANGUAGE_NAMES
+        .iter()
+        .find(|(candidate, _)| *candidate == name)
+        .map(|(_, language)| *language)
 }
 
 fn file_extension(file: &str) -> Option<String> {
@@ -850,10 +901,10 @@ mod tests {
     fn yaml_requires_document_prefix_for_highlighting() {
         let highlighter = highlighter();
 
-        assert!(highlighter.requires_document_prefix(Some("workflow.yml")));
-        assert!(highlighter.requires_document_prefix(Some("config.yaml")));
-        assert!(!highlighter.requires_document_prefix(Some("main.rs")));
-        assert!(!highlighter.requires_document_prefix(Some("README.md")));
+        assert!(highlighter.requires_document_prefix(Some("yaml")));
+        assert!(!highlighter.requires_document_prefix(Some("rust")));
+        assert!(!highlighter.requires_document_prefix(Some("markdown")));
+        assert!(!highlighter.requires_document_prefix(None));
     }
 
     #[test]
@@ -938,6 +989,45 @@ mod tests {
         assert_eq!(highlighter.language_id_for_name("hk"), Some("husk"));
         assert_eq!(highlighter.language_id_for_name("husk"), Some("husk"));
         assert_eq!(highlighter.language_id_for_name("unknown"), None);
+    }
+
+    #[test]
+    fn lists_bundled_language_ids_in_display_order() {
+        let highlighter = highlighter();
+
+        assert_eq!(
+            highlighter.language_ids(),
+            vec![
+                "bash",
+                "husk",
+                "javascript",
+                "json",
+                "jsx",
+                "lua",
+                "markdown",
+                "powershell",
+                "python",
+                "rust",
+                "toml",
+                "tsx",
+                "typescript",
+                "yaml",
+            ]
+        );
+    }
+
+    #[test]
+    fn matches_language_ids_by_name_and_extension_prefix() {
+        let highlighter = highlighter();
+
+        assert_eq!(highlighter.matching_language_ids("ru"), vec!["rust"]);
+        assert_eq!(highlighter.matching_language_ids("ym"), vec!["yaml"]);
+        assert_eq!(highlighter.matching_language_ids(".rs"), vec!["rust"]);
+        assert_eq!(
+            highlighter.matching_language_ids("ts"),
+            vec!["tsx", "typescript"]
+        );
+        assert!(highlighter.matching_language_ids("unknown").is_empty());
     }
 
     #[test]

--- a/src/matchit.rs
+++ b/src/matchit.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use regex::Regex;
 
 use crate::{
-    buffer::{Buffer, BufferId},
+    buffer::{Buffer, BufferId, SyntaxSelection},
     config::{MatchitConfig, MatchitLanguageConfig},
     undo::{TextPosition, TextRange},
 };
@@ -93,10 +93,13 @@ impl BracketMatchCache {
         let mut characters = rope.chars().enumerate().peekable();
         let mut state = BracketScanState::Code;
         let mut escaped = false;
-        let is_rust = buffer
-            .file
-            .as_deref()
-            .is_some_and(|file| file.ends_with(".rs"));
+        let is_rust = match buffer.syntax_selection() {
+            SyntaxSelection::Language(language) => language == "rust",
+            SyntaxSelection::Auto | SyntaxSelection::Off => buffer
+                .file
+                .as_deref()
+                .is_some_and(|file| file.ends_with(".rs")),
+        };
 
         while let Some((index, character)) = characters.next() {
             match state {
@@ -959,6 +962,25 @@ mod bracket_match_tests {
     fn rust_lifetimes_do_not_hide_later_matching_brackets() {
         let contents = "fn borrow<'value>(text: &str) { text.len() }";
         let buffer = Buffer::new(Some("borrow.rs".to_string()), contents.to_string());
+        let config = MatchitConfig::default();
+        let mut cache = None;
+
+        assert_eq!(
+            BracketMatchCache::matching_position(
+                &mut cache,
+                &buffer,
+                position(contents, "{", 0),
+                &config,
+            ),
+            Some(position(contents, "}", 0))
+        );
+    }
+
+    #[test]
+    fn forced_rust_syntax_keeps_lifetimes_from_hiding_matching_brackets() {
+        let contents = "fn borrow<'value>(text: &str) { text.len() }";
+        let mut buffer = Buffer::new(Some("borrow.txt".to_string()), contents.to_string());
+        buffer.set_syntax_selection(SyntaxSelection::Language("rust".to_string()));
         let config = MatchitConfig::default();
         let mut cache = None;
 

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -10,10 +10,10 @@ use red::{
         EditorToolCall, EditorToolRequest,
     },
     agent_workspace::ProposalWorkspace,
-    buffer::Buffer,
+    buffer::{Buffer, SyntaxSelection},
     clipboard::MemoryClipboardProvider,
     color::Color,
-    config::{Config, KeyAction},
+    config::{Config, KeyAction, MatchitLanguageConfig},
     editor::{Action, Content, Editor, Mode, SearchDirection},
     lsp::LspClient,
     plugin::{
@@ -534,6 +534,59 @@ async fn comment_unnamed_buffer_fails_without_changing_the_buffer() {
         Some("no comment syntax configured for unnamed buffer")
     );
     assert!(!harness.is_dirty());
+}
+
+#[tokio::test]
+async fn forced_syntax_controls_commenting_for_the_current_buffer() {
+    let mut config = default_key_config();
+    config
+        .commenting
+        .languages
+        .insert("txt".to_string(), "; %s".to_string());
+    let buffer = Buffer::new(Some("notes.txt".to_string()), "alpha".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    let revision = harness.editor.test_current_buffer().revision();
+
+    harness
+        .execute_action(Action::Command("syntax rs".to_string()))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness.editor.test_current_buffer().syntax_selection(),
+        &SyntaxSelection::Language("rust".to_string())
+    );
+    assert_eq!(harness.editor.test_current_buffer().revision(), revision);
+    assert!(!harness.is_dirty());
+    assert_eq!(harness.last_error(), Some("syntax: rust"));
+
+    type_normal_keys(&mut harness, "gcc").await;
+
+    harness.assert_buffer_contents("// alpha");
+}
+
+#[tokio::test]
+async fn forced_syntax_controls_language_specific_matchit_groups() {
+    let mut config = default_key_config();
+    config.matchit.languages.insert(
+        "rust".to_string(),
+        MatchitLanguageConfig {
+            groups: vec![vec!["\\bbegin\\b".to_string(), "\\bend\\b".to_string()]],
+        },
+    );
+    let buffer = Buffer::new(Some("notes.txt".to_string()), "begin value end".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    harness
+        .execute_action(Action::Command("syntax rust".to_string()))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::MatchitForward)
+        .await
+        .unwrap();
+
+    assert_eq!(harness.cursor_position(), (12, 0));
 }
 
 #[tokio::test]
@@ -2005,6 +2058,33 @@ fn command_tab_ignores_non_file_commands() {
     fs::remove_dir_all(root).unwrap();
 }
 
+#[test]
+fn command_tab_completes_syntax_names_and_aliases() {
+    for (command, expected) in [
+        ("syntax ru", "syntax rust"),
+        ("syn ym", "syn yaml"),
+        ("ft rs", "ft rust"),
+        ("syntax ", "syntax auto"),
+    ] {
+        let mut harness = EditorHarness::with_content("");
+        harness.set_commandline(Mode::Command, command);
+
+        harness.editor.test_complete_command_path_next();
+
+        assert_eq!(harness.commandline_text(), expected);
+    }
+}
+
+#[test]
+fn command_tab_does_not_complete_a_second_syntax_argument() {
+    let mut harness = EditorHarness::with_content("");
+    harness.set_commandline(Mode::Command, "syntax rust extra");
+
+    harness.editor.test_complete_command_path_next();
+
+    assert_eq!(harness.commandline_text(), "syntax rust extra");
+}
+
 #[tokio::test]
 async fn command_tab_key_event_completes_file_argument() {
     let root = env::temp_dir().join(format!(
@@ -2065,6 +2145,80 @@ async fn wrap_commands_toggle_line_wrapping() {
         .await
         .unwrap();
     assert!(harness.wrap());
+}
+
+#[tokio::test]
+async fn syntax_commands_set_reset_and_disable_buffer_local_syntax() {
+    let buffer = Buffer::new(Some("notes.txt".to_string()), "fn main() {}".to_string());
+    let mut harness = EditorHarness::with_buffer(buffer);
+
+    harness
+        .execute_action(Action::Command("ft RS".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(
+        harness.editor.test_current_buffer().syntax_selection(),
+        &SyntaxSelection::Language("rust".to_string())
+    );
+    assert_eq!(harness.last_error(), Some("syntax: rust"));
+    assert!(!harness.is_dirty());
+
+    harness
+        .execute_action(Action::Command("syn off".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(
+        harness.editor.test_current_buffer().syntax_selection(),
+        &SyntaxSelection::Off
+    );
+    assert_eq!(harness.last_error(), Some("syntax: off"));
+
+    harness
+        .execute_action(Action::Command("syntax auto".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(
+        harness.editor.test_current_buffer().syntax_selection(),
+        &SyntaxSelection::Auto
+    );
+    assert_eq!(harness.last_error(), Some("syntax: auto"));
+}
+
+#[tokio::test]
+async fn invalid_syntax_commands_leave_the_existing_selection_unchanged() {
+    let buffer = Buffer::new(Some("notes.txt".to_string()), "fn main() {}".to_string());
+    let mut harness = EditorHarness::with_buffer(buffer);
+    harness
+        .execute_action(Action::Command("syntax rust".to_string()))
+        .await
+        .unwrap();
+
+    harness
+        .execute_action(Action::Command("syntax madeup".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(
+        harness.editor.test_current_buffer().syntax_selection(),
+        &SyntaxSelection::Language("rust".to_string())
+    );
+    assert_eq!(
+        harness.last_error(),
+        Some("unknown syntax \"madeup\" (try :syntax)")
+    );
+
+    harness
+        .execute_action(Action::Command("syntax rust yaml".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(
+        harness.editor.test_current_buffer().syntax_selection(),
+        &SyntaxSelection::Language("rust".to_string())
+    );
+    assert_eq!(
+        harness.last_error(),
+        Some("usage: syntax [language|auto|off]")
+    );
+    assert!(!harness.is_dirty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Files without a recognized extension, scratch buffers, and files with a misleading extension currently cannot select the syntax they should use. This makes highlighting unavailable or incorrect and leaves language-aware editing commands such as commenting and matchit using the wrong language.

This adds a buffer-local syntax selection with three modes: detected (`auto`), disabled (`off`), or an explicit bundled language. `:syntax`, `:syn`, and `:ft` accept canonical names and familiar extension aliases, support Tab completion, and open a searchable language picker when invoked without an argument. Changing syntax immediately refreshes both full and incremental rendering, preserves YAML's required document-prefix context, invalidates the relevant caches, and updates commenting and matchit behavior without changing buffer contents or starting a different LSP server.

## How to Test

1. Open a text file containing Rust-like content but with a `.txt` extension, for example:

   ```text
   fn main() {
       let greeting = "hello";
       println!("{greeting}");
   }
   ```

   Run `:syntax rs`, or type `:syntax rs` and press Tab. The command completes to `:syntax rust`, Rust highlighting appears immediately, and `gcc` uses `//` comments.
2. Run `:syntax` with no argument. Confirm the searchable picker lists `auto`, `off`, and the bundled languages; filter for `yaml` or `rust`, select it, and confirm the buffer redraws with the selected syntax.
3. Run `:ft off`. Highlighting should disappear and the command line should report `syntax: off`. Run `:syntax auto` to restore extension-based detection. An invalid value such as `:syntax madeup` should leave the current selection intact and report an error.
4. Exercise the focused automated coverage:

   ```bash
   cargo test --lib syntax
   cargo test --lib forced_yaml
   cargo test --lib language_ids
   cargo test --test editing syntax
   cargo clippy --all-targets --all-features -- -D warnings
   ```

   Local validation also passed all 1,475 non-plugin-runtime tests and an interactive tmux smoke test. The existing 85-test `plugin::runtime::tests` group repeatedly stalled during the aggregate run and was excluded from that completed pass.
