### PR TITLE
refactor(ui): unify terminal rendering and component primitives

### DIFF
--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -1,0 +1,95 @@
+# Terminal UI architecture
+
+Red's terminal surfaces use a small set of concrete primitives. They do not form a
+general-purpose widget framework: the editor, plugin panels, LSP completion, and agent
+workspaces retain their own interaction, ownership, and security boundaries.
+
+## Authoritative owners
+
+- `src/editor/rendering.rs` owns complete-frame composition and window-aware,
+  document-context-aware row rendering. Incremental text edits use the same cached
+  highlighter and visible-row pipeline as a complete frame.
+- `src/plugin/overlay.rs` composites every visible plugin overlay into every frame,
+  ordered by its existing z-index. A clean overlay is still visible in the next newly
+  allocated render buffer.
+- `src/ui/dialog.rs` owns modal and popup border clipping, title and footer insets,
+  optional rounded corners, and `Dialog` or `Popup` theme-role updates.
+- `src/ui/prompt_buffer.rs` owns real, unnamed, rope-backed prompt buffers, grapheme
+  cursors, Vim modes, actual undo history, bounded prompt history, and terminal-paste
+  normalization. Floating and docked agent composers read their draft, cursor, and
+  history directly from this buffer.
+- `src/ui/selection.rs` owns selected-row viewport clamping and streaming
+  `FollowTailViewport` state. Text panels preserve a manually interrupted tail rather
+  than jumping to a newly streamed response.
+- `src/ui/geometry.rs` owns half-open terminal-cell rectangles shared by pickers and
+  plugin workspaces. Screen rectangles are not editor selections, buffer ranges, UTF-8
+  byte offsets, or UTF-16 LSP positions.
+- `src/ui/rich_text.rs` clips and paints the existing Markdown span model without
+  splitting graphemes. Hover and text panels retain their own background, link,
+  selection, and syntax-style policies.
+- `src/ui/icons.rs` is the lookup boundary for file, symbol, and LSP-completion icons.
+  Existing filename-before-extension priority, semantic file colors, ASCII, Unicode,
+  Nerd Font, hidden-icon modes, and distinct LSP completion glyphs are preserved.
+- `src/unicode_utils.rs` owns terminal-cell measurement and left- and right-clipped,
+  marker-aware grapheme truncation.
+
+Use `Action::Refresh` for a repaint that does not open a component. Preserve both
+`Refresh` and `ShowDialog` in the public plugin host contract.
+
+## Floating agent composer
+
+The floating agent composer is deliberately **right-aligned**. Source code is usually
+concentrated toward the left side of the editor; placing the prompt on the right keeps
+that code visible while composing a request. Border repairs and shared geometry must not
+center, move, or otherwise change this placement.
+
+## Boundaries that remain separate
+
+- LSP completion retains protocol-specific filtering, sorting, preselection, commit
+  characters, cursor anchoring, and editor-event passthrough.
+- `PanelSegment` and `WindowBarSegment` are public, separately serialized plugin wire
+  contracts. Share painters, not their JSON representation.
+- Row-panel selection, transcript following, and hover-link navigation are distinct
+  interaction policies even when they share viewport primitives.
+- Workspace access remains descriptor-relative, root-anchored, and symlink-safe.
+  Geometry or preview reuse must not weaken filesystem confinement.
+- Preferences, project configuration, agent approval, and staged file proposals retain
+  their existing independent ownership and persistence lifecycles.
+
+## Boundary-sensitive follow-up work
+
+The reusable UI milestone intentionally does not merge unrelated architecture projects
+into one change:
+
+- Colon commands and interactive search share normalized first-line paste, but their
+  command history, completion, and incremental-search state still have independent
+  owners. A complete `PromptBuffer` migration needs dedicated cursor, history, and
+  preview compatibility tests.
+- File previews retain the existing bounded, cached, syntax-aware picker
+  implementation. Extracting a separate preview service should first preserve FIFO
+  rejection, UTF-8 boundaries, match overlays, cache invalidation, and source offsets.
+- Husk plugins keep the existing versioned host contract. Exposing `IconCatalog` to
+  external plugins requires an explicitly versioned schema, runtime dispatch, Husk
+  declarations, and compatibility coverage.
+- Strongly typed document coordinates, shared descriptor-safe workspace confinement,
+  language-catalog consolidation, window and focus ownership, and larger native Husk
+  migrations remain separate, reviewable projects. They must not be introduced through
+  a terminal-UI refactor.
+
+## Regression coverage
+
+Run focused component and rendering checks while iterating:
+
+```shell
+CARGO_TARGET_DIR=/private/tmp/red-ui-unification-target cargo test --lib ui::
+CARGO_TARGET_DIR=/private/tmp/red-ui-unification-target cargo test --lib plugin::
+```
+
+At the final integration boundary, run the workspace tests, formatting check, and the
+repository-required all-target, all-feature Clippy command:
+
+```shell
+cargo fmt --check
+cargo test --workspace --all-targets --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+```

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1962,9 +1962,6 @@ pub struct Editor {
     /// Active dialog/popup component
     current_dialog: Option<Box<dyn Component>>,
 
-    /// UI component for displaying completions
-    completion_ui: CompletionUI,
-
     /// Number prefix for repeating commands
     repeater: Option<u16>,
 
@@ -2928,7 +2925,6 @@ impl Editor {
         for window in window_manager.windows_mut() {
             window.wrap = wrap;
         }
-        let completion_ui = CompletionUI::with_theme(&theme);
         let clipboard = Self::clipboard_provider_for_config(&config);
 
         let lsp_coordinator = lsp_coordinator::LspCoordinator::with_buffers(&buffers);
@@ -3024,7 +3020,6 @@ impl Editor {
             registers: HashMap::new(),
             clipboard,
             diagnostics: HashMap::new(),
-            completion_ui,
             indentation,
             jump_list: Vec::new(),
             jump_index: 0,
@@ -3991,59 +3986,6 @@ impl Editor {
                 style: span.style.clone(),
             })
             .collect())
-    }
-
-    fn fill_line(&mut self, buffer: &mut RenderBuffer, x: usize, y: usize, style: &Style) {
-        let width = self.vwidth().saturating_sub(x);
-        let line_fill = " ".repeat(width);
-        buffer.set_text(x, y, &line_fill, style);
-    }
-
-    fn draw_line(&mut self, buffer: &mut RenderBuffer) {
-        let line = self.viewport_line(self.cy).unwrap_or_default();
-        let language_id =
-            self.highlight_language_id_for_buffer_index(self.buffer_manager.active_index());
-        let style_info = if line.len() > MAX_HIGHLIGHT_SLICE_BYTES {
-            Vec::new()
-        } else {
-            self.highlight_spans_for_language(language_id, &line)
-                .unwrap_or_default()
-        };
-        let default_style = self.theme.style.clone();
-        let mut style_cursor = StyleCursor::new(&style_info);
-
-        let mut x = self.vx;
-        let mut iter = line.char_indices().peekable();
-
-        if line.is_empty() {
-            self.fill_line(buffer, x, self.cy, &default_style);
-            return;
-        }
-
-        while let Some((pos, c)) = iter.next() {
-            if c == '\n' || iter.peek().is_none() {
-                if c != '\n' {
-                    buffer.set_char(x, self.cy, c, &default_style, &self.theme);
-                    x += 1;
-                }
-                self.fill_line(buffer, x, self.cy, &default_style);
-                break;
-            }
-
-            if x < self.vwidth() {
-                if let Some(style) = style_cursor.style_at(pos) {
-                    buffer.set_char(x, self.cy, c, style, &self.theme);
-                } else {
-                    buffer.set_char(x, self.cy, c, &default_style, &self.theme);
-                }
-            }
-            x += 1;
-            if x >= self.vwidth() {
-                break;
-            }
-        }
-
-        self.draw_line_diagnostics(buffer, self.buffer_line());
     }
 
     pub fn draw_line_diagnostics(&mut self, buffer: &mut RenderBuffer, line_num: usize) {
@@ -9031,8 +8973,8 @@ impl Editor {
                                 }
                                 let (completion_x, completion_y) =
                                     self.render_cursor_position().unwrap_or((self.cx, self.cy));
-                                self.completion_ui.set_theme(&self.theme);
-                                self.completion_ui.show_with_bounds(
+                                let mut completion = CompletionUI::with_theme(&self.theme);
+                                completion.show_with_bounds(
                                     items,
                                     completion_x,
                                     completion_y,
@@ -9040,9 +8982,9 @@ impl Editor {
                                     self.size.1 as usize,
                                 );
                                 if let Some(filter) = self.completion_filter_for_response(msg) {
-                                    self.completion_ui.set_filter(&filter);
+                                    completion.set_filter(&filter);
                                 }
-                                self.current_dialog = Some(Box::new(self.completion_ui.clone()));
+                                self.current_dialog = Some(Box::new(completion));
                                 self.completion_snapshot = pending.or_else(|| {
                                     Some(PendingLspEdit {
                                         buffer_id: self.current_buffer().id(),
@@ -13068,7 +13010,7 @@ impl Editor {
                     self.render(buffer)?;
                 } else {
                     let draw_span = perf::PerfSpan::start("edit:draw_line");
-                    self.draw_line(buffer);
+                    self.render_edited_window_rows(buffer)?;
                     drop(draw_span);
                 }
             }
@@ -13080,7 +13022,7 @@ impl Editor {
                 );
                 self.commit_transaction(self.cursor_snapshot());
                 self.notify_change(runtime).await?;
-                self.draw_line(buffer);
+                self.render_edited_window_rows(buffer)?;
             }
             Action::DeleteRange(x0, y0, x1, y1) => {
                 self.begin_transaction("delete range");
@@ -13363,7 +13305,7 @@ impl Editor {
                     if started_transaction {
                         self.commit_transaction(self.cursor_snapshot());
                     }
-                    self.draw_line(buffer);
+                    self.render_edited_window_rows(buffer)?;
                 }
             }
             Action::ReplaceCharsAtCursor { character, count } => {
@@ -13386,7 +13328,7 @@ impl Editor {
                     );
                     self.commit_transaction(self.cursor_snapshot());
                     self.notify_change(runtime).await?;
-                    self.draw_line(buffer);
+                    self.render_edited_window_rows(buffer)?;
                 }
             }
             Action::ReplaceLineAt(y, contents) => {
@@ -13398,7 +13340,7 @@ impl Editor {
                 );
                 self.commit_transaction(self.cursor_snapshot());
                 self.notify_change(runtime).await?;
-                self.draw_line(buffer);
+                self.render_edited_window_rows(buffer)?;
             }
             Action::InsertNewLine => {
                 let started_transaction = !self.transaction_active();
@@ -13866,7 +13808,7 @@ impl Editor {
                             self.cx = prev_grapheme_idx;
 
                             self.notify_change(runtime).await?;
-                            self.draw_line(buffer);
+                            self.render_edited_window_rows(buffer)?;
                         }
                     }
                 } else if self.buffer_line() > 0 {
@@ -14661,7 +14603,7 @@ impl Editor {
                 {
                     self.render(buffer)?;
                 } else {
-                    self.draw_line(buffer);
+                    self.render_edited_window_rows(buffer)?;
                 }
             }
             Action::Save => {
@@ -14918,7 +14860,7 @@ impl Editor {
                 }
 
                 self.notify_change(runtime).await?;
-                self.draw_line(buffer);
+                self.render_edited_window_rows(buffer)?;
             }
             Action::NextBuffer => {
                 let new_index =
@@ -15282,7 +15224,7 @@ impl Editor {
                 if started_transaction {
                     self.commit_transaction(self.cursor_snapshot());
                 }
-                self.draw_line(buffer);
+                self.render_edited_window_rows(buffer)?;
             }
             Action::InsertPastedText(text) => {
                 let line = self.buffer_line();
@@ -16838,7 +16780,6 @@ impl Editor {
         self.highlight_cache.clear();
         self.workspace_manager.update_theme(&self.theme);
         self.force_full_redraw = true;
-        self.completion_ui.set_theme(&self.theme);
         if let Some(dialog) = &mut self.current_dialog {
             dialog.set_theme(&self.theme);
         }
@@ -21341,7 +21282,7 @@ mod test {
             .unwrap();
         editor
             .process_editor_event(
-                Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+                Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL)),
                 &mut buffer,
                 &mut runtime,
                 EventRenderMode::Immediate,

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -442,27 +442,12 @@ impl Editor {
         Ok(())
     }
 
-    /// Repaints edited rows through the same document-aware path as full frames.
+    /// Flushes one complete, document-aware frame after an edit.
     pub(super) fn render_edited_window_rows(
         &mut self,
         buffer: &mut RenderBuffer,
     ) -> anyhow::Result<()> {
-        self.update_gutter_width();
-        self.sync_to_window();
-
-        let window_id = self.window_manager.active_window_id();
-        let Some(window) = self.window_manager.window_at_index(window_id).cloned() else {
-            return Ok(());
-        };
-        let rows = (0..self.window_content_height(&window))
-            .map(|row| self.window_to_terminal_y(&window, row))
-            .collect::<Vec<_>>();
-
-        self.render_window_rows(buffer, window_id, &rows)?;
-        self.render_overlays_in_window(buffer, &window)?;
-        self.render_dialog(buffer)?;
-        self.update_and_render_overlays(buffer)?;
-        Ok(())
+        self.render(buffer)
     }
 
     fn render_window_rows(
@@ -2204,6 +2189,34 @@ mod tests {
         assert_eq!(by_line[&4].len(), 2);
         assert_eq!(by_line[&4][0].message, "first visible");
         assert_eq!(by_line[&4][1].message, "second visible");
+    }
+
+    #[test]
+    fn edited_window_rows_commit_a_single_complete_frame() {
+        let source = Buffer::new(None, "hello\nworld\n".to_string());
+        let mut editor = rendering_test_editor(source);
+        let mut buffer = RenderBuffer::new(60, 12, &Style::default());
+
+        editor.render(&mut buffer).unwrap();
+        let previous_generation = editor.render_generation;
+
+        editor.render_edited_window_rows(&mut buffer).unwrap();
+
+        assert_eq!(
+            editor.render_generation,
+            previous_generation.wrapping_add(1),
+            "edited rows must commit a final frame instead of forcing a second viewport render"
+        );
+        assert_eq!(
+            editor.previous_render_buffer.as_ref().unwrap().cells,
+            buffer.cells,
+            "the committed frame must match the visible render buffer"
+        );
+        assert_eq!(
+            editor.last_rendered_cursor_position,
+            editor.render_cursor_position(),
+            "the committed frame must update the rendered cursor"
+        );
     }
 
     #[test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -442,6 +442,28 @@ impl Editor {
         Ok(())
     }
 
+    /// Repaints edited rows through the same document-aware path as full frames.
+    pub(super) fn render_edited_window_rows(
+        &mut self,
+        buffer: &mut RenderBuffer,
+    ) -> anyhow::Result<()> {
+        self.update_gutter_width();
+        self.sync_to_window();
+
+        let window_id = self.window_manager.active_window_id();
+        let Some(window) = self.window_manager.window_at_index(window_id).cloned() else {
+            return Ok(());
+        };
+        let rows = (0..self.window_content_height(&window))
+            .map(|row| self.window_to_terminal_y(&window, row))
+            .collect::<Vec<_>>();
+
+        self.render_window_rows(buffer, window_id, &rows)?;
+        self.draw_line_diagnostics(buffer, self.buffer_line());
+        self.update_and_render_overlays(buffer)?;
+        Ok(())
+    }
+
     fn render_window_rows(
         &mut self,
         buffer: &mut RenderBuffer,

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -459,7 +459,8 @@ impl Editor {
             .collect::<Vec<_>>();
 
         self.render_window_rows(buffer, window_id, &rows)?;
-        self.draw_line_diagnostics(buffer, self.buffer_line());
+        self.render_overlays_in_window(buffer, &window)?;
+        self.render_dialog(buffer)?;
         self.update_and_render_overlays(buffer)?;
         Ok(())
     }
@@ -2096,7 +2097,25 @@ mod tests {
         lsp::{LspManager, Position, Range},
         plugin::{Decoration, DecorationAnchor},
         theme::Theme,
+        ui::CompletionUI,
     };
+
+    fn rendering_test_editor(source: Buffer) -> Editor {
+        let config = Config::default();
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let mut editor =
+            Editor::with_size(lsp, 60, 12, config, Theme::default(), vec![source]).unwrap();
+        editor.test_disable_terminal_output();
+        editor
+    }
+
+    fn rendered_rows(buffer: &RenderBuffer) -> Vec<String> {
+        buffer
+            .cells
+            .chunks(buffer.width)
+            .map(|row| row.iter().map(|cell| cell.text.as_str()).collect())
+            .collect()
+    }
 
     fn diagnostic(message: &str) -> Diagnostic {
         Diagnostic {
@@ -2185,6 +2204,72 @@ mod tests {
         assert_eq!(by_line[&4].len(), 2);
         assert_eq!(by_line[&4][0].message, "first visible");
         assert_eq!(by_line[&4][1].message, "second visible");
+    }
+
+    #[test]
+    fn edited_window_rows_preserve_completion_dialog() {
+        let source = Buffer::new(None, "hello\nworld\n".to_string());
+        let mut editor = rendering_test_editor(source);
+        let mut completion = CompletionUI::new();
+        let item = serde_json::from_value(serde_json::json!({ "label": "alpha" })).unwrap();
+        completion.show(vec![item], 0, 0);
+        editor.current_dialog = Some(Box::new(completion));
+        let mut buffer = RenderBuffer::new(60, 12, &Style::default());
+
+        editor.render(&mut buffer).unwrap();
+        assert!(rendered_rows(&buffer)
+            .iter()
+            .any(|row| row.contains("alpha")));
+
+        editor.render_edited_window_rows(&mut buffer).unwrap();
+
+        assert!(
+            rendered_rows(&buffer)
+                .iter()
+                .any(|row| row.contains("alpha")),
+            "edited window rows must repaint the active completion dialog"
+        );
+    }
+
+    #[test]
+    fn edited_window_rows_preserve_all_visible_diagnostics() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("diagnostics.rs");
+        let source = Buffer::new(
+            Some(path.to_string_lossy().into_owned()),
+            "first\nsecond\nthird\n".to_string(),
+        );
+        let mut editor = rendering_test_editor(source);
+        let uri = editor.current_buffer().uri().unwrap().unwrap();
+        let first = diagnostic("first visible diagnostic");
+        let mut second = diagnostic("second visible diagnostic");
+        second.range.start.line = 1;
+        second.range.end.line = 1;
+        editor.diagnostics.insert(uri, vec![first, second]);
+        let mut buffer = RenderBuffer::new(60, 12, &Style::default());
+
+        editor.render(&mut buffer).unwrap();
+        let rows = rendered_rows(&buffer);
+        assert!(rows
+            .iter()
+            .any(|row| row.contains("first visible diagnostic")));
+        assert!(rows
+            .iter()
+            .any(|row| row.contains("second visible diagnostic")));
+
+        editor.render_edited_window_rows(&mut buffer).unwrap();
+
+        let rows = rendered_rows(&buffer);
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("first visible diagnostic")),
+            "edited window rows must repaint the first visible diagnostic"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("second visible diagnostic")),
+            "edited window rows must repaint diagnostics beyond the cursor line"
+        );
     }
 
     #[test]

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -700,6 +700,14 @@ mod tests {
             missing.is_empty(),
             "runtime calls missing from schema: {missing:?}"
         );
+        let unreachable = documented
+            .difference(&dispatched)
+            .copied()
+            .collect::<Vec<_>>();
+        assert!(
+            unreachable.is_empty(),
+            "schema calls missing from runtime dispatch: {unreachable:?}"
+        );
     }
 
     #[test]

--- a/src/plugin/overlay.rs
+++ b/src/plugin/overlay.rs
@@ -150,14 +150,18 @@ impl PluginOverlay {
 
     pub fn render(&self, buffer: &mut RenderBuffer) {
         if let Some(pos) = self.position {
+            let content_height = buffer.height.saturating_sub(2);
             for (i, (text, style)) in self.content.lines.iter().enumerate() {
-                let y = pos.y + i;
-                if y < buffer.height - 2 {
-                    // Don't render over status line
-                    let text_width = display_width(text);
-                    let text_x = pos.x + self.width.saturating_sub(text_width);
-                    buffer.set_text(text_x, y, text, style);
+                let Some(y) = pos.y.checked_add(i) else {
+                    break;
+                };
+                if y >= content_height {
+                    break;
                 }
+
+                let text_width = display_width(text);
+                let text_x = pos.x.saturating_add(self.width.saturating_sub(text_width));
+                buffer.set_text(text_x, y, text, style);
             }
         }
     }
@@ -218,10 +222,8 @@ impl OverlayManager {
     pub fn render_all(&mut self, buffer: &mut RenderBuffer) {
         for id in &self.z_order {
             if let Some(overlay) = self.overlays.get_mut(id) {
-                if overlay.is_dirty() {
-                    overlay.render(buffer);
-                    overlay.mark_clean();
-                }
+                overlay.render(buffer);
+                overlay.mark_clean();
             }
         }
     }
@@ -255,7 +257,14 @@ mod tests {
         theme::Style,
     };
 
-    use super::PluginOverlay;
+    use super::{OverlayManager, PluginOverlay};
+
+    fn render_row(buffer: &RenderBuffer, y: usize) -> String {
+        buffer.cells[y * buffer.width..(y + 1) * buffer.width]
+            .iter()
+            .map(|cell| cell.c)
+            .collect()
+    }
 
     #[test]
     fn avoid_cursor_overlay_marks_dirty_when_position_changes() {
@@ -333,5 +342,80 @@ mod tests {
 
         assert_eq!(row(0), "...long.");
         assert_eq!(row(1), ".....👋 .");
+    }
+
+    #[test]
+    fn clean_overlay_is_composited_into_every_new_frame() {
+        let mut overlays = OverlayManager::new();
+        let overlay = overlays.create_overlay(
+            "persistent".to_string(),
+            OverlayConfig {
+                align: OverlayAlignment::Top,
+                x_padding: 0,
+                ..OverlayConfig::default()
+            },
+        );
+        overlay.update_content(vec![("visible".to_string(), Style::default())]);
+        overlays.update_positions(12, 6, None);
+
+        let mut first = RenderBuffer::new(12, 6, &Style::default());
+        overlays.render_all(&mut first);
+        assert!(render_row(&first, 0).contains("visible"));
+        assert!(!overlays.has_dirty_overlays());
+
+        let mut next = RenderBuffer::new(12, 6, &Style::default());
+        overlays.render_all(&mut next);
+        assert!(render_row(&next, 0).contains("visible"));
+        assert!(!overlays.has_dirty_overlays());
+    }
+
+    #[test]
+    fn overlay_rendering_saturates_tiny_terminal_heights() {
+        for height in 0..=2 {
+            let mut overlays = OverlayManager::new();
+            let overlay = overlays.create_overlay(
+                "tiny".to_string(),
+                OverlayConfig {
+                    align: OverlayAlignment::Top,
+                    ..OverlayConfig::default()
+                },
+            );
+            overlay.update_content(vec![("hidden".to_string(), Style::default())]);
+            overlays.update_positions(8, height, None);
+
+            let mut buffer = RenderBuffer::new(8, height, &Style::default());
+            overlays.render_all(&mut buffer);
+
+            assert_eq!(buffer.cells.len(), 8 * height);
+            assert!(buffer.cells.iter().all(|cell| cell.c == ' '));
+        }
+    }
+
+    #[test]
+    fn overlays_preserve_z_order_across_recomposed_frames() {
+        let mut overlays = OverlayManager::new();
+        for (id, text) in [("lower", "first"), ("upper", "above")] {
+            let overlay = overlays.create_overlay(
+                id.to_string(),
+                OverlayConfig {
+                    align: OverlayAlignment::Top,
+                    x_padding: 0,
+                    ..OverlayConfig::default()
+                },
+            );
+            overlay.update_content(vec![(text.to_string(), Style::default())]);
+        }
+        overlays.update_positions(10, 6, None);
+
+        for _ in 0..2 {
+            let mut buffer = RenderBuffer::new(10, 6, &Style::default());
+            overlays.render_all(&mut buffer);
+            assert!(render_row(&buffer, 0).ends_with("above"));
+        }
+
+        overlays.remove_overlay("upper");
+        let mut buffer = RenderBuffer::new(10, 6, &Style::default());
+        overlays.render_all(&mut buffer);
+        assert!(render_row(&buffer, 0).ends_with("first"));
     }
 }

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -1806,10 +1806,17 @@ fn render_text_spans(
     theme: &Theme,
 ) {
     paint_rich_text(buffer, x, y, width, line, |span| {
-        let mut style = span
-            .syntax_style
-            .clone()
-            .unwrap_or_else(|| text_panel_span_style(span.style, theme));
+        let base_style = text_panel_span_style(span.style, theme);
+        let mut style = if let Some(syntax_style) = &span.syntax_style {
+            Style {
+                fg: syntax_style.fg.or(base_style.fg),
+                bg: syntax_style.bg.or(base_style.bg).or(theme.style.bg),
+                bold: syntax_style.bold || base_style.bold,
+                italic: syntax_style.italic || base_style.italic,
+            }
+        } else {
+            base_style
+        };
         if span
             .link
             .as_ref()
@@ -2176,6 +2183,97 @@ mod tests {
         assert_eq!(block.kind, TextPanelBlockKind::Agent);
         assert_eq!(block.format, TextPanelBlockFormat::Markdown);
         assert_eq!(block.text, "# Heading");
+    }
+
+    #[test]
+    fn syntax_highlighted_text_panel_spans_preserve_panel_background() {
+        let panel_foreground = Color::Rgb {
+            r: 10,
+            g: 20,
+            b: 30,
+        };
+        let panel_background = Color::Rgb {
+            r: 40,
+            g: 50,
+            b: 60,
+        };
+        let code_foreground = Color::Rgb {
+            r: 70,
+            g: 80,
+            b: 90,
+        };
+        let syntax_foreground = Color::Rgb {
+            r: 100,
+            g: 110,
+            b: 120,
+        };
+        let syntax_background = Color::Rgb {
+            r: 130,
+            g: 140,
+            b: 150,
+        };
+        let theme = Theme {
+            style: Style {
+                fg: Some(panel_foreground),
+                bg: Some(panel_background),
+                ..Style::default()
+            },
+            token_styles: vec![crate::theme::TokenStyle {
+                name: None,
+                scope: vec!["markup.raw.block.markdown".to_string()],
+                style: Style {
+                    fg: Some(code_foreground),
+                    bold: true,
+                    ..Style::default()
+                },
+            }],
+            ..Theme::default()
+        };
+        let line = RenderedTextLine {
+            spans: vec![
+                RenderedTextSpan {
+                    text: "a".to_string(),
+                    style: TextPanelSpanStyle::Code,
+                    syntax_style: Some(Style {
+                        fg: Some(syntax_foreground),
+                        italic: true,
+                        ..Style::default()
+                    }),
+                    link: None,
+                },
+                RenderedTextSpan {
+                    text: "b".to_string(),
+                    style: TextPanelSpanStyle::Code,
+                    syntax_style: Some(Style {
+                        bg: Some(syntax_background),
+                        ..Style::default()
+                    }),
+                    link: None,
+                },
+            ],
+        };
+        let mut buffer = RenderBuffer::new(2, 1, &theme.style);
+
+        render_text_spans(&mut buffer, 0, 0, 2, &line, None, &theme);
+
+        assert_eq!(
+            buffer.cells[0].style,
+            Style {
+                fg: Some(syntax_foreground),
+                bg: Some(panel_background),
+                bold: true,
+                italic: true,
+            }
+        );
+        assert_eq!(
+            buffer.cells[1].style,
+            Style {
+                fg: Some(code_foreground),
+                bg: Some(syntax_background),
+                bold: true,
+                italic: false,
+            }
+        );
     }
 
     #[test]

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -21,10 +21,8 @@ use super::text_link::{TextPanelLink, TextPanelLinkTarget};
 use crate::{
     editor::{render_buffer::RenderBuffer, Point},
     theme::{SelectionForegroundPriority, Style, Theme, ThemeStyleSpec},
-    ui::{normalize_newlines, wrap_text},
-    unicode_utils::{
-        display_width, fit_display_width, grapheme_len, grapheme_to_byte, truncate_display_width,
-    },
+    ui::{paint_rich_text, wrap_text, FollowTailViewport, PromptBuffer, PROMPT_MAX_BYTES},
+    unicode_utils::{display_width, fit_display_width, grapheme_len, truncate_display_width},
 };
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -201,6 +199,7 @@ pub struct TextPanel {
     pub blocks: Vec<TextPanelBlock>,
     pub scroll: usize,
     pub follow_tail: bool,
+    viewport: FollowTailViewport,
     composer: Option<TextPanelComposer>,
     status: Option<TextPanelStatus>,
     busy_since: Option<Instant>,
@@ -223,132 +222,74 @@ fn format_elapsed(seconds: u64) -> String {
     }
 }
 
-const MAX_COMPOSER_BYTES: usize = 128 * 1024;
+const MAX_COMPOSER_BYTES: usize = PROMPT_MAX_BYTES;
 
 struct TextPanelComposer {
     config: TextPanelComposerConfig,
-    draft: String,
-    cursor: usize,
+    prompt: PromptBuffer,
     focused: bool,
     enabled: bool,
     status: Option<String>,
     validation: Option<&'static str>,
-    history: Vec<String>,
-    history_index: Option<usize>,
-    saved_draft: Option<String>,
 }
 
 impl TextPanelComposer {
     fn new(config: TextPanelComposerConfig) -> Self {
         Self {
             config,
-            draft: String::new(),
-            cursor: 0,
+            prompt: PromptBuffer::new(""),
             focused: false,
             enabled: true,
             status: None,
             validation: None,
-            history: Vec::new(),
-            history_index: None,
-            saved_draft: None,
         }
     }
 
     fn insert(&mut self, text: &str) {
-        let text = normalize_newlines(text);
-        if text.len() > MAX_COMPOSER_BYTES.saturating_sub(self.draft.len()) {
+        if self.prompt.insert(text) {
+            self.validation = None;
+        } else if text.len() > MAX_COMPOSER_BYTES.saturating_sub(self.prompt.text().len()) {
             self.validation = Some("Prompt exceeds 128 KiB");
-            return;
         }
-        let offset = grapheme_to_byte(&self.draft, self.cursor);
-        self.draft.insert_str(offset, &text);
-        self.cursor = grapheme_len(&self.draft[..offset + text.len()]);
-        self.validation = None;
     }
 
     fn backspace(&mut self) {
-        if self.cursor == 0 {
-            return;
+        if self.prompt.backspace() {
+            self.validation = None;
         }
-        let start = grapheme_to_byte(&self.draft, self.cursor - 1);
-        let end = grapheme_to_byte(&self.draft, self.cursor);
-        self.draft.replace_range(start..end, "");
-        self.cursor -= 1;
-        self.validation = None;
     }
 
     fn delete(&mut self) {
-        if self.cursor >= grapheme_len(&self.draft) {
-            return;
+        if self.prompt.delete() {
+            self.validation = None;
         }
-        let start = grapheme_to_byte(&self.draft, self.cursor);
-        let end = grapheme_to_byte(&self.draft, self.cursor + 1);
-        self.draft.replace_range(start..end, "");
-        self.validation = None;
     }
 
     fn take_submission(&mut self) -> Option<String> {
-        if self.draft.trim().is_empty() {
+        let Some(text) = self.prompt.take_submission() else {
             self.validation = Some("Prompt is empty");
             return None;
-        }
-        self.cursor = 0;
+        };
         self.validation = None;
-        let text = std::mem::take(&mut self.draft);
-        self.history.retain(|entry| entry != &text);
-        self.history.insert(0, text.clone());
-        self.history.truncate(50);
-        self.history_index = None;
-        self.saved_draft = None;
         Some(text)
     }
 
     fn history_previous(&mut self) {
-        if self.history.is_empty() {
-            return;
-        }
-        let index = self.history_index.map_or(0, |index| {
-            index.saturating_add(1).min(self.history.len() - 1)
-        });
-        if self.history_index.is_none() {
-            self.saved_draft = Some(self.draft.clone());
-        }
-        self.history_index = Some(index);
-        self.draft = self.history[index].clone();
-        self.cursor = grapheme_len(&self.draft);
+        self.prompt.history_previous();
     }
 
     fn history_next(&mut self) {
-        let Some(index) = self.history_index else {
-            return;
-        };
-        if index == 0 {
-            self.history_index = None;
-            self.draft = self.saved_draft.take().unwrap_or_default();
-        } else {
-            self.history_index = Some(index - 1);
-            self.draft = self.history[index - 1].clone();
-        }
-        self.cursor = grapheme_len(&self.draft);
+        self.prompt.history_next();
     }
 
     fn move_vertical(&mut self, delta: isize, width: usize) {
-        let wrapped = wrap_text(&self.draft, width.max(1));
-        let (row, column) = wrapped
-            .positions
-            .get(self.cursor)
-            .copied()
-            .unwrap_or_default();
-        let target = row.saturating_add_signed(delta);
-        if let Some((index, _)) = wrapped
-            .positions
-            .iter()
-            .enumerate()
-            .filter(|(_, position)| position.0 == target)
-            .min_by_key(|(_, position)| position.1.abs_diff(column))
-        {
-            self.cursor = index;
-        }
+        let code = if delta.is_negative() {
+            KeyCode::Up
+        } else {
+            KeyCode::Down
+        };
+        let event = Event::Key(crossterm::event::KeyEvent::new(code, KeyModifiers::NONE));
+        self.prompt.handle_event(&event, width);
     }
 }
 
@@ -361,6 +302,7 @@ impl TextPanel {
             blocks: Vec::new(),
             scroll: 0,
             follow_tail: true,
+            viewport: FollowTailViewport::default(),
             composer,
             status: None,
             busy_since: None,
@@ -388,8 +330,9 @@ impl TextPanel {
         panel_width: usize,
     ) {
         if blocks.is_empty() {
-            self.scroll = 0;
-            self.follow_tail = true;
+            self.viewport.reset();
+            self.scroll = self.viewport.offset();
+            self.follow_tail = self.viewport.is_following();
         }
         self.blocks = blocks;
         if self.follow_tail {
@@ -426,8 +369,10 @@ impl TextPanel {
 
     fn move_scroll(&mut self, delta: isize, panel_height: usize, panel_width: usize) {
         let max_scroll = self.max_scroll(panel_height, panel_width);
-        self.scroll = self.scroll.saturating_add_signed(delta).min(max_scroll);
-        self.follow_tail = self.scroll == max_scroll;
+        self.viewport.restore(self.scroll, self.follow_tail);
+        self.viewport.move_by(delta, max_scroll);
+        self.scroll = self.viewport.offset();
+        self.follow_tail = self.viewport.is_following();
     }
 
     fn page_scroll(&mut self, delta: isize, panel_height: usize, panel_width: usize) {
@@ -436,17 +381,24 @@ impl TextPanel {
     }
 
     fn scroll_to_top(&mut self) {
-        self.scroll = 0;
-        self.follow_tail = false;
+        self.viewport.scroll_to_top();
+        self.scroll = self.viewport.offset();
+        self.follow_tail = self.viewport.is_following();
     }
 
     fn scroll_to_bottom(&mut self, panel_height: usize, panel_width: usize) {
-        self.scroll = self.max_scroll(panel_height, panel_width);
-        self.follow_tail = true;
+        self.viewport
+            .follow(self.max_scroll(panel_height, panel_width));
+        self.scroll = self.viewport.offset();
+        self.follow_tail = self.viewport.is_following();
     }
 
     fn clamp_scroll(&mut self, panel_height: usize, panel_width: usize) {
-        self.scroll = self.scroll.min(self.max_scroll(panel_height, panel_width));
+        self.viewport.restore(self.scroll, self.follow_tail);
+        self.viewport
+            .clamp(self.max_scroll(panel_height, panel_width));
+        self.scroll = self.viewport.offset();
+        self.follow_tail = self.viewport.is_following();
     }
 
     fn max_scroll(&self, panel_height: usize, panel_width: usize) -> usize {
@@ -524,13 +476,10 @@ impl TextPanel {
         };
         let (link, line) = &links[index];
         self.selected_link = Some(link.id);
-        self.follow_tail = false;
-        let visible_rows = self.visible_rows(panel_height);
-        if *line < self.scroll {
-            self.scroll = *line;
-        } else if *line >= self.scroll.saturating_add(visible_rows) {
-            self.scroll = line.saturating_sub(visible_rows.saturating_sub(1));
-        }
+        self.viewport.restore(self.scroll, self.follow_tail);
+        self.viewport.reveal(*line, self.visible_rows(panel_height));
+        self.scroll = self.viewport.offset();
+        self.follow_tail = self.viewport.is_following();
         true
     }
 
@@ -1207,8 +1156,7 @@ impl PanelManager {
         else {
             return false;
         };
-        composer.draft.clear();
-        composer.cursor = 0;
+        composer.prompt.clear();
         composer.validation = None;
         true
     }
@@ -1259,9 +1207,17 @@ impl PanelManager {
                 }
                 (KeyCode::Backspace, _) => composer.backspace(),
                 (KeyCode::Delete, _) => composer.delete(),
-                (KeyCode::Left, _) => composer.cursor = composer.cursor.saturating_sub(1),
+                (KeyCode::Left, _) => composer
+                    .prompt
+                    .set_cursor(composer.prompt.cursor().saturating_sub(1)),
                 (KeyCode::Right, _) => {
-                    composer.cursor = (composer.cursor + 1).min(grapheme_len(&composer.draft));
+                    composer.prompt.set_cursor(
+                        composer
+                            .prompt
+                            .cursor()
+                            .saturating_add(1)
+                            .min(grapheme_len(&composer.prompt.text())),
+                    );
                 }
                 (KeyCode::Up, _) => {
                     composer.move_vertical(-1, panel_width.saturating_sub(2));
@@ -1269,8 +1225,10 @@ impl PanelManager {
                 (KeyCode::Down, _) => {
                     composer.move_vertical(1, panel_width.saturating_sub(2));
                 }
-                (KeyCode::Home, _) => composer.cursor = 0,
-                (KeyCode::End, _) => composer.cursor = grapheme_len(&composer.draft),
+                (KeyCode::Home, _) => composer.prompt.set_cursor(0),
+                (KeyCode::End, _) => composer
+                    .prompt
+                    .set_cursor(grapheme_len(&composer.prompt.text())),
                 (KeyCode::Tab, _) => composer.insert("\t"),
                 (KeyCode::Char(character), modifiers)
                     if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
@@ -1307,10 +1265,10 @@ impl PanelManager {
             .into_iter()
             .find(|placement| placement.id == id)?;
         let content_width = placement.width.saturating_sub(2).max(1);
-        let wrapped = wrap_text(&composer.draft, content_width);
+        let wrapped = wrap_text(&composer.prompt.text(), content_width);
         let (row, column) = wrapped
             .positions
-            .get(composer.cursor)
+            .get(composer.prompt.cursor())
             .copied()
             .unwrap_or_default();
         let rows = composer.config.rows.max(1);
@@ -1361,10 +1319,10 @@ impl PanelManager {
                 if let Some(composer) = panel.composer.as_mut() {
                     composer.focused = true;
                     let content_width = placement.width.saturating_sub(2).max(1);
-                    let wrapped = wrap_text(&composer.draft, content_width);
+                    let wrapped = wrap_text(&composer.prompt.text(), content_width);
                     let cursor_row = wrapped
                         .positions
-                        .get(composer.cursor)
+                        .get(composer.prompt.cursor())
                         .map_or(0, |position| position.0);
                     let rows = composer.config.rows.max(1);
                     let first = cursor_row.saturating_sub(rows.saturating_sub(1));
@@ -1377,7 +1335,7 @@ impl PanelManager {
                         .filter(|(_, position)| position.0 == row)
                         .min_by_key(|(_, position)| position.1.abs_diff(column))
                     {
-                        composer.cursor = index;
+                        composer.prompt.set_cursor(index);
                     }
                 }
                 "composer_focus"
@@ -1641,11 +1599,7 @@ fn render_text_panel(
     let visible_rows = content_height.saturating_sub(title_rows);
     let lines = panel.rendered_lines(width);
     let max_scroll = lines.len().saturating_sub(visible_rows);
-    let scroll = if panel.follow_tail {
-        max_scroll
-    } else {
-        panel.scroll.min(max_scroll)
-    };
+    let scroll = panel.viewport.visible_offset(max_scroll);
     for (offset, line) in lines.iter().skip(scroll).take(visible_rows).enumerate() {
         render_text_spans(
             buffer,
@@ -1712,10 +1666,10 @@ fn render_text_panel_composer(
 
     let rows = composer.config.rows.max(1);
     let content_width = width.saturating_sub(2).max(1);
-    let wrapped = wrap_text(&composer.draft, content_width);
+    let wrapped = wrap_text(&composer.prompt.text(), content_width);
     let cursor_row = wrapped
         .positions
-        .get(composer.cursor)
+        .get(composer.prompt.cursor())
         .map_or(0, |position| position.0);
     let first = cursor_row.saturating_sub(rows.saturating_sub(1));
     for row in 0..rows {
@@ -1725,7 +1679,7 @@ fn render_text_panel_composer(
             .get(first + row)
             .map(String::as_str)
             .unwrap_or("");
-        let text = if line.is_empty() && composer.draft.is_empty() && row == 0 {
+        let text = if line.is_empty() && composer.prompt.text().is_empty() && row == 0 {
             composer.config.placeholder.as_str()
         } else {
             line
@@ -1851,16 +1805,11 @@ fn render_text_spans(
     selected_link: Option<u64>,
     theme: &Theme,
 ) {
-    let mut used = 0;
-    for span in &line.spans {
-        if used >= width {
-            break;
-        }
-        let text = truncate_display_width(&span.text, width - used);
-        if text.is_empty() {
-            continue;
-        }
-        let mut style = text_panel_span_style(span.style, theme);
+    paint_rich_text(buffer, x, y, width, line, |span| {
+        let mut style = span
+            .syntax_style
+            .clone()
+            .unwrap_or_else(|| text_panel_span_style(span.style, theme));
         if span
             .link
             .as_ref()
@@ -1869,9 +1818,8 @@ fn render_text_spans(
             let selection = theme.list_selection_style();
             style = theme.selected_style(&style, &selection, SelectionForegroundPriority::Content);
         }
-        buffer.set_text(x + used, y, &text, &style);
-        used += display_width(&text);
-    }
+        style
+    });
 }
 
 fn text_panel_span_style(style: TextPanelSpanStyle, theme: &Theme) -> Style {
@@ -2275,13 +2223,13 @@ mod tests {
             80,
         );
         let recalled = manager.text_panels["agent"].composer.as_ref().unwrap();
-        assert_eq!(recalled.draft, "one 👨‍👩‍👧\ntwo\n世");
+        assert_eq!(recalled.prompt.text(), "one 👨‍👩‍👧\ntwo\n世");
         manager.handle_focused_text_input(
             &Event::Key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL)),
             80,
         );
         let restored = manager.text_panels["agent"].composer.as_ref().unwrap();
-        assert_eq!(restored.draft, "draft");
+        assert_eq!(restored.prompt.text(), "draft");
         assert!(manager.focused_text_panel_cursor_position(80, 20).is_some());
     }
 
@@ -2476,7 +2424,7 @@ mod tests {
         manager.handle_focused_text_input(&Event::Paste("X".to_string()), 80);
 
         let composer = manager.text_panels["agent"].composer.as_ref().unwrap();
-        assert_eq!(composer.draft, "first line\nsecXond line");
+        assert_eq!(composer.prompt.text(), "first line\nsecXond line");
     }
 
     #[test]
@@ -2509,7 +2457,7 @@ mod tests {
         assert_eq!(manager.reserved_right_width(), 25);
         assert!(manager.focus_text_panel_composer("agent"));
         let composer = manager.text_panels["agent"].composer.as_ref().unwrap();
-        assert_eq!(composer.draft, "keep this draft");
+        assert_eq!(composer.prompt.text(), "keep this draft");
     }
 
     #[test]

--- a/src/plugin/window_bar.rs
+++ b/src/plugin/window_bar.rs
@@ -7,14 +7,12 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
-use unicode_segmentation::UnicodeSegmentation;
-
 use crate::{
     theme::{Style, Theme, ThemeStyleSpec},
-    unicode_utils::display_width,
+    unicode_utils::{display_width, truncate_display_width, truncate_display_width_from_end},
     window::WindowId,
 };
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
@@ -306,7 +304,7 @@ fn clip_segments(
         return segments.to_vec();
     }
 
-    let marker = truncate_right(marker, width);
+    let marker = truncate_display_width(marker, width);
     let marker_width = display_width(&marker);
     let content_width = width.saturating_sub(marker_width);
     match overflow {
@@ -330,7 +328,7 @@ fn take_prefix(segments: &[WindowBarSegment], width: usize) -> Vec<WindowBarSegm
         if remaining == 0 {
             break;
         }
-        let text = truncate_right(&segment.text, remaining);
+        let text = truncate_display_width(&segment.text, remaining);
         remaining = remaining.saturating_sub(display_width(&text));
         if !text.is_empty() {
             result.push(WindowBarSegment {
@@ -349,7 +347,7 @@ fn take_suffix(segments: &[WindowBarSegment], width: usize) -> Vec<WindowBarSegm
         if remaining == 0 {
             break;
         }
-        let text = truncate_left(&segment.text, remaining);
+        let text = truncate_display_width_from_end(&segment.text, remaining);
         remaining = remaining.saturating_sub(display_width(&text));
         if !text.is_empty() {
             result.push(WindowBarSegment {
@@ -360,40 +358,6 @@ fn take_suffix(segments: &[WindowBarSegment], width: usize) -> Vec<WindowBarSegm
     }
     result.reverse();
     result
-}
-
-fn truncate_right(text: &str, width: usize) -> String {
-    let mut used = 0;
-    text.graphemes(true)
-        .take_while(|grapheme| {
-            let next = used + display_width(grapheme);
-            if next <= width {
-                used = next;
-                true
-            } else {
-                false
-            }
-        })
-        .collect()
-}
-
-fn truncate_left(text: &str, width: usize) -> String {
-    let mut used = 0;
-    let mut graphemes = text
-        .graphemes(true)
-        .rev()
-        .take_while(|grapheme| {
-            let next = used + display_width(grapheme);
-            if next <= width {
-                used = next;
-                true
-            } else {
-                false
-            }
-        })
-        .collect::<Vec<_>>();
-    graphemes.reverse();
-    graphemes.concat()
 }
 
 fn push_marker(segments: &mut Vec<WindowBarSegment>, text: String) {

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -14,7 +14,7 @@ use crate::{
     editor::render_buffer::RenderBuffer,
     highlighter::Highlighter,
     theme::{SelectionForegroundPriority, Style, Theme},
-    ui::{picker_file_icon, picker_file_icon_color},
+    ui::{IconCatalog, ScreenRect},
     unicode_utils::{display_width, fit_display_width, truncate_display_width},
 };
 
@@ -127,32 +127,7 @@ pub enum WorkspaceFocus {
     Detail,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct WorkspaceRect {
-    x: usize,
-    y: usize,
-    width: usize,
-    height: usize,
-}
-
-impl WorkspaceRect {
-    fn contains(self, column: usize, row: usize) -> bool {
-        column >= self.x
-            && column < self.x.saturating_add(self.width)
-            && row >= self.y
-            && row < self.y.saturating_add(self.height)
-    }
-
-    fn content_height(self) -> usize {
-        self.height.saturating_sub(1)
-    }
-
-    fn content_offset(self, row: usize) -> Option<usize> {
-        let content_y = self.y.saturating_add(1);
-        (row >= content_y && row < self.y.saturating_add(self.height))
-            .then_some(row.saturating_sub(content_y))
-    }
-}
+type WorkspaceRect = ScreenRect;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WorkspaceSeparator {
@@ -1059,16 +1034,16 @@ fn render_row_pane(
         buffer.set_text(x, y, &fit_display_width("", width), &row_style);
         let mut content_x = x + 1 + row.depth.saturating_mul(2);
         if let Some(path) = row.path.as_deref() {
-            let icon = picker_file_icon(path, icons.style);
-            if !icon.is_empty() {
+            let icon = IconCatalog::file(path, icons.style);
+            if !icon.glyph.is_empty() {
                 let mut icon_style = row_style.clone();
                 if icons.color {
-                    icon_style.fg = picker_file_icon_color(path).or(icon_style.fg);
+                    icon_style.fg = icon.color.or(icon_style.fg);
                 }
                 if selected {
                     icon_style = theme.ensure_text_contrast(&icon_style);
                 }
-                buffer.set_text(content_x, y, &fit_display_width(icon, 2), &icon_style);
+                buffer.set_text(content_x, y, &fit_display_width(icon.glyph, 2), &icon_style);
                 content_x += 3;
             }
         }

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -6,6 +6,7 @@
 
 use crate::color::Color;
 use crate::theme::{Style, Theme};
+use crate::unicode_utils::display_width;
 
 /// Content cells required for the full splash block.
 pub const FULL_MIN_WIDTH: usize = 60;
@@ -56,7 +57,7 @@ impl Line {
     pub fn width(&self) -> usize {
         self.spans
             .iter()
-            .map(|span| span.text.chars().count())
+            .map(|span| display_width(&span.text))
             .sum()
     }
 }
@@ -93,7 +94,7 @@ const HINT_VERB_WIDTH: usize = 7;
 const HINT_KEY_WIDTH: usize = 22;
 
 fn centered(text: &str, role: Role, width: usize) -> Line {
-    let pad = width.saturating_sub(text.chars().count()) / 2;
+    let pad = width.saturating_sub(display_width(text)) / 2;
     Line::new(vec![span(format!("{}{text}", " ".repeat(pad)), role)])
 }
 
@@ -290,6 +291,25 @@ mod tests {
         assert!(text.contains("red v0.1.1"));
         assert!(text.contains(":AgentReview<Enter>"));
         assert!(text.contains("every agent edit is a proposal"));
+    }
+
+    #[test]
+    fn splash_lines_measure_wide_graphemes_in_terminal_columns() {
+        let line = Line::new(vec![
+            span("👋", Role::Mark),
+            span("世", Role::Text),
+            span("e\u{301}", Role::Muted),
+        ]);
+
+        assert_eq!(line.width(), 5);
+    }
+
+    #[test]
+    fn centered_splash_text_reserves_the_display_width_of_wide_graphemes() {
+        let line = centered("👋世", Role::Text, 10);
+
+        assert_eq!(line.spans[0].text, "   👋世");
+        assert_eq!(line.width(), 7);
     }
 
     #[test]

--- a/src/ui/action_bar.rs
+++ b/src/ui/action_bar.rs
@@ -1,0 +1,852 @@
+//! Shared, display-width-aware actions for terminal UI surfaces.
+//!
+//! Actions are described once and can be projected into a dialog, composer,
+//! picker, or plugin workspace without cutting a key binding or hiding the
+//! number of actions that did not fit.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    editor::RenderBuffer,
+    theme::{Style, Theme},
+    unicode_utils::{display_width, truncate_display_width},
+};
+
+/// Determines which actions remain visible when a surface becomes narrow.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionPriority {
+    /// Submission, cancellation, approval, and other indispensable actions.
+    Essential,
+    /// Actions normally visible when enough terminal columns are available.
+    #[default]
+    Primary,
+    /// Discoverable conveniences that may move into the overflow list.
+    Secondary,
+}
+
+/// The interaction mode for which a surface action is currently meaningful.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionMode {
+    /// Vim insert mode or an editable text input.
+    Insert,
+    /// Vim normal mode.
+    Normal,
+    /// Vim visual mode.
+    Visual,
+    /// A focused, read-only conversation or list.
+    Read,
+}
+
+impl ActionMode {
+    /// Returns the full, user-facing mode indicator.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Insert => "INSERT",
+            Self::Normal => "NORMAL",
+            Self::Visual => "VISUAL",
+            Self::Read => "READ",
+        }
+    }
+
+    const fn compact_label(self) -> &'static str {
+        match self {
+            Self::Insert => "I",
+            Self::Normal => "N",
+            Self::Visual => "V",
+            Self::Read => "R",
+        }
+    }
+}
+
+const fn action_enabled_by_default() -> bool {
+    true
+}
+
+/// One semantic, optionally mode-specific keyboard or mouse action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct UiAction {
+    /// Stable surface-local identifier used for dispatch and overflow help.
+    pub id: String,
+    /// Display form of the actual active key binding.
+    #[serde(default)]
+    pub key: String,
+    /// Full user-facing action label.
+    pub label: String,
+    /// Optional shorter label that never changes the action's meaning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compact_label: Option<String>,
+    /// Optional shorter representation of the same key binding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compact_key: Option<String>,
+    /// Responsive display priority.
+    #[serde(default)]
+    pub priority: ActionPriority,
+    /// Empty means the action is available in every surface mode.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modes: Vec<ActionMode>,
+    /// Disabled actions are excluded from both the bar and overflow.
+    #[serde(default = "action_enabled_by_default")]
+    pub enabled: bool,
+}
+
+impl UiAction {
+    /// Creates an enabled, normally prioritized surface action.
+    #[must_use]
+    pub fn new(id: impl Into<String>, key: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            key: key.into(),
+            label: label.into(),
+            compact_label: None,
+            compact_key: None,
+            priority: ActionPriority::Primary,
+            modes: Vec::new(),
+            enabled: true,
+        }
+    }
+
+    /// Sets the responsive importance of this action.
+    #[must_use]
+    pub const fn with_priority(mut self, priority: ActionPriority) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Sets a shorter label used only when the full action does not fit.
+    #[must_use]
+    pub fn with_compact_label(mut self, label: impl Into<String>) -> Self {
+        self.compact_label = Some(label.into());
+        self
+    }
+
+    /// Sets a shorter, semantically equivalent key-binding display.
+    #[must_use]
+    pub fn with_compact_key(mut self, key: impl Into<String>) -> Self {
+        self.compact_key = Some(key.into());
+        self
+    }
+
+    /// Restricts this action to the supplied interaction modes.
+    #[must_use]
+    pub fn with_modes(mut self, modes: impl IntoIterator<Item = ActionMode>) -> Self {
+        self.modes.extend(modes);
+        self
+    }
+
+    /// Enables or disables this action without changing its definition.
+    #[must_use]
+    pub const fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    fn is_available(&self, mode: Option<ActionMode>) -> bool {
+        self.enabled
+            && (self.modes.is_empty() || mode.is_some_and(|mode| self.modes.contains(&mode)))
+    }
+}
+
+/// The semantic color role of one rendered action-bar fragment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionBarRole {
+    /// The current Vim or surface interaction mode.
+    Mode,
+    /// A complete keyboard shortcut.
+    Key,
+    /// The human-readable action label.
+    Label,
+    /// Whitespace or punctuation between actions.
+    Separator,
+    /// A nonessential status message.
+    Status,
+    /// The count of complete actions available in overflow.
+    Overflow,
+}
+
+/// One individually styled, grapheme-complete action-bar fragment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActionBarSpan {
+    /// Text that fits without splitting a terminal grapheme.
+    pub text: String,
+    /// The semantic theme role applied when the bar is rendered.
+    pub role: ActionBarRole,
+}
+
+/// The visible and hidden result of a responsive action-bar layout.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ActionBarLayout {
+    /// Ordered fragments that together fit within the requested width.
+    pub spans: Vec<ActionBarSpan>,
+    /// Complete action definitions omitted from the visible bar.
+    pub hidden_actions: Vec<UiAction>,
+}
+
+impl ActionBarLayout {
+    /// Returns the complete visible action-bar text.
+    #[must_use]
+    pub fn text(&self) -> String {
+        self.spans.iter().map(|span| span.text.as_str()).collect()
+    }
+
+    /// Returns the number of hidden but available surface actions.
+    #[must_use]
+    pub fn hidden_count(&self) -> usize {
+        self.hidden_actions.len()
+    }
+}
+
+/// Lays out a shared action bar without silently clipping keyboard shortcuts.
+#[derive(Debug, Clone, Copy)]
+pub struct ActionBar<'a> {
+    actions: &'a [UiAction],
+    mode: Option<ActionMode>,
+    status: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActionBarAlignment {
+    Left,
+    Right,
+}
+
+impl<'a> ActionBar<'a> {
+    /// Creates an action bar for a caller-owned action registry.
+    #[must_use]
+    pub const fn new(actions: &'a [UiAction]) -> Self {
+        Self {
+            actions,
+            mode: None,
+            status: None,
+        }
+    }
+
+    /// Displays the current interaction mode and filters mode-specific actions.
+    #[must_use]
+    pub const fn with_mode(mut self, mode: ActionMode) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    /// Appends status only after the primary actions and overflow are preserved.
+    #[must_use]
+    pub const fn with_status(mut self, status: Option<&'a str>) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Calculates complete action fragments for the supplied display-cell width.
+    #[must_use]
+    pub fn layout(&self, width: usize) -> ActionBarLayout {
+        if width == 0 {
+            return ActionBarLayout::default();
+        }
+
+        let mut available = self
+            .actions
+            .iter()
+            .enumerate()
+            .filter(|(_, action)| action.is_available(self.mode))
+            .collect::<Vec<_>>();
+        available.sort_by_key(|(index, action)| (action.priority, *index));
+
+        let essential_width = minimum_essential_width(&available);
+        let status_reserved = self
+            .status
+            .filter(|status| !status.is_empty())
+            .map(|status| {
+                let status_width = display_width(status);
+                let separator = if available.is_empty() {
+                    0
+                } else if essential_width
+                    .saturating_add(status_width)
+                    .saturating_add(3)
+                    <= width
+                {
+                    3
+                } else {
+                    1
+                };
+                status_width
+                    .saturating_add(separator)
+                    .min(width.saturating_sub(essential_width))
+            })
+            .unwrap_or_default();
+        let mut reserved = status_reserved;
+        let mut packed = self.pack(width, reserved, &available);
+        for _ in 0..3 {
+            let hidden = available.len().saturating_sub(packed.visible.len());
+            if hidden == 0 {
+                break;
+            }
+            let marker = overflow_marker(hidden, width);
+            let next_reserved = status_reserved
+                .saturating_add(display_width(&marker))
+                .saturating_add(usize::from(packed.used > 0))
+                .min(width.saturating_sub(essential_width));
+            if next_reserved == reserved {
+                break;
+            }
+            reserved = next_reserved;
+            packed = self.pack(width, reserved, &available);
+        }
+
+        let mut spans = Vec::new();
+        let mut used = 0;
+
+        if let Some(mode) = packed.mode {
+            push_span(&mut spans, &mut used, mode, ActionBarRole::Mode);
+        }
+
+        for (_, action, compact) in &packed.visible {
+            if used > 0 {
+                push_span(&mut spans, &mut used, "  ", ActionBarRole::Separator);
+            }
+            let key = if *compact {
+                action.compact_key.as_deref().unwrap_or(&action.key)
+            } else {
+                &action.key
+            };
+            let label = if *compact {
+                action.compact_label.as_deref().unwrap_or(&action.label)
+            } else {
+                &action.label
+            };
+            if !key.is_empty() {
+                push_span(&mut spans, &mut used, key, ActionBarRole::Key);
+            }
+            if !key.is_empty() && !label.is_empty() {
+                push_span(&mut spans, &mut used, " ", ActionBarRole::Separator);
+            }
+            if !label.is_empty() {
+                push_span(&mut spans, &mut used, label, ActionBarRole::Label);
+            }
+        }
+
+        let hidden_actions = available
+            .iter()
+            .filter(|(index, _)| {
+                !packed
+                    .visible
+                    .iter()
+                    .any(|(visible_index, _, _)| visible_index == index)
+            })
+            .map(|(_, action)| (*action).clone())
+            .collect::<Vec<_>>();
+
+        if !hidden_actions.is_empty() {
+            let separator_width = usize::from(used > 0);
+            let marker = overflow_marker(
+                hidden_actions.len(),
+                width.saturating_sub(used).saturating_sub(separator_width),
+            );
+            if !marker.is_empty() {
+                if used > 0 {
+                    push_span(&mut spans, &mut used, " ", ActionBarRole::Separator);
+                }
+                push_span(&mut spans, &mut used, &marker, ActionBarRole::Overflow);
+            }
+        }
+
+        if let Some(status) = self.status.filter(|status| !status.is_empty()) {
+            let separator = if used == 0 {
+                ""
+            } else if display_width(status).saturating_add(3) <= width.saturating_sub(used) {
+                " · "
+            } else {
+                " "
+            };
+            let separator_width = display_width(separator);
+            if width.saturating_sub(used) > separator_width {
+                let visible_status = truncate_display_width(
+                    status,
+                    width.saturating_sub(used).saturating_sub(separator_width),
+                );
+                if !visible_status.is_empty() {
+                    push_span(&mut spans, &mut used, separator, ActionBarRole::Separator);
+                    push_span(
+                        &mut spans,
+                        &mut used,
+                        &visible_status,
+                        ActionBarRole::Status,
+                    );
+                }
+            }
+        }
+
+        ActionBarLayout {
+            spans,
+            hidden_actions,
+        }
+    }
+
+    /// Paints a one-row bar while retaining the surrounding surface background.
+    pub fn render(
+        &self,
+        buffer: &mut RenderBuffer,
+        x: usize,
+        y: usize,
+        width: usize,
+        theme: &Theme,
+        surface: &Style,
+    ) -> ActionBarLayout {
+        self.render_aligned(
+            buffer,
+            x,
+            y,
+            width,
+            theme,
+            surface,
+            ActionBarAlignment::Left,
+        )
+    }
+
+    /// Paints actions against the right edge without changing their priority or background.
+    pub fn render_right_aligned(
+        &self,
+        buffer: &mut RenderBuffer,
+        x: usize,
+        y: usize,
+        width: usize,
+        theme: &Theme,
+        surface: &Style,
+    ) -> ActionBarLayout {
+        self.render_aligned(
+            buffer,
+            x,
+            y,
+            width,
+            theme,
+            surface,
+            ActionBarAlignment::Right,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn render_aligned(
+        &self,
+        buffer: &mut RenderBuffer,
+        x: usize,
+        y: usize,
+        width: usize,
+        theme: &Theme,
+        surface: &Style,
+        alignment: ActionBarAlignment,
+    ) -> ActionBarLayout {
+        let width = width.min(buffer.width.saturating_sub(x));
+        if width == 0 || y >= buffer.height {
+            return ActionBarLayout::default();
+        }
+
+        buffer.set_text(x, y, &" ".repeat(width), surface);
+        let layout = self.layout(width);
+        let mut column = match alignment {
+            ActionBarAlignment::Left => x,
+            ActionBarAlignment::Right => {
+                x.saturating_add(width.saturating_sub(display_width(&layout.text())))
+            }
+        };
+        for span in &layout.spans {
+            let style = match span.role {
+                ActionBarRole::Mode => theme.ui_style.popup_title.with_bg(surface.bg),
+                ActionBarRole::Key | ActionBarRole::Overflow => {
+                    theme.ui_style.picker_prompt.with_bg(surface.bg)
+                }
+                ActionBarRole::Separator | ActionBarRole::Status => {
+                    theme.ui_style.muted.with_bg(surface.bg)
+                }
+                ActionBarRole::Label => surface.clone(),
+            };
+            buffer.set_text(column, y, &span.text, &style);
+            column = column.saturating_add(display_width(&span.text));
+        }
+        layout
+    }
+
+    fn pack<'b>(
+        &self,
+        width: usize,
+        reserved: usize,
+        actions: &'b [(usize, &'a UiAction)],
+    ) -> PackedActions<'a> {
+        let essential_minimum = minimum_essential_width(actions);
+        let action_minimum = if essential_minimum == 0 {
+            actions
+                .first()
+                .map(|(_, action)| action_width(action, true))
+                .unwrap_or_default()
+        } else {
+            essential_minimum
+        };
+        let action_preferred = if essential_minimum == 0 {
+            actions
+                .first()
+                .map(|(_, action)| action_width(action, false))
+                .unwrap_or_default()
+        } else {
+            essential_width(actions, false)
+        };
+        let mode = self.mode.and_then(|mode| {
+            let full = mode.label();
+            if display_width(full)
+                .saturating_add(usize::from(action_preferred > 0) * 2)
+                .saturating_add(action_preferred)
+                .saturating_add(reserved)
+                <= width
+            {
+                Some(full)
+            } else if display_width(mode.compact_label())
+                .saturating_add(usize::from(action_preferred > 0) * 2)
+                .saturating_add(action_preferred)
+                .saturating_add(reserved)
+                <= width
+            {
+                Some(mode.compact_label())
+            } else if display_width(full)
+                .saturating_add(usize::from(action_minimum > 0) * 2)
+                .saturating_add(action_minimum)
+                .saturating_add(reserved)
+                <= width
+            {
+                Some(full)
+            } else if display_width(mode.compact_label())
+                .saturating_add(usize::from(action_minimum > 0) * 2)
+                .saturating_add(action_minimum)
+                .saturating_add(reserved)
+                <= width
+            {
+                Some(mode.compact_label())
+            } else {
+                None
+            }
+        });
+
+        let mut used = mode.map_or(0, display_width);
+        let mut visible = Vec::new();
+        let mut missing_essential = false;
+
+        for (position, (index, action)) in actions.iter().enumerate() {
+            if missing_essential && action.priority != ActionPriority::Essential {
+                continue;
+            }
+
+            let separator_width = usize::from(used > 0) * 2;
+            let remaining = width
+                .saturating_sub(used)
+                .saturating_sub(separator_width)
+                .saturating_sub(reserved);
+            let full_width = action_width(action, false);
+            let compact_width = action_width(action, true);
+            let remaining_essentials = minimum_essential_width(&actions[position + 1..]);
+            let following_separator = usize::from(remaining_essentials > 0) * 2;
+            let preserve_essentials = remaining_essentials.saturating_add(following_separator);
+            let compact = if full_width.saturating_add(preserve_essentials) <= remaining {
+                false
+            } else if compact_width.saturating_add(preserve_essentials) <= remaining
+                || (action.priority == ActionPriority::Essential && compact_width <= remaining)
+            {
+                true
+            } else {
+                if action.priority == ActionPriority::Essential {
+                    missing_essential = true;
+                }
+                continue;
+            };
+
+            used = used
+                .saturating_add(separator_width)
+                .saturating_add(if compact { compact_width } else { full_width });
+            visible.push((*index, *action, compact));
+        }
+
+        PackedActions {
+            mode,
+            visible,
+            used,
+        }
+    }
+}
+
+struct PackedActions<'a> {
+    mode: Option<&'static str>,
+    visible: Vec<(usize, &'a UiAction, bool)>,
+    used: usize,
+}
+
+fn minimum_essential_width(actions: &[(usize, &UiAction)]) -> usize {
+    essential_width(actions, true)
+}
+
+fn essential_width(actions: &[(usize, &UiAction)], compact: bool) -> usize {
+    let mut width = 0usize;
+    let mut count = 0usize;
+    for (_, action) in actions {
+        if action.priority != ActionPriority::Essential {
+            continue;
+        }
+        if count > 0 {
+            width = width.saturating_add(2);
+        }
+        width = width.saturating_add(action_width(action, compact));
+        count = count.saturating_add(1);
+    }
+    width
+}
+
+fn action_width(action: &UiAction, compact: bool) -> usize {
+    let key = if compact {
+        action.compact_key.as_deref().unwrap_or(&action.key)
+    } else {
+        &action.key
+    };
+    let label = if compact {
+        action.compact_label.as_deref().unwrap_or(&action.label)
+    } else {
+        &action.label
+    };
+    display_width(key)
+        .saturating_add(usize::from(!key.is_empty() && !label.is_empty()))
+        .saturating_add(display_width(label))
+}
+
+fn overflow_marker(hidden: usize, width: usize) -> String {
+    if hidden == 0 || width == 0 {
+        return String::new();
+    }
+    let marker = format!("… +{hidden}");
+    if display_width(&marker) <= width {
+        marker
+    } else if display_width("…") <= width {
+        "…".to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn push_span(spans: &mut Vec<ActionBarSpan>, used: &mut usize, text: &str, role: ActionBarRole) {
+    if text.is_empty() {
+        return;
+    }
+    *used = used.saturating_add(display_width(text));
+    spans.push(ActionBarSpan {
+        text: text.to_string(),
+        role,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actions() -> Vec<UiAction> {
+        vec![
+            UiAction::new("send", "Ctrl+Enter", "Send")
+                .with_compact_key("C-Enter")
+                .with_priority(ActionPriority::Essential),
+            UiAction::new("cancel", "Esc", "Close").with_priority(ActionPriority::Essential),
+            UiAction::new("newline", "Enter", "New line"),
+            UiAction::new("history", "Ctrl+P/N", "History")
+                .with_priority(ActionPriority::Secondary),
+        ]
+    }
+
+    #[test]
+    fn wide_layout_shows_all_complete_actions_without_overflow() {
+        let actions = actions();
+        let layout = ActionBar::new(&actions)
+            .with_mode(ActionMode::Insert)
+            .layout(100);
+
+        assert!(layout.text().starts_with("INSERT  Ctrl+Enter Send"));
+        assert!(layout.text().contains("Esc Close"));
+        assert!(layout.text().contains("Enter New line"));
+        assert!(layout.text().contains("Ctrl+P/N History"));
+        assert_eq!(layout.hidden_count(), 0);
+    }
+
+    #[test]
+    fn narrow_layout_prioritizes_complete_essential_actions_and_overflow() {
+        let actions = actions();
+        let layout = ActionBar::new(&actions)
+            .with_mode(ActionMode::Insert)
+            .layout(34);
+
+        assert!(display_width(&layout.text()) <= 34);
+        assert!(layout.text().contains("Enter Send"));
+        assert!(layout.text().contains("Esc Close"));
+        assert!(layout.text().contains('…'));
+        assert!(layout.hidden_count() >= 1);
+    }
+
+    #[test]
+    fn compact_key_fits_without_clipping_the_actual_binding() {
+        let actions = vec![UiAction::new("send", "Ctrl+Enter", "Send")
+            .with_compact_key("C-Enter")
+            .with_priority(ActionPriority::Essential)];
+        let layout = ActionBar::new(&actions)
+            .with_mode(ActionMode::Insert)
+            .layout(14);
+
+        assert!(layout.text().contains("C-Enter Send"));
+        assert!(display_width(&layout.text()) <= 14);
+    }
+
+    #[test]
+    fn hidden_actions_are_complete_and_stably_ordered() {
+        let actions = actions();
+        let layout = ActionBar::new(&actions).layout(21);
+
+        assert!(!layout.hidden_actions.is_empty());
+        assert!(layout
+            .hidden_actions
+            .iter()
+            .all(|action| !action.id.is_empty() && !action.label.is_empty()));
+        assert_eq!(layout.hidden_actions.last().unwrap().id, "history");
+    }
+
+    #[test]
+    fn disabled_actions_are_neither_advertised_nor_counted() {
+        let actions = vec![
+            UiAction::new("send", "Enter", "Send"),
+            UiAction::new("steer", "s", "Steer").with_enabled(false),
+        ];
+        let layout = ActionBar::new(&actions).layout(80);
+
+        assert!(layout.text().contains("Enter Send"));
+        assert!(!layout.text().contains("Steer"));
+        assert_eq!(layout.hidden_count(), 0);
+    }
+
+    #[test]
+    fn mode_specific_actions_follow_the_active_surface_mode() {
+        let actions = vec![
+            UiAction::new("edit", "i", "Edit").with_modes([ActionMode::Read]),
+            UiAction::new("send", "Enter", "Send").with_modes([ActionMode::Insert]),
+        ];
+
+        let reading = ActionBar::new(&actions)
+            .with_mode(ActionMode::Read)
+            .layout(40);
+        let editing = ActionBar::new(&actions)
+            .with_mode(ActionMode::Insert)
+            .layout(40);
+
+        assert!(reading.text().contains("i Edit"));
+        assert!(!reading.text().contains("Enter Send"));
+        assert!(editing.text().contains("Enter Send"));
+        assert!(!editing.text().contains("i Edit"));
+    }
+
+    #[test]
+    fn status_cannot_displace_submission_or_cancel_actions() {
+        let actions = actions();
+        let layout = ActionBar::new(&actions)
+            .with_mode(ActionMode::Insert)
+            .with_status(Some("an exceptionally long background agent status"))
+            .layout(34);
+
+        assert!(layout.text().contains("Enter Send"));
+        assert!(layout.text().contains("Esc Close"));
+        assert!(display_width(&layout.text()) <= 34);
+    }
+
+    #[test]
+    fn unicode_actions_are_measured_in_terminal_cells() {
+        let actions = vec![
+            UiAction::new("read", "漢", "Read 👨‍👩‍👧").with_priority(ActionPriority::Essential),
+            UiAction::new("extra", "e", "Additional action"),
+        ];
+
+        for width in 0..30 {
+            let layout = ActionBar::new(&actions).layout(width);
+            assert!(display_width(&layout.text()) <= width, "width {width}");
+            if layout.text().contains('漢') {
+                assert!(layout.text().contains("Read 👨‍👩‍👧"));
+            }
+        }
+    }
+
+    #[test]
+    fn zero_and_tiny_width_never_overflow() {
+        let actions = actions();
+        for width in 0..8 {
+            let layout = ActionBar::new(&actions)
+                .with_mode(ActionMode::Insert)
+                .layout(width);
+            assert!(display_width(&layout.text()) <= width, "width {width}");
+        }
+    }
+
+    #[test]
+    fn rendering_keeps_the_caller_surface_background() {
+        let actions = actions();
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(32, 2, &theme.style);
+
+        let layout = ActionBar::new(&actions)
+            .with_mode(ActionMode::Insert)
+            .render(&mut buffer, 0, 1, 32, &theme, &theme.style);
+
+        assert!(!layout.text().is_empty());
+        assert!(buffer.cells[32..64]
+            .iter()
+            .all(|cell| cell.style.bg == theme.style.bg));
+    }
+
+    #[test]
+    fn right_aligned_rendering_preserves_the_surface_and_complete_actions() {
+        let actions = vec![
+            UiAction::new("select", "Enter", "Select").with_priority(ActionPriority::Essential),
+            UiAction::new("close", "Esc", "Close").with_priority(ActionPriority::Essential),
+        ];
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(40, 2, &theme.style);
+
+        let layout = ActionBar::new(&actions).render_right_aligned(
+            &mut buffer,
+            2,
+            1,
+            34,
+            &theme,
+            &theme.style,
+        );
+
+        let row = buffer.cells[42..76]
+            .iter()
+            .map(|cell| cell.c)
+            .collect::<String>();
+        assert!(row.ends_with(&layout.text()), "{row:?}");
+        assert!(row.starts_with(' '), "{row:?}");
+        assert!(buffer.cells[42..76]
+            .iter()
+            .all(|cell| cell.style.bg == theme.style.bg));
+    }
+
+    #[test]
+    fn right_aligned_unicode_actions_remain_inside_the_available_columns() {
+        let actions = vec![
+            UiAction::new("select", "↵", "選ぶ").with_priority(ActionPriority::Essential),
+            UiAction::new("extra", "?", "More actions"),
+        ];
+        let theme = Theme::default();
+
+        for width in 1..24 {
+            let mut buffer = RenderBuffer::new(26, 2, &theme.style);
+            let layout = ActionBar::new(&actions).render_right_aligned(
+                &mut buffer,
+                1,
+                1,
+                width,
+                &theme,
+                &theme.style,
+            );
+
+            assert!(display_width(&layout.text()) <= width, "width {width}");
+            assert_eq!(buffer.cells[26].c, ' ', "width {width}");
+            assert_eq!(buffer.cells[27 + width].c, ' ', "width {width}");
+        }
+    }
+}

--- a/src/ui/agent_composer.rs
+++ b/src/ui/agent_composer.rs
@@ -585,6 +585,57 @@ mod tests {
     }
 
     #[test]
+    fn normal_mode_arrow_motions_keep_agent_composer_lines_intact() {
+        let editor = editor(60, 18);
+        let cases = [
+            (
+                "Left at second line start",
+                "one\ntwo",
+                4,
+                KeyCode::Left,
+                4,
+                "one\nwo",
+            ),
+            (
+                "Right at first line end",
+                "one\ntwo",
+                2,
+                KeyCode::Right,
+                2,
+                "on\ntwo",
+            ),
+        ];
+
+        for (name, text, cursor, arrow, expected_cursor, expected_text) in cases {
+            let mut composer = new_composer(&editor, None, 7, text.to_string(), vec![]);
+            composer.prompt.set_cursor(cursor);
+            composer.prompt.set_mode(Mode::Normal);
+
+            assert_eq!(
+                composer.handle_event(&key(arrow, KeyModifiers::NONE)),
+                Some(KeyAction::Single(Action::Refresh)),
+                "{name}: move with arrow key"
+            );
+            assert_eq!(
+                composer.prompt.cursor(),
+                expected_cursor,
+                "{name}: stay on line"
+            );
+
+            assert_eq!(
+                composer.handle_event(&key(KeyCode::Char('x'), KeyModifiers::NONE)),
+                Some(KeyAction::Single(Action::Refresh)),
+                "{name}: delete selected grapheme"
+            );
+            assert_eq!(
+                composer.prompt.text(),
+                expected_text,
+                "{name}: preserve lines"
+            );
+        }
+    }
+
+    #[test]
     fn combining_mark_insertion_keeps_agent_composer_cursor_after_merged_grapheme() {
         let editor = editor(60, 18);
         let mut composer = new_composer(&editor, None, 7, "aX".to_string(), vec![]);

--- a/src/ui/agent_composer.rs
+++ b/src/ui/agent_composer.rs
@@ -1,25 +1,25 @@
 //! A compact, multiline prompt composer for agent requests.
 
-use crossterm::event::{Event, KeyCode, KeyModifiers};
+use crossterm::event::Event;
 use serde_json::json;
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
     config::KeyAction,
-    editor::{Action, ComposerCallback, Editor, RenderBuffer},
+    editor::{Action, ComposerCallback, Editor, Mode, RenderBuffer},
     plugin::ComposerHandle,
     theme::{Style, Theme},
-    unicode_utils::{display_width, grapheme_len, grapheme_to_byte, truncate_display_width},
+    unicode_utils::{display_width, grapheme_len, truncate_display_width},
 };
 
 use super::{
-    dialog::{BorderStyle, Dialog},
-    Component,
+    dialog::{BorderStyle, Dialog, SurfaceRole},
+    normalize_prompt_newlines, ActionBar, ActionMode, ActionPriority, Component, PromptBuffer,
+    PromptInput, UiAction, PROMPT_MAX_BYTES,
 };
 
 const TAB_WIDTH: usize = 4;
-const MAX_PROMPT_BYTES: usize = 128 * 1024;
-const STATUS: &str = "Enter  ^J newline  Esc  ^P/N";
+const MAX_PROMPT_BYTES: usize = PROMPT_MAX_BYTES;
 const EMPTY_STATUS: &str = "Prompt is empty";
 const OVERSIZED_STATUS: &str = "Prompt exceeds 128 KiB";
 
@@ -33,12 +33,7 @@ pub(crate) struct WrappedText {
 pub struct AgentComposer {
     target: ComposerTarget,
     dialog: Dialog,
-    query: String,
-    cursor: usize,
-    history: Vec<String>,
-    history_position: Option<usize>,
-    history_draft: Option<String>,
-    preferred_column: Option<usize>,
+    prompt: PromptBuffer,
     validation_status: Option<&'static str>,
     viewport_width: usize,
     viewport_height: usize,
@@ -98,8 +93,6 @@ impl AgentComposer {
     ) -> Self {
         let theme = editor.theme.clone();
         let style = theme.ui_style.popup.clone();
-        let border_style = theme.ui_style.popup_border.clone();
-        let title_style = theme.ui_style.popup_title.clone();
         let viewport_width = editor.vwidth();
         let viewport_height = editor.vheight();
         let (x, y, width, height) = Self::geometry(viewport_width, viewport_height);
@@ -107,15 +100,15 @@ impl AgentComposer {
         let query = if initial_too_large {
             String::new()
         } else {
-            normalize_newlines(&query)
+            normalize_prompt_newlines(&query)
         };
         let history_len = history.len();
         let history = history
             .into_iter()
             .filter(|entry| entry.len() <= MAX_PROMPT_BYTES)
             .collect::<Vec<_>>();
-        let history_too_large = history.len() != history_len;
-        let cursor = grapheme_len(&query);
+        let prompt = PromptBuffer::with_history(&query, history);
+        let history_too_large = prompt.history().len() != history_len;
 
         Self {
             target,
@@ -129,14 +122,8 @@ impl AgentComposer {
                 BorderStyle::Single,
                 &theme,
             )
-            .with_border_draw_style(&border_style)
-            .with_title_style(&title_style),
-            query,
-            cursor,
-            history,
-            history_position: None,
-            history_draft: None,
-            preferred_column: None,
+            .with_surface_theme(&theme, SurfaceRole::Popup),
+            prompt,
             validation_status: (initial_too_large || history_too_large).then_some(OVERSIZED_STATUS),
             viewport_width,
             viewport_height,
@@ -170,13 +157,13 @@ impl AgentComposer {
                 Action::NotifyPlugin(
                     owner.clone(),
                     format!("composer:submitted:{id}"),
-                    json!(self.query),
+                    json!(self.prompt.text()),
                 ),
             ]),
             ComposerTarget::Callback(handle) => KeyAction::Multiple(vec![
                 Action::NotifyComposer(
                     *handle,
-                    Box::new(ComposerCallback::Submitted(self.query.clone())),
+                    Box::new(ComposerCallback::Submitted(self.prompt.text())),
                 ),
                 Action::CloseDialog,
             ]),
@@ -209,150 +196,11 @@ impl AgentComposer {
     }
 
     fn wrapped_text(&self) -> WrappedText {
-        wrap_text(&self.query, self.dialog.width)
-    }
-
-    fn insert(&mut self, text: &str) {
-        if text.len() > MAX_PROMPT_BYTES.saturating_sub(self.query.len()) {
-            self.validation_status = Some(OVERSIZED_STATUS);
-            return;
-        }
-        let text = normalize_newlines(text);
-        if text.is_empty() {
-            return;
-        }
-
-        let offset = grapheme_to_byte(&self.query, self.cursor);
-        self.query.insert_str(offset, &text);
-        self.cursor = self.query[..offset + text.len()].graphemes(true).count();
-        self.preferred_column = None;
-        self.validation_status = None;
-        self.history_position = None;
-        self.history_draft = None;
-    }
-
-    fn backspace(&mut self) {
-        if self.cursor == 0 {
-            return;
-        }
-        let start = grapheme_to_byte(&self.query, self.cursor - 1);
-        let end = grapheme_to_byte(&self.query, self.cursor);
-        self.query.replace_range(start..end, "");
-        self.cursor -= 1;
-        self.preferred_column = None;
-        self.validation_status = None;
-        self.history_position = None;
-        self.history_draft = None;
-    }
-
-    fn delete(&mut self) {
-        if self.cursor >= grapheme_len(&self.query) {
-            return;
-        }
-        let start = grapheme_to_byte(&self.query, self.cursor);
-        let end = grapheme_to_byte(&self.query, self.cursor + 1);
-        self.query.replace_range(start..end, "");
-        self.preferred_column = None;
-        self.validation_status = None;
-        self.history_position = None;
-        self.history_draft = None;
-    }
-
-    fn delete_previous_word(&mut self) {
-        if self.cursor == 0 {
-            return;
-        }
-        let end = grapheme_to_byte(&self.query, self.cursor);
-        let before = &self.query[..end];
-        let mut start = self.cursor;
-        let mut seen_word = false;
-
-        for grapheme in before.graphemes(true).rev() {
-            let whitespace = grapheme.chars().all(char::is_whitespace);
-            if seen_word && whitespace {
-                break;
-            }
-            seen_word |= !whitespace;
-            start -= 1;
-        }
-
-        let start_byte = grapheme_to_byte(&self.query, start);
-        self.query.replace_range(start_byte..end, "");
-        self.cursor = start;
-        self.preferred_column = None;
-        self.validation_status = None;
-        self.history_position = None;
-        self.history_draft = None;
-    }
-
-    fn move_vertically(&mut self, direction: isize) {
-        let wrapped = self.wrapped_text();
-        let Some(&(row, column)) = wrapped.positions.get(self.cursor) else {
-            return;
-        };
-        let target_row = row.saturating_add_signed(direction);
-        if target_row >= wrapped.rows.len() || target_row == row {
-            return;
-        }
-        let goal = *self.preferred_column.get_or_insert(column);
-        let mut target = None;
-        let mut distance = usize::MAX;
-
-        for (index, &(candidate_row, candidate_column)) in wrapped.positions.iter().enumerate() {
-            if candidate_row != target_row {
-                continue;
-            }
-            let candidate_distance = candidate_column.abs_diff(goal);
-            if candidate_distance < distance {
-                target = Some(index);
-                distance = candidate_distance;
-            }
-        }
-
-        if let Some(target) = target {
-            self.cursor = target;
-        }
-    }
-
-    fn history_back(&mut self) {
-        if self.history.is_empty() {
-            return;
-        }
-        let position = match self.history_position {
-            Some(position) => (position + 1).min(self.history.len() - 1),
-            None => {
-                self.history_draft = Some(self.query.clone());
-                0
-            }
-        };
-        self.history_position = Some(position);
-        self.query.clone_from(&self.history[position]);
-        self.query = normalize_newlines(&self.query);
-        self.cursor = grapheme_len(&self.query);
-        self.preferred_column = None;
-        self.validation_status = None;
-    }
-
-    fn history_forward(&mut self) {
-        let Some(position) = self.history_position else {
-            return;
-        };
-        if position > 0 {
-            let next = position - 1;
-            self.history_position = Some(next);
-            self.query.clone_from(&self.history[next]);
-            self.query = normalize_newlines(&self.query);
-        } else {
-            self.history_position = None;
-            self.query = self.history_draft.take().unwrap_or_default();
-        }
-        self.cursor = grapheme_len(&self.query);
-        self.preferred_column = None;
-        self.validation_status = None;
+        wrap_text(&self.prompt.buffer().contents(), self.dialog.width)
     }
 
     fn redraw() -> Option<KeyAction> {
-        Some(KeyAction::Single(Action::ShowDialog))
+        Some(KeyAction::Single(Action::Refresh))
     }
 }
 
@@ -366,36 +214,6 @@ impl Component for AgentComposer {
 
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         self.dialog.draw(buffer)?;
-        let right = self.dialog.x + self.dialog.width + 1;
-        let bottom = self.dialog.y + self.dialog.height + 1;
-        buffer.set_char(
-            self.dialog.x,
-            self.dialog.y,
-            '┌',
-            &self.dialog.border_draw_style,
-            &self.theme,
-        );
-        buffer.set_char(
-            right,
-            self.dialog.y,
-            '┐',
-            &self.dialog.border_draw_style,
-            &self.theme,
-        );
-        buffer.set_char(
-            self.dialog.x,
-            bottom,
-            '└',
-            &self.dialog.border_draw_style,
-            &self.theme,
-        );
-        buffer.set_char(
-            right,
-            bottom,
-            '┘',
-            &self.dialog.border_draw_style,
-            &self.theme,
-        );
         let body_height = self.body_height();
         let content_x = self.dialog.x + 1;
         let content_y = self.dialog.y + 1;
@@ -403,7 +221,7 @@ impl Component for AgentComposer {
             return Ok(());
         }
 
-        if self.query.is_empty() {
+        if self.prompt.text().is_empty() {
             let placeholder =
                 truncate_display_width("What should the agent do?", self.dialog.width);
             buffer.set_text(content_x, content_y, &placeholder, &self.muted_style);
@@ -411,7 +229,7 @@ impl Component for AgentComposer {
             let wrapped = self.wrapped_text();
             let cursor_row = wrapped
                 .positions
-                .get(self.cursor)
+                .get(self.prompt.cursor())
                 .map_or(0, |position| position.0);
             let scroll = cursor_row.saturating_sub(body_height - 1);
             for (offset, row) in wrapped
@@ -427,128 +245,89 @@ impl Component for AgentComposer {
 
         if self.dialog.height > body_height {
             let status_y = content_y + body_height;
-            let status = self.validation_status.unwrap_or(STATUS);
-            let status = truncate_display_width(status, self.dialog.width);
-            buffer.set_text(content_x, status_y, &status, &self.muted_style);
+            let escape_label = if self.prompt.mode() == Mode::Insert {
+                "Normal"
+            } else {
+                "Cancel"
+            };
+            let actions = [
+                UiAction::new("send", "Ctrl+Enter", "Send")
+                    .with_compact_key("^↵")
+                    .with_compact_label("")
+                    .with_priority(ActionPriority::Essential),
+                UiAction::new("cancel", "Esc", escape_label)
+                    .with_compact_label("")
+                    .with_priority(ActionPriority::Essential),
+                UiAction::new("newline", "Enter", "New line"),
+                UiAction::new("history", "Ctrl+P/N", "History")
+                    .with_compact_key("^P/N")
+                    .with_priority(ActionPriority::Secondary),
+            ];
+            let visible_actions = if self.validation_status.is_some() {
+                &actions[..2]
+            } else {
+                &actions[..]
+            };
+            ActionBar::new(visible_actions)
+                .with_mode(if self.prompt.mode() == Mode::Normal {
+                    ActionMode::Normal
+                } else {
+                    ActionMode::Insert
+                })
+                .with_status(self.validation_status)
+                .render(
+                    buffer,
+                    content_x,
+                    status_y,
+                    self.dialog.width,
+                    &self.theme,
+                    &self.style,
+                );
         }
         Ok(())
     }
 
     fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
-        match event {
-            Event::Paste(text) => {
-                self.insert(text);
+        let previous_bytes = self.prompt.text().len();
+        let inserted_bytes = match event {
+            Event::Paste(text) => normalize_prompt_newlines(text).len(),
+            Event::Key(key) => match key.code {
+                crossterm::event::KeyCode::Char(character)
+                    if !key.modifiers.intersects(
+                        crossterm::event::KeyModifiers::CONTROL
+                            | crossterm::event::KeyModifiers::ALT,
+                    ) =>
+                {
+                    character.len_utf8()
+                }
+                _ => 0,
+            },
+            _ => 0,
+        };
+
+        match self.prompt.handle_event(event, self.dialog.width) {
+            PromptInput::Changed => {
+                self.validation_status = None;
                 Self::redraw()
             }
-            Event::Key(key) => match (key.code, key.modifiers) {
-                (KeyCode::Esc, _) => Some(self.cancel_action()),
-                (KeyCode::Char('c' | 'C'), modifiers)
-                    if modifiers.contains(KeyModifiers::CONTROL) =>
-                {
-                    Some(self.cancel_action())
-                }
-                (KeyCode::Enter, modifiers) if modifiers.contains(KeyModifiers::SHIFT) => {
-                    self.insert("\n");
+            PromptInput::Submit => {
+                let text = self.prompt.text();
+                if text.len() > MAX_PROMPT_BYTES {
+                    self.validation_status = Some(OVERSIZED_STATUS);
                     Self::redraw()
-                }
-                (KeyCode::Enter, _) => {
-                    if self.query.len() > MAX_PROMPT_BYTES {
-                        self.validation_status = Some(OVERSIZED_STATUS);
-                        return Self::redraw();
-                    }
-                    if self.query.trim().is_empty() {
-                        self.validation_status = Some(EMPTY_STATUS);
-                        return Self::redraw();
-                    }
+                } else if text.trim().is_empty() {
+                    self.validation_status = Some(EMPTY_STATUS);
+                    Self::redraw()
+                } else {
                     Some(self.submit_action())
                 }
-                (KeyCode::Char('j' | 'J'), modifiers)
-                    if modifiers.contains(KeyModifiers::CONTROL) =>
-                {
-                    self.insert("\n");
-                    Self::redraw()
-                }
-                (KeyCode::Char('p' | 'P'), modifiers)
-                    if modifiers.contains(KeyModifiers::CONTROL) =>
-                {
-                    self.history_back();
-                    Self::redraw()
-                }
-                (KeyCode::Char('n' | 'N'), modifiers)
-                    if modifiers.contains(KeyModifiers::CONTROL) =>
-                {
-                    self.history_forward();
-                    Self::redraw()
-                }
-                (KeyCode::Char('w' | 'W'), modifiers)
-                    if modifiers.contains(KeyModifiers::CONTROL) =>
-                {
-                    self.delete_previous_word();
-                    Self::redraw()
-                }
-                (KeyCode::Home, _) => {
-                    self.cursor = 0;
-                    self.preferred_column = None;
-                    Self::redraw()
-                }
-                (KeyCode::Char('a' | 'A'), modifiers)
-                    if modifiers.contains(KeyModifiers::CONTROL) =>
-                {
-                    self.cursor = 0;
-                    self.preferred_column = None;
-                    Self::redraw()
-                }
-                (KeyCode::End, _) => {
-                    self.cursor = grapheme_len(&self.query);
-                    self.preferred_column = None;
-                    Self::redraw()
-                }
-                (KeyCode::Char('e' | 'E'), modifiers)
-                    if modifiers.contains(KeyModifiers::CONTROL) =>
-                {
-                    self.cursor = grapheme_len(&self.query);
-                    self.preferred_column = None;
-                    Self::redraw()
-                }
-                (KeyCode::Left, _) => {
-                    self.cursor = self.cursor.saturating_sub(1);
-                    self.preferred_column = None;
-                    Self::redraw()
-                }
-                (KeyCode::Right, _) => {
-                    self.cursor = (self.cursor + 1).min(grapheme_len(&self.query));
-                    self.preferred_column = None;
-                    Self::redraw()
-                }
-                (KeyCode::Up, _) => {
-                    self.move_vertically(-1);
-                    Self::redraw()
-                }
-                (KeyCode::Down, _) => {
-                    self.move_vertically(1);
-                    Self::redraw()
-                }
-                (KeyCode::Backspace, _) => {
-                    self.backspace();
-                    Self::redraw()
-                }
-                (KeyCode::Delete, _) => {
-                    self.delete();
-                    Self::redraw()
-                }
-                (KeyCode::Tab, _) => {
-                    self.insert("\t");
-                    Self::redraw()
-                }
-                (KeyCode::Char(character), modifiers)
-                    if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-                {
-                    self.insert(&character.to_string());
-                    Self::redraw()
-                }
-                _ => None,
-            },
-            _ => None,
+            }
+            PromptInput::Cancel => Some(self.cancel_action()),
+            PromptInput::Unhandled if inserted_bytes > MAX_PROMPT_BYTES - previous_bytes => {
+                self.validation_status = Some(OVERSIZED_STATUS);
+                Self::redraw()
+            }
+            PromptInput::Unhandled => None,
         }
     }
 
@@ -560,17 +339,13 @@ impl Component for AgentComposer {
         self.dialog.height = height;
         self.viewport_width = viewport_width;
         self.viewport_height = viewport_height;
-        self.preferred_column = None;
         true
     }
 
     fn set_theme(&mut self, theme: &Theme) {
         self.style = theme.ui_style.popup.clone();
         self.muted_style = theme.ui_style.muted.clone();
-        self.dialog.style = theme.ui_style.popup.clone();
-        self.dialog.border_draw_style = theme.ui_style.popup_border.clone();
-        self.dialog.title_style = theme.ui_style.popup_title.clone();
-        self.dialog.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Popup);
         self.theme = theme.clone();
     }
 
@@ -582,7 +357,7 @@ impl Component for AgentComposer {
         let wrapped = self.wrapped_text();
         let (row, column) = wrapped
             .positions
-            .get(self.cursor)
+            .get(self.prompt.cursor())
             .copied()
             .unwrap_or_default();
         let body_height = self.body_height();
@@ -601,10 +376,6 @@ impl Component for AgentComposer {
             .min(self.viewport_height.saturating_sub(1));
         Some((x, y))
     }
-}
-
-pub(crate) fn normalize_newlines(text: &str) -> String {
-    text.replace("\r\n", "\n").replace('\r', "\n")
 }
 
 pub(crate) fn wrap_text(text: &str, width: usize) -> WrappedText {
@@ -711,7 +482,7 @@ mod tests {
     }
 
     fn submit(composer: &mut AgentComposer) -> Option<KeyAction> {
-        composer.handle_event(&key(KeyCode::Enter, KeyModifiers::NONE))
+        composer.handle_event(&key(KeyCode::Enter, KeyModifiers::CONTROL))
     }
 
     fn new_composer(
@@ -771,7 +542,7 @@ mod tests {
             "first\tline\r\n  second\rthird\n".to_string(),
         ));
 
-        assert_eq!(composer.query, "first\tline\n  second\nthird\n");
+        assert_eq!(composer.prompt.text(), "first\tline\n  second\nthird\n");
         let wrapped = composer.wrapped_text();
         assert_eq!(wrapped.rows[0], "first   line");
         assert_eq!(wrapped.rows[1], "  second");
@@ -800,16 +571,16 @@ mod tests {
         composer.handle_event(&key(KeyCode::Delete, KeyModifiers::NONE));
         composer.handle_event(&key(KeyCode::Char('q'), KeyModifiers::CONTROL));
         composer.handle_event(&key(KeyCode::Char('z'), KeyModifiers::ALT));
-        assert_eq!(composer.query, "one tXo");
+        assert_eq!(composer.prompt.text(), "one tXo");
 
         composer.handle_event(&key(KeyCode::Char('w'), KeyModifiers::CONTROL));
-        assert_eq!(composer.query, "one o");
+        assert_eq!(composer.prompt.text(), "one o");
         composer.handle_event(&key(KeyCode::Char('a'), KeyModifiers::CONTROL));
         composer.handle_event(&key(KeyCode::Delete, KeyModifiers::NONE));
-        assert_eq!(composer.query, "ne o");
+        assert_eq!(composer.prompt.text(), "ne o");
         composer.handle_event(&key(KeyCode::Char('e'), KeyModifiers::CONTROL));
         composer.handle_event(&key(KeyCode::Backspace, KeyModifiers::NONE));
-        assert_eq!(composer.query, "ne ");
+        assert_eq!(composer.prompt.text(), "ne ");
     }
 
     #[test]
@@ -827,7 +598,7 @@ mod tests {
         composer.handle_event(&key(KeyCode::Enter, KeyModifiers::SHIFT));
         composer.handle_event(&key(KeyCode::Char('y'), KeyModifiers::NONE));
 
-        assert!(composer.query.ends_with("\nx\ny"));
+        assert!(composer.prompt.text().ends_with("\nx\ny"));
     }
 
     #[test]
@@ -836,12 +607,12 @@ mod tests {
         let mut composer = new_composer(&editor, None, 9, "e\u{301}👨‍👩‍👧漢".to_string(), vec![]);
 
         composer.handle_event(&key(KeyCode::Backspace, KeyModifiers::NONE));
-        assert_eq!(composer.query, "e\u{301}👨‍👩‍👧");
+        assert_eq!(composer.prompt.text(), "e\u{301}👨‍👩‍👧");
         composer.handle_event(&key(KeyCode::Backspace, KeyModifiers::NONE));
-        assert_eq!(composer.query, "e\u{301}");
+        assert_eq!(composer.prompt.text(), "e\u{301}");
         composer.handle_event(&key(KeyCode::Home, KeyModifiers::NONE));
         composer.handle_event(&key(KeyCode::Delete, KeyModifiers::NONE));
-        assert!(composer.query.is_empty());
+        assert!(composer.prompt.text().is_empty());
     }
 
     #[test]
@@ -856,13 +627,13 @@ mod tests {
         );
 
         composer.handle_event(&key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.query, "newer\nprompt");
+        assert_eq!(composer.prompt.text(), "newer\nprompt");
         composer.handle_event(&key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.query, "older");
+        assert_eq!(composer.prompt.text(), "older");
         composer.handle_event(&key(KeyCode::Char('n'), KeyModifiers::CONTROL));
-        assert_eq!(composer.query, "newer\nprompt");
+        assert_eq!(composer.prompt.text(), "newer\nprompt");
         composer.handle_event(&key(KeyCode::Char('n'), KeyModifiers::CONTROL));
-        assert_eq!(composer.query, "current draft");
+        assert_eq!(composer.prompt.text(), "current draft");
         assert!(composer.is_sensitive_input());
         assert_eq!(composer.picker_id(), None);
     }
@@ -874,12 +645,17 @@ mod tests {
 
         assert_eq!(
             submit(&mut composer),
-            Some(KeyAction::Single(Action::ShowDialog))
+            Some(KeyAction::Single(Action::Refresh))
         );
         let mut buffer = RenderBuffer::new(60, editor.vheight(), &Style::default());
         composer.draw(&mut buffer).unwrap();
         let status_y = composer.dialog.y + 1 + composer.body_height();
         assert!(rendered_row(&buffer, status_y).contains(EMPTY_STATUS));
+        assert_eq!(
+            composer.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        assert_eq!(composer.prompt.mode(), Mode::Normal);
         assert_eq!(
             composer.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
             Some(KeyAction::Multiple(vec![
@@ -937,11 +713,98 @@ mod tests {
         );
         assert_eq!(
             cancelled.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        assert_eq!(
+            cancelled.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
             Some(KeyAction::Multiple(vec![
                 Action::NotifyComposer(handle, Box::new(ComposerCallback::Cancelled)),
                 Action::CloseDialog,
             ]))
         );
+    }
+
+    #[test]
+    fn ordinary_enter_edits_the_real_prompt_buffer_in_insert_mode() {
+        let editor = editor(60, 18);
+        let mut composer = new_composer(&editor, None, 802, "first".to_string(), vec![]);
+
+        assert_eq!(
+            composer.handle_event(&key(KeyCode::Enter, KeyModifiers::NONE)),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        assert_eq!(composer.prompt.text(), "first\n");
+        assert_eq!(composer.prompt.buffer().contents(), "first\n");
+        assert!(composer.prompt.buffer().file.is_none());
+        assert_eq!(composer.prompt.buffer().undo_history.node_count(), 1);
+    }
+
+    #[test]
+    fn modified_enter_and_modified_linefeed_submit_scoped_callbacks() {
+        let editor = editor(60, 18);
+        let handle = ComposerHandle::from_raw(42);
+
+        for event in [
+            key(KeyCode::Enter, KeyModifiers::CONTROL),
+            key(KeyCode::Char('\n'), KeyModifiers::CONTROL),
+            key(KeyCode::Enter, KeyModifiers::ALT),
+            key(KeyCode::Char('\n'), KeyModifiers::ALT),
+        ] {
+            let mut composer = AgentComposer::new_callback(
+                &editor,
+                Some("Prompt".to_string()),
+                "send this exactly".to_string(),
+                vec![],
+                handle,
+            );
+
+            assert_eq!(
+                composer.handle_event(&event),
+                Some(KeyAction::Multiple(vec![
+                    Action::NotifyComposer(
+                        handle,
+                        Box::new(ComposerCallback::Submitted("send this exactly".to_string()))
+                    ),
+                    Action::CloseDialog,
+                ]))
+            );
+        }
+    }
+
+    #[test]
+    fn escape_enters_real_normal_mode_and_vim_undo_restores_word_deletion() {
+        let editor = editor(60, 18);
+        let mut composer = new_composer(&editor, None, 802, "first second".to_string(), vec![]);
+
+        composer.handle_event(&key(KeyCode::Home, KeyModifiers::NONE));
+        assert_eq!(
+            composer.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        assert_eq!(composer.prompt.mode(), Mode::Normal);
+        composer.handle_event(&key(KeyCode::Char('d'), KeyModifiers::NONE));
+        composer.handle_event(&key(KeyCode::Char('w'), KeyModifiers::NONE));
+        assert_eq!(composer.prompt.text(), "second");
+        composer.handle_event(&key(KeyCode::Char('u'), KeyModifiers::NONE));
+        assert_eq!(composer.prompt.text(), "first second");
+        assert_eq!(
+            composer.handle_event(&key(KeyCode::Char('i'), KeyModifiers::NONE)),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        assert_eq!(composer.prompt.mode(), Mode::Insert);
+    }
+
+    #[test]
+    fn control_s_neither_submits_nor_mutates_the_floating_prompt() {
+        let editor = editor(60, 18);
+        let mut composer = new_composer(&editor, None, 802, "keep editing".to_string(), vec![]);
+
+        assert_eq!(
+            composer.handle_event(&key(KeyCode::Char('s'), KeyModifiers::CONTROL)),
+            None
+        );
+        assert_eq!(composer.prompt.text(), "keep editing");
+        assert_eq!(composer.prompt.mode(), Mode::Insert);
     }
 
     #[test]
@@ -976,7 +839,7 @@ mod tests {
     }
 
     #[test]
-    fn compact_status_keeps_every_shortcut_visible_at_minimum_width() {
+    fn compact_status_preserves_complete_submission_and_cancel_actions() {
         let editor = editor(36, 14);
         let composer = new_composer(
             &editor,
@@ -990,7 +853,9 @@ mod tests {
         composer.draw(&mut buffer).unwrap();
         let status_y = composer.dialog.y + 1 + composer.body_height();
 
-        assert!(rendered_row(&buffer, status_y).contains(STATUS));
+        let status = rendered_row(&buffer, status_y);
+        assert!(status.contains("Send"), "{status:?}");
+        assert!(status.contains("Esc"), "{status:?}");
     }
 
     #[test]
@@ -1008,17 +873,17 @@ mod tests {
             KeyCode::Char('P'),
             KeyModifiers::CONTROL | KeyModifiers::SHIFT,
         ));
-        assert_eq!(composer.query, "recent");
+        assert_eq!(composer.prompt.text(), "recent");
         composer.handle_event(&key(
             KeyCode::Char('N'),
             KeyModifiers::CONTROL | KeyModifiers::ALT,
         ));
-        assert_eq!(composer.query, "draft");
+        assert_eq!(composer.prompt.text(), "draft");
         composer.handle_event(&key(
             KeyCode::Char('J'),
             KeyModifiers::CONTROL | KeyModifiers::SHIFT,
         ));
-        assert_eq!(composer.query, "draft\n");
+        assert_eq!(composer.prompt.text(), "draft\n");
     }
 
     #[test]
@@ -1028,17 +893,16 @@ mod tests {
         let oversized = "x".repeat(MAX_PROMPT_BYTES);
 
         composer.handle_event(&Event::Paste(oversized));
-        assert_eq!(composer.query, "draft");
+        assert_eq!(composer.prompt.text(), "draft");
         assert_eq!(composer.validation_status, Some(OVERSIZED_STATUS));
         let mut buffer = RenderBuffer::new(60, editor.vheight(), &Style::default());
         composer.draw(&mut buffer).unwrap();
         let status_y = composer.dialog.y + 1 + composer.body_height();
         assert!(rendered_row(&buffer, status_y).contains(OVERSIZED_STATUS));
 
-        composer.query = "x".repeat(MAX_PROMPT_BYTES);
-        composer.cursor = MAX_PROMPT_BYTES;
+        assert!(composer.prompt.set_text(&"x".repeat(MAX_PROMPT_BYTES)));
         composer.handle_event(&key(KeyCode::Char('!'), KeyModifiers::NONE));
-        assert_eq!(composer.query.len(), MAX_PROMPT_BYTES);
+        assert_eq!(composer.prompt.text().len(), MAX_PROMPT_BYTES);
         assert_eq!(composer.validation_status, Some(OVERSIZED_STATUS));
     }
 
@@ -1050,7 +914,7 @@ mod tests {
         let encoded = serde_json::to_vec(&accepted).unwrap();
 
         assert!(encoded.len() < 1024 * 1024);
-        assert_eq!(composer.query, accepted);
+        assert_eq!(composer.prompt.text(), accepted);
         assert_eq!(
             submit(&mut composer),
             Some(KeyAction::Multiple(vec![
@@ -1076,14 +940,14 @@ mod tests {
             vec![oversized, "safe history".to_string()],
         );
 
-        assert!(composer.query.is_empty());
-        assert_eq!(composer.cursor, 0);
-        assert_eq!(composer.history, vec!["safe history".to_string()]);
+        assert!(composer.prompt.text().is_empty());
+        assert_eq!(composer.prompt.cursor(), 0);
+        assert_eq!(composer.prompt.history(), ["safe history".to_string()]);
         assert_eq!(composer.validation_status, Some(OVERSIZED_STATUS));
         let wrapped = composer.wrapped_text();
         assert_eq!(wrapped.rows, vec![String::new()]);
         composer.handle_event(&key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.query, "safe history");
+        assert_eq!(composer.prompt.text(), "safe history");
         assert_eq!(composer.validation_status, None);
     }
 }

--- a/src/ui/agent_composer.rs
+++ b/src/ui/agent_composer.rs
@@ -585,6 +585,23 @@ mod tests {
     }
 
     #[test]
+    fn combining_mark_insertion_keeps_agent_composer_cursor_after_merged_grapheme() {
+        let editor = editor(60, 18);
+        let mut composer = new_composer(&editor, None, 7, "aX".to_string(), vec![]);
+
+        composer.handle_event(&key(KeyCode::Left, KeyModifiers::NONE));
+        composer.handle_event(&key(KeyCode::Char('\u{301}'), KeyModifiers::NONE));
+
+        assert_eq!(composer.prompt.text(), "a\u{301}X");
+        assert_eq!(composer.prompt.cursor(), 1);
+
+        composer.handle_event(&key(KeyCode::Char('Z'), KeyModifiers::NONE));
+
+        assert_eq!(composer.prompt.text(), "a\u{301}ZX");
+        assert_eq!(composer.prompt.cursor(), 2);
+    }
+
+    #[test]
     fn newline_shortcuts_and_vertical_motion_work_on_wrapped_lines() {
         let editor = editor(40, 14);
         let mut composer = new_composer(&editor, None, 1, "a".repeat(40), vec![]);

--- a/src/ui/agent_composer.rs
+++ b/src/ui/agent_composer.rs
@@ -245,20 +245,21 @@ impl Component for AgentComposer {
 
         if self.dialog.height > body_height {
             let status_y = content_y + body_height;
-            let escape_label = if self.prompt.mode() == Mode::Insert {
-                "Normal"
+            let normal_mode = self.prompt.mode() == Mode::Normal;
+            let (send_key, compact_send_key, escape_label) = if normal_mode {
+                ("Enter", "↵", "Cancel")
             } else {
-                "Cancel"
+                ("Ctrl+Enter", "^↵", "Normal")
             };
             let actions = [
-                UiAction::new("send", "Ctrl+Enter", "Send")
-                    .with_compact_key("^↵")
+                UiAction::new("send", send_key, "Send")
+                    .with_compact_key(compact_send_key)
                     .with_compact_label("")
                     .with_priority(ActionPriority::Essential),
                 UiAction::new("cancel", "Esc", escape_label)
                     .with_compact_label("")
                     .with_priority(ActionPriority::Essential),
-                UiAction::new("newline", "Enter", "New line"),
+                UiAction::new("newline", "Enter", "New line").with_modes([ActionMode::Insert]),
                 UiAction::new("history", "Ctrl+P/N", "History")
                     .with_compact_key("^P/N")
                     .with_priority(ActionPriority::Secondary),
@@ -269,7 +270,7 @@ impl Component for AgentComposer {
                 &actions[..]
             };
             ActionBar::new(visible_actions)
-                .with_mode(if self.prompt.mode() == Mode::Normal {
+                .with_mode(if normal_mode {
                     ActionMode::Normal
                 } else {
                     ActionMode::Insert
@@ -740,6 +741,51 @@ mod tests {
     }
 
     #[test]
+    fn composer_action_hints_follow_prompt_mode() {
+        let editor = editor(160, 24);
+        let mut composer = new_composer(&editor, None, 802, "send this".to_string(), vec![]);
+        let mut buffer = RenderBuffer::new(160, editor.vheight(), &Style::default());
+        let status_y = composer.dialog.y + 1 + composer.body_height();
+
+        composer.draw(&mut buffer).unwrap();
+        let insert_status = rendered_row(&buffer, status_y);
+        assert!(insert_status.contains("INSERT"), "{insert_status:?}");
+        assert!(
+            insert_status.contains("Ctrl+Enter Send"),
+            "{insert_status:?}"
+        );
+        assert!(
+            insert_status.contains("Enter New line"),
+            "{insert_status:?}"
+        );
+        assert!(insert_status.contains("Esc Normal"), "{insert_status:?}");
+
+        assert_eq!(
+            composer.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        composer.draw(&mut buffer).unwrap();
+        let normal_status = rendered_row(&buffer, status_y);
+        assert!(normal_status.contains("NORMAL"), "{normal_status:?}");
+        assert!(normal_status.contains("Enter Send"), "{normal_status:?}");
+        assert!(normal_status.contains("Esc Cancel"), "{normal_status:?}");
+        assert!(!normal_status.contains("Ctrl+Enter"), "{normal_status:?}");
+        assert!(!normal_status.contains("New line"), "{normal_status:?}");
+
+        assert_eq!(
+            composer.handle_event(&key(KeyCode::Enter, KeyModifiers::NONE)),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::NotifyPlugin(
+                    "agent".to_string(),
+                    "composer:submitted:802".to_string(),
+                    json!("send this"),
+                ),
+            ]))
+        );
+    }
+
+    #[test]
     fn modified_enter_and_modified_linefeed_submit_scoped_callbacks() {
         let editor = editor(60, 18);
         let handle = ComposerHandle::from_raw(42);
@@ -856,6 +902,32 @@ mod tests {
         let status = rendered_row(&buffer, status_y);
         assert!(status.contains("Send"), "{status:?}");
         assert!(status.contains("Esc"), "{status:?}");
+    }
+
+    #[test]
+    fn compact_normal_mode_status_preserves_submission_and_cancel_actions() {
+        let editor = editor(36, 14);
+        let mut composer = new_composer(
+            &editor,
+            Some("Agent prompt".to_string()),
+            802,
+            "send this".to_string(),
+            vec![],
+        );
+        let mut buffer = RenderBuffer::new(36, editor.vheight(), &Style::default());
+
+        assert_eq!(
+            composer.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        composer.draw(&mut buffer).unwrap();
+        let status_y = composer.dialog.y + 1 + composer.body_height();
+        let status = rendered_row(&buffer, status_y);
+
+        assert!(status.contains("Send"), "{status:?}");
+        assert!(status.contains("Esc"), "{status:?}");
+        assert!(!status.contains("New line"), "{status:?}");
+        assert!(!status.contains("^↵"), "{status:?}");
     }
 
     #[test]

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -13,10 +13,12 @@ use crate::{
     editor::{Action, RenderBuffer},
     lsp::types::{CompletionItemKind, CompletionResponseItem, Documentation},
     theme::{SelectionForegroundPriority, Style, Theme, UiStyle},
-    unicode_utils::{display_width, fit_display_width, truncate_display_width},
+    unicode_utils::{
+        display_width, fit_display_width, truncate_display_width_with_marker, TruncationSide,
+    },
 };
 
-use super::Component;
+use super::{dialog::BorderStyle, Component, IconCatalog, SelectionViewport};
 
 const MAX_WIDTH: usize = 80;
 const PAGE_SIZE: usize = 10;
@@ -27,8 +29,7 @@ pub struct CompletionUI {
     all_items: Vec<CompletionResponseItem>,
     items: Vec<usize>,
     filter: String,
-    selected: usize,
-    scroll_offset: usize,
+    viewport: SelectionViewport,
     visible: bool,
     x: usize,
     y: usize,
@@ -125,14 +126,14 @@ impl CompletionUI {
         self.items.extend(0..items.len());
         self.all_items = items;
         self.filter.clear();
-        self.selected = selected;
-        self.scroll_offset = 0;
         self.visible = true;
         self.x = x;
         self.y = y;
         self.width = width;
         self.max_rows = max_rows;
         self.max_height = min(min(self.items.len(), PAGE_SIZE), max_rows.saturating_sub(2));
+        self.viewport = SelectionViewport::new(self.items.len(), self.max_height);
+        self.viewport.select(selected);
     }
 
     pub fn hide(&mut self) {
@@ -148,7 +149,7 @@ impl CompletionUI {
 
     pub fn selected_item(&self) -> Option<&CompletionResponseItem> {
         self.items
-            .get(self.selected)
+            .get(self.viewport.selected())
             .and_then(|index| self.all_items.get(*index))
     }
 
@@ -223,12 +224,12 @@ impl CompletionUI {
             self.items.extend(matches.into_iter().map(|(_, idx)| idx));
         }
 
-        self.selected = 0;
-        self.scroll_offset = 0;
         self.max_height = min(
             min(self.items.len(), PAGE_SIZE),
             self.max_rows.saturating_sub(2),
         );
+        self.viewport.reset(self.items.len());
+        self.viewport.set_height(self.max_height);
     }
 
     fn push_filter_char(&mut self, c: char) {
@@ -246,20 +247,7 @@ impl CompletionUI {
             return;
         }
 
-        let new_selected = if delta.is_negative() {
-            self.selected.saturating_sub(delta.unsigned_abs())
-        } else {
-            self.selected.saturating_add(delta as usize)
-        };
-
-        self.selected = min(new_selected, self.items.len() - 1);
-
-        // Adjust scroll if selection is out of view
-        if self.selected < self.scroll_offset {
-            self.scroll_offset = self.selected;
-        } else if self.selected >= self.scroll_offset + self.max_height {
-            self.scroll_offset = self.selected - self.max_height + 1;
-        }
+        self.viewport.move_by(delta);
     }
 
     fn move_page(&mut self, up: bool) {
@@ -272,33 +260,7 @@ impl CompletionUI {
     }
 
     fn kind_to_icon(kind: &CompletionItemKind) -> &'static str {
-        match kind {
-            CompletionItemKind::Text => "abc",
-            CompletionItemKind::Method => "ƒ",
-            CompletionItemKind::Function => "λ",
-            CompletionItemKind::Constructor => "⚡",
-            CompletionItemKind::Field => "◆",
-            CompletionItemKind::Variable => "𝑥",
-            CompletionItemKind::Class => "○",
-            CompletionItemKind::Interface => "◌",
-            CompletionItemKind::Module => "□",
-            CompletionItemKind::Property => "◇",
-            CompletionItemKind::Unit => "∅",
-            CompletionItemKind::Value => "=",
-            CompletionItemKind::Enum => "ℰ",
-            CompletionItemKind::Keyword => "🔑",
-            CompletionItemKind::Snippet => "✂",
-            CompletionItemKind::Color => "🎨",
-            CompletionItemKind::File => "📄",
-            CompletionItemKind::Reference => "→",
-            CompletionItemKind::Folder => "📁",
-            CompletionItemKind::EnumMember => "ℯ",
-            CompletionItemKind::Constant => "π",
-            CompletionItemKind::Struct => "⚪",
-            CompletionItemKind::Event => "⚡",
-            CompletionItemKind::Operator => "±",
-            CompletionItemKind::TypeParameter => "𝑇",
-        }
+        IconCatalog::completion(kind).glyph
     }
 
     fn row_segments(
@@ -347,17 +309,10 @@ impl CompletionUI {
     }
 
     fn ellipsize(content: &str, width: usize) -> String {
-        if display_width(content) <= width {
-            return fit_display_width(content, width);
-        }
-
-        if width <= 3 {
-            return ".".repeat(width);
-        }
-
-        let mut truncated = truncate_display_width(content, width - 3);
-        truncated.push_str("...");
-        fit_display_width(&truncated, width)
+        fit_display_width(
+            &truncate_display_width_with_marker(content, width, "…", TruncationSide::Right),
+            width,
+        )
     }
 
     fn render_completion(&self) -> Vec<(usize, usize, String, Style)> {
@@ -368,12 +323,16 @@ impl CompletionUI {
         let mut output = Vec::new();
         let mut y_offset = 1;
         let last_row_offset = self.max_rows.saturating_sub(1);
+        let [horizontal, _, top_left, top_right, bottom_left, bottom_right] = BorderStyle::Rounded
+            .glyphs()
+            .expect("rounded completion borders have frame glyphs");
+        let horizontal = horizontal.to_string().repeat(self.width.saturating_sub(2));
 
         // Draw top border
         output.push((
             self.x,
             self.y + y_offset,
-            format!("╭{}╮", "─".repeat(self.width - 2)),
+            format!("{top_left}{horizontal}{top_right}"),
             self.styles.popup_border.clone(),
         ));
         y_offset += 1;
@@ -404,15 +363,18 @@ impl CompletionUI {
             .saturating_sub(preview_row_count);
         let visible_count = self.max_height.min(list_capacity);
         let scroll_offset = if visible_count == 0 {
-            self.scroll_offset
+            self.viewport.top()
         } else {
             let max_scroll_offset = self.items.len().saturating_sub(visible_count);
-            let offset = if self.selected < self.scroll_offset {
-                self.selected
-            } else if self.selected >= self.scroll_offset + visible_count {
-                self.selected - visible_count + 1
+            let offset = if self.viewport.selected() < self.viewport.top() {
+                self.viewport.selected()
+            } else if self.viewport.selected() >= self.viewport.top().saturating_add(visible_count)
+            {
+                self.viewport
+                    .selected()
+                    .saturating_sub(visible_count.saturating_sub(1))
             } else {
-                self.scroll_offset
+                self.viewport.top()
             };
             offset.min(max_scroll_offset)
         };
@@ -425,7 +387,7 @@ impl CompletionUI {
 
         // Render completion items.
         for (idx, item) in visible_items.enumerate() {
-            let is_selected = idx + scroll_offset == self.selected;
+            let is_selected = idx + scroll_offset == self.viewport.selected();
             let marker = if is_selected { ">" } else { " " };
             // Format item with icon and handle deprecated items
             let is_deprecated = item.deprecated.unwrap_or(false);
@@ -477,7 +439,7 @@ impl CompletionUI {
         output.push((
             self.x,
             self.y + y_offset,
-            format!("╰{}╯", "─".repeat(self.width - 2)),
+            format!("{bottom_left}{horizontal}{bottom_right}"),
             self.styles.popup_border.clone(),
         ));
 

--- a/src/ui/confirmation.rs
+++ b/src/ui/confirmation.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{
-    dialog::{BorderStyle, Dialog},
+    dialog::{BorderStyle, Dialog, SurfaceRole},
     Component, PickerItem,
 };
 
@@ -40,8 +40,6 @@ impl Confirmation {
         let title = title.into();
         let message = message.into();
         let style = editor.theme.ui_style.dialog.clone();
-        let border_style = editor.theme.ui_style.dialog_border.clone();
-        let title_style = editor.theme.ui_style.dialog_title.clone();
         let width = confirmation_width(editor.vwidth(), &message);
         let x = editor.vwidth().saturating_sub(width + 2) / 2;
         let y = editor.vheight().saturating_sub(4) / 2;
@@ -56,8 +54,7 @@ impl Confirmation {
                 BorderStyle::Single,
                 &editor.theme,
             )
-            .with_border_draw_style(&border_style)
-            .with_title_style(&title_style),
+            .with_surface_theme(&editor.theme, SurfaceRole::Dialog),
             message,
             accept_selected: false,
             callback_handle,
@@ -97,10 +94,7 @@ impl Component for Confirmation {
 
     fn set_theme(&mut self, theme: &Theme) {
         self.style = theme.ui_style.dialog.clone();
-        self.dialog.style = theme.ui_style.dialog.clone();
-        self.dialog.border_draw_style = theme.ui_style.dialog_border.clone();
-        self.dialog.title_style = theme.ui_style.dialog_title.clone();
-        self.dialog.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
         self.theme = theme.clone();
     }
 
@@ -156,11 +150,11 @@ impl Component for Confirmation {
             }
             (KeyCode::Left | KeyCode::BackTab, _) => {
                 self.accept_selected = true;
-                Some(KeyAction::Single(Action::ShowDialog))
+                Some(KeyAction::Single(Action::Refresh))
             }
             (KeyCode::Right | KeyCode::Tab, _) => {
                 self.accept_selected = false;
-                Some(KeyAction::Single(Action::ShowDialog))
+                Some(KeyAction::Single(Action::Refresh))
             }
             (KeyCode::Char('y' | 'Y'), _) => Some(self.terminal_action(true)),
             (KeyCode::Char('n' | 'N'), _) => Some(self.terminal_action(false)),

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -10,11 +10,15 @@ use crate::{
     unicode_utils::{display_width, truncate_display_width},
 };
 
-use super::Component;
+use super::{ActionBar, Component, UiAction};
 
 pub struct Dialog {
     title: Option<String>,
+    header_status: Option<String>,
     footer: Option<String>,
+    actions: Vec<UiAction>,
+    action_width: Option<usize>,
+    left_aligned_title: bool,
     pub x: usize,
     pub y: usize,
     pub width: usize,
@@ -25,12 +29,33 @@ pub struct Dialog {
     pub footer_style: Style,
     pub border_style: BorderStyle,
     pub theme: Theme,
+    surface_role: Option<SurfaceRole>,
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BorderStyle {
     None,
     Single,
+    Rounded,
+}
+
+impl BorderStyle {
+    /// Returns horizontal, vertical, and the four clockwise frame-corner glyphs.
+    #[must_use]
+    pub(crate) const fn glyphs(self) -> Option<[char; 6]> {
+        match self {
+            Self::None => None,
+            Self::Single => Some(['─', '│', '┌', '┐', '└', '┘']),
+            Self::Rounded => Some(['─', '│', '╭', '╮', '╰', '╯']),
+        }
+    }
+}
+
+/// Selects the theme-owned styles for a shared dialog or popup surface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SurfaceRole {
+    Dialog,
+    Popup,
 }
 
 impl Dialog {
@@ -47,7 +72,11 @@ impl Dialog {
     ) -> Self {
         Self {
             title,
+            header_status: None,
             footer: None,
+            actions: Vec::new(),
+            action_width: None,
+            left_aligned_title: false,
             x,
             y,
             width,
@@ -58,7 +87,30 @@ impl Dialog {
             footer_style: style.clone(),
             border_style,
             theme: theme.clone(),
+            surface_role: None,
         }
+    }
+
+    /// Associates this surface with its canonical theme role.
+    #[must_use]
+    pub(crate) fn with_surface_theme(mut self, theme: &Theme, role: SurfaceRole) -> Self {
+        self.apply_surface_theme(theme, role);
+        self
+    }
+
+    /// Refreshes all theme-derived chrome together.
+    pub(crate) fn apply_surface_theme(&mut self, theme: &Theme, role: SurfaceRole) {
+        let styles = &theme.ui_style;
+        let (surface, border, title) = match role {
+            SurfaceRole::Dialog => (&styles.dialog, &styles.dialog_border, &styles.dialog_title),
+            SurfaceRole::Popup => (&styles.popup, &styles.popup_border, &styles.popup_title),
+        };
+        self.style = surface.clone();
+        self.border_draw_style = border.clone();
+        self.title_style = title.clone();
+        self.footer_style = styles.muted.clone();
+        self.theme = theme.clone();
+        self.surface_role = Some(role);
     }
 
     pub fn with_border_draw_style(mut self, style: &Style) -> Self {
@@ -76,18 +128,51 @@ impl Dialog {
         self
     }
 
+    /// Places a modal title inside the left edge of its top border.
+    #[must_use]
+    #[cfg(test)]
+    pub(crate) const fn with_left_aligned_title(mut self) -> Self {
+        self.left_aligned_title = true;
+        self
+    }
+
+    /// Attaches complete, responsive footer actions to this dialog.
+    #[must_use]
+    #[cfg(test)]
+    pub fn with_actions(mut self, actions: Vec<UiAction>) -> Self {
+        self.set_actions(actions);
+        self
+    }
+
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 
+    /// Sets compact, right-aligned metadata in the dialog header.
+    #[cfg(test)]
+    pub(crate) fn set_header_status(&mut self, status: Option<String>) {
+        self.header_status = status;
+    }
+
     pub fn set_footer(&mut self, footer: Option<String>) {
         self.footer = footer;
+        self.actions.clear();
+    }
+
+    /// Replaces the responsive footer actions without changing legacy footers.
+    pub fn set_actions(&mut self, actions: Vec<UiAction>) {
+        self.set_footer(None);
+        self.actions = actions;
     }
 }
 
 impl Component for Dialog {
     fn set_theme(&mut self, theme: &Theme) {
-        self.theme = theme.clone();
+        if let Some(role) = self.surface_role {
+            self.apply_surface_theme(theme, role);
+        } else {
+            self.theme = theme.clone();
+        }
     }
 
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
@@ -95,10 +180,10 @@ impl Component for Dialog {
         let mut width = self.width;
 
         if self.border_style != BorderStyle::None {
-            height += 2;
+            height = height.saturating_add(2);
         }
         if self.border_style != BorderStyle::None {
-            width += 2;
+            width = width.saturating_add(2);
         }
 
         // Draw the dialog box
@@ -106,20 +191,12 @@ impl Component for Dialog {
 
         // Draw the border
         if self.border_style != BorderStyle::None {
-            let border_style = match self.border_style {
-                BorderStyle::Single => "─│┌┐└┘",
-                BorderStyle::None => unreachable!(),
-            };
-
-            let mut char_indices = border_style.char_indices();
-            let top = char_indices.next().unwrap().1;
+            let [top, left, top_left, top_right, bottom_left, bottom_right] = self
+                .border_style
+                .glyphs()
+                .expect("a visible border has frame glyphs");
             let bottom = top;
-            let left = char_indices.next().unwrap().1;
             let right = left;
-            let top_left = char_indices.next().unwrap().1;
-            let top_right = char_indices.next().unwrap().1;
-            let bottom_left = char_indices.next().unwrap().1;
-            let bottom_right = char_indices.next().unwrap().1;
 
             buffer.fill_rect(
                 self.x,
@@ -188,27 +265,61 @@ impl Component for Dialog {
             );
         }
 
+        let inset = usize::from(self.border_style != BorderStyle::None);
+        let inner_width = width.saturating_sub(inset.saturating_mul(2));
+
         if let Some(ref title) = self.title {
             let title = format!(" {} ", title);
-            let title = truncate_display_width(&title, width);
+            let status_width = self
+                .header_status
+                .as_ref()
+                .map_or(0, |status| display_width(status).saturating_add(3));
+            let title_width_limit = inner_width.saturating_sub(status_width);
+            let title = truncate_display_width(&title, title_width_limit);
             let title_width = display_width(&title);
-            let cx = self.x + width.saturating_sub(title_width) / 2;
+            let cx = if self.left_aligned_title {
+                self.x.saturating_add(inset)
+            } else {
+                self.x
+                    .saturating_add(inset)
+                    .saturating_add(inner_width.saturating_sub(title_width) / 2)
+            };
             buffer.set_text(cx, self.y, &title, &self.title_style);
         }
 
-        if let Some(ref footer) = self.footer {
-            let footer = format!(" {} ", footer);
-            let footer = truncate_display_width(&footer, width.saturating_sub(2));
-            let footer_width = display_width(&footer);
-            let cx = self
+        let footer_style = self.footer_style.with_bg(self.style.bg);
+
+        if let Some(status) = self.header_status.as_deref() {
+            let status = format!(" {status} ");
+            let status = truncate_display_width(&status, inner_width);
+            let status_x = self
                 .x
-                .saturating_add(width.saturating_sub(footer_width).saturating_sub(1));
-            buffer.set_text(
-                cx,
-                self.y + height.saturating_sub(1),
-                &footer,
-                &self.footer_style,
+                .saturating_add(width.saturating_sub(inset))
+                .saturating_sub(display_width(&status));
+            buffer.set_text(status_x, self.y, &status, &footer_style);
+        }
+
+        let footer_x = self.x.saturating_add(inset);
+        let footer_y = self
+            .y
+            .saturating_add(height.saturating_sub(inset.saturating_add(1)));
+        if !self.actions.is_empty() && inner_width > 0 {
+            let action_width = self.action_width.unwrap_or(inner_width).min(inner_width);
+            let action_x = footer_x.saturating_add(inner_width.saturating_sub(action_width));
+            ActionBar::new(&self.actions).render_right_aligned(
+                buffer,
+                action_x,
+                footer_y,
+                action_width,
+                &self.theme,
+                &footer_style,
             );
+        } else if let Some(ref footer) = self.footer {
+            let footer = format!(" {} ", footer);
+            let footer = truncate_display_width(&footer, inner_width);
+            let footer_width = display_width(&footer);
+            let cx = footer_x.saturating_add(inner_width.saturating_sub(footer_width));
+            buffer.set_text(cx, footer_y, &footer, &footer_style);
         }
 
         Ok(())
@@ -244,7 +355,84 @@ mod tests {
 
         dialog.draw(&mut buffer).unwrap();
 
-        assert_eq!(rendered_cells(&buffer, 0, 0, 5).len(), 5);
+        let header = rendered_cells(&buffer, 0, 0, 5);
+        assert_eq!(header.first(), Some(&'┌'));
+        assert_eq!(header.last(), Some(&'┐'));
+    }
+
+    #[test]
+    fn centered_title_and_metadata_preserve_both_corners() {
+        let style = Style::default();
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(16, 4, &style);
+        let mut dialog = Dialog::new(
+            Some("very long title".to_string()),
+            0,
+            0,
+            10,
+            1,
+            &style,
+            BorderStyle::Single,
+            &theme,
+        );
+        dialog.set_header_status(Some("12".to_string()));
+
+        dialog.draw(&mut buffer).unwrap();
+
+        let header = rendered_cells(&buffer, 0, 0, 12);
+        assert_eq!(header.first(), Some(&'┌'));
+        assert_eq!(header.last(), Some(&'┐'));
+        assert!(header.into_iter().collect::<String>().contains(" 12 "));
+    }
+
+    #[test]
+    fn rounded_border_preserves_all_four_corners() {
+        let style = Style::default();
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(8, 4, &style);
+        let dialog = Dialog::new(None, 1, 0, 4, 1, &style, BorderStyle::Rounded, &theme);
+
+        dialog.draw(&mut buffer).unwrap();
+
+        assert_eq!(buffer.cells[1].c, '╭');
+        assert_eq!(buffer.cells[6].c, '╮');
+        assert_eq!(buffer.cells[2 * buffer.width + 1].c, '╰');
+        assert_eq!(buffer.cells[2 * buffer.width + 6].c, '╯');
+    }
+
+    #[test]
+    fn themed_surface_refreshes_every_chrome_style() {
+        use crate::color::Color;
+
+        let style = Style::default();
+        let initial_theme = Theme::default();
+        let mut dialog = Dialog::new(
+            None,
+            0,
+            0,
+            4,
+            1,
+            &style,
+            BorderStyle::Single,
+            &initial_theme,
+        )
+        .with_surface_theme(&initial_theme, SurfaceRole::Popup);
+        let mut updated = Theme::default();
+        updated.ui_style.popup.fg = Some(Color::Rgb { r: 1, g: 2, b: 3 });
+        updated.ui_style.popup_border.fg = Some(Color::Rgb { r: 4, g: 5, b: 6 });
+        updated.ui_style.popup_title.fg = Some(Color::Rgb { r: 7, g: 8, b: 9 });
+        updated.ui_style.muted.fg = Some(Color::Rgb {
+            r: 10,
+            g: 11,
+            b: 12,
+        });
+
+        dialog.set_theme(&updated);
+
+        assert_eq!(dialog.style, updated.ui_style.popup);
+        assert_eq!(dialog.border_draw_style, updated.ui_style.popup_border);
+        assert_eq!(dialog.title_style, updated.ui_style.popup_title);
+        assert_eq!(dialog.footer_style, updated.ui_style.muted);
     }
 
     #[test]
@@ -279,8 +467,89 @@ mod tests {
         dialog.draw(&mut buffer).unwrap();
 
         assert_eq!(
-            rendered_cells(&buffer, 2, 6, 6),
-            vec![' ', 'E', 's', 'c', ' ', '┘']
+            rendered_cells(&buffer, 1, 6, 6),
+            vec![' ', 'E', 's', 'c', ' ', '│']
         );
+        assert_eq!(buffer.cells[2 * buffer.width].c, '└');
+        assert_eq!(buffer.cells[2 * buffer.width + 11].c, '┘');
+    }
+
+    #[test]
+    fn responsive_footer_preserves_complete_actions_inside_dialog_border() {
+        let style = Style::default();
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(32, 5, &style);
+        let dialog = Dialog::new(None, 0, 0, 28, 2, &style, BorderStyle::Single, &theme)
+            .with_actions(vec![
+                UiAction::new("select", "Enter", "Select"),
+                UiAction::new("close", "Esc", "Close"),
+            ]);
+
+        dialog.draw(&mut buffer).unwrap();
+
+        let footer = rendered_cells(&buffer, 2, 1, 28)
+            .into_iter()
+            .collect::<String>();
+        assert!(footer.contains("Enter Select"));
+        assert!(footer.contains("Esc Close"));
+        assert_eq!(buffer.cells[3 * buffer.width].c, '└');
+        assert_eq!(buffer.cells[3 * buffer.width + 29].c, '┘');
+    }
+
+    #[test]
+    fn header_metadata_preserves_both_corners_and_the_left_aligned_title() {
+        let style = Style::default();
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(40, 6, &style);
+        let mut dialog = Dialog::new(
+            Some("Themes".to_string()),
+            2,
+            1,
+            30,
+            3,
+            &style,
+            BorderStyle::Single,
+            &theme,
+        )
+        .with_left_aligned_title();
+        dialog.set_header_status(Some("133".to_string()));
+
+        dialog.draw(&mut buffer).unwrap();
+
+        let header = rendered_cells(&buffer, 1, 2, 32)
+            .into_iter()
+            .collect::<String>();
+        assert!(header.starts_with("┌ Themes "), "{header:?}");
+        assert!(header.ends_with(" 133 ┐"), "{header:?}");
+    }
+
+    #[test]
+    fn footer_actions_inherit_the_dialog_background() {
+        use crate::color::Color;
+
+        let surface_background = Color::Rgb { r: 9, g: 8, b: 7 };
+        let footer_background = Color::Rgb { r: 1, g: 2, b: 3 };
+        let style = Style {
+            bg: Some(surface_background),
+            ..Style::default()
+        };
+        let footer = Style {
+            bg: Some(footer_background),
+            ..Style::default()
+        };
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(30, 5, &Style::default());
+        let dialog = Dialog::new(None, 0, 0, 24, 2, &style, BorderStyle::Single, &theme)
+            .with_footer_style(&footer)
+            .with_actions(vec![UiAction::new("close", "Esc", "Close")]);
+
+        dialog.draw(&mut buffer).unwrap();
+
+        let row = &buffer.cells[2 * buffer.width + 1..2 * buffer.width + 25];
+        assert!(row
+            .iter()
+            .all(|cell| cell.style.bg == Some(surface_background)));
+        assert_eq!(buffer.cells[3 * buffer.width].c, '└');
+        assert_eq!(buffer.cells[3 * buffer.width + 25].c, '┘');
     }
 }

--- a/src/ui/geometry.rs
+++ b/src/ui/geometry.rs
@@ -1,0 +1,71 @@
+//! Saturating terminal-cell rectangles shared by editor-owned surfaces.
+
+/// A rectangle expressed in absolute terminal columns and rows.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ScreenRect {
+    pub(crate) x: usize,
+    pub(crate) y: usize,
+    pub(crate) width: usize,
+    pub(crate) height: usize,
+}
+
+impl ScreenRect {
+    /// Returns whether an absolute terminal cell lies inside the rectangle.
+    #[must_use]
+    pub(crate) fn contains(self, column: usize, row: usize) -> bool {
+        column >= self.x
+            && column < self.x.saturating_add(self.width)
+            && row >= self.y
+            && row < self.y.saturating_add(self.height)
+    }
+
+    /// Returns rows remaining after a one-line surface header.
+    #[must_use]
+    pub(crate) fn content_height(self) -> usize {
+        self.height.saturating_sub(1)
+    }
+
+    /// Maps an absolute terminal row to its zero-based content row.
+    #[must_use]
+    pub(crate) fn content_offset(self, row: usize) -> Option<usize> {
+        let content_y = self.y.saturating_add(1);
+        (row >= content_y && row < self.y.saturating_add(self.height))
+            .then_some(row.saturating_sub(content_y))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScreenRect;
+
+    #[test]
+    fn rectangle_uses_exclusive_saturating_edges() {
+        let rect = ScreenRect {
+            x: 3,
+            y: 4,
+            width: 5,
+            height: 3,
+        };
+
+        assert!(rect.contains(3, 4));
+        assert!(rect.contains(7, 6));
+        assert!(!rect.contains(8, 6));
+        assert!(!rect.contains(7, 7));
+        assert_eq!(rect.content_offset(5), Some(0));
+        assert_eq!(rect.content_offset(4), None);
+    }
+
+    #[test]
+    fn empty_and_near_maximum_rectangles_do_not_overflow() {
+        let rect = ScreenRect {
+            x: usize::MAX,
+            y: usize::MAX,
+            width: 2,
+            height: 0,
+        };
+
+        assert!(!rect.contains(usize::MAX, usize::MAX));
+        assert_eq!(rect.content_height(), 0);
+        assert_eq!(rect.content_offset(usize::MAX), None);
+    }
+}

--- a/src/ui/hover_info.rs
+++ b/src/ui/hover_info.rs
@@ -10,12 +10,12 @@ use crate::{
         RenderedTextSpan, TextPanelSpanStyle,
     },
     theme::{SelectionForegroundPriority, Style, Theme},
-    unicode_utils::{display_width, truncate_display_width},
+    unicode_utils::display_width,
 };
 
 use super::{
-    dialog::{BorderStyle, Dialog},
-    Component,
+    dialog::{BorderStyle, Dialog, SurfaceRole},
+    paint_rich_text, ActionPriority, Component, UiAction,
 };
 
 const MAX_PROSE_HOVER_WIDTH: usize = 80;
@@ -74,8 +74,13 @@ impl HoverInfo {
             &theme,
             &actions,
         );
-        let (x, y, height) =
-            hover_geometry(anchor, viewport_width, viewport_height, width, lines.len());
+        let (x, y, height) = hover_geometry(
+            anchor,
+            viewport_width,
+            viewport_height,
+            width,
+            lines.len().saturating_add(1),
+        );
         let style = theme.ui_style.dialog.clone();
         let mut info = Self {
             source,
@@ -103,8 +108,7 @@ impl HoverInfo {
                 BorderStyle::Single,
                 &theme,
             )
-            .with_border_draw_style(&theme.ui_style.dialog_border)
-            .with_title_style(&theme.ui_style.dialog_title)
+            .with_surface_theme(&theme, SurfaceRole::Dialog)
             .with_footer_style(&theme.ui_style.muted),
             theme,
         };
@@ -112,8 +116,12 @@ impl HoverInfo {
         info
     }
 
+    fn content_height(&self) -> usize {
+        self.height.saturating_sub(1)
+    }
+
     fn max_scroll(&self) -> usize {
-        self.lines.len().saturating_sub(self.height)
+        self.lines.len().saturating_sub(self.content_height())
     }
 
     fn scroll_by(&mut self, delta: isize) {
@@ -135,13 +143,18 @@ impl HoverInfo {
             )
         };
         self.dialog.set_title(Some(title));
-        let footer = match (!self.actions.is_empty(), self.max_scroll() > 0) {
-            (true, true) => "Tab actions · Enter open · ↑↓ scroll",
-            (true, false) => "Tab actions · Enter open",
-            (false, true) => "↑↓ scroll",
-            (false, false) => "Esc close",
-        };
-        self.dialog.set_footer(Some(footer.to_string()));
+        let mut actions =
+            vec![UiAction::new("close", "Esc", "Close").with_priority(ActionPriority::Essential)];
+        if !self.actions.is_empty() {
+            actions.push(
+                UiAction::new("open", "Enter", "Open").with_priority(ActionPriority::Essential),
+            );
+            actions.push(UiAction::new("actions", "Tab", "Actions"));
+        }
+        if self.max_scroll() > 0 {
+            actions.push(UiAction::new("scroll", "↑↓", "Scroll"));
+        }
+        self.dialog.set_actions(actions);
     }
 
     fn reflow(&mut self, viewport_width: usize, viewport_height: usize) {
@@ -158,7 +171,7 @@ impl HoverInfo {
             viewport_width,
             viewport_height,
             width,
-            lines.len(),
+            lines.len().saturating_add(1),
         );
         self.viewport_width = viewport_width;
         self.viewport_height = viewport_height;
@@ -199,10 +212,11 @@ impl HoverInfo {
         else {
             return;
         };
+        let content_height = self.content_height().max(1);
         if line < self.scroll {
             self.scroll = line;
-        } else if line >= self.scroll.saturating_add(self.height) {
-            self.scroll = line.saturating_sub(self.height.saturating_sub(1));
+        } else if line >= self.scroll.saturating_add(content_height) {
+            self.scroll = line.saturating_sub(content_height.saturating_sub(1));
         }
         self.scroll = self.scroll.min(self.max_scroll());
     }
@@ -224,7 +238,7 @@ impl Component for HoverInfo {
             .lines
             .iter()
             .skip(self.scroll)
-            .take(self.height)
+            .take(self.content_height())
             .enumerate()
         {
             let line_index = self.scroll + row;
@@ -248,7 +262,7 @@ impl Component for HoverInfo {
     }
 
     fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
-        let redraw = || Some(KeyAction::Single(Action::ShowDialog));
+        let redraw = || Some(KeyAction::Single(Action::Refresh));
         match event {
             Event::Key(key) => match (key.code, key.modifiers) {
                 (KeyCode::Esc | KeyCode::Char('q'), _) => {
@@ -263,11 +277,11 @@ impl Component for HoverInfo {
                     redraw()
                 }
                 (KeyCode::PageUp, _) | (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
-                    self.scroll_by(-(self.height.max(1) as isize));
+                    self.scroll_by(-(self.content_height().max(1) as isize));
                     redraw()
                 }
                 (KeyCode::PageDown, _) | (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
-                    self.scroll_by(self.height.max(1) as isize);
+                    self.scroll_by(self.content_height().max(1) as isize);
                     redraw()
                 }
                 (KeyCode::Home | KeyCode::Char('g'), _) => {
@@ -310,7 +324,7 @@ impl Component for HoverInfo {
                     let content_y = self.y.saturating_add(1);
                     if (content_x..content_x.saturating_add(self.width))
                         .contains(&(mouse.column as usize))
-                        && (content_y..content_y.saturating_add(self.height))
+                        && (content_y..content_y.saturating_add(self.content_height()))
                             .contains(&(mouse.row as usize))
                     {
                         let line = self.scroll.saturating_add(mouse.row as usize - content_y);
@@ -336,11 +350,7 @@ impl Component for HoverInfo {
 
     fn set_theme(&mut self, theme: &Theme) {
         self.theme = theme.clone();
-        self.dialog.style = theme.ui_style.dialog.clone();
-        self.dialog.border_draw_style = theme.ui_style.dialog_border.clone();
-        self.dialog.title_style = theme.ui_style.dialog_title.clone();
-        self.dialog.footer_style = theme.ui_style.muted.clone();
-        self.dialog.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
         self.reflow(self.viewport_width, self.viewport_height);
     }
 }
@@ -517,23 +527,14 @@ fn render_line(
         );
         buffer.set_text(x, y, &" ".repeat(width), &selected_style);
     }
-    let mut used = 0;
-    for span in &line.spans {
-        if used >= width {
-            break;
-        }
-        let text = truncate_display_width(&span.text, width - used);
-        if text.is_empty() {
-            continue;
-        }
+    paint_rich_text(buffer, x, y, width, line, |span| {
         let mut style = hover_span_style(span, theme);
         if selected {
             let selection = theme.list_selection_style();
             style = theme.selected_style(&style, &selection, SelectionForegroundPriority::Content);
         }
-        buffer.set_text(x + used, y, &text, &style);
-        used += display_width(&text);
-    }
+        style
+    });
 }
 
 fn hover_span_style(span: &RenderedTextSpan, theme: &Theme) -> Style {
@@ -690,6 +691,46 @@ mod tests {
                     Action::ExecuteLspCommand(command)
                 ] if command.command == "rust-analyzer.gotoLocation")
         ));
+    }
+
+    #[test]
+    fn hover_footer_reserves_an_interior_row_without_overwriting_content_or_border() {
+        let editor = test_editor(Theme::default(), 80, 24);
+        let info = HoverInfo::new(
+            &editor,
+            "The first documentation line\nThe final documentation line".to_string(),
+            HoverInfoFormat::Plaintext,
+            Vec::new(),
+        );
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        info.draw(&mut buffer).unwrap();
+
+        let first_start = (info.y + 1) * buffer.width + info.x + 1;
+        let last_start = (info.y + 2) * buffer.width + info.x + 1;
+        let footer_y = info.y + info.height;
+        let footer_start = footer_y * buffer.width + info.x + 1;
+        let first = buffer.cells[first_start..first_start + info.width]
+            .iter()
+            .map(|cell| cell.c)
+            .collect::<String>();
+        let last = buffer.cells[last_start..last_start + info.width]
+            .iter()
+            .map(|cell| cell.c)
+            .collect::<String>();
+        let footer = buffer.cells[footer_start..footer_start + info.width]
+            .iter()
+            .map(|cell| cell.c)
+            .collect::<String>();
+
+        assert!(first.contains("The first documentation line"), "{first:?}");
+        assert!(last.contains("The final documentation line"), "{last:?}");
+        assert!(footer.contains("Esc Close"), "{footer:?}");
+        assert_eq!(buffer.cells[(footer_y + 1) * buffer.width + info.x].c, '└');
+        assert_eq!(
+            buffer.cells[(footer_y + 1) * buffer.width + info.x + info.width + 1].c,
+            '┘'
+        );
     }
 
     #[test]

--- a/src/ui/icons.rs
+++ b/src/ui/icons.rs
@@ -1,0 +1,103 @@
+//! Authoritative lookup surface for existing file, symbol, and completion icons.
+
+use crate::{color::Color, config::PickerIconStyle, lsp::types::CompletionItemKind};
+
+use super::picker::{picker_file_icon, picker_file_icon_color, picker_kind_icon};
+
+/// A terminal icon and its optional semantic foreground.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct IconSpec {
+    pub(crate) glyph: &'static str,
+    pub(crate) color: Option<Color>,
+}
+
+/// Reuses the established filename-first inventory and configured icon modes.
+pub(crate) struct IconCatalog;
+
+impl IconCatalog {
+    /// Resolves a file without changing existing extension or filename precedence.
+    #[must_use]
+    pub(crate) fn file(path: &str, style: PickerIconStyle) -> IconSpec {
+        IconSpec {
+            glyph: picker_file_icon(path, style),
+            color: picker_file_icon_color(path),
+        }
+    }
+
+    /// Resolves a structured picker symbol in its configured visual mode.
+    #[must_use]
+    pub(crate) fn symbol(kind: &str, style: PickerIconStyle) -> IconSpec {
+        IconSpec {
+            glyph: picker_kind_icon(kind, style),
+            color: None,
+        }
+    }
+
+    /// Preserves LSP completion's deliberately distinct, protocol-specific glyphs.
+    #[must_use]
+    pub(crate) fn completion(kind: &CompletionItemKind) -> IconSpec {
+        let glyph = match kind {
+            CompletionItemKind::Text => "abc",
+            CompletionItemKind::Method => "ƒ",
+            CompletionItemKind::Function => "λ",
+            CompletionItemKind::Constructor => "⚡",
+            CompletionItemKind::Field => "◆",
+            CompletionItemKind::Variable => "𝑥",
+            CompletionItemKind::Class => "○",
+            CompletionItemKind::Interface => "◌",
+            CompletionItemKind::Module => "□",
+            CompletionItemKind::Property => "◇",
+            CompletionItemKind::Unit => "∅",
+            CompletionItemKind::Value => "=",
+            CompletionItemKind::Enum => "ℰ",
+            CompletionItemKind::Keyword => "🔑",
+            CompletionItemKind::Snippet => "✂",
+            CompletionItemKind::Color => "🎨",
+            CompletionItemKind::File => "📄",
+            CompletionItemKind::Reference => "→",
+            CompletionItemKind::Folder => "📁",
+            CompletionItemKind::EnumMember => "ℯ",
+            CompletionItemKind::Constant => "π",
+            CompletionItemKind::Struct => "⚪",
+            CompletionItemKind::Event => "⚡",
+            CompletionItemKind::Operator => "±",
+            CompletionItemKind::TypeParameter => "𝑇",
+        };
+        IconSpec { glyph, color: None }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{config::PickerIconStyle, lsp::types::CompletionItemKind};
+
+    use super::IconCatalog;
+
+    #[test]
+    fn filename_icons_keep_precedence_over_the_extension_fallback() {
+        let readme = IconCatalog::file("docs/README.md", PickerIconStyle::NerdFont);
+
+        assert_eq!(readme.glyph, "󰂺");
+        assert!(readme.color.is_some());
+    }
+
+    #[test]
+    fn icon_modes_preserve_hidden_and_ascii_symbols() {
+        assert_eq!(
+            IconCatalog::symbol("Function", PickerIconStyle::Ascii).glyph,
+            "fn"
+        );
+        assert_eq!(
+            IconCatalog::symbol("Function", PickerIconStyle::None).glyph,
+            ""
+        );
+    }
+
+    #[test]
+    fn lsp_completion_retains_its_protocol_specific_file_icon() {
+        assert_eq!(
+            IconCatalog::completion(&CompletionItemKind::File).glyph,
+            "📄"
+        );
+    }
+}

--- a/src/ui/info.rs
+++ b/src/ui/info.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use super::{
-    dialog::{BorderStyle, Dialog},
+    dialog::{BorderStyle, Dialog, SurfaceRole},
     Component,
 };
 
@@ -53,8 +53,6 @@ fn fit_info_geometry(
 impl Info {
     pub fn new(editor: &Editor, text: String) -> Self {
         let style = editor.theme.ui_style.dialog.clone();
-        let border_style = editor.theme.ui_style.dialog_border.clone();
-        let title_style = editor.theme.ui_style.dialog_title.clone();
 
         let width = text.lines().map(display_width).max().unwrap_or(0);
         let height = text.lines().count();
@@ -83,8 +81,7 @@ impl Info {
                 BorderStyle::Single,
                 &editor.theme,
             )
-            .with_border_draw_style(&border_style)
-            .with_title_style(&title_style),
+            .with_surface_theme(&editor.theme, SurfaceRole::Dialog),
             theme: editor.theme.clone(),
         }
     }
@@ -93,10 +90,7 @@ impl Info {
 impl Component for Info {
     fn set_theme(&mut self, theme: &Theme) {
         self.style = theme.ui_style.dialog.clone();
-        self.dialog.style = theme.ui_style.dialog.clone();
-        self.dialog.border_draw_style = theme.ui_style.dialog_border.clone();
-        self.dialog.title_style = theme.ui_style.dialog_title.clone();
-        self.dialog.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
         self.theme = theme.clone();
     }
 

--- a/src/ui/input_prompt.rs
+++ b/src/ui/input_prompt.rs
@@ -314,6 +314,23 @@ mod tests {
     }
 
     #[test]
+    fn combining_mark_paste_keeps_input_prompt_cursor_after_merged_grapheme() {
+        let editor = editor();
+        let mut prompt = InputPrompt::new(&editor, "Rename symbol", "aX", Action::Print);
+
+        prompt.handle_event(&key(KeyCode::Left));
+        prompt.handle_event(&Event::Paste("\u{301}".to_string()));
+
+        assert_eq!(prompt.prompt.text(), "a\u{301}X");
+        assert_eq!(prompt.prompt.cursor(), 1);
+
+        prompt.handle_event(&key(KeyCode::Char('Z')));
+
+        assert_eq!(prompt.prompt.text(), "a\u{301}ZX");
+        assert_eq!(prompt.prompt.cursor(), 2);
+    }
+
+    #[test]
     fn paste_is_single_line_and_backspace_removes_one_grapheme() {
         let editor = editor();
         let mut prompt = InputPrompt::new(&editor, "Rename symbol", "old", Action::Print);

--- a/src/ui/input_prompt.rs
+++ b/src/ui/input_prompt.rs
@@ -17,8 +17,8 @@ use crate::{
 };
 
 use super::{
-    dialog::{BorderStyle, Dialog},
-    Component,
+    dialog::{BorderStyle, Dialog, SurfaceRole},
+    first_prompt_line, Component, PromptBuffer,
 };
 
 type SubmitAction = Box<dyn Fn(String) -> Action + Send>;
@@ -27,8 +27,7 @@ type SubmitAction = Box<dyn Fn(String) -> Action + Send>;
 /// replacement is one keystroke, while cursor motion and paste remain Unicode-safe.
 pub struct InputPrompt {
     dialog: Dialog,
-    value: String,
-    cursor: usize,
+    prompt: PromptBuffer,
     selected: bool,
     masked: bool,
     submit: SubmitAction,
@@ -46,12 +45,12 @@ impl InputPrompt {
     ) -> Self {
         let title = title.into();
         let value = initial.into();
+        let selected = !value.is_empty();
+        let prompt = PromptBuffer::new(&value);
         let width = editor.vwidth().saturating_sub(2).clamp(1, 60);
         let x = editor.vwidth().saturating_sub(width + 2) / 2;
         let y = editor.vheight().saturating_sub(3) / 2;
         let style = editor.theme.ui_style.dialog.clone();
-        let border_style = editor.theme.ui_style.dialog_border.clone();
-        let title_style = editor.theme.ui_style.dialog_title.clone();
         Self {
             dialog: Dialog::new(
                 Some(title),
@@ -63,11 +62,9 @@ impl InputPrompt {
                 BorderStyle::Single,
                 &editor.theme,
             )
-            .with_border_draw_style(&border_style)
-            .with_title_style(&title_style),
-            cursor: grapheme_len(&value),
-            selected: !value.is_empty(),
-            value,
+            .with_surface_theme(&editor.theme, SurfaceRole::Dialog),
+            prompt,
+            selected,
             masked: false,
             submit: Box::new(submit),
             callback_handle: None,
@@ -104,15 +101,12 @@ impl InputPrompt {
     }
 
     fn insert(&mut self, text: &str) {
-        let text = text.split(['\r', '\n']).next().unwrap_or_default();
+        let text = first_prompt_line(text);
         if self.selected {
-            self.value.clear();
-            self.cursor = 0;
+            self.prompt.clear();
             self.selected = false;
         }
-        let offset = grapheme_to_byte(&self.value, self.cursor);
-        self.value.insert_str(offset, text);
-        self.cursor += grapheme_len(text);
+        self.prompt.insert(&text);
     }
 }
 
@@ -123,10 +117,7 @@ impl Component for InputPrompt {
 
     fn set_theme(&mut self, theme: &Theme) {
         self.style = theme.ui_style.dialog.clone();
-        self.dialog.style = theme.ui_style.dialog.clone();
-        self.dialog.border_draw_style = theme.ui_style.dialog_border.clone();
-        self.dialog.title_style = theme.ui_style.dialog_title.clone();
-        self.dialog.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
         self.theme = theme.clone();
     }
 
@@ -139,10 +130,11 @@ impl Component for InputPrompt {
 
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         self.dialog.draw(buffer)?;
+        let text = self.prompt.text();
         let visible = if self.masked {
-            "*".repeat(grapheme_len(&self.value).min(self.dialog.width))
+            "*".repeat(grapheme_len(&text).min(self.dialog.width))
         } else {
-            truncate_display_width(&self.value, self.dialog.width)
+            truncate_display_width(&text, self.dialog.width)
         };
         let style = if self.selected {
             self.theme.selected_style(
@@ -161,14 +153,14 @@ impl Component for InputPrompt {
         match ev {
             Event::Paste(text) => {
                 self.insert(text);
-                Some(KeyAction::Single(Action::ShowDialog))
+                Some(KeyAction::Single(Action::Refresh))
             }
             Event::Key(key) => match (key.code, key.modifiers) {
                 (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                     Some(self.cancel_action())
                 }
                 (KeyCode::Enter, _) => {
-                    let value = self.value.trim().to_string();
+                    let value = self.prompt.text().trim().to_string();
                     if value.is_empty() {
                         return Some(self.cancel_action());
                     }
@@ -180,54 +172,49 @@ impl Component for InputPrompt {
                 }
                 (KeyCode::Left, _) => {
                     self.selected = false;
-                    self.cursor = self.cursor.saturating_sub(1);
-                    Some(KeyAction::Single(Action::ShowDialog))
+                    self.prompt
+                        .set_cursor(self.prompt.cursor().saturating_sub(1));
+                    Some(KeyAction::Single(Action::Refresh))
                 }
                 (KeyCode::Right, _) => {
                     self.selected = false;
-                    self.cursor = (self.cursor + 1).min(grapheme_len(&self.value));
-                    Some(KeyAction::Single(Action::ShowDialog))
+                    self.prompt
+                        .set_cursor(self.prompt.cursor().saturating_add(1));
+                    Some(KeyAction::Single(Action::Refresh))
                 }
                 (KeyCode::Home, _) | (KeyCode::Char('a'), KeyModifiers::CONTROL) => {
                     self.selected = false;
-                    self.cursor = 0;
-                    Some(KeyAction::Single(Action::ShowDialog))
+                    self.prompt.set_cursor(0);
+                    Some(KeyAction::Single(Action::Refresh))
                 }
                 (KeyCode::End, _) | (KeyCode::Char('e'), KeyModifiers::CONTROL) => {
                     self.selected = false;
-                    self.cursor = grapheme_len(&self.value);
-                    Some(KeyAction::Single(Action::ShowDialog))
+                    self.prompt.set_cursor(grapheme_len(&self.prompt.text()));
+                    Some(KeyAction::Single(Action::Refresh))
                 }
                 (KeyCode::Backspace, _) => {
                     if self.selected {
-                        self.value.clear();
-                        self.cursor = 0;
+                        self.prompt.clear();
                         self.selected = false;
-                    } else if self.cursor > 0 {
-                        let start = grapheme_to_byte(&self.value, self.cursor - 1);
-                        let end = grapheme_to_byte(&self.value, self.cursor);
-                        self.value.replace_range(start..end, "");
-                        self.cursor -= 1;
+                    } else {
+                        self.prompt.backspace();
                     }
-                    Some(KeyAction::Single(Action::ShowDialog))
+                    Some(KeyAction::Single(Action::Refresh))
                 }
                 (KeyCode::Delete, _) => {
                     if self.selected {
-                        self.value.clear();
-                        self.cursor = 0;
+                        self.prompt.clear();
                         self.selected = false;
-                    } else if self.cursor < grapheme_len(&self.value) {
-                        let start = grapheme_to_byte(&self.value, self.cursor);
-                        let end = grapheme_to_byte(&self.value, self.cursor + 1);
-                        self.value.replace_range(start..end, "");
+                    } else {
+                        self.prompt.delete();
                     }
-                    Some(KeyAction::Single(Action::ShowDialog))
+                    Some(KeyAction::Single(Action::Refresh))
                 }
                 (KeyCode::Char(character), modifiers)
                     if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
                 {
                     self.insert(&character.to_string());
-                    Some(KeyAction::Single(Action::ShowDialog))
+                    Some(KeyAction::Single(Action::Refresh))
                 }
                 _ => None,
             },
@@ -237,9 +224,12 @@ impl Component for InputPrompt {
 
     fn cursor_position(&self) -> Option<(usize, usize)> {
         let offset = if self.masked {
-            self.cursor.min(self.dialog.width.saturating_sub(1))
+            self.prompt
+                .cursor()
+                .min(self.dialog.width.saturating_sub(1))
         } else {
-            let prefix = &self.value[..grapheme_to_byte(&self.value, self.cursor)];
+            let value = self.prompt.text();
+            let prefix = &value[..grapheme_to_byte(&value, self.prompt.cursor())];
             display_width(prefix).min(self.dialog.width.saturating_sub(1))
         };
         let x = self.dialog.x + 1 + offset;
@@ -298,6 +288,27 @@ mod tests {
             Some(KeyAction::Multiple(vec![
                 Action::CloseDialog,
                 Action::Print("ne".to_string())
+            ]))
+        );
+    }
+
+    #[test]
+    fn single_line_input_edits_the_shared_unnamed_prompt_buffer() {
+        let editor = editor();
+        let mut prompt = InputPrompt::new(&editor, "Rename symbol", "old", Action::Print);
+
+        prompt.handle_event(&Event::Paste("👨‍👩‍👧name\r\nignored".to_string()));
+        prompt.handle_event(&key(KeyCode::Left));
+        prompt.handle_event(&key(KeyCode::Backspace));
+
+        assert_eq!(prompt.prompt.text(), "👨‍👩‍👧nae");
+        assert!(prompt.prompt.buffer().file.is_none());
+        assert!(prompt.prompt.buffer().undo_history.node_count() > 0);
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Enter)),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::Print("👨‍👩‍👧nae".to_string())
             ]))
         );
     }

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -6,10 +6,10 @@
 use crate::{
     editor::RenderBuffer,
     theme::Style,
-    unicode_utils::{display_width, fit_display_width, truncate_display_width},
+    unicode_utils::{fit_display_width, truncate_display_width_with_marker, TruncationSide},
 };
 
-use super::Component;
+use super::{Component, SelectionViewport};
 
 pub struct List {
     x: usize,
@@ -17,12 +17,10 @@ pub struct List {
     width: usize,
     height: usize,
     items: Vec<String>,
-    item_count: usize,
     display_items: Vec<String>,
     item_style: Style,
     selected_item_style: Style,
-    selected_item: usize,
-    top_index: usize,
+    viewport: SelectionViewport,
 }
 
 impl List {
@@ -43,31 +41,19 @@ impl List {
             width,
             height,
             items,
-            item_count,
             display_items,
             item_style: item_style.clone(),
             selected_item_style: selected_item_style.clone(),
-            selected_item: 0,
-            top_index: 0,
+            viewport: SelectionViewport::new(item_count, height),
         }
     }
 
     pub fn move_down(&mut self) {
-        if self.item_count == 0 {
-            return;
-        }
-
-        self.selected_item = (self.selected_item + 1).min(self.item_count - 1);
-        if self.height > 0 && self.selected_item >= self.top_index + self.height {
-            self.top_index = self.selected_item.saturating_sub(self.height - 1);
-        }
+        self.viewport.move_by(1);
     }
 
     pub(crate) fn move_up(&mut self) {
-        self.selected_item = self.selected_item.saturating_sub(1);
-        if self.selected_item < self.top_index {
-            self.top_index = self.selected_item;
-        }
+        self.viewport.move_by(-1);
     }
 
     pub fn page_down(&mut self) {
@@ -79,52 +65,36 @@ impl List {
     }
 
     fn move_by(&mut self, delta: isize) {
-        if self.item_count == 0 || self.height == 0 {
+        if self.viewport.len() == 0 || self.height == 0 {
             return;
         }
-
-        let new_selected = if delta.is_negative() {
-            self.selected_item.saturating_sub(delta.unsigned_abs())
-        } else {
-            self.selected_item.saturating_add(delta as usize)
-        };
-
-        self.selected_item = new_selected.min(self.item_count - 1);
-        if self.selected_item < self.top_index {
-            self.top_index = self.selected_item;
-        } else if self.selected_item >= self.top_index + self.height {
-            self.top_index = self.selected_item.saturating_sub(self.height - 1);
-        }
+        self.viewport.move_by(delta);
     }
 
     pub fn selected_item(&self) -> String {
         self.items
-            .get(self.selected_item)
+            .get(self.viewport.selected())
             .cloned()
             .unwrap_or_default()
     }
 
     pub fn selected_index(&self) -> Option<usize> {
-        (self.item_count > 0).then_some(self.selected_item)
+        (self.viewport.len() > 0).then_some(self.viewport.selected())
     }
 
     pub fn set_items(&mut self, new_items: Vec<String>) {
-        self.selected_item = 0;
-        self.top_index = 0;
         self.display_items = new_items
             .iter()
             .map(|item| truncate(item, self.width))
             .collect();
         self.items = new_items;
-        self.item_count = self.items.len();
+        self.viewport.reset(self.items.len());
     }
 
     pub(crate) fn set_item_count(&mut self, count: usize) {
-        self.selected_item = 0;
-        self.top_index = 0;
         self.items.clear();
         self.display_items.clear();
-        self.item_count = count;
+        self.viewport.reset(count);
     }
 
     pub(crate) fn set_bounds(&mut self, x: usize, y: usize, width: usize, height: usize) {
@@ -137,11 +107,7 @@ impl List {
             .iter()
             .map(|item| truncate(item, self.width))
             .collect();
-        if self.height == 0 || self.selected_item < self.top_index {
-            self.top_index = self.selected_item;
-        } else if self.selected_item >= self.top_index + self.height {
-            self.top_index = self.selected_item.saturating_sub(self.height - 1);
-        }
+        self.viewport.set_height(height);
     }
 
     pub(crate) fn set_styles(&mut self, item_style: &Style, selected_item_style: &Style) {
@@ -153,24 +119,11 @@ impl List {
         let Some(index) = self.items.iter().position(|candidate| candidate == item) else {
             return;
         };
-        self.selected_item = index;
-        if self.height > 0 && self.selected_item >= self.top_index + self.height {
-            self.top_index = self.selected_item.saturating_sub(self.height - 1);
-        } else if self.selected_item < self.top_index {
-            self.top_index = self.selected_item;
-        }
+        self.viewport.select(index);
     }
 
     pub fn set_selected_index(&mut self, index: usize) {
-        if self.item_count == 0 {
-            return;
-        }
-        self.selected_item = index.min(self.item_count - 1);
-        if self.height > 0 && self.selected_item >= self.top_index + self.height {
-            self.top_index = self.selected_item.saturating_sub(self.height - 1);
-        } else if self.selected_item < self.top_index {
-            self.top_index = self.selected_item;
-        }
+        self.viewport.select(index);
     }
 
     pub fn items(&self) -> &Vec<String> {
@@ -178,19 +131,19 @@ impl List {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.item_count == 0
+        self.viewport.len() == 0
     }
 
     pub(crate) fn top_index(&self) -> usize {
-        self.top_index
+        self.viewport.top()
     }
 }
 
 impl Component for List {
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         for (i, y) in (self.y..self.y + self.height).enumerate() {
-            if let Some(item) = self.display_items.get(y - self.y + self.top_index) {
-                let style = if self.selected_item == self.top_index + i {
+            if let Some(item) = self.display_items.get(y - self.y + self.viewport.top()) {
+                let style = if self.viewport.selected() == self.viewport.top() + i {
                     &self.selected_item_style
                 } else {
                     &self.item_style
@@ -230,23 +183,18 @@ impl Component for List {
 }
 
 fn truncate(s: &str, max_width: usize) -> String {
-    let s = s.trim_start_matches("/");
-    if display_width(s) <= max_width {
-        return s.to_string();
-    }
-
-    if max_width == 0 {
-        return String::new();
-    }
-
-    let mut result = truncate_display_width(s, max_width - 1);
-    result.push('…');
-    result
+    truncate_display_width_with_marker(
+        s.trim_start_matches('/'),
+        max_width,
+        "…",
+        TruncationSide::Right,
+    )
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::unicode_utils::display_width;
 
     #[test]
     fn test_truncate() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,35 +6,50 @@
 //! editor directly. Sensitive components must report their input status so tracing and
 //! logging do not serialize secrets.
 
+mod action_bar;
 mod agent_composer;
 mod completion;
 mod confirmation;
 mod dialog;
 mod file_picker;
+mod geometry;
 mod hover_info;
+mod icons;
 mod info;
 mod input_prompt;
 mod keymap_hints;
 mod list;
 mod picker;
+mod prompt_buffer;
+mod rich_text;
+mod selection;
 
+pub use action_bar::{
+    ActionBar, ActionBarLayout, ActionBarRole, ActionBarSpan, ActionMode, ActionPriority, UiAction,
+};
+pub(crate) use agent_composer::wrap_text;
 pub use agent_composer::AgentComposer;
-pub(crate) use agent_composer::{normalize_newlines, wrap_text};
 pub use completion::CompletionUI;
 pub use confirmation::Confirmation;
 use crossterm::event::{Event, KeyCode, MouseEvent, MouseEventKind};
 use dialog::Dialog;
 pub use file_picker::FilePicker;
+pub(crate) use geometry::ScreenRect;
 pub use hover_info::{HoverInfo, HoverInfoFormat};
+pub(crate) use icons::IconCatalog;
 pub use info::Info;
 pub use input_prompt::InputPrompt;
 pub(crate) use keymap_hints::draw_keymap_hints;
 use list::List;
-pub(crate) use picker::{picker_file_icon, picker_file_icon_color};
 pub use picker::{
     LegacyPickerOptions, Picker, PickerIcon, PickerItem, PickerOptions, PickerPresentation,
     PickerPreview, PickerUpdate,
 };
+pub(crate) use prompt_buffer::{
+    first_prompt_line, normalize_prompt_newlines, PromptBuffer, PromptInput, PROMPT_MAX_BYTES,
+};
+pub(crate) use rich_text::paint_rich_text;
+pub(crate) use selection::{FollowTailViewport, SelectionViewport};
 
 use crate::{
     config::KeyAction,

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -37,7 +37,9 @@ use crate::{
     },
 };
 
-use super::{dialog::BorderStyle, Component, Dialog, List};
+use super::{
+    dialog::BorderStyle, first_prompt_line, Component, Dialog, IconCatalog, List, ScreenRect,
+};
 
 type SelectAction = Box<dyn Fn(String) -> Action + Send>;
 type FilterAction = Box<dyn Fn(&PickerItem, &str) -> Option<i64> + Send>;
@@ -307,13 +309,7 @@ struct PickerHistoryNavigation {
     position: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PickerRect {
-    x: usize,
-    y: usize,
-    width: usize,
-    height: usize,
-}
+type PickerRect = ScreenRect;
 
 #[derive(Debug, Clone, Copy)]
 enum PickerDivider {
@@ -1036,7 +1032,8 @@ impl Picker {
         }
         if item.icon.is_none() {
             if let Some(path) = item_file_path(item) {
-                let semantic = picker_file_icon_color(path)
+                let semantic = IconCatalog::file(path, self.icons.style)
+                    .color
                     .map(|fg| Style {
                         fg: Some(fg),
                         ..Style::default()
@@ -1059,13 +1056,13 @@ impl Picker {
         }
         if item.icon.is_none() {
             if let Some(path) = item_file_path(item) {
-                return picker_file_icon(path, self.icons.style);
+                return IconCatalog::file(path, self.icons.style).glyph;
             }
         }
         item.icon.as_ref().map(PickerIcon::text).unwrap_or_else(|| {
             item.kind
                 .as_deref()
-                .map(|kind| picker_kind_icon(kind, self.icons.style))
+                .map(|kind| IconCatalog::symbol(kind, self.icons.style).glyph)
                 .unwrap_or_default()
         })
     }
@@ -2047,7 +2044,7 @@ fn symbol_kind_scope(kind: &str) -> Option<&'static str> {
     }
 }
 
-fn picker_kind_icon(kind: &str, style: PickerIconStyle) -> &'static str {
+pub(crate) fn picker_kind_icon(kind: &str, style: PickerIconStyle) -> &'static str {
     match style {
         PickerIconStyle::Unicode => unicode_picker_kind_icon(kind),
         PickerIconStyle::NerdFont => nerd_font_picker_kind_icon(kind),
@@ -2690,13 +2687,7 @@ impl Component for Picker {
             Event::Paste(text) => {
                 self.reset_history_navigation();
                 let previous = self.selected_item();
-                let pasted = text
-                    .replace("\r\n", "\n")
-                    .replace('\r', "\n")
-                    .split('\n')
-                    .next()
-                    .unwrap_or_default()
-                    .to_string();
+                let pasted = first_prompt_line(text);
                 self.set_search(format!("{}{}", self.search, pasted));
                 self.changed_actions(previous)
             }

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -428,7 +428,10 @@ impl PromptBuffer {
             'k' => self.move_vertical(-1, wrap_width),
             'l' => self.set_cursor(self.cursor.saturating_add(1)),
             '0' => self.set_cursor(self.current_line_start()),
-            '$' => self.set_cursor(self.current_line_end()),
+            '$' => {
+                let line_end = self.current_line_end();
+                self.set_cursor(line_end.saturating_sub(1).max(self.current_line_start()));
+            }
             'w' => self.set_cursor(self.next_word_boundary()),
             'o' => {
                 self.set_cursor(self.current_line_end());
@@ -780,6 +783,78 @@ mod tests {
             PromptInput::Changed
         );
         assert_eq!(prompt.text(), "second");
+    }
+
+    #[test]
+    fn normal_mode_line_end_selects_the_current_lines_final_grapheme() {
+        let cases = [
+            ("single line", "abc", 0, 2, Some("ab"), "abZc"),
+            ("first line", "abc\ndef", 0, 2, Some("ab\ndef"), "abZc\ndef"),
+            (
+                "middle line",
+                "one\ntwo\nthree",
+                5,
+                6,
+                Some("one\ntw\nthree"),
+                "one\ntwZo\nthree",
+            ),
+            ("last line", "one\ntwo", 5, 6, Some("one\ntw"), "one\ntwZo"),
+            (
+                "Unicode graphemes",
+                "e\u{301}👨‍👩‍👧\nlast",
+                0,
+                1,
+                Some("e\u{301}\nlast"),
+                "e\u{301}Z👨‍👩‍👧\nlast",
+            ),
+            ("empty line", "first\n\nlast", 6, 6, None, "first\nZ\nlast"),
+            ("empty draft", "", 0, 0, None, "Z"),
+        ];
+
+        for (name, text, cursor, line_end, expected_delete, expected_insert) in cases {
+            let at_line_end = || {
+                let mut prompt = PromptBuffer::new(text);
+                prompt.set_cursor(cursor);
+                prompt.set_mode(Mode::Normal);
+
+                assert_eq!(
+                    prompt.handle_event(&key(KeyCode::Char('$'), KeyModifiers::NONE), 40),
+                    PromptInput::Changed,
+                    "{name}: move to current line end"
+                );
+                assert_eq!(prompt.mode(), Mode::Normal, "{name}: remain in normal mode");
+                assert_eq!(prompt.cursor(), line_end, "{name}: select final grapheme");
+                prompt
+            };
+
+            if let Some(expected) = expected_delete {
+                let mut prompt = at_line_end();
+                assert_eq!(
+                    prompt.handle_event(&key(KeyCode::Char('x'), KeyModifiers::NONE), 40),
+                    PromptInput::Changed,
+                    "{name}: delete final grapheme"
+                );
+                assert_eq!(prompt.text(), expected, "{name}: preserve other lines");
+            }
+
+            let mut prompt = at_line_end();
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Char('i'), KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: enter insert mode"
+            );
+            assert_eq!(prompt.mode(), Mode::Insert, "{name}: enter insert mode");
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Char('Z'), KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: insert before final grapheme"
+            );
+            assert_eq!(
+                prompt.text(),
+                expected_insert,
+                "{name}: insert on current line"
+            );
+        }
     }
 
     #[test]

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -345,11 +345,11 @@ impl PromptBuffer {
                         PromptInput::Changed
                     }
                     KeyCode::Left => {
-                        self.set_cursor(self.cursor.saturating_sub(1));
+                        self.move_horizontal(-1);
                         PromptInput::Changed
                     }
                     KeyCode::Right => {
-                        self.set_cursor(self.cursor.saturating_add(1));
+                        self.move_horizontal(1);
                         PromptInput::Changed
                     }
                     KeyCode::Up => {
@@ -429,18 +429,10 @@ impl PromptBuffer {
                 self.set_cursor(self.current_line_end());
                 self.set_mode(Mode::Insert);
             }
-            'h' => {
-                self.set_cursor(self.cursor.saturating_sub(1).max(self.current_line_start()));
-            }
+            'h' => self.move_horizontal(-1),
             'j' => self.move_vertical(1, wrap_width),
             'k' => self.move_vertical(-1, wrap_width),
-            'l' => {
-                self.set_cursor(
-                    self.cursor
-                        .saturating_add(1)
-                        .min(self.current_line_last_grapheme()),
-                );
-            }
+            'l' => self.move_horizontal(1),
             '0' => self.set_cursor(self.current_line_start()),
             '$' => self.set_cursor(self.current_line_last_grapheme()),
             'w' => self.set_cursor(self.next_word_boundary()),
@@ -522,6 +514,16 @@ impl PromptBuffer {
         self.buffer.undo_history.commit_transaction(after);
         self.buffer.refresh_dirty_from_history();
         true
+    }
+
+    fn move_horizontal(&mut self, direction: isize) {
+        let cursor = self.cursor.saturating_add_signed(direction);
+        let cursor = if self.mode == Mode::Normal {
+            cursor.clamp(self.current_line_start(), self.current_line_last_grapheme())
+        } else {
+            cursor
+        };
+        self.set_cursor(cursor);
     }
 
     fn move_vertical(&mut self, direction: isize, width: usize) {
@@ -967,6 +969,162 @@ mod tests {
                 );
                 assert_eq!(prompt.text(), expected, "{name}: preserve adjacent line");
             }
+        }
+    }
+
+    #[test]
+    fn normal_mode_line_boundary_arrow_motions_stay_on_current_line() {
+        let cases = [
+            (
+                "Left at second line start",
+                "one\ntwo",
+                4,
+                KeyCode::Left,
+                4,
+                Some("one\nwo"),
+            ),
+            (
+                "Right at first line end",
+                "one\ntwo",
+                2,
+                KeyCode::Right,
+                2,
+                Some("on\ntwo"),
+            ),
+            (
+                "Left within second line",
+                "one\ntwo",
+                5,
+                KeyCode::Left,
+                4,
+                Some("one\nwo"),
+            ),
+            (
+                "Right within second line",
+                "one\ntwo",
+                4,
+                KeyCode::Right,
+                5,
+                Some("one\nto"),
+            ),
+            (
+                "Left on empty line",
+                "one\n\ntwo",
+                4,
+                KeyCode::Left,
+                4,
+                None,
+            ),
+            (
+                "Right on empty line",
+                "one\n\ntwo",
+                4,
+                KeyCode::Right,
+                4,
+                None,
+            ),
+            (
+                "Right after Unicode grapheme",
+                "e\u{301}👨‍👩‍👧\nlast",
+                1,
+                KeyCode::Right,
+                1,
+                Some("e\u{301}\nlast"),
+            ),
+        ];
+
+        for (name, text, cursor, arrow, expected_cursor, expected_delete) in cases {
+            let mut prompt = PromptBuffer::new(text);
+            prompt.set_cursor(cursor);
+            prompt.set_mode(Mode::Normal);
+
+            assert_eq!(
+                prompt.handle_event(&key(arrow, KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: move with arrow key"
+            );
+            assert_eq!(prompt.mode(), Mode::Normal, "{name}: remain in normal mode");
+            assert_eq!(
+                prompt.cursor(),
+                expected_cursor,
+                "{name}: stay on current line"
+            );
+            assert_eq!(prompt.text(), text, "{name}: preserve line breaks");
+
+            if let Some(expected) = expected_delete {
+                assert_eq!(
+                    prompt.handle_event(&key(KeyCode::Char('x'), KeyModifiers::NONE), 40),
+                    PromptInput::Changed,
+                    "{name}: delete selected grapheme"
+                );
+                assert_eq!(prompt.text(), expected, "{name}: preserve adjacent line");
+            }
+        }
+    }
+
+    #[test]
+    fn insert_mode_arrow_motions_cross_prompt_line_boundaries() {
+        let cases = [
+            (
+                "Left from second line",
+                "one\ntwo",
+                4,
+                KeyCode::Left,
+                3,
+                "oneZ\ntwo",
+            ),
+            (
+                "Right across newline",
+                "one\ntwo",
+                3,
+                KeyCode::Right,
+                4,
+                "one\nZtwo",
+            ),
+            (
+                "Right across empty line",
+                "one\n\ntwo",
+                4,
+                KeyCode::Right,
+                5,
+                "one\n\nZtwo",
+            ),
+            (
+                "Left after Unicode graphemes",
+                "e\u{301}👨‍👩‍👧\nlast",
+                3,
+                KeyCode::Left,
+                2,
+                "e\u{301}👨‍👩‍👧Z\nlast",
+            ),
+        ];
+
+        for (name, text, cursor, arrow, expected_cursor, expected_text) in cases {
+            let mut prompt = PromptBuffer::new(text);
+            prompt.set_cursor(cursor);
+
+            assert_eq!(
+                prompt.handle_event(&key(arrow, KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: move with arrow key"
+            );
+            assert_eq!(prompt.mode(), Mode::Insert, "{name}: remain in insert mode");
+            assert_eq!(
+                prompt.cursor(),
+                expected_cursor,
+                "{name}: cross line boundary"
+            );
+
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Char('Z'), KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: insert at destination"
+            );
+            assert_eq!(
+                prompt.text(),
+                expected_text,
+                "{name}: preserve cursor semantics"
+            );
         }
     }
 

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -141,12 +141,16 @@ impl PromptBuffer {
             return false;
         }
         let cursor = self.cursor;
-        let inserted = grapheme_len(&text);
+        let mut resulting_prefix = self.text();
+        let insertion_byte = grapheme_to_byte(&resulting_prefix, cursor);
+        resulting_prefix.truncate(insertion_byte);
+        resulting_prefix.push_str(&text);
+        let resulting_cursor = grapheme_len(&resulting_prefix);
         self.replace_user_graphemes(
             cursor,
             cursor,
             &text,
-            cursor.saturating_add(inserted),
+            resulting_cursor,
             "insert into prompt",
         )
     }
@@ -689,6 +693,93 @@ mod tests {
         assert!(prompt.redo());
         assert_eq!(prompt.text(), "hello world");
         assert_eq!(prompt.cursor(), 11);
+    }
+
+    #[test]
+    fn insertion_keeps_cursor_after_merged_graphemes() {
+        let cases = [
+            (
+                "combining mark",
+                "aX",
+                1,
+                "\u{301}",
+                "a\u{301}X",
+                1,
+                "a\u{301}ZX",
+            ),
+            (
+                "stacked combining marks",
+                "a\u{301}X",
+                1,
+                "\u{327}",
+                "a\u{301}\u{327}X",
+                1,
+                "a\u{301}\u{327}ZX",
+            ),
+            ("emoji modifier", "👍X", 1, "🏽", "👍🏽X", 1, "👍🏽ZX"),
+            (
+                "joined emoji",
+                "👩X",
+                1,
+                "\u{200d}💻",
+                "👩\u{200d}💻X",
+                1,
+                "👩\u{200d}💻ZX",
+            ),
+            (
+                "multiline combining mark",
+                "one\naX\ntail",
+                5,
+                "\u{301}",
+                "one\na\u{301}X\ntail",
+                5,
+                "one\na\u{301}ZX\ntail",
+            ),
+            (
+                "multiple inserted graphemes",
+                "aX",
+                1,
+                "\u{301}b",
+                "a\u{301}bX",
+                2,
+                "a\u{301}bZX",
+            ),
+        ];
+
+        for (name, initial, cursor, inserted, merged, merged_cursor, subsequent) in cases {
+            let mut prompt = PromptBuffer::new(initial);
+            prompt.set_cursor(cursor);
+
+            assert!(prompt.insert(inserted), "{name}: insert grapheme extension");
+            assert_eq!(prompt.text(), merged, "{name}: preserve merged grapheme");
+            assert_eq!(
+                prompt.cursor(),
+                merged_cursor,
+                "{name}: position cursor after resulting prefix"
+            );
+
+            assert!(prompt.insert("Z"), "{name}: insert following character");
+            assert_eq!(prompt.text(), subsequent, "{name}: preserve following text");
+            assert_eq!(prompt.cursor(), merged_cursor + 1, "{name}: advance cursor");
+
+            assert!(prompt.undo(), "{name}: undo following character");
+            assert_eq!(prompt.text(), merged, "{name}: restore merged grapheme");
+            assert_eq!(
+                prompt.cursor(),
+                merged_cursor,
+                "{name}: restore merged cursor"
+            );
+            assert!(prompt.undo(), "{name}: undo grapheme extension");
+            assert_eq!(prompt.text(), initial, "{name}: restore original text");
+            assert_eq!(prompt.cursor(), cursor, "{name}: restore original cursor");
+
+            assert!(prompt.redo(), "{name}: redo grapheme extension");
+            assert_eq!(prompt.text(), merged, "{name}: redo merged grapheme");
+            assert_eq!(prompt.cursor(), merged_cursor, "{name}: redo merged cursor");
+            assert!(prompt.redo(), "{name}: redo following character");
+            assert_eq!(prompt.text(), subsequent, "{name}: redo following text");
+            assert_eq!(prompt.cursor(), merged_cursor + 1, "{name}: redo cursor");
+        }
     }
 
     #[test]

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -420,7 +420,7 @@ impl PromptBuffer {
                 self.set_mode(Mode::Insert);
             }
             'A' => {
-                self.set_cursor(grapheme_len(&self.text()));
+                self.set_cursor(self.current_line_end());
                 self.set_mode(Mode::Insert);
             }
             'h' => self.set_cursor(self.cursor.saturating_sub(1)),
@@ -780,6 +780,45 @@ mod tests {
             PromptInput::Changed
         );
         assert_eq!(prompt.text(), "second");
+    }
+
+    #[test]
+    fn normal_mode_append_stays_on_the_current_prompt_line() {
+        let cases = [
+            ("first line", "first\nsecond", 2, 5, "first!\nsecond"),
+            ("middle line", "one\ntwo\nthree", 5, 7, "one\ntwo!\nthree"),
+            ("last line", "first\nlast", 8, 10, "first\nlast!"),
+            ("empty line", "first\n\nlast", 6, 6, "first\n!\nlast"),
+            (
+                "Unicode graphemes",
+                "e\u{301}👨‍👩‍👧\nlast",
+                0,
+                2,
+                "e\u{301}👨‍👩‍👧!\nlast",
+            ),
+        ];
+
+        for (name, text, cursor, line_end, expected) in cases {
+            let mut prompt = PromptBuffer::new(text);
+            prompt.set_cursor(cursor);
+            prompt.set_mode(Mode::Normal);
+
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Char('A'), KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: enter append mode"
+            );
+            assert_eq!(prompt.mode(), Mode::Insert, "{name}: enter insert mode");
+            assert_eq!(prompt.cursor(), line_end, "{name}: stay on current line");
+
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Char('!'), KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: append to current line"
+            );
+            assert_eq!(prompt.text(), expected, "{name}: preserve remaining lines");
+            assert_eq!(prompt.cursor(), line_end + 1, "{name}: advance cursor");
+        }
     }
 
     #[test]

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -1,0 +1,852 @@
+//! Ephemeral, Vim-native prompt editing shared by agent surfaces.
+//!
+//! Prompt buffers use Red's real rope-backed [`Buffer`] and branching
+//! [`UndoHistory`](crate::undo::UndoHistory), but never have a file path or enter
+//! the editor's ordinary file-buffer collection.
+
+use crossterm::event::{Event, KeyCode, KeyModifiers};
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::{
+    buffer::Buffer,
+    editor::Mode,
+    undo::{CursorSnapshot, TextPosition, TextRange},
+    unicode_utils::{char_to_grapheme, grapheme_len, grapheme_to_byte},
+};
+
+use super::wrap_text;
+
+/// Largest prompt accepted by the direct Codex app-server integration.
+pub(crate) const PROMPT_MAX_BYTES: usize = 128 * 1024;
+
+/// Outcome of applying one terminal input event to an ephemeral prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PromptInput {
+    /// The draft, cursor, history selection, or editor mode changed.
+    Changed,
+    /// The current complete prompt should be validated and submitted.
+    Submit,
+    /// The containing floating surface should be cancelled.
+    Cancel,
+    /// The event is not a prompt-editing action.
+    Unhandled,
+}
+
+/// Fileless editor buffer, cursor, Vim mode, and thread-local prompt history.
+#[derive(Debug)]
+pub(crate) struct PromptBuffer {
+    buffer: Buffer,
+    cursor: usize,
+    mode: Mode,
+    preferred_column: Option<usize>,
+    history: Vec<String>,
+    history_position: Option<usize>,
+    history_draft: Option<String>,
+    pending_delete: bool,
+}
+
+impl PromptBuffer {
+    /// Creates an unnamed prompt in insert mode with no previous history.
+    pub(crate) fn new(text: impl AsRef<str>) -> Self {
+        Self::with_history(text, Vec::new())
+    }
+
+    /// Creates an unnamed prompt while preserving only bounded history entries.
+    pub(crate) fn with_history(text: impl AsRef<str>, history: Vec<String>) -> Self {
+        let normalized = normalize_prompt_newlines(text.as_ref());
+        let text = if normalized.len() <= PROMPT_MAX_BYTES {
+            normalized
+        } else {
+            String::new()
+        };
+        let cursor = grapheme_len(&text);
+        let mut prompt = Self {
+            buffer: scratch_buffer(&text),
+            cursor,
+            mode: Mode::Insert,
+            preferred_column: None,
+            history: history
+                .into_iter()
+                .filter(|entry| entry.len() <= PROMPT_MAX_BYTES)
+                .map(|entry| normalize_prompt_newlines(&entry))
+                .collect(),
+            history_position: None,
+            history_draft: None,
+            pending_delete: false,
+        };
+        prompt.sync_buffer_cursor();
+        prompt
+    }
+
+    /// Returns the underlying unnamed editor buffer.
+    #[must_use]
+    pub(crate) fn buffer(&self) -> &Buffer {
+        &self.buffer
+    }
+
+    /// Returns the exact UTF-8 draft without adding a synthetic newline.
+    #[must_use]
+    pub(crate) fn text(&self) -> String {
+        self.buffer.contents()
+    }
+
+    /// Returns the cursor as an absolute extended-grapheme index.
+    #[must_use]
+    pub(crate) const fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Returns the prompt's actual Normal or Insert editor mode.
+    #[must_use]
+    pub(crate) const fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    /// Changes the local prompt mode without mutating the global editor.
+    pub(crate) fn set_mode(&mut self, mode: Mode) {
+        if matches!(mode, Mode::Normal | Mode::Insert) {
+            self.mode = mode;
+            self.pending_delete = false;
+        }
+    }
+
+    /// Returns thread-local prompt history, newest submission first.
+    #[must_use]
+    pub(crate) fn history(&self) -> &[String] {
+        &self.history
+    }
+
+    /// Moves the cursor to a bounded absolute grapheme position.
+    pub(crate) fn set_cursor(&mut self, cursor: usize) {
+        self.cursor = cursor.min(grapheme_len(&self.text()));
+        self.preferred_column = None;
+        self.sync_buffer_cursor();
+    }
+
+    /// Replaces the complete draft through the real undo transaction boundary.
+    pub(crate) fn set_text(&mut self, text: &str) -> bool {
+        let text = normalize_prompt_newlines(text);
+        if text.len() > PROMPT_MAX_BYTES {
+            return false;
+        }
+        let previous = self.text();
+        let end = grapheme_len(&previous);
+        self.replace_graphemes(0, end, &text, grapheme_len(&text), "replace prompt")
+    }
+
+    /// Inserts exact normalized text as one undoable prompt transaction.
+    pub(crate) fn insert(&mut self, text: &str) -> bool {
+        let text = normalize_prompt_newlines(text);
+        if text.is_empty() {
+            return false;
+        }
+        let cursor = self.cursor;
+        let inserted = grapheme_len(&text);
+        let changed = self.replace_graphemes(
+            cursor,
+            cursor,
+            &text,
+            cursor.saturating_add(inserted),
+            "insert into prompt",
+        );
+        if changed {
+            self.history_position = None;
+            self.history_draft = None;
+        }
+        changed
+    }
+
+    /// Removes the previous complete extended grapheme.
+    pub(crate) fn backspace(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        let start = self.cursor - 1;
+        self.replace_graphemes(start, self.cursor, "", start, "delete prompt grapheme")
+    }
+
+    /// Removes the complete extended grapheme under the cursor.
+    pub(crate) fn delete(&mut self) -> bool {
+        if self.cursor >= grapheme_len(&self.text()) {
+            return false;
+        }
+        self.replace_graphemes(
+            self.cursor,
+            self.cursor + 1,
+            "",
+            self.cursor,
+            "delete prompt grapheme",
+        )
+    }
+
+    /// Removes the whitespace and word immediately preceding the cursor.
+    pub(crate) fn delete_previous_word(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        let text = self.text();
+        let end = grapheme_to_byte(&text, self.cursor);
+        let mut start = self.cursor;
+        let mut seen_word = false;
+        for grapheme in text[..end].graphemes(true).rev() {
+            let whitespace = grapheme.chars().all(char::is_whitespace);
+            if seen_word && whitespace {
+                break;
+            }
+            seen_word |= !whitespace;
+            start -= 1;
+        }
+        self.replace_graphemes(start, self.cursor, "", start, "delete prompt word")
+    }
+
+    /// Selects the previous submitted prompt while preserving the current draft.
+    pub(crate) fn history_previous(&mut self) -> bool {
+        if self.history.is_empty() {
+            return false;
+        }
+        let index = match self.history_position {
+            Some(index) => (index + 1).min(self.history.len() - 1),
+            None => {
+                self.history_draft = Some(self.text());
+                0
+            }
+        };
+        let entry = self.history[index].clone();
+        self.history_position = Some(index);
+        self.set_text(&entry)
+    }
+
+    /// Moves toward newer history or restores the exact unsent draft.
+    pub(crate) fn history_next(&mut self) -> bool {
+        let Some(index) = self.history_position else {
+            return false;
+        };
+        let next = if index == 0 {
+            self.history_position = None;
+            self.history_draft.take().unwrap_or_default()
+        } else {
+            self.history_position = Some(index - 1);
+            self.history[index - 1].clone()
+        };
+        self.set_text(&next)
+    }
+
+    /// Undoes one real, branch-preserving prompt edit.
+    pub(crate) fn undo(&mut self) -> bool {
+        let mut history = std::mem::take(&mut self.buffer.undo_history);
+        let restored = history.undo(&mut self.buffer);
+        self.buffer.undo_history = history;
+        let Some((cursor, _)) = restored else {
+            return false;
+        };
+        self.restore_cursor(cursor);
+        self.buffer.refresh_dirty_from_history();
+        true
+    }
+
+    /// Redoes one real prompt transaction on the selected undo branch.
+    pub(crate) fn redo(&mut self) -> bool {
+        let mut history = std::mem::take(&mut self.buffer.undo_history);
+        let restored = history.redo(&mut self.buffer);
+        self.buffer.undo_history = history;
+        let Some((cursor, _)) = restored else {
+            return false;
+        };
+        self.restore_cursor(cursor);
+        self.buffer.refresh_dirty_from_history();
+        true
+    }
+
+    /// Clears the draft without associating it with a file or losing history.
+    pub(crate) fn clear(&mut self) {
+        self.buffer = scratch_buffer("");
+        self.cursor = 0;
+        self.preferred_column = None;
+        self.history_position = None;
+        self.history_draft = None;
+        self.pending_delete = false;
+    }
+
+    /// Takes a nonblank draft and adds it to bounded, deduplicated history.
+    pub(crate) fn take_submission(&mut self) -> Option<String> {
+        let text = self.text();
+        if text.trim().is_empty() || text.len() > PROMPT_MAX_BYTES {
+            return None;
+        }
+        self.history.retain(|entry| entry != &text);
+        self.history.insert(0, text.clone());
+        self.history.truncate(50);
+        self.clear();
+        Some(text)
+    }
+
+    /// Applies terminal input while preserving Vim mode and modified-Enter semantics.
+    pub(crate) fn handle_event(&mut self, event: &Event, wrap_width: usize) -> PromptInput {
+        match event {
+            Event::Paste(text) => {
+                if self.insert(text) {
+                    PromptInput::Changed
+                } else {
+                    PromptInput::Unhandled
+                }
+            }
+            Event::Key(key) => {
+                let modifiers = key.modifiers;
+                match key.code {
+                    KeyCode::Enter | KeyCode::Char('\n')
+                        if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                    {
+                        PromptInput::Submit
+                    }
+                    KeyCode::Char('c' | 'C') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        PromptInput::Cancel
+                    }
+                    KeyCode::Esc if self.mode == Mode::Insert => {
+                        self.set_mode(Mode::Normal);
+                        PromptInput::Changed
+                    }
+                    KeyCode::Esc => PromptInput::Cancel,
+                    KeyCode::Enter if self.mode == Mode::Normal => PromptInput::Submit,
+                    KeyCode::Enter | KeyCode::Char('\n') => {
+                        self.insert("\n");
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char('j' | 'J') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        self.insert("\n");
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char('p' | 'P') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        self.history_previous();
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char('n' | 'N') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        self.history_next();
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char('w' | 'W') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        self.delete_previous_word();
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char('r' | 'R') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        self.redo();
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char('z' | 'Z') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        self.undo();
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char('a' | 'A') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        self.set_cursor(0);
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char('e' | 'E') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        self.set_cursor(grapheme_len(&self.text()));
+                        PromptInput::Changed
+                    }
+                    KeyCode::Left => {
+                        self.set_cursor(self.cursor.saturating_sub(1));
+                        PromptInput::Changed
+                    }
+                    KeyCode::Right => {
+                        self.set_cursor(self.cursor.saturating_add(1));
+                        PromptInput::Changed
+                    }
+                    KeyCode::Up => {
+                        self.move_vertical(-1, wrap_width);
+                        PromptInput::Changed
+                    }
+                    KeyCode::Down => {
+                        self.move_vertical(1, wrap_width);
+                        PromptInput::Changed
+                    }
+                    KeyCode::Home => {
+                        self.set_cursor(0);
+                        PromptInput::Changed
+                    }
+                    KeyCode::End => {
+                        self.set_cursor(grapheme_len(&self.text()));
+                        PromptInput::Changed
+                    }
+                    KeyCode::Backspace => {
+                        self.backspace();
+                        PromptInput::Changed
+                    }
+                    KeyCode::Delete => {
+                        self.delete();
+                        PromptInput::Changed
+                    }
+                    KeyCode::Tab if self.mode == Mode::Insert => {
+                        self.insert("\t");
+                        PromptInput::Changed
+                    }
+                    KeyCode::Char(character)
+                        if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                    {
+                        self.handle_character(character, wrap_width)
+                    }
+                    _ => PromptInput::Unhandled,
+                }
+            }
+            _ => PromptInput::Unhandled,
+        }
+    }
+
+    fn handle_character(&mut self, character: char, wrap_width: usize) -> PromptInput {
+        if self.mode == Mode::Insert {
+            return if self.insert(&character.to_string()) {
+                PromptInput::Changed
+            } else {
+                PromptInput::Unhandled
+            };
+        }
+
+        if self.pending_delete {
+            self.pending_delete = false;
+            return match character {
+                'w' => {
+                    let target = self.next_word_boundary();
+                    self.replace_graphemes(
+                        self.cursor,
+                        target,
+                        "",
+                        self.cursor,
+                        "delete prompt word",
+                    );
+                    PromptInput::Changed
+                }
+                _ => PromptInput::Unhandled,
+            };
+        }
+
+        match character {
+            'i' => self.set_mode(Mode::Insert),
+            'a' => {
+                self.set_cursor(self.cursor.saturating_add(1));
+                self.set_mode(Mode::Insert);
+            }
+            'A' => {
+                self.set_cursor(grapheme_len(&self.text()));
+                self.set_mode(Mode::Insert);
+            }
+            'h' => self.set_cursor(self.cursor.saturating_sub(1)),
+            'j' => self.move_vertical(1, wrap_width),
+            'k' => self.move_vertical(-1, wrap_width),
+            'l' => self.set_cursor(self.cursor.saturating_add(1)),
+            '0' => self.set_cursor(self.current_line_start()),
+            '$' => self.set_cursor(self.current_line_end()),
+            'w' => self.set_cursor(self.next_word_boundary()),
+            'o' => {
+                self.set_cursor(self.current_line_end());
+                self.insert("\n");
+                self.set_mode(Mode::Insert);
+            }
+            'x' => {
+                self.delete();
+            }
+            'u' => {
+                self.undo();
+            }
+            'd' => self.pending_delete = true,
+            _ => return PromptInput::Unhandled,
+        }
+        PromptInput::Changed
+    }
+
+    fn replace_graphemes(
+        &mut self,
+        start: usize,
+        end: usize,
+        replacement: &str,
+        cursor: usize,
+        label: &str,
+    ) -> bool {
+        let contents = self.text();
+        let start_byte = grapheme_to_byte(&contents, start);
+        let end_byte = grapheme_to_byte(&contents, end);
+        let old_text = &contents[start_byte..end_byte];
+        if old_text == replacement
+            || contents
+                .len()
+                .saturating_sub(old_text.len())
+                .saturating_add(replacement.len())
+                > PROMPT_MAX_BYTES
+        {
+            return false;
+        }
+        let start_char = contents[..start_byte].chars().count();
+        let end_char = contents[..end_byte].chars().count();
+        let range = TextRange::new(
+            self.buffer.char_idx_to_position(start_char),
+            self.buffer.char_idx_to_position(end_char),
+        );
+        let before = self.cursor_snapshot();
+        self.buffer.undo_history.begin_transaction(label, before);
+        self.buffer.undo_history.record_replace(
+            range,
+            start_char,
+            old_text.to_string(),
+            replacement.to_string(),
+        );
+        self.buffer.replace_range_raw(range, replacement);
+        self.cursor = cursor.min(grapheme_len(&self.text()));
+        self.preferred_column = None;
+        self.sync_buffer_cursor();
+        let after = self.cursor_snapshot();
+        self.buffer.undo_history.commit_transaction(after);
+        self.buffer.refresh_dirty_from_history();
+        true
+    }
+
+    fn move_vertical(&mut self, direction: isize, width: usize) {
+        let wrapped = wrap_text(&self.text(), width.max(1));
+        let Some(&(row, column)) = wrapped.positions.get(self.cursor) else {
+            return;
+        };
+        let target = row.saturating_add_signed(direction);
+        if target >= wrapped.rows.len() || target == row {
+            return;
+        }
+        let preferred = *self.preferred_column.get_or_insert(column);
+        if let Some((index, _)) = wrapped
+            .positions
+            .iter()
+            .enumerate()
+            .filter(|(_, position)| position.0 == target)
+            .min_by_key(|(_, position)| position.1.abs_diff(preferred))
+        {
+            self.cursor = index;
+            self.sync_buffer_cursor();
+        }
+    }
+
+    fn current_line_start(&self) -> usize {
+        let text = self.text();
+        let byte = grapheme_to_byte(&text, self.cursor);
+        text[..byte]
+            .rfind('\n')
+            .map_or(0, |index| grapheme_len(&text[..index + 1]))
+    }
+
+    fn current_line_end(&self) -> usize {
+        let text = self.text();
+        let byte = grapheme_to_byte(&text, self.cursor);
+        text[byte..].find('\n').map_or_else(
+            || grapheme_len(&text),
+            |index| grapheme_len(&text[..byte + index]),
+        )
+    }
+
+    fn next_word_boundary(&self) -> usize {
+        let text = self.text();
+        let byte = grapheme_to_byte(&text, self.cursor);
+        let mut index = self.cursor;
+        let mut passed_word = false;
+        for grapheme in text[byte..].graphemes(true) {
+            let whitespace = grapheme.chars().all(char::is_whitespace);
+            if passed_word && !whitespace {
+                break;
+            }
+            passed_word |= whitespace;
+            index += 1;
+        }
+        index.min(grapheme_len(&text))
+    }
+
+    fn cursor_snapshot(&self) -> CursorSnapshot {
+        let text = self.text();
+        let byte = grapheme_to_byte(&text, self.cursor);
+        let character = text[..byte].chars().count();
+        let position = self.buffer.char_idx_to_position(character);
+        let line = self.buffer.get(position.line).unwrap_or_default();
+        CursorSnapshot::new(
+            char_to_grapheme(&line, position.character),
+            position.line,
+            0,
+        )
+    }
+
+    fn sync_buffer_cursor(&mut self) {
+        let snapshot = self.cursor_snapshot();
+        self.buffer.pos = (snapshot.x, snapshot.y);
+    }
+
+    fn restore_cursor(&mut self, snapshot: CursorSnapshot) {
+        let prefix = self.buffer.line_range_contents(0, snapshot.y);
+        let line = self.buffer.get(snapshot.y).unwrap_or_default();
+        self.cursor = grapheme_len(&prefix)
+            .saturating_add(snapshot.x.min(grapheme_len(&line)))
+            .min(grapheme_len(&self.text()));
+        self.preferred_column = None;
+        self.sync_buffer_cursor();
+    }
+}
+
+fn scratch_buffer(text: &str) -> Buffer {
+    if !text.is_empty() {
+        return Buffer::new(None, text.to_string());
+    }
+    let mut buffer = Buffer::new(None, "\n".to_string());
+    buffer.replace_range_raw(
+        TextRange::new(TextPosition::new(0, 0), TextPosition::new(1, 0)),
+        "",
+    );
+    buffer.dirty = false;
+    buffer
+}
+
+/// Normalizes terminal and clipboard line endings before prompt editing.
+#[must_use]
+pub(crate) fn normalize_prompt_newlines(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+/// Keeps multiline paste from submitting or executing a single-line prompt.
+#[must_use]
+pub(crate) fn first_prompt_line(text: &str) -> String {
+    normalize_prompt_newlines(text)
+        .split('\n')
+        .next()
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+    use super::{
+        first_prompt_line, normalize_prompt_newlines, Mode, PromptBuffer, PromptInput,
+        PROMPT_MAX_BYTES,
+    };
+
+    #[test]
+    fn single_line_paste_shares_crlf_normalization_without_accepting_a_newline() {
+        assert_eq!(
+            normalize_prompt_newlines("first\r\nsecond\rthird"),
+            "first\nsecond\nthird"
+        );
+        assert_eq!(first_prompt_line("first\r\nsecond"), "first");
+        assert_eq!(first_prompt_line("\r\nsecond"), "");
+        assert_eq!(first_prompt_line("👨‍👩‍👧\nignored"), "👨‍👩‍👧");
+    }
+
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> Event {
+        Event::Key(KeyEvent::new(code, modifiers))
+    }
+
+    #[test]
+    fn empty_prompt_is_a_real_unnamed_buffer_without_a_synthetic_newline() {
+        let prompt = PromptBuffer::new("");
+
+        assert!(prompt.buffer().file.is_none());
+        assert_eq!(prompt.buffer().contents(), "");
+        assert_eq!(prompt.text(), "");
+        assert_eq!(prompt.cursor(), 0);
+        assert_eq!(prompt.mode(), Mode::Insert);
+        assert_eq!(prompt.buffer().undo_history.node_count(), 0);
+    }
+
+    #[test]
+    fn prompt_normalizes_initial_text_history_and_pasted_newlines() {
+        let mut prompt = PromptBuffer::with_history(
+            "first\r\nsecond\rthird",
+            vec!["history\r\nentry".to_string()],
+        );
+
+        assert_eq!(prompt.text(), "first\nsecond\nthird");
+        assert_eq!(prompt.history(), ["history\nentry"]);
+        assert_eq!(
+            prompt.handle_event(&Event::Paste("\r\nfourth".to_string()), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.text(), "first\nsecond\nthird\nfourth");
+    }
+
+    #[test]
+    fn edits_commit_to_the_real_buffer_undo_and_redo_history() {
+        let mut prompt = PromptBuffer::new("hello");
+
+        assert!(prompt.insert(" world"));
+        assert_eq!(prompt.text(), "hello world");
+        assert_eq!(prompt.buffer().undo_history.node_count(), 1);
+        assert!(prompt.undo());
+        assert_eq!(prompt.text(), "hello");
+        assert_eq!(prompt.cursor(), 5);
+        assert!(prompt.redo());
+        assert_eq!(prompt.text(), "hello world");
+        assert_eq!(prompt.cursor(), 11);
+    }
+
+    #[test]
+    fn deletion_and_undo_preserve_complete_unicode_graphemes() {
+        let mut prompt = PromptBuffer::new("e\u{301}👨‍👩‍👧漢");
+
+        assert!(prompt.backspace());
+        assert_eq!(prompt.text(), "e\u{301}👨‍👩‍👧");
+        assert!(prompt.backspace());
+        assert_eq!(prompt.text(), "e\u{301}");
+        assert!(prompt.undo());
+        assert_eq!(prompt.text(), "e\u{301}👨‍👩‍👧");
+        assert!(prompt.undo());
+        assert_eq!(prompt.text(), "e\u{301}👨‍👩‍👧漢");
+        prompt.set_cursor(0);
+        assert!(prompt.delete());
+        assert_eq!(prompt.text(), "👨‍👩‍👧漢");
+    }
+
+    #[test]
+    fn modified_enter_and_modified_linefeed_submit_in_insert_mode() {
+        for event in [
+            key(KeyCode::Enter, KeyModifiers::CONTROL),
+            key(KeyCode::Char('\n'), KeyModifiers::CONTROL),
+            key(KeyCode::Enter, KeyModifiers::ALT),
+            key(KeyCode::Char('\n'), KeyModifiers::ALT),
+        ] {
+            let mut prompt = PromptBuffer::new("send this");
+
+            assert_eq!(prompt.handle_event(&event, 40), PromptInput::Submit);
+            assert_eq!(prompt.text(), "send this");
+            assert_eq!(prompt.mode(), Mode::Insert);
+        }
+    }
+
+    #[test]
+    fn ordinary_enter_and_control_j_insert_real_newlines() {
+        let mut prompt = PromptBuffer::new("first");
+
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Enter, KeyModifiers::NONE), 40),
+            PromptInput::Changed
+        );
+        assert!(prompt.insert("second"));
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('j'), KeyModifiers::CONTROL), 40),
+            PromptInput::Changed
+        );
+
+        assert_eq!(prompt.text(), "first\nsecond\n");
+        assert_eq!(prompt.buffer().undo_history.node_count(), 3);
+    }
+
+    #[test]
+    fn escape_enters_normal_mode_and_enter_submits_without_mutating_the_draft() {
+        let mut prompt = PromptBuffer::new("draft");
+
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.mode(), Mode::Normal);
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Enter, KeyModifiers::NONE), 40),
+            PromptInput::Submit
+        );
+        assert_eq!(prompt.text(), "draft");
+    }
+
+    #[test]
+    fn normal_mode_supports_vim_word_deletion_and_real_undo() {
+        let mut prompt = PromptBuffer::new("first second");
+        prompt.set_cursor(0);
+        prompt.set_mode(Mode::Normal);
+
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('d'), KeyModifiers::NONE), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('w'), KeyModifiers::NONE), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.text(), "second");
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('u'), KeyModifiers::NONE), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.text(), "first second");
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('r'), KeyModifiers::CONTROL), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.text(), "second");
+    }
+
+    #[test]
+    fn normal_mode_open_line_enters_insert_without_sending() {
+        let mut prompt = PromptBuffer::new("first\nlast");
+        prompt.set_cursor(2);
+        prompt.set_mode(Mode::Normal);
+
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('o'), KeyModifiers::NONE), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.text(), "first\n\nlast");
+        assert_eq!(prompt.mode(), Mode::Insert);
+    }
+
+    #[test]
+    fn history_navigation_restores_the_exact_unsent_draft() {
+        let mut prompt = PromptBuffer::with_history(
+            "unsent draft",
+            vec!["newer\r\nentry".to_string(), "older".to_string()],
+        );
+
+        assert!(prompt.history_previous());
+        assert_eq!(prompt.text(), "newer\nentry");
+        assert!(prompt.history_previous());
+        assert_eq!(prompt.text(), "older");
+        assert!(prompt.history_next());
+        assert_eq!(prompt.text(), "newer\nentry");
+        assert!(prompt.history_next());
+        assert_eq!(prompt.text(), "unsent draft");
+    }
+
+    #[test]
+    fn submission_preserves_exact_text_and_deduplicates_bounded_history() {
+        let mut prompt = PromptBuffer::with_history(
+            "  first\nsecond  ",
+            vec!["  first\nsecond  ".to_string(), "older".to_string()],
+        );
+
+        assert_eq!(
+            prompt.take_submission().as_deref(),
+            Some("  first\nsecond  ")
+        );
+        assert_eq!(prompt.text(), "");
+        assert_eq!(prompt.cursor(), 0);
+        assert_eq!(prompt.history(), ["  first\nsecond  ", "older"]);
+        assert!(prompt.buffer().file.is_none());
+    }
+
+    #[test]
+    fn blank_submission_never_discards_the_existing_draft() {
+        let mut prompt = PromptBuffer::new(" \n\t");
+
+        assert!(prompt.take_submission().is_none());
+        assert_eq!(prompt.text(), " \n\t");
+    }
+
+    #[test]
+    fn oversized_edits_never_replace_the_existing_buffer_or_history() {
+        let mut prompt = PromptBuffer::new("safe draft");
+        let oversized = "x".repeat(PROMPT_MAX_BYTES);
+
+        assert!(!prompt.insert(&oversized));
+        assert_eq!(prompt.text(), "safe draft");
+        assert_eq!(prompt.buffer().undo_history.node_count(), 0);
+        assert!(!prompt.set_text(&"x".repeat(PROMPT_MAX_BYTES + 1)));
+        assert_eq!(prompt.text(), "safe draft");
+    }
+
+    #[test]
+    fn control_s_is_not_a_hidden_submission_shortcut() {
+        let mut prompt = PromptBuffer::new("keep editing");
+
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('s'), KeyModifiers::CONTROL), 40),
+            PromptInput::Unhandled
+        );
+        assert_eq!(prompt.text(), "keep editing");
+    }
+}

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -301,6 +301,8 @@ impl PromptBuffer {
                         PromptInput::Cancel
                     }
                     KeyCode::Esc if self.mode == Mode::Insert => {
+                        let cursor = self.cursor.saturating_sub(1).max(self.current_line_start());
+                        self.set_cursor(cursor);
                         self.set_mode(Mode::Normal);
                         PromptInput::Changed
                     }
@@ -420,22 +422,27 @@ impl PromptBuffer {
         match character {
             'i' => self.set_mode(Mode::Insert),
             'a' => {
-                self.set_cursor(self.cursor.saturating_add(1));
+                self.set_cursor(self.cursor.saturating_add(1).min(self.current_line_end()));
                 self.set_mode(Mode::Insert);
             }
             'A' => {
                 self.set_cursor(self.current_line_end());
                 self.set_mode(Mode::Insert);
             }
-            'h' => self.set_cursor(self.cursor.saturating_sub(1)),
+            'h' => {
+                self.set_cursor(self.cursor.saturating_sub(1).max(self.current_line_start()));
+            }
             'j' => self.move_vertical(1, wrap_width),
             'k' => self.move_vertical(-1, wrap_width),
-            'l' => self.set_cursor(self.cursor.saturating_add(1)),
-            '0' => self.set_cursor(self.current_line_start()),
-            '$' => {
-                let line_end = self.current_line_end();
-                self.set_cursor(line_end.saturating_sub(1).max(self.current_line_start()));
+            'l' => {
+                self.set_cursor(
+                    self.cursor
+                        .saturating_add(1)
+                        .min(self.current_line_last_grapheme()),
+                );
             }
+            '0' => self.set_cursor(self.current_line_start()),
+            '$' => self.set_cursor(self.current_line_last_grapheme()),
             'w' => self.set_cursor(self.next_word_boundary()),
             'o' => {
                 self.set_cursor(self.current_line_end());
@@ -443,7 +450,9 @@ impl PromptBuffer {
                 self.set_mode(Mode::Insert);
             }
             'x' => {
-                self.delete();
+                if self.cursor < self.current_line_end() {
+                    self.delete();
+                }
             }
             'u' => {
                 self.undo();
@@ -552,6 +561,12 @@ impl PromptBuffer {
             || grapheme_len(&text),
             |index| grapheme_len(&text[..byte + index]),
         )
+    }
+
+    fn current_line_last_grapheme(&self) -> usize {
+        self.current_line_end()
+            .saturating_sub(1)
+            .max(self.current_line_start())
     }
 
     fn next_word_boundary(&self) -> usize {
@@ -847,6 +862,171 @@ mod tests {
             PromptInput::Submit
         );
         assert_eq!(prompt.text(), "draft");
+    }
+
+    #[test]
+    fn normal_mode_line_boundary_escape_selects_a_current_line_grapheme() {
+        let cases = [
+            ("single line", "abc", 3, 2),
+            ("first line end", "abc\ndef", 3, 2),
+            ("second line start", "abc\ndef", 4, 4),
+            ("second line interior", "abc\ndef", 6, 5),
+            ("empty middle line", "abc\n\ndef", 4, 4),
+            ("empty draft", "", 0, 0),
+            ("Unicode graphemes", "e\u{301}👨‍👩‍👧", 2, 1),
+        ];
+
+        for (name, text, insertion_cursor, normal_cursor) in cases {
+            let mut prompt = PromptBuffer::new(text);
+            prompt.set_cursor(insertion_cursor);
+
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: enter normal mode"
+            );
+            assert_eq!(prompt.mode(), Mode::Normal, "{name}: set normal mode");
+            assert_eq!(
+                prompt.cursor(),
+                normal_cursor,
+                "{name}: remain on the current line"
+            );
+            assert_eq!(prompt.text(), text, "{name}: preserve draft");
+        }
+    }
+
+    #[test]
+    fn normal_mode_line_boundary_horizontal_motions_stay_on_current_line() {
+        let cases = [
+            (
+                "h at second line start",
+                "one\ntwo",
+                4,
+                'h',
+                4,
+                Some("one\nwo"),
+            ),
+            (
+                "l at first line end",
+                "one\ntwo",
+                2,
+                'l',
+                2,
+                Some("on\ntwo"),
+            ),
+            (
+                "h within second line",
+                "one\ntwo",
+                5,
+                'h',
+                4,
+                Some("one\nwo"),
+            ),
+            (
+                "l within second line",
+                "one\ntwo",
+                4,
+                'l',
+                5,
+                Some("one\nto"),
+            ),
+            ("h on empty line", "one\n\ntwo", 4, 'h', 4, None),
+            ("l on empty line", "one\n\ntwo", 4, 'l', 4, None),
+            (
+                "l after Unicode grapheme",
+                "e\u{301}👨‍👩‍👧\nlast",
+                1,
+                'l',
+                1,
+                Some("e\u{301}\nlast"),
+            ),
+        ];
+
+        for (name, text, cursor, motion, expected_cursor, expected_delete) in cases {
+            let mut prompt = PromptBuffer::new(text);
+            prompt.set_cursor(cursor);
+            prompt.set_mode(Mode::Normal);
+
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Char(motion), KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: apply horizontal motion"
+            );
+            assert_eq!(
+                prompt.cursor(),
+                expected_cursor,
+                "{name}: stay on current line"
+            );
+            assert_eq!(prompt.text(), text, "{name}: preserve line breaks");
+
+            if let Some(expected) = expected_delete {
+                assert_eq!(
+                    prompt.handle_event(&key(KeyCode::Char('x'), KeyModifiers::NONE), 40),
+                    PromptInput::Changed,
+                    "{name}: delete selected grapheme"
+                );
+                assert_eq!(prompt.text(), expected, "{name}: preserve adjacent line");
+            }
+        }
+    }
+
+    #[test]
+    fn normal_mode_line_boundary_delete_preserves_empty_line_separators() {
+        let cases = [
+            ("empty first line", "\ntwo", 0),
+            ("empty middle line", "one\n\ntwo", 4),
+            ("empty final line", "one\n", 4),
+            ("only a newline", "\n", 0),
+            ("empty draft", "", 0),
+        ];
+
+        for (name, text, cursor) in cases {
+            let mut prompt = PromptBuffer::new(text);
+            prompt.set_cursor(cursor);
+            prompt.set_mode(Mode::Normal);
+            let original_history = prompt.buffer().undo_history.node_count();
+
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Char('$'), KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: select empty line"
+            );
+            assert_eq!(prompt.cursor(), cursor, "{name}: remain on empty line");
+
+            assert_eq!(
+                prompt.handle_event(&key(KeyCode::Char('x'), KeyModifiers::NONE), 40),
+                PromptInput::Changed,
+                "{name}: ignore deletion on empty line"
+            );
+            assert_eq!(prompt.text(), text, "{name}: preserve newline separator");
+            assert_eq!(prompt.cursor(), cursor, "{name}: preserve cursor");
+            assert_eq!(
+                prompt.buffer().undo_history.node_count(),
+                original_history,
+                "{name}: avoid creating an undo transaction"
+            );
+        }
+    }
+
+    #[test]
+    fn normal_mode_line_boundary_append_stays_on_empty_line() {
+        let mut prompt = PromptBuffer::new("one\n\ntwo");
+        prompt.set_cursor(4);
+        prompt.set_mode(Mode::Normal);
+
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('a'), KeyModifiers::NONE), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.mode(), Mode::Insert);
+        assert_eq!(prompt.cursor(), 4);
+
+        assert_eq!(
+            prompt.handle_event(&key(KeyCode::Char('Z'), KeyModifiers::NONE), 40),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.text(), "one\nZ\ntwo");
+        assert_eq!(prompt.cursor(), 5);
     }
 
     #[test]

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -142,18 +142,13 @@ impl PromptBuffer {
         }
         let cursor = self.cursor;
         let inserted = grapheme_len(&text);
-        let changed = self.replace_graphemes(
+        self.replace_user_graphemes(
             cursor,
             cursor,
             &text,
             cursor.saturating_add(inserted),
             "insert into prompt",
-        );
-        if changed {
-            self.history_position = None;
-            self.history_draft = None;
-        }
-        changed
+        )
     }
 
     /// Removes the previous complete extended grapheme.
@@ -162,7 +157,7 @@ impl PromptBuffer {
             return false;
         }
         let start = self.cursor - 1;
-        self.replace_graphemes(start, self.cursor, "", start, "delete prompt grapheme")
+        self.replace_user_graphemes(start, self.cursor, "", start, "delete prompt grapheme")
     }
 
     /// Removes the complete extended grapheme under the cursor.
@@ -170,7 +165,7 @@ impl PromptBuffer {
         if self.cursor >= grapheme_len(&self.text()) {
             return false;
         }
-        self.replace_graphemes(
+        self.replace_user_graphemes(
             self.cursor,
             self.cursor + 1,
             "",
@@ -196,7 +191,7 @@ impl PromptBuffer {
             seen_word |= !whitespace;
             start -= 1;
         }
-        self.replace_graphemes(start, self.cursor, "", start, "delete prompt word")
+        self.replace_user_graphemes(start, self.cursor, "", start, "delete prompt word")
     }
 
     /// Selects the previous submitted prompt while preserving the current draft.
@@ -405,7 +400,7 @@ impl PromptBuffer {
             return match character {
                 'w' => {
                     let target = self.next_word_boundary();
-                    self.replace_graphemes(
+                    self.replace_user_graphemes(
                         self.cursor,
                         target,
                         "",
@@ -450,6 +445,22 @@ impl PromptBuffer {
             _ => return PromptInput::Unhandled,
         }
         PromptInput::Changed
+    }
+
+    fn replace_user_graphemes(
+        &mut self,
+        start: usize,
+        end: usize,
+        replacement: &str,
+        cursor: usize,
+        label: &str,
+    ) -> bool {
+        let changed = self.replace_graphemes(start, end, replacement, cursor, label);
+        if changed {
+            self.history_position = None;
+            self.history_draft = None;
+        }
+        changed
     }
 
     fn replace_graphemes(
@@ -798,6 +809,73 @@ mod tests {
         assert_eq!(prompt.text(), "older");
         assert!(prompt.history_next());
         assert_eq!(prompt.text(), "newer\nentry");
+        assert!(prompt.history_next());
+        assert_eq!(prompt.text(), "unsent draft");
+    }
+
+    #[test]
+    fn history_navigation_detaches_after_successful_prompt_deletions() {
+        type PromptEdit = fn(&mut PromptBuffer) -> bool;
+
+        let scenarios: [(&str, PromptEdit, &str); 4] = [
+            ("backspace", PromptBuffer::backspace, "recalled entr"),
+            (
+                "delete",
+                |prompt| {
+                    prompt.set_cursor(0);
+                    prompt.delete()
+                },
+                "ecalled entry",
+            ),
+            (
+                "delete previous word",
+                PromptBuffer::delete_previous_word,
+                "recalled ",
+            ),
+            (
+                "Vim dw",
+                |prompt| {
+                    prompt.set_cursor(0);
+                    prompt.set_mode(Mode::Normal);
+                    assert_eq!(
+                        prompt.handle_event(&key(KeyCode::Char('d'), KeyModifiers::NONE), 40),
+                        PromptInput::Changed
+                    );
+                    prompt.handle_event(&key(KeyCode::Char('w'), KeyModifiers::NONE), 40)
+                        == PromptInput::Changed
+                },
+                "entry",
+            ),
+        ];
+
+        for (name, edit, expected) in scenarios {
+            let mut prompt =
+                PromptBuffer::with_history("unsent draft", vec!["recalled entry".to_string()]);
+
+            assert!(prompt.history_previous(), "{name}: recall prompt");
+            assert!(edit(&mut prompt), "{name}: apply deletion");
+            assert_eq!(prompt.text(), expected, "{name}: preserve edited text");
+            assert!(
+                !prompt.history_next(),
+                "{name}: deletion must detach history navigation"
+            );
+            assert_eq!(prompt.text(), expected, "{name}: keep edited draft");
+
+            assert!(prompt.history_previous(), "{name}: restart navigation");
+            assert_eq!(prompt.text(), "recalled entry");
+            assert!(prompt.history_next(), "{name}: restore edited draft");
+            assert_eq!(prompt.text(), expected);
+        }
+    }
+
+    #[test]
+    fn unsuccessful_prompt_deletion_preserves_history_navigation() {
+        let mut prompt =
+            PromptBuffer::with_history("unsent draft", vec!["recalled entry".to_string()]);
+
+        assert!(prompt.history_previous());
+        prompt.set_cursor(0);
+        assert!(!prompt.backspace());
         assert!(prompt.history_next());
         assert_eq!(prompt.text(), "unsent draft");
     }

--- a/src/ui/rich_text.rs
+++ b/src/ui/rich_text.rs
@@ -1,0 +1,85 @@
+//! Grapheme-safe painting for the existing parsed Markdown span model.
+
+use crate::{
+    editor::RenderBuffer,
+    plugin::markdown::{RenderedTextLine, RenderedTextSpan},
+    theme::Style,
+    unicode_utils::{display_width, truncate_display_width},
+};
+
+/// Paints a styled line without splitting graphemes or crossing its terminal-cell bounds.
+///
+/// Callers retain ownership of their surface-specific theme, background, link selection,
+/// and syntax-highlighting policies.
+pub(crate) fn paint_rich_text(
+    buffer: &mut RenderBuffer,
+    x: usize,
+    y: usize,
+    width: usize,
+    line: &RenderedTextLine,
+    mut resolve_style: impl FnMut(&RenderedTextSpan) -> Style,
+) {
+    let mut used = 0_usize;
+    for span in &line.spans {
+        if used >= width {
+            break;
+        }
+        let text = truncate_display_width(&span.text, width.saturating_sub(used));
+        if text.is_empty() {
+            continue;
+        }
+        buffer.set_text(x.saturating_add(used), y, &text, &resolve_style(span));
+        used = used.saturating_add(display_width(&text));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        editor::RenderBuffer,
+        plugin::markdown::{RenderedTextLine, RenderedTextSpan, TextPanelSpanStyle},
+        theme::Style,
+    };
+
+    use super::paint_rich_text;
+
+    #[test]
+    fn rich_text_painting_clips_at_complete_graphemes() {
+        let style = Style::default();
+        let mut buffer = RenderBuffer::new(8, 1, &style);
+        let line = RenderedTextLine {
+            spans: vec![
+                RenderedTextSpan {
+                    text: "a👨‍👩‍👧".to_string(),
+                    style: TextPanelSpanStyle::Text,
+                    syntax_style: None,
+                    link: None,
+                },
+                RenderedTextSpan {
+                    text: "世z".to_string(),
+                    style: TextPanelSpanStyle::Strong,
+                    syntax_style: None,
+                    link: None,
+                },
+            ],
+        };
+
+        paint_rich_text(&mut buffer, 1, 0, 5, &line, |_| style.clone());
+
+        assert_eq!(buffer.cells[1].c, 'a');
+        assert_eq!(buffer.cells[2].c, '👨');
+        assert_eq!(buffer.cells[4].c, '世');
+        assert_eq!(buffer.cells[6].c, ' ');
+    }
+
+    #[test]
+    fn zero_width_rich_text_does_not_modify_the_surface() {
+        let style = Style::default();
+        let mut buffer = RenderBuffer::new(3, 1, &style);
+        let line = RenderedTextLine::plain("unchanged".to_string(), TextPanelSpanStyle::Text);
+
+        paint_rich_text(&mut buffer, 0, 0, 0, &line, |_| style.clone());
+
+        assert!(buffer.cells.iter().all(|cell| cell.c == ' '));
+    }
+}

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -1,0 +1,227 @@
+//! Selection and scrolling state shared by fixed-height terminal lists.
+
+/// Keeps a selected row visible in a bounded list viewport.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SelectionViewport {
+    selected: usize,
+    top: usize,
+    len: usize,
+    height: usize,
+}
+
+impl SelectionViewport {
+    /// Creates a selection for a list with the given row count and viewport height.
+    #[must_use]
+    pub(crate) const fn new(len: usize, height: usize) -> Self {
+        Self {
+            selected: 0,
+            top: 0,
+            len,
+            height,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn selected(self) -> usize {
+        self.selected
+    }
+
+    #[must_use]
+    pub(crate) const fn top(self) -> usize {
+        self.top
+    }
+
+    #[must_use]
+    pub(crate) const fn len(self) -> usize {
+        self.len
+    }
+
+    /// Replaces the list and returns selection and scrolling to the first row.
+    pub(crate) fn reset(&mut self, len: usize) {
+        self.len = len;
+        self.selected = 0;
+        self.top = 0;
+    }
+
+    /// Updates viewport height while keeping the current selection visible.
+    pub(crate) fn set_height(&mut self, height: usize) {
+        self.height = height;
+        self.ensure_visible();
+    }
+
+    /// Selects a bounded row and adjusts the visible window.
+    pub(crate) fn select(&mut self, index: usize) {
+        if self.len == 0 {
+            self.selected = 0;
+            self.top = 0;
+            return;
+        }
+        self.selected = index.min(self.len.saturating_sub(1));
+        self.ensure_visible();
+    }
+
+    /// Moves by a signed row count without overflowing terminal coordinates.
+    pub(crate) fn move_by(&mut self, delta: isize) {
+        if self.len == 0 {
+            return;
+        }
+        let selected = if delta.is_negative() {
+            self.selected.saturating_sub(delta.unsigned_abs())
+        } else {
+            self.selected.saturating_add(delta as usize)
+        };
+        self.select(selected);
+    }
+
+    fn ensure_visible(&mut self) {
+        if self.len == 0 {
+            self.selected = 0;
+            self.top = 0;
+        } else if self.height == 0 || self.selected < self.top {
+            self.top = self.selected;
+        } else if self.selected >= self.top.saturating_add(self.height) {
+            self.top = self.selected.saturating_sub(self.height.saturating_sub(1));
+        }
+    }
+}
+
+/// Tracks a streaming transcript without overriding manually interrupted tail following.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FollowTailViewport {
+    offset: usize,
+    following: bool,
+}
+
+impl Default for FollowTailViewport {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            following: true,
+        }
+    }
+}
+
+impl FollowTailViewport {
+    #[must_use]
+    pub(crate) const fn offset(self) -> usize {
+        self.offset
+    }
+
+    #[must_use]
+    pub(crate) const fn is_following(self) -> bool {
+        self.following
+    }
+
+    #[must_use]
+    pub(crate) fn visible_offset(self, maximum: usize) -> usize {
+        if self.following {
+            maximum
+        } else {
+            self.offset.min(maximum)
+        }
+    }
+
+    pub(crate) fn restore(&mut self, offset: usize, following: bool) {
+        self.offset = offset;
+        self.following = following;
+    }
+
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    pub(crate) fn move_by(&mut self, delta: isize, maximum: usize) {
+        self.offset = self.offset.saturating_add_signed(delta).min(maximum);
+        self.following = self.offset == maximum;
+    }
+
+    pub(crate) fn scroll_to_top(&mut self) {
+        self.offset = 0;
+        self.following = false;
+    }
+
+    pub(crate) fn follow(&mut self, maximum: usize) {
+        self.offset = maximum;
+        self.following = true;
+    }
+
+    pub(crate) fn clamp(&mut self, maximum: usize) {
+        self.offset = self.offset.min(maximum);
+    }
+
+    pub(crate) fn reveal(&mut self, row: usize, visible_rows: usize) {
+        self.following = false;
+        if row < self.offset {
+            self.offset = row;
+        } else if row >= self.offset.saturating_add(visible_rows) {
+            self.offset = row.saturating_sub(visible_rows.saturating_sub(1));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FollowTailViewport, SelectionViewport};
+
+    #[test]
+    fn movement_keeps_selection_inside_the_viewport() {
+        let mut viewport = SelectionViewport::new(12, 3);
+
+        viewport.move_by(5);
+        assert_eq!((viewport.selected(), viewport.top()), (5, 3));
+
+        viewport.move_by(-4);
+        assert_eq!((viewport.selected(), viewport.top()), (1, 1));
+    }
+
+    #[test]
+    fn resizing_and_reset_keep_selection_bounded() {
+        let mut viewport = SelectionViewport::new(8, 5);
+        viewport.select(7);
+
+        viewport.set_height(2);
+        assert_eq!((viewport.selected(), viewport.top()), (7, 6));
+
+        viewport.reset(0);
+        assert_eq!(
+            (viewport.selected(), viewport.top(), viewport.len()),
+            (0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn empty_and_zero_height_viewports_do_not_underflow() {
+        let mut empty = SelectionViewport::new(0, 0);
+        empty.move_by(isize::MIN);
+        assert_eq!((empty.selected(), empty.top()), (0, 0));
+
+        let mut hidden = SelectionViewport::new(4, 0);
+        hidden.select(3);
+        assert_eq!((hidden.selected(), hidden.top()), (3, 3));
+    }
+
+    #[test]
+    fn streaming_viewport_follows_growth_until_manual_scroll() {
+        let mut viewport = FollowTailViewport::default();
+        viewport.follow(8);
+        assert_eq!((viewport.offset(), viewport.is_following()), (8, true));
+
+        viewport.scroll_to_top();
+        assert_eq!(viewport.visible_offset(12), 0);
+        assert!(!viewport.is_following());
+
+        viewport.move_by(12, 12);
+        assert_eq!((viewport.offset(), viewport.is_following()), (12, true));
+    }
+
+    #[test]
+    fn revealing_a_link_interrupts_following_and_keeps_it_visible() {
+        let mut viewport = FollowTailViewport::default();
+        viewport.follow(10);
+
+        viewport.reveal(2, 4);
+
+        assert_eq!(viewport.offset(), 2);
+        assert!(!viewport.is_following());
+    }
+}

--- a/src/unicode_utils.rs
+++ b/src/unicode_utils.rs
@@ -15,6 +15,15 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthChar;
 use unicode_width::UnicodeWidthStr;
 
+/// The side on which hidden terminal text is replaced by an overflow marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TruncationSide {
+    /// Preserve the end of the text and place the marker on the left.
+    Left,
+    /// Preserve the beginning of the text and place the marker on the right.
+    Right,
+}
+
 /// Calculate the display width of a string in terminal columns
 pub fn display_width(s: &str) -> usize {
     s.width()
@@ -187,6 +196,59 @@ pub fn truncate_display_width(s: &str, max_width: usize) -> String {
     s.to_owned()
 }
 
+/// Return the longest complete-grapheme suffix that fits `max_width` cells.
+pub fn truncate_display_width_from_end(text: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+
+    let mut start = text.len();
+    let mut used = 0;
+    for (index, grapheme) in text.grapheme_indices(true).rev() {
+        let next = used + display_width(grapheme);
+        if next > max_width {
+            break;
+        }
+        used = next;
+        start = index;
+    }
+
+    text[start..].to_owned()
+}
+
+/// Clip at a complete grapheme and display a bounded, caller-selected marker.
+///
+/// Text that already fits is returned unchanged. The marker is itself clipped
+/// to the available terminal cells so zero-width and narrow surfaces are safe.
+pub fn truncate_display_width_with_marker(
+    text: &str,
+    max_width: usize,
+    marker: &str,
+    side: TruncationSide,
+) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    if display_width(text) <= max_width {
+        return text.to_owned();
+    }
+
+    let marker = truncate_display_width(marker, max_width);
+    let content_width = max_width.saturating_sub(display_width(&marker));
+    match side {
+        TruncationSide::Left => {
+            let mut result = marker;
+            result.push_str(&truncate_display_width_from_end(text, content_width));
+            result
+        }
+        TruncationSide::Right => {
+            let mut result = truncate_display_width(text, content_width);
+            result.push_str(&marker);
+            result
+        }
+    }
+}
+
 /// Pad or truncate a string so it occupies exactly `width` display columns.
 pub fn fit_display_width(s: &str, width: usize) -> String {
     let mut result = truncate_display_width(s, width);
@@ -357,6 +419,37 @@ mod tests {
         assert_eq!(fit_display_width("a👋b", 3), "a👋");
         assert_eq!(fit_display_width("a👋b", 5), "a👋b ");
         assert_eq!(fit_display_width("👨‍👩‍👧‍👦x", 2), "👨‍👩‍👧‍👦");
+    }
+
+    #[test]
+    fn suffix_truncation_preserves_complete_graphemes() {
+        assert_eq!(truncate_display_width_from_end("a👨‍👩‍👧‍👦世z", 4), "世z");
+        assert_eq!(truncate_display_width_from_end("e\u{301}👋x", 3), "👋x");
+        assert_eq!(truncate_display_width_from_end("visible", 0), "");
+    }
+
+    #[test]
+    fn marker_truncation_preserves_configured_direction_and_width() {
+        assert_eq!(
+            truncate_display_width_with_marker("src/👨‍👩‍👧‍👦/function", 10, "…", TruncationSide::Left,),
+            "…/function"
+        );
+        assert_eq!(
+            truncate_display_width_with_marker("ab👋cd", 5, "…", TruncationSide::Right,),
+            "ab👋…"
+        );
+        assert_eq!(
+            truncate_display_width_with_marker("visible", 2, "...", TruncationSide::Right,),
+            ".."
+        );
+        assert_eq!(
+            truncate_display_width_with_marker("fit", 5, "…", TruncationSide::Right),
+            "fit"
+        );
+        assert_eq!(
+            truncate_display_width_with_marker("hidden", 0, "…", TruncationSide::Left),
+            ""
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Red's dialogs, floating and docked composers, pickers, completions, panels, overlays, and plugin workspaces independently implemented prompt editing, action hints, scrolling, geometry, icons, Unicode clipping, and frame rendering. That duplication made narrow terminals, theme changes, streamed content, and document-aware highlighting inconsistent and difficult to maintain.

## What changed

- Introduce concrete shared UI primitives: a real rope-backed `PromptBuffer`, responsive `UiAction`/`ActionBar`, selection and follow-tail viewports, half-open `ScreenRect` geometry, Markdown rich-text painting, and a centralized icon catalog.
- Migrate floating composers, docked panel composers, single-line input, picker selection, LSP completions, plugin workspaces, and file icons onto the appropriate shared primitive without introducing a general-purpose widget framework.
- Keep the floating composer deliberately right-aligned so code remains visible on the left; preserve multiline editing, Vim modes, grapheme-aware cursor movement, undo/redo, prompt history, and Ctrl+Enter submission.
- Recompose visible overlays on every frame and route incremental edits through the existing document-aware window renderer so overlays and multiline syntax highlighting remain correct.
- Unify themed dialog and popup frames, responsive action hints, rounded completion borders, grapheme-safe truncation, and splash-screen display-width calculations.
- Verify the plugin host API against runtime dispatch in both directions and document component ownership and intentionally separate follow-up work in `docs/UI_ARCHITECTURE.md`.

This is a standalone UI refactor based directly on `master`. It contains no parallel-agent foundation commits, agent-workspace backend, worktree or checkpoint changes, or plugin host-contract expansion.

## How to Test

1. Exercise the shared components and the sensitive agent-composer regression:

   ```sh
   cargo test --lib ui::
   cargo test -p red --lib agent_composer_never_uses_picker_history_or_records_prompt_input
   cargo test --lib runtime_dispatch_is_covered_by_the_machine_readable_schema
   ```

   Expected: prompt history, Unicode editing, responsive actions, picker/completion behavior, right-aligned composer geometry, Ctrl+Enter submission, and bidirectional plugin-schema parity all pass.

2. Run the complete workspace and repository quality gates:

   ```sh
   cargo fmt --check
   cargo test --workspace --all-targets --all-features
   cargo clippy --all-targets --all-features -- -D warnings
   ```

   Expected: all workspace tests pass and formatting and Clippy report no warnings or errors.

3. Open the floating agent composer, enter a multiline Unicode draft, resize the terminal, and submit using Ctrl+Enter.

   Expected: Enter inserts a newline, the composer remains right-aligned, the editor remains visible on the left, and the exact draft is submitted without leaking into picker history.

4. Scroll upward in a streaming text panel and resize the editor while an overlay is visible.

   Expected: new transcript content does not interrupt manual scroll position, complete Unicode graphemes remain visible, and the overlay persists across subsequent rendered frames.
