### PR TITLE
feat(release): announce releases on Discord

### DIFF
--- a/.github/workflows/announce-discord.yml
+++ b/.github/workflows/announce-discord.yml
@@ -1,0 +1,85 @@
+name: Announce Discord release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing release tag to preview or announce
+        required: true
+        type: string
+      dry_run:
+        description: Generate a preview without posting to Discord
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: discord-release-${{ github.event.release.id || inputs.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    name: Announce ${{ github.event.release.tag_name || inputs.tag_name }}
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG_NAME: ${{ github.event.release.tag_name || inputs.tag_name }}
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+
+    steps:
+      - name: Checkout announcement tooling
+        uses: actions/checkout@v4
+
+      - name: Read published release
+        run: |
+          set -euo pipefail
+          gh release view "$TAG_NAME" \
+            --repo "${{ github.repository }}" \
+            --json tagName,url,publishedAt,body \
+            > "$RUNNER_TEMP/release.json"
+
+      - name: Build announcement
+        env:
+          MENTION_EVERYONE: ${{ vars.DISCORD_RELEASE_MENTION_EVERYONE }}
+        run: |
+          set -euo pipefail
+          mention_args=()
+          if [[ "$MENTION_EVERYONE" == "true" ]]; then
+            mention_args+=(--mention-everyone)
+          fi
+          python3 scripts/discord_release.py \
+            --release-json "$RUNNER_TEMP/release.json" \
+            --output "$RUNNER_TEMP/discord-release.json" \
+            --summary "$RUNNER_TEMP/discord-release.md" \
+            "${mention_args[@]}"
+          cat "$RUNNER_TEMP/discord-release.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check webhook configuration
+        if: env.DRY_RUN != 'true'
+        env:
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          if [[ -z "$DISCORD_RELEASE_WEBHOOK_URL" ]]; then
+            echo "DISCORD_RELEASE_WEBHOOK_URL is required to announce releases." >&2
+            exit 1
+          fi
+
+      - name: Post announcement
+        if: env.DRY_RUN != 'true'
+        env:
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          curl --fail-with-body \
+            --retry 3 \
+            --retry-all-errors \
+            --header "Content-Type: application/json" \
+            --data-binary "@$RUNNER_TEMP/discord-release.json" \
+            "${DISCORD_RELEASE_WEBHOOK_URL}?wait=true" \
+            > "$RUNNER_TEMP/discord-response.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Verify README release version
         run: python3 scripts/readme_release.py --check
 
+      - name: Test Discord release announcements
+        run: python3 -m unittest tests.test_discord_release
+
   test:
     name: Test Suite (${{ matrix.platform.standard }}, ${{ matrix.rust }})
     runs-on: >-

--- a/scripts/discord_release.py
+++ b/scripts/discord_release.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Build a concise Discord announcement from a GitHub release."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from collections import defaultdict
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+
+SECTION = re.compile(r"^###\s+(.+?)\s*$")
+BULLET = re.compile(r"^-\s+(.+?)\s*$")
+TRAILING_LINK = re.compile(r"\s*\(\[[^\]]+\]\([^)]+\)\)\s*$")
+SCOPE = re.compile(r"^\*\*([^*:]+):\*\*")
+SUPPORTED_SECTIONS = ("Features", "Performance", "Bug Fixes")
+RED = 0xE5484D
+IMPACT_TERMS = (
+    "interactive",
+    "language server",
+    "file management",
+    "standard library",
+    "comment operator",
+    "matching bracket",
+    "workflow",
+    "theme-aware",
+    "hang",
+    "failure",
+    "recover",
+    "latency",
+    "prevent",
+)
+
+
+def clean_item(item: str) -> str:
+    """Remove changelog provenance links while preserving useful Markdown."""
+    while TRAILING_LINK.search(item):
+        item = TRAILING_LINK.sub("", item)
+    return item.strip()
+
+
+def release_sections(body: str) -> dict[str, list[str]]:
+    """Extract announcement-worthy changelog sections from release notes."""
+    sections: dict[str, list[str]] = defaultdict(list)
+    current: str | None = None
+    for line in body.splitlines():
+        if line.startswith("## Installation"):
+            break
+        heading = SECTION.match(line)
+        if heading:
+            current = heading.group(1)
+            continue
+        bullet = BULLET.match(line)
+        if current in SUPPORTED_SECTIONS and bullet:
+            sections[current].append(clean_item(bullet.group(1)))
+    return dict(sections)
+
+
+def select_image(sections: dict[str, list[str]]) -> str:
+    """Choose the most relevant existing website capture for the release."""
+    preferred_items = sections.get("Features") or [
+        item for items in sections.values() for item in items
+    ]
+    scopes = {scope for item in preferred_items if (scope := item_scope(item))}
+    choices = (
+        (("agent",), "agent-pane-dark.png"),
+        (("theme", "themes"), "themes-dark.png"),
+        (("lsp",), "lsp-dialog-dark.png"),
+        (("picker",), "palette-dark.png"),
+        (("search", "grep"), "grep-dark.png"),
+        (("neotree", "git"), "editor-dark.png"),
+    )
+    for candidate_scopes, filename in choices:
+        if scopes.intersection(candidate_scopes):
+            return f"https://getred.dev/{filename}"
+    return "https://getred.dev/editing-dark.png"
+
+
+def plural(count: int, singular: str, plural_form: str | None = None) -> str:
+    return singular if count == 1 else (plural_form or f"{singular}s")
+
+
+def item_scope(item: str) -> str | None:
+    match = SCOPE.match(item)
+    return match.group(1).lower() if match else None
+
+
+def ranked_items(items: list[str]) -> list[str]:
+    """Prefer broad, user-visible changes while retaining scope variety."""
+    indexed = list(enumerate(items))
+
+    def score(entry: tuple[int, str]) -> tuple[int, int]:
+        index, item = entry
+        lowered = item.lower()
+        impact = sum(
+            len(IMPACT_TERMS) - position
+            for position, term in enumerate(IMPACT_TERMS)
+            if term in lowered
+        )
+        return impact, -index
+
+    ranked = sorted(indexed, key=score, reverse=True)
+    diverse: list[tuple[int, str]] = []
+    repeated: list[tuple[int, str]] = []
+    seen_scopes: set[str] = set()
+    for entry in ranked:
+        scope = item_scope(entry[1])
+        if scope is None or scope in seen_scopes:
+            repeated.append(entry)
+        else:
+            diverse.append(entry)
+            seen_scopes.add(scope)
+    return [item for _, item in [*diverse, *repeated]]
+
+
+def limited_bullets(items: list[str], limit: int, max_chars: int = 950) -> str:
+    selected: list[str] = []
+    for item in ranked_items(items)[:limit]:
+        candidate = "\n".join([*selected, f"• {item}"])
+        if len(candidate) > max_chars:
+            break
+        selected.append(f"• {item}")
+    return "\n".join(selected)
+
+
+def build_payload(release: dict[str, Any], mention_everyone: bool = False) -> dict[str, Any]:
+    tag = str(release["tagName"])
+    body = str(release.get("body") or "")
+    sections = release_sections(body)
+    features = sections.get("Features", [])
+    performance = sections.get("Performance", [])
+    fixes = sections.get("Bug Fixes", [])
+
+    counts: list[str] = []
+    if features:
+        counts.append(f"{len(features)} new {plural(len(features), 'feature')}")
+    if performance:
+        counts.append(f"{len(performance)} performance {plural(len(performance), 'improvement')}")
+    if fixes:
+        counts.append(f"{len(fixes)} {plural(len(fixes), 'fix', 'fixes')}")
+    count_summary = ", ".join(counts[:-1])
+    if len(counts) > 1:
+        count_summary += f" and {counts[-1]}"
+    elif counts:
+        count_summary = counts[0]
+
+    description = "A new release of **Red** is available."
+    if count_summary:
+        description = f"A new release of **Red** is available with {count_summary}."
+
+    fields: list[dict[str, Any]] = []
+    feature_highlights = limited_bullets(features, 5)
+    if feature_highlights:
+        fields.append({"name": "✨ Highlights", "value": feature_highlights, "inline": False})
+
+    polish = [*performance, *fixes]
+    polish_highlights = limited_bullets(polish, 3)
+    if polish_highlights:
+        fields.append({"name": "🛠️ Fixes & polish", "value": polish_highlights, "inline": False})
+
+    fields.append(
+        {
+            "name": "Install",
+            "value": (
+                "```bash\n"
+                "brew install codersauce/tap/red\n"
+                "# or\n"
+                "curl --proto '=https' --tlsv1.2 -fsSL https://getred.dev/install.sh | sh\n"
+                "```"
+            ),
+            "inline": False,
+        }
+    )
+
+    footer_parts = [
+        f"{len(features)} {plural(len(features), 'feature')}",
+        f"{len(fixes)} {plural(len(fixes), 'fix', 'fixes')}",
+    ]
+    payload: dict[str, Any] = {
+        "username": "Red Releases",
+        "avatar_url": "https://github.com/codersauce.png",
+        "allowed_mentions": {"parse": ["everyone"] if mention_everyone else []},
+        "embeds": [
+            {
+                "title": f"🚀 Red Editor {tag} is out!",
+                "url": release["url"],
+                "description": description,
+                "color": RED,
+                "fields": fields,
+                "image": {"url": select_image(sections)},
+                "footer": {"text": " • ".join(footer_parts)},
+                **(
+                    {"timestamp": release["publishedAt"]}
+                    if release.get("publishedAt")
+                    else {}
+                ),
+            }
+        ],
+    }
+    if mention_everyone:
+        payload["content"] = "@everyone A new Red release is ready."
+    return payload
+
+
+def markdown_preview(payload: dict[str, Any]) -> str:
+    embed = payload["embeds"][0]
+    lines = [f"# {embed['title']}", "", embed["description"], ""]
+    for field in embed["fields"]:
+        lines.extend((f"## {field['name']}", "", field["value"], ""))
+    lines.extend((f"Image: {embed['image']['url']}", "", f"Release: {embed['url']}", ""))
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--release-json", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument("--mention-everyone", action="store_true")
+    args = parser.parse_args()
+
+    release = json.loads(args.release_json.read_text(encoding="utf-8"))
+    payload = build_payload(release, mention_everyone=args.mention_everyone)
+    args.output.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    if args.summary:
+        args.summary.write_text(markdown_preview(payload), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_discord_release.py
+++ b/tests/test_discord_release.py
@@ -1,0 +1,92 @@
+import unittest
+
+from scripts.discord_release import (
+    build_payload,
+    clean_item,
+    ranked_items,
+    release_sections,
+)
+
+
+RELEASE = {
+    "tagName": "v0.2.4",
+    "url": "https://github.com/codersauce/red/releases/tag/v0.2.4",
+    "publishedAt": "2026-07-25T14:05:22Z",
+    "body": """## [0.2.4]
+
+### Features
+
+- **neotree:** Add native-style tree scrolling ([fe39cc0](https://example.test/commit))
+- **editor:** Highlight matching bracket pairs ([#138](https://example.test/issue)) ([ed72513](https://example.test/commit))
+
+### Bug Fixes
+
+- **lsp:** Prevent pathological batching hangs ([7b126be](https://example.test/commit))
+
+## Installation
+
+- This must not become a release highlight
+""",
+}
+
+
+class DiscordReleaseTest(unittest.TestCase):
+    def test_extracts_release_sections_and_strips_provenance_links(self) -> None:
+        sections = release_sections(RELEASE["body"])
+
+        self.assertEqual(
+            sections["Features"],
+            [
+                "**neotree:** Add native-style tree scrolling",
+                "**editor:** Highlight matching bracket pairs",
+            ],
+        )
+        self.assertEqual(
+            sections["Bug Fixes"],
+            ["**lsp:** Prevent pathological batching hangs"],
+        )
+        self.assertNotIn("This must not", str(sections))
+
+    def test_builds_a_branded_safe_embed(self) -> None:
+        payload = build_payload(RELEASE)
+        embed = payload["embeds"][0]
+
+        self.assertEqual(embed["title"], "🚀 Red Editor v0.2.4 is out!")
+        self.assertEqual(embed["url"], RELEASE["url"])
+        self.assertIn("2 new features and 1 fix", embed["description"])
+        self.assertEqual(embed["image"]["url"], "https://getred.dev/editor-dark.png")
+        self.assertEqual(payload["allowed_mentions"], {"parse": []})
+        self.assertNotIn("content", payload)
+
+    def test_everyone_mention_must_be_enabled_explicitly(self) -> None:
+        payload = build_payload(RELEASE, mention_everyone=True)
+
+        self.assertEqual(payload["allowed_mentions"], {"parse": ["everyone"]})
+        self.assertTrue(payload["content"].startswith("@everyone"))
+
+    def test_clean_item_preserves_non_provenance_markdown(self) -> None:
+        self.assertEqual(
+            clean_item("**editor:** Keep `:syntax` working ([abc1234](https://example.test))"),
+            "**editor:** Keep `:syntax` working",
+        )
+
+    def test_ranks_user_visible_changes_and_keeps_scope_variety(self) -> None:
+        items = [
+            "**neotree:** Add colors",
+            "**neotree:** Add file management actions",
+            "**husk:** Add full language server",
+            "**git:** Make dashboard interactive",
+        ]
+
+        self.assertEqual(
+            ranked_items(items)[:3],
+            [
+                "**git:** Make dashboard interactive",
+                "**husk:** Add full language server",
+                "**neotree:** Add file management actions",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Discord currently receives GitHub's general activity feed, but published Red releases are reduced to a generic link. This adds a dedicated release announcement that turns the reviewed GitHub release notes into a compact, branded summary with a relevant product screenshot and install commands.

The release-only workflow:

- runs automatically for published stable releases and supports manual dry-run previews;
- ranks user-visible highlights across scopes, summarizes fixes, and strips commit provenance noise;
- chooses an existing getred.dev screenshot based on the featured release scopes;
- keeps mentions disabled unless `DISCORD_RELEASE_MENTION_EVERYONE` is explicitly enabled; and
- posts through the separately configured `DISCORD_RELEASE_WEBHOOK_URL` secret, reusing the existing Discord channel without changing its general GitHub activity hook.

CI now exercises the announcement parser, ranking, image selection, and mention safety behavior.

## How to Test

1. Run `python3 -m unittest tests.test_discord_release`; expect all announcement tests to pass.
2. Generate a preview from a published release with `scripts/discord_release.py`; expect valid Discord JSON with concise feature/fix fields, install commands, no allowed mentions, and a live getred.dev image URL.
3. After merge, manually run **Announce Discord release** for `v0.2.4` with `dry_run` enabled; expect the rendered announcement in the Actions job summary and no Discord post.
4. For the non-happy path, publish a prerelease; expect the automatic announcement job to be skipped. A missing webhook secret on a non-dry run must fail before sending.
