### PR TITLE
feat(replay): group meaningful source-backed changes

### DIFF
--- a/docs/pr-replay/domain-model.md
+++ b/docs/pr-replay/domain-model.md
@@ -69,6 +69,34 @@ hunk digest, original before/after text, and same-file prerequisites.
 An ordering profile must reference original hunk IDs; it must never regenerate
 their identities from their new presentation positions.
 
+## Semantic review change
+
+A semantic review change is a source-backed presentation overlay, not a
+replacement for the immutable original hunks:
+
+```rust
+struct SemanticReviewChange {
+    id: HunkId,
+    original_hunk_ids: Vec<HunkId>,
+    title: String,
+    why: String,
+    details: Vec<String>,
+}
+```
+
+The current implementation groups consecutive hunks within the same file when
+they form one meaningful behavior. Incidental whitespace belongs to its nearest
+substantive change, and replacing derived deserialization plus adding its
+compatibility implementation is presented as one change. The visible identity
+uses the substantive original hunk so findings and inline comments retain a real
+source anchor.
+
+Every exact original hunk still appears once in the overlay and remains present
+in the displayed unified diff. Grouped application, validation, undo, progress,
+and recovery operate on the underlying hunks in their original order. The
+presentation title and rationale must describe actual changed source behavior;
+nearby hunk headings and unrelated PR-body prose are not sufficient evidence.
+
 ## Ordering and logical replay groups
 
 An ordering plan is a separate, versioned overlay:

--- a/docs/pr-replay/reconstruction-and-ordering.md
+++ b/docs/pr-replay/reconstruction-and-ordering.md
@@ -31,6 +31,15 @@ Each original hunk becomes one `ReplayStep`. Later hunks in the same file
 depend on earlier hunks through `prior_by_path`. No current dependency connects
 different files.
 
+A separate semantic presentation overlay can group consecutive same-file
+original hunks without changing their identities, relative order, source
+anchors, or exact patches. Formatting-only hunks attach to the next meaningful
+change when possible. Related compatibility changes, such as removing derived
+deserialization and adding an explicit backwards-compatible implementation,
+form one reviewable unit. Applying or undoing that unit remains one ordinary
+editor transaction while each original hunk retains independent completion and
+recovery metadata.
+
 For example, Git path order can produce:
 
 ```text
@@ -41,9 +50,11 @@ For example, Git path order can produce:
 The intermediate scratch repository cannot compile after step 1 because the
 referenced module does not yet exist.
 
-The presentation compiler currently traverses the raw parsed patch and expects
-`session.steps[steps.len()]` to refer to the same file and hunk. Therefore,
-changing the visible list order alone would violate existing plan assumptions.
+The presentation compiler still retains every raw parsed hunk and verifies that
+each semantic group references consecutive hunks in its original file. The
+current overlay groups changes but does not reorder them; changing the visible
+list order independently would still violate same-file prerequisites and
+source-image assumptions.
 
 ## Separate original identity from presentation order
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3978,6 +3978,27 @@ impl Editor {
             .position(|buffer| buffer.id() == *source_buffer)
     }
 
+    fn replay_semantic_hunk_ids(&self, workspace_id: &str, step_id: &str) -> Option<Vec<String>> {
+        let workspace = self.replay_demo_workspace.as_ref()?;
+        if workspace.id != workspace_id {
+            return None;
+        }
+        if let Some(change) = workspace
+            .plan
+            .semantic_changes
+            .iter()
+            .find(|change| change.id == step_id)
+        {
+            return Some(change.original_hunk_ids.clone());
+        }
+        workspace
+            .plan
+            .steps
+            .iter()
+            .any(|step| step.id == step_id)
+            .then(|| vec![step_id.to_string()])
+    }
+
     fn focus_replay_demo_source(&mut self, workspace_id: &str) -> bool {
         let Some(workspace) = self.replay_demo_workspace.as_ref() else {
             return false;
@@ -4400,18 +4421,24 @@ impl Editor {
         let index = session
             .active_step
             .as_deref()
-            .and_then(|id| workspace.plan.steps.iter().position(|step| step.id == id))
+            .and_then(|id| {
+                presentation.steps.iter().position(|step| {
+                    step.id == id || step.original_hunk_ids.iter().any(|original| original == id)
+                })
+            })
             .unwrap_or_default();
         let notes = session
             .notes
             .iter()
             .filter_map(|note| {
                 let step_id = note.step_id.as_deref()?;
-                let index = workspace
-                    .plan
-                    .steps
-                    .iter()
-                    .position(|step| step.id == step_id)?;
+                let index = presentation.steps.iter().position(|step| {
+                    step.id == step_id
+                        || step
+                            .original_hunk_ids
+                            .iter()
+                            .any(|original| original == step_id)
+                })?;
                 Some(json!({
                     "index": index,
                     "step_id": note.step_id,
@@ -4420,14 +4447,38 @@ impl Editor {
                 }))
             })
             .collect::<Vec<_>>();
-        let completions = session
+        let completions = presentation
             .steps
             .iter()
             .enumerate()
-            .filter_map(|(index, step)| {
-                let completion = match step.completion? {
-                    crate::replay::ReplayCompletion::Manual => "manually reconstructed",
-                    crate::replay::ReplayCompletion::Automatic => "automatically applied",
+            .filter_map(|(index, change)| {
+                let originals = if change.original_hunk_ids.is_empty() {
+                    vec![change.id.as_str()]
+                } else {
+                    change
+                        .original_hunk_ids
+                        .iter()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>()
+                };
+                let completed = originals
+                    .iter()
+                    .filter_map(|id| session.steps.iter().find(|step| step.id == *id))
+                    .collect::<Vec<_>>();
+                if completed.len() != originals.len()
+                    || completed
+                        .iter()
+                        .any(|step| step.status != crate::replay::ReplayStepStatus::Done)
+                {
+                    return None;
+                }
+                let automatic = completed.iter().all(|step| {
+                    step.completion == Some(crate::replay::ReplayCompletion::Automatic)
+                });
+                let completion = if automatic {
+                    "automatically applied"
+                } else {
+                    "manually reconstructed"
                 };
                 Some(json!({ "index": index, "completion": completion }))
             })
@@ -5019,7 +5070,7 @@ impl Editor {
         )?;
         let presentation =
             crate::replay::replay_presentation_plan(&plan, self.replay_controller.limits())?;
-        let initial_step = plan
+        let initial_step = presentation
             .steps
             .first()
             .map(|step| step.id.clone())
@@ -5181,9 +5232,13 @@ impl Editor {
         let contents = source.contents();
         let revision = source.revision();
         let state = if self.replay_controller.session(workspace_id).is_ok() {
-            let validation = match self.replay_controller.validate_step(
+            let Some(original_hunk_ids) = self.replay_semantic_hunk_ids(workspace_id, step_id)
+            else {
+                return json!({ "ok": false, "error": "semantic change is no longer available" });
+            };
+            let validation = match self.replay_controller.validate_step_group(
                 workspace_id,
-                step_id,
+                &original_hunk_ids,
                 Path::new(&step.path),
                 &contents,
             ) {
@@ -5194,26 +5249,28 @@ impl Editor {
             };
             match validation {
                 crate::replay::ReplayValidation::Exact => {
-                    let completed = self
-                        .replay_controller
-                        .session(workspace_id)
-                        .ok()
-                        .and_then(|session| {
-                            session
-                                .steps
-                                .iter()
-                                .find(|candidate| candidate.id == step_id)
-                        })
-                        .is_some_and(|candidate| {
-                            candidate.status == crate::replay::ReplayStepStatus::Done
-                        });
-                    if !completed {
-                        if let Err(error) = self.replay_controller.complete_step(
-                            workspace_id,
-                            step_id,
-                            crate::replay::ReplayCompletion::Manual,
-                        ) {
-                            return json!({ "ok": false, "error": error.to_string() });
+                    for original in original_hunk_ids {
+                        let completed = self
+                            .replay_controller
+                            .session(workspace_id)
+                            .ok()
+                            .and_then(|session| {
+                                session
+                                    .steps
+                                    .iter()
+                                    .find(|candidate| candidate.id == original)
+                            })
+                            .is_some_and(|candidate| {
+                                candidate.status == crate::replay::ReplayStepStatus::Done
+                            });
+                        if !completed {
+                            if let Err(error) = self.replay_controller.complete_step(
+                                workspace_id,
+                                &original,
+                                crate::replay::ReplayCompletion::Manual,
+                            ) {
+                                return json!({ "ok": false, "error": error.to_string() });
+                            }
                         }
                     }
                     "exact"
@@ -5272,11 +5329,23 @@ impl Editor {
         let source_buffer = source.id();
         let contents = source.contents();
         let real_session = self.replay_controller.session(workspace_id).is_ok();
+        let original_hunk_ids = self
+            .replay_semantic_hunk_ids(workspace_id, step_id)
+            .ok_or_else(|| anyhow::anyhow!("semantic change is no longer available"))?;
+        let first_original = original_hunk_ids
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("semantic change has no original source hunks"))?;
         let (range, replacement) = if real_session {
             let path = Path::new(&step.path);
+            self.replay_controller.preview_step_group(
+                workspace_id,
+                &original_hunk_ids,
+                path,
+                &contents,
+            )?;
             let stage = self.replay_controller.stage_step(
                 workspace_id,
-                step_id,
+                first_original,
                 path,
                 &contents,
                 revision,
@@ -5335,14 +5404,38 @@ impl Editor {
             },
         );
         self.replace_range(range, &replacement);
-        self.commit_transaction(self.cursor_snapshot());
         if real_session {
             self.replay_controller.complete_step(
                 workspace_id,
-                step_id,
+                first_original,
                 crate::replay::ReplayCompletion::Automatic,
             )?;
+            for original in original_hunk_ids.iter().skip(1) {
+                let contents = self.current_buffer().contents();
+                let revision = self.current_buffer().revision();
+                let path = Path::new(&step.path);
+                let stage = self.replay_controller.stage_step(
+                    workspace_id,
+                    original,
+                    path,
+                    &contents,
+                    revision,
+                )?;
+                let stage = self.replay_controller.consume_stage(
+                    &stage.token,
+                    path,
+                    &contents,
+                    revision,
+                )?;
+                self.replace_range(stage.range, &stage.replacement);
+                self.replay_controller.complete_step(
+                    workspace_id,
+                    original,
+                    crate::replay::ReplayCompletion::Automatic,
+                )?;
+            }
         }
+        self.commit_transaction(self.cursor_snapshot());
         if let Some(workspace) = self.replay_demo_workspace.as_mut() {
             workspace.applied_steps.push(ReplayAppliedStep {
                 source_buffer,
@@ -5417,13 +5510,17 @@ impl Editor {
             }
         }
 
+        let original_hunk_ids = self
+            .replay_semantic_hunk_ids(&workspace_id, &applied.step_id)
+            .unwrap_or_else(|| vec![applied.step_id.clone()]);
         if let Ok(session) = self.replay_controller.session(&workspace_id) {
             if session.steps.iter().any(|candidate| {
                 candidate.status == crate::replay::ReplayStepStatus::Done
+                    && !original_hunk_ids.iter().any(|id| id == &candidate.id)
                     && candidate
                         .dependencies
                         .iter()
-                        .any(|dependency| dependency == &applied.step_id)
+                        .any(|dependency| original_hunk_ids.contains(dependency))
             }) {
                 self.last_error = Some(
                     "Undo the completed dependent replay hunk before its prerequisite".to_string(),
@@ -5442,8 +5539,10 @@ impl Editor {
         }
         self.undo_transaction(render_buffer, runtime).await?;
         if self.replay_controller.session(&workspace_id).is_ok() {
-            self.replay_controller
-                .reopen_step(&workspace_id, &applied.step_id)?;
+            for original in original_hunk_ids.iter().rev() {
+                self.replay_controller
+                    .reopen_step(&workspace_id, original)?;
+            }
         }
         if let Some(workspace) = self.replay_demo_workspace.as_mut() {
             workspace.applied_steps.pop();
@@ -25973,6 +26072,95 @@ mod test {
         (directory, session, workspace)
     }
 
+    fn semantic_replay_session_fixture() -> (
+        tempfile::TempDir,
+        crate::replay::ReplaySession,
+        crate::replay::ReplayWorkspace,
+        &'static str,
+        &'static str,
+    ) {
+        let before = concat!(
+            "fn existing_request() {\n",
+            "    preserve_original_behavior();\n",
+            "}\n",
+            "#[test]\n",
+            "fn neighboring_test() {\n",
+            "    let one = 1;\n",
+            "    let two = 2;\n",
+            "    let three = 3;\n",
+            "    let four = 4;\n",
+            "    let five = 5;\n",
+            "    assert_eq!(one + two + three + four, 10);\n",
+            "    assert_eq!(five, 5);\n",
+            "}\n",
+        );
+        let after = concat!(
+            "fn existing_request() {\n",
+            "    preserve_original_behavior();\n",
+            "}\n",
+            "\n",
+            "#[test]\n",
+            "fn neighboring_test() {\n",
+            "    let one = 1;\n",
+            "    let two = 2;\n",
+            "    let three = 3;\n",
+            "    let four = 4;\n",
+            "    let five = 5;\n",
+            "    assert_eq!(one + two + three + four, 10);\n",
+            "    assert_eq!(five, 5);\n",
+            "}\n",
+            "\n",
+            "#[test]\n",
+            "fn legacy_requests_default_missing_blocking_to_true() {\n",
+            "    assert!(legacy_request().is_blocking);\n",
+            "}\n",
+        );
+        let path = "src/token.rs";
+        let patch = format!(
+            "diff --git a/{path} b/{path}\n{}",
+            similar::TextDiff::from_lines(before, after)
+                .unified_diff()
+                .context_radius(3)
+                .header(&format!("a/{path}"), &format!("b/{path}")),
+        );
+        let directory = tempfile::tempdir().expect("isolated semantic replay source fixture");
+        let root = directory.path();
+        std::fs::create_dir(root.join("src")).expect("semantic fixture source directory");
+        std::fs::write(root.join(path), before).expect("original semantic fixture source");
+        let base = crate::replay::GitObjectId::parse(&"a".repeat(40)).unwrap();
+        let source = crate::replay::ReplaySource {
+            id: "semantic-replay-source".to_string(),
+            repository: crate::replay::ReplayRepository {
+                root: root.to_path_buf(),
+                common_directory: root.join(".git"),
+                host: "github.com".to_string(),
+                owner: "example".to_string(),
+                name: "repository".to_string(),
+            },
+            kind: crate::replay::ReplaySourceKind::LocalRange,
+            base_commit: base.clone(),
+            target_commit: crate::replay::GitObjectId::parse(&"b".repeat(40)).unwrap(),
+            patch_digest: crate::replay::digest(patch.as_bytes()),
+            patch,
+            pull_request: None,
+            review_context: None,
+        };
+        let workspace = crate::replay::ReplayWorkspace {
+            root: root.to_path_buf(),
+            branch: "replay/semantic-bbbbbbb".to_string(),
+            base_commit: base,
+            created_by_replay: true,
+        };
+        let session = crate::replay::ReplaySession::from_source(
+            source,
+            workspace.clone(),
+            crate::replay::ReplayLimits::default(),
+        )
+        .expect("source-backed semantic review session");
+        assert_eq!(session.steps.len(), 2);
+        (directory, session, workspace, before, after)
+    }
+
     fn real_author_replay_session_fixture() -> (
         tempfile::TempDir,
         crate::replay::ReplaySession,
@@ -27377,6 +27565,191 @@ mod test {
                 .unwrap()
                 .contains("before_second()")
         );
+    }
+
+    #[tokio::test]
+    async fn real_replay_groups_incidental_hunks_into_one_atomic_apply_and_undo() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let (_directory, session, workspace, before, after) = semantic_replay_session_fixture();
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 28);
+        let mut render_buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 28, &Style::default());
+        let mut runtime = Runtime::new();
+        let response = editor
+            .install_replay_source_session(session, "feature/replay", workspace, &mut render_buffer)
+            .await
+            .expect("open one semantic change backed by two exact original hunks");
+        let workspace_id = response["workspace_id"].as_str().unwrap();
+        let changes = response["plan"]["steps"].as_array().unwrap();
+        assert_eq!(changes.len(), 1);
+        let change_id = changes[0]["id"].as_str().unwrap();
+        let originals = changes[0]["original_hunk_ids"].as_array().unwrap();
+        assert_eq!(originals.len(), 2);
+        assert_eq!(
+            change_id,
+            originals[1].as_str().unwrap(),
+            "inline findings must anchor to the meaningful source hunk",
+        );
+        let validation = editor.replay_demo_step_validation(workspace_id, change_id);
+        assert_eq!(validation["state"], "incomplete");
+        let revision = validation["revision"].as_u64().unwrap();
+
+        editor
+            .apply_replay_demo_step(workspace_id, change_id, revision, &mut runtime)
+            .await
+            .expect("apply both exact original hunks in one attributed source transaction");
+
+        assert_eq!(editor.current_buffer().contents(), after);
+        let transaction = editor
+            .current_buffer()
+            .undo_history
+            .latest_transaction()
+            .expect("one atomic semantic-change transaction");
+        assert_eq!(transaction.edits.len(), 2);
+        assert!(matches!(
+            &transaction.origin,
+            EditOrigin::Replay { session_id, step_id }
+                if session_id == workspace_id && step_id == change_id
+        ));
+        let applied = editor.replay_controller.session(workspace_id).unwrap();
+        assert!(applied.steps.iter().all(|step| {
+            step.status == crate::replay::ReplayStepStatus::Done
+                && step.completion == Some(crate::replay::ReplayCompletion::Automatic)
+        }));
+        assert_eq!(
+            editor
+                .replay_demo_workspace
+                .as_ref()
+                .unwrap()
+                .applied_steps
+                .len(),
+            1,
+        );
+
+        editor
+            .execute(&Action::ReplayUndo, &mut render_buffer, &mut runtime)
+            .await
+            .expect("undo the complete grouped semantic change atomically");
+
+        assert_eq!(editor.current_buffer().contents(), before);
+        let reopened = editor.replay_controller.session(workspace_id).unwrap();
+        assert!(reopened
+            .steps
+            .iter()
+            .all(|step| step.status != crate::replay::ReplayStepStatus::Done));
+    }
+
+    #[tokio::test]
+    async fn real_replay_validates_every_manually_reconstructed_semantic_hunk() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let (_directory, session, workspace, _before, after) = semantic_replay_session_fixture();
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 28);
+        let mut render_buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 28, &Style::default());
+        let response = editor
+            .install_replay_source_session(session, "feature/replay", workspace, &mut render_buffer)
+            .await
+            .expect("open one manually reconstructible semantic change");
+        let workspace_id = response["workspace_id"].as_str().unwrap();
+        let change_id = response["plan"]["steps"][0]["id"].as_str().unwrap();
+        let source = editor.current_buffer();
+        let end = source.char_idx_to_position(source.contents().chars().count());
+        editor.begin_transaction("manually reconstruct semantic change");
+        editor.replace_range(
+            TextRange::new(TextPosition::new(/*line*/ 0, /*character*/ 0), end),
+            after,
+        );
+        editor.commit_transaction(editor.cursor_snapshot());
+
+        let validation = editor.replay_demo_step_validation(workspace_id, change_id);
+
+        assert_eq!(validation["state"], "exact");
+        let session = editor.replay_controller.session(workspace_id).unwrap();
+        assert!(session.steps.iter().all(|step| {
+            step.status == crate::replay::ReplayStepStatus::Done
+                && step.completion == Some(crate::replay::ReplayCompletion::Manual)
+        }));
+        assert_eq!(
+            editor.active_replay_session_payload()["completions"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1,
+        );
+    }
+
+    #[tokio::test]
+    async fn real_replay_recovers_grouped_original_hunks_and_their_atomic_undo() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let (_directory, session, workspace, before, after) = semantic_replay_session_fixture();
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 28);
+        let mut render_buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 28, &Style::default());
+        let mut runtime = Runtime::new();
+        let response = editor
+            .install_replay_source_session(session, "feature/replay", workspace, &mut render_buffer)
+            .await
+            .expect("open the recoverable semantic replay session");
+        let workspace_id = response["workspace_id"].as_str().unwrap().to_string();
+        let change_id = response["plan"]["steps"][0]["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let revision = editor.replay_demo_step_validation(&workspace_id, &change_id)["revision"]
+            .as_u64()
+            .unwrap();
+        editor
+            .apply_replay_demo_step(&workspace_id, &change_id, revision, &mut runtime)
+            .await
+            .expect("apply both exact original hunks before recovery");
+        let snapshot = editor.test_session_snapshot();
+
+        let buffers = Editor::buffers_from_session_snapshot(&snapshot);
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut recovered = Editor::with_size(
+            lsp,
+            /*width*/ 100,
+            /*height*/ 28,
+            config,
+            Theme::default(),
+            buffers,
+        )
+        .expect("restore the semantic scratch buffer and its undo transaction");
+        recovered.test_disable_terminal_output();
+        recovered
+            .restore_session_snapshot(&snapshot)
+            .expect("recover every exact original hunk without modifying the worktree");
+
+        assert_eq!(recovered.current_buffer().contents(), after);
+        let restored = recovered.active_replay_session_payload();
+        assert_eq!(restored["plan"]["steps"].as_array().unwrap().len(), 1);
+        assert_eq!(restored["completions"].as_array().unwrap().len(), 1);
+        assert_eq!(restored["plan"]["steps"][0]["id"], change_id);
+        assert!(recovered
+            .replay_controller
+            .session(&workspace_id)
+            .unwrap()
+            .steps
+            .iter()
+            .all(|step| step.status == crate::replay::ReplayStepStatus::Done));
+
+        recovered
+            .undo_replay_step(&mut render_buffer, &mut runtime)
+            .await
+            .expect("undo the recovered semantic change as one editor transaction");
+
+        assert_eq!(recovered.current_buffer().contents(), before);
+        assert!(recovered
+            .replay_controller
+            .session(&workspace_id)
+            .unwrap()
+            .steps
+            .iter()
+            .all(|step| step.status != crate::replay::ReplayStepStatus::Done));
     }
 
     #[tokio::test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -4710,10 +4710,22 @@ impl Editor {
             .replay_controller
             .active_session()
             .map(|session| &session.id);
+        let open_paths = self
+            .buffer_manager
+            .iter()
+            .filter_map(|buffer| buffer.file.as_deref())
+            .map(Path::new)
+            .collect::<HashSet<_>>();
 
         self.replay_controller
             .sessions()
             .into_iter()
+            .filter(|session| {
+                session.steps.iter().all(|step| {
+                    let path = session.workspace.root.join(&step.path);
+                    open_paths.contains(path.as_path())
+                })
+            })
             .map(|session| {
                 let branch = self
                     .replay_source_displays
@@ -26868,6 +26880,40 @@ mod test {
                 .discarded_sessions[0]
                 .id,
             original_id,
+        );
+    }
+
+    #[tokio::test]
+    async fn live_review_without_its_original_buffers_cannot_hide_a_recoverable_snapshot() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_plugin_requests();
+        let (directory, session, workspace) = real_replay_session_fixture();
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 28);
+        let mut render_buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 28, &Style::default());
+        editor
+            .install_replay_source_session(session, "feature/replay", workspace, &mut render_buffer)
+            .await
+            .expect("open every original scratch source buffer");
+        assert_eq!(editor.live_replay_reviews().len(), 1);
+
+        let missing = directory.path().join("src/second.rs");
+        let index = editor
+            .buffer_manager
+            .iter()
+            .position(|buffer| {
+                buffer
+                    .file
+                    .as_deref()
+                    .is_some_and(|path| Path::new(path) == missing.as_path())
+            })
+            .expect("the original second source buffer was opened");
+        editor.buffer_manager.remove_buffer(index);
+
+        assert!(editor.replay_controller.active_session().is_some());
+        assert!(
+            editor.live_replay_reviews().is_empty(),
+            "controller-only sessions must not replace older snapshots with complete source",
         );
     }
 

--- a/src/plugin/replay_panel.rs
+++ b/src/plugin/replay_panel.rs
@@ -1477,6 +1477,17 @@ fn replay_current_change_lines(state: &ReplayPanelState, width: usize) -> Vec<Re
             TextPanelSpanStyle::Strong,
         );
     }
+    for detail in step.details.iter().take(2) {
+        lines.push(RenderedTextLine::plain(
+            truncate_display_width_with_marker(
+                &format!("  · {detail}"),
+                width,
+                "…",
+                TruncationSide::Right,
+            ),
+            TextPanelSpanStyle::Muted,
+        ));
+    }
     lines
 }
 
@@ -3011,6 +3022,8 @@ mod tests {
             why: "Keep the original source hunk attached to its learning step.".to_string(),
             task: "Reconstruct the original source change.".to_string(),
             hint: String::new(),
+            original_hunk_ids: Vec::new(),
+            details: Vec::new(),
             before: before.to_string(),
             after: after.to_string(),
             diff,
@@ -3273,6 +3286,32 @@ mod tests {
         assert!(rows
             .iter()
             .any(|row| row.contains("handle_backtrack_overlay_event")));
+    }
+
+    #[test]
+    fn semantic_change_details_remain_visible_without_unbounded_panel_growth() {
+        let mut replay = model();
+        replay.steps[0].title =
+            "Add is_blocking to RequestParams with backward-compatible deserialization".to_string();
+        replay.steps[0].details = vec![
+            "Add the `is_blocking` field to `RequestParams`.".to_string(),
+            "Default missing blocking information to `true` for legacy payloads.".to_string(),
+            "Never allow a third detail to crowd out the actual original source.".to_string(),
+        ];
+        let state = ReplayPanelState::parse(&serde_json::to_string(&replay).unwrap()).unwrap();
+        let width = 82;
+        let lines = replay_current_change_lines(&state, width);
+        let details = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .filter(|span| span.text.starts_with("  · "))
+            .map(|span| span.text.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(details.len(), 2);
+        assert!(details[0].contains("is_blocking"));
+        assert!(details[1].contains("legacy payloads"));
+        assert!(details.iter().all(|detail| display_width(detail) <= width));
     }
 
     #[test]

--- a/src/replay/demo.rs
+++ b/src/replay/demo.rs
@@ -31,6 +31,12 @@ pub struct ReplayDemoStep {
     pub task: String,
     /// Optional graduated hint.
     pub hint: String,
+    /// Exact original hunks represented by this reviewer-visible semantic change.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub original_hunk_ids: Vec<String>,
+    /// Concise source-backed details describing all meaningful grouped changes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<String>,
     /// Exact complete source buffer before this step.
     pub before: String,
     /// Exact complete source buffer after this step.
@@ -56,6 +62,9 @@ pub struct ReplayDemoPlan {
     pub initial_source: String,
     /// Ordered, contiguous original-author unified hunks.
     pub steps: Vec<ReplayDemoStep>,
+    /// Reviewer-facing groups over immutable original hunks; empty for legacy demos.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub semantic_changes: Vec<super::ReplaySemanticChange>,
 }
 
 struct DemoSpec {
@@ -160,6 +169,8 @@ pub fn replay_demo_plan() -> Result<ReplayDemoPlan, ReplayError> {
             why: spec.why.to_string(),
             task: spec.task.to_string(),
             hint: spec.hint.to_string(),
+            original_hunk_ids: Vec::new(),
+            details: Vec::new(),
             before: source,
             after: after.clone(),
             diff,
@@ -175,6 +186,7 @@ pub fn replay_demo_plan() -> Result<ReplayDemoPlan, ReplayError> {
         source_path: DEMO_SOURCE_PATH.to_string(),
         initial_source: DEMO_BASE.to_string(),
         steps,
+        semantic_changes: Vec::new(),
     })
 }
 

--- a/src/replay/mod.rs
+++ b/src/replay/mod.rs
@@ -30,7 +30,7 @@ pub use patch::{
 };
 pub use plan::{
     replay_plan_from_session, replay_presentation_plan, ReplayPresentationPlan,
-    ReplayPresentationStep,
+    ReplayPresentationStep, ReplaySemanticChange,
 };
 pub(crate) use review::{reconcile_prepared_review, submit_prepared_review};
 pub use review::{

--- a/src/replay/plan.rs
+++ b/src/replay/plan.rs
@@ -18,6 +18,26 @@ use super::{
     ReplaySession, ReplayStep, ReplayStepKind,
 };
 
+/// One reviewer-facing concept backed by complete, immutable original Git hunks.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplaySemanticChange {
+    /// Stable identity of the meaningful original hunk representing this concept.
+    pub id: String,
+    /// Every exact original hunk represented by the reviewer-facing concept.
+    pub original_hunk_ids: Vec<String>,
+    /// Source-grounded description of the complete semantic change.
+    pub title: String,
+    /// Relevant original-author explanation for the complete change.
+    pub why: String,
+    /// Concrete reviewer-facing reconstruction instruction.
+    pub task: String,
+    /// Optional source-grounded reconstruction hint.
+    pub hint: String,
+    /// Individually understandable behaviors included in this change.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<String>,
+}
+
 /// Bounded reviewer-visible source context for one original-author hunk.
 ///
 /// The editor retains the complete scratch-file images for validation and
@@ -41,6 +61,12 @@ pub struct ReplayPresentationStep {
     pub task: String,
     /// Optional graduated reconstruction hint.
     pub hint: String,
+    /// Exact original hunks included in this atomic reviewer-facing change.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub original_hunk_ids: Vec<String>,
+    /// Source-backed details describing all meaningful grouped behaviors.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<String>,
     /// Exact old hunk and its original surrounding context.
     pub before: String,
     /// Exact new hunk and its original surrounding context.
@@ -91,38 +117,56 @@ pub fn replay_presentation_plan(
         });
     }
 
-    let steps = plan
-        .steps
-        .iter()
-        .map(|step| {
-            let patch = parse_patch(&step.diff, limits)?;
-            if patch.files.len() != 1 {
-                return Err(ReplayError::InvalidPatch(
-                    "presentation step is not one original source file".to_string(),
-                ));
-            }
-            let file = &patch.files[0];
-            if file.path() != Some(Path::new(&step.path)) || file.hunks.len() != 1 {
-                return Err(ReplayError::InvalidPatch(
-                    "presentation step is not one original source hunk".to_string(),
-                ));
-            }
-            let hunk = &file.hunks[0];
-            Ok(ReplayPresentationStep {
+    let semantic_changes = if plan.semantic_changes.is_empty() {
+        plan.steps
+            .iter()
+            .map(|step| ReplaySemanticChange {
                 id: step.id.clone(),
-                ordinal: step.ordinal,
-                path: step.path.clone(),
-                kind: step.kind.clone(),
-                title: refined_presentation_title(step, &hunk.before, &hunk.after),
+                original_hunk_ids: vec![step.id.clone()],
+                title: step.title.clone(),
                 why: step.why.clone(),
                 task: step.task.clone(),
                 hint: step.hint.clone(),
-                before: hunk.before.clone(),
-                after: hunk.after.clone(),
-                diff: step.diff.clone(),
+                details: step.details.clone(),
             })
-        })
-        .collect::<Result<Vec<_>, ReplayError>>()?;
+            .collect::<Vec<_>>()
+    } else {
+        plan.semantic_changes.clone()
+    };
+    let original_steps = plan
+        .steps
+        .iter()
+        .map(|step| (step.id.as_str(), step))
+        .collect::<HashMap<_, _>>();
+    let mut covered = HashSet::with_capacity(plan.steps.len());
+    let mut steps = Vec::with_capacity(semantic_changes.len());
+    for (index, change) in semantic_changes.iter().enumerate() {
+        let mut members = Vec::with_capacity(change.original_hunk_ids.len());
+        for id in &change.original_hunk_ids {
+            let step = original_steps.get(id.as_str()).ok_or_else(|| {
+                ReplayError::InvalidPatch(
+                    "semantic change does not reference an original source hunk".to_string(),
+                )
+            })?;
+            if !covered.insert(id.as_str()) {
+                return Err(ReplayError::InvalidPatch(
+                    "semantic changes repeat an original source hunk".to_string(),
+                ));
+            }
+            members.push(*step);
+        }
+        steps.push(present_semantic_change(
+            change,
+            &members,
+            index + 1,
+            limits,
+        )?);
+    }
+    if covered.len() != plan.steps.len() {
+        return Err(ReplayError::InvalidPatch(
+            "semantic changes do not cover every original source hunk".to_string(),
+        ));
+    }
 
     let presentation = ReplayPresentationPlan {
         pull_request: plan.pull_request,
@@ -142,6 +186,93 @@ pub fn replay_presentation_plan(
     }
 
     Ok(presentation)
+}
+
+fn present_semantic_change(
+    change: &ReplaySemanticChange,
+    members: &[&ReplayDemoStep],
+    ordinal: usize,
+    limits: ReplayLimits,
+) -> Result<ReplayPresentationStep, ReplayError> {
+    let first = members.first().ok_or_else(|| {
+        ReplayError::InvalidPatch("semantic change has no original source hunks".to_string())
+    })?;
+    if !members.iter().any(|step| step.id == change.id) {
+        return Err(ReplayError::InvalidPatch(
+            "semantic change identity does not match an original source hunk".to_string(),
+        ));
+    }
+
+    let mut diff = String::new();
+    let mut before = String::new();
+    let mut after = String::new();
+    let mut previous_ordinal = None;
+    for (index, step) in members.iter().enumerate() {
+        if step.path != first.path
+            || previous_ordinal.is_some_and(|previous: usize| step.ordinal != previous + 1)
+        {
+            return Err(ReplayError::InvalidPatch(
+                "semantic change crosses source files or reorders original hunks".to_string(),
+            ));
+        }
+        previous_ordinal = Some(step.ordinal);
+        let patch = parse_patch(&step.diff, limits)?;
+        if patch.files.len() != 1 {
+            return Err(ReplayError::InvalidPatch(
+                "presentation step is not one original source file".to_string(),
+            ));
+        }
+        let file = &patch.files[0];
+        if file.path() != Some(Path::new(&step.path)) || file.hunks.len() != 1 {
+            return Err(ReplayError::InvalidPatch(
+                "presentation step is not one original source hunk".to_string(),
+            ));
+        }
+        let hunk = &file.hunks[0];
+        if index == 0 {
+            diff.push_str(&step.diff);
+            before.clone_from(&hunk.before);
+        } else {
+            let header = step.diff.find("\n@@ ").ok_or_else(|| {
+                ReplayError::InvalidPatch("grouped original hunk has no unified header".to_string())
+            })?;
+            if !diff.ends_with('\n') {
+                diff.push('\n');
+            }
+            diff.push_str(&step.diff[header + 1..]);
+            if !after.is_empty() {
+                after.push_str("\n…\n");
+            }
+        }
+        after.push_str(&hunk.after);
+    }
+    let grouped = parse_patch(&diff, limits)?;
+    if grouped.files.len() != 1 || grouped.files[0].hunks.len() != members.len() {
+        return Err(ReplayError::InvalidPatch(
+            "semantic change did not retain every original source hunk".to_string(),
+        ));
+    }
+
+    let title = if change.title == first.title {
+        refined_presentation_title(first, &before, &after)
+    } else {
+        change.title.clone()
+    };
+    Ok(ReplayPresentationStep {
+        id: change.id.clone(),
+        ordinal,
+        path: first.path.clone(),
+        kind: first.kind.clone(),
+        title,
+        why: change.why.clone(),
+        task: change.task.clone(),
+        hint: change.hint.clone(),
+        original_hunk_ids: change.original_hunk_ids.clone(),
+        details: change.details.clone(),
+        before,
+        after,
+        diff,
+    })
 }
 
 fn refined_presentation_title(step: &ReplayDemoStep, before: &str, after: &str) -> String {
@@ -256,6 +387,8 @@ pub fn replay_plan_from_session(
                 why: replay_rationale(session, source_step, &display_path),
                 task: replay_task(source_step, &display_path),
                 hint: replay_hint(source_step, &display_path),
+                original_hunk_ids: vec![source_step.id.clone()],
+                details: Vec::new(),
                 before,
                 after,
                 diff,
@@ -273,6 +406,7 @@ pub fn replay_plan_from_session(
     })?;
     let context = session.source.review_context.as_ref();
     let pull_request = session.source.pull_request.as_ref();
+    let semantic_changes = build_semantic_changes(session, &steps);
 
     Ok(ReplayDemoPlan {
         pull_request: pull_request.map_or(0, |request| request.number),
@@ -288,6 +422,7 @@ pub fn replay_plan_from_session(
         source_path,
         initial_source,
         steps,
+        semantic_changes,
     })
 }
 
@@ -394,6 +529,402 @@ const fn replay_kind(kind: ReplayStepKind) -> &'static str {
 const MAX_REPLAY_RATIONALE_CHARS: usize = 240;
 const MAX_SEMANTIC_SOURCE_LINES: usize = 32;
 const MAX_SEMANTIC_SOURCE_CHARS: usize = 8 * 1024;
+
+#[derive(Debug, Clone, Default)]
+struct ReplaySemanticFacts {
+    public_fields: Vec<String>,
+    functions: Vec<String>,
+    deserialize_target: Option<String>,
+    removes_derived_deserialize: bool,
+    defaults_missing_to_true: bool,
+    deprecates_compatibility_field: bool,
+    adds_test: bool,
+    substantive_lines: usize,
+}
+
+impl ReplaySemanticFacts {
+    fn from_step(step: &ReplayStep) -> Self {
+        let changed = changed_source_lines(step);
+        let removed = source_lines_not_retained(&step.after, &step.before);
+        let mut facts = Self {
+            substantive_lines: changed
+                .iter()
+                .filter(|line| !line.trim().is_empty())
+                .count()
+                + removed
+                    .iter()
+                    .filter(|line| !line.trim().is_empty())
+                    .count(),
+            removes_derived_deserialize: removed
+                .iter()
+                .any(|line| line.contains("#[derive(") && line.contains("Deserialize"))
+                && changed
+                    .iter()
+                    .any(|line| line.contains("#[derive(") && !line.contains("Deserialize")),
+            ..Self::default()
+        };
+
+        for line in changed {
+            let line = line.trim();
+            if let Some(declaration) = line.strip_prefix("pub ") {
+                if let Some((field, _)) = declaration.split_once(':') {
+                    let field = field.trim();
+                    if is_source_identifier(field) {
+                        facts.public_fields.push(field.to_string());
+                    }
+                }
+            }
+            if let Some((kind, name)) = source_symbol(line) {
+                if kind == "fn" && !facts.functions.iter().any(|existing| existing == name) {
+                    facts.functions.push(name.to_string());
+                }
+            }
+            if line.starts_with("impl") && line.contains("Deserialize") {
+                if let Some((_, target)) = line.split_once(" for ") {
+                    let target = target
+                        .split(|character: char| character.is_whitespace() || character == '{')
+                        .next()
+                        .unwrap_or_default();
+                    if is_source_identifier(target) {
+                        facts.deserialize_target = Some(target.to_string());
+                    }
+                }
+            }
+            facts.defaults_missing_to_true |=
+                line.contains(".unwrap_or(true)") || line.contains(".unwrap_or_else(|| true)");
+            facts.deprecates_compatibility_field |= line.contains("@deprecated");
+            facts.adds_test |= line.starts_with("#[test]") || line.starts_with("#[tokio::test]");
+        }
+
+        facts
+    }
+
+    fn merge(&mut self, other: Self) {
+        for field in other.public_fields {
+            if !self.public_fields.contains(&field) {
+                self.public_fields.push(field);
+            }
+        }
+        for function in other.functions {
+            if !self.functions.contains(&function) {
+                self.functions.push(function);
+            }
+        }
+        if self.deserialize_target.is_none() {
+            self.deserialize_target = other.deserialize_target;
+        }
+        self.removes_derived_deserialize |= other.removes_derived_deserialize;
+        self.defaults_missing_to_true |= other.defaults_missing_to_true;
+        self.deprecates_compatibility_field |= other.deprecates_compatibility_field;
+        self.adds_test |= other.adds_test;
+        self.substantive_lines = self
+            .substantive_lines
+            .saturating_add(other.substantive_lines);
+    }
+
+    const fn is_incidental(&self) -> bool {
+        self.substantive_lines == 0
+    }
+
+    fn is_backward_compatible_deserialization(&self) -> bool {
+        self.deserialize_target.is_some()
+            && (self.defaults_missing_to_true || self.removes_derived_deserialize)
+    }
+}
+
+#[derive(Debug)]
+struct ReplaySemanticGroup {
+    member_indices: Vec<usize>,
+    facts: ReplaySemanticFacts,
+}
+
+fn build_semantic_changes(
+    session: &ReplaySession,
+    steps: &[ReplayDemoStep],
+) -> Vec<ReplaySemanticChange> {
+    let originals = session
+        .steps
+        .iter()
+        .map(|step| (step.id.as_str(), step))
+        .collect::<HashMap<_, _>>();
+    let mut groups: Vec<ReplaySemanticGroup> = Vec::new();
+    let mut incidental: Vec<usize> = Vec::new();
+
+    for (index, step) in steps.iter().enumerate() {
+        let Some(original) = originals.get(step.id.as_str()) else {
+            continue;
+        };
+        let facts = ReplaySemanticFacts::from_step(original);
+        if facts.is_incidental() {
+            if incidental
+                .first()
+                .is_some_and(|first| steps[*first].path != step.path)
+            {
+                flush_incidental_semantic_group(&mut groups, &mut incidental, steps);
+            }
+            incidental.push(index);
+            continue;
+        }
+
+        if incidental
+            .first()
+            .is_some_and(|first| steps[*first].path != step.path)
+        {
+            flush_incidental_semantic_group(&mut groups, &mut incidental, steps);
+        }
+
+        let merge_with_previous = groups.last().is_some_and(|previous| {
+            previous
+                .member_indices
+                .last()
+                .is_some_and(|last| steps[*last].path == step.path)
+                && previous.facts.removes_derived_deserialize
+                && facts.deserialize_target.is_some()
+        });
+        if merge_with_previous {
+            if let Some(previous) = groups.last_mut() {
+                previous.member_indices.append(&mut incidental);
+                previous.member_indices.push(index);
+                previous.facts.merge(facts);
+            }
+        } else {
+            incidental.push(index);
+            groups.push(ReplaySemanticGroup {
+                member_indices: std::mem::take(&mut incidental),
+                facts,
+            });
+        }
+    }
+
+    flush_incidental_semantic_group(&mut groups, &mut incidental, steps);
+
+    groups
+        .into_iter()
+        .map(|group| semantic_change(session, steps, &originals, group))
+        .collect()
+}
+
+fn flush_incidental_semantic_group(
+    groups: &mut Vec<ReplaySemanticGroup>,
+    incidental: &mut Vec<usize>,
+    steps: &[ReplayDemoStep],
+) {
+    let Some(first) = incidental.first().copied() else {
+        return;
+    };
+    if let Some(previous) = groups.last_mut().filter(|group| {
+        group
+            .member_indices
+            .last()
+            .is_some_and(|last| steps[*last].path == steps[first].path)
+    }) {
+        previous.member_indices.append(incidental);
+    } else {
+        groups.push(ReplaySemanticGroup {
+            member_indices: std::mem::take(incidental),
+            facts: ReplaySemanticFacts::default(),
+        });
+    }
+}
+
+fn semantic_change(
+    session: &ReplaySession,
+    steps: &[ReplayDemoStep],
+    originals: &HashMap<&str, &ReplayStep>,
+    group: ReplaySemanticGroup,
+) -> ReplaySemanticChange {
+    let first = &steps[group.member_indices[0]];
+    let meaningful = group
+        .member_indices
+        .iter()
+        .filter_map(|index| {
+            let step = &steps[*index];
+            let original = originals.get(step.id.as_str())?;
+            (!ReplaySemanticFacts::from_step(original).is_incidental()).then_some((step, *original))
+        })
+        .collect::<Vec<_>>();
+    let primary = meaningful.last().map_or(first, |(step, _)| *step);
+    let mut details = Vec::new();
+
+    let title = if group.facts.is_backward_compatible_deserialization() {
+        let target = group
+            .facts
+            .deserialize_target
+            .as_deref()
+            .unwrap_or("request");
+        for field in &group.facts.public_fields {
+            details.push(format!("Add the `{field}` field to `{target}`."));
+        }
+        if group.facts.removes_derived_deserialize {
+            details.push(
+                "Replace derived deserialization with an explicit compatibility implementation."
+                    .to_string(),
+            );
+        }
+        if group.facts.defaults_missing_to_true {
+            details.push(
+                "Default missing blocking information to `true` for legacy payloads.".to_string(),
+            );
+        }
+        if group.facts.deprecates_compatibility_field {
+            details.push("Keep the existing timeout as deprecated compatibility data.".to_string());
+        }
+        if let Some(field) = group.facts.public_fields.first() {
+            format!("Add {field} to {target} with backward-compatible deserialization")
+        } else {
+            format!("Preserve backward-compatible {target} deserialization")
+        }
+    } else if group.facts.adds_test {
+        group.facts.functions.last().map_or_else(
+            || primary.title.clone(),
+            |function| semantic_test_title(function),
+        )
+    } else if let Some(function) = group.facts.functions.first().filter(|_| {
+        meaningful
+            .last()
+            .is_some_and(|(_, original)| original.kind == ReplayStepKind::Add)
+    }) {
+        match rust_function_owner(&primary.after, function) {
+            Some(Some(owner)) => format!("Add {function} to {owner}"),
+            Some(None) => format!("Add {function}"),
+            None => primary.title.clone(),
+        }
+    } else if group.facts.is_incidental() {
+        let filename = Path::new(&first.path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(&first.path);
+        format!("Preserve formatting in {filename}")
+    } else {
+        primary.title.clone()
+    };
+
+    let why = semantic_rationale(session, &meaningful, &group.facts)
+        .unwrap_or_else(|| primary.why.clone());
+    let task = if group.member_indices.len() > 1 {
+        format!(
+            "Reconstruct the complete original change in {}.",
+            first.path
+        )
+    } else {
+        primary.task.clone()
+    };
+
+    ReplaySemanticChange {
+        id: primary.id.clone(),
+        original_hunk_ids: group
+            .member_indices
+            .iter()
+            .map(|index| steps[*index].id.clone())
+            .collect(),
+        title,
+        why,
+        task,
+        hint: primary.hint.clone(),
+        details,
+    }
+}
+
+fn rust_function_owner(source: &str, function: &str) -> Option<Option<String>> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
+        .ok()?;
+    let tree = parser.parse(source, None)?;
+    find_rust_function_owner(tree.root_node(), source.as_bytes(), function)
+}
+
+fn find_rust_function_owner(
+    node: tree_sitter::Node<'_>,
+    source: &[u8],
+    function: &str,
+) -> Option<Option<String>> {
+    if node.kind() == "function_item"
+        && node
+            .child_by_field_name("name")
+            .and_then(|name| name.utf8_text(source).ok())
+            == Some(function)
+    {
+        let mut parent = node.parent();
+        while let Some(ancestor) = parent {
+            if matches!(ancestor.kind(), "impl_item" | "trait_item") {
+                return Some(
+                    ancestor
+                        .child_by_field_name("type")
+                        .or_else(|| ancestor.child_by_field_name("name"))
+                        .and_then(|target| target.utf8_text(source).ok())
+                        .map(str::to_string),
+                );
+            }
+            parent = ancestor.parent();
+        }
+        return Some(None);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if let Some(owner) = find_rust_function_owner(child, source, function) {
+            return Some(owner);
+        }
+    }
+    None
+}
+
+fn semantic_test_title(function: &str) -> String {
+    if let Some(subject) = function.strip_prefix("test_") {
+        return format!("Test {}", subject.replace('_', " "));
+    }
+    if function.contains("legacy") && function.contains("blocking") {
+        return "Verify legacy requests default missing blocking information to true".to_string();
+    }
+    format!("Test {}", function.replace('_', " "))
+}
+
+fn semantic_rationale(
+    session: &ReplaySession,
+    meaningful: &[(&ReplayDemoStep, &ReplayStep)],
+    facts: &ReplaySemanticFacts,
+) -> Option<String> {
+    if meaningful.is_empty() {
+        return Some(
+            "Preserve the original source formatting without changing behavior.".to_string(),
+        );
+    }
+    let context = session.source.review_context.as_ref()?;
+    if facts.is_backward_compatible_deserialization() {
+        for line in context.body.lines() {
+            let Some(bullet) = markdown_bullet(line.trim()) else {
+                continue;
+            };
+            let normalized = bullet.to_ascii_lowercase();
+            if (normalized.contains("legacy") || normalized.contains("missing"))
+                && (normalized.contains("default") || normalized.contains("deserializ"))
+                && (normalized.contains("blocking") || normalized.contains("compatib"))
+            {
+                return Some(bounded_rationale(bullet));
+            }
+        }
+    }
+
+    if meaningful.len() == 1 {
+        let (presentation, original) = meaningful[0];
+        return Some(replay_rationale(session, original, &presentation.path));
+    }
+
+    let mut best: Option<(usize, String)> = None;
+    for (presentation, original) in meaningful {
+        if let Some(candidate) = review_body_rationale(&context.body, original, &presentation.path)
+        {
+            let score = semantic_tokens(&candidate)
+                .intersection(&changed_semantic_tokens(original))
+                .count();
+            if best.as_ref().is_none_or(|(previous, _)| score > *previous) {
+                best = Some((score, candidate));
+            }
+        }
+    }
+    best.map(|(_, rationale)| bounded_rationale(&rationale))
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ReviewSection {
@@ -582,7 +1113,9 @@ fn named_change_task(kind: ReplayStepKind, name: &str, noun: &str, container: &s
 }
 
 fn replay_rationale(session: &ReplaySession, step: &ReplayStep, path: &str) -> String {
-    if let Some(documentation) = added_documentation(step) {
+    if let Some(documentation) =
+        added_documentation(step).filter(|documentation| !documentation.starts_with("@deprecated"))
+    {
         return bounded_rationale(&documentation);
     }
 
@@ -617,6 +1150,10 @@ fn changed_source_lines(step: &ReplayStep) -> Vec<&str> {
     } else {
         (&step.before, &step.after)
     };
+    source_lines_not_retained(original, changed)
+}
+
+fn source_lines_not_retained<'source>(original: &str, changed: &'source str) -> Vec<&'source str> {
     let mut remaining = HashMap::<&str, usize>::new();
     for line in original.lines() {
         *remaining.entry(line).or_default() += 1;
@@ -884,6 +1421,7 @@ fn added_documentation(step: &ReplayStep) -> Option<String> {
 
 fn review_body_rationale(body: &str, step: &ReplayStep, path: &str) -> Option<String> {
     let keywords = replay_semantic_tokens(step, path);
+    let changed_keywords = changed_semantic_tokens(step);
     let mut section = ReviewSection::Other;
     let mut fenced = false;
     let mut motivation = String::new();
@@ -915,8 +1453,11 @@ fn review_body_rationale(body: &str, step: &ReplayStep, path: &str) -> Option<St
 
         if let Some(bullet) = markdown_bullet(trimmed) {
             if section == ReviewSection::Changes {
-                let score = semantic_tokens(bullet).intersection(&keywords).count();
+                let bullet_keywords = semantic_tokens(bullet);
+                let score = bullet_keywords.intersection(&keywords).count();
+                let changed_score = bullet_keywords.intersection(&changed_keywords).count();
                 if score >= 2
+                    && changed_score > 0
                     && best_change
                         .as_ref()
                         .is_none_or(|(best_score, _)| score > *best_score)
@@ -1002,6 +1543,16 @@ fn replay_semantic_tokens(step: &ReplayStep, path: &str) -> HashSet<String> {
     semantic_tokens(&source)
 }
 
+fn changed_semantic_tokens(step: &ReplayStep) -> HashSet<String> {
+    let source = changed_source_lines(step)
+        .into_iter()
+        .filter(|line| !line.trim().is_empty())
+        .take(MAX_SEMANTIC_SOURCE_LINES)
+        .collect::<Vec<_>>()
+        .join(" ");
+    semantic_tokens(&source)
+}
+
 fn semantic_tokens(text: &str) -> HashSet<String> {
     let mut tokens = HashSet::new();
     let mut current = String::new();
@@ -1058,6 +1609,7 @@ mod tests {
         digest, replay_demo_plan, GitObjectId, ReplayRepository, ReplayReviewContext, ReplaySource,
         ReplaySourceKind, ReplayWorkspace,
     };
+    use similar::TextDiff;
 
     const MULTI_FILE_PATCH: &str = concat!(
         "diff --git a/src/token.rs b/src/token.rs\n",
@@ -1161,6 +1713,242 @@ mod tests {
         let session = ReplaySession::from_source(source, workspace, ReplayLimits::default())
             .expect("source-linked replay session");
         (directory, session)
+    }
+
+    fn semantic_source_session(before: &str, after: &str) -> (tempfile::TempDir, ReplaySession) {
+        let path = "src/token.rs";
+        let patch = format!(
+            "diff --git a/{path} b/{path}\n{}",
+            TextDiff::from_lines(before, after)
+                .unified_diff()
+                .context_radius(3)
+                .header(&format!("a/{path}"), &format!("b/{path}")),
+        );
+        let (directory, session) = source_session(&patch);
+        std::fs::write(directory.path().join(path), before)
+            .expect("write the original semantic-change fixture");
+        (directory, session)
+    }
+
+    #[test]
+    fn groups_derived_deserialization_and_legacy_compatibility_into_one_honest_change() {
+        let before = concat!(
+            "#[derive(Serialize, Deserialize, Debug)]\n",
+            "#[serde(rename_all = \"camelCase\")]\n",
+            "/// Original request parameters.\n",
+            "pub struct RequestParams {\n",
+            "    pub thread_id: String,\n",
+            "    pub turn_id: String,\n",
+            "    pub item_id: String,\n",
+            "    pub questions: Vec<String>,\n",
+            "    #[serde(default)]\n",
+            "    pub timeout_ms: Option<u64>,\n",
+            "}\n",
+            "\n",
+            "pub struct NextItem;\n",
+        );
+        let after = concat!(
+            "#[derive(Serialize, Debug)]\n",
+            "#[serde(rename_all = \"camelCase\")]\n",
+            "/// Original request parameters.\n",
+            "pub struct RequestParams {\n",
+            "    pub thread_id: String,\n",
+            "    pub turn_id: String,\n",
+            "    pub item_id: String,\n",
+            "    pub questions: Vec<String>,\n",
+            "    pub is_blocking: bool,\n",
+            "    /// @deprecated Use `isBlocking` for request behavior.\n",
+            "    #[serde(default)]\n",
+            "    pub timeout_ms: Option<u64>,\n",
+            "}\n",
+            "\n",
+            "impl<'de> Deserialize<'de> for RequestParams {\n",
+            "    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>\n",
+            "    where\n",
+            "        D: serde::Deserializer<'de>,\n",
+            "    {\n",
+            "        let wire = WireRequestParams::deserialize(deserializer)?;\n",
+            "        Ok(Self {\n",
+            "            is_blocking: wire.is_blocking.unwrap_or(true),\n",
+            "            ..wire.into()\n",
+            "        })\n",
+            "    }\n",
+            "}\n",
+            "\n",
+            "pub struct NextItem;\n",
+        );
+        let (_directory, mut session) = semantic_source_session(before, after);
+        session.source.review_context = Some(codex_review_context(concat!(
+            "## Why\n\nKeep legacy requests compatible.\n\n",
+            "## What changed\n\n",
+            "- Add the new blocking field throughout generated request schemas.\n",
+            "- Default missing blocking information during deserialization so legacy payloads continue to load safely.\n",
+        )));
+
+        assert_eq!(session.steps.len(), 2);
+        let plan = replay_plan_from_session(&session, "feature/replay", ReplayLimits::default())
+            .expect("group the complete original compatibility change");
+        let presentation = replay_presentation_plan(&plan, ReplayLimits::default())
+            .expect("retain both exact original unified hunks");
+
+        assert_eq!(plan.steps.len(), 2);
+        assert_eq!(plan.semantic_changes.len(), 1);
+        assert_eq!(presentation.steps.len(), 1);
+        let change = &presentation.steps[0];
+        assert_eq!(
+            change.title,
+            "Add is_blocking to RequestParams with backward-compatible deserialization",
+        );
+        assert_eq!(
+            change.why,
+            "Default missing blocking information during deserialization so legacy payloads continue to load safely.",
+        );
+        assert_eq!(change.original_hunk_ids.len(), 2);
+        assert!(change
+            .details
+            .iter()
+            .any(|detail| detail.contains("derived deserialization")));
+        assert!(change
+            .details
+            .iter()
+            .any(|detail| detail.contains("legacy payloads")));
+        assert!(!change.why.contains("@deprecated"));
+        let patch = parse_patch(&change.diff, ReplayLimits::default())
+            .expect("parse every original grouped hunk independently");
+        assert_eq!(patch.files[0].hunks.len(), 2);
+    }
+
+    #[test]
+    fn attaches_a_whitespace_only_hunk_to_the_following_meaningful_test() {
+        let before = concat!(
+            "fn existing_request() {\n",
+            "    preserve_original_behavior();\n",
+            "}\n",
+            "#[test]\n",
+            "fn neighboring_test() {\n",
+            "    let one = 1;\n",
+            "    let two = 2;\n",
+            "    let three = 3;\n",
+            "    let four = 4;\n",
+            "    let five = 5;\n",
+            "    assert_eq!(one + two + three + four, 10);\n",
+            "    assert_eq!(five, 5);\n",
+            "}\n",
+        );
+        let after = concat!(
+            "fn existing_request() {\n",
+            "    preserve_original_behavior();\n",
+            "}\n",
+            "\n",
+            "#[test]\n",
+            "fn neighboring_test() {\n",
+            "    let one = 1;\n",
+            "    let two = 2;\n",
+            "    let three = 3;\n",
+            "    let four = 4;\n",
+            "    let five = 5;\n",
+            "    assert_eq!(one + two + three + four, 10);\n",
+            "    assert_eq!(five, 5);\n",
+            "}\n",
+            "\n",
+            "#[test]\n",
+            "fn legacy_requests_default_missing_blocking_to_true() {\n",
+            "    assert!(legacy_request().is_blocking);\n",
+            "}\n",
+        );
+        let (_directory, mut session) = semantic_source_session(before, after);
+        session.source.review_context = Some(codex_review_context(concat!(
+            "## Why\n\nPreserve existing request behavior.\n\n",
+            "## What changed\n\n",
+            "- Add generated request schemas and protocol event fields.\n",
+            "- Verify legacy requests default missing blocking information to true.\n",
+        )));
+
+        assert_eq!(session.steps.len(), 2);
+        let plan = replay_plan_from_session(&session, "feature/replay", ReplayLimits::default())
+            .expect("attach incidental formatting to the substantive test");
+        let presentation = replay_presentation_plan(&plan, ReplayLimits::default())
+            .expect("preserve the incidental original hunk");
+
+        assert_eq!(plan.steps.len(), 2);
+        assert_eq!(presentation.steps.len(), 1);
+        let change = &presentation.steps[0];
+        assert_eq!(change.original_hunk_ids.len(), 2);
+        assert_eq!(
+            change.title,
+            "Verify legacy requests default missing blocking information to true",
+        );
+        assert!(!change.title.contains("existing_request"));
+        assert!(!change.why.contains("generated request schemas"));
+        let patch = parse_patch(&change.diff, ReplayLimits::default())
+            .expect("keep whitespace and test hunks in the exact original diff");
+        assert_eq!(patch.files[0].hunks.len(), 2);
+    }
+
+    #[test]
+    fn added_top_level_function_does_not_inherit_the_previous_hunk_heading() {
+        let before = concat!(
+            "fn existing_request() {\n",
+            "    preserve_original_behavior();\n",
+            "}\n",
+        );
+        let after = concat!(
+            "fn existing_request() {\n",
+            "    preserve_original_behavior();\n",
+            "}\n",
+            "\n",
+            "fn decode_request() {\n",
+            "    deserialize_new_request();\n",
+            "}\n",
+        );
+        let (_directory, session) = semantic_source_session(before, after);
+        let plan = replay_plan_from_session(&session, "feature/replay", ReplayLimits::default())
+            .expect("identify the added function from its actual syntax");
+        let presentation = replay_presentation_plan(&plan, ReplayLimits::default())
+            .expect("present the original top-level function change");
+
+        assert_eq!(presentation.steps.len(), 1);
+        assert_eq!(presentation.steps[0].title, "Add decode_request");
+        assert!(!presentation.steps[0].title.contains("existing_request"));
+    }
+
+    #[test]
+    fn incidental_hunks_never_cross_file_boundaries() {
+        let first_before = "fn existing_request() {\n    preserve_original_behavior();\n}\n";
+        let first_after = "fn existing_request() {\n    preserve_original_behavior();\n}\n\n";
+        let second_before = "assert_eq!(token(), 1);\n";
+        let second_after = "assert_eq!(token(), 2);\n";
+        let first = "src/token.rs";
+        let second = "tests/token.rs";
+        let patch = format!(
+            "diff --git a/{first} b/{first}\n{}diff --git a/{second} b/{second}\n{}",
+            TextDiff::from_lines(first_before, first_after)
+                .unified_diff()
+                .context_radius(3)
+                .header(&format!("a/{first}"), &format!("b/{first}")),
+            TextDiff::from_lines(second_before, second_after)
+                .unified_diff()
+                .context_radius(3)
+                .header(&format!("a/{second}"), &format!("b/{second}")),
+        );
+        let (directory, session) = source_session(&patch);
+        std::fs::write(directory.path().join(first), first_before)
+            .expect("original formatting-only source");
+        let plan = replay_plan_from_session(&session, "feature/replay", ReplayLimits::default())
+            .expect("retain formatting-only changes within their original source file");
+        let presentation = replay_presentation_plan(&plan, ReplayLimits::default())
+            .expect("never combine original hunks from unrelated files");
+
+        assert_eq!(presentation.steps.len(), 2);
+        assert_eq!(presentation.steps[0].path, first);
+        assert_eq!(presentation.steps[1].path, second);
+        assert!(presentation.steps[0]
+            .title
+            .starts_with("Preserve formatting"));
+        assert!(presentation
+            .steps
+            .iter()
+            .all(|change| change.original_hunk_ids.len() == 1));
     }
 
     #[test]

--- a/src/replay/session.rs
+++ b/src/replay/session.rs
@@ -800,6 +800,83 @@ impl ReplayController {
         ))
     }
 
+    /// Validates a complete semantic change without hiding original-hunk prerequisites.
+    ///
+    /// Each exact original hunk remains independently identified. A temporary
+    /// session image advances only for validation, so partially reconstructed
+    /// groups never mutate reviewer progress or editor source.
+    pub fn validate_step_group(
+        &self,
+        session_id: &str,
+        step_ids: &[String],
+        path: &Path,
+        text: &str,
+    ) -> Result<ReplayValidation, ReplayError> {
+        validate_semantic_group_ids(step_ids)?;
+        let mut simulated = self.session(session_id)?.clone();
+        for id in step_ids {
+            let index = simulated
+                .steps
+                .iter()
+                .position(|step| step.id == *id)
+                .ok_or_else(|| missing("replay step", id))?;
+            if !simulated.dependencies_complete(index) {
+                return Ok(ReplayValidation::Blocked);
+            }
+            let step = &simulated.steps[index];
+            if step.path != path {
+                return Ok(ReplayValidation::Conflict);
+            }
+            match validate_text(step, text, effective_old_start(&simulated, step)) {
+                ReplayValidation::Exact => simulated.steps[index].status = ReplayStepStatus::Done,
+                other => return Ok(other),
+            }
+        }
+        Ok(ReplayValidation::Exact)
+    }
+
+    /// Checks that every grouped hunk can be applied before any editor mutation.
+    pub fn preview_step_group(
+        &self,
+        session_id: &str,
+        step_ids: &[String],
+        path: &Path,
+        text: &str,
+    ) -> Result<(), ReplayError> {
+        validate_semantic_group_ids(step_ids)?;
+        let mut simulated = self.session(session_id)?.clone();
+        let mut image = text.to_string();
+        for id in step_ids {
+            let index = simulated
+                .steps
+                .iter()
+                .position(|step| step.id == *id)
+                .ok_or_else(|| missing("replay step", id))?;
+            if !simulated.dependencies_complete(index) {
+                return Err(ReplayError::DependencyBlocked);
+            }
+            let step = &simulated.steps[index];
+            if step.path != path {
+                return Err(ReplayError::AnchorConflict);
+            }
+            if step.before.is_empty() {
+                if !image.is_empty() && image != "\n" {
+                    return Err(ReplayError::AnchorConflict);
+                }
+                image.clone_from(&step.after);
+            } else {
+                let start = anchored_hunk_offset(
+                    &image,
+                    &step.before,
+                    effective_old_start(&simulated, step),
+                )?;
+                image.replace_range(start..start + step.before.len(), &step.after);
+            }
+            simulated.steps[index].status = ReplayStepStatus::Done;
+        }
+        Ok(())
+    }
+
     /// Issues one immutable, session-owned preview without changing an editor buffer.
     pub fn stage_step(
         &mut self,
@@ -1681,6 +1758,24 @@ impl ReplaySession {
     }
 }
 
+fn validate_semantic_group_ids(step_ids: &[String]) -> Result<(), ReplayError> {
+    if step_ids.is_empty() {
+        return Err(ReplayError::InvalidPatch(
+            "semantic change has no original source hunks".to_string(),
+        ));
+    }
+    let mut originals = HashSet::with_capacity(step_ids.len());
+    if step_ids
+        .iter()
+        .any(|step_id| !originals.insert(step_id.as_str()))
+    {
+        return Err(ReplayError::InvalidPatch(
+            "semantic change contains the same original source hunk more than once".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_text(step: &ReplayStep, text: &str, old_start: usize) -> ReplayValidation {
     if step.before.is_empty() {
         if text == step.after || (text.ends_with('\n') && text.trim_end_matches('\n') == step.after)
@@ -2020,6 +2115,70 @@ mod tests {
                 .unwrap(),
             ReplayValidation::Exact
         );
+    }
+
+    #[test]
+    fn semantic_group_preflight_never_mutates_original_progress() {
+        let (controller, session_id, step_id) = controller_with_session();
+        let original = "fn refresh() {\n    old();\n}\n";
+        let group = vec![step_id];
+        let before = controller.session(&session_id).unwrap().steps[0].clone();
+
+        controller
+            .preview_step_group(&session_id, &group, Path::new("src/token.rs"), original)
+            .expect("preflight the immutable original hunk without consuming progress");
+
+        let after = &controller.session(&session_id).unwrap().steps[0];
+        assert_eq!(after.status, before.status);
+        assert_eq!(after.completion, before.completion);
+        assert_eq!(after.id, before.id);
+    }
+
+    #[test]
+    fn semantic_groups_reject_empty_duplicate_and_cross_file_original_hunks() {
+        let (mut controller, session_id, step_id) = controller_with_session();
+        let original = "fn refresh() {\n    old();\n}\n";
+        assert!(matches!(
+            controller.preview_step_group(&session_id, &[], Path::new("src/token.rs"), original,),
+            Err(ReplayError::InvalidPatch(_)),
+        ));
+        let duplicate = vec![step_id.clone(), step_id.clone()];
+        assert!(matches!(
+            controller.validate_step_group(
+                &session_id,
+                &duplicate,
+                Path::new("src/token.rs"),
+                original,
+            ),
+            Err(ReplayError::InvalidPatch(_)),
+        ));
+
+        let other_id = "other-original-hunk".to_string();
+        let session = controller.sessions.get_mut(&session_id).unwrap();
+        let mut other = session.steps[0].clone();
+        other.id = other_id.clone();
+        other.ordinal = 2;
+        other.path = PathBuf::from("src/other.rs");
+        other.dependencies = vec![step_id.clone()];
+        other.status = ReplayStepStatus::Pending;
+        other.completion = None;
+        session.steps.push(other);
+
+        assert!(matches!(
+            controller.preview_step_group(
+                &session_id,
+                &[step_id, other_id],
+                Path::new("src/token.rs"),
+                original,
+            ),
+            Err(ReplayError::AnchorConflict),
+        ));
+        assert!(controller
+            .session(&session_id)
+            .unwrap()
+            .steps
+            .iter()
+            .all(|step| step.status != ReplayStepStatus::Done));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -2330,7 +2330,9 @@ fn collect_snapshot_replay_reviews(
 ) {
     if let Some(recovery) = &snapshot.replay {
         let has_unseen_review = recovery.controller.sessions.iter().any(|session| {
-            if discarded_sessions.contains(&session.id) {
+            if discarded_sessions.contains(&session.id)
+                || !snapshot_has_replay_source_buffers(snapshot, session)
+            {
                 return false;
             }
             let id = replay_workspace_review_id(&session.workspace.root);
@@ -2346,7 +2348,9 @@ fn collect_snapshot_replay_reviews(
         let mut controller = crate::replay::ReplayController::default();
         if has_unseen_review && controller.restore(&recovery.controller).is_ok() {
             for session in controller.sessions() {
-                if discarded_sessions.contains(&session.id) {
+                if discarded_sessions.contains(&session.id)
+                    || !snapshot_has_replay_source_buffers(snapshot, session)
+                {
                     continue;
                 }
                 let id = replay_workspace_review_id(&session.workspace.root);
@@ -2536,6 +2540,23 @@ fn legacy_pull_request_workspace(path: &Path) -> Option<(PathBuf, u64, String)> 
         return Some((ancestor.to_path_buf(), number, short_head.to_string()));
     }
     None
+}
+
+fn snapshot_has_replay_source_buffers(
+    snapshot: &SessionSnapshot,
+    session: &crate::replay::ReplaySession,
+) -> bool {
+    let saved_paths = snapshot
+        .buffers
+        .iter()
+        .filter_map(|buffer| buffer.path.as_deref())
+        .map(Path::new)
+        .collect::<HashSet<_>>();
+
+    session.steps.iter().all(|step| {
+        let path = session.workspace.root.join(&step.path);
+        saved_paths.contains(path.as_path())
+    })
 }
 
 fn insert_snapshot_replay_review(
@@ -2952,6 +2973,56 @@ mod tests {
             Some(replacement_id.as_str())
         );
         assert_ne!(reviews[0].session_id.as_deref(), Some(original_id.as_str()));
+    }
+
+    #[test]
+    fn review_discovery_skips_newer_snapshots_missing_original_scratch_buffers() {
+        let (directory, mut complete, workspace) =
+            recoverable_replay_snapshot("incomplete-review-repository");
+        let root = directory.path().join("sessions");
+        complete.saved_at_ms = 10;
+        SessionStore::for_owner(&root, "editor-complete")
+            .unwrap()
+            .write(&mut complete)
+            .unwrap();
+
+        let mut incomplete = complete.clone();
+        incomplete.saved_at_ms = 20;
+        incomplete.buffers[0].path = None;
+        SessionStore::for_owner(&root, "editor-incomplete")
+            .unwrap()
+            .write(&mut incomplete)
+            .unwrap();
+
+        let reviews = SessionStore::list_replay_reviews(&root, /*active_workspace*/ None)
+            .expect("fall back to the newest snapshot that retains the actual scratch source");
+
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].owner, "editor-complete");
+        assert_eq!(reviews[0].workspace_root, workspace.root);
+        assert_eq!(reviews[0].last_activity_ms, 10);
+    }
+
+    #[test]
+    fn incomplete_replay_snapshots_do_not_trigger_repository_discovery() {
+        let (_directory, mut snapshot, workspace) =
+            recoverable_replay_snapshot("missing-buffer-repository");
+        snapshot.buffers[0].path = None;
+        let mut reviews = HashMap::new();
+        let mut repositories = HashMap::new();
+
+        collect_snapshot_replay_reviews(
+            &snapshot,
+            "editor-incomplete",
+            Some(&workspace.root),
+            &mut reviews,
+            &mut repositories,
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        assert!(reviews.is_empty());
+        assert!(repositories.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Why

Raw Git hunks are not always meaningful review steps. A standalone blank-line hunk can inherit the name of a neighboring function, while a larger compatibility change can be reduced to its first added field and receive an unrelated pull-request summary. That makes PR Replay harder to trust precisely when reviewers are trying to understand what the original code actually does.

## What changed

- Add an immutable-hunk-backed semantic presentation overlay that groups related consecutive changes within the same file without discarding their original diffs, stable identities, source anchors, or prerequisite ordering.
- Attach incidental whitespace changes to the nearest substantive change and combine derived-deserializer removal with the matching backwards-compatible deserialization implementation.
- Generate change titles, explanations, and bounded supporting details from actual added/removed source, Rust syntax ownership, compatibility behavior, and relevant author-written rationale instead of neighboring hunk headers or unrelated PR text.
- Apply, manually validate, undo, and recover every original hunk in a semantic group as one attributable editor operation while preserving individual original-hunk completion and inline-comment anchors.
- Render a bounded summary of important secondary behavior beneath the selected change and document the semantic overlay and original-hunk invariants.
- Cover whitespace-only hunks, unrelated neighboring symbols, backwards-compatible deserialization, cross-file isolation, duplicate/malformed groups, manual reconstruction, atomic apply/undo, crash recovery, and compact panel details.

## How to Test

1. From a repository with a pull request containing a formatting-only hunk followed by a real change, launch this branch and start Replay with `Space R g`. Confirm the blank line is not presented as an independent named change, the substantive change remains accurately named, and its original diff still includes both exact hunks.
2. Review a change that removes derived deserialization, adds a field, introduces an explicit deserializer, and supplies a backwards-compatible default. Confirm Replay presents the full compatibility behavior with a relevant `WHY` and bounded supporting details rather than describing only the first field.
3. Select a grouped change, press `a`, and confirm every displayed original hunk applies together. Press `u` and confirm the complete group reverts in one undo without overwriting reviewer-authored changes.
4. Reconstruct the same grouped change manually and validate it; confirm all underlying original hunks are marked complete while the change list records one semantic completion.
5. Apply a grouped change, restart with `--resume`, and confirm its progress, original source anchors, and single-step undo are restored.
6. Run `cargo test --lib` and `cargo clippy --all-targets --all-features -- -D warnings`.
