### PR TITLE
fix(language-packs): accept supported host API versions

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -586,13 +586,14 @@ fn installed_grammar_consent_message(
 fn catalog_package_availability(
     package: &plugin::catalog::CatalogPackage,
 ) -> (String, Option<String>) {
-    let host_api = semver::Version::parse(plugin::RED_HOST_API_VERSION)
-        .expect("Red host API version is valid SemVer");
-    if !package.red_api.matches(&host_api) {
+    if !package
+        .supports_current_red_release()
+        .expect("supported Red API versions are valid SemVer")
+    {
         return (
             format!("Requires Red API {}", package.red_api),
             Some(format!(
-                "Language pack `{}` requires Red API `{}`, but this release provides `{host_api}`.",
+                "Language pack `{}` requires Red API `{}`, which this Red release does not support.",
                 package.id, package.red_api
             )),
         );
@@ -15656,10 +15657,9 @@ impl Editor {
                     let package = self.plugin_catalog.get(&id).ok_or_else(|| {
                         anyhow::anyhow!("language pack `{id}` is no longer in the catalog")
                     })?;
-                    let host_api = semver::Version::parse(plugin::RED_HOST_API_VERSION)?;
                     anyhow::ensure!(
-                        package.red_api.matches(&host_api),
-                        "language pack `{id}` requires Red API `{}`, but this release provides `{host_api}`",
+                        package.supports_current_red_release()?,
+                        "language pack `{id}` requires Red API `{}`, which this Red release does not support",
                         package.red_api
                     );
                     let artifact = package
@@ -23288,6 +23288,22 @@ mod test {
     }
 
     #[test]
+    fn language_pack_picker_accepts_a_supported_prior_host_api() {
+        let mut package = catalog_test_package();
+        package.red_api = semver::VersionReq::parse("^0.6.0").unwrap();
+        let catalog = BTreeMap::from([(package.id.clone(), package)]);
+
+        let items =
+            plugin_manager_items(&[], &catalog, plugin::catalog::DEFAULT_PLUGIN_CATALOG_URL);
+
+        assert_eq!(items[0].id, "catalog:go-language");
+        let (_, message) = catalog_package_availability(
+            &catalog[&plugin::package::PluginId::parse("go-language").unwrap()],
+        );
+        assert!(message.is_none());
+    }
+
+    #[test]
     fn language_pack_picker_keeps_api_incompatible_catalog_entries_recoverable() {
         let mut package = catalog_test_package();
         package.red_api = semver::VersionReq::parse(">=999.0.0").unwrap();
@@ -23305,7 +23321,7 @@ mod test {
         let (_, message) = catalog_package_availability(
             &catalog[&plugin::package::PluginId::parse("go-language").unwrap()],
         );
-        assert!(message.unwrap().contains("this release provides"));
+        assert!(message.unwrap().contains("does not support"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,9 +338,8 @@ async fn run_plugin_command(command: &PluginCommand) -> anyhow::Result<()> {
         PluginCommand::Catalog(arguments) => {
             let url = arguments.catalog_url.clone().unwrap_or_else(catalog_url);
             let catalog = PluginCatalog::fetch(&url).await?;
-            let host_api = semver::Version::parse(red::plugin::RED_HOST_API_VERSION)?;
             for package in catalog.packages {
-                let compatibility = if package.red_api.matches(&host_api) {
+                let compatibility = if package.supports_current_red_release()? {
                     "compatible"
                 } else {
                     "incompatible"

--- a/src/plugin/catalog.rs
+++ b/src/plugin/catalog.rs
@@ -149,7 +149,7 @@ impl PluginCatalog {
             .find(|package| &package.id == id)
             .ok_or_else(|| anyhow::anyhow!("language pack `{id}` is not in the catalog"))?;
         anyhow::ensure!(
-            host_api_requirement_is_supported(&package.red_api)?,
+            package.supports_current_red_release()?,
             "language pack `{id}` requires Red API `{}`, but this release supports {}",
             package.red_api,
             SUPPORTED_HOST_API_VERSIONS.join(", ")
@@ -181,6 +181,11 @@ impl PluginCatalog {
 }
 
 impl CatalogPackage {
+    /// Whether this package targets any Red API version supported by this release.
+    pub fn supports_current_red_release(&self) -> Result<bool> {
+        host_api_requirement_is_supported(&self.red_api)
+    }
+
     #[must_use]
     pub fn artifact(&self, target: &str) -> Option<&CatalogArtifact> {
         self.artifacts.get(target)
@@ -415,6 +420,7 @@ mod tests {
         let catalog = PluginCatalog::from_slice(&bytes).unwrap();
         let id = PluginId::parse("go-language").unwrap();
 
+        assert!(catalog.packages[0].supports_current_red_release().unwrap());
         assert!(catalog.installable(&id, "aarch64-apple-darwin").is_ok());
         assert!(catalog
             .installable(&id, "unsupported-target")


### PR DESCRIPTION
## Why

Red deliberately supports multiple host API versions, but the language-pack picker and `red plugin catalog` compared package requirements only with the current `0.7.0` API. Because pre-1.0 caret requirements do not cross minor versions, released packs declaring `^0.6.0`—including PowerShell—were incorrectly shown and rejected as incompatible even though the installer supports them.

## What Changed

- Add one catalog-package compatibility method backed by the supported host API set.
- Use the shared rule for catalog install validation, picker availability and selection, and CLI catalog output.
- Cover supported prior APIs and genuinely unsupported requirements with picker and catalog regressions.

## How to Test

1. Run `cargo run --quiet -- plugin catalog`.
   - Expect Go, PowerShell, and Swift to be reported as `compatible`.
2. Open **Language packs** from the command palette and select PowerShell.
   - Expect the pack to be available and the install choices to open without a Red API error.
3. Run `cargo test --lib language_pack_picker`.
   - Expect the `^0.6.0` regression to remain selectable and the unsupported API case to remain unavailable.
4. Run `cargo clippy --all-targets --all-features -- -D warnings`.
   - Expect no warnings or errors.