### PR TITLE
feat(editor): add relative line numbers

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -21,6 +21,10 @@ scrolloff = 3
 # Wrap long lines at the window edge. This matches Vim/Neovim's 'wrap'.
 wrap = true
 
+# Show the absolute line number on the cursor line and the distance from the
+# cursor on every other line, like Vim/Neovim's 'relativenumber'.
+relative_line_numbers = false
+
 # Indent the continuation rows of wrapped lines to match the line's leading
 # whitespace, like Vim/Neovim's 'breakindent'. At least 20 columns of text
 # are kept per row, mirroring 'breakindentopt' min:20.

--- a/src/config.rs
+++ b/src/config.rs
@@ -184,6 +184,9 @@ pub struct Config {
     pub scrolloff: Option<usize>,
     /// Whether long lines wrap to continuation rows.
     pub wrap: Option<bool>,
+    /// Show the cursor line's absolute number and distances on other lines.
+    /// Defaults to off.
+    pub relative_line_numbers: Option<bool>,
     /// Indent wrapped continuation rows to the line's leading whitespace,
     /// like vim's 'breakindent'. Defaults to on.
     pub breakindent: Option<bool>,
@@ -1213,6 +1216,7 @@ fn known_top_level_field(field: &str) -> bool {
             | "mouse_scroll_lines"
             | "scrolloff"
             | "wrap"
+            | "relative_line_numbers"
             | "breakindent"
             | "sidescroll"
             | "sidescrolloff"
@@ -2055,6 +2059,37 @@ wrap = "yes"
             loaded.config.keys.normal.get("x"),
             Some(&KeyAction::Single(Action::MoveScreenLineDown))
         );
+    }
+
+    #[test]
+    fn relative_line_numbers_are_an_optional_opt_in_setting() {
+        let defaults = Config::load_user_toml("", Path::new("/tmp/config.toml"), &[]).unwrap();
+        assert_eq!(defaults.config.relative_line_numbers, Some(false));
+
+        let enabled = Config::load_user_toml(
+            "relative_line_numbers = true",
+            Path::new("/tmp/config.toml"),
+            &[],
+        )
+        .unwrap();
+        assert!(enabled.is_clean());
+        assert_eq!(enabled.config.relative_line_numbers, Some(true));
+    }
+
+    #[test]
+    fn invalid_relative_line_numbers_falls_back_independently() {
+        let loaded = Config::load_user_toml(
+            r#"relative_line_numbers = "yes""#,
+            Path::new("/tmp/config.toml"),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(loaded.config.relative_line_numbers, Some(false));
+        assert!(loaded.diagnostics.iter().any(|diagnostic| {
+            diagnostic.path == "relative_line_numbers"
+                && diagnostic.fallback == "kept the previous valid value"
+        }));
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8033,15 +8033,9 @@ impl Editor {
             drain_repeated_motion =
                 !from_waiting_key_action && self.should_drain_repeated_motion(&ev, &action);
             let action_span = perf::PerfSpan::start("event:handle_action");
-            // A count is one input command even though KeyAction expands it internally.
-            // Relative numbers should publish the resulting cursor position once.
-            let should_quit = if self.should_defer_counted_relative_motion(&action) {
-                self.handle_key_action_with_deferred_motion(&ev, &action, buffer, runtime)
-                    .await?
-            } else {
-                self.handle_key_action(&ev, &action, buffer, runtime)
-                    .await?
-            };
+            let should_quit = self
+                .handle_resolved_key_action(&ev, &action, buffer, runtime)
+                .await?;
             drop(action_span);
             if should_quit {
                 self.finish_semantic_change_event();
@@ -8241,6 +8235,23 @@ impl Editor {
             self.flush_deferred_motion_render(buffer)?;
         }
         Ok(quit)
+    }
+
+    async fn handle_resolved_key_action(
+        &mut self,
+        ev: &event::Event,
+        action: &KeyAction,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        // A count is one input command even though KeyAction expands it internally.
+        // Keep that render boundary for both direct input and replayed events.
+        if self.should_defer_counted_relative_motion(action) {
+            self.handle_key_action_with_deferred_motion(ev, action, buffer, runtime)
+                .await
+        } else {
+            self.handle_key_action(ev, action, buffer, runtime).await
+        }
     }
 
     fn key_signature(ev: &event::Event) -> Option<KeySignature> {
@@ -8603,7 +8614,7 @@ impl Editor {
             for event in &change.events {
                 if let Some(action) = self.handle_event_with_runtime(event, Some(runtime))? {
                     if self
-                        .handle_key_action(event, &action, buffer, runtime)
+                        .handle_resolved_key_action(event, &action, buffer, runtime)
                         .await?
                     {
                         anyhow::bail!("repeated change attempted to quit the editor");
@@ -8676,7 +8687,7 @@ impl Editor {
                     self.handle_event_with_runtime(&replay.event, Some(runtime))?
                 {
                     if self
-                        .handle_key_action(&replay.event, &action, buffer, runtime)
+                        .handle_resolved_key_action(&replay.event, &action, buffer, runtime)
                         .await?
                     {
                         anyhow::bail!("macro attempted to quit the editor");
@@ -25311,7 +25322,7 @@ mod test {
         );
     }
 
-    async fn run_counted_down_motion(relative_line_numbers: bool) -> (Editor, RenderBuffer, u64) {
+    fn counted_down_motion_editor(relative_line_numbers: bool) -> (Editor, RenderBuffer, Runtime) {
         let mut config = Config {
             relative_line_numbers: Some(relative_line_numbers),
             ..Default::default()
@@ -25328,8 +25339,18 @@ mod test {
         let buffer = Buffer::new(None, content);
         let mut editor =
             Editor::with_size(lsp, 40, 20, config, Theme::default(), vec![buffer]).unwrap();
-        let mut render_buffer = RenderBuffer::new(40, 20, &Style::default());
-        let mut runtime = Runtime::new();
+        editor.test_disable_terminal_output();
+
+        (
+            editor,
+            RenderBuffer::new(40, 20, &Style::default()),
+            Runtime::new(),
+        )
+    }
+
+    async fn run_counted_down_motion(relative_line_numbers: bool) -> (Editor, RenderBuffer, u64) {
+        let (mut editor, mut render_buffer, mut runtime) =
+            counted_down_motion_editor(relative_line_numbers);
 
         editor.render(&mut render_buffer).unwrap();
         for key in ['1', '0'] {
@@ -25369,6 +25390,31 @@ mod test {
         let rows = render_text_rows(&render_buffer);
         assert_eq!(rows[10].chars().take(5).collect::<String>(), "  11 ");
         assert_eq!(rows[15].chars().take(5).collect::<String>(), "   5 ");
+    }
+
+    #[tokio::test]
+    async fn macro_replayed_counted_relative_line_motion_renders_only_the_final_frame() {
+        let _guard = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        let (mut editor, mut render_buffer, mut runtime) = counted_down_motion_editor(true);
+        install_event_recorder(&mut editor, &mut runtime).await;
+        editor.set_register('a', Content::charwise("10j".to_string()));
+        editor.render(&mut render_buffer).unwrap();
+        let generation_before_motion = editor.render_generation;
+
+        editor
+            .play_macro('a', &mut render_buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert_eq!(editor.buffer_line(), 10);
+        assert_eq!(
+            editor.render_generation,
+            generation_before_motion.wrapping_add(1)
+        );
+        assert_eq!(
+            collect_print_requests(),
+            vec!["cursor:MoveDown:0,0->0,10:Normal".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3306,7 +3306,8 @@ impl Editor {
             self.render(buffer)
         } else if self.can_render_cursor_motion_delta() {
             self.render_cursor_motion_delta(buffer)
-        } else if self.uses_synthetic_block_cursor()
+        } else if self.relative_line_numbers_enabled()
+            || self.uses_synthetic_block_cursor()
             || !self.last_rendered_bracket_rows.is_empty()
             || self.matching_bracket_positions().is_some()
         {
@@ -3775,6 +3776,10 @@ impl Editor {
 
     fn active_tab_width(&self) -> usize {
         self.tab_width_for_buffer_index(self.buffer_manager.active_index())
+    }
+
+    fn relative_line_numbers_enabled(&self) -> bool {
+        self.config.relative_line_numbers.unwrap_or(false)
     }
 
     fn break_indent_options_for_buffer_index(&self, buffer_index: usize) -> BreakIndentOptions {
@@ -7202,6 +7207,9 @@ impl Editor {
                             "log_file" => json!(self.config.log_file),
                             "mouse_scroll_lines" => json!(self.config.mouse_scroll_lines),
                             "scrolloff" => json!(self.config.scrolloff),
+                            "relative_line_numbers" => {
+                                json!(self.config.relative_line_numbers)
+                            }
                             "show_diagnostics" => json!(self.config.show_diagnostics),
                             "startup_file_count" => json!(self.config.startup_file_count),
                             "cwd" => json!(std::env::current_dir()
@@ -7222,6 +7230,7 @@ impl Editor {
                             "log_file": self.config.log_file,
                             "mouse_scroll_lines": self.config.mouse_scroll_lines,
                             "scrolloff": self.config.scrolloff,
+                            "relative_line_numbers": self.config.relative_line_numbers,
                             "show_diagnostics": self.config.show_diagnostics,
                             "startup_file_count": self.config.startup_file_count,
                             "cwd": std::env::current_dir().ok().map(|path| path.to_string_lossy().to_string()),
@@ -8024,9 +8033,15 @@ impl Editor {
             drain_repeated_motion =
                 !from_waiting_key_action && self.should_drain_repeated_motion(&ev, &action);
             let action_span = perf::PerfSpan::start("event:handle_action");
-            let should_quit = self
-                .handle_key_action(&ev, &action, buffer, runtime)
-                .await?;
+            // A count is one input command even though KeyAction expands it internally.
+            // Relative numbers should publish the resulting cursor position once.
+            let should_quit = if self.should_defer_counted_relative_motion(&action) {
+                self.handle_key_action_with_deferred_motion(&ev, &action, buffer, runtime)
+                    .await?
+            } else {
+                self.handle_key_action(&ev, &action, buffer, runtime)
+                    .await?
+            };
             drop(action_span);
             if should_quit {
                 self.finish_semantic_change_event();
@@ -8197,7 +8212,8 @@ impl Editor {
             self.render(buffer)
         } else if self.can_render_cursor_motion_delta() {
             self.render_cursor_motion_delta(buffer)
-        } else if self.uses_synthetic_block_cursor()
+        } else if self.relative_line_numbers_enabled()
+            || self.uses_synthetic_block_cursor()
             || !self.last_rendered_bracket_rows.is_empty()
             || self.matching_bracket_positions().is_some()
         {
@@ -8205,6 +8221,26 @@ impl Editor {
         } else {
             self.draw_cursor_preserving_cursor_goal()
         }
+    }
+
+    async fn handle_key_action_with_deferred_motion(
+        &mut self,
+        ev: &event::Event,
+        action: &KeyAction,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        let was_deferring_motion = self.defer_motion_render;
+        self.defer_motion_render = true;
+        let result = self.handle_key_action(ev, action, buffer, runtime).await;
+        self.defer_motion_render = was_deferring_motion;
+
+        let quit = result?;
+        if !was_deferring_motion {
+            self.flush_deferred_plugin_event(runtime).await?;
+            self.flush_deferred_motion_render(buffer)?;
+        }
+        Ok(quit)
     }
 
     fn key_signature(ev: &event::Event) -> Option<KeySignature> {
@@ -8328,6 +8364,11 @@ impl Editor {
             && self.pending_operator.is_none()
             && self.waiting_key_action.is_none()
             && Self::key_action_is_pure_motion(action)
+    }
+
+    fn should_defer_counted_relative_motion(&self, action: &KeyAction) -> bool {
+        self.relative_line_numbers_enabled()
+            && matches!(action, KeyAction::Repeating(_, repeated) if Self::key_action_is_pure_motion(repeated))
     }
 
     fn key_action_is_pure_motion(action: &KeyAction) -> bool {
@@ -25229,6 +25270,115 @@ mod test {
         assert_eq!(
             render_buffer.cells[row5].style.fg, styled,
             "upward delta render must keep highlighting"
+        );
+    }
+
+    #[tokio::test]
+    async fn relative_line_numbers_repaint_the_whole_gutter_after_cursor_motion() {
+        let config = Config {
+            relative_line_numbers: Some(true),
+            ..Default::default()
+        };
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "one\ntwo\nthree\nfour".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 30, 8, config, Theme::default(), vec![buffer]).unwrap();
+        let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor.render(&mut render_buffer).unwrap();
+        assert_eq!(
+            render_text_rows(&render_buffer)[2]
+                .chars()
+                .take(4)
+                .collect::<String>(),
+            "  2 "
+        );
+        assert!(!editor.can_render_cursor_motion_delta());
+
+        editor
+            .execute(&Action::MoveDown, &mut render_buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            render_text_rows(&render_buffer)[2]
+                .chars()
+                .take(4)
+                .collect::<String>(),
+            "  1 ",
+            "moving the cursor must refresh relative numbers outside the old and new cursor rows"
+        );
+    }
+
+    async fn run_counted_down_motion(relative_line_numbers: bool) -> (Editor, RenderBuffer, u64) {
+        let mut config = Config {
+            relative_line_numbers: Some(relative_line_numbers),
+            ..Default::default()
+        };
+        config
+            .keys
+            .normal
+            .insert("j".to_string(), KeyAction::Single(Action::MoveDown));
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let content = (1..=30)
+            .map(|line| format!("line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let buffer = Buffer::new(None, content);
+        let mut editor =
+            Editor::with_size(lsp, 40, 20, config, Theme::default(), vec![buffer]).unwrap();
+        let mut render_buffer = RenderBuffer::new(40, 20, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor.render(&mut render_buffer).unwrap();
+        for key in ['1', '0'] {
+            editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)),
+                    &mut render_buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+        let generation_before_motion = editor.render_generation;
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        (editor, render_buffer, generation_before_motion)
+    }
+
+    #[tokio::test]
+    async fn counted_relative_line_motion_renders_only_the_final_frame() {
+        let (editor, render_buffer, generation_before_motion) = run_counted_down_motion(true).await;
+
+        assert_eq!(editor.buffer_line(), 10);
+        assert_eq!(
+            editor.render_generation,
+            generation_before_motion.wrapping_add(1)
+        );
+        let rows = render_text_rows(&render_buffer);
+        assert_eq!(rows[10].chars().take(5).collect::<String>(), "  11 ");
+        assert_eq!(rows[15].chars().take(5).collect::<String>(), "   5 ");
+    }
+
+    #[tokio::test]
+    async fn counted_motion_keeps_the_existing_render_path_without_relative_numbers() {
+        let (editor, _, generation_before_motion) = run_counted_down_motion(false).await;
+
+        assert_eq!(editor.buffer_line(), 10);
+        assert_eq!(
+            editor.render_generation,
+            generation_before_motion.wrapping_add(10)
         );
     }
 

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -240,6 +240,11 @@ impl Editor {
     /// Renders the entire editor state to the terminal
     /// This is the main entry point for all rendering operations
     pub fn render(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        if self.relative_line_numbers_enabled() && self.defer_motion_render {
+            self.deferred_motion_needs_full_render = true;
+            return Ok(());
+        }
+
         let _span = super::perf::PerfSpan::start("render:full");
         self.update_gutter_width();
         self.apply_panel_layout();
@@ -365,6 +370,7 @@ impl Editor {
 
     pub(crate) fn can_render_cursor_motion_delta(&self) -> bool {
         self.terminal_output_enabled
+            && !self.relative_line_numbers_enabled()
             && self.uses_synthetic_block_cursor()
             && self.current_dialog.is_none()
             && !self.panel_manager.has_focused_panel()
@@ -520,7 +526,18 @@ impl Editor {
         let segment = layout.row(row).filter(|segment| segment.first_segment);
         let line_number = segment
             .filter(|segment| segment.line < line_count)
-            .map(|segment| segment.line + 1);
+            .map(|segment| {
+                if self.relative_line_numbers_enabled() {
+                    let cursor_line = window.vtop + window.cy;
+                    if segment.line == cursor_line {
+                        segment.line + 1
+                    } else {
+                        segment.line.abs_diff(cursor_line)
+                    }
+                } else {
+                    segment.line + 1
+                }
+            });
         let number_text = line_number
             .map(|line_number| format!("{line_number:>number_width$} "))
             .unwrap_or_else(|| " ".repeat(number_width + 1));

--- a/tests/common/editor_harness.rs
+++ b/tests/common/editor_harness.rs
@@ -606,6 +606,48 @@ mod tests {
     }
 
     #[test]
+    fn test_relative_line_numbers_show_distances_and_absolute_cursor_line() {
+        let content = (1..=12)
+            .map(|line| format!("Line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let config = Config {
+            relative_line_numbers: Some(true),
+            ..Default::default()
+        };
+        let buffer = Buffer::new(None, content);
+        let mut harness = EditorHarness::with_config(buffer, config);
+        harness.set_viewport_cursor(0, 0, 4);
+
+        let first_row = harness.render_row(0).unwrap();
+        let cursor_row = harness.render_row(4).unwrap();
+        let lower_row = harness.render_row(7).unwrap();
+
+        assert_eq!(first_row.chars().take(5).collect::<String>(), "   4 ");
+        assert_eq!(cursor_row.chars().take(5).collect::<String>(), "   5 ");
+        assert_eq!(lower_row.chars().take(5).collect::<String>(), "   3 ");
+    }
+
+    #[test]
+    fn test_relative_line_numbers_leave_wrapped_continuations_blank() {
+        let config = Config {
+            relative_line_numbers: Some(true),
+            ..Default::default()
+        };
+        let buffer = Buffer::new(None, "abcdefghi\nsecond".to_string());
+        let mut harness = EditorHarness::with_config_and_size(buffer, config, 12, 8);
+        harness.set_viewport_cursor(0, 0, 1);
+
+        let first_row = harness.render_row(0).unwrap();
+        let continuation_row = harness.render_row(1).unwrap();
+        let cursor_row = harness.render_row(2).unwrap();
+
+        assert_eq!(first_row.chars().take(4).collect::<String>(), "  1 ");
+        assert_eq!(continuation_row.chars().take(4).collect::<String>(), "    ");
+        assert_eq!(cursor_row.chars().take(4).collect::<String>(), "  2 ");
+    }
+
+    #[test]
     fn test_plugin_gutter_sign_precedes_line_number() {
         let mut harness = EditorHarness::with_content("Line 1\nLine 2");
         harness.editor.test_set_gutter_signs(


### PR DESCRIPTION
## Why

Issue #169 requests optional relative line numbers for users coming from Vim, Neovim, and Helix. Showing line distances makes count-based motions such as `5j`, `8k`, and `d6j` easier to plan while retaining the absolute number on the cursor line.

Closes #169.

## What Changed

- Add an opt-in `relative_line_numbers` configuration setting, documented in `default_config.toml` and exposed through the plugin configuration API.
- Render the cursor line with its absolute number and other visible logical lines with their distance from the cursor, while leaving wrapped continuation rows blank and preserving gutter signs.
- Treat counted relative-number motions as one rendered input command so motions such as `10j` publish only the final frame.
- Preserve the existing counted-motion render path when relative line numbers are disabled.
- Add configuration, gutter-rendering, cursor-motion, counted-motion, wrapped-line, and option-disabled regression coverage.

## How to Test

1. Add `relative_line_numbers = true` to the user configuration and open a file with enough lines to extend above and below the cursor. Verify the cursor line shows its absolute number and other visible lines show their distance from it.
2. Press `10j`, then `5k`. Verify each command moves directly to its final line without displaying intermediate cursor frames, and verify the gutter reflects the final cursor position.
3. Open a narrow window containing a wrapped line. Verify only the first visual row has a line number and continuation rows remain blank.
4. Remove the setting or set `relative_line_numbers = false`, then repeat the counted motions. Verify absolute line numbers and the existing motion-rendering behavior are unchanged.
5. Run `cargo test --lib relative_line_numbers --all-features -- --nocapture` and `cargo test --test movement relative_line_numbers --all-features -- --nocapture`; expect the focused configuration, rendering, and counted-motion regressions to pass.
6. Run `cargo clippy --all-targets --all-features -- -D warnings`; expect no warnings or errors.