### PR TITLE
fix(editor): make global hotkeys work from panels

### DIFF
--- a/almanac/architecture/commands/command-discovery.md
+++ b/almanac/architecture/commands/command-discovery.md
@@ -18,6 +18,12 @@ sources:
   - id: plugin-runtime
     type: file
     path: src/plugin/runtime.rs
+  - id: plugin-api
+    type: file
+    path: src/plugin/api.rs
+  - id: neotree-plugin
+    type: file
+    path: plugins/neotree.hk
 ---
 
 # Command Discovery
@@ -50,12 +56,14 @@ The same module produces delayed keymap hints for nested key prefixes. `keymap_h
 
 ## Panel-Focused Key Dispatch
 
-Configured normal-mode bindings are not automatically global when a plugin panel owns focus. After dialogs, workspace mode, command mode, and search mode have had a chance to handle input, `process_editor_event` gives focused panels their own event path and only falls back to `panel_global_key_action` for editor actions admitted by `key_action_runs_from_panel` [@editor-dispatch]. This lets panel-local keys such as row navigation, expansion, activation, toggles, and close stay local while selected editor-level commands still work from a focused panel [@editor-dispatch].
+Configured normal-mode bindings are not automatically global when a plugin panel owns focus. After dialogs, workspace mode, command mode, and search mode have had a chance to handle input, `process_editor_event` gives focused panels their own event path and only falls back to `panel_global_key_action` for actions admitted by `action_runs_from_panel` [@editor-dispatch]. This lets panel-local keys such as row navigation, expansion, activation, toggles, and close stay local while selected editor-level commands still work from a focused panel [@editor-dispatch].
 
-The panel-global allowlist currently admits command/search entry, plugin commands, the command palette, next/previous window focus, and nested mappings whose descendants include an admitted action; the `Ctrl-w` nested prefix is returned before that recursive check so window-prefix continuations can be collected while a panel is focused [@editor-dispatch]. The default normal map binds `Ctrl-p` to `FilePicker` and `Ctrl-z` to `Suspend`, but those built-in actions are not in the panel-global allowlist, while plugin launchers such as `Ctrl-j` buffer picker and `Ctrl-e` Neo-tree are admitted because all `Action::PluginCommand(_)` values pass the allowlist [@default-config] [@editor-dispatch]. A future binding that should work from panels therefore needs both a normal-mode keymap entry and an explicit panel-global dispatch decision unless it is a plugin command or already inside the admitted command/search, palette, or focus-navigation set [@editor-dispatch].
+Panel-local handling comes first. Row panels prefer unmodified character keys other than `:` and `;`, so a user mapping such as normal-mode `x = FilePicker` does not steal a row-panel `x` action [@editor-dispatch]. The editor also reserves explicit panel chords such as row-panel `Ctrl-r` before trying the global normal-mode map, which lets Neo-tree clear its clipboard even if the user maps `Ctrl-r` globally [@editor-dispatch] [@default-config] [@neotree-plugin]. Other modified keys can fall through to `panel_global_key_action`, so global defaults such as `Ctrl-p` for `FilePicker`, `Ctrl-z` for `Suspend`, and `F1` for the command palette still work from a focused panel [@default-config] [@editor-dispatch].
+
+The panel-global allowlist currently admits command/search entry, file picker, command palette, configuration diagnostics, suspend, logs, plugin listing, window and split management, and nested mappings whose descendants include an admitted action [@editor-dispatch]. Plugin commands are admitted only when the active runtime reports `CommandScope::Global` for that command; an unscoped or missing plugin command remains editor-scoped even if it has a normal-mode key binding [@editor-dispatch] [@plugin-runtime]. A future binding that should work from panels therefore needs both a normal-mode keymap entry and either an allowlisted editor action or plugin command metadata with `scope = "global"` [@editor-dispatch] [@plugin-runtime].
 
 ## Plugin Command Metadata
 
-Plugins register command discovery data through the runtime's `CommandMetadata`, which carries optional title, category, description, and alias fields [@plugin-runtime]. `Runtime::registered_commands` returns active command records with command name, owning plugin, callback, and metadata sorted by command name for stable discovery UI [@plugin-runtime]. Because palette entries retain the owning plugin in their ids, duplicate command names have deterministic runtime behavior before discovery surfaces display them [@plugin-runtime].
+Plugins register command discovery data through the runtime's `CommandMetadata`, which carries optional title, category, description, aliases, visibility, and panel key-dispatch scope [@plugin-runtime]. Declarative `#[red::command]` metadata accepts `scope = "editor"` or `scope = "global"` and defaults to editor scope, while imperative `red::add_command` metadata is deserialized into the same runtime structure [@plugin-api] [@plugin-runtime]. `Runtime::registered_commands` returns active command records with command name, owning plugin, callback, and metadata sorted by command name for stable discovery UI, and `Runtime::command_scope` is the editor's lookup path when deciding whether a plugin command may run from focused panels [@plugin-runtime] [@editor-dispatch]. Because palette entries retain the owning plugin in their ids, duplicate command names have deterministic runtime behavior before discovery surfaces display them [@plugin-runtime].
 
 This command system does not make colon syntax a general shell. Arguments are split simply, command names are case-sensitive where plugin names are involved, and plugin command execution stays behind the plugin host boundary [@command-parser] [@editor-dispatch]. The CLI-level command surface is documented in [Red Command](../../reference/cli/red-command), and exact default keymaps and plugin command bindings belong in [Default Config](../../reference/configuration/default-config).

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.6.0` is defined by
+Red host API version `0.7.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -24,9 +24,9 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 annotations use `HUSK-A0004`. `--no-typecheck` is an unsupported development
 escape hatch; compatibility guarantees do not apply while it is enabled.
 
-Red `0.6.0` retains the complete `0.4.0` contract, so existing packages that
-declare `"red_api_version": "^0.4.0"` continue to load. New packages should
-target `"red_api_version": "^0.6.0"` to use the external-package primitives.
+Red `0.7.0` retains the complete `0.4.0` and `0.6.0` contracts, so existing
+packages that declare either minor continue to load. New packages should target
+`"red_api_version": "^0.7.0"` to use global command scope.
 
 ## External package primitives
 
@@ -134,7 +134,8 @@ string-array `aliases` field. `visible = false` hides a command from the command
 palette and colon completion without disabling direct invocation or keymaps.
 The optional `scope` is `"editor"` by default. Set it to `"global"` only for
 commands that are safe and meaningful when a plugin panel owns focus, such as
-workspace pickers or pane toggles.
+workspace pickers or pane toggles. Packages using command scope must declare
+`"red_api_version": "^0.7.0"`.
 `#[red::on]` takes exactly one nonempty event-name string and requires a
 one-argument function. A function may subscribe to multiple distinct events by
 repeating `#[red::on(...)]`.
@@ -224,7 +225,7 @@ payloads use the declared `PickerItem`, `PickerCancelled`, and `PickerActionEven
 the `PickerItem.data` field remains `Json` so a plugin can attach its own payload.
 
 `OpenPicker` was added in host API `0.3.0`. New plugins targeting this Red release should
-declare `"red_api_version": "^0.6.0"`. The numeric-ID `OpenDynamicPicker` API remains
+declare `"red_api_version": "^0.7.0"`. The numeric-ID `OpenDynamicPicker` API remains
 available for compatibility, but new plugins should not use it.
 
 ## Agent composer

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -111,6 +111,7 @@ fn configuration_loaded(event: Json) {
     category = "LSP",
     description = "Find symbols in the current document",
     aliases = ["outline", "symbols"],
+    scope = "global",
 )]
 fn document_symbols() {
     red::request("DocumentSymbols", show_document_symbols);
@@ -131,6 +132,9 @@ fn stop_background_work() {
 optional string `title`, `category`, and `description` fields plus an optional
 string-array `aliases` field. `visible = false` hides a command from the command
 palette and colon completion without disabling direct invocation or keymaps.
+The optional `scope` is `"editor"` by default. Set it to `"global"` only for
+commands that are safe and meaningful when a plugin panel owns focus, such as
+workspace pickers or pane toggles.
 `#[red::on]` takes exactly one nonempty event-name string and requires a
 one-argument function. A function may subscribe to multiple distinct events by
 repeating `#[red::on(...)]`.
@@ -174,12 +178,18 @@ Annotations are supported on top-level functions only, including functions in
 package source modules. Other attribute namespaces are ignored by Red.
 
 `red::add_command(name, callback[, metadata])` accepts an optional `Json` object
-with `title`, `category`, `description`, `aliases: [String]`, and `visible:
-bool`. Red uses visible commands to populate the command palette; aliases are
-search terms and do not create alternate colon commands. The palette shows the
-exact, case-sensitive `:Name` invocation when it is available and resolves
-keymaps from the user's effective configuration. Existing two-argument
-registrations continue to work. Imperative `red::add_command` and `red::on`
+with `title`, `category`, `description`, `aliases: [String]`, `visible: bool`,
+and `scope`. Red uses visible commands to populate the command palette; aliases
+are search terms and do not create alternate colon commands. The palette shows
+the exact, case-sensitive `:Name` invocation when it is available and resolves
+keymaps from the user's effective configuration.
+
+The optional scope is `"editor"` by default. Set it to `"global"` only for
+commands that are safe and meaningful when a plugin panel owns focus, such as
+workspace pickers or pane toggles. Global commands use the configured
+normal-mode binding from focused panels, subject to keys reserved by that
+panel's own input handling. Existing two-argument registrations and metadata
+without a scope continue to work. Imperative `red::add_command` and `red::on`
 remain supported for dynamic or conditional registrations, including
 process-specific and filesystem-watch-specific event names.
 

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -80,11 +80,15 @@ Direct `:Name` invocation requires an exact, case-sensitive registered name and 
 currently pass arguments to the callback. Built-in commands and their abbreviations take
 precedence over plugin commands with the same name.
 
-The optional command metadata object accepts `title`, `category`, `description`,
-`aliases`, and `visible`. All fields are optional; `aliases` is an array of
+The optional command metadata accepts `title`, `category`, `description`,
+`aliases`, `visible`, and `scope`, whether declared with `#[red::command]` or
+passed to `red::add_command`. All fields are optional; `aliases` is an array of
 additional search terms, not alternate colon commands. `visible = false` hides
 a command from the palette and colon completion without disabling direct
-invocation. Existing two-argument registrations remain valid.
+invocation. `scope = "global"` allows a configured normal-mode binding to invoke
+a command while a plugin panel owns focus; the default `"editor"` scope keeps
+keymap dispatch local to the editor surface. Existing two-argument
+registrations remain valid.
 
 Use `red::request` for actions that return a value:
 

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.6.0",
+  "api_version": "0.7.0",
   "changes": [
+    {
+      "version": "0.7.0",
+      "kind": "introduced",
+      "symbols": ["CommandMetadata.scope", "#[red::command(scope)]"],
+      "migration_note": "docs/PLUGIN_API.md#declarative-plugin-authoring"
+    },
     {
       "version": "0.6.0",
       "kind": "introduced",

--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -300,6 +300,7 @@ fn state() -> AgentState {
     category = "Agent",
     description = "Start a new agent session",
     aliases = ["new chat"],
+    scope = "global",
 )]
 fn start() {
     red::request("GetConfig", cwd_loaded, "cwd");
@@ -348,6 +349,7 @@ fn session_created(event: AgentSessionEvent) {
     category = "Agent",
     description = "Open the agent prompt",
     aliases = ["ask ai", "chat"],
+    scope = "global",
 )]
 #[red::command(
     name = "AgentPrompt",
@@ -355,6 +357,7 @@ fn session_created(event: AgentSessionEvent) {
     category = "Agent",
     description = "Ask a question in the active agent session",
     aliases = ["ask ai", "chat"],
+    scope = "global",
 )]
 fn prompt() {
     if red::string(state().session_id, "") != "" {
@@ -369,6 +372,7 @@ fn prompt() {
     category = "Agent",
     description = "Show and focus the conversation pane without opening a prompt",
     aliases = ["show chat", "open chat"],
+    scope = "global",
 )]
 fn open_conversation() {
     let was_created = state().panel_created;
@@ -822,6 +826,7 @@ fn panel_event(event: AgentPanelEvent) {
     category = "Agent",
     description = "Clear the visible conversation while preserving context",
     aliases = ["clear chat"],
+    scope = "global",
 )]
 fn clear_conversation() {
     reset_stream_render();
@@ -852,6 +857,7 @@ fn reset_stream_render() {
     category = "Agent",
     description = "Hide the conversation pane without ending the session",
     aliases = ["hide chat"],
+    scope = "global",
 )]
 fn close_conversation() {
     if state().panel_open {
@@ -867,6 +873,7 @@ fn close_conversation() {
     category = "Agent",
     description = "Reset the session and start a new conversation",
     aliases = ["new conversation"],
+    scope = "global",
 )]
 fn new_conversation() {
     let session_id = red::string(state().session_id, "");
@@ -898,6 +905,7 @@ fn prompt_cancelled(event: ComposerCancelled) {}
     category = "Agent",
     description = "Cancel the active agent request",
     aliases = ["stop agent"],
+    scope = "global",
 )]
 fn cancel() {
     let session_id = state().session_id;
@@ -1377,6 +1385,7 @@ fn bounded_transcript_blocks(blocks: [AgentTextBlock], keep_id: String) -> Bound
     category = "Agent",
     description = "Review changes proposed by the agent",
     aliases = ["proposals"],
+    scope = "global",
 )]
 fn review() {
     red::state_patch(AgentState { review_open: true });
@@ -1588,6 +1597,7 @@ fn proposal_conflict(event: AgentProposalConflictEvent) {
     category = "Agent",
     description = "Inspect previous agent transactions",
     aliases = ["transactions"],
+    scope = "global",
 )]
 fn history() {
     red::state_patch(AgentState { history_open: true });

--- a/plugins/buffer_picker.hk
+++ b/plugins/buffer_picker.hk
@@ -32,6 +32,7 @@ struct BufferPickerHandlers {
     category = "Buffer",
     description = "Find and switch between open buffers",
     aliases = ["buffers"],
+    scope = "global",
 )]
 fn buffer_picker() {
     red::request("GetEditorInfo", editor_info_loaded);

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -416,6 +416,7 @@ fn empty_state() -> GitState {
     category = "Git",
     description = "Inspect and manage workspace changes",
     aliases = ["source control", "status"],
+    scope = "global",
 )]
 fn dashboard() {
     if plugin_state().dashboard_open {

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -138,6 +138,7 @@ fn symbol_icon(kind: String) -> Json {
     category = "LSP",
     description = "Find symbols in the current document",
     aliases = ["outline", "symbols"],
+    scope = "global",
 )]
 fn document_symbols() {
     begin_symbol_flow();
@@ -153,6 +154,7 @@ fn document_symbols() {
     category = "LSP",
     description = "Find symbols across the workspace",
     aliases = ["symbols"],
+    scope = "global",
 )]
 fn workspace_symbols() {
     begin_symbol_flow();

--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -204,6 +204,7 @@ fn state() -> NeoTreeState {
     category = "File",
     description = "Show or hide the workspace file tree",
     aliases = ["explorer", "neotree"],
+    scope = "global",
 )]
 fn neotree() {
     if state().created {

--- a/plugins/project_search.hk
+++ b/plugins/project_search.hk
@@ -109,6 +109,7 @@ fn state() -> ProjectSearchState {
     category = "Search",
     description = "Find text across the workspace",
     aliases = ["ripgrep", "find text"],
+    scope = "global",
 )]
 fn project_search() {
     close_search_picker();

--- a/plugins/theme_browser.hk
+++ b/plugins/theme_browser.hk
@@ -59,6 +59,7 @@ fn state() -> ThemeBrowserState {
     category = "View",
     description = "Preview and select an editor theme",
     aliases = ["colorscheme", "theme"],
+    scope = "global",
 )]
 fn theme_browser() {
     red::state_patch(ThemeBrowserState { original: "" });

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -1299,6 +1299,7 @@ mod tests {
                 description: Some("Find text across the workspace".to_string()),
                 aliases: vec!["ripgrep".to_string()],
                 visible: true,
+                ..CommandMetadata::default()
             },
         };
 
@@ -1399,6 +1400,7 @@ mod tests {
                     description: Some("Inspect and manage workspace changes".to_string()),
                     aliases: vec!["source control".to_string()],
                     visible: true,
+                    ..CommandMetadata::default()
                 },
             },
             RegisteredPluginCommand {
@@ -1410,6 +1412,7 @@ mod tests {
                     description: Some("Get information together".to_string()),
                     aliases: vec![],
                     visible: true,
+                    ..CommandMetadata::default()
                 },
             },
         ];

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10556,7 +10556,11 @@ impl Editor {
 
     fn row_panel_prefers_key(event: &KeyEvent) -> bool {
         !event.modifiers.intersects(
-            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER | KeyModifiers::HYPER,
+            KeyModifiers::CONTROL
+                | KeyModifiers::ALT
+                | KeyModifiers::SUPER
+                | KeyModifiers::HYPER
+                | KeyModifiers::META,
         ) && matches!(event.code, KeyCode::Char(c) if !matches!(c, ':' | ';'))
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10849,7 +10849,12 @@ impl Editor {
             KeyAction::Repeating(_, action) => {
                 Self::collect_pending_panel_plugin_commands(action, runtime, commands);
             }
-            KeyAction::None | KeyAction::Single(_) | KeyAction::Nested(_) => {}
+            KeyAction::Nested(actions) => {
+                for action in actions.values() {
+                    Self::collect_pending_panel_plugin_commands(action, runtime, commands);
+                }
+            }
+            KeyAction::None | KeyAction::Single(_) => {}
         }
     }
 
@@ -30643,7 +30648,7 @@ while True:
     }
 
     #[tokio::test]
-    async fn focused_panel_lazy_activates_plugin_commands_before_checking_scope() {
+    async fn focused_panel_resolves_nested_lazy_commands_before_exposing_prefixes() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_plugin_requests();
         let root = tempfile::tempdir().unwrap();
@@ -30701,12 +30706,18 @@ while True:
 
         let mut editor = test_editor(40, 10);
         editor.config.keys.normal.insert(
-            "Ctrl-v".to_string(),
-            KeyAction::Single(Action::PluginCommand("LazyGlobal".to_string())),
+            "F2".to_string(),
+            KeyAction::Nested(HashMap::from([(
+                "x".to_string(),
+                KeyAction::Single(Action::PluginCommand("LazyContextual".to_string())),
+            )])),
         );
         editor.config.keys.normal.insert(
-            "Ctrl-t".to_string(),
-            KeyAction::Single(Action::PluginCommand("LazyContextual".to_string())),
+            "F3".to_string(),
+            KeyAction::Nested(HashMap::from([(
+                "x".to_string(),
+                KeyAction::Single(Action::PluginCommand("LazyGlobal".to_string())),
+            )])),
         );
         editor.test_create_panel(
             "tree",
@@ -30735,7 +30746,7 @@ while True:
 
         editor
             .process_editor_event(
-                Event::Key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL)),
+                Event::Key(KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE)),
                 &mut render_buffer,
                 &mut runtime,
                 EventRenderMode::Immediate,
@@ -30747,11 +30758,23 @@ while True:
             editor.plugin_registry.statuses().get("lazy-panel-commands"),
             Some(&plugin::PluginStatus::Active)
         );
-        assert_eq!(collect_print_requests(), ["panel fallback"]);
+        assert!(editor.waiting_key_action.is_none());
+        assert!(collect_print_requests().is_empty());
 
         editor
             .process_editor_event(
-                Event::Key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL)),
+                Event::Key(KeyEvent::new(KeyCode::F(3), KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert!(editor.waiting_key_action.is_some());
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
                 &mut render_buffer,
                 &mut runtime,
                 EventRenderMode::Immediate,

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10264,13 +10264,6 @@ impl Editor {
             if !self.panel_manager.focused_text_input_active() && self.handle_repeater(ev) {
                 return Ok(None);
             }
-            if self.panel_manager.focused_text_panel_has_composer()
-                && !self.panel_manager.focused_text_input_active()
-            {
-                if let Some(action) = self.panel_global_key_action(ev, runtime) {
-                    return Ok(Some(action));
-                }
-            }
             if let Some(action) = self.handle_panel_event(ev, runtime) {
                 return Ok(Some(action));
             }
@@ -10506,6 +10499,18 @@ impl Editor {
                     KeyCode::Left | KeyCode::Char('h') => "collapse",
                     KeyCode::Right | KeyCode::Char('l') => "expand",
                     KeyCode::Enter => "activate",
+                    KeyCode::Char(' ')
+                        if event.modifiers.is_empty()
+                            && self.panel_manager.focused_text_panel_has_composer()
+                            && !self.panel_manager.focused_text_input_active() =>
+                    {
+                        if let Some(action @ KeyAction::Nested(_)) =
+                            self.panel_global_key_action(ev, runtime)
+                        {
+                            return Some(action);
+                        }
+                        "toggle"
+                    }
                     KeyCode::Char(' ') => "toggle",
                     KeyCode::Char('q') => "close",
                     KeyCode::Char('R') => "refresh",

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8455,11 +8455,29 @@ impl Editor {
         let mut drain_repeated_motion = false;
 
         let from_waiting_key_action = self.waiting_key_action.is_some();
+        let started_with_panel_focus = self.panel_manager.focused_panel_id().is_some();
         let started_in_normal = self.is_normal();
         let semantic_can_start = started_in_normal || self.is_visual();
         let was_recording_macro = self.macro_recording.is_some();
         let resolve_span = perf::PerfSpan::start("event:resolve_action");
-        let action = self.handle_event_with_runtime(&ev, Some(runtime))?;
+        let mut action = self.handle_event_with_runtime(&ev, Some(runtime))?;
+        if started_with_panel_focus {
+            let pending_commands = action.as_ref().map_or_else(Vec::new, |action| {
+                Self::pending_panel_plugin_commands(action, runtime)
+            });
+            if !pending_commands.is_empty() {
+                for command in pending_commands {
+                    self.plugin_registry
+                        .ensure_command_registered(runtime, &command)
+                        .await;
+                }
+                action = if from_waiting_key_action {
+                    action.and_then(|action| self.key_action_for_panel(&action, Some(runtime)))
+                } else {
+                    self.handle_event_with_runtime(&ev, Some(runtime))?
+                };
+            }
+        }
         if !sensitive_input {
             if was_recording_macro && self.macro_recording.is_some() {
                 self.record_macro_event(&ev);
@@ -10769,34 +10787,73 @@ impl Editor {
                 _ => None,
             })?;
 
-        Self::key_action_for_panel(action, runtime)
+        self.key_action_for_panel(action, runtime)
     }
 
-    fn key_action_for_panel(action: &KeyAction, runtime: Option<&Runtime>) -> Option<KeyAction> {
+    fn key_action_for_panel(
+        &self,
+        action: &KeyAction,
+        runtime: Option<&Runtime>,
+    ) -> Option<KeyAction> {
         match action {
-            KeyAction::Single(action) => Self::action_runs_from_panel(action, runtime)
+            KeyAction::Single(action) => self
+                .action_runs_from_panel(action, runtime)
                 .then(|| KeyAction::Single(action.clone())),
             KeyAction::Multiple(actions) => actions
                 .iter()
-                .all(|action| Self::action_runs_from_panel(action, runtime))
+                .all(|action| self.action_runs_from_panel(action, runtime))
                 .then(|| KeyAction::Multiple(actions.clone())),
             KeyAction::Nested(actions) => {
                 let actions = actions
                     .iter()
                     .filter_map(|(key, action)| {
-                        Self::key_action_for_panel(action, runtime)
+                        self.key_action_for_panel(action, runtime)
                             .map(|action| (key.clone(), action))
                     })
                     .collect::<HashMap<_, _>>();
                 (!actions.is_empty()).then_some(KeyAction::Nested(actions))
             }
-            KeyAction::Repeating(times, action) => Self::key_action_for_panel(action, runtime)
+            KeyAction::Repeating(times, action) => self
+                .key_action_for_panel(action, runtime)
                 .map(|action| KeyAction::Repeating(*times, Box::new(action))),
             KeyAction::None => None,
         }
     }
 
-    fn action_runs_from_panel(action: &Action, runtime: Option<&Runtime>) -> bool {
+    fn pending_panel_plugin_commands(action: &KeyAction, runtime: &Runtime) -> Vec<String> {
+        let mut commands = Vec::new();
+        Self::collect_pending_panel_plugin_commands(action, runtime, &mut commands);
+        commands
+    }
+
+    fn collect_pending_panel_plugin_commands(
+        action: &KeyAction,
+        runtime: &Runtime,
+        commands: &mut Vec<String>,
+    ) {
+        match action {
+            KeyAction::Single(Action::PluginCommand(command)) => {
+                if runtime.command_scope(command).is_none() && !commands.contains(command) {
+                    commands.push(command.clone());
+                }
+            }
+            KeyAction::Multiple(actions) => {
+                for action in actions {
+                    if let Action::PluginCommand(command) = action {
+                        if runtime.command_scope(command).is_none() && !commands.contains(command) {
+                            commands.push(command.clone());
+                        }
+                    }
+                }
+            }
+            KeyAction::Repeating(_, action) => {
+                Self::collect_pending_panel_plugin_commands(action, runtime, commands);
+            }
+            KeyAction::None | KeyAction::Single(_) | KeyAction::Nested(_) => {}
+        }
+    }
+
+    fn action_runs_from_panel(&self, action: &Action, runtime: Option<&Runtime>) -> bool {
         match action {
             Action::EnterMode(Mode::Command | Mode::Search)
             | Action::FilePicker
@@ -10826,7 +10883,10 @@ impl Editor {
             | Action::MaximizeWindow
             | Action::OnlyWindow => true,
             Action::PluginCommand(command) => runtime.is_some_and(|runtime| {
-                runtime.command_scope(command) == Some(plugin::CommandScope::Global)
+                runtime.command_scope(command).map_or_else(
+                    || self.plugin_registry.has_pending_command(command),
+                    |scope| scope == plugin::CommandScope::Global,
+                )
             }),
             _ => false,
         }
@@ -30580,6 +30640,126 @@ while True:
             render_buffer.cells[cursor_index].style, focused_style,
             "focusing a panel should repaint the synthetic editor cursor away"
         );
+    }
+
+    #[tokio::test]
+    async fn focused_panel_lazy_activates_plugin_commands_before_checking_scope() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let root = tempfile::tempdir().unwrap();
+        let husk_root = root.path().join("husk");
+        std::fs::create_dir_all(husk_root.join("src")).unwrap();
+        std::fs::write(
+            root.path().join("red-plugin.toml"),
+            r#"
+                schema_version = 1
+
+                [plugin]
+                id = "lazy-panel-commands"
+                name = "Lazy Panel Commands"
+                version = "0.1.0"
+                red_api = "^0.7.0"
+                husk_manifest = "husk/Husk.toml"
+
+                [activation]
+                commands = ["LazyGlobal", "LazyContextual"]
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            husk_root.join("Husk.toml"),
+            r#"
+                schema_version = 1
+
+                [package]
+                name = "lazy-panel-commands"
+                version = "0.1.0"
+                entry = "src/main.hk"
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            husk_root.join("src/main.hk"),
+            r#"
+                pub fn activate() {
+                    red::add_command("LazyGlobal", run_global, Json { scope: "global" });
+                    red::add_command("LazyContextual", run_contextual);
+                    red::on("panel:event:tree", panel_event);
+                }
+
+                fn run_global() { red::execute("Print", "global command"); }
+                fn run_contextual() { red::execute("Print", "contextual command"); }
+
+                fn panel_event(event: Json) {
+                    if event.action == "Ctrl-t" {
+                        red::execute("Print", "panel fallback");
+                    }
+                }
+            "#,
+        )
+        .unwrap();
+
+        let mut editor = test_editor(40, 10);
+        editor.config.keys.normal.insert(
+            "Ctrl-v".to_string(),
+            KeyAction::Single(Action::PluginCommand("LazyGlobal".to_string())),
+        );
+        editor.config.keys.normal.insert(
+            "Ctrl-t".to_string(),
+            KeyAction::Single(Action::PluginCommand("LazyContextual".to_string())),
+        );
+        editor.test_create_panel(
+            "tree",
+            plugin::PanelConfig {
+                side: plugin::PanelSide::Left,
+                width: 10,
+                ..plugin::PanelConfig::default()
+            },
+        );
+        assert!(editor.test_focus_panel("tree"));
+        editor.plugin_registry.add(
+            "lazy-panel-commands",
+            husk_root.join("Husk.toml").to_str().unwrap(),
+        );
+        let mut runtime = Runtime::new();
+        editor
+            .plugin_registry
+            .initialize(&mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(
+            editor.plugin_registry.statuses().get("lazy-panel-commands"),
+            Some(&plugin::PluginStatus::Pending)
+        );
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            editor.plugin_registry.statuses().get("lazy-panel-commands"),
+            Some(&plugin::PluginStatus::Active)
+        );
+        assert_eq!(collect_print_requests(), ["panel fallback"]);
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(collect_print_requests(), ["global command"]);
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10490,6 +10490,12 @@ impl Editor {
                     KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                         "interrupt"
                     }
+                    KeyCode::Char('r')
+                        if self.panel_manager.focused_row_panel()
+                            && event.modifiers.contains(KeyModifiers::CONTROL) =>
+                    {
+                        "Ctrl-r"
+                    }
                     KeyCode::Char('H') => "history",
                     KeyCode::Char('N') => "new",
                     KeyCode::Char('a') if !self.panel_manager.focused_row_panel() => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10267,15 +10267,15 @@ impl Editor {
             if self.panel_manager.focused_text_panel_has_composer()
                 && !self.panel_manager.focused_text_input_active()
             {
-                if let Some(action) = self.panel_global_key_action(ev) {
+                if let Some(action) = self.panel_global_key_action(ev, runtime) {
                     return Ok(Some(action));
                 }
             }
-            if let Some(action) = self.handle_panel_event(ev) {
+            if let Some(action) = self.handle_panel_event(ev, runtime) {
                 return Ok(Some(action));
             }
 
-            if let Some(action) = self.panel_global_key_action(ev) {
+            if let Some(action) = self.panel_global_key_action(ev, runtime) {
                 return Ok(Some(action));
             }
 
@@ -10299,7 +10299,7 @@ impl Editor {
         }
 
         if matches!(ev, Event::Mouse(_)) {
-            if let Some(action) = self.handle_panel_event(ev) {
+            if let Some(action) = self.handle_panel_event(ev, runtime) {
                 return Ok(Some(action));
             }
         }
@@ -10433,7 +10433,11 @@ impl Editor {
         false
     }
 
-    fn handle_panel_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
+    fn handle_panel_event(
+        &mut self,
+        ev: &event::Event,
+        runtime: Option<&Runtime>,
+    ) -> Option<KeyAction> {
         if let Some(event) = self
             .panel_manager
             .handle_focused_text_input(ev, usize::from(self.size.0))
@@ -10506,10 +10510,25 @@ impl Editor {
                     KeyCode::Char('q') => "close",
                     KeyCode::Char('R') => "refresh",
                     _ => {
-                        if let Some(action) = self.panel_global_key_action(ev) {
+                        let action = Self::key_string_for_event(ev)?;
+                        if self.panel_manager.focused_row_panel()
+                            && Self::row_panel_prefers_key(event)
+                        {
+                            let panel_height = usize::from(self.size.1.saturating_sub(2));
+                            let scrolloff = self.config.scrolloff.unwrap_or(0);
+                            return self
+                                .panel_manager
+                                .handle_focused_key(
+                                    &action,
+                                    panel_height,
+                                    usize::from(self.size.0),
+                                    scrolloff,
+                                )
+                                .and_then(Self::panel_event_key_action);
+                        }
+                        if let Some(action) = self.panel_global_key_action(ev, runtime) {
                             return Some(action);
                         }
-                        let action = Self::key_string_for_event(ev)?;
                         let panel_height = usize::from(self.size.1.saturating_sub(2));
                         let scrolloff = self.config.scrolloff.unwrap_or(0);
                         return self
@@ -10533,6 +10552,12 @@ impl Editor {
             Event::Mouse(event) => self.handle_panel_mouse_event(event),
             _ => None,
         }
+    }
+
+    fn row_panel_prefers_key(event: &KeyEvent) -> bool {
+        !event.modifiers.intersects(
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER | KeyModifiers::HYPER,
+        ) && matches!(event.code, KeyCode::Char(c) if !matches!(c, ':' | ';'))
     }
 
     fn handle_divider_mouse_event(&mut self, event: &MouseEvent) -> Option<KeyAction> {
@@ -10712,45 +10737,82 @@ impl Editor {
             .map(|buffer| buffer.name().to_string())
     }
 
-    fn panel_global_key_action(&self, ev: &event::Event) -> Option<KeyAction> {
+    fn panel_global_key_action(
+        &self,
+        ev: &event::Event,
+        runtime: Option<&Runtime>,
+    ) -> Option<KeyAction> {
         let key = Self::key_string_for_event(ev)?;
         let action = self
             .config
             .keys
             .normal
             .get(&key)
-            .cloned()
             .or_else(|| match key.as_str() {
-                "Space" => self.config.keys.normal.get(" ").cloned(),
-                "Tab" => self.config.keys.normal.get("Tab").cloned(),
+                "Space" => self.config.keys.normal.get(" "),
+                "Tab" => self.config.keys.normal.get("Tab"),
                 _ => None,
             })?;
 
-        if key == "Ctrl-w" && matches!(action, KeyAction::Nested(_)) {
-            return Some(action);
-        }
-
-        Self::key_action_runs_from_panel(&action).then_some(action)
+        Self::key_action_for_panel(action, runtime)
     }
 
-    fn key_action_runs_from_panel(action: &KeyAction) -> bool {
+    fn key_action_for_panel(action: &KeyAction, runtime: Option<&Runtime>) -> Option<KeyAction> {
         match action {
-            KeyAction::Single(
-                Action::EnterMode(Mode::Command | Mode::Search)
-                | Action::PluginCommand(_)
-                | Action::CommandPalette
-                | Action::NextWindow
-                | Action::PreviousWindow,
-            ) => true,
-            KeyAction::Multiple(actions) => actions.iter().any(|action| {
-                matches!(
-                    action,
-                    Action::EnterMode(Mode::Command | Mode::Search)
-                        | Action::PluginCommand(_)
-                        | Action::CommandPalette
-                )
+            KeyAction::Single(action) => Self::action_runs_from_panel(action, runtime)
+                .then(|| KeyAction::Single(action.clone())),
+            KeyAction::Multiple(actions) => actions
+                .iter()
+                .all(|action| Self::action_runs_from_panel(action, runtime))
+                .then(|| KeyAction::Multiple(actions.clone())),
+            KeyAction::Nested(actions) => {
+                let actions = actions
+                    .iter()
+                    .filter_map(|(key, action)| {
+                        Self::key_action_for_panel(action, runtime)
+                            .map(|action| (key.clone(), action))
+                    })
+                    .collect::<HashMap<_, _>>();
+                (!actions.is_empty()).then_some(KeyAction::Nested(actions))
+            }
+            KeyAction::Repeating(times, action) => Self::key_action_for_panel(action, runtime)
+                .map(|action| KeyAction::Repeating(*times, Box::new(action))),
+            KeyAction::None => None,
+        }
+    }
+
+    fn action_runs_from_panel(action: &Action, runtime: Option<&Runtime>) -> bool {
+        match action {
+            Action::EnterMode(Mode::Command | Mode::Search)
+            | Action::FilePicker
+            | Action::CommandPalette
+            | Action::ConfigDiagnostics
+            | Action::Suspend
+            | Action::ViewLogs
+            | Action::ListPlugins
+            | Action::SplitHorizontal
+            | Action::SplitVertical
+            | Action::CloseWindow
+            | Action::NextWindow
+            | Action::PreviousWindow
+            | Action::MoveWindowUp
+            | Action::MoveWindowDown
+            | Action::MoveWindowLeft
+            | Action::MoveWindowRight
+            | Action::MoveWindowToLeft
+            | Action::MoveWindowToBottom
+            | Action::MoveWindowToTop
+            | Action::MoveWindowToRight
+            | Action::ResizeWindowUp(_)
+            | Action::ResizeWindowDown(_)
+            | Action::ResizeWindowLeft(_)
+            | Action::ResizeWindowRight(_)
+            | Action::BalanceWindows
+            | Action::MaximizeWindow
+            | Action::OnlyWindow => true,
+            Action::PluginCommand(command) => runtime.is_some_and(|runtime| {
+                runtime.command_scope(command) == Some(plugin::CommandScope::Global)
             }),
-            KeyAction::Nested(actions) => actions.values().any(Self::key_action_runs_from_panel),
             _ => false,
         }
     }
@@ -22700,6 +22762,15 @@ impl Editor {
     #[doc(hidden)]
     pub fn test_handle_event(&mut self, event: event::Event) -> anyhow::Result<Option<KeyAction>> {
         self.handle_event(&event)
+    }
+
+    #[doc(hidden)]
+    pub fn test_handle_event_with_runtime(
+        &mut self,
+        event: event::Event,
+        runtime: &Runtime,
+    ) -> anyhow::Result<Option<KeyAction>> {
+        self.handle_event_with_runtime(&event, Some(runtime))
     }
 }
 

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -15,8 +15,8 @@ use std::{
 
 use husk_ast::{
     Attribute, AttributeArgumentKind, AttributeValueKind, Expr, ExprKind, ExternItemKind, File,
-    ImplItemKind, ItemKind, LiteralKind, ModItemKind, Param, Span, Stmt, StmtKind, TypeExpr,
-    TypeExprKind, UnaryOp,
+    ImplItemKind, ItemKind, LiteralKind, ModItemKind, Param, PatternKind, Span, Stmt, StmtKind,
+    TypeExpr, TypeExprKind, UnaryOp,
 };
 use husk_diagnostics::{Diagnostic, Report, SourceFile};
 use once_cell::sync::Lazy;
@@ -450,27 +450,33 @@ struct RedSourceSites<'a> {
     uses_command_scope: bool,
 }
 
+#[derive(Default)]
+struct RedSourceVisitor<'a> {
+    host_calls: Vec<HostCallSite<'a>>,
+    uses_command_scope: bool,
+    command_metadata_bindings: HashMap<String, bool>,
+}
+
 fn red_source_sites(file: &File) -> RedSourceSites<'_> {
-    let mut calls = Vec::new();
-    let mut uses_command_scope = false;
+    let mut visitor = RedSourceVisitor::default();
     for item in &file.items {
         match &item.kind {
             ItemKind::Fn { body, .. } => {
-                uses_command_scope |= command_attribute_uses_scope(&item.attributes);
-                visit_statements(body, &mut calls, &mut uses_command_scope);
+                visitor.uses_command_scope |= command_attribute_uses_scope(&item.attributes);
+                visitor.visit_body(body);
             }
             ItemKind::Trait(definition) => {
                 for item in &definition.items {
                     let husk_ast::TraitItemKind::Method(method) = &item.kind;
                     if let Some(body) = &method.default_body {
-                        visit_statements(body, &mut calls, &mut uses_command_scope);
+                        visitor.visit_body(body);
                     }
                 }
             }
             ItemKind::Impl(block) => {
                 for item in &block.items {
                     if let ImplItemKind::Method(method) = &item.kind {
-                        visit_statements(&method.body, &mut calls, &mut uses_command_scope);
+                        visitor.visit_body(&method.body);
                     }
                 }
             }
@@ -483,8 +489,8 @@ fn red_source_sites(file: &File) -> RedSourceSites<'_> {
         }
     }
     RedSourceSites {
-        host_calls: calls,
-        uses_command_scope,
+        host_calls: visitor.host_calls,
+        uses_command_scope: visitor.uses_command_scope,
     }
 }
 
@@ -510,195 +516,220 @@ fn host_call_sites(file: &File) -> Vec<HostCallSite<'_>> {
     red_source_sites(file).host_calls
 }
 
-fn visit_statements<'a>(
-    statements: &'a [Stmt],
-    calls: &mut Vec<HostCallSite<'a>>,
-    uses_command_scope: &mut bool,
-) {
-    for statement in statements {
-        visit_statement(statement, calls, uses_command_scope);
+impl<'a> RedSourceVisitor<'a> {
+    fn visit_body(&mut self, statements: &'a [Stmt]) {
+        self.command_metadata_bindings.clear();
+        self.visit_statements(statements);
     }
-}
 
-fn visit_statement<'a>(
-    statement: &'a Stmt,
-    calls: &mut Vec<HostCallSite<'a>>,
-    uses_command_scope: &mut bool,
-) {
-    match &statement.kind {
-        StmtKind::Let {
-            value, else_block, ..
-        } => {
-            if let Some(value) = value {
-                visit_expression(value, calls, uses_command_scope);
-            }
-            if let Some(block) = else_block {
-                visit_statements(&block.stmts, calls, uses_command_scope);
-            }
+    fn visit_statements(&mut self, statements: &'a [Stmt]) {
+        for statement in statements {
+            self.visit_statement(statement);
         }
-        StmtKind::Assign { target, value, .. } => {
-            visit_expression(target, calls, uses_command_scope);
-            visit_expression(value, calls, uses_command_scope);
-        }
-        StmtKind::Expr(expression) | StmtKind::Semi(expression) => {
-            visit_expression(expression, calls, uses_command_scope);
-        }
-        StmtKind::Return { value } => {
-            if let Some(value) = value {
-                visit_expression(value, calls, uses_command_scope);
-            }
-        }
-        StmtKind::If {
-            cond,
-            then_branch,
-            else_branch,
-        } => {
-            visit_expression(cond, calls, uses_command_scope);
-            visit_statements(&then_branch.stmts, calls, uses_command_scope);
-            if let Some(branch) = else_branch {
-                visit_statement(branch, calls, uses_command_scope);
-            }
-        }
-        StmtKind::While { cond, body } => {
-            visit_expression(cond, calls, uses_command_scope);
-            visit_statements(&body.stmts, calls, uses_command_scope);
-        }
-        StmtKind::Loop { body } | StmtKind::Block(body) => {
-            visit_statements(&body.stmts, calls, uses_command_scope);
-        }
-        StmtKind::ForIn { iterable, body, .. } => {
-            visit_expression(iterable, calls, uses_command_scope);
-            visit_statements(&body.stmts, calls, uses_command_scope);
-        }
-        StmtKind::IfLet {
-            scrutinee,
-            then_branch,
-            else_branch,
-            ..
-        } => {
-            visit_expression(scrutinee, calls, uses_command_scope);
-            visit_statements(&then_branch.stmts, calls, uses_command_scope);
-            if let Some(branch) = else_branch {
-                visit_statement(branch, calls, uses_command_scope);
-            }
-        }
-        StmtKind::Break | StmtKind::Continue => {}
     }
-}
 
-fn visit_expression<'a>(
-    expression: &'a Expr,
-    calls: &mut Vec<HostCallSite<'a>>,
-    uses_command_scope: &mut bool,
-) {
-    match &expression.kind {
-        ExprKind::Call { callee, args, .. } => {
-            if let ExprKind::Path { segments } = &callee.kind {
-                if matches!(segments.as_slice(), [module, method] if module.name == "red" && method.name == "add_command")
-                    && args.get(2).is_some_and(|metadata| {
-                        matches!(
-                            &metadata.kind,
-                            ExprKind::Struct { fields, .. }
-                                if fields.iter().any(|field| field.name.name == "scope")
-                        )
-                    })
-                {
-                    *uses_command_scope = true;
+    fn visit_statement(&mut self, statement: &'a Stmt) {
+        match &statement.kind {
+            StmtKind::Let {
+                pattern,
+                value,
+                else_block,
+                ..
+            } => {
+                if let Some(value) = value {
+                    if let PatternKind::Binding(binding) = &pattern.kind {
+                        self.command_metadata_bindings.insert(
+                            binding.name.clone(),
+                            self.command_metadata_expression_uses_scope(value),
+                        );
+                    }
+                    self.visit_expression(value);
                 }
-                let kind = match segments.as_slice() {
-                    [module, method] if module.name == "red" && method.name == "execute" => {
-                        Some("execute")
+                if let Some(block) = else_block {
+                    self.visit_statements(&block.stmts);
+                }
+            }
+            StmtKind::Assign { target, value, .. } => {
+                self.update_command_metadata_binding(target, value);
+                self.visit_expression(target);
+                self.visit_expression(value);
+            }
+            StmtKind::Expr(expression) | StmtKind::Semi(expression) => {
+                self.visit_expression(expression);
+            }
+            StmtKind::Return { value } => {
+                if let Some(value) = value {
+                    self.visit_expression(value);
+                }
+            }
+            StmtKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                self.visit_expression(cond);
+                self.visit_statements(&then_branch.stmts);
+                if let Some(branch) = else_branch {
+                    self.visit_statement(branch);
+                }
+            }
+            StmtKind::While { cond, body } => {
+                self.visit_expression(cond);
+                self.visit_statements(&body.stmts);
+            }
+            StmtKind::Loop { body } | StmtKind::Block(body) => {
+                self.visit_statements(&body.stmts);
+            }
+            StmtKind::ForIn { iterable, body, .. } => {
+                self.visit_expression(iterable);
+                self.visit_statements(&body.stmts);
+            }
+            StmtKind::IfLet {
+                scrutinee,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                self.visit_expression(scrutinee);
+                self.visit_statements(&then_branch.stmts);
+                if let Some(branch) = else_branch {
+                    self.visit_statement(branch);
+                }
+            }
+            StmtKind::Break | StmtKind::Continue => {}
+        }
+    }
+
+    fn visit_expression(&mut self, expression: &'a Expr) {
+        match &expression.kind {
+            ExprKind::Call { callee, args, .. } => {
+                if let ExprKind::Path { segments } = &callee.kind {
+                    if matches!(segments.as_slice(), [module, method] if module.name == "red" && method.name == "add_command")
+                        && args.get(2).is_some_and(|metadata| {
+                            self.command_metadata_expression_uses_scope(metadata)
+                        })
+                    {
+                        self.uses_command_scope = true;
                     }
-                    [module, method] if module.name == "red" && method.name == "request" => {
-                        Some("request")
-                    }
-                    _ => None,
-                };
-                if let (Some(kind), Some(action)) = (kind, args.first()) {
-                    if let ExprKind::Literal(literal) = &action.kind {
-                        if let LiteralKind::String(action) = &literal.kind {
-                            calls.push(HostCallSite {
-                                kind,
-                                action,
-                                action_span: literal.span.range.start + 1
-                                    ..literal.span.range.end.saturating_sub(1),
-                                arguments: &args[1..],
-                            });
+                    let kind = match segments.as_slice() {
+                        [module, method] if module.name == "red" && method.name == "execute" => {
+                            Some("execute")
+                        }
+                        [module, method] if module.name == "red" && method.name == "request" => {
+                            Some("request")
+                        }
+                        _ => None,
+                    };
+                    if let (Some(kind), Some(action)) = (kind, args.first()) {
+                        if let ExprKind::Literal(literal) = &action.kind {
+                            if let LiteralKind::String(action) = &literal.kind {
+                                self.host_calls.push(HostCallSite {
+                                    kind,
+                                    action,
+                                    action_span: literal.span.range.start + 1
+                                        ..literal.span.range.end.saturating_sub(1),
+                                    arguments: &args[1..],
+                                });
+                            }
                         }
                     }
                 }
+                self.visit_expression(callee);
+                for argument in args {
+                    self.visit_expression(argument);
+                }
             }
-            visit_expression(callee, calls, uses_command_scope);
-            for argument in args {
-                visit_expression(argument, calls, uses_command_scope);
+            ExprKind::Field { base, .. } | ExprKind::TupleField { base, .. } => {
+                self.visit_expression(base);
             }
-        }
-        ExprKind::Field { base, .. } | ExprKind::TupleField { base, .. } => {
-            visit_expression(base, calls, uses_command_scope);
-        }
-        ExprKind::MethodCall { receiver, args, .. } => {
-            visit_expression(receiver, calls, uses_command_scope);
-            for argument in args {
-                visit_expression(argument, calls, uses_command_scope);
+            ExprKind::MethodCall { receiver, args, .. } => {
+                self.visit_expression(receiver);
+                for argument in args {
+                    self.visit_expression(argument);
+                }
             }
-        }
-        ExprKind::Unary { expr, .. } | ExprKind::Cast { expr, .. } | ExprKind::Try { expr } => {
-            visit_expression(expr, calls, uses_command_scope);
-        }
-        ExprKind::Binary { left, right, .. } => {
-            visit_expression(left, calls, uses_command_scope);
-            visit_expression(right, calls, uses_command_scope);
-        }
-        ExprKind::If {
-            cond,
-            then_branch,
-            else_branch,
-        } => {
-            visit_expression(cond, calls, uses_command_scope);
-            visit_expression(then_branch, calls, uses_command_scope);
-            visit_expression(else_branch, calls, uses_command_scope);
-        }
-        ExprKind::Match { scrutinee, arms } => {
-            visit_expression(scrutinee, calls, uses_command_scope);
-            for arm in arms {
-                visit_expression(&arm.expr, calls, uses_command_scope);
+            ExprKind::Unary { expr, .. } | ExprKind::Cast { expr, .. } | ExprKind::Try { expr } => {
+                self.visit_expression(expr);
             }
-        }
-        ExprKind::Block(block) => visit_statements(&block.stmts, calls, uses_command_scope),
-        ExprKind::Struct { fields, .. } => {
-            for field in fields {
-                visit_expression(&field.value, calls, uses_command_scope);
+            ExprKind::Binary { left, right, .. } => {
+                self.visit_expression(left);
+                self.visit_expression(right);
             }
-        }
-        ExprKind::FormatPrint { args, .. }
-        | ExprKind::Format { args, .. }
-        | ExprKind::Array { elements: args }
-        | ExprKind::Tuple { elements: args } => {
-            for argument in args {
-                visit_expression(argument, calls, uses_command_scope);
+            ExprKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                self.visit_expression(cond);
+                self.visit_expression(then_branch);
+                self.visit_expression(else_branch);
             }
-        }
-        ExprKind::Closure { body, .. } => visit_expression(body, calls, uses_command_scope),
-        ExprKind::Index { base, index } => {
-            visit_expression(base, calls, uses_command_scope);
-            visit_expression(index, calls, uses_command_scope);
-        }
-        ExprKind::Range { start, end, .. } => {
-            if let Some(start) = start {
-                visit_expression(start, calls, uses_command_scope);
+            ExprKind::Match { scrutinee, arms } => {
+                self.visit_expression(scrutinee);
+                for arm in arms {
+                    self.visit_expression(&arm.expr);
+                }
             }
-            if let Some(end) = end {
-                visit_expression(end, calls, uses_command_scope);
+            ExprKind::Block(block) => self.visit_statements(&block.stmts),
+            ExprKind::Struct { fields, .. } => {
+                for field in fields {
+                    self.visit_expression(&field.value);
+                }
             }
+            ExprKind::FormatPrint { args, .. }
+            | ExprKind::Format { args, .. }
+            | ExprKind::Array { elements: args }
+            | ExprKind::Tuple { elements: args } => {
+                for argument in args {
+                    self.visit_expression(argument);
+                }
+            }
+            ExprKind::Closure { body, .. } => self.visit_expression(body),
+            ExprKind::Index { base, index } => {
+                self.visit_expression(base);
+                self.visit_expression(index);
+            }
+            ExprKind::Range { start, end, .. } => {
+                if let Some(start) = start {
+                    self.visit_expression(start);
+                }
+                if let Some(end) = end {
+                    self.visit_expression(end);
+                }
+            }
+            ExprKind::Assign { target, value, .. } => {
+                self.update_command_metadata_binding(target, value);
+                self.visit_expression(target);
+                self.visit_expression(value);
+            }
+            ExprKind::Literal(_)
+            | ExprKind::Ident(_)
+            | ExprKind::Path { .. }
+            | ExprKind::JsLiteral { .. } => {}
         }
-        ExprKind::Assign { target, value, .. } => {
-            visit_expression(target, calls, uses_command_scope);
-            visit_expression(value, calls, uses_command_scope);
+    }
+
+    fn update_command_metadata_binding(&mut self, target: &Expr, value: &Expr) {
+        if let ExprKind::Ident(binding) = &target.kind {
+            self.command_metadata_bindings.insert(
+                binding.name.clone(),
+                self.command_metadata_expression_uses_scope(value),
+            );
         }
-        ExprKind::Literal(_)
-        | ExprKind::Ident(_)
-        | ExprKind::Path { .. }
-        | ExprKind::JsLiteral { .. } => {}
+    }
+
+    fn command_metadata_expression_uses_scope(&self, expression: &Expr) -> bool {
+        match &expression.kind {
+            ExprKind::Struct { fields, .. } => {
+                fields.iter().any(|field| field.name.name == "scope")
+            }
+            ExprKind::Ident(binding) => self
+                .command_metadata_bindings
+                .get(&binding.name)
+                .copied()
+                .unwrap_or(true),
+            _ => true,
+        }
     }
 }
 

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -22,6 +22,8 @@ use husk_diagnostics::{Diagnostic, Report, SourceFile};
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 
+use super::runtime::CommandScope;
+
 #[derive(Debug, Deserialize)]
 pub struct HostApiSchema {
     pub version: String,
@@ -68,6 +70,7 @@ pub(crate) enum RedFunctionAnnotation {
         description: Option<String>,
         aliases: Vec<String>,
         visible: bool,
+        scope: CommandScope,
     },
     Event {
         name: String,
@@ -145,6 +148,7 @@ pub(crate) fn red_function_annotations(
             let mut description = None;
             let mut aliases = Vec::new();
             let mut visible = true;
+            let mut scope = CommandScope::Editor;
             for argument in arguments {
                 let AttributeArgumentKind::Named { name: key, value } = &argument.kind else {
                     return Err(annotation_value_error(
@@ -213,6 +217,24 @@ pub(crate) fn red_function_annotations(
                         };
                         visible = *visible_value;
                     }
+                    "scope" => {
+                        let Some(scope_value) = value.as_str() else {
+                            return Err(annotation_value_error(
+                                &value.span,
+                                "command metadata `scope` must be a string",
+                            ));
+                        };
+                        scope = match scope_value {
+                            "editor" => CommandScope::Editor,
+                            "global" => CommandScope::Global,
+                            _ => {
+                                return Err(annotation_value_error(
+                                    &value.span,
+                                    "command metadata `scope` must be `editor` or `global`",
+                                ));
+                            }
+                        };
+                    }
                     _ => {
                         return Err(annotation_value_error(
                             &key.span,
@@ -234,6 +256,7 @@ pub(crate) fn red_function_annotations(
                 description,
                 aliases,
                 visible,
+                scope,
             });
         } else if attribute.matches_path(&["red", "on"]) {
             if parameter_count != 1 {
@@ -987,6 +1010,7 @@ mod tests {
                 category = "LSP",
                 description = "Browse symbols",
                 aliases = ["outline", "symbols"],
+                scope = "global",
             )]
             fn open_symbols() {}
 
@@ -1006,6 +1030,7 @@ mod tests {
                 description: Some("Browse symbols".to_string()),
                 aliases: vec!["outline".to_string(), "symbols".to_string()],
                 visible: true,
+                scope: CommandScope::Global,
             }]
         );
         assert_eq!(
@@ -1079,6 +1104,7 @@ mod tests {
                 description: None,
                 aliases: Vec::new(),
                 visible: false,
+                scope: CommandScope::Editor,
             }]
         );
         validate_source("valid", "plugins/valid.hk", source).unwrap();
@@ -1108,6 +1134,10 @@ mod tests {
             (
                 "#[red::command(name = \"Open\", visible = \"no\")] fn open() {}",
                 "`visible` must be a boolean",
+            ),
+            (
+                "#[red::command(name = \"Open\", scope = \"workspace\")] fn open() {}",
+                "`scope` must be `editor` or `global`",
             ),
             ("#[red::on(\"changed\")] fn changed() {}", "exactly one parameter"),
             (

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -445,23 +445,32 @@ struct HostCallSite<'a> {
     arguments: &'a [Expr],
 }
 
-fn host_call_sites(file: &File) -> Vec<HostCallSite<'_>> {
+struct RedSourceSites<'a> {
+    host_calls: Vec<HostCallSite<'a>>,
+    uses_command_scope: bool,
+}
+
+fn red_source_sites(file: &File) -> RedSourceSites<'_> {
     let mut calls = Vec::new();
+    let mut uses_command_scope = false;
     for item in &file.items {
         match &item.kind {
-            ItemKind::Fn { body, .. } => visit_statements(body, &mut calls),
+            ItemKind::Fn { body, .. } => {
+                uses_command_scope |= command_attribute_uses_scope(&item.attributes);
+                visit_statements(body, &mut calls, &mut uses_command_scope);
+            }
             ItemKind::Trait(definition) => {
                 for item in &definition.items {
                     let husk_ast::TraitItemKind::Method(method) = &item.kind;
                     if let Some(body) = &method.default_body {
-                        visit_statements(body, &mut calls);
+                        visit_statements(body, &mut calls, &mut uses_command_scope);
                     }
                 }
             }
             ItemKind::Impl(block) => {
                 for item in &block.items {
                     if let ImplItemKind::Method(method) = &item.kind {
-                        visit_statements(&method.body, &mut calls);
+                        visit_statements(&method.body, &mut calls, &mut uses_command_scope);
                     }
                 }
             }
@@ -473,37 +482,70 @@ fn host_call_sites(file: &File) -> Vec<HostCallSite<'_>> {
             | ItemKind::Use { .. } => {}
         }
     }
-    calls
-}
-
-fn visit_statements<'a>(statements: &'a [Stmt], calls: &mut Vec<HostCallSite<'a>>) {
-    for statement in statements {
-        visit_statement(statement, calls);
+    RedSourceSites {
+        host_calls: calls,
+        uses_command_scope,
     }
 }
 
-fn visit_statement<'a>(statement: &'a Stmt, calls: &mut Vec<HostCallSite<'a>>) {
+fn command_attribute_uses_scope(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(|attribute| {
+        attribute.matches_path(&["red", "command"])
+            && attribute.arguments.as_ref().is_some_and(|arguments| {
+                arguments.iter().any(|argument| {
+                    matches!(
+                        &argument.kind,
+                        AttributeArgumentKind::Named { name, .. } if name.name == "scope"
+                    )
+                })
+            })
+    })
+}
+
+pub(crate) fn source_uses_command_scope(file: &File) -> bool {
+    red_source_sites(file).uses_command_scope
+}
+
+fn host_call_sites(file: &File) -> Vec<HostCallSite<'_>> {
+    red_source_sites(file).host_calls
+}
+
+fn visit_statements<'a>(
+    statements: &'a [Stmt],
+    calls: &mut Vec<HostCallSite<'a>>,
+    uses_command_scope: &mut bool,
+) {
+    for statement in statements {
+        visit_statement(statement, calls, uses_command_scope);
+    }
+}
+
+fn visit_statement<'a>(
+    statement: &'a Stmt,
+    calls: &mut Vec<HostCallSite<'a>>,
+    uses_command_scope: &mut bool,
+) {
     match &statement.kind {
         StmtKind::Let {
             value, else_block, ..
         } => {
             if let Some(value) = value {
-                visit_expression(value, calls);
+                visit_expression(value, calls, uses_command_scope);
             }
             if let Some(block) = else_block {
-                visit_statements(&block.stmts, calls);
+                visit_statements(&block.stmts, calls, uses_command_scope);
             }
         }
         StmtKind::Assign { target, value, .. } => {
-            visit_expression(target, calls);
-            visit_expression(value, calls);
+            visit_expression(target, calls, uses_command_scope);
+            visit_expression(value, calls, uses_command_scope);
         }
         StmtKind::Expr(expression) | StmtKind::Semi(expression) => {
-            visit_expression(expression, calls);
+            visit_expression(expression, calls, uses_command_scope);
         }
         StmtKind::Return { value } => {
             if let Some(value) = value {
-                visit_expression(value, calls);
+                visit_expression(value, calls, uses_command_scope);
             }
         }
         StmtKind::If {
@@ -511,20 +553,22 @@ fn visit_statement<'a>(statement: &'a Stmt, calls: &mut Vec<HostCallSite<'a>>) {
             then_branch,
             else_branch,
         } => {
-            visit_expression(cond, calls);
-            visit_statements(&then_branch.stmts, calls);
+            visit_expression(cond, calls, uses_command_scope);
+            visit_statements(&then_branch.stmts, calls, uses_command_scope);
             if let Some(branch) = else_branch {
-                visit_statement(branch, calls);
+                visit_statement(branch, calls, uses_command_scope);
             }
         }
         StmtKind::While { cond, body } => {
-            visit_expression(cond, calls);
-            visit_statements(&body.stmts, calls);
+            visit_expression(cond, calls, uses_command_scope);
+            visit_statements(&body.stmts, calls, uses_command_scope);
         }
-        StmtKind::Loop { body } | StmtKind::Block(body) => visit_statements(&body.stmts, calls),
+        StmtKind::Loop { body } | StmtKind::Block(body) => {
+            visit_statements(&body.stmts, calls, uses_command_scope);
+        }
         StmtKind::ForIn { iterable, body, .. } => {
-            visit_expression(iterable, calls);
-            visit_statements(&body.stmts, calls);
+            visit_expression(iterable, calls, uses_command_scope);
+            visit_statements(&body.stmts, calls, uses_command_scope);
         }
         StmtKind::IfLet {
             scrutinee,
@@ -532,20 +576,35 @@ fn visit_statement<'a>(statement: &'a Stmt, calls: &mut Vec<HostCallSite<'a>>) {
             else_branch,
             ..
         } => {
-            visit_expression(scrutinee, calls);
-            visit_statements(&then_branch.stmts, calls);
+            visit_expression(scrutinee, calls, uses_command_scope);
+            visit_statements(&then_branch.stmts, calls, uses_command_scope);
             if let Some(branch) = else_branch {
-                visit_statement(branch, calls);
+                visit_statement(branch, calls, uses_command_scope);
             }
         }
         StmtKind::Break | StmtKind::Continue => {}
     }
 }
 
-fn visit_expression<'a>(expression: &'a Expr, calls: &mut Vec<HostCallSite<'a>>) {
+fn visit_expression<'a>(
+    expression: &'a Expr,
+    calls: &mut Vec<HostCallSite<'a>>,
+    uses_command_scope: &mut bool,
+) {
     match &expression.kind {
         ExprKind::Call { callee, args, .. } => {
             if let ExprKind::Path { segments } = &callee.kind {
+                if matches!(segments.as_slice(), [module, method] if module.name == "red" && method.name == "add_command")
+                    && args.get(2).is_some_and(|metadata| {
+                        matches!(
+                            &metadata.kind,
+                            ExprKind::Struct { fields, .. }
+                                if fields.iter().any(|field| field.name.name == "scope")
+                        )
+                    })
+                {
+                    *uses_command_scope = true;
+                }
                 let kind = match segments.as_slice() {
                     [module, method] if module.name == "red" && method.name == "execute" => {
                         Some("execute")
@@ -569,46 +628,46 @@ fn visit_expression<'a>(expression: &'a Expr, calls: &mut Vec<HostCallSite<'a>>)
                     }
                 }
             }
-            visit_expression(callee, calls);
+            visit_expression(callee, calls, uses_command_scope);
             for argument in args {
-                visit_expression(argument, calls);
+                visit_expression(argument, calls, uses_command_scope);
             }
         }
         ExprKind::Field { base, .. } | ExprKind::TupleField { base, .. } => {
-            visit_expression(base, calls);
+            visit_expression(base, calls, uses_command_scope);
         }
         ExprKind::MethodCall { receiver, args, .. } => {
-            visit_expression(receiver, calls);
+            visit_expression(receiver, calls, uses_command_scope);
             for argument in args {
-                visit_expression(argument, calls);
+                visit_expression(argument, calls, uses_command_scope);
             }
         }
         ExprKind::Unary { expr, .. } | ExprKind::Cast { expr, .. } | ExprKind::Try { expr } => {
-            visit_expression(expr, calls);
+            visit_expression(expr, calls, uses_command_scope);
         }
         ExprKind::Binary { left, right, .. } => {
-            visit_expression(left, calls);
-            visit_expression(right, calls);
+            visit_expression(left, calls, uses_command_scope);
+            visit_expression(right, calls, uses_command_scope);
         }
         ExprKind::If {
             cond,
             then_branch,
             else_branch,
         } => {
-            visit_expression(cond, calls);
-            visit_expression(then_branch, calls);
-            visit_expression(else_branch, calls);
+            visit_expression(cond, calls, uses_command_scope);
+            visit_expression(then_branch, calls, uses_command_scope);
+            visit_expression(else_branch, calls, uses_command_scope);
         }
         ExprKind::Match { scrutinee, arms } => {
-            visit_expression(scrutinee, calls);
+            visit_expression(scrutinee, calls, uses_command_scope);
             for arm in arms {
-                visit_expression(&arm.expr, calls);
+                visit_expression(&arm.expr, calls, uses_command_scope);
             }
         }
-        ExprKind::Block(block) => visit_statements(&block.stmts, calls),
+        ExprKind::Block(block) => visit_statements(&block.stmts, calls, uses_command_scope),
         ExprKind::Struct { fields, .. } => {
             for field in fields {
-                visit_expression(&field.value, calls);
+                visit_expression(&field.value, calls, uses_command_scope);
             }
         }
         ExprKind::FormatPrint { args, .. }
@@ -616,25 +675,25 @@ fn visit_expression<'a>(expression: &'a Expr, calls: &mut Vec<HostCallSite<'a>>)
         | ExprKind::Array { elements: args }
         | ExprKind::Tuple { elements: args } => {
             for argument in args {
-                visit_expression(argument, calls);
+                visit_expression(argument, calls, uses_command_scope);
             }
         }
-        ExprKind::Closure { body, .. } => visit_expression(body, calls),
+        ExprKind::Closure { body, .. } => visit_expression(body, calls, uses_command_scope),
         ExprKind::Index { base, index } => {
-            visit_expression(base, calls);
-            visit_expression(index, calls);
+            visit_expression(base, calls, uses_command_scope);
+            visit_expression(index, calls, uses_command_scope);
         }
         ExprKind::Range { start, end, .. } => {
             if let Some(start) = start {
-                visit_expression(start, calls);
+                visit_expression(start, calls, uses_command_scope);
             }
             if let Some(end) = end {
-                visit_expression(end, calls);
+                visit_expression(end, calls, uses_command_scope);
             }
         }
         ExprKind::Assign { target, value, .. } => {
-            visit_expression(target, calls);
-            visit_expression(value, calls);
+            visit_expression(target, calls, uses_command_scope);
+            visit_expression(value, calls, uses_command_scope);
         }
         ExprKind::Literal(_)
         | ExprKind::Ident(_)

--- a/src/plugin/catalog.rs
+++ b/src/plugin/catalog.rs
@@ -9,7 +9,10 @@ use anyhow::{Context, Result};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
-use super::{package::PluginId, RED_HOST_API_VERSION};
+use super::{
+    package::PluginId,
+    registry::{host_api_requirement_is_supported, SUPPORTED_HOST_API_VERSIONS},
+};
 
 pub const PLUGIN_CATALOG_SCHEMA: u32 = 1;
 pub const DEFAULT_PLUGIN_CATALOG_URL: &str =
@@ -145,11 +148,11 @@ impl PluginCatalog {
             .iter()
             .find(|package| &package.id == id)
             .ok_or_else(|| anyhow::anyhow!("language pack `{id}` is not in the catalog"))?;
-        let host_api = Version::parse(RED_HOST_API_VERSION)?;
         anyhow::ensure!(
-            package.red_api.matches(&host_api),
-            "language pack `{id}` requires Red API `{}`, but this release provides `{host_api}`",
-            package.red_api
+            host_api_requirement_is_supported(&package.red_api)?,
+            "language pack `{id}` requires Red API `{}`, but this release supports {}",
+            package.red_api,
+            SUPPORTED_HOST_API_VERSIONS.join(", ")
         );
         anyhow::ensure!(
             package.artifacts.contains_key(target),
@@ -412,15 +415,7 @@ mod tests {
         let catalog = PluginCatalog::from_slice(&bytes).unwrap();
         let id = PluginId::parse("go-language").unwrap();
 
-        let result = catalog.installable(&id, "aarch64-apple-darwin");
-        if VersionReq::parse("^0.6.0")
-            .unwrap()
-            .matches(&Version::parse(RED_HOST_API_VERSION).unwrap())
-        {
-            assert!(result.is_ok());
-        } else {
-            assert!(result.unwrap_err().to_string().contains("requires Red API"));
-        }
+        assert!(catalog.installable(&id, "aarch64-apple-darwin").is_ok());
         assert!(catalog
             .installable(&id, "unsupported-target")
             .unwrap_err()

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "0.7.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -44,8 +44,8 @@ pub use panel::{
 };
 pub use registry::{PluginRegistry, PluginStatus, RED_HOST_API_VERSION};
 pub use runtime::{
-    poll_timer_callbacks, CommandMetadata, ComposerHandle, PickerHandle, RegisteredPluginCommand,
-    RequestId, Runtime,
+    poll_timer_callbacks, CommandMetadata, CommandScope, ComposerHandle, PickerHandle,
+    RegisteredPluginCommand, RequestId, Runtime,
 };
 
 pub(crate) fn husk_lsp_declarations() -> &'static str {

--- a/src/plugin/package.rs
+++ b/src/plugin/package.rs
@@ -1707,6 +1707,17 @@ symbol = "tree_sitter_buildspec"
     fn package_manifest_accepts_supported_prior_host_api() {
         let package = tempfile::tempdir().unwrap();
         write_package(package.path(), "compatible-package", "1.0.0");
+        fs::write(
+            package.path().join("src/main.hk"),
+            r#"
+                pub fn activate() {
+                    let metadata = Json { title: "Test" };
+                    red::add_command("Test", test, metadata);
+                }
+                fn test() {}
+            "#,
+        )
+        .unwrap();
         let manifest_path = package.path().join(PLUGIN_MANIFEST_FILE);
         let source = fs::read_to_string(&manifest_path)
             .unwrap()
@@ -1736,6 +1747,16 @@ symbol = "tree_sitter_buildspec"
                 r#"
                     pub fn activate() {
                         red::add_command("Test", test, Json { scope: "global" });
+                    }
+                    fn test() {}
+                "#,
+            ),
+            (
+                "imperative-variable",
+                r#"
+                    pub fn activate() {
+                        let metadata = Json { scope: "global" };
+                        red::add_command("Test", test, metadata);
                     }
                     fn test() {}
                 "#,

--- a/src/plugin/package.rs
+++ b/src/plugin/package.rs
@@ -24,7 +24,8 @@ use crate::{config::LanguageConfig, language::GrammarTrustStore};
 
 use super::{
     catalog::{validate_catalog_url, CatalogArtifact, CatalogPackage, PluginCatalog},
-    Runtime, RED_HOST_API_VERSION,
+    registry::{host_api_requirement_is_supported, SUPPORTED_HOST_API_VERSIONS},
+    Runtime,
 };
 
 /// File name of the Red-specific package manifest.
@@ -231,11 +232,11 @@ impl PluginPackageManifest {
                 || !self.languages.is_empty(),
             "plugin package must declare a Husk entrypoint, native companion, or language"
         );
-        let host_api = Version::parse(RED_HOST_API_VERSION)?;
         anyhow::ensure!(
-            self.plugin.red_api.matches(&host_api),
-            "plugin requires Red host API `{}`, but this release provides `{host_api}`",
-            self.plugin.red_api
+            host_api_requirement_is_supported(&self.plugin.red_api)?,
+            "plugin requires Red host API `{}`, but this release supports {}",
+            self.plugin.red_api,
+            SUPPORTED_HOST_API_VERSIONS.join(", ")
         );
 
         for relative in self
@@ -529,12 +530,12 @@ impl PluginPackageManager {
     ) -> Result<InstalledPlugin> {
         validate_catalog_url(catalog_url)?;
         package.validate()?;
-        let host_api = Version::parse(RED_HOST_API_VERSION)?;
         anyhow::ensure!(
-            package.red_api.matches(&host_api),
-            "language pack `{}` requires Red API `{}`, but this release provides `{host_api}`",
+            host_api_requirement_is_supported(&package.red_api)?,
+            "language pack `{}` requires Red API `{}`, but this release supports {}",
             package.id,
-            package.red_api
+            package.red_api,
+            SUPPORTED_HOST_API_VERSIONS.join(", ")
         );
         let artifact = package.artifact(host_target()).ok_or_else(|| {
             anyhow::anyhow!(
@@ -1116,7 +1117,6 @@ fn installed_from_record(record: PluginInstallRecord) -> Result<InstalledPlugin>
         manifest.plugin.id == record.id,
         "install record id does not match plugin manifest"
     );
-    let host_api = Version::parse(RED_HOST_API_VERSION)?;
     let has_husk = manifest.husk_entry(&record.package_root).is_some();
     let languages = manifest.languages.keys().cloned().collect::<Vec<_>>();
     let has_native_grammars = manifest.languages.iter().any(|(id, language)| {
@@ -1133,7 +1133,7 @@ fn installed_from_record(record: PluginInstallRecord) -> Result<InstalledPlugin>
         name: manifest.plugin.name,
         version: manifest.plugin.version,
         enabled: record.enabled,
-        compatible: manifest.plugin.red_api.matches(&host_api),
+        compatible: host_api_requirement_is_supported(&manifest.plugin.red_api)?,
         has_companion: manifest.companion.is_some(),
         has_husk,
         has_languages: !manifest.languages.is_empty(),
@@ -1501,6 +1501,7 @@ fn set_executable(_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plugin::RED_HOST_API_VERSION;
 
     fn catalog_package(artifact: CatalogArtifact) -> CatalogPackage {
         CatalogPackage {
@@ -1667,6 +1668,24 @@ symbol = "tree_sitter_buildspec"
             ),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn package_manifest_accepts_supported_prior_host_api() {
+        let package = tempfile::tempdir().unwrap();
+        write_package(package.path(), "compatible-package", "1.0.0");
+        let manifest_path = package.path().join(PLUGIN_MANIFEST_FILE);
+        let source = fs::read_to_string(&manifest_path)
+            .unwrap()
+            .replace(&format!("^{RED_HOST_API_VERSION}"), "^0.6.0");
+        fs::write(&manifest_path, source).unwrap();
+
+        let manifest = PluginPackageManifest::load(package.path()).unwrap();
+
+        assert_eq!(
+            manifest.plugin.red_api,
+            VersionReq::parse("^0.6.0").unwrap()
+        );
     }
 
     #[tokio::test]

--- a/src/plugin/package.rs
+++ b/src/plugin/package.rs
@@ -15,6 +15,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use flate2::read::GzDecoder;
+use husk_runtime::{PackageLimits, ResolvedPackage};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -24,7 +25,10 @@ use crate::{config::LanguageConfig, language::GrammarTrustStore};
 
 use super::{
     catalog::{validate_catalog_url, CatalogArtifact, CatalogPackage, PluginCatalog},
-    registry::{host_api_requirement_is_supported, SUPPORTED_HOST_API_VERSIONS},
+    registry::{
+        host_api_requirement_is_supported, host_api_requirement_requires_at_least,
+        SUPPORTED_HOST_API_VERSIONS,
+    },
     Runtime,
 };
 
@@ -38,6 +42,7 @@ const MAX_PACKAGE_ARCHIVE_BYTES: usize = 128 * 1024 * 1024;
 const MAX_PACKAGE_UNPACKED_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_PACKAGE_ARCHIVE_FILES: usize = 1024;
 const MAX_CATALOG_GRAMMAR_BYTES: u64 = 64 * 1024 * 1024;
+const COMMAND_SCOPE_API_VERSION: &str = "0.7.0";
 
 /// A parsed and validated stable plugin identifier.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -263,6 +268,16 @@ impl PluginPackageManifest {
                 target.display()
             );
         }
+        if self.uses_command_scope(package_root) {
+            anyhow::ensure!(
+                host_api_requirement_requires_at_least(
+                    &self.plugin.red_api,
+                    COMMAND_SCOPE_API_VERSION
+                )?,
+                "plugin uses command scope introduced in Red host API {COMMAND_SCOPE_API_VERSION}, but manifest range `{}` includes an older supported API; declare `red_api = \"^{COMMAND_SCOPE_API_VERSION}\"` or later",
+                self.plugin.red_api
+            );
+        }
         for (target, artifact) in self
             .companion
             .iter()
@@ -333,6 +348,24 @@ impl PluginPackageManifest {
         }
         validate_keymaps(&self.keymaps)?;
         Ok(())
+    }
+
+    fn uses_command_scope(&self, package_root: &Path) -> bool {
+        if let Some(manifest) = &self.plugin.husk_manifest {
+            return ResolvedPackage::open(package_root.join(manifest), PackageLimits::default())
+                .is_ok_and(|package| {
+                    package
+                        .modules
+                        .iter()
+                        .any(|module| super::api::source_uses_command_scope(&module.syntax))
+                });
+        }
+        self.plugin.entry.as_ref().is_some_and(|entry| {
+            fs::read_to_string(package_root.join(entry))
+                .ok()
+                .and_then(|source| husk_parser::parse_str(&source).file)
+                .is_some_and(|file| super::api::source_uses_command_scope(&file))
+        })
     }
 
     /// Returns the absolute Husk source or package manifest used by the registry.
@@ -1686,6 +1719,61 @@ symbol = "tree_sitter_buildspec"
             manifest.plugin.red_api,
             VersionReq::parse("^0.6.0").unwrap()
         );
+    }
+
+    #[test]
+    fn package_manifest_requires_current_api_for_command_scope() {
+        for (label, plugin_source) in [
+            (
+                "declarative",
+                r#"
+                    #[red::command(name = "Test", scope = "global")]
+                    pub fn test() {}
+                "#,
+            ),
+            (
+                "imperative",
+                r#"
+                    pub fn activate() {
+                        red::add_command("Test", test, Json { scope: "global" });
+                    }
+                    fn test() {}
+                "#,
+            ),
+        ] {
+            let package = tempfile::tempdir().unwrap();
+            write_package(package.path(), &format!("{label}-scope"), "1.0.0");
+            fs::write(package.path().join("src/main.hk"), plugin_source).unwrap();
+            let manifest_path = package.path().join(PLUGIN_MANIFEST_FILE);
+            let source = fs::read_to_string(&manifest_path)
+                .unwrap()
+                .replace(&format!("^{RED_HOST_API_VERSION}"), "^0.6.0");
+            fs::write(&manifest_path, source).unwrap();
+
+            let error = PluginPackageManifest::load(package.path()).unwrap_err();
+
+            assert!(
+                error.to_string().contains("command scope introduced"),
+                "{label}: {error}"
+            );
+            assert!(error.to_string().contains(COMMAND_SCOPE_API_VERSION));
+        }
+    }
+
+    #[test]
+    fn package_manifest_accepts_current_api_command_scope() {
+        let package = tempfile::tempdir().unwrap();
+        write_package(package.path(), "current-scope", "1.0.0");
+        fs::write(
+            package.path().join("src/main.hk"),
+            r#"
+                #[red::command(name = "Test", scope = "global")]
+                pub fn test() {}
+            "#,
+        )
+        .unwrap();
+
+        PluginPackageManifest::load(package.path()).unwrap();
     }
 
     #[tokio::test]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -927,6 +927,23 @@ pub(crate) fn host_api_requirement_is_supported(requirement: &VersionReq) -> any
         .any(|version| requirement.matches(&version)))
 }
 
+pub(crate) fn host_api_requirement_requires_at_least(
+    requirement: &VersionReq,
+    introduced: &str,
+) -> anyhow::Result<bool> {
+    let introduced = Version::parse(introduced)?;
+    let supported = SUPPORTED_HOST_API_VERSIONS
+        .iter()
+        .map(|version| Version::parse(version))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(supported
+        .iter()
+        .any(|version| version >= &introduced && requirement.matches(version))
+        && supported
+            .iter()
+            .all(|version| version >= &introduced || !requirement.matches(version)))
+}
+
 fn diagnostic_stage(error: &anyhow::Error) -> &'static str {
     if error.downcast_ref::<husk_diagnostics::Report>().is_some() {
         "compile"

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -33,8 +33,8 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.6.0";
-const SUPPORTED_HOST_API_VERSIONS: &[&str] = &["0.4.0", RED_HOST_API_VERSION];
+pub const RED_HOST_API_VERSION: &str = "0.7.0";
+pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &["0.4.0", "0.6.0", RED_HOST_API_VERSION];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PluginModification {
@@ -897,18 +897,22 @@ fn check_api_compatibility(metadata: &PluginMetadata) -> anyhow::Result<()> {
     };
     let requirement = VersionReq::parse(requirement)
         .map_err(|error| anyhow::anyhow!("invalid red_api_version `{requirement}`: {error}"))?;
-    let compatible = SUPPORTED_HOST_API_VERSIONS
-        .iter()
-        .map(|version| Version::parse(version))
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .any(|version| requirement.matches(&version));
+    let compatible = host_api_requirement_is_supported(&requirement)?;
     anyhow::ensure!(
         compatible,
         "plugin requires Red host API `{requirement}`, but this release supports {}; see docs/PLUGIN_API.md",
         SUPPORTED_HOST_API_VERSIONS.join(", ")
     );
     Ok(())
+}
+
+pub(crate) fn host_api_requirement_is_supported(requirement: &VersionReq) -> anyhow::Result<bool> {
+    Ok(SUPPORTED_HOST_API_VERSIONS
+        .iter()
+        .map(|version| Version::parse(version))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .any(|version| requirement.matches(&version)))
 }
 
 fn diagnostic_stage(error: &anyhow::Error) -> &'static str {
@@ -1409,6 +1413,9 @@ mod tests {
     fn pre_one_minor_host_api_requirements_do_not_cross_minor_versions() {
         let mut metadata = PluginMetadata::minimal("composer-plugin".to_string());
         metadata.red_api_version = Some("^0.4.0".to_string());
+        check_api_compatibility(&metadata).unwrap();
+
+        metadata.red_api_version = Some("^0.6.0".to_string());
         check_api_compatibility(&metadata).unwrap();
 
         metadata.red_api_version = Some("^0.5.0".to_string());

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -290,24 +290,7 @@ impl PluginRegistry {
 
     /// Executes a plugin command and quarantines its owner on callback failure.
     pub async fn execute(&mut self, runtime: &mut Runtime, command: &str) -> anyhow::Result<()> {
-        if runtime.command_plugin(command).is_none() {
-            let candidate = self
-                .plugins
-                .iter()
-                .find(|(name, _)| {
-                    matches!(self.statuses.get(name), Some(PluginStatus::Pending))
-                        && self.metadata.get(name).is_some_and(|metadata| {
-                            metadata
-                                .activation_events
-                                .iter()
-                                .any(|event| event == &format!("onCommand:{command}"))
-                        })
-                })
-                .cloned();
-            if let Some((name, path)) = candidate {
-                self.activate_one(runtime, &name, &path).await;
-            }
-        }
+        self.ensure_command_registered(runtime, command).await;
         let owner = runtime.command_plugin(command);
         if let Err(error) = runtime.execute_command(command).await {
             crate::log!("Plugin command `{command}` failed: {error:?}");
@@ -322,6 +305,35 @@ impl PluginRegistry {
             }
         }
         Ok(())
+    }
+
+    /// Activates the pending plugin that declares `command`, if any.
+    pub(crate) async fn ensure_command_registered(&mut self, runtime: &mut Runtime, command: &str) {
+        if runtime.command_plugin(command).is_some() {
+            return;
+        }
+        if let Some((name, path)) = self.pending_command_plugin(command) {
+            self.activate_one(runtime, &name, &path).await;
+        }
+    }
+
+    pub(crate) fn has_pending_command(&self, command: &str) -> bool {
+        self.pending_command_plugin(command).is_some()
+    }
+
+    fn pending_command_plugin(&self, command: &str) -> Option<(String, String)> {
+        self.plugins
+            .iter()
+            .find(|(name, _)| {
+                matches!(self.statuses.get(name), Some(PluginStatus::Pending))
+                    && self.metadata.get(name).is_some_and(|metadata| {
+                        metadata
+                            .activation_events
+                            .iter()
+                            .any(|event| event == &format!("onCommand:{command}"))
+                    })
+            })
+            .cloned()
     }
 
     /// Broadcasts an event while isolating and quarantining per-plugin failures.

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -74,6 +74,7 @@ pub struct CommandMetadata {
     pub description: Option<String>,
     pub aliases: Vec<String>,
     pub visible: bool,
+    pub scope: CommandScope,
 }
 
 impl Default for CommandMetadata {
@@ -84,8 +85,20 @@ impl Default for CommandMetadata {
             description: None,
             aliases: Vec::new(),
             visible: true,
+            scope: CommandScope::Editor,
         }
     }
+}
+
+/// Surfaces from which a registered plugin command may be invoked by keymap.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandScope {
+    /// Only dispatch the command through the keymap owned by the active editor surface.
+    #[default]
+    Editor,
+    /// Allow configured normal-mode bindings to invoke the command from focused panels too.
+    Global,
 }
 
 /// Opaque identifier for a one-shot request issued by a Red plugin.
@@ -145,6 +158,7 @@ struct CommandMetadata {
     description: String,
     aliases: [String],
     visible: bool,
+    scope: String,
 }
 struct Position {
     line: i32,
@@ -2788,6 +2802,7 @@ impl Host for RedHost {
                     description,
                     aliases,
                     visible,
+                    scope,
                 } => {
                     if let Some(existing) = self.policy().commands.get(&name) {
                         if existing.callback.plugin() == plugin {
@@ -2808,6 +2823,7 @@ impl Host for RedHost {
                                 description,
                                 aliases,
                                 visible,
+                                scope,
                             },
                         },
                     );
@@ -3557,6 +3573,19 @@ impl Runtime {
             .commands
             .get(command)
             .map(|command| command.callback.plugin().to_string())
+    }
+
+    /// Returns the key-dispatch scope declared by an active plugin command.
+    #[must_use]
+    pub fn command_scope(&self, command: &str) -> Option<CommandScope> {
+        self.inner
+            .lock()
+            .unwrap()
+            .host
+            .policy()
+            .commands
+            .get(command)
+            .map(|command| command.metadata.scope)
     }
 
     /// Returns the active plugin commands in a stable order for discovery UI.
@@ -4696,6 +4725,7 @@ mod tests {
                     title: "Search project",
                     category: "Search",
                     aliases: ["ripgrep"],
+                    scope: "global",
                 });
                 red::add_command("BufferPicker", buffers);
             }
@@ -4722,6 +4752,16 @@ mod tests {
         );
         assert_eq!(commands[1].metadata.category.as_deref(), Some("Search"));
         assert_eq!(commands[1].metadata.aliases, vec!["ripgrep"]);
+        assert_eq!(commands[0].metadata.scope, CommandScope::Editor);
+        assert_eq!(commands[1].metadata.scope, CommandScope::Global);
+        assert_eq!(
+            runtime.command_scope("BufferPicker"),
+            Some(CommandScope::Editor)
+        );
+        assert_eq!(
+            runtime.command_scope("ProjectSearch"),
+            Some(CommandScope::Global)
+        );
     }
 
     #[tokio::test]
@@ -4739,6 +4779,7 @@ mod tests {
                 category = "LSP",
                 description = "Browse document symbols",
                 aliases = ["outline", "symbols"],
+                scope = "global",
             )]
             fn open() {
                 red::execute("Print", "command");
@@ -4769,6 +4810,7 @@ mod tests {
             Some("Browse document symbols")
         );
         assert_eq!(command.metadata.aliases, ["outline", "symbols"]);
+        assert_eq!(command.metadata.scope, CommandScope::Global);
 
         runtime.execute_command("OpenSymbols").await.unwrap();
         assert!(matches!(
@@ -12852,6 +12894,9 @@ mod tests {
         assert_eq!(document.metadata.aliases, ["outline", "symbols"]);
         assert_eq!(commands[1].metadata.aliases, ["usages", "references"]);
         assert_eq!(commands[2].metadata.aliases, ["symbols"]);
+        assert_eq!(document.metadata.scope, CommandScope::Global);
+        assert_eq!(commands[1].metadata.scope, CommandScope::Editor);
+        assert_eq!(commands[2].metadata.scope, CommandScope::Global);
     }
 
     #[tokio::test]

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -5437,7 +5437,16 @@ fn focused_row_panel_pages_with_control_keys_and_page_keys() {
 #[tokio::test]
 async fn focused_agent_panel_keeps_global_leader_until_the_composer_is_focused() {
     let buffer = Buffer::new(None, "abcdef".to_string());
-    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    let mut config = default_key_config();
+    config
+        .keys
+        .normal
+        .insert("q".to_string(), KeyAction::Single(Action::FilePicker));
+    config
+        .keys
+        .normal
+        .insert("Ctrl-c".to_string(), KeyAction::Single(Action::Suspend));
+    let mut harness = EditorHarness::with_config(buffer, config);
     harness.editor.test_create_text_panel(
         "agent",
         PanelConfig {
@@ -5494,6 +5503,25 @@ async fn focused_agent_panel_keeps_global_leader_until_the_composer_is_focused()
             "Agent".to_string()
         )))
     );
+
+    for (code, modifiers, expected) in [
+        (KeyCode::Char('q'), KeyModifiers::NONE, "close"),
+        (KeyCode::Char('c'), KeyModifiers::CONTROL, "interrupt"),
+    ] {
+        let action = harness
+            .editor
+            .test_handle_event_with_runtime(Event::Key(KeyEvent::new(code, modifiers)), &runtime)
+            .unwrap();
+        assert!(matches!(
+            action,
+            Some(KeyAction::Multiple(actions))
+                if actions.iter().any(|action| matches!(
+                    action,
+                    Action::NotifyPlugins(name, payload)
+                        if name == "panel:event:agent" && payload["action"] == expected
+                ))
+        ));
+    }
 
     assert!(harness.editor.test_focus_text_panel_composer("agent"));
     let action = harness

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -5353,7 +5353,12 @@ async fn focused_panel_allows_explicitly_global_plugin_commands() {
 #[test]
 fn focused_row_panel_forwards_file_operation_keys_to_its_plugin() {
     let buffer = Buffer::new(None, "abcdef".to_string());
-    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    let mut config = default_key_config();
+    config
+        .keys
+        .normal
+        .insert("Ctrl-r".to_string(), KeyAction::Single(Action::FilePicker));
+    let mut harness = EditorHarness::with_config(buffer, config);
     add_tree_panel(&mut harness);
     assert!(harness.editor.test_focus_panel("tree"));
 

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -5253,6 +5253,10 @@ fn focused_panel_allows_global_builtin_hotkeys() {
         .keys
         .normal
         .insert("x".to_string(), KeyAction::Single(Action::FilePicker));
+    config
+        .keys
+        .normal
+        .insert("Meta-p".to_string(), KeyAction::Single(Action::FilePicker));
     let mut harness = EditorHarness::with_config(buffer, config);
     add_tree_panel(&mut harness);
     assert!(harness.editor.test_focus_panel("tree"));
@@ -5263,6 +5267,7 @@ fn focused_panel_allows_global_builtin_hotkeys() {
             KeyModifiers::CONTROL,
             Action::FilePicker,
         ),
+        (KeyCode::Char('p'), KeyModifiers::META, Action::FilePicker),
         (KeyCode::Char('z'), KeyModifiers::CONTROL, Action::Suspend),
         (KeyCode::F(1), KeyModifiers::NONE, Action::CommandPalette),
     ] {

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -17,7 +17,8 @@ use red::{
     editor::{Action, Content, Editor, Mode, SearchDirection},
     lsp::LspClient,
     plugin::{
-        PanelConfig, PanelRow, PanelRowKind, PanelSegment, PanelSide, TextPanelComposerConfig,
+        PanelConfig, PanelRow, PanelRowKind, PanelSegment, PanelSide, Runtime,
+        TextPanelComposerConfig,
     },
     preferences::PreferencesStore,
     theme::{Style, Theme},
@@ -5245,18 +5246,78 @@ async fn focused_panel_does_not_fall_through_to_editing_keys() {
 }
 
 #[test]
-fn focused_panel_allows_ctrl_e_neotree_toggle() {
+fn focused_panel_allows_global_builtin_hotkeys() {
+    let buffer = Buffer::new(None, "abcdef".to_string());
+    let mut config = default_key_config();
+    config
+        .keys
+        .normal
+        .insert("x".to_string(), KeyAction::Single(Action::FilePicker));
+    let mut harness = EditorHarness::with_config(buffer, config);
+    add_tree_panel(&mut harness);
+    assert!(harness.editor.test_focus_panel("tree"));
+
+    for (code, modifiers, expected) in [
+        (
+            KeyCode::Char('p'),
+            KeyModifiers::CONTROL,
+            Action::FilePicker,
+        ),
+        (KeyCode::Char('z'), KeyModifiers::CONTROL, Action::Suspend),
+        (KeyCode::F(1), KeyModifiers::NONE, Action::CommandPalette),
+    ] {
+        let action = harness
+            .editor
+            .test_handle_event(Event::Key(KeyEvent::new(code, modifiers)))
+            .unwrap();
+        assert_eq!(action, Some(KeyAction::Single(expected)));
+    }
+
+    let local = harness
+        .editor
+        .test_handle_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+        )))
+        .unwrap();
+    assert!(matches!(
+        local,
+        Some(KeyAction::Multiple(actions))
+            if actions.iter().any(|action| matches!(
+                action,
+                Action::NotifyPlugins(name, payload)
+                    if name == "panel:event:tree" && payload["action"] == "x"
+            ))
+    ));
+}
+
+#[tokio::test]
+async fn focused_panel_allows_explicitly_global_plugin_commands() {
     let buffer = Buffer::new(None, "abcdef".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());
     add_tree_panel(&mut harness);
     assert!(harness.editor.test_focus_panel("tree"));
+    let mut runtime = Runtime::new();
+    runtime
+        .load_plugin(
+            "navigation",
+            r#"
+                pub fn activate() {
+                    red::add_command("NeoTree", noop, Json { scope: "global" });
+                    red::add_command("LspDocumentSymbols", noop);
+                }
+                fn noop() {}
+            "#,
+        )
+        .await
+        .unwrap();
 
     let action = harness
         .editor
-        .test_handle_event(Event::Key(KeyEvent::new(
-            KeyCode::Char('e'),
-            KeyModifiers::CONTROL,
-        )))
+        .test_handle_event_with_runtime(
+            Event::Key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL)),
+            &runtime,
+        )
         .unwrap();
 
     assert_eq!(
@@ -5265,6 +5326,23 @@ fn focused_panel_allows_ctrl_e_neotree_toggle() {
             "NeoTree".to_string()
         )))
     );
+
+    let contextual = harness
+        .editor
+        .test_handle_event_with_runtime(
+            Event::Key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL)),
+            &runtime,
+        )
+        .unwrap();
+    assert!(matches!(
+        contextual,
+        Some(KeyAction::Multiple(actions))
+            if actions.iter().any(|action| matches!(
+                action,
+                Action::NotifyPlugins(name, payload)
+                    if name == "panel:event:tree" && payload["action"] == "Ctrl-t"
+            ))
+    ));
 }
 
 #[test]
@@ -5351,8 +5429,8 @@ fn focused_row_panel_pages_with_control_keys_and_page_keys() {
     );
 }
 
-#[test]
-fn focused_agent_panel_keeps_leader_available_until_the_composer_is_focused() {
+#[tokio::test]
+async fn focused_agent_panel_keeps_global_leader_until_the_composer_is_focused() {
     let buffer = Buffer::new(None, "abcdef".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());
     harness.editor.test_create_text_panel(
@@ -5371,17 +5449,40 @@ fn focused_agent_panel_keeps_leader_available_until_the_composer_is_focused() {
         },
     );
     assert!(harness.editor.test_focus_panel("agent"));
+    let mut runtime = Runtime::new();
+    runtime
+        .load_plugin(
+            "agent",
+            r#"
+                pub fn activate() {
+                    red::add_command("Agent", noop, Json { scope: "global" });
+                }
+                fn noop() {}
+            "#,
+        )
+        .await
+        .unwrap();
 
     let action = harness
         .editor
-        .test_handle_event(Event::Key(KeyEvent::new(
-            KeyCode::Char(' '),
-            KeyModifiers::NONE,
-        )))
+        .test_handle_event_with_runtime(
+            Event::Key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)),
+            &runtime,
+        )
         .unwrap();
     let Some(KeyAction::Nested(leader)) = action else {
         panic!("expected Space to start the leader sequence from the conversation, got {action:?}");
     };
+    assert_eq!(leader.len(), 3);
+    assert!(leader.contains_key("A"));
+    assert!(leader.contains_key("?"));
+    assert!(leader.contains_key("d"));
+    for contextual in [" ", "a", "n", "p", "b", "f", ".", "r"] {
+        assert!(
+            !leader.contains_key(contextual),
+            "contextual leader branch {contextual:?} must be filtered"
+        );
+    }
     assert_eq!(
         leader.get("A"),
         Some(&KeyAction::Single(Action::PluginCommand(


### PR DESCRIPTION
Focused plugin panels currently intercept normal-mode keymaps before editor commands can run. That leaves built-in shortcuts such as `Ctrl-p` and `Ctrl-z` unavailable in Neo-tree, while the blanket allowance for plugin commands and nested prefixes can expose commands that are not safe or meaningful from a panel.

This change introduces an explicit command scope for panel-safe dispatch:

- admit panel-safe built-in actions such as file/command pickers, suspend, diagnostics, and window management
- add plugin command metadata with an `editor` default and explicit `global` opt-in
- mark bundled workspace pickers, pane toggles, Agent commands, Git dashboard, and symbol launchers as global
- filter nested keymaps to global leaves so contextual sibling commands cannot leak through
- preserve unmodified row-panel keys, including Neo-tree file operations, ahead of user-defined global bindings
- document the new plugin command scope in `docs/PLUGIN_API.md` and `docs/PLUGIN_SYSTEM.md`

## How to Test

1. Open Neo-tree with `Ctrl-e`, keep focus in the tree, and press `Ctrl-p`. The file picker should open.
2. From a focused panel, verify `Ctrl-z`, `F1`, and `Ctrl-w w` still invoke their application/window actions.
3. In Neo-tree, verify unmodified file-operation keys such as `x` remain panel-local even if the normal keymap assigns that key to a global action.
4. Run:
   - `cargo test --all-targets --all-features`
   - `cargo clippy --all-targets --all-features -- -D warnings`
