### PR TITLE
fix(editor): match neovim motions and operators

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -170,6 +170,7 @@ Esc = { EnterMode = "Normal" }
 
 [keys.normal]
 "w" = [ "MoveToNextWord" ]
+"W" = "MoveToNextBigWord"
 "b" = [ "MoveToPreviousWord" ]
 "e" = "MoveToNextWordEnd"
 "E" = "MoveToNextBigWordEnd"
@@ -177,7 +178,7 @@ Esc = { EnterMode = "Normal" }
 "o" = [ { EnterMode = "Insert" }, "InsertLineBelowCursor" ]
 "O" = [ { EnterMode = "Insert" }, "InsertLineAtCursor" ]
 "G" = "MoveToBottom"
-"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "c" = { StartCommentOperator = 1 }, "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd", "e" = "MoveToPreviousWordEnd", "E" = "MoveToPreviousBigWordEnd", "J" = { JoinLinesKeepSpaces = 2 }, "u" = { StartLowercaseOperator = 1 }, "U" = { StartUppercaseOperator = 1 }, "~" = { StartToggleCaseOperator = 1 }, "-" = "SelectPreviousUndoBranch", "+" = "SelectNextUndoBranch" }
+"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "c" = { StartCommentOperator = 1 }, "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd", "e" = "MoveToPreviousWordEnd", "E" = "MoveToPreviousBigWordEnd", "J" = { JoinLinesKeepSpaces = 2 }, "W" = "ToggleWrap", "u" = { StartLowercaseOperator = 1 }, "U" = { StartUppercaseOperator = 1 }, "~" = { StartToggleCaseOperator = 1 }, "-" = "SelectPreviousUndoBranch", "+" = "SelectNextUndoBranch" }
 "u" = "Undo"
 "U" = "Redo"
 "Ctrl-r" = "Redo"
@@ -194,8 +195,9 @@ Esc = { EnterMode = "Normal" }
 "Home" = "MoveToLineStart"
 "$" = "MoveToLineEnd"
 "End" = "MoveToLineEnd"
-"H" = "MoveToFirstLineChar"
-"L" = "MoveToLastLineChar"
+"H" = { MoveToViewportTop = 1 }
+"M" = "MoveToViewportMiddle"
+"L" = { MoveToViewportBottom = 1 }
 "Ctrl-b" = "PageUp"
 "Ctrl-f" = "PageDown"
 "Ctrl-u" = { HalfPageUp = 0 }
@@ -222,7 +224,7 @@ Esc = { EnterMode = "Normal" }
 "A" = [ "MoveToLineEnd", { EnterMode = "Insert" }, "MoveRight" ]
 "i" = { EnterMode = "Insert" }
 "I" = [ { EnterMode = "Insert" }, "MoveToFirstLineChar" ]
-";" = { EnterMode = "Command" }
+";" = { RepeatCharSearch = 1 }
 ":" = { EnterMode = "Command" }
 "/" = { EnterSearch = "Forward" }
 "?" = { EnterSearch = "Backward" }
@@ -237,7 +239,6 @@ Esc = { EnterMode = "Normal" }
 "Ctrl-e" = { PluginCommand = "NeoTree" }
 "Ctrl-t" = { PluginCommand = "LspDocumentSymbols" }
 "K" = "Hover"
-"W" = "ToggleWrap"
 # "L" = "DecreaseLeft"
 # "R" = "IncreaseLeft"
 "v" = { EnterMode = "Visual" }

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -1,7 +1,7 @@
 # Red Vim compatibility matrix
 
-**Matrix version:** 1.1
-**Validated against:** Red 0.1.1, July 2026  
+**Matrix version:** 1.2
+**Validated against:** Red 0.2.4, July 2026
 **Status vocabulary:** **supported**, **intentional difference**, **not yet supported**
 
 “Real Vim keys” means the rows marked **supported** below. It does not mean complete
@@ -13,21 +13,21 @@ the corresponding integration tests.
 | Area | Status | Red behavior |
 |---|---|---|
 | Counts | **supported** | Decimal prefixes apply to motions, joins, line-end edits, substitute/delete-character aliases, macro playback, dot-repeat, find/till, and `r`. Nested mappings preserve the prefix until their final key. |
-| Basic motions | **supported** | `h j k l`, arrows, `0`, `^`, `$`, `w`, `b`, `e`, `ge`, `B`, `E`, `gE`, `gg`, `G`, screen-line motions, full/half-page motions, and file percentages use grapheme-safe cursor positions. The typed `MoveToNextBigWord` action can be mapped when `W` semantics are preferred. |
-| Character motions | **supported** | `f{char}`, `t{char}`, `F{char}`, `T{char}`, counted forms, and `,` reverse-repeat; delete, change, and yank accept the same suffixes. Forward-repeat is available as the remappable `RepeatCharSearch` action. |
-| Operators | **supported** | `d`, `c`, and `y` with line, vertical, line-start/end, forward/backward word, find/till, match, and supported text-object targets. `cw` preserves trailing whitespace like Vim. |
-| Text objects | **supported** | Inner/around word, parentheses, brackets, braces, single quotes, double quotes, and backticks. |
+| Basic motions | **supported** | `h j k l`, arrows, `0`, `^`, `$`, `w`, `W`, `b`, `e`, `ge`, `B`, `E`, `gE`, `gg`, `G`, viewport-relative `H`, `M`, and `L`, screen-line motions, full/half-page motions, and file percentages use grapheme-safe cursor positions. Counted `H` and `L` honor the visible viewport. |
+| Character motions | **supported** | `f{char}`, `t{char}`, `F{char}`, `T{char}`, counted forms, `;` forward-repeat, and `,` reverse-repeat; delete, change, and yank accept the same suffixes. |
+| Operators | **supported** | `d`, `c`, and `y` with horizontal, line, vertical, file-boundary, line-start/end, small/big-word, previous-word-end, find/till, match, and supported text-object targets. Counted word operators treat blank lines as Neovim motion boundaries; `cw` and `cW` preserve trailing whitespace like Vim. |
+| Text objects | **supported** | Inner/around small words, big words, paragraphs, parentheses, brackets, braces, single quotes, double quotes, and backticks. |
 | `r{char}` | **supported** | Replaces one or a counted run of graphemes and is one undoable change. A count longer than the remaining line is rejected without editing. |
 | Editing aliases | **supported** | `D`, `C`, and Neovim-style `Y` operate to line end; `S`, `s`, and `X` provide line/character substitute and backward-delete shortcuts. Counts, default-register kind, undo, and Insert transitions are preserved. `U` is an additional redo alias. |
 | Case changes | **supported** | `~`, `gu{motion}`, `gU{motion}`, `g~{motion}`, and the `guu`/`gUU`/`g~~` line forms transform Unicode text as one transaction. |
 | Join | **supported** | `J` joins at least two lines, removes following indentation, and inserts a space unless trailing whitespace or `)` makes it unnecessary; `gJ` preserves whitespace. Normal counts, Visual joins, `:j[oin][!] [count]`, undo, dot-repeat, and macros are covered. |
-| Ex commands and default-key differences | **intentional difference** | Red implements a documented Ex subset and uses `;` as an additional command-line entry key, `W` to toggle wrapping, and `Ctrl-e` for NeoTree; these defaults intentionally differ from Vim and can be remapped. Red does not implement Vimscript. |
+| Ex commands and default-key differences | **intentional difference** | Red implements a documented Ex subset, uses `gW` to toggle wrapping, and uses `Ctrl-e` for NeoTree; these Red-specific defaults can be remapped. `:` enters the command line, while `;` and `W` retain their Vim meanings. Red does not implement Vimscript. |
 
 ## Registers, repeat, and macros
 
 | Area | Status | Red behavior |
 |---|---|---|
-| Default register | **supported** | Yank, delete, change, `p`, and `P`; default-register writes also update the configured system clipboard. |
+| Default register | **supported** | Yank, delete, change, `p`, and `P`; characterwise paste preserves Neovim cursor placement for single-line and multiline text. Default-register writes also update the configured system clipboard. |
 | Named text-register prefix (`"a`) | **not yet supported** | Named storage exists for macros, but interactive text-operation register selection is not implemented. |
 | Dot-repeat (`.`) | **supported** | Replays the last completed content-changing input recipe through normal key resolution. Covered: direct changes, operator+motion, operator+text object, insert sessions, paste, replace, indent, open-line, and visual-block insert. |
 | Count before dot | **supported** | `N.` replays the completed change N times. A failed/no-op change does not replace the previous definition. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -2598,13 +2598,39 @@ input_position = "left"
     }
 
     #[test]
-    fn default_config_maps_wrap_toggle_key() {
+    fn default_config_maps_vim_word_character_and_screen_motions() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 
         assert_eq!(
             config.keys.normal.get("W"),
-            Some(&KeyAction::Single(Action::ToggleWrap))
+            Some(&KeyAction::Single(Action::MoveToNextBigWord))
         );
+        assert_eq!(
+            config.keys.normal.get(";"),
+            Some(&KeyAction::Single(Action::RepeatCharSearch(1)))
+        );
+        assert_eq!(
+            config.keys.normal.get("H"),
+            Some(&KeyAction::Single(Action::MoveToViewportTop(1)))
+        );
+        assert_eq!(
+            config.keys.normal.get("M"),
+            Some(&KeyAction::Single(Action::MoveToViewportMiddle))
+        );
+        assert_eq!(
+            config.keys.normal.get("L"),
+            Some(&KeyAction::Single(Action::MoveToViewportBottom(1)))
+        );
+    }
+
+    #[test]
+    fn default_config_preserves_wrap_toggle_under_gw() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+        let Some(KeyAction::Nested(g)) = config.keys.normal.get("g") else {
+            panic!("default config should map g to nested actions");
+        };
+
+        assert_eq!(g.get("W"), Some(&KeyAction::Single(Action::ToggleWrap)));
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -11815,15 +11815,25 @@ impl Editor {
             let Some(&character) = characters.get(end) else {
                 break;
             };
+            let final_motion = index + 1 == count;
+            if final_motion && matches!(character, '\r' | '\n') {
+                end += 1;
+                if character == '\r' && characters.get(end) == Some(&'\n') {
+                    end += 1;
+                }
+                continue;
+            }
+
             let kind = word_kind(character);
-            while characters
-                .get(end)
-                .is_some_and(|&next| word_kind(next) == kind)
-            {
+            while characters.get(end).is_some_and(|&next| {
+                word_kind(next) == kind && (!final_motion || !matches!(next, '\r' | '\n'))
+            }) {
                 end += 1;
             }
             if !preserve_trailing_whitespace || index + 1 < count {
-                while characters.get(end).is_some_and(|next| next.is_whitespace()) {
+                while characters.get(end).is_some_and(|&next| {
+                    next.is_whitespace() && (!final_motion || !matches!(next, '\r' | '\n'))
+                }) {
                     end += 1;
                 }
             }
@@ -14594,20 +14604,9 @@ impl Editor {
                 }
             }
             Action::DeleteWord => {
-                let cx = self.cx;
-                let line = self.buffer_line();
-                let char_cx = self.grapheme_to_char_on_line(cx, line);
-
-                if let Some((end_x, end_y)) = self.current_buffer().find_next_word((char_cx, line))
-                {
+                if let Some(range) = self.word_motion_range(1, false) {
                     self.begin_transaction("delete word");
-                    self.replace_range(
-                        TextRange::new(
-                            TextPosition::new(line, char_cx),
-                            TextPosition::new(end_y, end_x),
-                        ),
-                        "",
-                    );
+                    self.replace_range(range, "");
                     self.commit_transaction(self.cursor_snapshot());
                 }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1222,6 +1222,9 @@ pub enum Action {
     MoveToLineStart,
     MoveToFirstLineChar,
     MoveToLastLineChar,
+    MoveToViewportTop(u16),
+    MoveToViewportMiddle,
+    MoveToViewportBottom(u16),
     MoveScreenLineUp,
     MoveScreenLineDown,
     MoveToScreenLineEnd,
@@ -2550,7 +2553,7 @@ enum EditOperator {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PendingOperatorStep {
     Operator,
-    CommentTextObject,
+    GPrefix,
     FindForward,
     TillForward,
     FindBackward,
@@ -2619,6 +2622,8 @@ enum TextObjectScope {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TextObjectKind {
     Word,
+    BigWord,
+    Paragraph,
     Delimited { open: char, close: char },
     Quote(char),
 }
@@ -2637,6 +2642,8 @@ fn is_keyword_char(c: char) -> bool {
 fn text_object_kind_for_key(c: char) -> Option<TextObjectKind> {
     match c {
         'w' => Some(TextObjectKind::Word),
+        'W' => Some(TextObjectKind::BigWord),
+        'p' => Some(TextObjectKind::Paragraph),
         '(' | ')' | 'b' => Some(TextObjectKind::Delimited {
             open: '(',
             close: ')',
@@ -7902,6 +7909,9 @@ impl Editor {
                 | Action::MoveDown
                 | Action::MoveLeft
                 | Action::MoveRight
+                | Action::MoveToViewportTop(_)
+                | Action::MoveToViewportMiddle
+                | Action::MoveToViewportBottom(_)
                 | Action::MoveScreenLineUp
                 | Action::MoveScreenLineDown
                 | Action::MoveToScreenLineEnd
@@ -7944,6 +7954,9 @@ impl Editor {
                 | Action::MoveToLineStart
                 | Action::MoveToFirstLineChar
                 | Action::MoveToLastLineChar
+                | Action::MoveToViewportTop(_)
+                | Action::MoveToViewportMiddle
+                | Action::MoveToViewportBottom(_)
                 | Action::MoveScreenLineUp
                 | Action::MoveScreenLineDown
                 | Action::MoveToScreenLineEnd
@@ -10983,6 +10996,9 @@ impl Editor {
                 return Some(KeyAction::None);
             };
 
+            if kind == TextObjectKind::Paragraph && self.select_linewise_text_range(range) {
+                return Some(KeyAction::Single(Action::Refresh));
+            }
             if self.select_text_range(range) {
                 return Some(KeyAction::Single(Action::Refresh));
             }
@@ -11491,7 +11507,7 @@ impl Editor {
                 'g' => {
                     self.waiting_command = Some(format!("{}g", pending.operator.as_str()));
                     self.pending_operator = Some(PendingOperator {
-                        step: PendingOperatorStep::CommentTextObject,
+                        step: PendingOperatorStep::GPrefix,
                         ..pending
                     });
                     Some(KeyAction::None)
@@ -11501,8 +11517,28 @@ impl Editor {
                     self.word_motion_range(
                         pending.count(),
                         pending.operator == EditOperator::Change,
+                        false,
                     ),
                     "no word under cursor",
+                ),
+                'W' => self.operator_action_for_range(
+                    pending.operator,
+                    self.word_motion_range(
+                        pending.count(),
+                        pending.operator == EditOperator::Change,
+                        true,
+                    ),
+                    "no word under cursor",
+                ),
+                'h' => self.operator_action_for_range(
+                    pending.operator,
+                    self.horizontal_motion_range(pending.count(), true),
+                    "no text before cursor",
+                ),
+                'l' => self.operator_action_for_range(
+                    pending.operator,
+                    self.horizontal_motion_range(pending.count(), false),
+                    "no text under cursor",
                 ),
                 'b' => self.operator_action_for_range(
                     pending.operator,
@@ -11539,6 +11575,19 @@ impl Editor {
                     self.line_start_motion_range(true),
                     "no text under cursor",
                 ),
+                'G' => {
+                    let target = if pending.motion_count.is_some() || pending.operator_count > 1 {
+                        usize::from(pending.count().saturating_sub(1))
+                            .min(self.last_navigable_line())
+                    } else {
+                        self.last_navigable_line()
+                    };
+                    self.operator_action_for_linewise_range(
+                        pending.operator,
+                        Some(self.file_linewise_motion_range(target, pending.operator)),
+                        "no line under cursor",
+                    )
+                }
                 'j' => self.operator_action_for_linewise_range(
                     pending.operator,
                     self.vertical_motion_range(pending.count(), false),
@@ -11604,17 +11653,40 @@ impl Editor {
                 }
                 _ => self.pending_operator_invalid(),
             },
-            PendingOperatorStep::CommentTextObject => {
-                if c != 'c' {
-                    return self.pending_operator_invalid();
+            PendingOperatorStep::GPrefix => match c {
+                'c' => {
+                    let range = self.comment_text_object_range();
+                    self.operator_action_for_linewise_range(
+                        pending.operator,
+                        range,
+                        "comment block not found",
+                    )
                 }
-                let range = self.comment_text_object_range();
-                self.operator_action_for_linewise_range(
+                'g' => {
+                    let target = if pending.motion_count.is_some() || pending.operator_count > 1 {
+                        usize::from(pending.count().saturating_sub(1))
+                            .min(self.last_navigable_line())
+                    } else {
+                        0
+                    };
+                    self.operator_action_for_linewise_range(
+                        pending.operator,
+                        Some(self.file_linewise_motion_range(target, pending.operator)),
+                        "no line under cursor",
+                    )
+                }
+                'e' => self.operator_action_for_range(
                     pending.operator,
-                    range,
-                    "comment block not found",
-                )
-            }
+                    self.previous_end_word_motion_range(pending.count(), false),
+                    "no word under cursor",
+                ),
+                'E' => self.operator_action_for_range(
+                    pending.operator,
+                    self.previous_end_word_motion_range(pending.count(), true),
+                    "no word under cursor",
+                ),
+                _ => self.pending_operator_invalid(),
+            },
             PendingOperatorStep::FindForward => {
                 self.last_character_motion = Some((ForwardCharacterMotion::Find, c));
                 self.operator_action_for_range(
@@ -11793,20 +11865,34 @@ impl Editor {
         characters[start..end].iter().collect()
     }
 
-    fn word_motion_range(&self, count: u16, change_word: bool) -> Option<TextRange> {
+    fn word_motion_range(
+        &self,
+        count: u16,
+        change_word: bool,
+        big_word: bool,
+    ) -> Option<TextRange> {
         let start = self.cursor_text_position();
         let buffer = self.current_buffer();
-        let characters = buffer.contents().chars().collect::<Vec<_>>();
+        let contents = buffer.contents();
+        let characters = contents.chars().collect::<Vec<_>>();
         let mut end = buffer.position_to_char_idx(start);
+        characters.get(end)?;
         let word_kind = |character: char| {
             if character.is_whitespace() {
                 0
-            } else if character.is_alphanumeric() || character == '_' {
+            } else if big_word || character.is_alphanumeric() || character == '_' {
                 1
             } else {
                 2
             }
         };
+        let word_kinds = contents
+            .graphemes(true)
+            .flat_map(|grapheme| {
+                let kind = word_kind(grapheme.chars().next().unwrap_or_default());
+                grapheme.chars().map(move |_| kind)
+            })
+            .collect::<Vec<_>>();
         let preserve_trailing_whitespace = change_word
             && characters
                 .get(end)
@@ -11816,30 +11902,61 @@ impl Editor {
                 break;
             };
             let final_motion = index + 1 == count;
-            if final_motion && matches!(character, '\r' | '\n') {
+            if matches!(character, '\r' | '\n') {
+                if final_motion && (change_word || (!big_word && index > 0)) {
+                    break;
+                }
                 end += 1;
                 if character == '\r' && characters.get(end) == Some(&'\n') {
                     end += 1;
                 }
+                if !final_motion {
+                    while characters
+                        .get(end)
+                        .is_some_and(|next| next.is_whitespace() && !matches!(next, '\r' | '\n'))
+                    {
+                        end += 1;
+                    }
+                }
                 continue;
             }
 
-            let kind = word_kind(character);
-            while characters.get(end).is_some_and(|&next| {
-                word_kind(next) == kind && (!final_motion || !matches!(next, '\r' | '\n'))
-            }) {
+            let kind = word_kinds[end];
+            while word_kinds.get(end) == Some(&kind)
+                && characters
+                    .get(end)
+                    .is_some_and(|next| !matches!(next, '\r' | '\n'))
+            {
                 end += 1;
             }
             if !preserve_trailing_whitespace || index + 1 < count {
-                while characters.get(end).is_some_and(|&next| {
-                    next.is_whitespace() && (!final_motion || !matches!(next, '\r' | '\n'))
-                }) {
+                while characters
+                    .get(end)
+                    .is_some_and(|&next| next.is_whitespace() && !matches!(next, '\r' | '\n'))
+                {
                     end += 1;
+                }
+                if !final_motion {
+                    if change_word {
+                        while characters.get(end).is_some_and(|next| next.is_whitespace()) {
+                            end += 1;
+                        }
+                    } else if let Some(&line_ending @ ('\r' | '\n')) = characters.get(end) {
+                        end += 1;
+                        if line_ending == '\r' && characters.get(end) == Some(&'\n') {
+                            end += 1;
+                        }
+                        while characters.get(end).is_some_and(|next| {
+                            next.is_whitespace() && !matches!(next, '\r' | '\n')
+                        }) {
+                            end += 1;
+                        }
+                    }
                 }
             }
         }
         let end = buffer.char_idx_to_position(end);
-        (start != end).then(|| TextRange::new(start, end))
+        (start != end || change_word).then(|| TextRange::new(start, end))
     }
 
     fn word_motion_target(
@@ -11941,15 +12058,98 @@ impl Editor {
         (start != end).then(|| TextRange::new(start, end))
     }
 
+    fn previous_end_word_motion_range(&self, count: u16, big_word: bool) -> Option<TextRange> {
+        let cursor = self.cursor_text_position();
+        let start = self
+            .word_motion_target(count, true, true, big_word)
+            .or_else(|| {
+                let characters = self.current_buffer().contents().chars().collect::<Vec<_>>();
+                let mut index = self.current_buffer().position_to_char_idx(cursor);
+                let current = *characters.get(index)?;
+                if index == 0 || current.is_whitespace() {
+                    return None;
+                }
+                let kind = |character: char| {
+                    if character.is_whitespace() {
+                        0
+                    } else if big_word || is_keyword_char(character) {
+                        1
+                    } else {
+                        2
+                    }
+                };
+                let current_kind = kind(current);
+                while index > 0 && kind(characters[index - 1]) == current_kind {
+                    index -= 1;
+                }
+                Some(self.current_buffer().char_idx_to_position(index))
+            })?;
+        let end = TextPosition::new(cursor.line, cursor.character.saturating_add(1));
+        Some(TextRange::new(start, end))
+    }
+
     fn end_word_motion_range(&self, count: u16, big_word: bool) -> Option<TextRange> {
         let start = self.cursor_text_position();
-        let target = self.word_motion_target(count, false, true, big_word)?;
+        let target = self
+            .word_motion_target(count, false, true, big_word)
+            .or_else(|| {
+                let index = self.current_buffer().position_to_char_idx(start);
+                self.current_buffer()
+                    .contents()
+                    .chars()
+                    .nth(index)
+                    .filter(|character| !character.is_whitespace())
+                    .map(|_| start)
+            })?;
         let end_index = self
             .current_buffer()
             .position_to_char_idx(target)
             .saturating_add(1);
         let end = self.current_buffer().char_idx_to_position(end_index);
         (start != end).then(|| TextRange::new(start, end))
+    }
+
+    fn horizontal_motion_range(&self, count: u16, backward: bool) -> Option<TextRange> {
+        let line = self.buffer_line();
+        let cursor = self.cx;
+        let target = if backward {
+            cursor.saturating_sub(usize::from(count))
+        } else {
+            cursor
+                .saturating_add(usize::from(count))
+                .min(self.length_for_line(line))
+        };
+        if cursor == target {
+            return None;
+        }
+
+        let start = self.grapheme_to_char_on_line(cursor.min(target), line);
+        let end = self.grapheme_to_char_on_line(cursor.max(target), line);
+        Some(TextRange::new(
+            TextPosition::new(line, start),
+            TextPosition::new(line, end),
+        ))
+    }
+
+    fn file_linewise_motion_range(&self, target: usize, operator: EditOperator) -> TextRange {
+        let current = self.buffer_line();
+        let first_line = current.min(target);
+        let last_line = current.max(target);
+        let end = if last_line < self.current_buffer().len() {
+            TextPosition::new(last_line + 1, 0)
+        } else {
+            TextPosition::new(last_line, self.line_character_len(last_line))
+        };
+        let start = if operator == EditOperator::Delete
+            && first_line > 0
+            && last_line == self.current_buffer().len()
+        {
+            let previous_line = first_line - 1;
+            TextPosition::new(previous_line, self.line_character_len(previous_line))
+        } else {
+            TextPosition::new(first_line, 0)
+        };
+        TextRange::new(start, end)
     }
 
     fn line_character_len(&self, line: usize) -> usize {
@@ -12130,7 +12330,9 @@ impl Editor {
 
     fn text_object_range(&self, scope: TextObjectScope, kind: TextObjectKind) -> Option<TextRange> {
         match kind {
-            TextObjectKind::Word => self.word_text_object_range(scope),
+            TextObjectKind::Word => self.word_text_object_range(scope, false),
+            TextObjectKind::BigWord => self.word_text_object_range(scope, true),
+            TextObjectKind::Paragraph => self.paragraph_text_object_range(scope),
             TextObjectKind::Delimited { open, close } => {
                 self.delimited_text_object_range(scope, open, close)
             }
@@ -12138,38 +12340,45 @@ impl Editor {
         }
     }
 
-    fn word_text_object_range(&self, scope: TextObjectScope) -> Option<TextRange> {
+    fn word_text_object_range(&self, scope: TextObjectScope, big_word: bool) -> Option<TextRange> {
         let line_index = self.buffer_line();
         let line = self.current_buffer().get(line_index)?;
-        let line = line.trim_end_matches('\n');
+        let line = trim_line_ending(&line);
         let chars = line.chars().collect::<Vec<_>>();
         if chars.is_empty() {
             return None;
         }
 
+        let unit_kind = |character: char| {
+            if big_word && !character.is_whitespace() {
+                Some(TextUnitKind::Keyword)
+            } else {
+                text_unit_kind(character)
+            }
+        };
         let cursor = self
             .grapheme_to_char_on_line(self.cx, line_index)
             .min(chars.len().saturating_sub(1));
-        let target = if text_unit_kind(chars[cursor]).is_some() {
+        let target = if unit_kind(chars[cursor]).is_some() {
             cursor
         } else {
             (cursor..chars.len())
-                .find(|idx| text_unit_kind(chars[*idx]).is_some())
+                .find(|idx| unit_kind(chars[*idx]).is_some())
                 .or_else(|| {
                     (0..=cursor)
                         .rev()
-                        .find(|idx| text_unit_kind(chars[*idx]).is_some())
+                        .find(|idx| unit_kind(chars[*idx]).is_some())
                 })?
         };
 
-        let kind = text_unit_kind(chars[target])?;
+        let kind = unit_kind(chars[target])?;
         let mut start = target;
-        while start > 0 && text_unit_kind(chars[start - 1]) == Some(kind) {
+        while start > 0 && unit_kind(chars[start - 1]) == Some(kind) {
             start -= 1;
         }
 
         let mut end = target + 1;
-        while end < chars.len() && text_unit_kind(chars[end]) == Some(kind) {
+        while end < chars.len() && unit_kind(chars[end]) == Some(kind) {
             end += 1;
         }
 
@@ -12189,6 +12398,70 @@ impl Editor {
             TextPosition::new(line_index, start),
             TextPosition::new(line_index, end),
         ))
+    }
+
+    fn paragraph_text_object_range(&self, scope: TextObjectScope) -> Option<TextRange> {
+        let buffer = self.current_buffer();
+        if buffer.is_empty() {
+            return None;
+        }
+
+        let last_line = self.last_navigable_line();
+        let cursor_line = self.buffer_line().min(last_line);
+        let is_blank = |line: usize| {
+            buffer
+                .get(line)
+                .is_some_and(|text| trim_line_ending(&text).trim().is_empty())
+        };
+
+        let mut first_line = cursor_line;
+        let mut last_exclusive = cursor_line + 1;
+        let cursor_is_blank = is_blank(cursor_line);
+
+        while first_line > 0 && is_blank(first_line - 1) == cursor_is_blank {
+            first_line -= 1;
+        }
+        while last_exclusive <= last_line && is_blank(last_exclusive) == cursor_is_blank {
+            last_exclusive += 1;
+        }
+
+        if scope == TextObjectScope::Around {
+            if cursor_is_blank {
+                while last_exclusive <= last_line && !is_blank(last_exclusive) {
+                    last_exclusive += 1;
+                }
+            } else {
+                while last_exclusive <= last_line && is_blank(last_exclusive) {
+                    last_exclusive += 1;
+                }
+            }
+        }
+
+        let ends_at_eof = last_exclusive > last_line;
+        let start = if ends_at_eof && first_line > 0 {
+            if scope == TextObjectScope::Around {
+                while first_line > 0 && is_blank(first_line - 1) {
+                    first_line -= 1;
+                }
+                if first_line > 0 {
+                    let previous_line = first_line - 1;
+                    TextPosition::new(previous_line, self.line_character_len(previous_line))
+                } else {
+                    TextPosition::new(0, 0)
+                }
+            } else {
+                TextPosition::new(first_line - 1, self.line_character_len(first_line - 1))
+            }
+        } else {
+            TextPosition::new(first_line, 0)
+        };
+        let end = if ends_at_eof {
+            TextPosition::new(last_line, self.line_character_len(last_line))
+        } else {
+            TextPosition::new(last_exclusive, 0)
+        };
+
+        (start != end).then(|| TextRange::new(start, end))
     }
 
     fn word_under_cursor(&self) -> Option<String> {
@@ -12576,6 +12849,40 @@ impl Editor {
                         .position(|g| !g.chars().all(char::is_whitespace))
                         .unwrap_or(0);
                     self.cx = grapheme_len(line).saturating_sub(trailing + 1);
+                }
+            }
+            Action::MoveToViewportTop(count) | Action::MoveToViewportBottom(count) => {
+                let Some(window) = self.active_window_with_editor_view() else {
+                    return Ok(false);
+                };
+                let layout = self.layout_for_window(&window);
+                let mut visible_lines = Vec::new();
+                for segment in &layout.rows {
+                    if visible_lines.last().copied() != Some(segment.line) {
+                        visible_lines.push(segment.line);
+                    }
+                }
+                let offset = usize::from(count.saturating_sub(1));
+                let target = if matches!(action, Action::MoveToViewportTop(_)) {
+                    visible_lines.get(offset.min(visible_lines.len().saturating_sub(1)))
+                } else {
+                    visible_lines.get(visible_lines.len().saturating_sub(offset + 1))
+                };
+                if let Some(&line) = target {
+                    self.move_to_text_position(TextPosition::new(line, 0));
+                    self.move_to_first_non_blank_on_current_line();
+                    self.finish_cursor_motion(buffer, false)?;
+                }
+            }
+            Action::MoveToViewportMiddle => {
+                let Some(window) = self.active_window_with_editor_view() else {
+                    return Ok(false);
+                };
+                let layout = self.layout_for_window(&window);
+                if let Some(segment) = layout.rows.get(layout.rows.len().saturating_sub(1) / 2) {
+                    self.move_to_text_position(TextPosition::new(segment.line, 0));
+                    self.move_to_first_non_blank_on_current_line();
+                    self.finish_cursor_motion(buffer, false)?;
                 }
             }
             Action::MoveScreenLineUp => {
@@ -14604,7 +14911,7 @@ impl Editor {
                 }
             }
             Action::DeleteWord => {
-                if let Some(range) = self.word_motion_range(1, false) {
+                if let Some(range) = self.word_motion_range(1, false, false) {
                     self.begin_transaction("delete word");
                     self.replace_range(range, "");
                     self.commit_transaction(self.cursor_snapshot());
@@ -16124,6 +16431,8 @@ impl Editor {
             text.push('\n');
         }
         self.replace_range(TextRange::insertion(TextPosition::new(target_y, 0)), &text);
+        self.move_to_text_position(TextPosition::new(target_y, 0));
+        self.move_to_first_non_blank_on_current_line();
     }
 
     fn insert_blockwise(&mut self, x: usize, y: usize, contents: &Content, before: bool) {
@@ -16164,14 +16473,18 @@ impl Editor {
         let insertion = if before {
             insert_x
         } else {
-            let after_x = self.grapheme_to_char_on_line(x + 1, y);
-            self.cx += 1;
-            after_x
+            self.grapheme_to_char_on_line(x.saturating_add(1), y)
         };
-        self.replace_range(
-            TextRange::insertion(TextPosition::new(y, insertion)),
-            &contents.text,
-        );
+        let start = TextPosition::new(y, insertion);
+        self.replace_range(TextRange::insertion(start), &contents.text);
+        let inserted = self.current_buffer().range_for_text(start, &contents.text);
+        let cursor = if contents.text.contains('\n') {
+            inserted.start
+        } else {
+            self.previous_text_position(inserted.end, inserted.start)
+                .unwrap_or(inserted.start)
+        };
+        self.move_to_text_position(cursor);
     }
 
     fn insert_content_as_transaction(&mut self, x: usize, y: usize, content: &Content) {
@@ -17035,6 +17348,12 @@ impl Editor {
                     KeyAction::Single(Action::RepeatCharSearchOpposite(_)) => {
                         KeyAction::Single(Action::RepeatCharSearchOpposite(count))
                     }
+                    KeyAction::Single(Action::MoveToViewportTop(_)) => {
+                        KeyAction::Single(Action::MoveToViewportTop(count))
+                    }
+                    KeyAction::Single(Action::MoveToViewportBottom(_)) => {
+                        KeyAction::Single(Action::MoveToViewportBottom(count))
+                    }
                     KeyAction::Single(Action::HalfPageDown(_)) => {
                         KeyAction::Single(Action::HalfPageDown(count))
                     }
@@ -17300,6 +17619,13 @@ impl Editor {
 
     fn delete_text_range(&mut self, range: TextRange, label: &str) -> bool {
         let deleted_text = self.current_buffer().text_in_range(range);
+        let deletes_through_eof = range.end.line == self.last_navigable_line()
+            && range.end.character == self.line_character_len(range.end.line);
+        let move_to_first_non_blank = (range.start.character == 0
+            && (deleted_text.ends_with('\n') || deleted_text.ends_with('\r')))
+            || (deletes_through_eof
+                && range.start.character > 0
+                && (deleted_text.starts_with('\n') || deleted_text.starts_with("\r\n")));
         self.set_default_register(Content::charwise(deleted_text.clone()));
         self.move_to_text_position(range.start);
 
@@ -17310,6 +17636,9 @@ impl Editor {
         self.begin_transaction(label);
         self.replace_range(range, "");
         self.move_to_text_position(range.start);
+        if move_to_first_non_blank {
+            self.move_to_first_non_blank_on_current_line();
+        }
         self.commit_transaction(self.cursor_snapshot());
         true
     }
@@ -17610,6 +17939,7 @@ impl Editor {
         self.begin_transaction(label);
         self.replace_range(range, "");
         self.move_to_text_position(range.start);
+        self.move_to_first_non_blank_on_current_line();
         self.commit_transaction(self.cursor_snapshot());
         true
     }
@@ -17730,6 +18060,30 @@ impl Editor {
         self.selection_start = Some(start);
         self.set_selection(start, end);
         self.move_to_text_position(end_position);
+        true
+    }
+
+    fn select_linewise_text_range(&mut self, range: TextRange) -> bool {
+        let first_line = if range.start.character > 0 {
+            range.start.line.saturating_add(1)
+        } else {
+            range.start.line
+        };
+        let last_line = if range.end.character == 0 && range.end.line > first_line {
+            range.end.line - 1
+        } else {
+            range.end.line
+        };
+        if last_line < first_line {
+            return false;
+        }
+
+        let start = Point::new(0, first_line);
+        let end = Point::new(0, last_line);
+        self.mode = Mode::VisualLine;
+        self.selection_start = Some(start);
+        self.set_selection(start, end);
+        self.move_to_text_position(TextPosition::new(last_line, 0));
         true
     }
 

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -729,7 +729,8 @@ async fn dot_repeats_linewise_paste_and_visual_block_insert() {
     let buffer = Buffer::new(None, "one\ntwo\nthree\nfour".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());
     type_normal_keys(&mut harness, "yyjpj.").await;
-    harness.assert_buffer_contents("one\ntwo\none\none\nthree\nfour");
+    harness.assert_buffer_contents("one\ntwo\none\nthree\none\nfour");
+    harness.assert_cursor_at(0, 4);
 
     let buffer = Buffer::new(None, "a\nb\nc\nd".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());
@@ -2168,6 +2169,25 @@ async fn wrap_commands_toggle_line_wrapping() {
         .await
         .unwrap();
     assert!(harness.wrap());
+}
+
+#[tokio::test]
+async fn vim_parity_gw_toggles_wrapping_without_overriding_big_word_motion() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "foo.bar baz".to_string()),
+        default_key_config(),
+    );
+    let initial_wrap = harness.wrap();
+
+    type_normal_keys(&mut harness, "gW").await;
+
+    assert_eq!(harness.wrap(), !initial_wrap);
+    harness.assert_cursor_at(0, 0);
+
+    type_normal_keys(&mut harness, "gW").await;
+
+    assert_eq!(harness.wrap(), initial_wrap);
+    harness.assert_cursor_at(0, 0);
 }
 
 #[tokio::test]
@@ -6010,6 +6030,299 @@ async fn test_change_to_end_of_line() {
 }
 
 #[tokio::test]
+async fn vim_parity_counted_word_operators_stop_at_blank_line_boundaries() {
+    for (contents, keys, expected, cursor) in [
+        (
+            "alpha beta\n\nnext line",
+            "wd2w",
+            "alpha \nnext line",
+            (5, 0),
+        ),
+        (
+            "alpha beta\n\nnext line",
+            "w2dw",
+            "alpha \nnext line",
+            (5, 0),
+        ),
+        ("alpha beta\n\nnext line", "wd3w", "alpha line", (6, 0)),
+        ("\n    next line", "dw", "    next line", (4, 0)),
+        ("\n    next line", "cwX", "X\n    next line", (0, 0)),
+        (
+            "alpha beta\n\nnext line",
+            "wy2wp",
+            "alpha bbeta\neta\n\nnext line",
+            (7, 0),
+        ),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_big_word_operators_and_text_objects_match_neovim() {
+    for (contents, keys, expected, cursor) in [
+        ("foo.bar baz", "dW", "baz", (0, 0)),
+        ("foo.bar baz qux", "d2W", "qux", (0, 0)),
+        ("foo.bar baz", "cWX", "X baz", (0, 0)),
+        ("foo.bar baz", "yWp", "ffoo.bar oo.bar baz", (8, 0)),
+        ("foo.bar baz", "diW", " baz", (0, 0)),
+        ("foo.bar baz", "daW", "baz", (0, 0)),
+        ("α.β γδ", "dW", "γδ", (0, 0)),
+        ("foo.bar\n\n baz qux", "d2W", " baz qux", (1, 0)),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_character_operators_accept_horizontal_motions_and_counts() {
+    for (contents, keys, expected, cursor) in [
+        ("alpha", "dl", "lpha", (0, 0)),
+        ("alpha", "ldh", "lpha", (0, 0)),
+        ("alpha", "d2l", "pha", (0, 0)),
+        ("alpha", "d99l", "", (0, 0)),
+        ("alpha", "3ld99h", "ha", (0, 0)),
+        ("alpha", "clX", "Xlpha", (0, 0)),
+        ("alpha", "ylp", "aalpha", (1, 0)),
+        ("αβγ", "dl", "βγ", (0, 0)),
+        ("αβγ", "ldh", "βγ", (0, 0)),
+        ("αβγ", "d2l", "γ", (0, 0)),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_end_word_operators_include_the_final_buffer_character() {
+    for (contents, keys, expected, cursor) in [
+        ("alpha beta", "de", " beta", (0, 0)),
+        ("alpha", "$de", "alph", (3, 0)),
+        ("alpha", "$dE", "alph", (3, 0)),
+        ("x", "de", "", (0, 0)),
+        ("alpha", "$ceX", "alphX", (4, 0)),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_linewise_operators_accept_file_boundary_motions() {
+    for (contents, keys, expected, cursor) in [
+        ("one\ntwo\nthree", "dG", "", (0, 0)),
+        ("one\ntwo\nthree", "jdG", "one", (0, 0)),
+        ("one\ntwo\nthree", "jdgg", "three", (0, 0)),
+        ("one\ntwo\nthree\nfour", "2dG", "three\nfour", (0, 0)),
+        ("one\ntwo\nthree\nfour", "d2G", "three\nfour", (0, 0)),
+        ("one\ntwo\nthree\nfour", "jjd2gg", "one\nfour", (0, 1)),
+        (
+            "one\ntwo\nthree",
+            "yGp",
+            "one\none\ntwo\nthree\ntwo\nthree",
+            (0, 1),
+        ),
+        ("one\ntwo\nthree", "cGX", "X", (0, 0)),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+        if harness.is_insert() {
+            command_key(&mut harness, KeyCode::Esc).await;
+        }
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_operators_accept_previous_word_end_g_motions() {
+    for (contents, keys, expected, cursor) in [
+        ("alpha beta gamma", "wdge", "alpheta gamma", (4, 0)),
+        ("alpha.beta gamma", "wdgE", "beta gamma", (0, 0)),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_charwise_paste_places_the_cursor_on_the_last_inserted_grapheme() {
+    for (contents, keys, expected, cursor) in [
+        ("alpha beta", "ywp", "aalpha lpha beta", (6, 0)),
+        (
+            "alpha beta\nnext line",
+            "wywp",
+            "alpha bbetaeta\nnext line",
+            (10, 0),
+        ),
+        ("alpha", "ylp", "aalpha", (1, 0)),
+        ("αβ γδ", "ywp", "ααβ β γδ", (3, 0)),
+        (
+            "a\u{301}bc next",
+            "ywp",
+            "a\u{301}a\u{301}bc bc next",
+            (4, 0),
+        ),
+        ("alpha beta", "ywP", "alpha alpha beta", (5, 0)),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_paragraph_text_objects_preserve_inner_blank_line_semantics() {
+    for (contents, keys, expected, cursor) in [
+        (
+            "one paragraph\nstill one\n\nnext paragraph",
+            "dip",
+            "\nnext paragraph",
+            (0, 0),
+        ),
+        (
+            "one paragraph\nstill one\n\nnext paragraph",
+            "dap",
+            "next paragraph",
+            (0, 0),
+        ),
+        (
+            "one\n\nsecond line\nsecond end\n\nthird",
+            "jjdip",
+            "one\n\n\nthird",
+            (0, 2),
+        ),
+        (
+            "one\n\nsecond line\nsecond end\n\nthird",
+            "jjdap",
+            "one\n\nthird",
+            (0, 2),
+        ),
+        ("one\n\n\nnext", "jdip", "one\nnext", (0, 1)),
+        ("one\n\n\nnext", "jdap", "one", (0, 0)),
+        ("one\nsecond", "dip", "", (0, 0)),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(cursor.0, cursor.1);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_visual_big_word_and_paragraph_objects_match_operator_objects() {
+    for (contents, keys, expected) in [
+        ("foo.bar baz", "viWx", " baz"),
+        (
+            "one paragraph\nstill one\n\nnext paragraph",
+            "vipx",
+            "\nnext paragraph",
+        ),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(expected);
+        harness.assert_cursor_at(0, 0);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_default_character_search_repeat_honors_counts() {
+    for (contents, keys, expected_x) in [("foo.bar.baz", "f.;", 7), ("foo.bar.baz.qux", "f.2;", 11)]
+    {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(contents);
+        harness.assert_cursor_at(expected_x, 0);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
 async fn vim_editing_shortcuts_honor_counts_and_register_kinds() {
     let cases = [
         ("one two\nthree four\nfive", "w2D", "one \nfive"),
@@ -6156,29 +6469,18 @@ async fn vim_case_changes_and_visual_replace_are_transactional() {
 }
 
 #[tokio::test]
-async fn vim_word_and_character_repeat_actions_remain_remappable() {
-    let mut config = default_key_config();
-    config.keys.normal.insert(
-        "W".to_string(),
-        KeyAction::Single(Action::MoveToNextBigWord),
+async fn vim_word_and_character_repeat_actions_use_the_default_keymap() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "alpha.beta gamma".to_string()),
+        default_key_config(),
     );
-    config.keys.normal.insert(
-        ";".to_string(),
-        KeyAction::Single(Action::RepeatCharSearch(1)),
-    );
-
-    let mut harness =
-        EditorHarness::with_config(Buffer::new(None, "alpha.beta gamma".to_string()), config);
     type_normal_keys(&mut harness, "W").await;
     harness.assert_cursor_at(11, 0);
 
-    let mut config = default_key_config();
-    config.keys.normal.insert(
-        ";".to_string(),
-        KeyAction::Single(Action::RepeatCharSearch(1)),
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "alpha.beta.gamma".to_string()),
+        default_key_config(),
     );
-    let mut harness =
-        EditorHarness::with_config(Buffer::new(None, "alpha.beta.gamma".to_string()), config);
     type_normal_keys(&mut harness, "f.;").await;
     harness.assert_cursor_at(10, 0);
 }

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -3619,6 +3619,66 @@ async fn test_delete_word() {
 }
 
 #[tokio::test]
+async fn delete_word_at_line_end_preserves_the_line_break() {
+    for (contents, keys, expected) in [
+        ("alpha beta\nnext line", "wdw", "alpha \nnext line"),
+        (
+            "alpha beta   \n    next line",
+            "wdw",
+            "alpha \n    next line",
+        ),
+        ("alpha !!!\nnext line", "wdw", "alpha \nnext line"),
+        ("alpha βeta\n    δelta", "wdw", "alpha \n    δelta"),
+        ("alpha beta\r\nnext line", "wdw", "alpha \r\nnext line"),
+        ("alpha beta   \nnext line", "weldw", "alpha beta\nnext line"),
+        ("   \nnext line", "dw", "\nnext line"),
+        ("\n    next line", "dw", "    next line"),
+        ("\n\nnext line", "dw", "\nnext line"),
+    ] {
+        let buffer = Buffer::new(None, contents.to_string());
+        let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(expected);
+    }
+}
+
+#[tokio::test]
+async fn counted_delete_word_can_cross_a_line_break() {
+    for keys in ["wd2w", "w2dw"] {
+        let buffer = Buffer::new(None, "alpha beta\n    next line".to_string());
+        let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents("alpha line");
+    }
+}
+
+#[tokio::test]
+async fn delete_word_action_preserves_line_breaks_and_deletes_through_eof() {
+    for (contents, expected) in [
+        ("alpha beta\nnext line", "alpha \nnext line"),
+        ("alpha beta   \n    next line", "alpha \n    next line"),
+        ("alpha beta\r\nnext line", "alpha \r\nnext line"),
+        ("alpha βeta\n    δelta", "alpha \n    δelta"),
+        ("alpha beta", "alpha "),
+        ("alpha βeta", "alpha "),
+    ] {
+        let mut harness = EditorHarness::with_content(contents);
+        harness
+            .execute_action(Action::MoveToNextWord)
+            .await
+            .unwrap();
+
+        harness.execute_action(Action::DeleteWord).await.unwrap();
+
+        harness.assert_buffer_contents(expected);
+    }
+}
+
+#[tokio::test]
 async fn test_join_lines() {
     for (contents, keys, expected, cursor) in [
         ("alpha\n    beta", "J", "alpha beta", (5, 0)),

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -49,6 +49,68 @@ fn wrapped_long_line_harness(line_count: usize) -> EditorHarness {
 }
 
 #[tokio::test]
+async fn vim_parity_default_big_word_motion_treats_punctuation_as_part_of_a_word() {
+    for (contents, keys, expected_x) in [("foo.bar baz", "W", 8), ("foo.bar baz qux", "2W", 12)] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(contents);
+        harness.assert_cursor_at(expected_x, 0);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_screen_motions_target_the_visible_top_middle_and_bottom() {
+    for (keys, expected_y) in [("jjH", 0), ("M", 2), ("L", 4)] {
+        let contents = "one\ntwo\nthree\nfour\nfive";
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(contents);
+        harness.assert_cursor_at(0, expected_y);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn vim_parity_screen_motions_respect_a_scrolled_viewport_and_counts() {
+    let contents = (0..40)
+        .map(|line| format!("  line-{line:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    for (keys, expected_line) in [("H", 16), ("2H", 17), ("M", 19), ("L", 23), ("2L", 22)] {
+        let mut harness = EditorHarness::with_config_and_size(
+            Buffer::new(None, contents.clone()),
+            default_key_config(),
+            80,
+            10,
+        );
+        harness
+            .execute_action(Action::SetCursor(0, 20))
+            .await
+            .unwrap();
+        type_normal_keys(&mut harness, "zz").await;
+        assert_eq!(harness.viewport_top(), 16);
+
+        type_normal_keys(&mut harness, keys).await;
+
+        harness.assert_buffer_contents(&contents);
+        harness.assert_cursor_at(2, expected_line);
+        harness.assert_mode(Mode::Normal);
+    }
+}
+
+#[tokio::test]
 async fn test_basic_cursor_movement() {
     let mut harness = EditorHarness::with_content("Hello, World!\nThis is a test\nThird line");
 


### PR DESCRIPTION
## Why

Red's Vim-compatible editing diverged from Neovim at line boundaries, blank lines, and several default motion and operator bindings. In particular, `dw` could join the following line, while big-word, screen, character-repeat, and file-boundary commands either performed unrelated actions or were rejected.

## What changed

- Preserve LF and CRLF boundaries for `dw`, distinguish blank-line boundaries in counted small- and big-word operators, and keep combining graphemes together.
- Give `W`, `;`, `H`, `M`, and `L` their Neovim meanings; preserve wrapping as `gW`.
- Support horizontal, big-word, `G`, `gg`, `ge`, and `gE` motions with delete, change, and yank operators, including counts and linewise register behavior.
- Match Neovim cursor placement for characterwise and linewise paste, including linewise dot-repeat.
- Add inner/around big-word and paragraph objects, including linewise visual paragraph selection.
- Add Neovim-oracle regression coverage and update `docs/VIM_COMPATIBILITY.md` to describe the actual shipped behavior.

## How to Test

1. Run `cargo test -p red vim_parity_`; confirm the word, operator, paste, paragraph, default-key, and scrolled-viewport regressions all pass.
2. Run `cargo test --workspace --all-features`; confirm the complete editor, Husk, Unicode, comment, macro, undo, and dot-repeat suites pass.
3. Run `cargo clippy --all-targets --all-features -- -D warnings`; confirm there are no warnings.
4. Open a buffer containing `alpha beta` followed by another line, position on `beta`, and press `dw`; confirm the following line remains separate. Repeat with an intervening blank line and `d2w`; confirm the blank-line boundary matches Neovim.
5. On `foo.bar baz`, verify `W`, `dW`, `diW`, and `daW` treat `foo.bar` as one word; verify `gW` still toggles wrapping, `f.;` repeats a character search, and `H`/`M`/`L` select the visible top, middle, and bottom.