### PR TITLE
feat(plugins): add external plugin package platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,6 +2249,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "similar",
  "tempfile",
  "textwrap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,27 +446,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
+checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
+checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
+checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
+checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
 dependencies = [
  "serde",
  "serde_derive",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
+checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
+checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -529,24 +529,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
+checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
+checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
+checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
+checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -569,15 +569,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
+checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
+checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
+checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
 
 [[package]]
 name = "crc32fast"
@@ -2063,9 +2063,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
+checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2075,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
+checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3419,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
+checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -3462,9 +3462,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
+checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -3493,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e48f8d4966d62a10b6d70722bc432c1e163890be2801d3b5784589ad36ffc3"
+checksum = "f60f3492a55dbd4eb2e4f1f33ed0626d141f5f4cf4c0194168a4c5006f6601b0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -3508,15 +3508,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
+checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
+checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -3526,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
+checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -3553,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
+checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3568,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
+checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -3578,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
+checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3590,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
+checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -3603,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
+checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3614,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80009f46991622814196d96fac6fc0a938f46b5cba737a8f4e21e24e5a03856f"
+checksum = "d1d9d3ffd05d6e864adc35cff702f56307c454caec3b1d2d89dd6c843219b663"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ ropey = "1.6.1"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 semver = "1.0"
+sha2 = "0.10"
 similar = "2.6.0"
 textwrap = "0.16"
 tempfile = "3.15.0"

--- a/crates/husk-wasm/Cargo.toml
+++ b/crates/husk-wasm/Cargo.toml
@@ -14,7 +14,7 @@ husk-value.workspace = true
 semver = "1.0"
 serde_json = "1.0.113"
 thiserror = "1.0"
-wasmtime = { version = "46.0.1", default-features = false, features = [
+wasmtime = { version = "46.0.2", default-features = false, features = [
     "anyhow",
     "component-model",
     "cranelift",

--- a/docs/EXTERNAL_PLUGINS.md
+++ b/docs/EXTERNAL_PLUGINS.md
@@ -1,0 +1,102 @@
+# External plugins
+
+Red loads external plugins from isolated package directories under
+`$XDG_CONFIG_HOME/red/plugins` (or the platform-equivalent Red configuration
+directory). A package contains a `red-plugin.toml` manifest and either a Husk
+entrypoint, a native companion, or both.
+
+The editor remains the authority for buffers, undo history, UI focus, sessions,
+and user confirmations. Plugins request attributed operations through the
+versioned host API; they do not edit Red's internal state directly.
+
+The same manager is available in the editor through `:plugins`. It opens
+immediately from local installation records and supports install, update,
+enable/disable, and data-preserving removal. The destructive purge remains an
+explicit CLI operation. Network and build work runs after selection rather than
+during editor startup.
+
+Packages using companion RPC or document transactions declare:
+
+```toml
+[plugin]
+red_api = "^0.6.0"
+```
+
+## Development install
+
+```console
+red plugin install --path ~/code/my-red-plugin
+red plugin list
+```
+
+Path installs are linked through an installation record, so editing a package
+and restarting or reloading Red picks up the local source without copying it.
+User keymaps override defaults declared by a package.
+
+## Lifecycle
+
+Plugins may be enabled, disabled, updated, and removed:
+
+```console
+red plugin disable replay
+red plugin enable replay
+red plugin update replay
+red plugin remove replay
+red plugin remove replay --purge
+```
+
+Ordinary removal preserves namespaced plugin data for later reinstall. `--purge`
+also removes that data. Install and update stage a complete package, validate
+compatibility and checksums, and atomically replace the active package. Failed
+updates leave the previous installation intact.
+
+## Manifest
+
+```toml
+schema_version = 1
+
+[plugin]
+id = "my-plugin"
+name = "My Plugin"
+version = "0.1.0"
+red_api = "^0.6.0"
+husk_manifest = "husk/Husk.toml"
+
+[activation]
+commands = ["MyPlugin"]
+
+[companion]
+command = "bin/my-plugin"
+
+[companion.commands]
+x86_64-pc-windows-msvc = "bin/my-plugin.cmd"
+```
+
+Husk packages are compiled during install before an installation record is
+replaced. Companions start lazily on the first `CompanionCall`; listing plugins
+and opening Red do not start them. Release packages may omit `command` and
+provide per-target `artifacts` with HTTPS GitHub URLs and SHA-256 digests.
+
+Packages extracted from Red can declare migration without adding product
+knowledge to the host:
+
+```toml
+[migration.legacy_session_fields]
+old_top_level_field = "private_storage_key"
+```
+
+Unknown legacy fields remain in the session snapshot. When a compatible package
+is installed and enabled, Red copies the declared value once into that
+package's private storage. The package owns validation and conversion.
+
+## Host-owned safety boundaries
+
+- `DocumentSnapshot`, `DocumentApply`, and `DocumentUndo` preserve editor
+  revisions, preimages, attributed transactions, dirty tracking, and LSP
+  notifications.
+- `CompanionCall` uses bounded JSON-lines frames, monotonic request IDs,
+  timeouts, cancellation, lazy startup, and editor-shutdown supervision.
+- Plugin storage is namespaced and co-snapshotted without interpreting unknown
+  values.
+- Package discovery reads local records only. Updates occur only when the user
+  asks for them.

--- a/docs/EXTERNAL_PLUGINS.md
+++ b/docs/EXTERNAL_PLUGINS.md
@@ -33,6 +33,11 @@ Path installs are linked through an installation record, so editing a package
 and restarting or reloading Red picks up the local source without copying it.
 User keymaps override defaults declared by a package.
 
+Plugin keymaps may share a leader, such as `Space R g` and `Space R n`, but a
+package cannot bind both a leader (`Space R`) and one of its descendants
+(`Space R g`). Install and update reject these ambiguous declarations instead
+of silently dropping one binding.
+
 ## Lifecycle
 
 Plugins may be enabled, disabled, updated, and removed:

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.4.0` is defined by
+Red host API version `0.6.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -22,6 +22,31 @@ literal host call absent from the canonical schema. Literal host calls also chec
 required/optional arity (`HUSK-A0002`) and obvious literal argument types
 (`HUSK-A0003`) against the machine-readable signature. `--no-typecheck` is an unsupported
 development escape hatch; compatibility guarantees do not apply while it is enabled.
+
+Red `0.6.0` retains the complete `0.4.0` contract, so existing packages that
+declare `"red_api_version": "^0.4.0"` continue to load. New packages should
+target `"red_api_version": "^0.6.0"` to use the external-package primitives.
+
+## External package primitives
+
+`CompanionCall(callback, method, params, timeout_ms?)` lazily starts the calling
+package's declared native companion and exchanges bounded JSON-lines RPC
+messages. Red owns the process, matches responses to requests, enforces the
+timeout, and stops the process when the package or editor shuts down.
+
+`DocumentSnapshot(callback, path?)` returns the current text and revision for an
+open document. `DocumentApply(callback, options)` atomically applies non-overlapping
+edits after checking the expected revision and optional preimages. The result
+contains an attributed transaction ID. `DocumentUndo(callback, options)` reverts
+that exact transaction only while it is still the most recent transaction from
+the same plugin. Red remains responsible for buffer state, dirty tracking, LSP
+notifications, and undo history.
+
+Plugin-owned storage is captured as an opaque namespaced extension in Red session
+snapshots. Unknown extensions survive load/save cycles, allowing a package to
+restore its workflow without Red understanding the payload.
+
+These calls were introduced in host API `0.6.0`.
 
 ## Workspace file operations
 
@@ -95,8 +120,8 @@ picker. They do not use global `picker:*:<id>` subscriptions. Picker items and c
 payloads use the declared `PickerItem`, `PickerCancelled`, and `PickerActionEvent` records;
 the `PickerItem.data` field remains `Json` so a plugin can attach its own payload.
 
-`OpenPicker` was added in host API `0.3.0`. Plugins targeting this Red release should
-declare `"red_api_version": "^0.4.0"`. The numeric-ID `OpenDynamicPicker` API remains
+`OpenPicker` was added in host API `0.3.0`. New plugins targeting this Red release should
+declare `"red_api_version": "^0.6.0"`. The numeric-ID `OpenDynamicPicker` API remains
 available for compatibility, but new plugins should not use it.
 
 ## Agent composer

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.4.0",
+  "api_version": "0.6.0",
   "changes": [
+    {
+      "version": "0.6.0",
+      "kind": "introduced",
+      "symbols": ["CompanionCall", "DocumentSnapshot", "DocumentApply", "DocumentUndo", "UpdatePickerBusy"],
+      "migration_note": "docs/PLUGIN_API.md#external-package-primitives"
+    },
     {
       "version": "0.4.0",
       "kind": "introduced",

--- a/examples/external-hello-plugin/Husk.toml
+++ b/examples/external-hello-plugin/Husk.toml
@@ -1,0 +1,7 @@
+schema_version = 1
+
+[package]
+name = "hello-panel"
+version = "0.1.0"
+entry = "src/main.hk"
+

--- a/examples/external-hello-plugin/red-plugin.toml
+++ b/examples/external-hello-plugin/red-plugin.toml
@@ -1,0 +1,17 @@
+schema_version = 1
+
+[plugin]
+id = "hello-panel"
+name = "Hello Panel"
+version = "0.1.0"
+red_api = "^0.6.0"
+husk_manifest = "Husk.toml"
+description = "Minimal external package fixture with no native companion"
+license = "MIT"
+
+[activation]
+commands = ["HelloPanel"]
+
+[keymaps.normal]
+"Space H" = "HelloPanel"
+

--- a/examples/external-hello-plugin/src/main.hk
+++ b/examples/external-hello-plugin/src/main.hk
@@ -1,0 +1,25 @@
+pub fn activate() {
+    red::add_command("HelloPanel", open, Json {
+        title: "Open external hello panel",
+        category: "Examples",
+        description: "Proves that external UI packages do not depend on Replay",
+    });
+}
+
+fn open() {
+    red::execute("CreateTextPanel", "external-hello", PanelConfig {
+        side: "right",
+        width: 36,
+        title: "EXTERNAL PLUGIN",
+        header_actions: [
+            Json { id: "close", label: "Close", compact_label: "×" },
+        ],
+    });
+    red::execute("UpdateTextPanel", "external-hello", [TextPanelBlock {
+        id: "hello",
+        kind: "text",
+        format: "markdown",
+        text: "# Hello from a package\n\nLoaded lazily from a multi-file external plugin package.",
+    }]);
+    red::execute("FocusPanel", "external-hello");
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,11 +5,17 @@
 //! boundaries rather than supported interactive workflows, so callers should prefer the
 //! public modes documented by the CLI.
 
-use clap::Parser;
+use std::path::PathBuf;
+
+use clap::{Args as ClapArgs, Parser, Subcommand};
 
 #[derive(Debug, Parser)]
 #[command(version)]
 pub struct Args {
+    /// Non-interactive Red utilities.
+    #[command(subcommand)]
+    pub command: Option<RootCommand>,
+
     /// Root path
     #[clap(short, long)]
     pub root: Option<String>,
@@ -87,9 +93,73 @@ pub struct Args {
     pub files: Vec<String>,
 }
 
+#[derive(Debug, Subcommand)]
+pub enum RootCommand {
+    /// Install and manage external plugin packages.
+    Plugin(PluginArgs),
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct PluginArgs {
+    #[command(subcommand)]
+    pub command: PluginCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PluginCommand {
+    /// Install a plugin from GitHub or a local development checkout.
+    Install(PluginInstallArgs),
+    /// List installed external plugins.
+    List,
+    /// Update one plugin or every enabled plugin.
+    Update(PluginUpdateArgs),
+    /// Disable an installed plugin without deleting state.
+    Disable(PluginIdArgs),
+    /// Enable a disabled installed plugin.
+    Enable(PluginIdArgs),
+    /// Remove an installed plugin, preserving its data by default.
+    Remove(PluginRemoveArgs),
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct PluginInstallArgs {
+    /// GitHub repository in `owner/repository` form, optionally followed by `@tag`.
+    #[arg(required_unless_present = "path", conflicts_with = "path")]
+    pub source: Option<String>,
+    /// Install a local package checkout for development.
+    #[arg(long, value_name = "DIRECTORY")]
+    pub path: Option<PathBuf>,
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct PluginUpdateArgs {
+    /// Installed plugin identifier.
+    #[arg(required_unless_present = "all", conflicts_with = "all")]
+    pub id: Option<String>,
+    /// Update every enabled external plugin.
+    #[arg(long)]
+    pub all: bool,
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct PluginIdArgs {
+    /// Installed plugin identifier.
+    pub id: String,
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct PluginRemoveArgs {
+    /// Installed plugin identifier.
+    pub id: String,
+    /// Also delete the plugin's namespaced saved data.
+    #[arg(long)]
+    pub purge: bool,
+}
+
 impl Args {
     pub fn utility_requested(&self) -> bool {
-        self.self_check
+        self.command.is_some()
+            || self.self_check
             || self.check_config
             || self.agent_check
             || self.runtime_files
@@ -186,6 +256,38 @@ mod tests {
         let args = Args::try_parse_from(["red", "--process-editor-replace", "todo"]).unwrap();
         assert!(args.process_editor_replace);
         assert!(args.validate_utility_args().is_ok());
+
+        let args =
+            Args::try_parse_from(["red", "plugin", "install", "codersauce/replay@v1.2.3"]).unwrap();
+        assert!(matches!(
+            args.command,
+            Some(RootCommand::Plugin(PluginArgs {
+                command: PluginCommand::Install(PluginInstallArgs {
+                    source: Some(_),
+                    path: None,
+                }),
+            }))
+        ));
+
+        let args =
+            Args::try_parse_from(["red", "plugin", "install", "--path", "../replay"]).unwrap();
+        assert!(matches!(
+            args.command,
+            Some(RootCommand::Plugin(PluginArgs {
+                command: PluginCommand::Install(PluginInstallArgs {
+                    source: None,
+                    path: Some(_),
+                }),
+            }))
+        ));
+
+        let args = Args::try_parse_from(["red", "plugin", "update", "--all"]).unwrap();
+        assert!(matches!(
+            args.command,
+            Some(RootCommand::Plugin(PluginArgs {
+                command: PluginCommand::Update(PluginUpdateArgs { all: true, .. }),
+            }))
+        ));
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -133,6 +133,42 @@ const MAX_HIGHLIGHT_SLICE_BYTES: usize = 512 * 1024;
 const MAX_PLUGIN_VIEWPORT_LINE_CHARS: usize = 64 * 1024;
 const MAX_DIRECTORY_LISTING_ENTRIES: usize = 160;
 const AGENT_BRIDGE_CAPACITY: usize = 64;
+const PLUGIN_MANAGER_PICKER_ID: i32 = 9_101;
+const PLUGIN_MANAGER_ACTION_PICKER_ID: i32 = 9_102;
+
+async fn apply_plugin_manager_operation(
+    manager: &plugin::package::PluginPackageManager,
+    operation: &str,
+) -> anyhow::Result<String> {
+    let (verb, raw_id) = operation
+        .split_once('\t')
+        .ok_or_else(|| anyhow::anyhow!("invalid plugin operation"))?;
+    let id = plugin::package::PluginId::parse(raw_id)?;
+    match verb {
+        "enable" => {
+            manager.set_enabled(&id, true)?;
+            Ok(format!("Enabled plugin {id}."))
+        }
+        "disable" => {
+            manager.set_enabled(&id, false)?;
+            Ok(format!("Disabled plugin {id}."))
+        }
+        "update" => {
+            let installed = manager.update(&id).await?;
+            Ok(format!(
+                "Updated {} to {}.",
+                installed.name, installed.version
+            ))
+        }
+        "remove" => {
+            manager.remove(&id, false)?;
+            Ok(format!(
+                "Removed plugin {id}; its private data was preserved."
+            ))
+        }
+        _ => anyhow::bail!("unknown plugin operation `{verb}`"),
+    }
+}
 const MACRO_MAX_REPLAY_DEPTH: usize = 20;
 const MACRO_MAX_REPLAY_EVENTS: usize = 10_000;
 const MIN_EDITOR_WINDOW_WIDTH: usize = 10;
@@ -704,6 +740,10 @@ pub enum PluginRequest {
         id: i32,
         status: Option<String>,
     },
+    UpdatePickerBusy {
+        id: i32,
+        busy: bool,
+    },
     UpdatePickerPreview {
         id: i32,
         preview: Option<PickerPreview>,
@@ -952,6 +992,31 @@ pub enum PluginRequest {
     UnwatchDirectory {
         watch_id: i32,
     },
+    CompanionCall {
+        owner: String,
+        method: String,
+        params: Value,
+        timeout_ms: Option<u64>,
+        request_id: RequestId,
+    },
+    DocumentSnapshot {
+        path: Option<String>,
+        request_id: RequestId,
+    },
+    DocumentApply {
+        owner: String,
+        path: Option<String>,
+        expected_revision: u64,
+        label: String,
+        edits: Vec<plugin::DocumentEdit>,
+        request_id: RequestId,
+    },
+    DocumentUndo {
+        owner: String,
+        path: Option<String>,
+        transaction_id: String,
+        request_id: RequestId,
+    },
 }
 
 impl PluginRequest {
@@ -983,6 +1048,7 @@ impl PluginRequest {
             Self::UpdatePickerItems { .. } => "UpdatePickerItems",
             Self::UpdatePickerQuery { .. } => "UpdatePickerQuery",
             Self::UpdatePickerStatus { .. } => "UpdatePickerStatus",
+            Self::UpdatePickerBusy { .. } => "UpdatePickerBusy",
             Self::UpdatePickerPreview { .. } => "UpdatePickerPreview",
             Self::ClosePicker { .. } => "ClosePicker",
             Self::BufferInsert { .. } => "BufferInsert",
@@ -1019,6 +1085,10 @@ impl PluginRequest {
             Self::DisplayColumnToCharIndex { .. } => "DisplayColumnToCharIndex",
             Self::IntervalCallback { .. } => "IntervalCallback",
             Self::TimeoutCallback { .. } => "TimeoutCallback",
+            Self::CompanionCall { .. } => "CompanionCall",
+            Self::DocumentSnapshot { .. } => "DocumentSnapshot",
+            Self::DocumentApply { .. } => "DocumentApply",
+            Self::DocumentUndo { .. } => "DocumentUndo",
             Self::CreateOverlay { .. } => "CreateOverlay",
             Self::UpdateOverlay { .. } => "UpdateOverlay",
             Self::RemoveOverlay { .. } => "RemoveOverlay",
@@ -1462,6 +1532,9 @@ pub enum Action {
     ResolvePluginRequest(i64, Value),
     ViewLogs,
     ListPlugins,
+    PluginManagerInstall(String),
+    PluginManagerAction(String),
+    PluginManagerFinished(String),
 
     // Window management actions
     SplitHorizontal,
@@ -1770,6 +1843,9 @@ pub struct Editor {
 
     /// Plugin system registry
     plugin_registry: PluginRegistry,
+
+    /// Lazily spawned native companions owned by installed plugins.
+    companion_manager: Arc<tokio::sync::Mutex<plugin::companion::CompanionManager>>,
 
     /// Syntax highlighting engine
     highlighter: Highlighter,
@@ -2483,6 +2559,14 @@ struct PendingLspEdit {
     uri: String,
 }
 
+struct PluginDocumentTransaction {
+    owner: String,
+    path: Option<String>,
+    expected_revision: u64,
+    label: String,
+    edits: Vec<plugin::DocumentEdit>,
+}
+
 #[derive(Debug, Clone)]
 struct PendingLspFormatSave {
     save_as: Option<String>,
@@ -2963,6 +3047,9 @@ impl Editor {
             config_diagnostics_acknowledged: true,
             theme,
             plugin_registry,
+            companion_manager: Arc::new(tokio::sync::Mutex::new(
+                plugin::companion::CompanionManager::new(Config::config_dir()),
+            )),
             highlighter,
             highlight_cache: HashMap::new(),
             bracket_match_cache: None,
@@ -6054,6 +6141,7 @@ impl Editor {
         if let Err(err) = self.plugin_registry.deactivate_all(runtime).await {
             log!("Plugin deactivate failed: {}", err);
         }
+        self.companion_manager.lock().await.shutdown().await;
     }
 
     fn abort_agent_bridge(&mut self) {
@@ -6821,6 +6909,12 @@ impl Editor {
                 PluginRequest::UpdatePickerStatus { id, status } => {
                     if let Some(dialog) = &mut self.current_dialog {
                         dialog.update_picker(id, PickerUpdate::Status(status));
+                    }
+                    needs_render = true;
+                }
+                PluginRequest::UpdatePickerBusy { id, busy } => {
+                    if let Some(dialog) = &mut self.current_dialog {
+                        dialog.update_picker(id, PickerUpdate::Busy(busy));
                     }
                     needs_render = true;
                 }
@@ -7645,6 +7739,118 @@ impl Editor {
                     self.reconcile_plugin_file_operation(&outcome).await?;
                     self.plugin_registry
                         .resolve_request(runtime, request_id, outcome.payload)
+                        .await?;
+                    needs_render = true;
+                }
+                PluginRequest::CompanionCall {
+                    owner,
+                    method,
+                    params,
+                    timeout_ms,
+                    request_id,
+                } => {
+                    let timeout = timeout_ms.map(Duration::from_millis);
+                    let companion_manager = Arc::clone(&self.companion_manager);
+                    let mut callback_runtime = runtime.clone();
+                    tokio::spawn(async move {
+                        let payload = match companion_manager
+                            .lock()
+                            .await
+                            .call(&owner, &method, params, timeout)
+                            .await
+                        {
+                            Ok(response) => json!({
+                                "ok": true,
+                                "result": response.result,
+                                "progress": response.progress,
+                            }),
+                            Err(error) => json!({
+                                "ok": false,
+                                "error": error.to_string(),
+                            }),
+                        };
+                        if let Err(error) =
+                            callback_runtime.resolve_request(request_id, payload).await
+                        {
+                            log!(
+                                "{}",
+                                json!({
+                                    "event": "plugin_companion_callback_failed",
+                                    "plugin": owner,
+                                    "request_id": request_id.get(),
+                                    "error": error.to_string(),
+                                })
+                            );
+                        }
+                    });
+                }
+                PluginRequest::DocumentSnapshot { path, request_id } => {
+                    let payload = self.plugin_document_snapshot(path.as_deref()).map_or_else(
+                        |error| json!({ "ok": false, "error": error.to_string() }),
+                        |snapshot| json!({ "ok": true, "document": snapshot }),
+                    );
+                    self.plugin_registry
+                        .resolve_request(runtime, request_id, payload)
+                        .await?;
+                }
+                PluginRequest::DocumentApply {
+                    owner,
+                    path,
+                    expected_revision,
+                    label,
+                    edits,
+                    request_id,
+                } => {
+                    let payload = match self
+                        .apply_plugin_document_transaction(
+                            buffer,
+                            runtime,
+                            PluginDocumentTransaction {
+                                owner,
+                                path,
+                                expected_revision,
+                                label,
+                                edits,
+                            },
+                        )
+                        .await
+                    {
+                        Ok(transaction_id) => json!({
+                            "ok": true,
+                            "transaction_id": transaction_id,
+                            "revision": self.current_buffer().revision(),
+                        }),
+                        Err(error) => json!({ "ok": false, "error": error.to_string() }),
+                    };
+                    self.plugin_registry
+                        .resolve_request(runtime, request_id, payload)
+                        .await?;
+                    needs_render = true;
+                }
+                PluginRequest::DocumentUndo {
+                    owner,
+                    path,
+                    transaction_id,
+                    request_id,
+                } => {
+                    let payload = match self
+                        .undo_plugin_document_transaction(
+                            buffer,
+                            runtime,
+                            &owner,
+                            path.as_deref(),
+                            &transaction_id,
+                        )
+                        .await
+                    {
+                        Ok(()) => json!({
+                            "ok": true,
+                            "revision": self.current_buffer().revision(),
+                        }),
+                        Err(error) => json!({ "ok": false, "error": error.to_string() }),
+                    };
+                    self.plugin_registry
+                        .resolve_request(runtime, request_id, payload)
                         .await?;
                     needs_render = true;
                 }
@@ -14277,88 +14483,86 @@ impl Editor {
             }
             Action::ListPlugins => {
                 add_to_history = false;
-
-                // Create a buffer with plugin information
-                let mut content = String::from("# Loaded Plugins\n\n");
-
-                let metadata = self.plugin_registry.all_metadata();
-                if metadata.is_empty() {
-                    content.push_str("No plugins loaded.\n");
-                } else {
-                    for (plugin_name, meta) in metadata {
-                        content.push_str(&format!("## {}\n", meta.name));
-                        content.push_str(&format!("Version: {}\n", meta.version));
-                        if let Some(status) = self.plugin_registry.statuses().get(plugin_name) {
-                            content.push_str(&format!("Status: {status:?}\n"));
-                            if let plugin::PluginStatus::Quarantined {
-                                path, diagnostic, ..
-                            } = status
-                            {
-                                content.push_str(&format!("Source: {path}\n"));
-                                content.push_str(&format!("Diagnostic: {diagnostic}\n"));
-                                content.push_str(
-                                    "Actions: fix and save to retry, remove from config to disable, or open docs/PLUGIN_API.md\n",
-                                );
-                            }
-                        }
-
-                        if let Some(desc) = &meta.description {
-                            content.push_str(&format!("Description: {}\n", desc));
-                        }
-
-                        if let Some(author) = &meta.author {
-                            content.push_str(&format!("Author: {}\n", author));
-                        }
-
-                        if let Some(license) = &meta.license {
-                            content.push_str(&format!("License: {}\n", license));
-                        }
-
-                        if !meta.keywords.is_empty() {
-                            content.push_str(&format!("Keywords: {}\n", meta.keywords.join(", ")));
-                        }
-
-                        content.push_str(&format!("Main: {}\n", meta.main));
-
-                        // Show capabilities
-                        if meta.capabilities.commands
-                            || meta.capabilities.events
-                            || meta.capabilities.buffer_manipulation
-                            || meta.capabilities.ui_components
-                        {
-                            content.push_str("Capabilities: ");
-                            let mut caps = vec![];
-                            if meta.capabilities.commands {
-                                caps.push("commands");
-                            }
-                            if meta.capabilities.events {
-                                caps.push("events");
-                            }
-                            if meta.capabilities.buffer_manipulation {
-                                caps.push("buffer manipulation");
-                            }
-                            if meta.capabilities.ui_components {
-                                caps.push("UI components");
-                            }
-                            if meta.capabilities.lsp_integration {
-                                caps.push("LSP integration");
-                            }
-                            content.push_str(&caps.join(", "));
-                            content.push('\n');
-                        }
-
-                        content.push('\n');
+                let manager = plugin::package::PluginPackageManager::new(Config::config_dir());
+                let mut items = vec!["Install plugin…".to_string()];
+                match manager.list() {
+                    Ok(installed) => {
+                        items.extend(installed.into_iter().map(|plugin| {
+                            format!(
+                                "{}\t{}\t{}\t{}",
+                                plugin.id,
+                                plugin.name,
+                                plugin.version,
+                                if plugin.enabled {
+                                    "enabled"
+                                } else {
+                                    "disabled"
+                                }
+                            )
+                        }));
                     }
+                    Err(error) => self.last_error = Some(error.to_string()),
                 }
-
-                // Create a new buffer with the plugin list
-                let plugin_list_buffer = Buffer::new(Some("[Plugin List]".to_string()), content);
-                self.buffer_manager.add_buffer(plugin_list_buffer);
-                self.cx = 0;
-                self.cy = 0;
-                self.vtop = 0;
-                self.vleft = 0;
-                self.skipcol = 0;
+                self.current_dialog = Some(Box::new(Picker::new(
+                    Some("Plugin manager".to_string()),
+                    self,
+                    &items,
+                    Some(PLUGIN_MANAGER_PICKER_ID),
+                )));
+                self.render(buffer)?;
+            }
+            Action::PluginManagerInstall(source) => {
+                add_to_history = false;
+                let source = source.trim().to_string();
+                if source.is_empty() {
+                    self.last_error = Some("plugin source cannot be empty".to_string());
+                } else {
+                    self.last_error = Some(format!("Installing plugin from {source}…"));
+                    tokio::spawn(async move {
+                        let manager =
+                            plugin::package::PluginPackageManager::new(Config::config_dir());
+                        let result = if Path::new(&source).exists() {
+                            manager.install_path(Path::new(&source)).await
+                        } else {
+                            let (repository, version) = source
+                                .rsplit_once('@')
+                                .map_or((source.as_str(), None), |(repository, version)| {
+                                    (repository, Some(version))
+                                });
+                            manager.install_github(repository, version).await
+                        };
+                        let message = match result {
+                            Ok(plugin) => format!(
+                                "Installed {} {}. Restart Red to activate it.",
+                                plugin.name, plugin.version
+                            ),
+                            Err(error) => format!("Plugin install failed: {error}"),
+                        };
+                        ACTION_DISPATCHER.send_request(PluginRequest::Action(
+                            Action::PluginManagerFinished(message),
+                        ));
+                    });
+                }
+            }
+            Action::PluginManagerAction(operation) => {
+                add_to_history = false;
+                let operation = operation.clone();
+                self.last_error = Some("Updating plugin installation…".to_string());
+                tokio::spawn(async move {
+                    let manager = plugin::package::PluginPackageManager::new(Config::config_dir());
+                    let result = apply_plugin_manager_operation(&manager, &operation).await;
+                    let message = match result {
+                        Ok(message) => format!("{message} Restart Red to refresh plugins."),
+                        Err(error) => format!("Plugin operation failed: {error}"),
+                    };
+                    ACTION_DISPATCHER.send_request(PluginRequest::Action(
+                        Action::PluginManagerFinished(message),
+                    ));
+                });
+            }
+            Action::PluginManagerFinished(message) => {
+                add_to_history = false;
+                self.last_error = Some(message.clone());
             }
             Action::Command(cmd) => {
                 log!("Handling command: {cmd}");
@@ -15418,7 +15622,35 @@ impl Editor {
             }
             Action::Picked(item, id) => {
                 log!("picked: {item} - {id:?}");
-                if let Some(id) = id {
+                if *id == Some(PLUGIN_MANAGER_PICKER_ID) {
+                    if item == "Install plugin…" {
+                        self.current_dialog = Some(Box::new(InputPrompt::new(
+                            self,
+                            "GitHub owner/repo[@tag] or local path",
+                            "",
+                            Action::PluginManagerInstall,
+                        )));
+                    } else if let Some(plugin_id) = item.split('\t').next() {
+                        let enabled = item.ends_with("\tenabled");
+                        let toggle = if enabled { "disable" } else { "enable" };
+                        let actions = vec![
+                            format!("{toggle}\t{plugin_id}"),
+                            format!("update\t{plugin_id}"),
+                            format!("remove\t{plugin_id}"),
+                        ];
+                        self.current_dialog = Some(Box::new(Picker::new(
+                            Some(format!("Manage {plugin_id}")),
+                            self,
+                            &actions,
+                            Some(PLUGIN_MANAGER_ACTION_PICKER_ID),
+                        )));
+                    }
+                    self.render(buffer)?;
+                } else if *id == Some(PLUGIN_MANAGER_ACTION_PICKER_ID) {
+                    return self
+                        .execute(&Action::PluginManagerAction(item.clone()), buffer, runtime)
+                        .await;
+                } else if let Some(id) = id {
                     self.plugin_registry
                         .notify(
                             runtime,
@@ -17044,6 +17276,139 @@ impl Editor {
         self.ensure_buffer_lsp_opened(buffer_index).await
     }
 
+    fn plugin_document_index(&self, path: Option<&str>) -> anyhow::Result<usize> {
+        let Some(path) = path else {
+            return Ok(self.buffer_manager.active_index());
+        };
+        let requested = Path::new(path)
+            .absolutize()
+            .map(|path| path.into_owned())
+            .unwrap_or_else(|_| PathBuf::from(path));
+        self.buffer_manager
+            .iter()
+            .position(|buffer| {
+                buffer.file.as_deref().is_some_and(|candidate| {
+                    candidate == path
+                        || Path::new(candidate)
+                            .absolutize()
+                            .map(|candidate| candidate.as_ref() == requested)
+                            .unwrap_or(false)
+                })
+            })
+            .ok_or_else(|| anyhow::anyhow!("document is not open in Red: {path}"))
+    }
+
+    fn plugin_document_snapshot(
+        &self,
+        path: Option<&str>,
+    ) -> anyhow::Result<plugin::DocumentSnapshot> {
+        let buffer_index = self.plugin_document_index(path)?;
+        let buffer = self
+            .buffer_manager
+            .get(buffer_index)
+            .ok_or_else(|| anyhow::anyhow!("document buffer disappeared"))?;
+        Ok(plugin::DocumentSnapshot {
+            buffer_index,
+            path: buffer.file.clone(),
+            revision: buffer.revision(),
+            text: buffer.contents(),
+        })
+    }
+
+    async fn apply_plugin_document_transaction(
+        &mut self,
+        render_buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+        transaction: PluginDocumentTransaction,
+    ) -> anyhow::Result<String> {
+        anyhow::ensure!(
+            !transaction.edits.is_empty(),
+            "document transaction contains no edits"
+        );
+        let buffer_index = self.plugin_document_index(transaction.path.as_deref())?;
+        if buffer_index != self.buffer_manager.active_index() {
+            self.set_current_buffer(render_buffer, buffer_index).await?;
+        }
+        anyhow::ensure!(
+            self.current_buffer().revision() == transaction.expected_revision,
+            "document revision changed: expected {}, found {}",
+            transaction.expected_revision,
+            self.current_buffer().revision()
+        );
+
+        let mut prepared = transaction
+            .edits
+            .into_iter()
+            .map(|edit| {
+                let start = self.current_buffer().position_to_char_idx(edit.range.start);
+                let end = self.current_buffer().position_to_char_idx(edit.range.end);
+                anyhow::ensure!(start <= end, "document edit range is reversed");
+                if let Some(expected_text) = &edit.expected_text {
+                    anyhow::ensure!(
+                        self.current_buffer().text_in_range(edit.range) == *expected_text,
+                        "document edit preimage no longer matches"
+                    );
+                }
+                Ok((start, end, edit))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        prepared.sort_by_key(|(start, end, _)| (*start, *end));
+        anyhow::ensure!(
+            prepared.windows(2).all(|pair| pair[0].1 <= pair[1].0),
+            "document transaction contains overlapping edits"
+        );
+
+        self.begin_transaction_with_origin(
+            &transaction.label,
+            EditOrigin::Plugin {
+                name: transaction.owner,
+            },
+        );
+        for (_, _, edit) in prepared.into_iter().rev() {
+            self.replace_range(edit.range, &edit.text);
+        }
+        anyhow::ensure!(
+            self.commit_transaction(self.cursor_snapshot()),
+            "document transaction made no changes"
+        );
+        let transaction_id = self
+            .current_buffer()
+            .undo_history
+            .latest_transaction()
+            .map(|transaction| transaction.id.clone())
+            .ok_or_else(|| anyhow::anyhow!("document transaction was not recorded"))?;
+        self.notify_change(runtime).await?;
+        Ok(transaction_id)
+    }
+
+    async fn undo_plugin_document_transaction(
+        &mut self,
+        render_buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+        owner: &str,
+        path: Option<&str>,
+        transaction_id: &str,
+    ) -> anyhow::Result<()> {
+        let buffer_index = self.plugin_document_index(path)?;
+        if buffer_index != self.buffer_manager.active_index() {
+            self.set_current_buffer(render_buffer, buffer_index).await?;
+        }
+        let latest = self
+            .current_buffer()
+            .undo_history
+            .latest_transaction()
+            .ok_or_else(|| anyhow::anyhow!("document has no transaction to undo"))?;
+        anyhow::ensure!(
+            latest.id == transaction_id,
+            "plugin transaction is no longer the document's latest change"
+        );
+        anyhow::ensure!(
+            matches!(&latest.origin, EditOrigin::Plugin { name } if name == owner),
+            "plugin cannot undo a transaction owned by another actor"
+        );
+        self.undo_transaction(render_buffer, runtime).await
+    }
+
     async fn reconcile_plugin_file_operation(
         &mut self,
         outcome: &plugin::filesystem::FileOperationOutcome,
@@ -18585,6 +18950,56 @@ impl Editor {
                 .clone()
                 .map(|workspace| Arc::new(Mutex::new(ProposalWorkspace::from_snapshot(workspace)))),
         );
+        if let Err(error) = self
+            .preferences
+            .merge_plugin_storage_snapshot(&snapshot.plugin_extensions)
+        {
+            log!(
+                "{}",
+                json!({
+                    "event": "recovery_plugin_extension_persistence_failed",
+                    "level": "warn",
+                    "service": "red",
+                    "error": error.to_string(),
+                })
+            );
+        }
+        let package_manager = plugin::package::PluginPackageManager::new(Config::config_dir());
+        match package_manager.legacy_session_imports(&snapshot.legacy_extensions) {
+            Ok(imports) => {
+                for (plugin_id, storage_key, value) in imports {
+                    if self
+                        .preferences
+                        .plugin_storage(plugin_id.as_str(), &storage_key)
+                        .is_none()
+                    {
+                        if let Err(error) = self.preferences.set_plugin_storage(
+                            plugin_id.as_str(),
+                            &storage_key,
+                            value,
+                        ) {
+                            log!(
+                                "{}",
+                                json!({
+                                    "event": "legacy_plugin_session_import_failed",
+                                    "level": "warn",
+                                    "plugin": plugin_id.as_str(),
+                                    "error": error.to_string(),
+                                })
+                            );
+                        }
+                    }
+                }
+            }
+            Err(error) => log!(
+                "{}",
+                json!({
+                    "event": "legacy_plugin_session_discovery_failed",
+                    "level": "warn",
+                    "error": error.to_string(),
+                })
+            ),
+        }
         if let Some(transcript) = &snapshot.agent_transcript {
             let transcript_persisted = if let Err(error) = self.preferences.set_plugin_storage(
                 "agent",
@@ -18787,6 +19202,8 @@ impl Editor {
                 agent_transcript,
                 agent_workspace,
                 agent_session_resumable: false,
+                plugin_extensions: self.preferences.plugin_storage_snapshot(),
+                legacy_extensions: std::collections::BTreeMap::new(),
             },
             disk_fingerprints,
         )

--- a/src/editor/buffer_manager.rs
+++ b/src/editor/buffer_manager.rs
@@ -63,7 +63,8 @@ impl BufferManager {
         self.buffers.len()
     }
 
-    /// Adds a buffer and makes it active.
+    /// Adds a buffer and makes it active in editor tests.
+    #[cfg(test)]
     pub fn add_buffer(&mut self, buffer: Buffer) -> usize {
         self.buffers.push(buffer);
         self.current_index = self.buffers.len() - 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,9 +28,11 @@ use crossterm::{style, QueueableCommand};
 
 use red::assets;
 use red::buffer::Buffer;
-use red::cli::Args;
-use red::config::{Config, ConfigDiagnosticSeverity, ConfigRecovery, LoadedConfig};
-use red::editor::Editor;
+use red::cli::{Args, PluginCommand, RootCommand};
+use red::config::{
+    Config, ConfigDiagnosticSeverity, ConfigRecovery, KeyAction, Keys, LoadedConfig,
+};
+use red::editor::{Action, Editor};
 #[cfg(any(unix, test))]
 use red::headless::{InputEvent as DetachedInput, KeyCode as DetachedKeyCode, KeyModifier};
 use red::logger::Logger;
@@ -80,6 +82,10 @@ fn forwarded_husk_arguments_from(
 async fn run() -> anyhow::Result<()> {
     let args = Args::parse();
     args.validate_utility_args()?;
+
+    if let Some(RootCommand::Plugin(plugin)) = &args.command {
+        return run_plugin_command(&plugin.command).await;
+    }
 
     if let Some(session) = &args.attach {
         return attach_session(session).await;
@@ -282,6 +288,102 @@ async fn run() -> anyhow::Result<()> {
     cleanup_result?;
     result?;
 
+    Ok(())
+}
+
+async fn run_plugin_command(command: &PluginCommand) -> anyhow::Result<()> {
+    use red::plugin::package::{PluginId, PluginPackageManager};
+
+    let manager = PluginPackageManager::new(Config::config_dir());
+    match command {
+        PluginCommand::Install(arguments) => {
+            let installed = if let Some(path) = &arguments.path {
+                manager.install_path(path).await?
+            } else {
+                let source = arguments
+                    .source
+                    .as_deref()
+                    .expect("clap requires a source or --path");
+                let (repository, version) = source
+                    .rsplit_once('@')
+                    .map_or((source, None), |(repository, version)| {
+                        (repository, Some(version))
+                    });
+                manager.install_github(repository, version).await?
+            };
+            println!(
+                "Installed {} {} ({})",
+                installed.id,
+                installed.version,
+                installed.package_root.display()
+            );
+        }
+        PluginCommand::List => {
+            let plugins = manager.list()?;
+            if plugins.is_empty() {
+                println!("No external plugins installed.");
+            }
+            for plugin in plugins {
+                let state = if plugin.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
+                let compatibility = if plugin.compatible {
+                    "compatible"
+                } else {
+                    "incompatible"
+                };
+                let companion = if plugin.has_companion {
+                    "companion"
+                } else {
+                    "husk"
+                };
+                println!(
+                    "{}\t{}\t{}\t{}\t{}",
+                    plugin.id, plugin.version, state, compatibility, companion
+                );
+            }
+        }
+        PluginCommand::Update(arguments) if arguments.all => {
+            let results = manager.update_all().await;
+            for (id, result) in results {
+                match result {
+                    Ok(plugin) => println!("Updated {} to {}", id, plugin.version),
+                    Err(error) => eprintln!("Failed to update {id}: {error:#}"),
+                }
+            }
+        }
+        PluginCommand::Update(arguments) => {
+            let id = PluginId::parse(
+                arguments
+                    .id
+                    .as_deref()
+                    .expect("clap requires an id or --all"),
+            )?;
+            let plugin = manager.update(&id).await?;
+            println!("Updated {} to {}", plugin.id, plugin.version);
+        }
+        PluginCommand::Disable(arguments) => {
+            let id = PluginId::parse(&arguments.id)?;
+            manager.set_enabled(&id, false)?;
+            println!("Disabled {id}");
+        }
+        PluginCommand::Enable(arguments) => {
+            let id = PluginId::parse(&arguments.id)?;
+            manager.set_enabled(&id, true)?;
+            println!("Enabled {id}");
+        }
+        PluginCommand::Remove(arguments) => {
+            let id = PluginId::parse(&arguments.id)?;
+            manager.remove(&id, arguments.purge)?;
+            if arguments.purge {
+                println!("Removed {id} and purged its saved data");
+            } else {
+                println!("Removed {id}; saved data was preserved");
+            }
+        }
+    }
     Ok(())
 }
 
@@ -660,6 +762,23 @@ fn finalize_runtime_config(
     mut loaded: LoadedConfig,
 ) -> anyhow::Result<(LoadedConfig, Theme, Option<Logger>)> {
     let config_dir = Config::config_dir();
+    let package_manager = red::plugin::package::PluginPackageManager::new(&config_dir);
+    for installed in package_manager
+        .list()?
+        .into_iter()
+        .filter(|plugin| plugin.enabled && plugin.compatible)
+    {
+        let manifest = red::plugin::package::PluginPackageManifest::load(&installed.package_root)?;
+        apply_plugin_default_keymaps(&mut loaded.config.keys, &manifest.keymaps);
+        let Some(entrypoint) = manifest.husk_entry(&installed.package_root) else {
+            continue;
+        };
+        loaded
+            .config
+            .plugins
+            .entry(installed.id.to_string())
+            .or_insert_with(|| entrypoint.to_string_lossy().into_owned());
+    }
     for plugin in loaded.config.missing_plugins(&config_dir) {
         loaded.config.plugins.remove(&plugin);
         loaded.add_runtime_diagnostic(
@@ -726,6 +845,58 @@ fn finalize_runtime_config(
     }
 
     Ok((loaded, theme, logger))
+}
+
+fn apply_plugin_default_keymaps(
+    keys: &mut Keys,
+    keymaps: &std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
+) {
+    for (mode, bindings) in keymaps {
+        let target = match mode.as_str() {
+            "normal" => &mut keys.normal,
+            "insert" => &mut keys.insert,
+            "command" => &mut keys.command,
+            "visual" => &mut keys.visual,
+            "visual_line" => &mut keys.visual_line,
+            "visual_block" => &mut keys.visual_block,
+            _ => continue,
+        };
+        for (sequence, command) in bindings {
+            let sequence = sequence
+                .split_whitespace()
+                .map(|key| if key == "Space" { " " } else { key })
+                .collect::<Vec<_>>();
+            insert_plugin_default_binding(target, &sequence, command);
+        }
+    }
+}
+
+fn insert_plugin_default_binding(
+    bindings: &mut std::collections::HashMap<String, KeyAction>,
+    sequence: &[&str],
+    command: &str,
+) {
+    let Some((key, remainder)) = sequence.split_first() else {
+        return;
+    };
+    if remainder.is_empty() {
+        bindings
+            .entry((*key).to_string())
+            .or_insert_with(|| KeyAction::Single(Action::PluginCommand(command.to_string())));
+        return;
+    }
+    match bindings.entry((*key).to_string()) {
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            let mut nested = std::collections::HashMap::new();
+            insert_plugin_default_binding(&mut nested, remainder, command);
+            entry.insert(KeyAction::Nested(nested));
+        }
+        std::collections::hash_map::Entry::Occupied(mut entry) => {
+            if let KeyAction::Nested(nested) = entry.get_mut() {
+                insert_plugin_default_binding(nested, remainder, command);
+            }
+        }
+    }
 }
 
 fn resolve_log_path(config_dir: &Path, configured_path: &str) -> anyhow::Result<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -920,6 +920,39 @@ async fn load_startup_buffers(files: &[String]) -> anyhow::Result<Vec<Buffer>> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn plugin_default_keymaps_install_shared_leader_siblings() {
+        let mut keys = Keys::default();
+        let keymaps = std::collections::BTreeMap::from([(
+            "normal".to_string(),
+            std::collections::BTreeMap::from([
+                ("Space R g".to_string(), "Replay".to_string()),
+                ("Space R n".to_string(), "ReplayNext".to_string()),
+            ]),
+        )]);
+
+        apply_plugin_default_keymaps(&mut keys, &keymaps);
+
+        let Some(KeyAction::Nested(space)) = keys.normal.get(" ") else {
+            panic!("expected Space to become a leader");
+        };
+        let Some(KeyAction::Nested(replay)) = space.get("R") else {
+            panic!("expected Space R to become the Replay leader");
+        };
+        assert_eq!(
+            replay.get("g"),
+            Some(&KeyAction::Single(Action::PluginCommand(
+                "Replay".to_string()
+            )))
+        );
+        assert_eq!(
+            replay.get("n"),
+            Some(&KeyAction::Single(Action::PluginCommand(
+                "ReplayNext".to_string()
+            )))
+        );
+    }
+
     #[tokio::test]
     async fn startup_opens_missing_file_without_creating_it_until_save() {
         let directory = tempfile::tempdir().unwrap();

--- a/src/plugin/companion.rs
+++ b/src/plugin/companion.rs
@@ -195,10 +195,7 @@ impl CompanionManager {
         let diagnostic_sink = Arc::clone(&diagnostics);
         tokio::spawn(async move {
             let mut chunk = [0_u8; 1024];
-            loop {
-                let Ok(read) = stderr.read(&mut chunk).await else {
-                    break;
-                };
+            while let Ok(read) = stderr.read(&mut chunk).await {
                 if read == 0 {
                     break;
                 }

--- a/src/plugin/companion.rs
+++ b/src/plugin/companion.rs
@@ -1,0 +1,314 @@
+//! Lazy, supervised native companion processes for trusted external plugins.
+//!
+//! A companion is started only after its owning Husk plugin issues its first RPC
+//! request. Messages are newline-delimited JSON with bounded frame sizes. Red supplies
+//! monotonically increasing request IDs, enforces timeouts, validates response
+//! ownership, and tears children down with the editor.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::{
+    io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader},
+    process::{Child, ChildStdin, ChildStdout, Command},
+    sync::Mutex,
+    time::timeout,
+};
+
+use super::package::{PluginId, PluginPackageManager, PluginPackageManifest};
+
+const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+const MAX_DIAGNOSTIC_BYTES: usize = 16 * 1024;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+const MAX_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// One successful companion response and any progress frames received before it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CompanionCallResult {
+    pub result: Value,
+    pub progress: Vec<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct CompanionRequest<'a> {
+    id: u64,
+    method: &'a str,
+    params: &'a Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompanionResponse {
+    id: u64,
+    #[serde(default)]
+    result: Value,
+    error: Option<CompanionResponseError>,
+    progress: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompanionResponseError {
+    code: Option<String>,
+    message: String,
+}
+
+struct CompanionProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    diagnostics: Arc<Mutex<Vec<u8>>>,
+    next_request_id: u64,
+}
+
+/// Owns lazily spawned companion children for one editor instance.
+pub struct CompanionManager {
+    packages: PluginPackageManager,
+    processes: HashMap<PluginId, CompanionProcess>,
+}
+
+impl CompanionManager {
+    /// Creates an idle manager. Construction performs no process or network work.
+    #[must_use]
+    pub fn new(config_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            packages: PluginPackageManager::new(config_dir),
+            processes: HashMap::new(),
+        }
+    }
+
+    /// Calls one companion method and waits for its matching bounded response.
+    pub async fn call(
+        &mut self,
+        owner: &str,
+        method: &str,
+        params: Value,
+        timeout_duration: Option<Duration>,
+    ) -> Result<CompanionCallResult> {
+        anyhow::ensure!(!method.trim().is_empty(), "companion method is empty");
+        let owner = PluginId::parse(owner)?;
+        if method == "$cancel" {
+            self.stop(&owner).await?;
+            return Ok(CompanionCallResult {
+                result: serde_json::json!({ "cancelled": true }),
+                progress: Vec::new(),
+            });
+        }
+        if !self.processes.contains_key(&owner) {
+            let process = self.spawn(&owner).await?;
+            self.processes.insert(owner.clone(), process);
+        }
+        let process = self
+            .processes
+            .get_mut(&owner)
+            .ok_or_else(|| anyhow::anyhow!("companion process disappeared"))?;
+        let request_id = process.next_request_id;
+        process.next_request_id = process.next_request_id.saturating_add(1).max(1);
+        let frame = serde_json::to_vec(&CompanionRequest {
+            id: request_id,
+            method,
+            params: &params,
+        })?;
+        anyhow::ensure!(
+            frame.len() <= MAX_FRAME_BYTES,
+            "companion request exceeds {MAX_FRAME_BYTES} bytes"
+        );
+        process.stdin.write_all(&frame).await?;
+        process.stdin.write_all(b"\n").await?;
+        process.stdin.flush().await?;
+
+        let duration = timeout_duration.unwrap_or(DEFAULT_TIMEOUT).min(MAX_TIMEOUT);
+        let response = timeout(duration, read_response(process, request_id)).await;
+        match response {
+            Ok(result) => result,
+            Err(_) => {
+                self.stop(&owner).await?;
+                anyhow::bail!(
+                    "companion request `{method}` timed out after {} ms",
+                    duration.as_millis()
+                )
+            }
+        }
+    }
+
+    /// Stops all children owned by this editor instance.
+    pub async fn shutdown(&mut self) {
+        let owners = self.processes.keys().cloned().collect::<Vec<_>>();
+        for owner in owners {
+            let _ = self.stop(&owner).await;
+        }
+    }
+
+    async fn spawn(&self, owner: &PluginId) -> Result<CompanionProcess> {
+        let installed = self
+            .packages
+            .installed(owner)?
+            .ok_or_else(|| anyhow::anyhow!("plugin `{owner}` is not installed"))?;
+        anyhow::ensure!(installed.enabled, "plugin `{owner}` is disabled");
+        let manifest = PluginPackageManifest::load(&installed.package_root)?;
+        let command = manifest
+            .companion_command(&installed.package_root)
+            .ok_or_else(|| {
+                anyhow::anyhow!("plugin `{owner}` has no companion for this platform")
+            })?;
+        ensure_executable_in_package(&command, &installed.package_root)?;
+        let data_dir = self.packages.data_dir(owner);
+        tokio::fs::create_dir_all(&data_dir)
+            .await
+            .with_context(|| format!("failed to create {}", data_dir.display()))?;
+
+        let mut child = Command::new(&command)
+            .current_dir(&installed.package_root)
+            .env("RED_PLUGIN_ID", owner.as_str())
+            .env("RED_PLUGIN_PROTOCOL", "1")
+            .env("RED_PLUGIN_DATA_DIR", data_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .with_context(|| {
+                format!(
+                    "failed to start companion for `{owner}` from {}",
+                    command.display()
+                )
+            })?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("companion stdin was not captured"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("companion stdout was not captured"))?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("companion stderr was not captured"))?;
+        let diagnostics = Arc::new(Mutex::new(Vec::new()));
+        let diagnostic_sink = Arc::clone(&diagnostics);
+        tokio::spawn(async move {
+            let mut chunk = [0_u8; 1024];
+            loop {
+                let Ok(read) = stderr.read(&mut chunk).await else {
+                    break;
+                };
+                if read == 0 {
+                    break;
+                }
+                let mut retained = diagnostic_sink.lock().await;
+                retained.extend_from_slice(&chunk[..read]);
+                if retained.len() > MAX_DIAGNOSTIC_BYTES {
+                    let overflow = retained.len() - MAX_DIAGNOSTIC_BYTES;
+                    retained.drain(..overflow);
+                }
+            }
+        });
+        Ok(CompanionProcess {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            diagnostics,
+            next_request_id: 1,
+        })
+    }
+
+    async fn stop(&mut self, owner: &PluginId) -> Result<()> {
+        let Some(mut process) = self.processes.remove(owner) else {
+            return Ok(());
+        };
+        if process.child.try_wait()?.is_none() {
+            process.child.start_kill()?;
+            let _ = timeout(Duration::from_secs(2), process.child.wait()).await;
+        }
+        Ok(())
+    }
+}
+
+async fn read_response(
+    process: &mut CompanionProcess,
+    request_id: u64,
+) -> Result<CompanionCallResult> {
+    let mut progress = Vec::new();
+    loop {
+        let mut line = Vec::new();
+        let read = process
+            .stdout
+            .read_until(b'\n', &mut line)
+            .await
+            .context("failed to read companion response")?;
+        if read == 0 {
+            let diagnostics = process.diagnostics.lock().await;
+            let message = String::from_utf8_lossy(&diagnostics).trim().to_string();
+            if message.is_empty() {
+                anyhow::bail!("companion exited before responding");
+            }
+            anyhow::bail!("companion exited before responding: {message}");
+        }
+        anyhow::ensure!(
+            line.len() <= MAX_FRAME_BYTES,
+            "companion response exceeds {MAX_FRAME_BYTES} bytes"
+        );
+        let response: CompanionResponse =
+            serde_json::from_slice(&line).context("companion returned invalid JSON")?;
+        anyhow::ensure!(
+            response.id == request_id,
+            "companion response id {} does not match request {request_id}",
+            response.id
+        );
+        if let Some(value) = response.progress {
+            progress.push(value);
+            continue;
+        }
+        if let Some(error) = response.error {
+            let code = error.code.unwrap_or_else(|| "companion_error".to_string());
+            anyhow::bail!("{code}: {}", error.message);
+        }
+        return Ok(CompanionCallResult {
+            result: response.result,
+            progress,
+        });
+    }
+}
+
+fn ensure_executable_in_package(command: &Path, package_root: &Path) -> Result<()> {
+    let command = command
+        .canonicalize()
+        .with_context(|| format!("failed to resolve companion {}", command.display()))?;
+    let root = package_root
+        .canonicalize()
+        .with_context(|| format!("failed to resolve package {}", package_root.display()))?;
+    anyhow::ensure!(
+        command.starts_with(&root),
+        "companion executable escapes its plugin package"
+    );
+    anyhow::ensure!(command.is_file(), "companion executable is not a file");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn companion_paths_cannot_escape_the_package() {
+        let package = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        assert!(ensure_executable_in_package(outside.path(), package.path()).is_err());
+    }
+
+    #[test]
+    fn manager_construction_never_starts_or_scans_a_companion() {
+        let config = tempfile::tempdir().unwrap();
+        let manager = CompanionManager::new(config.path());
+
+        assert!(manager.processes.is_empty());
+        assert!(!config.path().join("plugin-data").exists());
+    }
+}

--- a/src/plugin/document.rs
+++ b/src/plugin/document.rs
@@ -1,0 +1,28 @@
+//! Revision-checked editor document requests for external plugins.
+//!
+//! Plugins describe edits against an exact Red buffer revision and optional textual
+//! preimages. The editor applies the batch as one attributed undo transaction. It
+//! remains responsible for buffers, dirty state, LSP notifications, and undo history.
+
+use serde::{Deserialize, Serialize};
+
+use crate::undo::TextRange;
+
+/// Read-only document state returned across the plugin host boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentSnapshot {
+    pub buffer_index: usize,
+    pub path: Option<String>,
+    pub revision: u64,
+    pub text: String,
+}
+
+/// One replacement within an attributed document transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DocumentEdit {
+    pub range: TextRange,
+    pub text: String,
+    /// Optional exact text expected at `range` before the transaction begins.
+    pub expected_text: Option<String>,
+}

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.6.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },
@@ -40,6 +40,7 @@
     { "name": "UpdatePickerItems", "kind": "execute", "signature": "(id: i32, items: [PickerItem])", "introduced": "0.1.0" },
     { "name": "UpdatePickerQuery", "kind": "execute", "signature": "(id: i32, query: String)", "introduced": "0.1.0" },
     { "name": "UpdatePickerStatus", "kind": "execute", "signature": "(id: i32, status: String)", "introduced": "0.1.0" },
+    { "name": "UpdatePickerBusy", "kind": "execute", "signature": "(id: i32, busy: bool)", "introduced": "0.6.0" },
     { "name": "ClosePicker", "kind": "execute", "signature": "(id: i32)", "introduced": "0.1.0" },
     { "name": "OpenLocation", "kind": "execute", "signature": "(location: Location, target?: String)", "introduced": "0.1.0" },
     { "name": "OpenBuffer", "kind": "execute", "signature": "(name: String)", "introduced": "0.1.0" },
@@ -102,6 +103,10 @@
     { "name": "DisplayColumnToCharIndex", "kind": "request", "signature": "(callback: fn(Json), column: i32, y: i32)", "introduced": "0.1.0" },
     { "name": "ListDirectory", "kind": "request", "signature": "(callback: fn(Json), path: String)", "introduced": "0.1.0" },
     { "name": "GetGitStatus", "kind": "request", "signature": "(callback: fn(Json), path: String)", "introduced": "0.1.0" },
-    { "name": "FileOperation", "kind": "request", "signature": "(callback: fn(Json), operation: Json)", "introduced": "0.4.0" }
+    { "name": "FileOperation", "kind": "request", "signature": "(callback: fn(Json), operation: Json)", "introduced": "0.4.0" },
+    { "name": "CompanionCall", "kind": "request", "signature": "(callback: fn(Json), method: String, params: Json, timeout_ms?: i32)", "introduced": "0.6.0" },
+    { "name": "DocumentSnapshot", "kind": "request", "signature": "(callback: fn(Json), path?: String)", "introduced": "0.6.0" },
+    { "name": "DocumentApply", "kind": "request", "signature": "(callback: fn(Json), options: Json)", "introduced": "0.6.0" },
+    { "name": "DocumentUndo", "kind": "request", "signature": "(callback: fn(Json), options: Json)", "introduced": "0.6.0" }
   ]
 }

--- a/src/plugin/metadata.rs
+++ b/src/plugin/metadata.rs
@@ -9,6 +9,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use super::package::PluginPackageManifest;
+
 /// Plugin metadata structure based on package.json format
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginMetadata {
@@ -114,6 +116,53 @@ impl PluginMetadata {
         let content = std::fs::read_to_string(path)?;
         let metadata: PluginMetadata = serde_json::from_str(&content)?;
         Ok(metadata)
+    }
+
+    /// Adapts the external package manifest to the legacy registry metadata view.
+    pub fn from_package(package: &PluginPackageManifest) -> Self {
+        Self {
+            name: package.plugin.id.to_string(),
+            version: package.plugin.version.to_string(),
+            description: package.plugin.description.clone(),
+            author: None,
+            license: package.plugin.license.clone(),
+            main: package
+                .plugin
+                .entry
+                .as_ref()
+                .or(package.plugin.husk_manifest.as_ref())
+                .map_or_else(default_main, |path| path.to_string_lossy().into_owned()),
+            homepage: None,
+            repository: package.plugin.repository.as_ref().map(|url| Repository {
+                repo_type: "git".to_string(),
+                url: url.clone(),
+            }),
+            keywords: vec![],
+            engines: None,
+            dependencies: HashMap::new(),
+            red_api_version: Some(package.plugin.red_api.to_string()),
+            config_schema: None,
+            activation_events: package
+                .activation
+                .events
+                .iter()
+                .cloned()
+                .chain(
+                    package
+                        .activation
+                        .commands
+                        .iter()
+                        .map(|command| format!("onCommand:{command}")),
+                )
+                .collect(),
+            capabilities: PluginCapabilities {
+                commands: !package.activation.commands.is_empty(),
+                events: !package.activation.events.is_empty(),
+                buffer_manipulation: false,
+                ui_components: true,
+                lsp_integration: false,
+            },
+        }
     }
 
     /// Create minimal metadata with just a name

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -11,13 +11,16 @@
 //! schema, but must not independently redefine its version.
 
 mod api;
+pub mod companion;
 pub mod decoration;
+pub mod document;
 pub(crate) mod filesystem;
 pub mod gutter;
 pub mod location;
 pub(crate) mod markdown;
 mod metadata;
 pub mod overlay;
+pub mod package;
 pub mod panel;
 pub mod process;
 mod registry;
@@ -28,6 +31,7 @@ pub mod window_bar;
 pub mod workspace;
 
 pub use decoration::{Decoration, DecorationAnchor, DecorationManager};
+pub use document::{DocumentEdit, DocumentSnapshot};
 pub use gutter::{GutterSign, GutterSignManager};
 pub use location::{LocationColumnEncoding, OpenLocationTarget, PluginLocation};
 pub use metadata::PluginMetadata;

--- a/src/plugin/package.rs
+++ b/src/plugin/package.rs
@@ -257,6 +257,7 @@ impl PluginPackageManifest {
                 "legacy session migration keys cannot be empty"
             );
         }
+        validate_keymaps(&self.keymaps)?;
         Ok(())
     }
 
@@ -613,6 +614,50 @@ fn default_manifest_schema() -> u32 {
     PLUGIN_MANIFEST_SCHEMA
 }
 
+fn validate_keymaps(keymaps: &BTreeMap<String, BTreeMap<String, String>>) -> Result<()> {
+    const SUPPORTED_MODES: [&str; 6] = [
+        "normal",
+        "insert",
+        "command",
+        "visual",
+        "visual_line",
+        "visual_block",
+    ];
+
+    for (mode, bindings) in keymaps {
+        anyhow::ensure!(
+            SUPPORTED_MODES.contains(&mode.as_str()),
+            "plugin keymap uses unsupported mode `{mode}`"
+        );
+
+        let mut sequences: Vec<(&str, Vec<&str>)> = Vec::with_capacity(bindings.len());
+        for (sequence, command) in bindings {
+            anyhow::ensure!(
+                !command.trim().is_empty(),
+                "plugin keymap command for `{sequence}` in mode `{mode}` is empty"
+            );
+            let keys = sequence.split_whitespace().collect::<Vec<_>>();
+            anyhow::ensure!(
+                !keys.is_empty(),
+                "plugin keymap sequence in mode `{mode}` is empty"
+            );
+
+            for (existing_sequence, existing_keys) in &sequences {
+                anyhow::ensure!(
+                    keys != *existing_keys,
+                    "plugin keymap sequences `{existing_sequence}` and `{sequence}` normalize to the same keys in mode `{mode}`"
+                );
+                anyhow::ensure!(
+                    !keys.starts_with(existing_keys) && !existing_keys.starts_with(&keys),
+                    "plugin keymap prefix conflict in mode `{mode}`: `{existing_sequence}` and `{sequence}` cannot both be declared"
+                );
+            }
+            sequences.push((sequence, keys));
+        }
+    }
+    Ok(())
+}
+
 fn validate_relative_path(path: &Path) -> Result<()> {
     anyhow::ensure!(!path.as_os_str().is_empty(), "plugin path is empty");
     anyhow::ensure!(!path.is_absolute(), "plugin path must be package-relative");
@@ -837,6 +882,66 @@ entry = "src/main.hk"
             .unwrap_err()
             .to_string()
             .contains("unsafe component"));
+    }
+
+    #[test]
+    fn rejects_keymap_prefix_conflicts() {
+        let directory = tempfile::tempdir().unwrap();
+        write_package(directory.path(), "test", "1.0.0");
+        let manifest_path = directory.path().join(PLUGIN_MANIFEST_FILE);
+        let mut source = fs::read_to_string(&manifest_path).unwrap();
+        source.push_str(
+            r#"
+
+[keymaps.normal]
+"Space R" = "Test"
+"Space R g" = "Test"
+"#,
+        );
+        fs::write(manifest_path, source).unwrap();
+
+        let error = PluginPackageManifest::load(directory.path()).unwrap_err();
+        assert!(error.to_string().contains("keymap prefix conflict"));
+        assert!(error.to_string().contains("Space R"));
+        assert!(error.to_string().contains("Space R g"));
+    }
+
+    #[test]
+    fn accepts_keymap_siblings_under_a_shared_prefix() {
+        let directory = tempfile::tempdir().unwrap();
+        write_package(directory.path(), "test", "1.0.0");
+        let manifest_path = directory.path().join(PLUGIN_MANIFEST_FILE);
+        let mut source = fs::read_to_string(&manifest_path).unwrap();
+        source.push_str(
+            r#"
+
+[keymaps.normal]
+"Space R g" = "Test"
+"Space R n" = "Test"
+"#,
+        );
+        fs::write(manifest_path, source).unwrap();
+
+        PluginPackageManifest::load(directory.path()).unwrap();
+    }
+
+    #[test]
+    fn rejects_keymaps_for_unsupported_modes() {
+        let directory = tempfile::tempdir().unwrap();
+        write_package(directory.path(), "test", "1.0.0");
+        let manifest_path = directory.path().join(PLUGIN_MANIFEST_FILE);
+        let mut source = fs::read_to_string(&manifest_path).unwrap();
+        source.push_str(
+            r#"
+
+[keymaps.select]
+"Space R" = "Test"
+"#,
+        );
+        fs::write(manifest_path, source).unwrap();
+
+        let error = PluginPackageManifest::load(directory.path()).unwrap_err();
+        assert!(error.to_string().contains("unsupported mode `select`"));
     }
 
     #[tokio::test]

--- a/src/plugin/package.rs
+++ b/src/plugin/package.rs
@@ -1,0 +1,907 @@
+//! External plugin package manifests, installation records, and lifecycle operations.
+//!
+//! Packages live in isolated directories below Red's configuration directory. An
+//! installation record may point at a local development checkout or contain a package
+//! fetched directly from GitHub. Updates are staged and validated before an atomic
+//! directory swap so a failed install never replaces a working plugin.
+
+use std::{
+    collections::BTreeMap,
+    fmt, fs,
+    path::{Component, Path, PathBuf},
+    process::Stdio,
+};
+
+use anyhow::{Context, Result};
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::{io::AsyncWriteExt as _, process::Command};
+
+use super::{Runtime, RED_HOST_API_VERSION};
+
+/// File name of the Red-specific package manifest.
+pub const PLUGIN_MANIFEST_FILE: &str = "red-plugin.toml";
+/// File name of Red's installation record inside an installed package directory.
+pub const INSTALL_RECORD_FILE: &str = ".red-install.json";
+/// Current external plugin manifest schema.
+pub const PLUGIN_MANIFEST_SCHEMA: u32 = 1;
+
+/// A parsed and validated stable plugin identifier.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PluginId(String);
+
+impl PluginId {
+    /// Parses an identifier accepted in manifests and lifecycle commands.
+    pub fn parse(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        anyhow::ensure!(
+            !value.is_empty()
+                && value.len() <= 64
+                && value.bytes().all(|byte| byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(byte, b'-' | b'_')),
+            "plugin id must contain only lowercase ASCII letters, digits, `-`, or `_`"
+        );
+        Ok(Self(value))
+    }
+
+    /// Returns the identifier as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for PluginId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// External plugin package manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginPackageManifest {
+    #[serde(default = "default_manifest_schema")]
+    pub schema_version: u32,
+    pub plugin: PluginManifestSection,
+    #[serde(default)]
+    pub activation: PluginActivation,
+    #[serde(default)]
+    pub keymaps: BTreeMap<String, BTreeMap<String, String>>,
+    pub companion: Option<PluginCompanionManifest>,
+    #[serde(default)]
+    pub migration: PluginMigration,
+}
+
+/// Declarative imports from fields written by a formerly bundled plugin.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginMigration {
+    /// Old top-level session field mapped to the plugin's private storage key.
+    #[serde(default)]
+    pub legacy_session_fields: BTreeMap<String, String>,
+}
+
+/// Identity and host compatibility for one plugin package.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginManifestSection {
+    pub id: PluginId,
+    pub name: String,
+    pub version: Version,
+    pub red_api: VersionReq,
+    pub husk_manifest: Option<PathBuf>,
+    pub entry: Option<PathBuf>,
+    pub description: Option<String>,
+    pub repository: Option<String>,
+    pub license: Option<String>,
+}
+
+/// Lazy activation declarations.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginActivation {
+    #[serde(default)]
+    pub events: Vec<String>,
+    #[serde(default)]
+    pub commands: Vec<String>,
+}
+
+/// Native companion declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginCompanionManifest {
+    /// Package-relative development or bundled executable.
+    pub command: Option<PathBuf>,
+    /// Platform-specific development or bundled executable overrides.
+    #[serde(default)]
+    pub commands: BTreeMap<String, PathBuf>,
+    /// Release artifacts keyed by Rust target triple.
+    #[serde(default)]
+    pub artifacts: BTreeMap<String, PluginCompanionArtifact>,
+}
+
+/// One downloadable native companion executable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginCompanionArtifact {
+    pub url: String,
+    pub sha256: String,
+}
+
+/// Origin retained so an installed package can be updated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum PluginInstallSource {
+    Path {
+        path: PathBuf,
+    },
+    GitHub {
+        repository: String,
+        requested_version: Option<String>,
+    },
+}
+
+/// Crash-safe record associated with an installed plugin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginInstallRecord {
+    pub schema_version: u32,
+    pub id: PluginId,
+    pub version: Version,
+    pub enabled: bool,
+    pub source: PluginInstallSource,
+    pub package_root: PathBuf,
+    pub installed_at_ms: u64,
+}
+
+/// Installed plugin information shown by CLI and editor management surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InstalledPlugin {
+    pub id: PluginId,
+    pub name: String,
+    pub version: Version,
+    pub enabled: bool,
+    pub compatible: bool,
+    pub has_companion: bool,
+    pub source: PluginInstallSource,
+    pub package_root: PathBuf,
+}
+
+/// External package lifecycle authority for one Red configuration root.
+#[derive(Debug, Clone)]
+pub struct PluginPackageManager {
+    config_dir: PathBuf,
+}
+
+impl PluginPackageManifest {
+    /// Loads, parses, and validates a package manifest.
+    pub fn load(package_root: &Path) -> Result<Self> {
+        let path = package_root.join(PLUGIN_MANIFEST_FILE);
+        let source = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read plugin manifest {}", path.display()))?;
+        let manifest: Self = toml::from_str(&source)
+            .with_context(|| format!("failed to parse plugin manifest {}", path.display()))?;
+        manifest.validate(package_root)?;
+        Ok(manifest)
+    }
+
+    /// Ensures paths remain within the package and the declared host API is supported.
+    pub fn validate(&self, package_root: &Path) -> Result<()> {
+        anyhow::ensure!(
+            self.schema_version == PLUGIN_MANIFEST_SCHEMA,
+            "unsupported plugin manifest schema {}",
+            self.schema_version
+        );
+        anyhow::ensure!(!self.plugin.name.trim().is_empty(), "plugin name is empty");
+        anyhow::ensure!(
+            self.plugin.husk_manifest.is_some()
+                || self.plugin.entry.is_some()
+                || self.companion.is_some(),
+            "plugin package must declare a Husk entrypoint or native companion"
+        );
+        let host_api = Version::parse(RED_HOST_API_VERSION)?;
+        anyhow::ensure!(
+            self.plugin.red_api.matches(&host_api),
+            "plugin requires Red host API `{}`, but this release provides `{host_api}`",
+            self.plugin.red_api
+        );
+
+        for relative in self
+            .plugin
+            .husk_manifest
+            .iter()
+            .chain(self.plugin.entry.iter())
+            .chain(
+                self.companion
+                    .iter()
+                    .filter_map(|companion| companion.command.as_ref()),
+            )
+            .chain(
+                self.companion
+                    .iter()
+                    .flat_map(|companion| companion.commands.values()),
+            )
+        {
+            validate_relative_path(relative)?;
+            let target = package_root.join(relative);
+            anyhow::ensure!(
+                target.is_file(),
+                "plugin package file does not exist: {}",
+                target.display()
+            );
+        }
+        for (target, artifact) in self
+            .companion
+            .iter()
+            .flat_map(|companion| &companion.artifacts)
+        {
+            anyhow::ensure!(!target.trim().is_empty(), "companion target is empty");
+            anyhow::ensure!(
+                artifact.url.starts_with("https://github.com/")
+                    || artifact.url.starts_with("https://api.github.com/"),
+                "companion artifacts must use a GitHub HTTPS URL"
+            );
+            anyhow::ensure!(
+                artifact.sha256.len() == 64
+                    && artifact.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()),
+                "companion artifact for `{target}` has an invalid SHA-256 digest"
+            );
+        }
+        for (field, storage_key) in &self.migration.legacy_session_fields {
+            anyhow::ensure!(
+                !field.trim().is_empty() && !storage_key.trim().is_empty(),
+                "legacy session migration keys cannot be empty"
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns the absolute Husk source or package manifest used by the registry.
+    #[must_use]
+    pub fn husk_entry(&self, package_root: &Path) -> Option<PathBuf> {
+        self.plugin
+            .husk_manifest
+            .as_ref()
+            .or(self.plugin.entry.as_ref())
+            .map(|relative| package_root.join(relative))
+    }
+
+    /// Resolves the native companion executable for the running host.
+    #[must_use]
+    pub fn companion_command(&self, package_root: &Path) -> Option<PathBuf> {
+        self.companion.as_ref().and_then(|companion| {
+            companion
+                .commands
+                .get(host_target())
+                .or(companion.command.as_ref())
+                .map(|relative| package_root.join(relative))
+                .or_else(|| {
+                    let downloaded = package_root
+                        .join(".red")
+                        .join("bin")
+                        .join(companion_binary_name());
+                    downloaded.is_file().then_some(downloaded)
+                })
+        })
+    }
+}
+
+impl PluginPackageManager {
+    /// Creates a manager rooted at Red's platform configuration directory.
+    #[must_use]
+    pub fn new(config_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            config_dir: config_dir.into(),
+        }
+    }
+
+    /// Directory containing isolated installed package records.
+    #[must_use]
+    pub fn packages_dir(&self) -> PathBuf {
+        self.config_dir.join("plugins")
+    }
+
+    /// Durable, namespaced storage owned by one plugin.
+    #[must_use]
+    pub fn data_dir(&self, id: &PluginId) -> PathBuf {
+        self.config_dir.join("plugin-data").join(id.as_str())
+    }
+
+    /// Installs a local development checkout without copying its source.
+    pub async fn install_path(&self, source: &Path) -> Result<InstalledPlugin> {
+        let source = source
+            .canonicalize()
+            .with_context(|| format!("failed to resolve plugin path {}", source.display()))?;
+        let manifest = PluginPackageManifest::load(&source)?;
+        validate_husk_package(&manifest, &source).await?;
+        let install_source = PluginInstallSource::Path {
+            path: source.clone(),
+        };
+        self.install_record(&manifest, source, install_source).await
+    }
+
+    /// Installs a package directly from a GitHub repository.
+    pub async fn install_github(
+        &self,
+        repository: &str,
+        requested_version: Option<&str>,
+    ) -> Result<InstalledPlugin> {
+        validate_github_repository(repository)?;
+        let staging = self.staging_dir("github");
+        if let Some(parent) = staging.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        remove_if_exists(&staging)?;
+
+        let mut command = Command::new("git");
+        command
+            .args(["clone", "--depth", "1"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+        if let Some(version) = requested_version {
+            command.args(["--branch", version]);
+        }
+        command
+            .arg(format!("https://github.com/{repository}.git"))
+            .arg(&staging);
+        let output = command
+            .output()
+            .await
+            .context("failed to launch git for plugin install")?;
+        anyhow::ensure!(
+            output.status.success(),
+            "git clone failed: {}",
+            bounded_stderr(&output.stderr)
+        );
+
+        let manifest = PluginPackageManifest::load(&staging)?;
+        validate_husk_package(&manifest, &staging).await?;
+        let id = manifest.plugin.id.clone();
+        let destination = self.packages_dir().join(id.as_str());
+        let record = PluginInstallRecord {
+            schema_version: 1,
+            id: id.clone(),
+            version: manifest.plugin.version.clone(),
+            enabled: true,
+            source: PluginInstallSource::GitHub {
+                repository: repository.to_string(),
+                requested_version: requested_version.map(str::to_string),
+            },
+            package_root: destination.clone(),
+            installed_at_ms: now_ms(),
+        };
+        write_record(&staging, &record)?;
+        self.install_companion_artifact(&manifest, &staging).await?;
+        atomic_replace_directory(&staging, &destination)?;
+        self.installed(&id)?
+            .ok_or_else(|| anyhow::anyhow!("installed plugin `{id}` could not be read"))
+    }
+
+    /// Lists installed packages in stable identifier order.
+    pub fn list(&self) -> Result<Vec<InstalledPlugin>> {
+        let mut plugins = Vec::new();
+        let directory = self.packages_dir();
+        if !directory.is_dir() {
+            return Ok(plugins);
+        }
+        for entry in fs::read_dir(&directory)
+            .with_context(|| format!("failed to list {}", directory.display()))?
+        {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir()
+                || entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".red-stage-")
+            {
+                continue;
+            }
+            let record_path = entry.path().join(INSTALL_RECORD_FILE);
+            if !record_path.is_file() {
+                continue;
+            }
+            let record = read_record(&record_path)?;
+            plugins.push(installed_from_record(record)?);
+        }
+        plugins.sort_by(|left, right| left.id.cmp(&right.id));
+        Ok(plugins)
+    }
+
+    /// Returns enabled Husk entrypoints for editor startup.
+    ///
+    /// This only reads manifests and installation records. It never launches a
+    /// companion, accesses Git, or performs a network request.
+    pub fn enabled_husk_plugins(&self) -> Result<Vec<(PluginId, PathBuf)>> {
+        self.list()?
+            .into_iter()
+            .filter(|plugin| plugin.enabled && plugin.compatible)
+            .filter_map(|plugin| {
+                let manifest = match PluginPackageManifest::load(&plugin.package_root) {
+                    Ok(manifest) => manifest,
+                    Err(error) => return Some(Err(error)),
+                };
+                manifest
+                    .husk_entry(&plugin.package_root)
+                    .map(|entry| Ok((plugin.id, entry)))
+            })
+            .collect()
+    }
+
+    /// Resolves manifest-declared legacy session fields into private plugin storage.
+    ///
+    /// Unknown fields remain in the session snapshot as well, so a missing or
+    /// disabled package never destroys migration data.
+    pub fn legacy_session_imports(
+        &self,
+        legacy: &BTreeMap<String, serde_json::Value>,
+    ) -> Result<Vec<(PluginId, String, serde_json::Value)>> {
+        let mut imports = Vec::new();
+        for plugin in self
+            .list()?
+            .into_iter()
+            .filter(|plugin| plugin.enabled && plugin.compatible)
+        {
+            let manifest = PluginPackageManifest::load(&plugin.package_root)?;
+            for (field, storage_key) in &manifest.migration.legacy_session_fields {
+                if let Some(value) = legacy.get(field) {
+                    imports.push((plugin.id.clone(), storage_key.clone(), value.clone()));
+                }
+            }
+        }
+        Ok(imports)
+    }
+
+    /// Returns one installed package.
+    pub fn installed(&self, id: &PluginId) -> Result<Option<InstalledPlugin>> {
+        let record_path = self
+            .packages_dir()
+            .join(id.as_str())
+            .join(INSTALL_RECORD_FILE);
+        if !record_path.is_file() {
+            return Ok(None);
+        }
+        installed_from_record(read_record(&record_path)?).map(Some)
+    }
+
+    /// Enables or disables an installed package without deleting its state.
+    pub fn set_enabled(&self, id: &PluginId, enabled: bool) -> Result<()> {
+        let install_dir = self.packages_dir().join(id.as_str());
+        let path = install_dir.join(INSTALL_RECORD_FILE);
+        let mut record = read_record(&path)?;
+        record.enabled = enabled;
+        write_record_atomic(&install_dir, &record)
+    }
+
+    /// Updates an installed package from its retained source.
+    pub async fn update(&self, id: &PluginId) -> Result<InstalledPlugin> {
+        let installed = self
+            .installed(id)?
+            .ok_or_else(|| anyhow::anyhow!("plugin `{id}` is not installed"))?;
+        match installed.source {
+            PluginInstallSource::Path { path } => self.install_path(&path).await,
+            PluginInstallSource::GitHub {
+                repository,
+                requested_version,
+            } => {
+                self.install_github(&repository, requested_version.as_deref())
+                    .await
+            }
+        }
+    }
+
+    /// Updates every enabled installed package.
+    pub async fn update_all(&self) -> Vec<(PluginId, Result<InstalledPlugin>)> {
+        let plugins = match self.list() {
+            Ok(plugins) => plugins,
+            Err(error) => {
+                return vec![(
+                    PluginId::parse("registry").expect("static plugin id is valid"),
+                    Err(error),
+                )]
+            }
+        };
+        let mut results = Vec::with_capacity(plugins.len());
+        for plugin in plugins.into_iter().filter(|plugin| plugin.enabled) {
+            let id = plugin.id;
+            let result = self.update(&id).await;
+            results.push((id, result));
+        }
+        results
+    }
+
+    /// Removes an installation. Namespaced plugin data survives unless `purge` is true.
+    pub fn remove(&self, id: &PluginId, purge: bool) -> Result<()> {
+        let install_dir = self.packages_dir().join(id.as_str());
+        anyhow::ensure!(install_dir.is_dir(), "plugin `{id}` is not installed");
+        fs::remove_dir_all(&install_dir)
+            .with_context(|| format!("failed to remove {}", install_dir.display()))?;
+        if purge {
+            remove_if_exists(&self.config_dir.join("plugin-data").join(id.as_str()))?;
+        }
+        Ok(())
+    }
+
+    async fn install_record(
+        &self,
+        manifest: &PluginPackageManifest,
+        package_root: PathBuf,
+        source: PluginInstallSource,
+    ) -> Result<InstalledPlugin> {
+        let id = manifest.plugin.id.clone();
+        let staging = self.staging_dir(id.as_str());
+        remove_if_exists(&staging)?;
+        fs::create_dir_all(&staging)?;
+        let record = PluginInstallRecord {
+            schema_version: 1,
+            id: id.clone(),
+            version: manifest.plugin.version.clone(),
+            enabled: true,
+            source,
+            package_root,
+            installed_at_ms: now_ms(),
+        };
+        write_record(&staging, &record)?;
+        atomic_replace_directory(&staging, &self.packages_dir().join(id.as_str()))?;
+        self.installed(&id)?
+            .ok_or_else(|| anyhow::anyhow!("installed plugin `{id}` could not be read"))
+    }
+
+    async fn install_companion_artifact(
+        &self,
+        manifest: &PluginPackageManifest,
+        package_root: &Path,
+    ) -> Result<()> {
+        let Some(companion) = &manifest.companion else {
+            return Ok(());
+        };
+        if companion.command.is_some() || companion.commands.contains_key(host_target()) {
+            return Ok(());
+        }
+        let target = host_target();
+        let Some(artifact) = companion.artifacts.get(target) else {
+            anyhow::bail!("plugin has no native companion for `{target}`");
+        };
+        let response = reqwest::get(&artifact.url)
+            .await
+            .with_context(|| format!("failed to download companion from {}", artifact.url))?
+            .error_for_status()
+            .with_context(|| format!("companion download failed for {}", artifact.url))?;
+        let bytes = response.bytes().await?;
+        let actual = format!("{:x}", Sha256::digest(&bytes));
+        anyhow::ensure!(
+            actual.eq_ignore_ascii_case(&artifact.sha256),
+            "companion checksum mismatch: expected {}, got {actual}",
+            artifact.sha256
+        );
+        let bin_dir = package_root.join(".red").join("bin");
+        tokio::fs::create_dir_all(&bin_dir).await?;
+        let path = bin_dir.join(companion_binary_name());
+        let mut file = tokio::fs::File::create(&path).await?;
+        file.write_all(&bytes).await?;
+        file.sync_all().await?;
+        set_executable(&path)?;
+        Ok(())
+    }
+
+    fn staging_dir(&self, label: &str) -> PathBuf {
+        self.packages_dir().join(format!(
+            ".red-stage-{label}-{}-{}",
+            std::process::id(),
+            now_ms()
+        ))
+    }
+}
+
+async fn validate_husk_package(
+    manifest: &PluginPackageManifest,
+    package_root: &Path,
+) -> Result<()> {
+    let Some(entry) = manifest.husk_entry(package_root) else {
+        return Ok(());
+    };
+    Runtime::new()
+        .load_plugin_package(manifest.plugin.id.as_str(), &entry)
+        .await
+        .with_context(|| format!("failed to compile Husk package {}", entry.display()))
+}
+
+fn default_manifest_schema() -> u32 {
+    PLUGIN_MANIFEST_SCHEMA
+}
+
+fn validate_relative_path(path: &Path) -> Result<()> {
+    anyhow::ensure!(!path.as_os_str().is_empty(), "plugin path is empty");
+    anyhow::ensure!(!path.is_absolute(), "plugin path must be package-relative");
+    anyhow::ensure!(
+        path.components()
+            .all(|component| matches!(component, Component::Normal(_))),
+        "plugin path contains an unsafe component: {}",
+        path.display()
+    );
+    Ok(())
+}
+
+fn validate_github_repository(repository: &str) -> Result<()> {
+    let parts = repository.split('/').collect::<Vec<_>>();
+    anyhow::ensure!(
+        parts.len() == 2
+            && parts.iter().all(|part| {
+                !part.is_empty()
+                    && part.bytes().all(|byte| {
+                        byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+                    })
+            }),
+        "GitHub plugin source must be `owner/repository`"
+    );
+    Ok(())
+}
+
+fn installed_from_record(record: PluginInstallRecord) -> Result<InstalledPlugin> {
+    anyhow::ensure!(
+        record.schema_version == 1,
+        "unsupported install record schema"
+    );
+    let manifest = PluginPackageManifest::load(&record.package_root)?;
+    anyhow::ensure!(
+        manifest.plugin.id == record.id,
+        "install record id does not match plugin manifest"
+    );
+    let host_api = Version::parse(RED_HOST_API_VERSION)?;
+    Ok(InstalledPlugin {
+        id: record.id,
+        name: manifest.plugin.name,
+        version: manifest.plugin.version,
+        enabled: record.enabled,
+        compatible: manifest.plugin.red_api.matches(&host_api),
+        has_companion: manifest.companion.is_some(),
+        source: record.source,
+        package_root: record.package_root,
+    })
+}
+
+fn read_record(path: &Path) -> Result<PluginInstallRecord> {
+    let source = fs::read_to_string(path)
+        .with_context(|| format!("failed to read install record {}", path.display()))?;
+    serde_json::from_str(&source)
+        .with_context(|| format!("failed to parse install record {}", path.display()))
+}
+
+fn write_record(directory: &Path, record: &PluginInstallRecord) -> Result<()> {
+    fs::create_dir_all(directory)?;
+    let bytes = serde_json::to_vec_pretty(record)?;
+    fs::write(directory.join(INSTALL_RECORD_FILE), bytes)?;
+    Ok(())
+}
+
+fn write_record_atomic(directory: &Path, record: &PluginInstallRecord) -> Result<()> {
+    let path = directory.join(INSTALL_RECORD_FILE);
+    let temporary = directory.join(format!("{INSTALL_RECORD_FILE}.tmp"));
+    fs::write(&temporary, serde_json::to_vec_pretty(record)?)?;
+    fs::rename(&temporary, &path)?;
+    Ok(())
+}
+
+fn atomic_replace_directory(staging: &Path, destination: &Path) -> Result<()> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("plugin destination has no parent"))?;
+    fs::create_dir_all(parent)?;
+    let backup = parent.join(format!(
+        ".red-backup-{}-{}",
+        destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("plugin"),
+        now_ms()
+    ));
+    if destination.exists() {
+        fs::rename(destination, &backup).with_context(|| {
+            format!(
+                "failed to stage previous plugin installation {}",
+                destination.display()
+            )
+        })?;
+    }
+    if let Err(error) = fs::rename(staging, destination) {
+        if backup.exists() {
+            let _ = fs::rename(&backup, destination);
+        }
+        return Err(error).with_context(|| {
+            format!(
+                "failed to activate plugin installation {}",
+                destination.display()
+            )
+        });
+    }
+    remove_if_exists(&backup)?;
+    Ok(())
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => {
+            fs::remove_dir_all(path).with_context(|| format!("failed to remove {}", path.display()))
+        }
+        Ok(_) => {
+            fs::remove_file(path).with_context(|| format!("failed to remove {}", path.display()))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("failed to inspect {}", path.display())),
+    }
+}
+
+fn bounded_stderr(stderr: &[u8]) -> String {
+    const LIMIT: usize = 4 * 1024;
+    String::from_utf8_lossy(&stderr[..stderr.len().min(LIMIT)])
+        .trim()
+        .to_string()
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or_default()
+}
+
+fn host_target() -> &'static str {
+    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        "aarch64-apple-darwin"
+    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        "x86_64-apple-darwin"
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        "x86_64-unknown-linux-gnu"
+    } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        "x86_64-pc-windows-msvc"
+    } else {
+        "unsupported"
+    }
+}
+
+fn companion_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "companion.exe"
+    } else {
+        "companion"
+    }
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_package(root: &Path, id: &str, version: &str) {
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join(PLUGIN_MANIFEST_FILE),
+            format!(
+                r#"
+schema_version = 1
+
+[plugin]
+id = "{id}"
+name = "Test plugin"
+version = "{version}"
+red_api = "^{RED_HOST_API_VERSION}"
+husk_manifest = "Husk.toml"
+
+[activation]
+commands = ["Test"]
+"#
+            ),
+        )
+        .unwrap();
+        fs::write(
+            root.join("Husk.toml"),
+            r#"
+schema_version = 1
+[package]
+name = "test-plugin"
+version = "0.1.0"
+entry = "src/main.hk"
+"#,
+        )
+        .unwrap();
+        fs::write(root.join("src/main.hk"), "pub fn activate() {}").unwrap();
+    }
+
+    #[test]
+    fn rejects_unsafe_manifest_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        write_package(directory.path(), "test", "1.0.0");
+        let source = fs::read_to_string(directory.path().join(PLUGIN_MANIFEST_FILE))
+            .unwrap()
+            .replace("Husk.toml", "../Husk.toml");
+        fs::write(directory.path().join(PLUGIN_MANIFEST_FILE), source).unwrap();
+
+        assert!(PluginPackageManifest::load(directory.path())
+            .unwrap_err()
+            .to_string()
+            .contains("unsafe component"));
+    }
+
+    #[tokio::test]
+    async fn local_install_preserves_source_and_data_across_remove() {
+        let config = tempfile::tempdir().unwrap();
+        let package = tempfile::tempdir().unwrap();
+        write_package(package.path(), "test", "1.0.0");
+        let manager = PluginPackageManager::new(config.path());
+        let plugin = manager.install_path(package.path()).await.unwrap();
+        assert_eq!(plugin.id.as_str(), "test");
+        assert_eq!(plugin.package_root, package.path().canonicalize().unwrap());
+
+        let data = config.path().join("plugin-data/test/session.json");
+        fs::create_dir_all(data.parent().unwrap()).unwrap();
+        fs::write(&data, "{}").unwrap();
+        manager.remove(&plugin.id, false).unwrap();
+        assert!(data.exists());
+    }
+
+    #[tokio::test]
+    async fn disable_and_update_local_install_are_transactional() {
+        let config = tempfile::tempdir().unwrap();
+        let package = tempfile::tempdir().unwrap();
+        write_package(package.path(), "test", "1.0.0");
+        let manager = PluginPackageManager::new(config.path());
+        let plugin = manager.install_path(package.path()).await.unwrap();
+        manager.set_enabled(&plugin.id, false).unwrap();
+        assert!(!manager.installed(&plugin.id).unwrap().unwrap().enabled);
+
+        write_package(package.path(), "test", "1.1.0");
+        let updated = manager.update(&plugin.id).await.unwrap();
+        assert_eq!(updated.version, Version::parse("1.1.0").unwrap());
+    }
+
+    #[tokio::test]
+    async fn installed_package_declares_legacy_session_import_without_host_product_knowledge() {
+        let config = tempfile::tempdir().unwrap();
+        let package = tempfile::tempdir().unwrap();
+        write_package(package.path(), "extracted-feature", "1.0.0");
+        let manifest_path = package.path().join(PLUGIN_MANIFEST_FILE);
+        let mut source = fs::read_to_string(&manifest_path).unwrap();
+        source.push_str(
+            r#"
+
+[migration.legacy_session_fields]
+old_feature = "legacy_session"
+"#,
+        );
+        fs::write(manifest_path, source).unwrap();
+
+        let manager = PluginPackageManager::new(config.path());
+        manager.install_path(package.path()).await.unwrap();
+        let legacy = BTreeMap::from([(
+            "old_feature".to_string(),
+            serde_json::json!({ "version": 1 }),
+        )]);
+        let imports = manager.legacy_session_imports(&legacy).unwrap();
+
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].0.as_str(), "extracted-feature");
+        assert_eq!(imports[0].1, "legacy_session");
+        assert_eq!(imports[0].2, serde_json::json!({ "version": 1 }));
+        assert_eq!(
+            legacy.get("old_feature"),
+            Some(&serde_json::json!({ "version": 1 }))
+        );
+    }
+}

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -825,12 +825,13 @@ fn plugin_metadata_path(plugin: &str) -> Option<std::path::PathBuf> {
 }
 
 fn plugin_metadata(name: &str, plugin: &str) -> anyhow::Result<PluginMetadata> {
-    if is_husk_package(plugin) {
-        let root = Path::new(plugin)
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Husk package manifest has no parent"))?;
-        let package = PluginPackageManifest::load(root)?;
+    if let Some((_, package)) = external_plugin_package(plugin)? {
         return Ok(PluginMetadata::from_package(&package));
+    }
+    if is_husk_package(plugin) {
+        // A standalone Husk package has no Red package metadata, so it loads
+        // eagerly with the same minimal metadata as a single-file plugin.
+        return Ok(PluginMetadata::minimal(name.to_string()));
     }
     let Some(path) = plugin_metadata_path(plugin).filter(|path| path.exists()) else {
         return Ok(PluginMetadata::minimal(name.to_string()));
@@ -838,18 +839,44 @@ fn plugin_metadata(name: &str, plugin: &str) -> anyhow::Result<PluginMetadata> {
     PluginMetadata::from_file(&path)
 }
 
+fn external_plugin_package(
+    plugin: &str,
+) -> anyhow::Result<Option<(std::path::PathBuf, PluginPackageManifest)>> {
+    if crate::assets::is_bundled_plugin_specifier(plugin) {
+        return Ok(None);
+    }
+    let plugin_path = Path::new(plugin);
+    let canonical_plugin = plugin_path.canonicalize().ok();
+    for root in plugin_path.ancestors().skip(1) {
+        if !root.join(PLUGIN_MANIFEST_FILE).is_file() {
+            continue;
+        }
+        let package = PluginPackageManifest::load(root)?;
+        let Some(entry) = package.husk_entry(root) else {
+            continue;
+        };
+        let canonical_entry = entry.canonicalize().ok();
+        let matches = entry == plugin_path
+            || canonical_plugin
+                .as_ref()
+                .zip(canonical_entry.as_ref())
+                .is_some_and(|(plugin, entry)| plugin == entry);
+        if matches {
+            return Ok(Some((root.to_path_buf(), package)));
+        }
+    }
+    Ok(None)
+}
+
 fn plugin_modification(plugin: &str) -> PluginModification {
-    if is_husk_package(plugin) {
-        let root = Path::new(plugin).parent();
+    if let Ok(Some((root, _))) = external_plugin_package(plugin) {
         return PluginModification {
             source: fs::metadata(plugin)
                 .and_then(|metadata| metadata.modified())
                 .ok(),
-            metadata: root.and_then(|root| {
-                fs::metadata(root.join(PLUGIN_MANIFEST_FILE))
-                    .and_then(|metadata| metadata.modified())
-                    .ok()
-            }),
+            metadata: fs::metadata(root.join(PLUGIN_MANIFEST_FILE))
+                .and_then(|metadata| metadata.modified())
+                .ok(),
         };
     }
     PluginModification {
@@ -917,9 +944,6 @@ async fn load_plugin(runtime: &mut Runtime, name: &str, plugin: &str) -> anyhow:
 fn is_husk_package(plugin: &str) -> bool {
     !crate::assets::is_bundled_plugin_specifier(plugin)
         && Path::new(plugin).file_name().and_then(|name| name.to_str()) == Some("Husk.toml")
-        && Path::new(plugin)
-            .parent()
-            .is_some_and(|root| root.join(PLUGIN_MANIFEST_FILE).is_file())
 }
 
 fn is_lazy(metadata: &PluginMetadata) -> bool {
@@ -993,6 +1017,86 @@ mod tests {
             }
             _ => panic!("unexpected plugin request"),
         }
+    }
+
+    #[tokio::test]
+    async fn lazily_activates_external_package_with_nested_husk_manifest() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let root = tempfile_dir("external-husk-package");
+        let husk_root = root.join("husk");
+        fs::create_dir_all(husk_root.join("src")).unwrap();
+        fs::write(
+            root.join(PLUGIN_MANIFEST_FILE),
+            r#"
+                schema_version = 1
+
+                [plugin]
+                id = "external-husk-package"
+                name = "External Husk Package"
+                version = "0.1.0"
+                red_api = "^0.6.0"
+                husk_manifest = "husk/Husk.toml"
+
+                [activation]
+                commands = ["ExternalHello"]
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            husk_root.join("Husk.toml"),
+            r#"
+                schema_version = 1
+
+                [package]
+                name = "external-husk-package"
+                version = "0.1.0"
+                entry = "src/main.hk"
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            husk_root.join("src/main.hk"),
+            r#"
+                pub fn activate() {
+                    red::add_command("ExternalHello", hello);
+                }
+
+                fn hello() {
+                    red::execute("Print", "hello from external package");
+                }
+            "#,
+        )
+        .unwrap();
+
+        let mut registry = PluginRegistry::new();
+        registry.add(
+            "external-husk-package",
+            husk_root.join("Husk.toml").to_str().unwrap(),
+        );
+        let mut runtime = Runtime::new();
+
+        registry.initialize(&mut runtime).await.unwrap();
+        assert_eq!(
+            registry.statuses().get("external-husk-package"),
+            Some(&PluginStatus::Pending)
+        );
+
+        registry
+            .execute(&mut runtime, "ExternalHello")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry.statuses().get("external-husk-package"),
+            Some(&PluginStatus::Active)
+        );
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::Action(Action::Print(message))
+                if message == "hello from external package"
+        ));
     }
 
     #[tokio::test]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -19,6 +19,7 @@ use crate::editor::EditorStateSnapshot;
 use semver::{Version, VersionReq};
 use serde::Serialize;
 
+use super::package::{PluginPackageManifest, PLUGIN_MANIFEST_FILE};
 use super::{PluginMetadata, RequestId, Runtime};
 
 /// Lifecycle authority for configured Husk plugins.
@@ -32,7 +33,8 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.4.0";
+pub const RED_HOST_API_VERSION: &str = "0.6.0";
+const SUPPORTED_HOST_API_VERSIONS: &[&str] = &["0.4.0", RED_HOST_API_VERSION];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PluginModification {
@@ -167,24 +169,22 @@ impl PluginRegistry {
                     progressed = true;
                     continue;
                 }
-                match plugin_source(&plugin) {
-                    Ok(source) => match runtime
-                        .load_plugin_at(&name, plugin_display_path(&plugin), &source)
-                        .await
-                    {
-                        Ok(()) => {
-                            self.statuses.insert(name, PluginStatus::Active);
-                        }
-                        Err(error) => self.quarantine(
+                if is_lazy(&metadata) {
+                    progressed = true;
+                    continue;
+                }
+                match load_plugin(runtime, &name, &plugin).await {
+                    Ok(()) => {
+                        self.statuses.insert(name, PluginStatus::Active);
+                    }
+                    Err(error) => {
+                        self.quarantine(
                             runtime,
                             &name,
                             &plugin,
                             diagnostic_stage(&error),
                             error.to_string(),
-                        ),
-                    },
-                    Err(error) => {
-                        self.quarantine(runtime, &name, &plugin, "source", error.to_string())
+                        );
                     }
                 }
                 progressed = true;
@@ -290,6 +290,24 @@ impl PluginRegistry {
 
     /// Executes a plugin command and quarantines its owner on callback failure.
     pub async fn execute(&mut self, runtime: &mut Runtime, command: &str) -> anyhow::Result<()> {
+        if runtime.command_plugin(command).is_none() {
+            let candidate = self
+                .plugins
+                .iter()
+                .find(|(name, _)| {
+                    matches!(self.statuses.get(name), Some(PluginStatus::Pending))
+                        && self.metadata.get(name).is_some_and(|metadata| {
+                            metadata
+                                .activation_events
+                                .iter()
+                                .any(|event| event == &format!("onCommand:{command}"))
+                        })
+                })
+                .cloned();
+            if let Some((name, path)) = candidate {
+                self.activate_one(runtime, &name, &path).await;
+            }
+        }
         let owner = runtime.command_plugin(command);
         if let Err(error) = runtime.execute_command(command).await {
             crate::log!("Plugin command `{command}` failed: {error:?}");
@@ -314,6 +332,22 @@ impl PluginRegistry {
         args: serde_json::Value,
     ) -> anyhow::Result<()> {
         let _span = crate::editor::perf::PerfSpan::with_detail("notify", event);
+        let pending = self
+            .plugins
+            .iter()
+            .filter(|(name, _)| matches!(self.statuses.get(name), Some(PluginStatus::Pending)))
+            .filter(|(name, _)| {
+                self.metadata.get(name).is_some_and(|metadata| {
+                    metadata.activation_events.iter().any(|activation| {
+                        activation == event || activation == &format!("onEvent:{event}")
+                    })
+                })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for (name, path) in pending {
+            self.activate_one(runtime, &name, &path).await;
+        }
         for (plugin, error) in runtime.notify_isolated(event, args) {
             let path = self
                 .plugins
@@ -335,6 +369,16 @@ impl PluginRegistry {
         args: serde_json::Value,
     ) -> anyhow::Result<()> {
         let _span = crate::editor::perf::PerfSpan::with_detail("notify_plugin", event);
+        if matches!(self.statuses.get(plugin), Some(PluginStatus::Pending)) {
+            if let Some((name, path)) = self
+                .plugins
+                .iter()
+                .find(|(name, _)| name == plugin)
+                .cloned()
+            {
+                self.activate_one(runtime, &name, &path).await;
+            }
+        }
         for (failed_plugin, error) in runtime.notify_plugin_isolated(plugin, event, args) {
             let path = self
                 .plugins
@@ -345,6 +389,30 @@ impl PluginRegistry {
             self.quarantine(runtime, &failed_plugin, &path, "runtime", error.to_string());
         }
         Ok(())
+    }
+
+    async fn activate_one(&mut self, runtime: &mut Runtime, name: &str, path: &str) {
+        let metadata = self
+            .metadata
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| PluginMetadata::minimal(name.to_string()));
+        if let Some((stage, diagnostic)) = self.activation_error(&metadata) {
+            self.quarantine(runtime, name, path, stage, diagnostic);
+            return;
+        }
+        match load_plugin(runtime, name, path).await {
+            Ok(()) => {
+                self.statuses.insert(name.to_string(), PluginStatus::Active);
+            }
+            Err(error) => self.quarantine(
+                runtime,
+                name,
+                path,
+                diagnostic_stage(&error),
+                error.to_string(),
+            ),
+        }
     }
 
     /// Delivers a callback-scoped picker event only to the plugin that opened it.
@@ -757,6 +825,13 @@ fn plugin_metadata_path(plugin: &str) -> Option<std::path::PathBuf> {
 }
 
 fn plugin_metadata(name: &str, plugin: &str) -> anyhow::Result<PluginMetadata> {
+    if is_husk_package(plugin) {
+        let root = Path::new(plugin)
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Husk package manifest has no parent"))?;
+        let package = PluginPackageManifest::load(root)?;
+        return Ok(PluginMetadata::from_package(&package));
+    }
     let Some(path) = plugin_metadata_path(plugin).filter(|path| path.exists()) else {
         return Ok(PluginMetadata::minimal(name.to_string()));
     };
@@ -764,6 +839,19 @@ fn plugin_metadata(name: &str, plugin: &str) -> anyhow::Result<PluginMetadata> {
 }
 
 fn plugin_modification(plugin: &str) -> PluginModification {
+    if is_husk_package(plugin) {
+        let root = Path::new(plugin).parent();
+        return PluginModification {
+            source: fs::metadata(plugin)
+                .and_then(|metadata| metadata.modified())
+                .ok(),
+            metadata: root.and_then(|root| {
+                fs::metadata(root.join(PLUGIN_MANIFEST_FILE))
+                    .and_then(|metadata| metadata.modified())
+                    .ok()
+            }),
+        };
+    }
     PluginModification {
         source: fs::metadata(plugin)
             .and_then(|metadata| metadata.modified())
@@ -782,10 +870,16 @@ fn check_api_compatibility(metadata: &PluginMetadata) -> anyhow::Result<()> {
     };
     let requirement = VersionReq::parse(requirement)
         .map_err(|error| anyhow::anyhow!("invalid red_api_version `{requirement}`: {error}"))?;
-    let current = Version::parse(RED_HOST_API_VERSION)?;
+    let compatible = SUPPORTED_HOST_API_VERSIONS
+        .iter()
+        .map(|version| Version::parse(version))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .any(|version| requirement.matches(&version));
     anyhow::ensure!(
-        requirement.matches(&current),
-        "plugin requires Red host API `{requirement}`, but this release provides `{current}`; see docs/PLUGIN_API.md"
+        compatible,
+        "plugin requires Red host API `{requirement}`, but this release supports {}; see docs/PLUGIN_API.md",
+        SUPPORTED_HOST_API_VERSIONS.join(", ")
     );
     Ok(())
 }
@@ -793,6 +887,8 @@ fn check_api_compatibility(metadata: &PluginMetadata) -> anyhow::Result<()> {
 fn diagnostic_stage(error: &anyhow::Error) -> &'static str {
     if error.downcast_ref::<husk_diagnostics::Report>().is_some() {
         "compile"
+    } else if error.downcast_ref::<std::io::Error>().is_some() {
+        "source"
     } else {
         "activation"
     }
@@ -806,6 +902,28 @@ fn plugin_source(plugin: &str) -> anyhow::Result<String> {
     }
 
     Ok(fs::read_to_string(plugin)?)
+}
+
+async fn load_plugin(runtime: &mut Runtime, name: &str, plugin: &str) -> anyhow::Result<()> {
+    if is_husk_package(plugin) {
+        return runtime.load_plugin_package(name, Path::new(plugin)).await;
+    }
+    let source = plugin_source(plugin)?;
+    runtime
+        .load_plugin_at(name, plugin_display_path(plugin), &source)
+        .await
+}
+
+fn is_husk_package(plugin: &str) -> bool {
+    !crate::assets::is_bundled_plugin_specifier(plugin)
+        && Path::new(plugin).file_name().and_then(|name| name.to_str()) == Some("Husk.toml")
+        && Path::new(plugin)
+            .parent()
+            .is_some_and(|root| root.join(PLUGIN_MANIFEST_FILE).is_file())
+}
+
+fn is_lazy(metadata: &PluginMetadata) -> bool {
+    !metadata.activation_events.is_empty()
 }
 
 fn plugin_display_path(plugin: &str) -> String {
@@ -1189,10 +1307,10 @@ mod tests {
         metadata.red_api_version = Some("^0.4.0".to_string());
         check_api_compatibility(&metadata).unwrap();
 
-        metadata.red_api_version = Some("^0.3.0".to_string());
+        metadata.red_api_version = Some("^0.5.0".to_string());
         let error = check_api_compatibility(&metadata).unwrap_err().to_string();
 
-        assert!(error.contains("^0.3.0"));
+        assert!(error.contains("^0.5.0"));
         assert!(error.contains(RED_HOST_API_VERSION));
         assert!(error.contains("docs/PLUGIN_API.md"));
     }
@@ -1270,12 +1388,16 @@ mod tests {
         registry.initialize(&mut runtime).await.unwrap();
         assert_eq!(
             registry.statuses().get("example-plugin"),
-            Some(&PluginStatus::Active)
+            Some(&PluginStatus::Pending)
         );
         registry
             .execute(&mut runtime, "ExampleCommand")
             .await
             .unwrap();
+        assert_eq!(
+            registry.statuses().get("example-plugin"),
+            Some(&PluginStatus::Active)
+        );
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::Action(Action::Print(message))

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -999,6 +999,12 @@ impl RedHost {
                 let status = args.get(1).map(value_to_string);
                 self.send_request(PluginRequest::UpdatePickerStatus { id, status });
             }
+            "UpdatePickerBusy" => {
+                let id = args.first().and_then(value_to_i32).unwrap_or(1);
+                self.ensure_picker_owner(plugin, id, "UpdatePickerBusy")?;
+                let busy = args.get(1).and_then(Value::as_bool).unwrap_or(false);
+                self.send_request(PluginRequest::UpdatePickerBusy { id, busy });
+            }
             "ClosePicker" => {
                 let id = args.first().and_then(value_to_i32).unwrap_or(1);
                 self.ensure_picker_owner(plugin, id, "ClosePicker")?;
@@ -1561,6 +1567,74 @@ impl RedHost {
                     .unwrap_or(serde_json::Value::Null),
                 request_id,
             },
+            "CompanionCall" => PluginRequest::CompanionCall {
+                owner: plugin.to_string(),
+                method: args
+                    .first()
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("CompanionCall requires a method"))?
+                    .to_string(),
+                params: args
+                    .get(1)
+                    .map(value_to_json)
+                    .unwrap_or(serde_json::Value::Null),
+                timeout_ms: args.get(2).and_then(value_to_u64),
+                request_id,
+            },
+            "DocumentSnapshot" => PluginRequest::DocumentSnapshot {
+                path: args.first().and_then(Value::as_str).map(str::to_string),
+                request_id,
+            },
+            "DocumentApply" => {
+                let options = args
+                    .first()
+                    .map(value_to_json)
+                    .ok_or_else(|| anyhow::anyhow!("DocumentApply requires options"))?;
+                PluginRequest::DocumentApply {
+                    owner: plugin.to_string(),
+                    path: options
+                        .get("path")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
+                    expected_revision: options
+                        .get("expected_revision")
+                        .and_then(serde_json::Value::as_u64)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("DocumentApply requires expected_revision")
+                        })?,
+                    label: options
+                        .get("label")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("plugin edit")
+                        .to_string(),
+                    edits: serde_json::from_value(
+                        options
+                            .get("edits")
+                            .cloned()
+                            .ok_or_else(|| anyhow::anyhow!("DocumentApply requires edits"))?,
+                    )?,
+                    request_id,
+                }
+            }
+            "DocumentUndo" => {
+                let options = args
+                    .first()
+                    .map(value_to_json)
+                    .ok_or_else(|| anyhow::anyhow!("DocumentUndo requires options"))?;
+                PluginRequest::DocumentUndo {
+                    owner: plugin.to_string(),
+                    path: options
+                        .get("path")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
+                    transaction_id: options
+                        .get("transaction_id")
+                        .and_then(serde_json::Value::as_str)
+                        .ok_or_else(|| anyhow::anyhow!("DocumentUndo requires transaction_id"))?
+                        .to_string(),
+                    request_id,
+                }
+            }
             other => anyhow::bail!("unsupported Red host request: {other}"),
         };
         self.send_request(request);
@@ -2708,6 +2782,41 @@ impl Runtime {
         result
     }
 
+    /// Resolves and transactionally loads a multi-file Husk package.
+    pub async fn load_plugin_package(
+        &mut self,
+        name: &str,
+        manifest_path: &std::path::Path,
+    ) -> anyhow::Result<()> {
+        let _span = crate::editor::perf::PerfSpan::with_detail("husk:load_package", name);
+        let package = ResolvedPackage::open(manifest_path, PackageLimits::default())?;
+        let mut inner = self.inner.lock().unwrap();
+        let program = if inner.typecheck_enabled {
+            compile_plugin_package(name, &package)?
+        } else {
+            CompiledProgram::compile_package(
+                &package,
+                &CompileOptions::legacy_runtime_compatibility(),
+            )?
+        };
+        let RuntimeInner { plugins, host, .. } = &mut *inner;
+        host.begin_reload();
+        let was_loaded = plugins.contains_key(name);
+        let vm = plugins
+            .entry(name.to_string())
+            .or_insert_with(new_plugin_vm);
+        let result = vm.reload_compiled_plugin(name, program, host);
+        if result.is_ok() {
+            host.commit_reload();
+        } else {
+            host.rollback_reload();
+            if !was_loaded {
+                plugins.remove(name);
+            }
+        }
+        result
+    }
+
     pub fn unload_plugin(&mut self, name: &str) -> anyhow::Result<()> {
         let mut inner = self.inner.lock().unwrap();
         let RuntimeInner { plugins, host, .. } = &mut *inner;
@@ -3118,6 +3227,37 @@ fn compile_plugin_source(name: &str, path: &str, source: &str) -> anyhow::Result
         .with_declaration(host.clone());
     let program = CompiledProgram::compile_at(name, path, source, &options)?;
     super::api::validate_parsed_source(name, path, source, program.syntax())?;
+    Ok(program)
+}
+
+fn compile_plugin_package(
+    name: &str,
+    package: &ResolvedPackage,
+) -> anyhow::Result<CompiledProgram> {
+    let host = RED_HOST_AST.get_or_init(|| {
+        let parsed = husk_parser::parse_str(RED_HOST_DECLARATIONS);
+        assert!(
+            parsed.errors.is_empty(),
+            "Red host declarations must parse: {:?}",
+            parsed.errors
+        );
+        parsed
+            .file
+            .expect("Red host declarations must produce an AST")
+    });
+    let options = CompileOptions::legacy_runtime_compatibility()
+        .with_typecheck(true)
+        .with_profile(SemanticProfile::LegacyJavaScript)
+        .with_declaration(host.clone());
+    let program = CompiledProgram::compile_package(package, &options)?;
+    for module in &package.modules {
+        super::api::validate_parsed_source(
+            name,
+            &module.display_path.to_string_lossy(),
+            &module.source,
+            &module.syntax,
+        )?;
+    }
     Ok(program)
 }
 

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -167,6 +167,29 @@ impl PreferencesStore {
         self.save()
     }
 
+    /// Returns an opaque copy suitable for co-snapshotting with editor recovery.
+    ///
+    /// Keys and values are intentionally not interpreted here so data from an
+    /// unavailable or newer plugin survives Red upgrades and plugin reinstalls.
+    #[must_use]
+    pub fn plugin_storage_snapshot(&self) -> HashMap<String, serde_json::Value> {
+        self.preferences.plugin_storage.clone()
+    }
+
+    /// Restores opaque plugin values without deleting keys written after the snapshot.
+    pub fn merge_plugin_storage_snapshot(
+        &mut self,
+        snapshot: &HashMap<String, serde_json::Value>,
+    ) -> anyhow::Result<()> {
+        for (key, value) in snapshot {
+            self.preferences
+                .plugin_storage
+                .entry(key.clone())
+                .or_insert_with(|| value.clone());
+        }
+        self.save()
+    }
+
     /// Persists owner-only JSON for filesystem-backed stores.
     ///
     /// In-memory stores treat saving as a successful no-op.

--- a/src/session.rs
+++ b/src/session.rs
@@ -113,6 +113,15 @@ pub struct SessionSnapshot {
     /// invents Codex thread resume support that the adapter did not negotiate.
     #[serde(default)]
     pub agent_session_resumable: bool,
+    /// Opaque plugin-owned values co-snapshotted with buffers and undo history.
+    ///
+    /// Red preserves unknown keys so uninstalling or temporarily disabling a plugin
+    /// never destroys its recovery payload.
+    #[serde(default)]
+    pub plugin_extensions: HashMap<String, serde_json::Value>,
+    /// Unknown top-level fields retained for manifest-declared plugin migrations.
+    #[serde(default, flatten)]
+    pub legacy_extensions: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2257,7 +2266,31 @@ mod tests {
             agent_transcript: None,
             agent_workspace: None,
             agent_session_resumable: false,
+            plugin_extensions: HashMap::new(),
+            legacy_extensions: std::collections::BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn unknown_top_level_session_fields_survive_for_plugin_migration() {
+        let value = serde_json::to_value(snapshot("source")).unwrap();
+        let mut object = value.as_object().unwrap().clone();
+        object.insert(
+            "former_plugin".to_string(),
+            serde_json::json!({ "version": 1, "reviews": [1, 2] }),
+        );
+
+        let restored: SessionSnapshot =
+            serde_json::from_value(serde_json::Value::Object(object)).unwrap();
+        assert_eq!(
+            restored.legacy_extensions.get("former_plugin"),
+            Some(&serde_json::json!({ "version": 1, "reviews": [1, 2] }))
+        );
+        let encoded = serde_json::to_value(restored).unwrap();
+        assert_eq!(
+            encoded.get("former_plugin"),
+            Some(&serde_json::json!({ "version": 1, "reviews": [1, 2] }))
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,6 +23,7 @@ mod picker;
 mod prompt_buffer;
 mod rich_text;
 mod selection;
+mod spinner;
 
 pub use action_bar::{
     ActionBar, ActionBarLayout, ActionBarRole, ActionBarSpan, ActionMode, ActionPriority, UiAction,
@@ -50,6 +51,7 @@ pub(crate) use prompt_buffer::{
 };
 pub(crate) use rich_text::paint_rich_text;
 pub(crate) use selection::{FollowTailViewport, SelectionViewport};
+pub(crate) use spinner::{spinner_frame, SPINNER_FRAME_INTERVAL_MS};
 
 use crate::{
     config::KeyAction,

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -21,7 +21,7 @@ use std::{
     io::{self, BufRead as _, BufReader, Read as _, Seek as _, SeekFrom},
     path::PathBuf,
     sync::Arc,
-    time::SystemTime,
+    time::{Instant, SystemTime},
 };
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -38,7 +38,8 @@ use crate::{
 };
 
 use super::{
-    dialog::BorderStyle, first_prompt_line, Component, Dialog, IconCatalog, List, ScreenRect,
+    dialog::BorderStyle, first_prompt_line, spinner_frame, Component, Dialog, IconCatalog, List,
+    ScreenRect, SPINNER_FRAME_INTERVAL_MS,
 };
 
 type SelectAction = Box<dyn Fn(String) -> Action + Send>;
@@ -145,6 +146,8 @@ pub struct PickerOptions {
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
+    pub busy: bool,
+    #[serde(default)]
     pub actions: Vec<PickerKeyAction>,
     #[serde(default)]
     pub preview: Option<PickerPreview>,
@@ -174,6 +177,7 @@ pub enum PickerUpdate {
     Items(Vec<PickerItem>),
     Query(String),
     Status(Option<String>),
+    Busy(bool),
     Preview(Option<PickerPreview>),
 }
 
@@ -288,6 +292,8 @@ pub struct Picker {
     command_column_widths: Cell<Option<CommandColumns>>,
     external_filter: bool,
     status: Option<String>,
+    busy_since: Option<Instant>,
+    busy_frame: u64,
     key_actions: Vec<PickerKeyAction>,
     preview: Option<PickerPreview>,
     item_preview_root: Option<PathBuf>,
@@ -434,6 +440,8 @@ impl Picker {
             command_column_widths: Cell::new(None),
             external_filter: false,
             status: None,
+            busy_since: None,
+            busy_frame: 0,
             key_actions: Vec::new(),
             preview: None,
             item_preview_root: None,
@@ -504,6 +512,7 @@ impl Picker {
         picker.external_filter = options.external_filter;
         picker.placeholder = options.placeholder;
         picker.status = options.status;
+        picker.set_busy(options.busy);
         picker.key_actions = options.actions;
         picker.preview = options.preview;
         picker.search = options.initial_query;
@@ -687,6 +696,7 @@ impl Picker {
                 self.reset_preview_scroll_if_selection_changed(previous);
             }
             PickerUpdate::Status(status) => self.status = status,
+            PickerUpdate::Busy(busy) => self.set_busy(busy),
             PickerUpdate::Preview(preview) => self.preview = preview,
         }
         true
@@ -718,6 +728,18 @@ impl Picker {
 
     pub fn set_status(&mut self, status: Option<String>) {
         self.status = status;
+    }
+
+    fn set_busy(&mut self, busy: bool) {
+        if busy {
+            if self.busy_since.is_none() {
+                self.busy_since = Some(Instant::now());
+                self.busy_frame = 0;
+            }
+        } else {
+            self.busy_since = None;
+            self.busy_frame = 0;
+        }
     }
 
     pub(crate) fn query(&self) -> &str {
@@ -1386,7 +1408,15 @@ impl Picker {
             .or(self.status.as_deref())
             .or(file_status.as_deref())
         {
-            let status = truncate_display_width(status, self.width.saturating_sub(4));
+            let status = if let Some(since) = self.busy_since {
+                Cow::Owned(format!(
+                    "{} {status}",
+                    spinner_frame(since.elapsed().as_millis() as u64)
+                ))
+            } else {
+                Cow::Borrowed(status)
+            };
+            let status = truncate_display_width(&status, self.width.saturating_sub(4));
             let status = format!(" {status} ");
             let status_x = self.x + self.width + 1 - display_width(&status);
             buffer.set_text(
@@ -2660,6 +2690,18 @@ fn merge_preview_style(base: &Style, syntax: &Style) -> Style {
 }
 
 impl Component for Picker {
+    fn tick(&mut self) -> anyhow::Result<bool> {
+        let Some(since) = self.busy_since else {
+            return Ok(false);
+        };
+        let frame = since.elapsed().as_millis() as u64 / SPINNER_FRAME_INTERVAL_MS;
+        if frame == self.busy_frame {
+            return Ok(false);
+        }
+        self.busy_frame = frame;
+        Ok(true)
+    }
+
     fn update_picker(&mut self, id: i32, update: PickerUpdate) -> bool {
         self.apply_update(id, update)
     }

--- a/src/ui/spinner.rs
+++ b/src/ui/spinner.rs
@@ -1,0 +1,32 @@
+//! Shared terminal spinner frames for editor-owned loading surfaces.
+
+/// Delay between adjacent frames in the compact Braille loading animation.
+pub(crate) const SPINNER_FRAME_INTERVAL_MS: u64 = 120;
+
+/// One complete revolution of the compact Braille loading animation.
+pub(crate) const SPINNER_FRAME_COUNT: usize = 10;
+
+const SPINNER_FRAMES: [&str; SPINNER_FRAME_COUNT] =
+    ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Returns the shared spinner glyph for the elapsed animation time.
+pub(crate) fn spinner_frame(elapsed_ms: u64) -> &'static str {
+    let index = (elapsed_ms / SPINNER_FRAME_INTERVAL_MS) as usize;
+    SPINNER_FRAMES[index % SPINNER_FRAME_COUNT]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{spinner_frame, SPINNER_FRAME_COUNT, SPINNER_FRAME_INTERVAL_MS};
+
+    #[test]
+    fn braille_spinner_advances_and_wraps_at_the_shared_interval() {
+        assert_eq!(spinner_frame(0), "⠋");
+        assert_eq!(spinner_frame(SPINNER_FRAME_INTERVAL_MS - 1), "⠋");
+        assert_eq!(spinner_frame(SPINNER_FRAME_INTERVAL_MS), "⠙");
+        assert_eq!(
+            spinner_frame(SPINNER_FRAME_INTERVAL_MS * SPINNER_FRAME_COUNT as u64),
+            "⠋"
+        );
+    }
+}


### PR DESCRIPTION
## Why

Plugins such as PR Replay currently rely on host-compiled behavior and bundled Husk sources, so they cannot be extracted into independently versioned repositories without compromising Red's ownership of editor state, recovery, and safety boundaries. Red needs a reusable external package platform instead of more product-specific host integrations.

## What Changed

- Add a versioned external plugin package format, local-development and GitHub installation, atomic updates, enable/disable/remove lifecycle operations, and SHA-256-verified native companion artifacts.
- Expose package management through both `red plugin ...` and the in-editor `:plugins` picker, with lazy activation, user-keymap precedence, shared-leader support, and validation that rejects ambiguous prefix bindings.
- Add supervised companion JSON-lines RPC plus host-owned document snapshot, attributed apply, and undo primitives while preserving compatibility with existing plugin API consumers.
- Preserve namespaced plugin storage and unknown legacy session fields so extracted packages can declare their own migrations without embedding product knowledge in Red.
- Document the external package contract and include `examples/external-hello-plugin` as a minimal development-install fixture.

## How to Test

1. Run `cargo test --lib plugin --all-features`; expect plugin package validation, transactional install/update/remove, nested Husk activation, and keymap-prefix regressions to pass.
2. Run `cargo run -- plugin install --path examples/external-hello-plugin`, followed by `cargo run -- plugin list`; expect the enabled `hello-panel` package to appear without starting a native companion.
3. Start Red, invoke `:HelloPanel` or its `Space H` binding, and open `:plugins`; expect the external package to activate and appear in the editor-owned manager.
4. Run `cargo run -- plugin disable hello-panel`, `cargo run -- plugin enable hello-panel`, and `cargo run -- plugin remove hello-panel`; expect lifecycle changes to take effect while ordinary removal preserves package-owned data.
5. Copy `examples/external-hello-plugin` to a temporary directory, add `"Space H g" = "HelloPanel"` alongside its existing `"Space H"` binding, and install that copy; expect an explicit keymap-prefix validation failure with the previous installation left untouched.

Validated with `cargo clippy --all-targets --all-features -- -D warnings`.
