### PR TITLE
refactor(neotree): reuse native husk standard library

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -48,8 +48,11 @@ jobs:
           cargo test --all-features -p red plugin::runtime::tests::lsp_symbols_
           cargo test --all-features -p red plugin::runtime::tests::git_
           cargo test --all-features -p red plugin::runtime::tests::embedded_git_core_
+          cargo test --all-features -p red plugin::runtime::tests::neotree_
+          cargo test --all-features -p red plugin::runtime::tests::embedded_neotree_core_
           cargo test --all-features -p husk -p husk-ast -p husk-diagnostics -p husk-lexer -p husk-package -p husk-parser -p husk-semantic -p husk-stdlib -p husk-types
           cargo run --all-features -p husk-cli -- test --locked plugins/git_core
+          cargo run --all-features -p husk-cli -- test --locked plugins/neotree_core
 
       - name: Validate example plugin metadata
         run: python3 -m json.tool examples/example-plugin/package.json > /dev/null

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -136,10 +136,13 @@ capability inventory; the bundled `.hk` sources are working examples.
 The Git plugin keeps its event, picker, and permissioned-process shell in
 `plugins/git.hk`, while its status model, diff and hunk parsing, selection
 logic, and Git argument construction live in the native, multi-file
-`plugins/git_core` Husk package. Red embeds those pure sources and exposes a
-small internal bridge to the compatibility shell, so installed builds do not
-depend on a checkout-relative source path. The bridge is bundled-plugin
-implementation detail, not a public plugin API.
+`plugins/git_core` Husk package. Neo-tree follows the same split: filesystem
+actions, confirmations, and panel events stay in `plugins/neotree.hk`, while
+normalized path handling, typed Git-status presentation, and bounded tree-row
+construction live in `plugins/neotree_core`. Red embeds those pure sources and
+exposes small internal bridges to the compatibility shells, so installed
+builds do not depend on checkout-relative source paths. The bridges are
+bundled-plugin implementation detail, not public plugin APIs.
 
 `buffer:changed`, cursor, mode, viewport, file, theme, window, LSP, timer, picker, composer, panel, process, filesystem, workspace, and agent events are emitted by the production runtime. Subscribe only to the events a plugin needs and debounce expensive work.
 
@@ -150,6 +153,7 @@ Run:
 ```shell
 cargo test --workspace
 cargo run -p husk-cli -- test --locked plugins/git_core
+cargo run -p husk-cli -- test --locked plugins/neotree_core
 cargo clippy --all-targets --all-features -- -D warnings
 cargo run -- --self-check
 cargo run -- --runtime-files

--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -23,7 +23,7 @@ pub fn activate() {
         statuses: [],
         error: red::null(),
     });
-    red::state_set("status_index", Json {});
+    red::state_set("status_entries", []);
     red::state_set("cwd", ".");
     red::state_set("current_file", "");
     red::state_set("selected", []);
@@ -504,61 +504,27 @@ fn reset_tree() {
 }
 
 fn path_name(path: String) -> String {
-    let parts = red::split(normalize_path(path), "/");
-    return parts[red::len(parts) - 1];
+    return red::string(red::neotree_core("path_name", path), "");
 }
 
 fn path_parent(path: String) -> String {
-    let normalized = normalize_path(path);
-    let parts = red::split(normalized, "/");
-    if red::len(parts) <= 2 {
-        return ".";
-    }
-    let parent = ".";
-    let index = 1;
-    while index < red::len(parts) - 1 {
-        parent = parent + "/" + parts[index];
-        index = index + 1;
-    }
-    return parent;
+    return red::string(red::neotree_core("path_parent", path), ".");
 }
 
 fn path_join(parent: String, child: String) -> String {
-    let child = normalize_path(child);
-    if red::starts_with(child, "./") || red::starts_with(child, "/") {
-        return child;
-    }
-    if parent == "." {
-        return "./" + child;
-    }
-    return normalize_path(parent) + "/" + child;
+    return red::string(red::neotree_core("path_join", parent, child), "");
 }
 
 fn workspace_path(path: String) -> String {
-    let path = normalize_path(path);
-    if red::starts_with(path, "./") || red::starts_with(path, "/") {
-        return path;
-    }
-    return "./" + path;
+    return red::string(red::neotree_core("workspace_path", path), "");
 }
 
 fn name_extension(name: String) -> String {
-    let parts = red::split(name, ".");
-    if red::len(parts) <= 1 {
-        return "";
-    }
-    if red::starts_with(name, ".") && red::len(parts) == 2 {
-        return "";
-    }
-    return "." + parts[red::len(parts) - 1];
+    return red::string(red::neotree_core("name_extension", name), "");
 }
 
 fn basename(name: String) -> String {
-    let extension = name_extension(name);
-    if extension == "" {
-        return name;
-    }
-    return red::slice(name, 0, red::len(name) - red::len(extension));
+    return red::string(red::neotree_core("basename", name), "");
 }
 
 fn reload_visible_tree() {
@@ -593,7 +559,7 @@ fn directory_loaded(listing: Json) {
 
 fn git_status_loaded(result: Json) {
     red::state_set("status", result);
-    red::state_set("status_index", result.status_index);
+    red::state_set("status_entries", red::neotree_core("status_entries", result.status_index));
     render();
 }
 
@@ -660,27 +626,11 @@ fn try_reveal_current_file() {
 }
 
 fn tree_path_for_file(file: String, cwd: String) -> String {
-    if file == "" {
-        return "";
-    }
-
-    let normalized_file = normalize_path(file);
-    let normalized_cwd = normalize_path(cwd);
-    if red::starts_with(normalized_file, normalized_cwd + "/") {
-        return "./" + red::slice(normalized_file, red::len(normalized_cwd) + 1);
-    }
-    if red::starts_with(normalized_file, "/") {
-        return "";
-    }
-    if red::starts_with(normalized_file, "./") {
-        return normalized_file;
-    }
-    return "./" + normalized_file;
+    return red::string(red::neotree_core("tree_path", file, cwd), "");
 }
 
 fn start_reveal(tree_path: String) {
-    let relative = strip_dot_slash(tree_path);
-    let parts = red::split(relative, "/");
+    let parts = red::neotree_core("reveal_parts", tree_path);
     if red::len(parts) == 0 {
         return;
     }
@@ -783,15 +733,6 @@ fn children_for(path: String) -> Json {
     return [];
 }
 
-fn children_truncated(path: String) -> bool {
-    for child in red::state("children") {
-        if child.path == path {
-            return red::bool(child.truncated, false);
-        }
-    }
-    return false;
-}
-
 fn toggle_directory(path: String) {
     if is_expanded(path) {
         collapse_directory(path);
@@ -849,125 +790,16 @@ fn loading_rows() -> Json {
 }
 
 fn build_rows() -> Json {
-    let rows = [];
-    let root = ".";
-    let root_status = status_for_path(root);
-    rows = red::push(rows, PanelRow {
-        id: root,
-        path: root,
-        expanded: is_expanded(root),
-        kind: "directory",
-        segments: [
-            segment(" ", [], false),
-            segment(" ", ["symbolIcon.folderForeground", "sideBarTitle.foreground", "list.highlightForeground"], false),
-            segment(root_label(), ["sideBarTitle.foreground", "symbolIcon.folderForeground", "list.highlightForeground"], true),
-        ],
-        right_segments: status_segments(root_status),
-    });
-
-    if is_expanded(root) {
-        rows = append_rows(root, [], rows);
-    }
-    if red::len(rows) >= 200 {
-        rows = red::push(rows, truncation_row("tree-limit", "… tree limited to 200 rows"));
-    }
-    return rows;
-}
-
-fn append_rows(path: String, ancestors: Json, rows: Json) -> Json {
-    let entries = [];
-    for entry in children_for(path) {
-        if entry.kind == "directory" || entry.kind == "file" {
-            entries = red::push(entries, entry);
-        }
-    }
-    let index = 0;
-    while index < red::len(entries) && red::len(rows) < 200 {
-        let entry = entries[index];
-        let is_last = index == red::len(entries) - 1;
-        let is_directory = entry.kind == "directory";
-        let expanded = is_directory && is_expanded(entry.path);
-        let status = status_for_path(entry.path);
-        let segments = [
-            segment(selection_marker(entry.path), ["list.highlightForeground"], true),
-        ];
-        for prefix in branch_prefix(ancestors, is_last) {
-            segments = red::push(segments, prefix);
-        }
-        segments = red::push(segments, segment(entry_icon(entry.name, is_directory, expanded) + " ", entry_style_keys(status, is_directory), false));
-        segments = red::push(segments, segment(entry.name, entry_style_keys(status, is_directory), false));
-        rows = red::push(rows, PanelRow {
-            id: entry.path,
-            path: entry.path,
-            expanded: expanded,
-            kind: entry.kind,
-            segments: segments,
-            right_segments: status_segments(status),
-        });
-
-        if expanded {
-            let next_ancestors = red::push(ancestors, Ancestor {
-                last: is_last,
-                visible: red::len(ancestors) > 0,
-            });
-            rows = append_rows(entry.path, next_ancestors, rows);
-        }
-        index = index + 1;
-    }
-    if children_truncated(path) && red::len(rows) < 200 {
-        rows = red::push(rows, truncation_row("directory-limit:" + path, "… directory listing truncated"));
-    }
-    return rows;
-}
-
-fn selection_marker(path: String) -> String {
-    if red::contains(red::state("selected"), path) {
-        return "✓ ";
-    }
-    for entry in red::state("clipboard") {
-        if entry.path == path {
-            if entry.action == "move" {
-                return "✂ ";
-            }
-            return "⧉ ";
-        }
-    }
-    return "  ";
-}
-
-fn truncation_row(id: String, text: String) -> Json {
-    return PanelRow {
-        id: id,
-        path: red::null(),
-        expanded: false,
-        kind: "file",
-        segments: [
-            segment("  ", ["tree.indentGuidesStroke"], false),
-            segment(text, ["gitDecoration.ignoredResourceForeground"], false),
-        ],
-        right_segments: [],
-    };
-}
-
-fn branch_prefix(ancestors: Json, is_last: bool) -> Json {
-    let segments = [];
-    for ancestor in ancestors {
-        if ancestor.visible && !ancestor.last {
-            segments = red::push(segments, segment("│ ", ["tree.indentGuidesStroke"], false));
-        } else {
-            segments = red::push(segments, segment("  ", ["tree.indentGuidesStroke"], false));
-        }
-    }
-    if red::len(ancestors) > 0 {
-        if is_last {
-            segments = red::push(segments, segment("└ ", ["tree.indentGuidesStroke"], false));
-        } else {
-            segments = red::push(segments, segment("├ ", ["tree.indentGuidesStroke"], false));
-        }
-    } else {
-        segments = red::push(segments, segment("  ", ["tree.indentGuidesStroke"], false));
-    }
-    return segments;
+    return red::neotree_core(
+        "build_rows",
+        red::string(red::state("cwd"), "."),
+        red::state("children"),
+        red::state("expanded"),
+        red::state("selected"),
+        red::state("clipboard"),
+        red::string(red::state("status").root, ""),
+        red::state("status_entries")
+    );
 }
 
 fn segment(text: String, foreground: Json, bold: bool) -> Json {
@@ -980,159 +812,6 @@ fn segment(text: String, foreground: Json, bold: bool) -> Json {
     };
 }
 
-fn entry_style_keys(status: String, directory: bool) -> Json {
-    if status == "ignored" {
-        return ["gitDecoration.ignoredResourceForeground"];
-    }
-    if directory {
-        return ["symbolIcon.folderForeground", "sideBarTitle.foreground", "list.highlightForeground"];
-    }
-    return ["sideBar.foreground"];
-}
-
-fn entry_icon(name: String, directory: bool, expanded: bool) -> String {
-    if directory {
-        if expanded {
-            return "";
-        }
-        return "";
-    }
-
-    let parts = red::split(red::lower(name), ".");
-    let extension = parts[red::len(parts) - 1];
-    if extension == "js" || extension == "mjs" || extension == "cjs" {
-        return "";
-    }
-    if extension == "ts" {
-        return "";
-    }
-    if extension == "tsx" || extension == "jsx" {
-        return "";
-    }
-    if extension == "json" {
-        return "";
-    }
-    if extension == "toml" {
-        return "";
-    }
-    if extension == "rs" {
-        return "";
-    }
-    if extension == "lua" {
-        return "";
-    }
-    if extension == "md" || extension == "markdown" {
-        return "";
-    }
-    if extension == "lock" {
-        return "";
-    }
-    if extension == "sh" || extension == "zsh" || extension == "fish" {
-        return "";
-    }
-    return "󰈙";
-}
-
-fn status_segments(status: String) -> Json {
-    if status == "" {
-        return [];
-    }
-    return [segment(status_symbol(status), status_style_keys(status), status == "conflict")];
-}
-
-fn status_symbol(status: String) -> String {
-    if status == "added" {
-        return "✚";
-    }
-    if status == "deleted" {
-        return "✖";
-    }
-    if status == "modified" {
-        return "";
-    }
-    if status == "renamed" {
-        return "";
-    }
-    if status == "untracked" {
-        return "";
-    }
-    if status == "ignored" {
-        return "";
-    }
-    if status == "staged" {
-        return "";
-    }
-    if status == "conflict" {
-        return "";
-    }
-    return "";
-}
-
-fn status_style_keys(status: String) -> Json {
-    if status == "added" {
-        return ["gitDecoration.addedResourceForeground", "gitDecoration.untrackedResourceForeground"];
-    }
-    if status == "deleted" {
-        return ["gitDecoration.deletedResourceForeground", "gitDecoration.stageDeletedResourceForeground"];
-    }
-    if status == "modified" {
-        return ["gitDecoration.modifiedResourceForeground", "gitDecoration.stageModifiedResourceForeground"];
-    }
-    if status == "renamed" {
-        return ["gitDecoration.renamedResourceForeground", "gitDecoration.modifiedResourceForeground"];
-    }
-    if status == "untracked" {
-        return ["gitDecoration.untrackedResourceForeground", "gitDecoration.addedResourceForeground"];
-    }
-    if status == "ignored" {
-        return ["gitDecoration.ignoredResourceForeground"];
-    }
-    if status == "staged" {
-        return ["gitDecoration.stageModifiedResourceForeground", "gitDecoration.addedResourceForeground"];
-    }
-    return ["gitDecoration.conflictingResourceForeground"];
-}
-
-fn status_for_path(path: String) -> String {
-    let result = red::state("status");
-    let root = normalize_path(red::string(result.root, ""));
-    if root == "" {
-        return "";
-    }
-
-    let relative = strip_dot_slash(normalize_path(path));
-    let absolute = root;
-    if relative != "." && relative != "" {
-        if root == "/" {
-            absolute = root + relative;
-        } else {
-            absolute = root + "/" + relative;
-        }
-    }
-
-    return red::string(red::state("status_index")[absolute], "");
-}
-
-fn root_label() -> String {
-    let cwd = normalize_path(red::string(red::state("cwd"), "."));
-    if cwd == "." {
-        return ".";
-    }
-    let parts = red::split(cwd, "/");
-    return parts[red::len(parts) - 1];
-}
-
-fn strip_dot_slash(path: String) -> String {
-    if red::starts_with(path, "./") {
-        return red::slice(path, 2);
-    }
-    return path;
-}
-
 fn normalize_path(path: String) -> String {
-    let normalized = red::replace_all(path, "\\", "/");
-    while red::len(normalized) > 1 && red::ends_with(normalized, "/") {
-        normalized = red::slice(normalized, 0, red::len(normalized) - 1);
-    }
-    return normalized;
+    return red::string(red::neotree_core("normalize_path", path), "");
 }

--- a/plugins/neotree_core/Husk.lock
+++ b/plugins/neotree_core/Husk.lock
@@ -1,0 +1,5 @@
+schema_version = 1
+
+[package]
+name = "red-neotree-core"
+version = "0.1.0"

--- a/plugins/neotree_core/Husk.toml
+++ b/plugins/neotree_core/Husk.toml
@@ -1,0 +1,6 @@
+schema_version = 1
+
+[package]
+name = "red-neotree-core"
+version = "0.1.0"
+entry = "src/main.hk"

--- a/plugins/neotree_core/src/main.hk
+++ b/plugins/neotree_core/src/main.hk
@@ -1,0 +1,3 @@
+mod path;
+mod status;
+mod tree;

--- a/plugins/neotree_core/src/path.hk
+++ b/plugins/neotree_core/src/path.hk
@@ -1,0 +1,123 @@
+// Pure, normalized project-path operations shared by Neo-tree actions and rendering.
+
+pub fn normalize(value: String) -> String {
+    let mut value = value.replace("\\", "/");
+    while value.len() > 1 && value.ends_with("/") {
+        value = value.strip_suffix("/").unwrap_or(value);
+    }
+    value
+}
+
+pub fn name(path: String) -> String {
+    let path = normalize(path);
+    if let Some(parts) = path.rsplit_once("/") {
+        return parts.1;
+    }
+    path
+}
+
+pub fn parent(path: String) -> String {
+    let path = normalize(path);
+    let Some(parts) = path.rsplit_once("/") else {
+        return ".";
+    };
+    if parts.0.is_empty() || parts.0 == "." {
+        return ".";
+    }
+    parts.0
+}
+
+pub fn join(parent: String, child: String) -> String {
+    let child = normalize(child);
+    if child.starts_with("./") || child.starts_with("/") {
+        return child;
+    }
+    if parent == "." {
+        return "./" + child;
+    }
+    normalize(parent) + "/" + child
+}
+
+pub fn workspace(path: String) -> String {
+    let path = normalize(path);
+    if path.starts_with("./") || path.starts_with("/") {
+        return path;
+    }
+    "./" + path
+}
+
+pub fn extension(name: String) -> String {
+    let Some(parts) = name.rsplit_once(".") else {
+        return "";
+    };
+    if parts.0.is_empty() {
+        return "";
+    }
+    "." + parts.1
+}
+
+pub fn basename(name: String) -> String {
+    let suffix = extension(name);
+    name.strip_suffix(suffix).unwrap_or(name)
+}
+
+pub fn tree_path(file: String, cwd: String) -> String {
+    if file.is_empty() {
+        return "";
+    }
+    let file = normalize(file);
+    let cwd = normalize(cwd);
+    let mut prefix = cwd + "/";
+    if cwd == "/" {
+        prefix = "/";
+    }
+    if let Some(relative) = file.strip_prefix(prefix) {
+        return "./" + relative;
+    }
+    if file.starts_with("/") {
+        return "";
+    }
+    if file.starts_with("./") {
+        return file;
+    }
+    "./" + file
+}
+
+pub fn reveal_parts(path: String) -> [String] {
+    let path = normalize(path);
+    let path = path.strip_prefix("./").unwrap_or(path);
+    if path.is_empty() || path == "." {
+        return [];
+    }
+    path.split("/")
+}
+
+#[test]
+fn normalizes_and_joins_workspace_paths() {
+    assert(normalize(".\\src\\main.rs/") == "./src/main.rs");
+    assert(name("./src/main.rs") == "main.rs");
+    assert(parent("./src/main.rs") == "./src");
+    assert(parent("./main.rs") == ".");
+    assert(join("./src/", "main.rs") == "./src/main.rs");
+    assert(join(".", "./other.rs") == "./other.rs");
+    assert(workspace("src/main.rs") == "./src/main.rs");
+}
+
+#[test]
+fn preserves_dotfiles_and_multi_part_extensions() {
+    assert(extension("main.test.rs") == ".rs");
+    assert(basename("main.test.rs") == "main.test");
+    assert(extension(".gitignore") == "");
+    assert(basename(".gitignore") == ".gitignore");
+    assert(extension("README") == "");
+}
+
+#[test]
+fn confines_reveal_paths_to_the_workspace() {
+    assert(tree_path("/repo/src/main.rs", "/repo") == "./src/main.rs");
+    assert(tree_path("/src/main.rs", "/") == "./src/main.rs");
+    assert(tree_path("/outside/main.rs", "/repo") == "");
+    assert(tree_path("src/main.rs", "/repo") == "./src/main.rs");
+    assert(reveal_parts("./src/main.rs").join("/") == "src/main.rs");
+    assert(reveal_parts(".").is_empty());
+}

--- a/plugins/neotree_core/src/status.hk
+++ b/plugins/neotree_core/src/status.hk
@@ -1,0 +1,83 @@
+// Typed Git-status presentation. Unknown values remain undecorated instead of
+// being interpreted as a valid status.
+
+enum GitStatus {
+    Added,
+    Deleted,
+    Modified,
+    Renamed,
+    Untracked,
+    Ignored,
+    Staged,
+    Conflict,
+    Unknown,
+}
+
+fn status(value: String) -> GitStatus {
+    if value == "added" { return GitStatus::Added; }
+    if value == "deleted" { return GitStatus::Deleted; }
+    if value == "modified" { return GitStatus::Modified; }
+    if value == "renamed" { return GitStatus::Renamed; }
+    if value == "untracked" { return GitStatus::Untracked; }
+    if value == "ignored" { return GitStatus::Ignored; }
+    if value == "staged" { return GitStatus::Staged; }
+    if value == "conflict" { return GitStatus::Conflict; }
+    GitStatus::Unknown
+}
+
+pub fn symbol(value: String) -> String {
+    match status(value) {
+        GitStatus::Added => "✚",
+        GitStatus::Deleted => "✖",
+        GitStatus::Modified => "",
+        GitStatus::Renamed => "",
+        GitStatus::Untracked => "",
+        GitStatus::Ignored => "",
+        GitStatus::Staged => "",
+        GitStatus::Conflict => "",
+        GitStatus::Unknown => "",
+    }
+}
+
+pub fn style_keys(value: String) -> [String] {
+    match status(value) {
+        GitStatus::Added => ["gitDecoration.addedResourceForeground", "gitDecoration.untrackedResourceForeground"],
+        GitStatus::Deleted => ["gitDecoration.deletedResourceForeground", "gitDecoration.stageDeletedResourceForeground"],
+        GitStatus::Modified => ["gitDecoration.modifiedResourceForeground", "gitDecoration.stageModifiedResourceForeground"],
+        GitStatus::Renamed => ["gitDecoration.renamedResourceForeground", "gitDecoration.modifiedResourceForeground"],
+        GitStatus::Untracked => ["gitDecoration.untrackedResourceForeground", "gitDecoration.addedResourceForeground"],
+        GitStatus::Ignored => ["gitDecoration.ignoredResourceForeground"],
+        GitStatus::Staged => ["gitDecoration.stageModifiedResourceForeground", "gitDecoration.addedResourceForeground"],
+        GitStatus::Conflict => ["gitDecoration.conflictingResourceForeground"],
+        GitStatus::Unknown => [],
+    }
+}
+
+pub fn entry_style_keys(value: String, directory: bool) -> [String] {
+    if let GitStatus::Ignored = status(value) {
+        return ["gitDecoration.ignoredResourceForeground"];
+    }
+    if directory {
+        return ["symbolIcon.folderForeground", "sideBarTitle.foreground", "list.highlightForeground"];
+    }
+    ["sideBar.foreground"]
+}
+
+pub fn is_conflict(value: String) -> bool {
+    if let GitStatus::Conflict = status(value) {
+        return true;
+    }
+    false
+}
+
+#[test]
+fn maps_git_statuses_to_semantic_decorations() {
+    assert(symbol("modified") == "");
+    assert(symbol("conflict") == "");
+    assert(symbol("unknown").is_empty());
+    assert(style_keys("renamed")[0] == "gitDecoration.renamedResourceForeground");
+    assert(style_keys("unknown").is_empty());
+    assert(entry_style_keys("ignored", true)[0] == "gitDecoration.ignoredResourceForeground");
+    assert(is_conflict("conflict"));
+    assert(!is_conflict("modified"));
+}

--- a/plugins/neotree_core/src/tree.hk
+++ b/plugins/neotree_core/src/tree.hk
@@ -1,0 +1,345 @@
+// Typed, bounded Neo-tree row construction. Host-provided strings are parsed
+// once at the boundary and all presentation work stays in this pure core.
+
+struct DirectoryEntry {
+    name: String,
+    path: String,
+    kind: String,
+}
+
+struct Children {
+    path: String,
+    entries: [DirectoryEntry],
+    truncated: bool,
+}
+
+struct ClipboardEntry {
+    path: String,
+    action: String,
+}
+
+pub struct PathStatus {
+    path: String,
+    status: String,
+}
+
+struct Ancestor {
+    last: bool,
+    visible: bool,
+}
+
+struct ThemeStyleSpec {
+    foreground: [String],
+    bold: bool,
+}
+
+struct PanelSegment {
+    text: String,
+    semantic: ThemeStyleSpec,
+}
+
+pub struct PanelRow {
+    id: String,
+    path: Option<String>,
+    expanded: bool,
+    kind: String,
+    segments: [PanelSegment],
+    right_segments: [PanelSegment],
+}
+
+enum EntryKind {
+    File,
+    Directory,
+    Unknown,
+}
+
+enum ClipboardAction {
+    Copy,
+    Move,
+    Unknown,
+}
+
+fn entry_kind(value: String) -> EntryKind {
+    if value == "file" { return EntryKind::File; }
+    if value == "directory" { return EntryKind::Directory; }
+    EntryKind::Unknown
+}
+
+fn clipboard_action(value: String) -> ClipboardAction {
+    if value == "copy" { return ClipboardAction::Copy; }
+    if value == "move" { return ClipboardAction::Move; }
+    ClipboardAction::Unknown
+}
+
+pub fn build_rows(
+    cwd: String,
+    children: [Children],
+    expanded: [String],
+    selected: [String],
+    clipboard: [ClipboardEntry],
+    status_root: String,
+    statuses: [PathStatus]
+) -> [PanelRow] {
+    let root = ".";
+    let root_status = status_for_path(root, status_root, statuses);
+    let mut rows = [PanelRow {
+        id: root,
+        path: Some(root),
+        expanded: expanded.contains(root),
+        kind: "directory",
+        segments: [
+            segment(" ", [], false),
+            segment(" ", ["symbolIcon.folderForeground", "sideBarTitle.foreground", "list.highlightForeground"], false),
+            segment(path::name(cwd), ["sideBarTitle.foreground", "symbolIcon.folderForeground", "list.highlightForeground"], true),
+        ],
+        right_segments: status_segments(root_status),
+    }];
+
+    if expanded.contains(root) {
+        rows = append_rows(root, [], rows, children, expanded, selected, clipboard, status_root, statuses);
+    }
+    if rows.len() >= 200 {
+        rows.push(truncation_row("tree-limit", "… tree limited to 200 rows"));
+    }
+    rows
+}
+
+fn append_rows(
+    path: String,
+    ancestors: [Ancestor],
+    rows: [PanelRow],
+    children: [Children],
+    expanded: [String],
+    selected: [String],
+    clipboard: [ClipboardEntry],
+    status_root: String,
+    statuses: [PathStatus]
+) -> [PanelRow] {
+    let entries = children_for(path, children);
+    let mut visible: [DirectoryEntry] = [];
+    for entry in entries {
+        match entry_kind(entry.kind) {
+            EntryKind::File => visible.push(entry),
+            EntryKind::Directory => visible.push(entry),
+            EntryKind::Unknown => {},
+        };
+    }
+
+    let mut rows = rows;
+    let mut index = 0;
+    while index < visible.len() && rows.len() < 200 {
+        let entry = visible[index];
+        let directory = entry.kind == "directory";
+        let open = directory && expanded.contains(entry.path);
+        let last = index == visible.len() - 1;
+        let status = status_for_path(entry.path, status_root, statuses);
+        let mut segments = [segment(selection_marker(entry.path, selected, clipboard), ["list.highlightForeground"], true)];
+        for prefix in branch_prefix(ancestors, last) {
+            segments.push(prefix);
+        }
+        let style = status::entry_style_keys(status, directory);
+        segments.push(segment(entry_icon(entry.name, directory, open) + " ", style, false));
+        segments.push(segment(entry.name, style, false));
+        rows.push(PanelRow {
+            id: entry.path,
+            path: Some(entry.path),
+            expanded: open,
+            kind: entry.kind,
+            segments: segments,
+            right_segments: status_segments(status),
+        });
+
+        if open {
+            let mut next_ancestors = ancestors;
+            next_ancestors.push(Ancestor { last: last, visible: !ancestors.is_empty() });
+            rows = append_rows(entry.path, next_ancestors, rows, children, expanded, selected, clipboard, status_root, statuses);
+        }
+        index += 1;
+    }
+    if children_truncated(path, children) && rows.len() < 200 {
+        rows.push(truncation_row("directory-limit:" + path, "… directory listing truncated"));
+    }
+    rows
+}
+
+fn children_for(path: String, children: [Children]) -> [DirectoryEntry] {
+    for child in children {
+        if child.path == path {
+            return child.entries;
+        }
+    }
+    []
+}
+
+fn children_truncated(path: String, children: [Children]) -> bool {
+    for child in children {
+        if child.path == path {
+            return child.truncated;
+        }
+    }
+    false
+}
+
+fn status_for_path(path: String, root: String, statuses: [PathStatus]) -> String {
+    let root = path::normalize(root);
+    if root.is_empty() {
+        return "";
+    }
+    let path = path::normalize(path);
+    let relative = path.strip_prefix("./").unwrap_or(path);
+    let mut absolute = root;
+    if !relative.is_empty() && relative != "." {
+        if root == "/" {
+            absolute = root + relative;
+        } else {
+            absolute = root + "/" + relative;
+        }
+    }
+
+    let mut low = 0;
+    let mut high = statuses.len();
+    while low < high {
+        let middle = low + (high - low) / 2;
+        let candidate = statuses[middle];
+        if candidate.path == absolute {
+            return candidate.status;
+        }
+        if candidate.path < absolute {
+            low = middle + 1;
+        } else {
+            high = middle;
+        }
+    }
+    ""
+}
+
+fn selection_marker(path: String, selected: [String], clipboard: [ClipboardEntry]) -> String {
+    if selected.contains(path) {
+        return "✓ ";
+    }
+    for entry in clipboard {
+        if entry.path == path {
+            return match clipboard_action(entry.action) {
+                ClipboardAction::Move => "✂ ",
+                ClipboardAction::Copy => "⧉ ",
+                ClipboardAction::Unknown => "  ",
+            };
+        }
+    }
+    "  "
+}
+
+fn branch_prefix(ancestors: [Ancestor], last: bool) -> [PanelSegment] {
+    let mut segments = [];
+    for ancestor in ancestors {
+        if ancestor.visible && !ancestor.last {
+            segments.push(segment("│ ", ["tree.indentGuidesStroke"], false));
+        } else {
+            segments.push(segment("  ", ["tree.indentGuidesStroke"], false));
+        }
+    }
+    if ancestors.is_empty() {
+        segments.push(segment("  ", ["tree.indentGuidesStroke"], false));
+    } else if last {
+        segments.push(segment("└ ", ["tree.indentGuidesStroke"], false));
+    } else {
+        segments.push(segment("├ ", ["tree.indentGuidesStroke"], false));
+    }
+    segments
+}
+
+fn entry_icon(name: String, directory: bool, expanded: bool) -> String {
+    if directory {
+        if expanded {
+            return "";
+        }
+        return "";
+    }
+    let name = name.to_lowercase();
+    let extension = name.rsplit_once(".").unwrap_or(("", name)).1;
+    if extension == "js" || extension == "mjs" || extension == "cjs" { return ""; }
+    if extension == "ts" { return ""; }
+    if extension == "tsx" || extension == "jsx" { return ""; }
+    if extension == "json" { return ""; }
+    if extension == "toml" { return ""; }
+    if extension == "rs" { return ""; }
+    if extension == "lua" { return ""; }
+    if extension == "md" || extension == "markdown" { return ""; }
+    if extension == "lock" { return ""; }
+    if extension == "sh" || extension == "zsh" || extension == "fish" { return ""; }
+    "󰈙"
+}
+
+fn status_segments(value: String) -> [PanelSegment] {
+    let symbol = status::symbol(value);
+    if symbol.is_empty() {
+        return [];
+    }
+    [segment(symbol, status::style_keys(value), status::is_conflict(value))]
+}
+
+fn truncation_row(id: String, text: String) -> PanelRow {
+    PanelRow {
+        id: id,
+        path: None,
+        expanded: false,
+        kind: "file",
+        segments: [
+            segment("  ", ["tree.indentGuidesStroke"], false),
+            segment(text, ["gitDecoration.ignoredResourceForeground"], false),
+        ],
+        right_segments: [],
+    }
+}
+
+fn segment(text: String, foreground: [String], bold: bool) -> PanelSegment {
+    PanelSegment {
+        text: text,
+        semantic: ThemeStyleSpec { foreground: foreground, bold: bold },
+    }
+}
+
+#[test]
+fn renders_typed_rows_with_status_and_selection_markers() {
+    assert(selection_marker("./src", [], [ClipboardEntry { path: "./src", action: "move" }]) == "✂ ");
+    let rows = build_rows(
+        "/repo",
+        [Children {
+            path: ".",
+            entries: [
+                DirectoryEntry { name: "src", path: "./src", kind: "directory" },
+                DirectoryEntry { name: "main.rs", path: "./main.rs", kind: "file" },
+            ],
+            truncated: false,
+        }],
+        ["."],
+        ["./main.rs"],
+        [ClipboardEntry { path: "./src", action: "move" }],
+        "/repo",
+        [
+            PathStatus { path: "/repo", status: "modified" },
+            PathStatus { path: "/repo/main.rs", status: "modified" },
+            PathStatus { path: "/repo/src", status: "conflict" },
+        ]
+    );
+
+    assert(rows.len() == 3);
+    assert(rows[0].right_segments[0].text == "");
+    assert_msg(rows[1].segments[0].text == "✂ ", "unexpected first row marker for " + rows[1].id + ": " + rows[1].segments[0].text);
+    assert(rows[1].right_segments[0].text == "");
+    assert(rows[2].segments[0].text == "✓ ");
+    assert(rows[2].segments[2].text == " ");
+}
+
+#[test]
+fn caps_pathological_visible_listings() {
+    let mut entries: [DirectoryEntry] = [];
+    for index in 0..1000 {
+        entries.push(DirectoryEntry { name: "file-" + index + ".rs", path: "./file-" + index + ".rs", kind: "file" });
+    }
+    let rows = build_rows("/repo", [Children { path: ".", entries: entries, truncated: true }], ["."], [], [], "", []);
+
+    assert(rows.len() == 201);
+    assert(rows[200].path == None);
+    assert(rows[200].segments[1].text == "… tree limited to 200 rows");
+}

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -60,6 +60,7 @@ lazy_static::lazy_static! {
 const PLUGIN_INSTRUCTION_BUDGET: usize = 100_000;
 static NEXT_PLUGIN_VM_GENERATION: AtomicU64 = AtomicU64::new(1);
 static GIT_CORE_PROGRAM: OnceLock<Result<CompiledProgram, String>> = OnceLock::new();
+static NEOTREE_CORE_PROGRAM: OnceLock<Result<CompiledProgram, String>> = OnceLock::new();
 
 /// User-facing metadata attached to a registered Red plugin command.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -193,6 +194,7 @@ extern "red" {
         fn null() -> JsValue;
         fn parse_json() -> JsValue;
         fn git_core() -> JsValue;
+        fn neotree_core() -> JsValue;
     }
 }
 "#;
@@ -230,6 +232,7 @@ struct RedHost {
     staged_replacement_start: Option<usize>,
     staged_teardown_start: Option<usize>,
     git_core: Option<husk_runtime::Vm>,
+    neotree_core: Option<husk_runtime::Vm>,
 }
 
 #[derive(Debug, Clone)]
@@ -415,6 +418,7 @@ impl RedHost {
             staged_replacement_start: None,
             staged_teardown_start: None,
             git_core: None,
+            neotree_core: None,
         }
     }
 
@@ -1912,6 +1916,10 @@ impl RedHost {
                 let operation = red_required_string(args, 0, path)?;
                 self.call_git_core(operation, &args[1..])
             }
+            "red::neotree_core" => {
+                let operation = red_required_string(args, 0, path)?;
+                self.call_neotree_core(operation, &args[1..])
+            }
             _ => anyhow::bail!("unknown Red host function `{path}`"),
         })())
     }
@@ -1939,7 +1947,7 @@ impl RedHost {
         if self.git_core.is_none() {
             let program = git_core_program()?;
             let mut vm = new_plugin_vm();
-            let mut host = GitCoreHost;
+            let mut host = NativeCoreHost;
             vm.load_compiled_plugin("red-git-core", program, &mut host)?;
             self.git_core = Some(vm);
         }
@@ -1947,15 +1955,50 @@ impl RedHost {
             .git_core
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("Git core VM did not initialize"))?;
-        let mut host = GitCoreHost;
+        let mut host = NativeCoreHost;
         let result = vm.call_export("red-git-core", function, args.to_vec(), &mut host)?;
-        Ok(normalize_git_core_value(result))
+        Ok(normalize_native_core_value(result))
+    }
+
+    fn call_neotree_core(&mut self, operation: &str, args: &[Value]) -> anyhow::Result<Value> {
+        if operation == "status_entries" {
+            return neotree_status_entries(args.first());
+        }
+
+        let function = match operation {
+            "normalize_path" => "path::normalize",
+            "path_name" => "path::name",
+            "path_parent" => "path::parent",
+            "path_join" => "path::join",
+            "workspace_path" => "path::workspace",
+            "name_extension" => "path::extension",
+            "basename" => "path::basename",
+            "tree_path" => "path::tree_path",
+            "reveal_parts" => "path::reveal_parts",
+            "build_rows" => "tree::build_rows",
+            _ => anyhow::bail!("unknown Neo-tree core operation `{operation}`"),
+        };
+
+        if self.neotree_core.is_none() {
+            let program = neotree_core_program()?;
+            let mut vm = new_plugin_vm();
+            let mut host = NativeCoreHost;
+            vm.load_compiled_plugin("red-neotree-core", program, &mut host)?;
+            self.neotree_core = Some(vm);
+        }
+        let vm = self
+            .neotree_core
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Neo-tree core VM did not initialize"))?;
+        let mut host = NativeCoreHost;
+        let result = vm.call_export("red-neotree-core", function, args.to_vec(), &mut host)?;
+        Ok(normalize_native_core_value(result))
     }
 }
 
-struct GitCoreHost;
+struct NativeCoreHost;
 
-impl Host for GitCoreHost {
+impl Host for NativeCoreHost {
     fn log(&mut self, _message: &str) {}
 }
 
@@ -1994,7 +2037,70 @@ fn git_core_program() -> anyhow::Result<CompiledProgram> {
         .map_err(|error| anyhow::anyhow!("{error}"))
 }
 
-fn normalize_git_core_value(value: Value) -> Value {
+fn neotree_core_program() -> anyhow::Result<CompiledProgram> {
+    let compiled = NEOTREE_CORE_PROGRAM.get_or_init(|| {
+        let package = ResolvedPackage::from_sources(
+            "plugins/neotree_core",
+            include_str!("../../plugins/neotree_core/Husk.toml"),
+            &[
+                (
+                    "src/main.hk",
+                    include_str!("../../plugins/neotree_core/src/main.hk"),
+                ),
+                (
+                    "src/path.hk",
+                    include_str!("../../plugins/neotree_core/src/path.hk"),
+                ),
+                (
+                    "src/status.hk",
+                    include_str!("../../plugins/neotree_core/src/status.hk"),
+                ),
+                (
+                    "src/tree.hk",
+                    include_str!("../../plugins/neotree_core/src/tree.hk"),
+                ),
+            ],
+            PackageLimits::default(),
+        )
+        .map_err(|error| format!("failed to resolve embedded Neo-tree core: {error}"))?;
+        CompiledProgram::compile_package(&package, &CompileOptions::default())
+            .map_err(|error| format!("failed to compile embedded Neo-tree core: {error}"))
+    });
+    compiled
+        .as_ref()
+        .cloned()
+        .map_err(|error| anyhow::anyhow!("{error}"))
+}
+
+fn neotree_status_entries(value: Option<&Value>) -> anyhow::Result<Value> {
+    let mut statuses = match value {
+        Some(Value::Object(entries)) => entries
+            .iter()
+            .filter_map(|(path, status)| status.as_str().map(|status| (path.clone(), status)))
+            .collect::<Vec<_>>(),
+        Some(Value::Json(serde_json::Value::Object(entries))) => entries
+            .iter()
+            .filter_map(|(path, status)| status.as_str().map(|status| (path.clone(), status)))
+            .collect::<Vec<_>>(),
+        Some(Value::Unit | Value::Null | Value::Missing(_)) | None => Vec::new(),
+        Some(_) => anyhow::bail!("Neo-tree status index must be an object"),
+    };
+    statuses.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    Ok(Value::Array(Arc::new(
+        statuses
+            .into_iter()
+            .map(|(path, status)| Value::Struct {
+                type_name: "PathStatus".to_string(),
+                fields: Arc::new(BTreeMap::from([
+                    ("path".to_string(), Value::String(path)),
+                    ("status".to_string(), Value::String(status.to_string())),
+                ])),
+            })
+            .collect(),
+    )))
+}
+
+fn normalize_native_core_value(value: Value) -> Value {
     match value {
         Value::Variant {
             type_name,
@@ -2002,33 +2108,33 @@ fn normalize_git_core_value(value: Value) -> Value {
             fields,
         } if type_name == "Option" => match (case.as_str(), fields.as_slice()) {
             ("None", []) => Value::Null,
-            ("Some", [value]) => normalize_git_core_value(value.clone()),
+            ("Some", [value]) => normalize_native_core_value(value.clone()),
             _ => Value::Null,
         },
         Value::Array(values) => Value::Array(Arc::new(
             values
                 .iter()
                 .cloned()
-                .map(normalize_git_core_value)
+                .map(normalize_native_core_value)
                 .collect(),
         )),
         Value::Tuple(values) => Value::Tuple(Arc::new(
             values
                 .iter()
                 .cloned()
-                .map(normalize_git_core_value)
+                .map(normalize_native_core_value)
                 .collect(),
         )),
         Value::Object(fields) => Value::Object(Arc::new(
             fields
                 .iter()
-                .map(|(name, value)| (name.clone(), normalize_git_core_value(value.clone())))
+                .map(|(name, value)| (name.clone(), normalize_native_core_value(value.clone())))
                 .collect(),
         )),
         Value::Struct { fields, .. } => Value::Object(Arc::new(
             fields
                 .iter()
-                .map(|(name, value)| (name.clone(), normalize_git_core_value(value.clone())))
+                .map(|(name, value)| (name.clone(), normalize_native_core_value(value.clone())))
                 .collect(),
         )),
         Value::Variant {
@@ -2042,7 +2148,7 @@ fn normalize_git_core_value(value: Value) -> Value {
                 fields
                     .iter()
                     .cloned()
-                    .map(normalize_git_core_value)
+                    .map(normalize_native_core_value)
                     .collect(),
             ),
         },
@@ -3455,6 +3561,82 @@ mod tests {
         let error = host.call_git_core("not_an_operation", &[]).unwrap_err();
         assert!(
             error.to_string().contains("unknown Git core operation"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn embedded_neotree_core_compiles_as_a_native_multi_file_package_and_renders_typed_rows() {
+        let program = neotree_core_program().unwrap();
+        assert_eq!(program.semantic_profile(), SemanticProfile::Native);
+        assert_eq!(program.source_map().sources().len(), 4);
+        assert_eq!(program.module_semantic_results().len(), 4);
+
+        let mut host = RedHost::new(HashMap::new());
+        let statuses = host
+            .call_neotree_core(
+                "status_entries",
+                &[Value::from_json(serde_json::json!({
+                    "/repo/src": "conflict",
+                    "/repo": "modified",
+                    "/repo/main.rs": "modified",
+                    "/repo/invalid": 42
+                }))],
+            )
+            .unwrap();
+        assert_eq!(
+            statuses.to_json(),
+            serde_json::json!([
+                { "path": "/repo", "status": "modified" },
+                { "path": "/repo/main.rs", "status": "modified" },
+                { "path": "/repo/src", "status": "conflict" }
+            ])
+        );
+
+        let rows = host
+            .call_neotree_core(
+                "build_rows",
+                &[
+                    Value::String("/repo".to_string()),
+                    Value::from_json(serde_json::json!([{
+                        "path": ".",
+                        "entries": [
+                            { "name": "src", "path": "./src", "kind": "directory" },
+                            { "name": "main.rs", "path": "./main.rs", "kind": "file" }
+                        ],
+                        "truncated": true
+                    }])),
+                    Value::from_json(serde_json::json!(["."])),
+                    Value::from_json(serde_json::json!(["./main.rs"])),
+                    Value::from_json(serde_json::json!([{
+                        "path": "./src",
+                        "action": "move"
+                    }])),
+                    Value::String("/repo".to_string()),
+                    statuses,
+                ],
+            )
+            .unwrap()
+            .to_json();
+        assert_eq!(rows[0]["right_segments"][0]["text"], "");
+        assert_eq!(rows[1]["segments"][0]["text"], "✂ ");
+        assert_eq!(rows[1]["right_segments"][0]["text"], "");
+        assert_eq!(rows[2]["segments"][0]["text"], "✓ ");
+        assert_eq!(rows[2]["segments"][2]["text"], " ");
+        assert!(rows[3]["path"].is_null());
+
+        let error = host
+            .call_neotree_core("status_entries", &[Value::String("invalid".to_string())])
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("status index must be an object"),
+            "{error}"
+        );
+        let error = host.call_neotree_core("not_an_operation", &[]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("unknown Neo-tree core operation"),
             "{error}"
         );
     }


### PR DESCRIPTION
## Why

Neo-tree still performs path normalization, Git-status decoration, and tree-row construction through compatibility helpers even though Husk now has a native standard library. Moving the pure presentation work into a native package makes it typed and directly testable while keeping permissioned filesystem actions and confirmations in the existing shell.

## What Changed

- add the embedded, multi-file `plugins/neotree_core` package for normalized paths, typed status presentation, selection and clipboard markers, icons, and bounded tree rendering
- convert the host status index into sorted typed entries once at the bridge and use bounded lookup during rendering
- simplify `plugins/neotree.hk` while preserving workspace confinement, destructive-action confirmations, directory truncation, and the 200-row instruction-budget guard
- add native-core and embedded-bridge coverage, wire the Neo-tree suites into plugin CI, and document the new package

## How to Test

Run the focused native and runtime regressions:

```shell
cargo run --all-features --locked -p husk-cli -- test --locked plugins/neotree_core
cargo test --all-features --locked -p red --lib plugin::runtime::tests::neotree_
cargo test --all-features --locked -p red --lib plugin::runtime::tests::embedded_neotree_core_
```

All tests should pass, including filesystem-root repositories, create/delete flows, large Git-status listings, and pathological directory listings capped at 200 rows.

Verify the bundled runtime and lint gate:

```shell
cargo fmt --all -- --check
cargo clippy --all-targets --all-features --locked -- -D warnings
cargo run --all-features --locked -- --self-check
```

The self-check should report `plugin neotree: active` and finish successfully.