### PR TITLE
feat(editor): match Neovim line number behavior

### DIFF
--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -33,6 +33,7 @@ pub(crate) const BUILTIN_COLON_COMMANDS: &[&str] = &[
     "only",
     "noh",
     "nohlsearch",
+    "set",
     "wrap",
     "nowrap",
     "syntax",
@@ -556,6 +557,24 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Some(":nowrap"),
             &[],
             Action::SetWrap(false),
+        ),
+        builtin(
+            "view.enable_relative_line_numbers",
+            "Enable relative line numbers",
+            "View",
+            "Show each non-cursor line's distance from the cursor",
+            Some(":set relativenumber"),
+            &[":set rnu"],
+            Action::SetRelativeLineNumbers(true),
+        ),
+        builtin(
+            "view.disable_relative_line_numbers",
+            "Disable relative line numbers",
+            "View",
+            "Show absolute numbers on every line",
+            Some(":set norelativenumber"),
+            &[":set nornu"],
+            Action::SetRelativeLineNumbers(false),
         ),
         builtin(
             "view.syntax",
@@ -1199,6 +1218,26 @@ mod tests {
         assert!(syntax.aliases.iter().any(|alias| alias == ":syn"));
         assert!(syntax.aliases.iter().any(|alias| alias == ":ft"));
         assert_eq!(syntax.action, Action::OpenSyntaxPicker);
+    }
+
+    #[test]
+    fn palette_lists_relative_line_number_set_commands() {
+        let entries = entries(&default_keys(), &[]);
+        let enable = entries
+            .iter()
+            .find(|entry| entry.id == "view.enable_relative_line_numbers")
+            .expect("relative line number enable action should appear in the command palette");
+        let disable = entries
+            .iter()
+            .find(|entry| entry.id == "view.disable_relative_line_numbers")
+            .expect("relative line number disable action should appear in the command palette");
+
+        assert_eq!(enable.colon.as_deref(), Some(":set relativenumber"));
+        assert!(enable.aliases.iter().any(|alias| alias == ":set rnu"));
+        assert_eq!(enable.action, Action::SetRelativeLineNumbers(true));
+        assert_eq!(disable.colon.as_deref(), Some(":set norelativenumber"));
+        assert!(disable.aliases.iter().any(|alias| alias == ":set nornu"));
+        assert_eq!(disable.action, Action::SetRelativeLineNumbers(false));
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1359,6 +1359,7 @@ pub enum Action {
     ScrollCursorToViewEnd,
     ToggleWrap,
     SetWrap(bool),
+    SetRelativeLineNumbers(bool),
 
     DeletePreviousChar,
     DeleteCharAtCursorPos,
@@ -10593,6 +10594,26 @@ impl Editor {
             return vec![Action::SetSyntax(syntax.to_string())];
         }
 
+        if name == "set" {
+            let mut options = arguments.split_whitespace();
+            let Some(option) = options.next() else {
+                self.last_error = Some("usage: set {relativenumber|norelativenumber}".to_string());
+                return Vec::new();
+            };
+            if options.next().is_some() {
+                self.last_error = Some("usage: set {relativenumber|norelativenumber}".to_string());
+                return Vec::new();
+            }
+            return match option {
+                "relativenumber" | "rnu" => vec![Action::SetRelativeLineNumbers(true)],
+                "norelativenumber" | "nornu" => vec![Action::SetRelativeLineNumbers(false)],
+                _ => {
+                    self.last_error = Some(format!("unknown option {option:?}"));
+                    Vec::new()
+                }
+            };
+        }
+
         let parsed = command::parse(command_palette::BUILTIN_COLON_COMMANDS, cmd);
 
         let Some(parsed) = parsed else {
@@ -15143,6 +15164,10 @@ impl Editor {
                 self.wrap = *wrap;
                 self.vleft = 0;
                 self.skipcol = 0;
+                self.render(buffer)?;
+            }
+            Action::SetRelativeLineNumbers(enabled) => {
+                self.config.relative_line_numbers = Some(*enabled);
                 self.render(buffer)?;
             }
             Action::MoveToNextWord => {
@@ -22323,6 +22348,65 @@ mod test {
     }
 
     #[tokio::test]
+    async fn set_relative_line_number_commands_update_and_repaint_the_gutter() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let content = (1..=120)
+            .map(|line| format!("line {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut editor = Editor::with_size(
+            lsp,
+            40,
+            10,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, content)],
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor.vtop = 28;
+        editor.cy = 3;
+        let mut buffer = RenderBuffer::new(40, 10, &Style::default());
+        let mut runtime = Runtime::new();
+
+        enter_colon_command(&mut editor, &mut buffer, &mut runtime, "set relativenumber").await;
+
+        assert!(editor.relative_line_numbers_enabled());
+        let rows = render_text_rows(&buffer);
+        assert_eq!(rows[2].chars().take(6).collect::<String>(), "    1 ");
+        assert_eq!(rows[3].chars().take(6).collect::<String>(), "  32  ");
+
+        enter_colon_command(
+            &mut editor,
+            &mut buffer,
+            &mut runtime,
+            "set norelativenumber",
+        )
+        .await;
+
+        assert!(!editor.relative_line_numbers_enabled());
+        let rows = render_text_rows(&buffer);
+        assert_eq!(rows[2].chars().take(6).collect::<String>(), "   31 ");
+        assert_eq!(rows[3].chars().take(6).collect::<String>(), "   32 ");
+    }
+
+    #[test]
+    fn set_relative_line_number_aliases_match_neovim() {
+        let mut editor = test_editor(40, 10);
+        let runtime = Runtime::new();
+
+        assert_eq!(
+            editor.handle_command("set rnu", &runtime),
+            vec![Action::SetRelativeLineNumbers(true)]
+        );
+        assert_eq!(
+            editor.handle_command("set nornu", &runtime),
+            vec![Action::SetRelativeLineNumbers(false)]
+        );
+    }
+
+    #[tokio::test]
     async fn syntax_picker_opens_from_colon_command_and_applies_selected_language() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_plugin_requests();
@@ -25286,24 +25370,55 @@ mod test {
 
     #[tokio::test]
     async fn relative_line_numbers_repaint_the_whole_gutter_after_cursor_motion() {
+        let normal_line_number = Color::Rgb {
+            r: 70,
+            g: 71,
+            b: 72,
+        };
+        let active_line_number = Color::Rgb {
+            r: 180,
+            g: 190,
+            b: 200,
+        };
         let config = Config {
             relative_line_numbers: Some(true),
             ..Default::default()
         };
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
         let buffer = Buffer::new(None, "one\ntwo\nthree\nfour".to_string());
-        let mut editor =
-            Editor::with_size(lsp, 30, 8, config, Theme::default(), vec![buffer]).unwrap();
+        let mut theme = Theme {
+            gutter_style: Style {
+                fg: Some(normal_line_number),
+                ..Style::default()
+            },
+            ..Theme::default()
+        };
+        theme.colors.insert(
+            "editorLineNumber.activeForeground".to_string(),
+            active_line_number,
+        );
+        let mut editor = Editor::with_size(lsp, 30, 8, config, theme, vec![buffer]).unwrap();
         let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
         let mut runtime = Runtime::new();
 
         editor.render(&mut render_buffer).unwrap();
+        let number_column = GUTTER_SIGN_COLUMN_WIDTH;
         assert_eq!(
             render_text_rows(&render_buffer)[2]
                 .chars()
                 .take(4)
                 .collect::<String>(),
             "  2 "
+        );
+        assert_eq!(
+            render_buffer.cells[number_column].style.fg,
+            Some(active_line_number)
+        );
+        assert_eq!(
+            render_buffer.cells[2 * render_buffer.width + number_column]
+                .style
+                .fg,
+            Some(normal_line_number)
         );
         assert!(!editor.can_render_cursor_motion_delta());
 
@@ -25319,6 +25434,68 @@ mod test {
                 .collect::<String>(),
             "  1 ",
             "moving the cursor must refresh relative numbers outside the old and new cursor rows"
+        );
+        assert_eq!(
+            render_buffer.cells[number_column].style.fg,
+            Some(normal_line_number)
+        );
+        assert_eq!(
+            render_buffer.cells[render_buffer.width + number_column]
+                .style
+                .fg,
+            Some(active_line_number)
+        );
+    }
+
+    #[test]
+    fn absolute_line_numbers_use_the_theme_active_foreground_on_the_cursor_line() {
+        let normal_line_number = Color::Rgb {
+            r: 70,
+            g: 71,
+            b: 72,
+        };
+        let active_line_number = Color::Rgb {
+            r: 180,
+            g: 190,
+            b: 200,
+        };
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "one\ntwo\nthree".to_string());
+        let mut theme = Theme {
+            gutter_style: Style {
+                fg: Some(normal_line_number),
+                ..Style::default()
+            },
+            ..Theme::default()
+        };
+        theme.colors.insert(
+            "editorLineNumber.activeForeground".to_string(),
+            active_line_number,
+        );
+        let mut editor = Editor::with_size(lsp, 30, 8, config, theme, vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        editor.cy = 1;
+        let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+
+        editor.render(&mut render_buffer).unwrap();
+
+        let number_column = GUTTER_SIGN_COLUMN_WIDTH;
+        assert_eq!(
+            render_buffer.cells[number_column].style.fg,
+            Some(normal_line_number)
+        );
+        assert_eq!(
+            render_buffer.cells[render_buffer.width + number_column]
+                .style
+                .fg,
+            Some(active_line_number)
+        );
+        assert_eq!(
+            render_buffer.cells[2 * render_buffer.width + number_column]
+                .style
+                .fg,
+            Some(normal_line_number)
         );
     }
 

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -524,12 +524,14 @@ impl Editor {
         let number_width = self.line_number_width_for_window(window);
         let gutter_style = self.theme.gutter_style.fallback_bg(&self.theme.style);
         let segment = layout.row(row).filter(|segment| segment.first_segment);
+        let cursor_line = window.vtop + window.cy;
+        let is_cursor_line =
+            segment.is_some_and(|segment| segment.line < line_count && segment.line == cursor_line);
         let line_number = segment
             .filter(|segment| segment.line < line_count)
             .map(|segment| {
                 if self.relative_line_numbers_enabled() {
-                    let cursor_line = window.vtop + window.cy;
-                    if segment.line == cursor_line {
+                    if is_cursor_line {
                         segment.line + 1
                     } else {
                         segment.line.abs_diff(cursor_line)
@@ -539,12 +541,26 @@ impl Editor {
                 }
             });
         let number_text = line_number
-            .map(|line_number| format!("{line_number:>number_width$} "))
+            .map(|line_number| {
+                if self.relative_line_numbers_enabled() && is_cursor_line {
+                    format!("{line_number:<number_width$} ")
+                } else {
+                    format!("{line_number:>number_width$} ")
+                }
+            })
             .unwrap_or_else(|| " ".repeat(number_width + 1));
         let text = format!("{}{number_text}", " ".repeat(GUTTER_SIGN_COLUMN_WIDTH));
         let term_x = window.position.x;
         let term_y = self.window_to_terminal_y(window, row);
         buffer.set_text(term_x, term_y, &text, &gutter_style);
+        if is_cursor_line {
+            buffer.set_text(
+                term_x + GUTTER_SIGN_COLUMN_WIDTH,
+                term_y,
+                &number_text,
+                &self.theme.current_line_number_style(),
+            );
+        }
 
         let Some(segment) = segment else {
             return;

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -66,6 +66,16 @@ pub struct ThemeStyleSpec {
 }
 
 impl Theme {
+    pub(crate) fn current_line_number_style(&self) -> Style {
+        let mut style = self.gutter_style.fallback_bg(&self.style);
+        style.fg = self
+            .colors
+            .get("editorLineNumber.activeForeground")
+            .copied()
+            .or(self.style.fg);
+        style
+    }
+
     pub fn get_style(&self, scope: &str) -> Option<Style> {
         compatible_scopes(scope).into_iter().find_map(|candidate| {
             self.token_styles.iter().find_map(|ts| {
@@ -611,6 +621,71 @@ mod tests {
             token_styles,
             ..Theme::default()
         }
+    }
+
+    #[test]
+    fn current_line_number_style_prefers_theme_active_foreground() {
+        let active = Color::Rgb {
+            r: 180,
+            g: 190,
+            b: 200,
+        };
+        let gutter_background = Color::Rgb {
+            r: 20,
+            g: 21,
+            b: 22,
+        };
+        let mut theme = Theme {
+            gutter_style: Style {
+                fg: Some(Color::Rgb {
+                    r: 70,
+                    g: 71,
+                    b: 72,
+                }),
+                bg: Some(gutter_background),
+                italic: true,
+                ..Style::default()
+            },
+            ..Theme::default()
+        };
+        theme
+            .colors
+            .insert("editorLineNumber.activeForeground".to_string(), active);
+
+        let style = theme.current_line_number_style();
+
+        assert_eq!(style.fg, Some(active));
+        assert_eq!(style.bg, Some(gutter_background));
+        assert!(style.italic);
+    }
+
+    #[test]
+    fn current_line_number_style_falls_back_to_editor_foreground() {
+        let editor_foreground = Color::Rgb {
+            r: 210,
+            g: 211,
+            b: 212,
+        };
+        let theme = Theme {
+            style: Style {
+                fg: Some(editor_foreground),
+                ..Style::default()
+            },
+            gutter_style: Style {
+                fg: Some(Color::Rgb {
+                    r: 80,
+                    g: 81,
+                    b: 82,
+                }),
+                ..Style::default()
+            },
+            ..Theme::default()
+        };
+
+        assert_eq!(
+            theme.current_line_number_style().fg,
+            Some(editor_foreground)
+        );
     }
 
     fn cursor_contrast_theme(editor_fg: Color, editor_bg: Color, cursor_fg: Color) -> Theme {

--- a/tests/common/editor_harness.rs
+++ b/tests/common/editor_harness.rs
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn test_relative_line_numbers_show_distances_and_absolute_cursor_line() {
-        let content = (1..=12)
+        let content = (1..=120)
             .map(|line| format!("Line {line}"))
             .collect::<Vec<_>>()
             .join("\n");
@@ -621,11 +621,11 @@ mod tests {
 
         let first_row = harness.render_row(0).unwrap();
         let cursor_row = harness.render_row(4).unwrap();
-        let lower_row = harness.render_row(7).unwrap();
+        let two_digit_row = harness.render_row(14).unwrap();
 
-        assert_eq!(first_row.chars().take(5).collect::<String>(), "   4 ");
-        assert_eq!(cursor_row.chars().take(5).collect::<String>(), "   5 ");
-        assert_eq!(lower_row.chars().take(5).collect::<String>(), "   3 ");
+        assert_eq!(first_row.chars().take(6).collect::<String>(), "    4 ");
+        assert_eq!(cursor_row.chars().take(6).collect::<String>(), "  5   ");
+        assert_eq!(two_digit_row.chars().take(6).collect::<String>(), "   10 ");
     }
 
     #[test]


### PR DESCRIPTION
Relative line numbers added in #171 still rendered every gutter number with the same emphasis and alignment. That made the cursor line harder to identify and left the hybrid number layout inconsistent with Neovim. The mode could also only be selected through startup configuration.

This change:

- styles the cursor line number with `editorLineNumber.activeForeground`, falling back to the editor foreground when the theme does not provide it
- right-aligns relative distances while left-aligning the cursor line's absolute number
- adds `:set relativenumber` and `:set norelativenumber`, including the `rnu` and `nornu` aliases
- exposes both runtime actions through command discovery and the command palette
- preserves the existing `relative_line_numbers` configuration as the startup default

## How to Test

1. Open a file with at least 100 lines and run `:set relativenumber`. Non-cursor lines should show right-aligned distances, while the cursor line shows its left-aligned absolute number.
2. Move the cursor through the file. The active line number should use the theme's active line-number color and the entire relative-number gutter should update.
3. Run `:set norelativenumber`. Every line should immediately return to right-aligned absolute numbers. Repeat with `:set rnu` and `:set nornu` to verify the aliases.
4. Run the focused regressions `cargo test --lib editor::test::set_relative_line_number` and `cargo test --lib palette_lists_relative_line_number_set_commands`.
