### PR TITLE
fix(cli): open nonexistent files on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -226,10 +226,7 @@ async fn run() -> anyhow::Result<()> {
         let buffer = Buffer::new(None, String::new());
         buffers.push(buffer);
     } else {
-        for file in &args.files {
-            let buffer = Buffer::from_file(Some(file.clone())).await?;
-            buffers.push(buffer);
-        }
+        buffers = load_startup_buffers(&args.files).await?;
     }
 
     let diagnostics = std::mem::take(&mut loaded.diagnostics);
@@ -740,9 +737,100 @@ fn resolve_log_path(config_dir: &Path, configured_path: &str) -> anyhow::Result<
     }
 }
 
+async fn load_startup_buffers(files: &[String]) -> anyhow::Result<Vec<Buffer>> {
+    let mut buffers = Vec::with_capacity(files.len());
+    for file in files {
+        buffers.push(Buffer::load_or_create(Some(file.clone())).await?);
+    }
+    Ok(buffers)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn startup_opens_missing_file_without_creating_it_until_save() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("new.rs");
+        let file = path.to_string_lossy().into_owned();
+
+        let mut buffers = load_startup_buffers(std::slice::from_ref(&file))
+            .await
+            .unwrap();
+
+        assert_eq!(buffers.len(), 1);
+        assert_eq!(buffers[0].file.as_deref(), Some(file.as_str()));
+        assert_eq!(buffers[0].contents(), "\n");
+        assert!(!buffers[0].is_dirty());
+        assert!(!path.exists());
+
+        buffers[0].save().unwrap();
+
+        assert_eq!(fs::read_to_string(path).unwrap(), "\n");
+        assert!(!buffers[0].is_dirty());
+    }
+
+    #[tokio::test]
+    async fn startup_opens_existing_and_missing_files_in_argument_order() {
+        let directory = tempfile::tempdir().unwrap();
+        let existing_path = directory.path().join("existing.rs");
+        let missing_path = directory.path().join("new.rs");
+        fs::write(&existing_path, "fn main() {}\n").unwrap();
+        let existing = existing_path.to_string_lossy().into_owned();
+        let missing = missing_path.to_string_lossy().into_owned();
+
+        let buffers = load_startup_buffers(&[existing.clone(), missing.clone()])
+            .await
+            .unwrap();
+
+        assert_eq!(buffers.len(), 2);
+        assert_eq!(buffers[0].file.as_deref(), Some(existing.as_str()));
+        assert_eq!(buffers[0].contents(), "fn main() {}\n");
+        assert_eq!(buffers[1].file.as_deref(), Some(missing.as_str()));
+        assert_eq!(buffers[1].contents(), "\n");
+        assert!(!missing_path.exists());
+    }
+
+    #[tokio::test]
+    async fn startup_opens_missing_parent_but_reports_error_on_save() {
+        let directory = tempfile::tempdir().unwrap();
+        let parent = directory.path().join("missing");
+        let path = parent.join("new.rs");
+        let file = path.to_string_lossy().into_owned();
+
+        let mut buffers = load_startup_buffers(std::slice::from_ref(&file))
+            .await
+            .unwrap();
+
+        let error = buffers[0].save().unwrap_err();
+
+        assert_eq!(
+            error
+                .downcast_ref::<std::io::Error>()
+                .map(|error| error.kind()),
+            Some(std::io::ErrorKind::NotFound)
+        );
+        assert!(!parent.exists());
+        assert!(!path.exists());
+        assert_eq!(buffers[0].file.as_deref(), Some(file.as_str()));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn startup_rejects_broken_symlinks() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("broken.rs");
+        std::os::unix::fs::symlink(directory.path().join("missing.rs"), &path).unwrap();
+        let file = path.to_string_lossy().into_owned();
+
+        let error = load_startup_buffers(std::slice::from_ref(&file))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("not found"));
+        assert!(fs::symlink_metadata(path).unwrap().file_type().is_symlink());
+    }
 
     #[test]
     fn forwards_only_the_husk_subcommand() {


### PR DESCRIPTION
## Why

Starting Red with a nonexistent path failed before the editor opened, even though in-editor file opening already supports a named, unsaved buffer. This prevents the Neovim-style workflow of opening a new path and creating it only with `:w`.

## What Changed

- Route command-line file arguments through the existing `Buffer::load_or_create` behavior.
- Preserve argument order when opening a mix of existing and nonexistent files.
- Keep filesystem creation deferred until the first successful save; report missing parent directories on save without creating them.
- Add startup regression coverage for deferred file creation, mixed file arguments, missing parent directories, and broken symlinks.

## How to Test

1. From a directory that exists, run `cargo run -- new-file.rs`. Confirm Red opens a named blank buffer and `new-file.rs` does not exist. Enter text and run `:w`; confirm the file is created with the saved contents.
2. Run `cargo run -- missing-dir/new-file.rs` with no `missing-dir` present. Confirm the buffer opens, `:w` reports the missing parent, and neither the directory nor file is created.
3. Run `cargo test --bin red startup_` and confirm all four startup regression tests pass.

## Validation

- `cargo test --bin red` (14 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`