### PR TITLE
feat(picker): improve file search relevance and highlighting

### DIFF
--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -22,7 +22,7 @@ use crate::{
     theme::Theme,
 };
 
-use super::{Component, Picker, PickerItem, PickerPreview};
+use super::{picker::PickerFilterHighlights, Component, Picker, PickerItem, PickerPreview};
 
 const FILENAME_MATCH_BONUS: i64 = 1;
 
@@ -77,12 +77,16 @@ impl FilePicker {
         sender: mpsc::Sender<FilePickerLoad>,
         receiver: Receiver<FilePickerLoad>,
     ) -> Self {
-        let matcher = SkimMatcherV2::default();
+        let score_matcher = SkimMatcherV2::default();
+        let highlight_matcher = SkimMatcherV2::default();
         let mut picker = Picker::builder()
             .title("Find Files")
             .items(vec![])
-            .filter_action(move |item, query| file_match_score(&matcher, item, query))
+            .filter_action(move |item, query| file_match_score(&score_matcher, item, query))
             .filter_tie_breaker(|item| item.id.len())
+            .filter_highlight_action(move |item, query| {
+                file_match_highlights(&highlight_matcher, item, query)
+            })
             .history_key("find_files")
             .select_action(Action::OpenFile)
             .build(editor);
@@ -253,6 +257,79 @@ fn file_match_score(matcher: &SkimMatcherV2, item: &PickerItem, query: &str) -> 
     }
 }
 
+fn file_match_highlights(
+    matcher: &SkimMatcherV2,
+    item: &PickerItem,
+    query: &str,
+) -> PickerFilterHighlights {
+    let Some((filename_score, filename_indices)) = matcher.fuzzy_indices(&item.label, query) else {
+        return matcher
+            .fuzzy_indices(&item.id, query)
+            .map(|(_, indices)| path_match_highlights(item, indices))
+            .unwrap_or_default();
+    };
+    let filename_score = filename_score.saturating_add(FILENAME_MATCH_BONUS);
+    let query_matches_parent = item
+        .annotation
+        .as_deref()
+        .is_some_and(|parent| fuzzy_subsequence_matches(parent, query));
+
+    if query_matches_parent {
+        if let Some((path_score, path_indices)) = matcher.fuzzy_indices(&item.id, query) {
+            if path_score > filename_score {
+                return path_match_highlights(item, path_indices);
+            }
+        }
+    }
+
+    PickerFilterHighlights {
+        label: indices_to_ranges(filename_indices),
+        annotation: Vec::new(),
+    }
+}
+
+fn path_match_highlights(item: &PickerItem, indices: Vec<usize>) -> PickerFilterHighlights {
+    let label_start = item
+        .id
+        .chars()
+        .count()
+        .saturating_sub(item.label.chars().count());
+    let annotation_len = item
+        .annotation
+        .as_deref()
+        .map(|annotation| annotation.chars().count())
+        .unwrap_or_default();
+    let mut label_indices = Vec::new();
+    let mut annotation_indices = Vec::new();
+
+    for index in indices {
+        if index >= label_start {
+            label_indices.push(index - label_start);
+        } else if index < annotation_len {
+            annotation_indices.push(index);
+        }
+    }
+
+    PickerFilterHighlights {
+        label: indices_to_ranges(label_indices),
+        annotation: indices_to_ranges(annotation_indices),
+    }
+}
+
+fn indices_to_ranges(indices: Vec<usize>) -> Vec<[usize; 2]> {
+    let mut ranges: Vec<[usize; 2]> = Vec::new();
+    for index in indices {
+        if let Some(last) = ranges.last_mut() {
+            if last[1] == index {
+                last[1] += 1;
+                continue;
+            }
+        }
+        ranges.push([index, index + 1]);
+    }
+    ranges
+}
+
 fn fuzzy_subsequence_matches(candidate: &str, query: &str) -> bool {
     let case_sensitive = query
         .chars()
@@ -331,6 +408,7 @@ mod tests {
 
     use crate::{
         buffer::Buffer,
+        color::Color,
         config::{Config, KeyAction},
         editor::Editor,
         lsp::LspManager,
@@ -359,11 +437,15 @@ mod tests {
     }
 
     fn test_editor() -> Editor {
+        test_editor_with_theme(Theme::default())
+    }
+
+    fn test_editor_with_theme(theme: Theme) -> Editor {
         let config = Config::default();
         let lsp = Box::new(LspManager::new(config.lsp.clone()));
         let buffer = Buffer::new(None, String::new());
 
-        Editor::with_size(lsp, 80, 24, config, Theme::default(), vec![buffer]).unwrap()
+        Editor::with_size(lsp, 80, 24, config, theme, vec![buffer]).unwrap()
     }
 
     fn key(code: KeyCode) -> Event {
@@ -414,6 +496,36 @@ mod tests {
                 _ => None,
             })
             .expect("file picker selection should open a file")
+    }
+
+    fn picker_item(path: &str) -> PickerItem {
+        let path = Path::new(path);
+        PickerItem {
+            id: path.to_string_lossy().into_owned(),
+            icon: None,
+            label: path.file_name().unwrap().to_string_lossy().into_owned(),
+            kind: Some("FilePath".to_string()),
+            annotation: path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .map(|parent| parent.to_string_lossy().into_owned()),
+            detail: None,
+            data: serde_json::Value::Null,
+            matches: Vec::new(),
+            detail_matches: Vec::new(),
+            preview: None,
+        }
+    }
+
+    fn rendered_text_start(buffer: &RenderBuffer, needle: &str) -> usize {
+        for (row_index, row) in buffer.cells.chunks(buffer.width).enumerate() {
+            let text = row.iter().map(|cell| cell.c).collect::<String>();
+            if let Some(byte_column) = text.find(needle) {
+                let column = text[..byte_column].chars().count();
+                return row_index * buffer.width + column;
+            }
+        }
+        panic!("{needle:?} was not rendered");
     }
 
     #[test]
@@ -541,6 +653,95 @@ mod tests {
 
         assert!(picker.tick().unwrap());
         assert_eq!(selected_file(&mut picker), "deep/src/main.rs");
+    }
+
+    #[test]
+    fn file_match_highlights_filename_characters() {
+        let highlights = file_match_highlights(
+            &SkimMatcherV2::default(),
+            &picker_item("src/main.rs"),
+            "main",
+        );
+
+        assert_eq!(highlights.label, vec![[0, 4]]);
+        assert!(highlights.annotation.is_empty());
+    }
+
+    #[test]
+    fn file_match_highlights_parent_and_filename_characters() {
+        let highlights = file_match_highlights(
+            &SkimMatcherV2::default(),
+            &picker_item("src/main.rs"),
+            "smn",
+        );
+
+        assert_eq!(highlights.label, vec![[0, 1], [3, 4]]);
+        assert_eq!(highlights.annotation, vec![[0, 1]]);
+    }
+
+    #[test]
+    fn file_match_highlights_use_character_indices_for_unicode() {
+        let highlights = file_match_highlights(
+            &SkimMatcherV2::default(),
+            &picker_item("src/mäin.rs"),
+            "min",
+        );
+
+        assert_eq!(highlights.label, vec![[0, 1], [2, 4]]);
+    }
+
+    #[test]
+    fn file_picker_renders_query_matches_with_the_list_highlight_color() {
+        let match_color = Color::Rgb {
+            r: 255,
+            g: 204,
+            b: 102,
+        };
+        let selected_background = Color::Rgb { r: 0, g: 0, b: 0 };
+        let mut theme = Theme::default();
+        theme
+            .colors
+            .insert("list.highlightForeground".to_string(), match_color);
+        theme.ui_style.picker_item = Style {
+            fg: Some(Color::Rgb { r: 0, g: 0, b: 0 }),
+            bg: Some(Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255,
+            }),
+            ..Style::default()
+        };
+        theme.ui_style.picker_selected_item = Style {
+            fg: Some(Color::Rgb {
+                r: 80,
+                g: 250,
+                b: 123,
+            }),
+            bg: Some(selected_background),
+            ..Style::default()
+        };
+        let editor = test_editor_with_theme(theme);
+        let mut picker = FilePicker::loading(&editor);
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+        for character in "main".chars() {
+            picker.handle_event(&key(KeyCode::Char(character)));
+        }
+        send_load(
+            &picker,
+            picker.load_generation,
+            Ok(vec!["src/main.rs".to_string()]),
+        );
+
+        assert!(picker.tick().unwrap());
+        picker.draw(&mut buffer).unwrap();
+        let start = rendered_text_start(&buffer, "main.rs src");
+        let row_background = buffer.cells[start + 4].style.bg;
+
+        for cell in &buffer.cells[start..start + 4] {
+            assert_eq!(cell.style.fg, Some(match_color));
+            assert_eq!(cell.style.bg, row_background);
+        }
+        assert_ne!(buffer.cells[start + 4].style.fg, Some(match_color));
     }
 
     #[test]

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -24,6 +24,8 @@ use crate::{
 
 use super::{Component, Picker, PickerItem, PickerPreview};
 
+const FILENAME_MATCH_BONUS: i64 = 1;
+
 pub struct FilePicker {
     picker: Picker,
     receiver: Receiver<FilePickerLoad>,
@@ -79,7 +81,8 @@ impl FilePicker {
         let mut picker = Picker::builder()
             .title("Find Files")
             .items(vec![])
-            .filter_action(move |item, query| matcher.fuzzy_match(&item.id, query))
+            .filter_action(move |item, query| file_match_score(&matcher, item, query))
+            .filter_tie_breaker(|item| item.id.len())
             .history_key("find_files")
             .select_action(Action::OpenFile)
             .build(editor);
@@ -228,6 +231,55 @@ impl Component for FilePicker {
     }
 }
 
+fn file_match_score(matcher: &SkimMatcherV2, item: &PickerItem, query: &str) -> Option<i64> {
+    if !fuzzy_subsequence_matches(&item.label, query) {
+        return matcher.fuzzy_match(&item.id, query);
+    }
+
+    let filename_score = matcher
+        .fuzzy_match(&item.label, query)
+        .map(|score| score.saturating_add(FILENAME_MATCH_BONUS))?;
+    let query_matches_parent = item
+        .annotation
+        .as_deref()
+        .is_some_and(|parent| fuzzy_subsequence_matches(parent, query));
+
+    if query_matches_parent {
+        matcher
+            .fuzzy_match(&item.id, query)
+            .map(|path_score| path_score.max(filename_score))
+    } else {
+        Some(filename_score)
+    }
+}
+
+fn fuzzy_subsequence_matches(candidate: &str, query: &str) -> bool {
+    let case_sensitive = query
+        .chars()
+        .any(|character| character.is_ascii_uppercase());
+    let mut query = query.chars();
+    let Some(mut expected) = query.next() else {
+        return true;
+    };
+
+    for character in candidate.chars() {
+        let matches = if case_sensitive {
+            character == expected
+        } else {
+            character.eq_ignore_ascii_case(&expected)
+        };
+        if !matches {
+            continue;
+        }
+        let Some(next) = query.next() else {
+            return true;
+        };
+        expected = next;
+    }
+
+    false
+}
+
 fn load_file_picker_items(
     root_path: &Path,
     visibility: FilePickerVisibility,
@@ -351,6 +403,19 @@ mod tests {
             .join("\n")
     }
 
+    fn selected_file(picker: &mut FilePicker) -> String {
+        let Some(KeyAction::Multiple(actions)) = picker.handle_event(&key(KeyCode::Enter)) else {
+            panic!("expected file picker selection actions");
+        };
+        actions
+            .into_iter()
+            .find_map(|action| match action {
+                Action::OpenFile(path) => Some(path),
+                _ => None,
+            })
+            .expect("file picker selection should open a file")
+    }
+
     #[test]
     fn file_picker_draws_loading_message_before_files_arrive() {
         let editor = test_editor();
@@ -419,6 +484,86 @@ mod tests {
                 Action::OpenFile("crates/husk-parser/src/lib.rs".to_string()),
             ]))
         );
+    }
+
+    #[test]
+    fn file_picker_prefers_shorter_paths_when_match_scores_are_equal() {
+        let editor = test_editor();
+        let mut picker = FilePicker::loading(&editor);
+        for character in "main".chars() {
+            picker.handle_event(&key(KeyCode::Char(character)));
+        }
+        send_load(
+            &picker,
+            picker.load_generation,
+            Ok(vec![
+                "crates/husk-cli/src/main.rs".to_string(),
+                "crates/husk-lsp/src/main.rs".to_string(),
+                "examples/external-hello-plugin/src/main.hk".to_string(),
+                "plugins/git_core/src/main.hk".to_string(),
+                "plugins/neotree_core/src/main.hk".to_string(),
+                "src/main.rs".to_string(),
+                "tools/husk-standalone/smoke/src/main.rs".to_string(),
+            ]),
+        );
+
+        assert!(picker.tick().unwrap());
+        for expected in [
+            "src/main.rs",
+            "crates/husk-cli/src/main.rs",
+            "crates/husk-lsp/src/main.rs",
+            "plugins/git_core/src/main.hk",
+            "plugins/neotree_core/src/main.hk",
+            "tools/husk-standalone/smoke/src/main.rs",
+            "examples/external-hello-plugin/src/main.hk",
+        ] {
+            assert_eq!(selected_file(&mut picker), expected);
+            picker.handle_event(&key(KeyCode::Down));
+        }
+    }
+
+    #[test]
+    fn file_picker_prefers_filename_matches_over_directory_matches() {
+        let editor = test_editor();
+        let mut picker = FilePicker::loading(&editor);
+        for character in "main".chars() {
+            picker.handle_event(&key(KeyCode::Char(character)));
+        }
+        send_load(
+            &picker,
+            picker.load_generation,
+            Ok(vec![
+                "main/lib.rs".to_string(),
+                "deep/src/main.rs".to_string(),
+                "src/domain/mainland.rs".to_string(),
+            ]),
+        );
+
+        assert!(picker.tick().unwrap());
+        assert_eq!(selected_file(&mut picker), "deep/src/main.rs");
+    }
+
+    #[test]
+    fn file_picker_preserves_a_stronger_parent_path_match() {
+        let editor = test_editor();
+        let mut picker = FilePicker::loading(&editor);
+        for character in "src".chars() {
+            picker.handle_event(&key(KeyCode::Char(character)));
+        }
+        send_load(
+            &picker,
+            picker.load_generation,
+            Ok(vec![
+                "lib/source.rs".to_string(),
+                "src/source.rs".to_string(),
+                "src/main.rs".to_string(),
+            ]),
+        );
+
+        assert!(picker.tick().unwrap());
+        assert_eq!(selected_file(&mut picker), "src/main.rs");
+        picker.handle_event(&key(KeyCode::Down));
+        assert_eq!(selected_file(&mut picker), "src/source.rs");
     }
 
     #[test]

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -45,6 +45,7 @@ use super::{
 type SelectAction = Box<dyn Fn(String) -> Action + Send>;
 type FilterAction = Box<dyn Fn(&PickerItem, &str) -> Option<i64> + Send>;
 type FilterTieBreaker = Box<dyn Fn(&PickerItem) -> usize + Send>;
+type FilterHighlightAction = Box<dyn Fn(&PickerItem, &str) -> PickerFilterHighlights + Send>;
 const MIN_HORIZONTAL_PREVIEW_PANE_WIDTH: usize = 40;
 const MAX_PREVIEW_HIGHLIGHT_BYTES: usize = 64 * 1024;
 const MAX_UNFOCUSED_PREVIEW_BYTES: u64 = 256 * 1024;
@@ -285,6 +286,7 @@ pub struct Picker {
     select_action: Option<SelectAction>,
     filter_action: Option<FilterAction>,
     filter_tie_breaker: Option<FilterTieBreaker>,
+    filter_highlight_action: Option<FilterHighlightAction>,
     search: String,
     empty_message: Option<String>,
     theme: Theme,
@@ -345,6 +347,12 @@ struct CommandColumns {
     title: usize,
     shortcut: usize,
     colon: usize,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct PickerFilterHighlights {
+    pub label: Vec<[usize; 2]>,
+    pub annotation: Vec<[usize; 2]>,
 }
 
 impl Picker {
@@ -434,6 +442,7 @@ impl Picker {
             select_action: None,
             filter_action: None,
             filter_tie_breaker: None,
+            filter_highlight_action: None,
             search: String::new(),
             empty_message: None,
             theme: editor.theme.clone(),
@@ -1156,6 +1165,23 @@ impl Picker {
         }
     }
 
+    fn result_filter_match_style(&self, base: &Style) -> Style {
+        let foreground = self
+            .theme_color("list.highlightForeground")
+            .or(self.theme.ui_style.picker_prompt.fg)
+            .or(base.fg);
+        let mut style = self.theme.ensure_text_contrast(&Style {
+            fg: foreground,
+            bg: base.bg,
+            bold: base.bold,
+            italic: base.italic,
+        });
+        if style.fg == base.fg {
+            style.bold = true;
+        }
+        style
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn draw_text_with_matches(
         &self,
@@ -1459,6 +1485,16 @@ impl Picker {
             let item_index = top + offset;
             let is_selected = selected == Some(item_index);
             let row_style = self.result_row_style(is_selected);
+            let filter_highlights = self
+                .filter_highlight_action
+                .as_ref()
+                .filter(|_| !self.search.is_empty())
+                .map(|highlight| highlight(item, &self.search));
+            let derived_label_matches = filter_highlights
+                .as_ref()
+                .map(|highlights| highlights.label.as_slice())
+                .filter(|matches| !matches.is_empty());
+            let label_matches = derived_label_matches.unwrap_or(&item.matches);
             let y = rect.y + offset;
             buffer.set_text(rect.x, y, &" ".repeat(rect.width), &row_style);
 
@@ -1475,7 +1511,11 @@ impl Picker {
                 let category_gap = usize::from(command_columns.category > 0) * COMMAND_COLUMN_GAP;
                 let label_x = x + command_columns.category + category_gap;
                 let label_style = self.result_label_style(&row_style);
-                let match_style = self.result_match_style(&label_style);
+                let match_style = if derived_label_matches.is_some() {
+                    self.result_filter_match_style(&label_style)
+                } else {
+                    self.result_match_style(&label_style)
+                };
                 self.draw_text_with_matches(
                     buffer,
                     label_x,
@@ -1484,7 +1524,7 @@ impl Picker {
                     command_columns.title,
                     &label_style,
                     &match_style,
-                    &item.matches,
+                    label_matches,
                 );
 
                 let content_style = self.result_content_style(&row_style, is_selected);
@@ -1552,7 +1592,11 @@ impl Picker {
             let label_x = x;
             let label_width = display_width(&item.label).min(primary_width);
             let label_style = self.result_label_style(&row_style);
-            let match_style = self.result_match_style(&label_style);
+            let match_style = if derived_label_matches.is_some() {
+                self.result_filter_match_style(&label_style)
+            } else {
+                self.result_match_style(&label_style)
+            };
             let used = self.draw_text_with_matches(
                 buffer,
                 label_x,
@@ -1561,7 +1605,7 @@ impl Picker {
                 label_width,
                 &label_style,
                 &match_style,
-                &item.matches,
+                label_matches,
             );
             let annotation_remaining = primary_width.saturating_sub(used);
 
@@ -1571,9 +1615,21 @@ impl Picker {
                 {
                     let annotation_style = self.result_annotation_style(&row_style, is_selected);
                     let annotation_x = label_x + used + 1;
-                    let visible =
-                        truncate_display_width(annotation, annotation_remaining.saturating_sub(1));
-                    buffer.set_text(annotation_x, y, &visible, &annotation_style);
+                    let annotation_match_style = self.result_filter_match_style(&annotation_style);
+                    let annotation_matches = filter_highlights
+                        .as_ref()
+                        .map(|highlights| highlights.annotation.as_slice())
+                        .unwrap_or_default();
+                    self.draw_text_with_matches(
+                        buffer,
+                        annotation_x,
+                        y,
+                        annotation,
+                        annotation_remaining.saturating_sub(1),
+                        &annotation_style,
+                        &annotation_match_style,
+                        annotation_matches,
+                    );
                 }
             }
 
@@ -3012,6 +3068,7 @@ pub struct PickerBuilder {
     select_action: Option<SelectAction>,
     filter_action: Option<FilterAction>,
     filter_tie_breaker: Option<FilterTieBreaker>,
+    filter_highlight_action: Option<FilterHighlightAction>,
     placeholder: Option<String>,
     history_key: Option<String>,
 }
@@ -3032,6 +3089,7 @@ impl PickerBuilder {
             select_action: None,
             filter_action: None,
             filter_tie_breaker: None,
+            filter_highlight_action: None,
             placeholder: None,
             history_key: None,
         }
@@ -3082,6 +3140,15 @@ impl PickerBuilder {
         self
     }
 
+    /// Sets a query highlighter evaluated only for rows that are being rendered.
+    pub(crate) fn filter_highlight_action(
+        mut self,
+        highlight: impl Fn(&PickerItem, &str) -> PickerFilterHighlights + Send + 'static,
+    ) -> Self {
+        self.filter_highlight_action = Some(Box::new(highlight));
+        self
+    }
+
     /// Sets the prompt hint shown while the picker query is empty.
     pub fn placeholder(mut self, placeholder: impl Into<String>) -> Self {
         self.placeholder = Some(placeholder.into());
@@ -3105,6 +3172,7 @@ impl PickerBuilder {
         let select_action = self.select_action;
         let filter_action = self.filter_action;
         let filter_tie_breaker = self.filter_tie_breaker;
+        let filter_highlight_action = self.filter_highlight_action;
         let placeholder = self.placeholder;
         let history_key = self.history_key;
 
@@ -3119,6 +3187,7 @@ impl PickerBuilder {
         }
         picker.filter_action = filter_action;
         picker.filter_tie_breaker = filter_tie_breaker;
+        picker.filter_highlight_action = filter_highlight_action;
         picker.placeholder = placeholder;
         if let Some(history_key) = history_key {
             let history = editor.picker_history(&history_key).to_vec();
@@ -3131,12 +3200,15 @@ impl PickerBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
     use serde_json::json;
 
-    use super::{picker_file_icon, picker_file_icon_color};
+    use super::{picker_file_icon, picker_file_icon_color, PickerFilterHighlights};
     use crate::{
         buffer::Buffer,
         color::{contrast_ratio, Color},
@@ -5351,6 +5423,34 @@ mod tests {
             picker.selected_dynamic_item().map(|item| item.id.as_str()),
             Some("alpha")
         );
+    }
+
+    #[test]
+    fn structured_picker_only_derives_filter_highlights_for_visible_rows() {
+        let editor = test_editor();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let highlight_calls = Arc::clone(&calls);
+        let items = (0..100)
+            .map(|index| dynamic_item(&format!("item-{index}"), &format!("item {index}")))
+            .collect();
+        let mut picker = Picker::builder()
+            .structured_items(items)
+            .filter_action(|_, _| Some(1))
+            .filter_highlight_action(move |_, _| {
+                highlight_calls.fetch_add(1, Ordering::Relaxed);
+                PickerFilterHighlights::default()
+            })
+            .build(&editor);
+        picker.set_search("i".to_string());
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        picker.draw(&mut buffer).unwrap();
+
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            picker.layout().results.height
+        );
+        assert!(calls.load(Ordering::Relaxed) < 100);
     }
 
     #[test]

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -44,6 +44,7 @@ use super::{
 
 type SelectAction = Box<dyn Fn(String) -> Action + Send>;
 type FilterAction = Box<dyn Fn(&PickerItem, &str) -> Option<i64> + Send>;
+type FilterTieBreaker = Box<dyn Fn(&PickerItem) -> usize + Send>;
 const MIN_HORIZONTAL_PREVIEW_PANE_WIDTH: usize = 40;
 const MAX_PREVIEW_HIGHLIGHT_BYTES: usize = 64 * 1024;
 const MAX_UNFOCUSED_PREVIEW_BYTES: u64 = 256 * 1024;
@@ -283,6 +284,7 @@ pub struct Picker {
     matcher: SkimMatcherV2,
     select_action: Option<SelectAction>,
     filter_action: Option<FilterAction>,
+    filter_tie_breaker: Option<FilterTieBreaker>,
     search: String,
     empty_message: Option<String>,
     theme: Theme,
@@ -431,6 +433,7 @@ impl Picker {
             matcher: SkimMatcherV2::default(),
             select_action: None,
             filter_action: None,
+            filter_tie_breaker: None,
             search: String::new(),
             empty_message: None,
             theme: editor.theme.clone(),
@@ -605,11 +608,20 @@ impl Picker {
                                 || self.matcher.fuzzy_match(&item.label, term),
                                 |filter| filter(item, term),
                             )
-                            .map(|score| (index, score))
+                            .map(|score| {
+                                let tie_breaker = self
+                                    .filter_tie_breaker
+                                    .as_ref()
+                                    .map_or(0, |tie_breaker| tie_breaker(item));
+                                (index, score, tie_breaker)
+                            })
                     })
                     .collect::<Vec<_>>();
-                matches.sort_unstable_by_key(|(index, score)| (Reverse(*score), *index));
-                self.visible_dynamic_items = matches.into_iter().map(|(index, _)| index).collect();
+                matches.sort_unstable_by_key(|(index, score, tie_breaker)| {
+                    (Reverse(*score), *tie_breaker, *index)
+                });
+                self.visible_dynamic_items =
+                    matches.into_iter().map(|(index, _, _)| index).collect();
             }
             self.list.set_item_count(self.visible_dynamic_items.len());
             self.command_column_widths.set(None);
@@ -2999,6 +3011,7 @@ pub struct PickerBuilder {
     id: Option<i32>,
     select_action: Option<SelectAction>,
     filter_action: Option<FilterAction>,
+    filter_tie_breaker: Option<FilterTieBreaker>,
     placeholder: Option<String>,
     history_key: Option<String>,
 }
@@ -3018,6 +3031,7 @@ impl PickerBuilder {
             id: None,
             select_action: None,
             filter_action: None,
+            filter_tie_breaker: None,
             placeholder: None,
             history_key: None,
         }
@@ -3059,6 +3073,15 @@ impl PickerBuilder {
         self
     }
 
+    /// Sets an ascending secondary sort key for structured rows with equal filter scores.
+    pub fn filter_tie_breaker(
+        mut self,
+        tie_breaker: impl Fn(&PickerItem) -> usize + Send + 'static,
+    ) -> Self {
+        self.filter_tie_breaker = Some(Box::new(tie_breaker));
+        self
+    }
+
     /// Sets the prompt hint shown while the picker query is empty.
     pub fn placeholder(mut self, placeholder: impl Into<String>) -> Self {
         self.placeholder = Some(placeholder.into());
@@ -3081,6 +3104,7 @@ impl PickerBuilder {
         let id = self.id;
         let select_action = self.select_action;
         let filter_action = self.filter_action;
+        let filter_tie_breaker = self.filter_tie_breaker;
         let placeholder = self.placeholder;
         let history_key = self.history_key;
 
@@ -3094,6 +3118,7 @@ impl PickerBuilder {
             picker.select_action = Some(select_action);
         }
         picker.filter_action = filter_action;
+        picker.filter_tie_breaker = filter_tie_breaker;
         picker.placeholder = placeholder;
         if let Some(history_key) = history_key {
             let history = editor.picker_history(&history_key).to_vec();
@@ -5305,6 +5330,27 @@ mod tests {
         assert_eq!(selected.id, "b");
         assert_eq!(selected.label.as_ptr(), original_label);
         assert!(picker.list.items().is_empty());
+    }
+
+    #[test]
+    fn structured_picker_can_break_equal_score_ties_with_an_item_key() {
+        let editor = test_editor();
+        let items = vec![
+            dynamic_item("long/path/alpha", "alpha"),
+            dynamic_item("alpha", "alpha"),
+        ];
+        let mut picker = Picker::builder()
+            .structured_items(items)
+            .filter_action(|_, _| Some(1))
+            .filter_tie_breaker(|item| item.id.len())
+            .build(&editor);
+
+        picker.filter("a");
+
+        assert_eq!(
+            picker.selected_dynamic_item().map(|item| item.id.as_str()),
+            Some("alpha")
+        );
     }
 
     #[test]


### PR DESCRIPTION
File search currently treats filename and parent-directory matches too similarly and renders every result uniformly. In larger repositories, that makes the most useful files harder to find and the result list slower to scan.

This change improves file-picker search by:

- preferring filename matches while preserving stronger full-path matches
- using shorter relative paths to break equal-score ties
- highlighting fuzzy-match characters in filenames and parent paths
- deriving highlight ranges only for visible rows so large candidate sets retain the score-only filtering path

Match colors use the theme's `list.highlightForeground` value with a visible fallback, while preserving selection backgrounds and Unicode-safe character ranges.

## How to Test

1. Run `cargo run`, press `Ctrl-p`, and search for `main`.
   - `src/main.rs` should rank before longer equivalent matches.
   - Matched characters should be highlighted in filenames and matching parent paths.
2. Move through the results.
   - The selected-row background should remain intact while matched characters remain distinguishable.
3. Search for a shorthand that spans a directory and filename, such as `smn` for `src/main.rs`.
   - Matches should be highlighted in both displayed fields.
4. Clear the query.
   - Results should render without query-match highlighting.

Focused automated coverage: `cargo test ui::file_picker::tests` and `cargo test ui::picker::tests`.
