### PR TITLE
feat(statusline): add configurable layout and field catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2243,6 +2245,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bon",
+ "chrono",
  "clap",
  "core-foundation",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,7 @@ dependencies = [
  "thiserror 1.0.57",
  "tokio",
  "toml",
+ "toml_edit",
  "trash",
  "tree-sitter",
  "tree-sitter-bash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ tempfile = "3.15.0"
 thiserror = "1.0"
 tokio = { version = "1.41.0", features = ["full"] }
 toml = "0.8.23"
+toml_edit = "0.22.27"
 trash = "5.2.2"
 tree-sitter = "0.25"
 tree-sitter-language = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ arboard = "3.4.1"
 async-recursion = "1.0.5"
 async-trait = "0.1.77"
 bon = "3.3.2"
+chrono = "0.4.45"
 clap = { version = "4.5.26", features = ["derive", "env"] }
 crossterm = { version = "0.27.0", features = ["event-stream", "serde"] }
 futures = "0.3.30"

--- a/default_config.toml
+++ b/default_config.toml
@@ -79,13 +79,13 @@ input_position = "bottom"
 style = "nerd_font"
 color = true
 
-# Status-line sections may be reordered, moved between sides, or omitted.
+# Sections are ordered from the outer edge toward the center on both sides.
+# Run :statusline to arrange them in a terminal panel with a live preview.
 # Available sections: mode, git_branch, filename, syntax, and position.
-# Context sections use a middle shade derived from the active theme, while
-# mode and position retain the stronger accent color.
+# The first three positions use the theme's accent, middle, and base shades.
 [statusline]
 left = ["mode", "git_branch", "filename"]
-right = ["syntax", "position"]
+right = ["position", "syntax"]
 
 # Nerd Font icons match nvim-web-devicons. "unicode" and "ascii" are
 # portable fallbacks; "none" keeps the labels while hiding their icons.

--- a/default_config.toml
+++ b/default_config.toml
@@ -80,8 +80,8 @@ style = "nerd_font"
 color = true
 
 # Sections are ordered from the outer edge toward the center on both sides.
-# Run :statusline to arrange them in a terminal panel with a live preview.
-# Available sections: mode, git_branch, filename, syntax, and position.
+# Run :statusline to browse editor, Git, LSP, file, and agent fields, then
+# arrange them in a terminal panel with a live preview.
 # The first three positions use the theme's accent, middle, and base shades.
 [statusline]
 left = ["mode", "git_branch", "filename"]

--- a/default_config.toml
+++ b/default_config.toml
@@ -79,6 +79,20 @@ input_position = "bottom"
 style = "nerd_font"
 color = true
 
+# Status-line sections may be reordered, moved between sides, or omitted.
+# Available sections: mode, git_branch, filename, syntax, and position.
+# Context sections use a middle shade derived from the active theme, while
+# mode and position retain the stronger accent color.
+[statusline]
+left = ["mode", "git_branch", "filename"]
+right = ["syntax", "position"]
+
+# Nerd Font icons match nvim-web-devicons. "unicode" and "ascii" are
+# portable fallbacks; "none" keeps the labels while hiding their icons.
+[statusline.icons]
+style = "nerd_font"
+color = true
+
 # Show available continuations after a keymap prefix such as Space or Ctrl-w.
 # Fast key sequences complete before the guide appears.
 [key_hints]

--- a/src/agent_workspace.rs
+++ b/src/agent_workspace.rs
@@ -198,6 +198,16 @@ impl ProposalWorkspace {
     }
 
     #[must_use]
+    pub fn has_pending_files(&self) -> bool {
+        self.sessions.values().any(|session| {
+            session
+                .files
+                .values()
+                .any(|proposal| proposal.base_contents != proposal.proposed_contents)
+        })
+    }
+
+    #[must_use]
     /// Captures visible files, session proposals, and ownership metadata.
     pub fn snapshot(&self) -> ProposalWorkspaceSnapshot {
         ProposalWorkspaceSnapshot {

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -41,6 +41,7 @@ pub(crate) const BUILTIN_COLON_COMMANDS: &[&str] = &[
     "ft",
     "languages",
     "plugins",
+    "statusline",
     "config-diagnostics",
 ];
 
@@ -370,6 +371,15 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Some(":config-diagnostics"),
             &[],
             Action::ConfigDiagnostics,
+        ),
+        builtin(
+            "editor.statusline_manager",
+            "Configure status line",
+            "Editor",
+            "Arrange available fields on the left and right with a live preview",
+            Some(":statusline"),
+            &["status bar", "branch", "syntax", "layout"],
+            Action::OpenStatuslineManager,
         ),
         builtin(
             "editor.reload_languages",
@@ -984,6 +994,7 @@ fn action_label(action: &Action) -> String {
     match action {
         Action::CommandPalette => "All commands".to_string(),
         Action::ConfigDiagnostics => "Configuration diagnostics".to_string(),
+        Action::OpenStatuslineManager => "Configure status line".to_string(),
         Action::PluginCommand(name) => humanize_identifier(name),
         Action::Save => "Save file".to_string(),
         Action::Quit(_) => "Quit".to_string(),
@@ -1145,6 +1156,13 @@ mod tests {
             .unwrap();
         assert_eq!(save.colon.as_deref(), Some(":w"));
         assert!(save.aliases.iter().any(|alias| alias == ":write"));
+
+        let statusline = entries
+            .iter()
+            .find(|entry| entry.id == "editor.statusline_manager")
+            .unwrap();
+        assert_eq!(statusline.colon.as_deref(), Some(":statusline"));
+        assert_eq!(statusline.action, Action::OpenStatuslineManager);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -244,6 +244,9 @@ pub struct Config {
     /// Picker layout behavior.
     #[serde(default)]
     pub picker: PickerConfig,
+    /// Ordered status-line sections and icon presentation.
+    #[serde(default)]
+    pub statusline: StatuslineConfig,
     /// Delayed key-prefix guide behavior.
     #[serde(default)]
     pub key_hints: KeyHintsConfig,
@@ -365,6 +368,54 @@ impl Default for PickerConfig {
             icons: PickerIconsConfig::default(),
         }
     }
+}
+
+/// Configurable status-line layout.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StatuslineConfig {
+    /// Sections rendered from the left edge toward the center.
+    #[serde(default = "default_statusline_left")]
+    pub left: Vec<StatuslineSection>,
+    /// Sections rendered from the right edge toward the center.
+    #[serde(default = "default_statusline_right")]
+    pub right: Vec<StatuslineSection>,
+    /// Icon style shared by Git and syntax sections.
+    #[serde(default)]
+    pub icons: PickerIconsConfig,
+}
+
+impl Default for StatuslineConfig {
+    fn default() -> Self {
+        Self {
+            left: default_statusline_left(),
+            right: default_statusline_right(),
+            icons: PickerIconsConfig::default(),
+        }
+    }
+}
+
+fn default_statusline_left() -> Vec<StatuslineSection> {
+    vec![
+        StatuslineSection::Mode,
+        StatuslineSection::GitBranch,
+        StatuslineSection::Filename,
+    ]
+}
+
+fn default_statusline_right() -> Vec<StatuslineSection> {
+    vec![StatuslineSection::Syntax, StatuslineSection::Position]
+}
+
+/// A piece of editor context that can be placed on either status-line side.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatuslineSection {
+    Mode,
+    GitBranch,
+    Filename,
+    Syntax,
+    Position,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
@@ -1515,6 +1566,7 @@ fn known_top_level_field(field: &str) -> bool {
             | "splash"
             | "search"
             | "picker"
+            | "statusline"
             | "key_hints"
             | "clipboard"
             | "lsp"
@@ -1663,6 +1715,9 @@ fn known_schema_path(path: &[String]) -> bool {
             "incsearch" | "hlsearch" | "wrapscan" | "ignorecase" | "smartcase"
         ),
         ["picker", "input_position"] => true,
+        ["picker", "icons", field] => matches!(*field, "style" | "color"),
+        ["statusline", field] => matches!(*field, "left" | "right" | "icons"),
+        ["statusline", "icons", field] => matches!(*field, "style" | "color"),
         ["key_hints", field] => matches!(*field, "enabled" | "delay_ms"),
         ["clipboard", field] => {
             matches!(*field, "enabled" | "sync_on_yank" | "sync_on_paste")
@@ -2928,6 +2983,77 @@ input_position = "top"
         .unwrap();
 
         assert_eq!(config.picker.input_position, PickerInputPosition::Top);
+    }
+
+    #[test]
+    fn statusline_defaults_match_the_bundled_neovim_inspired_layout() {
+        let config = Config::from_user_toml_with_overrides("", &[]).unwrap();
+
+        assert_eq!(
+            config.statusline.left,
+            [
+                StatuslineSection::Mode,
+                StatuslineSection::GitBranch,
+                StatuslineSection::Filename,
+            ]
+        );
+        assert_eq!(
+            config.statusline.right,
+            [StatuslineSection::Syntax, StatuslineSection::Position]
+        );
+        assert_eq!(config.statusline.icons.style, PickerIconStyle::NerdFont);
+        assert!(config.statusline.icons.color);
+    }
+
+    #[test]
+    fn statusline_sections_can_move_between_sides_and_change_icon_style() {
+        let config = Config::from_user_toml_with_overrides(
+            r#"
+[statusline]
+left = ["syntax", "filename"]
+right = ["mode", "git_branch", "position"]
+
+[statusline.icons]
+style = "ascii"
+color = false
+"#,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.statusline.left,
+            [StatuslineSection::Syntax, StatuslineSection::Filename]
+        );
+        assert_eq!(
+            config.statusline.right,
+            [
+                StatuslineSection::Mode,
+                StatuslineSection::GitBranch,
+                StatuslineSection::Position,
+            ]
+        );
+        assert_eq!(config.statusline.icons.style, PickerIconStyle::Ascii);
+        assert!(!config.statusline.icons.color);
+    }
+
+    #[test]
+    fn invalid_statusline_section_keeps_the_default_side() {
+        let loaded = Config::load_user_toml(
+            r#"
+[statusline]
+left = ["mode", "weather"]
+"#,
+            Path::new("/tmp/config.toml"),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(loaded.config.statusline.left, default_statusline_left());
+        assert!(loaded
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.path == "statusline.left"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -416,15 +416,55 @@ pub enum StatuslineSection {
     Filename,
     Syntax,
     Position,
+    Diagnostics,
+    GitChanges,
+    LspStatus,
+    CurrentSymbol,
+    Selection,
+    Recording,
+    SearchMatches,
+    Indentation,
+    Encoding,
+    LineEndings,
+    ReadOnly,
+    Modified,
+    Workspace,
+    RelativePath,
+    BufferIndex,
+    WindowIndex,
+    FileSize,
+    AgentActivity,
+    Formatter,
+    Clock,
 }
 
 impl StatuslineSection {
-    pub const ALL: [Self; 5] = [
+    pub const ALL: [Self; 25] = [
         Self::Mode,
         Self::GitBranch,
         Self::Filename,
         Self::Syntax,
         Self::Position,
+        Self::Diagnostics,
+        Self::GitChanges,
+        Self::LspStatus,
+        Self::CurrentSymbol,
+        Self::Selection,
+        Self::Recording,
+        Self::SearchMatches,
+        Self::Indentation,
+        Self::Encoding,
+        Self::LineEndings,
+        Self::ReadOnly,
+        Self::Modified,
+        Self::Workspace,
+        Self::RelativePath,
+        Self::BufferIndex,
+        Self::WindowIndex,
+        Self::FileSize,
+        Self::AgentActivity,
+        Self::Formatter,
+        Self::Clock,
     ];
 
     #[must_use]
@@ -435,6 +475,26 @@ impl StatuslineSection {
             Self::Filename => "filename",
             Self::Syntax => "syntax",
             Self::Position => "position",
+            Self::Diagnostics => "diagnostics",
+            Self::GitChanges => "git_changes",
+            Self::LspStatus => "lsp_status",
+            Self::CurrentSymbol => "current_symbol",
+            Self::Selection => "selection",
+            Self::Recording => "recording",
+            Self::SearchMatches => "search_matches",
+            Self::Indentation => "indentation",
+            Self::Encoding => "encoding",
+            Self::LineEndings => "line_endings",
+            Self::ReadOnly => "read_only",
+            Self::Modified => "modified",
+            Self::Workspace => "workspace",
+            Self::RelativePath => "relative_path",
+            Self::BufferIndex => "buffer_index",
+            Self::WindowIndex => "window_index",
+            Self::FileSize => "file_size",
+            Self::AgentActivity => "agent_activity",
+            Self::Formatter => "formatter",
+            Self::Clock => "clock",
         }
     }
 
@@ -446,6 +506,26 @@ impl StatuslineSection {
             Self::Filename => "Filename",
             Self::Syntax => "Syntax",
             Self::Position => "Cursor position",
+            Self::Diagnostics => "Diagnostics",
+            Self::GitChanges => "Git changes",
+            Self::LspStatus => "LSP status",
+            Self::CurrentSymbol => "Current symbol",
+            Self::Selection => "Selection",
+            Self::Recording => "Macro recording",
+            Self::SearchMatches => "Search matches",
+            Self::Indentation => "Indentation",
+            Self::Encoding => "Encoding",
+            Self::LineEndings => "Line endings",
+            Self::ReadOnly => "Read-only",
+            Self::Modified => "Modified",
+            Self::Workspace => "Workspace",
+            Self::RelativePath => "Relative path",
+            Self::BufferIndex => "Buffer index",
+            Self::WindowIndex => "Window index",
+            Self::FileSize => "File size",
+            Self::AgentActivity => "Agent activity",
+            Self::Formatter => "Formatter",
+            Self::Clock => "Clock",
         }
     }
 }
@@ -3172,6 +3252,21 @@ color = false
         );
         assert_eq!(config.statusline.icons.style, PickerIconStyle::Ascii);
         assert!(!config.statusline.icons.color);
+    }
+
+    #[test]
+    fn every_statusline_section_round_trips_through_toml() {
+        let statusline = StatuslineConfig {
+            left: StatuslineSection::ALL.to_vec(),
+            right: Vec::new(),
+            icons: PickerIconsConfig::default(),
+        };
+
+        let serialized = toml::to_string(&statusline).unwrap();
+        let parsed = toml::from_str::<StatuslineConfig>(&serialized).unwrap();
+
+        assert_eq!(parsed.left, StatuslineSection::ALL);
+        assert!(parsed.right.is_empty());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -404,7 +404,7 @@ fn default_statusline_left() -> Vec<StatuslineSection> {
 }
 
 fn default_statusline_right() -> Vec<StatuslineSection> {
-    vec![StatuslineSection::Syntax, StatuslineSection::Position]
+    vec![StatuslineSection::Position, StatuslineSection::Syntax]
 }
 
 /// A piece of editor context that can be placed on either status-line side.
@@ -416,6 +416,38 @@ pub enum StatuslineSection {
     Filename,
     Syntax,
     Position,
+}
+
+impl StatuslineSection {
+    pub const ALL: [Self; 5] = [
+        Self::Mode,
+        Self::GitBranch,
+        Self::Filename,
+        Self::Syntax,
+        Self::Position,
+    ];
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mode => "mode",
+            Self::GitBranch => "git_branch",
+            Self::Filename => "filename",
+            Self::Syntax => "syntax",
+            Self::Position => "position",
+        }
+    }
+
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Mode => "Mode",
+            Self::GitBranch => "Git branch",
+            Self::Filename => "Filename",
+            Self::Syntax => "Syntax",
+            Self::Position => "Cursor position",
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
@@ -1446,6 +1478,21 @@ impl Config {
         Ok(())
     }
 
+    /// Persists the status-line table without rewriting unrelated user configuration.
+    pub fn persist_statusline(statusline: &StatuslineConfig) -> anyhow::Result<()> {
+        let config_path = Self::path("config.toml");
+        let contents = match fs::read_to_string(&config_path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
+            Err(error) => return Err(error.into()),
+        };
+        fs::write(
+            config_path,
+            update_statusline_config_contents(&contents, statusline)?,
+        )?;
+        Ok(())
+    }
+
     /// Resolves a plugin path or bundled-plugin specifier for runtime loading.
     pub fn resolve_plugin_path(configured_path: &str) -> String {
         let configured = PathBuf::from(configured_path);
@@ -2289,6 +2336,44 @@ fn update_theme_config_contents(contents: &str, theme_name: &str) -> anyhow::Res
     Ok(updated)
 }
 
+fn update_statusline_config_contents(
+    contents: &str,
+    statusline: &StatuslineConfig,
+) -> anyhow::Result<String> {
+    use toml_edit::{Array, DocumentMut, Item, Table, Value as EditValue};
+
+    let mut document = if contents.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        contents
+            .parse::<DocumentMut>()
+            .map_err(|error| anyhow::anyhow!("could not update config.toml: {error}"))?
+    };
+    let section_array = |sections: &[StatuslineSection]| {
+        let mut array = Array::new();
+        for section in sections {
+            array.push(section.as_str());
+        }
+        array
+    };
+
+    let mut table = Table::new();
+    table["left"] = Item::Value(EditValue::Array(section_array(&statusline.left)));
+    table["right"] = Item::Value(EditValue::Array(section_array(&statusline.right)));
+    let mut icons = Table::new();
+    icons["style"] = toml_edit::value(match statusline.icons.style {
+        PickerIconStyle::Unicode => "unicode",
+        PickerIconStyle::NerdFont => "nerd_font",
+        PickerIconStyle::Ascii => "ascii",
+        PickerIconStyle::None => "none",
+    });
+    icons["color"] = toml_edit::value(statusline.icons.color);
+    table["icons"] = Item::Table(icons);
+    document["statusline"] = Item::Table(table);
+
+    Ok(document.to_string())
+}
+
 fn is_theme_assignment(line: &str) -> bool {
     let line = line.trim_start();
     if line.starts_with('#') {
@@ -2718,6 +2803,58 @@ theme = "kanso-zen.json"
     }
 
     #[test]
+    fn update_statusline_config_preserves_unrelated_settings_and_comments() {
+        let contents = r#"# keep this comment
+theme = "mocha.json"
+
+[statusline]
+left = ["filename"]
+right = ["position"]
+
+[statusline.icons]
+style = "ascii"
+color = false
+
+[keys.normal]
+"x" = "DeleteChar"
+"#;
+        let statusline = StatuslineConfig {
+            left: vec![StatuslineSection::Mode, StatuslineSection::Filename],
+            right: vec![StatuslineSection::Syntax, StatuslineSection::Position],
+            icons: PickerIconsConfig {
+                style: PickerIconStyle::Unicode,
+                color: true,
+            },
+        };
+
+        let updated = update_statusline_config_contents(contents, &statusline).unwrap();
+        let value = updated.parse::<toml::Value>().unwrap();
+
+        assert!(updated.contains("# keep this comment"));
+        assert!(updated.contains("[keys.normal]"));
+        assert!(updated.contains(r#""x" = "DeleteChar""#));
+        assert_eq!(
+            value["statusline"]["left"].as_array().unwrap(),
+            &vec!["mode".into(), "filename".into()]
+        );
+        assert_eq!(
+            value["statusline"]["icons"]["style"].as_str(),
+            Some("unicode")
+        );
+        assert_eq!(value["statusline"]["icons"]["color"].as_bool(), Some(true));
+        assert_eq!(updated.matches("[statusline]").count(), 1);
+    }
+
+    #[test]
+    fn update_statusline_config_refuses_to_overwrite_malformed_toml() {
+        let error =
+            update_statusline_config_contents("[statusline\n", &StatuslineConfig::default())
+                .unwrap_err();
+
+        assert!(error.to_string().contains("could not update config.toml"));
+    }
+
+    #[test]
     fn test_lsp_config_defaults_to_rust() {
         let config: Config = toml::from_str(
             r#"
@@ -2999,7 +3136,7 @@ input_position = "top"
         );
         assert_eq!(
             config.statusline.right,
-            [StatuslineSection::Syntax, StatuslineSection::Position]
+            [StatuslineSection::Position, StatuslineSection::Syntax]
         );
         assert_eq!(config.statusline.icons.style, PickerIconStyle::NerdFont);
         assert!(config.statusline.icons.color);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2346,8 +2346,18 @@ enum TerminalCursorState {
 #[derive(Debug, Default)]
 struct StatuslineGitCache {
     search_dir: Option<PathBuf>,
+    repository_root: Option<PathBuf>,
     branch: Option<String>,
+    changes: Option<StatuslineGitChanges>,
+    changes_loaded: bool,
     refreshed_at: Option<Instant>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct StatuslineGitChanges {
+    added: usize,
+    modified: usize,
+    deleted: usize,
 }
 
 /// Single-task owner of Red's interactive application state.

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2336,6 +2336,13 @@ enum TerminalCursorState {
     Visible((usize, usize)),
 }
 
+#[derive(Debug, Default)]
+struct StatuslineGitCache {
+    search_dir: Option<PathBuf>,
+    branch: Option<String>,
+    refreshed_at: Option<Instant>,
+}
+
 /// Single-task owner of Red's interactive application state.
 ///
 /// The editor coordinates buffers, windows, rendering, LSP, plugins,
@@ -2372,6 +2379,9 @@ pub struct Editor {
 
     /// Visual theme settings
     pub theme: Theme,
+
+    /// Short-lived Git metadata used by configurable status-line sections.
+    statusline_git_cache: StatuslineGitCache,
 
     /// Plugin system registry
     plugin_registry: PluginRegistry,
@@ -3697,6 +3707,7 @@ impl Editor {
             language_config_path: Config::path("config.toml"),
             language_config_overrides: Vec::new(),
             theme,
+            statusline_git_cache: StatuslineGitCache::default(),
             plugin_registry,
             plugin_catalog: BTreeMap::new(),
             plugin_catalog_url: plugin::catalog::catalog_url(),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -79,7 +79,10 @@ use crate::{
     color::Color,
     command, command_palette,
     comment::CommentSyntax,
-    config::{Config, ConfigDiagnostic, ConfigDiagnosticSource, ConfigRecovery, KeyAction},
+    config::{
+        Config, ConfigDiagnostic, ConfigDiagnosticSource, ConfigRecovery, KeyAction,
+        StatuslineConfig,
+    },
     dispatcher::Dispatcher,
     highlighter::{Highlighter, LanguageRegistry},
     log,
@@ -106,7 +109,7 @@ use crate::{
     ui::{
         AgentComposer, CompletionUI, Component, Confirmation, FilePicker, HoverInfo,
         HoverInfoFormat, Info, InputPrompt, LegacyPickerOptions, Picker, PickerItem, PickerOptions,
-        PickerPreview, PickerUpdate,
+        PickerPreview, PickerUpdate, StatuslineLayoutPanel,
     },
     undo::{AppliedTextEdit, CursorSnapshot, EditOrigin, RevertEdit, TextPosition, TextRange},
     utils::{expand_user_path, get_workspace_path},
@@ -1931,6 +1934,10 @@ pub enum Action {
     CommandPalette,
     OpenSyntaxPicker,
     SetSyntax(String),
+    OpenStatuslineManager,
+    PreviewStatuslineLayout(StatuslineConfig),
+    SaveStatuslineLayout(StatuslineConfig),
+    CancelStatuslineLayout(StatuslineConfig),
     ConfigDiagnostics,
     ReloadLanguages,
     ShowDialog,
@@ -4493,6 +4500,10 @@ impl Editor {
 
     pub(crate) fn picker_icons(&self) -> crate::config::PickerIconsConfig {
         self.config.picker.icons
+    }
+
+    pub(crate) fn statusline_config(&self) -> &StatuslineConfig {
+        &self.config.statusline
     }
 
     /// Window-aware coordinate transformation methods
@@ -11124,6 +11135,7 @@ impl Editor {
             Action::EnterMode(Mode::Command | Mode::Search)
             | Action::FilePicker
             | Action::CommandPalette
+            | Action::OpenStatuslineManager
             | Action::ConfigDiagnostics
             | Action::Suspend
             | Action::ViewLogs
@@ -11580,6 +11592,10 @@ impl Editor {
 
             if cmd == "nowrap" {
                 actions.push(Action::SetWrap(false));
+            }
+
+            if cmd == "statusline" {
+                actions.push(Action::OpenStatuslineManager);
             }
         }
         actions
@@ -17045,6 +17061,41 @@ impl Editor {
                 self.bracket_match_cache = None;
                 self.force_full_redraw = true;
                 self.last_error = Some(format!("syntax: {label}"));
+                self.render(buffer)?;
+            }
+            Action::OpenStatuslineManager => {
+                self.release_current_dialog_callbacks(runtime);
+                self.current_dialog = Some(Box::new(StatuslineLayoutPanel::new(self)));
+                self.render(buffer)?;
+            }
+            Action::PreviewStatuslineLayout(statusline) => {
+                add_to_history = false;
+                self.config.statusline = statusline.clone();
+                self.force_full_redraw = true;
+                self.render(buffer)?;
+            }
+            Action::SaveStatuslineLayout(statusline) => {
+                add_to_history = false;
+                match Config::persist_statusline(statusline) {
+                    Ok(()) => {
+                        self.config.statusline = statusline.clone();
+                        self.current_dialog = None;
+                        self.last_error = Some("saved status-line layout".to_string());
+                    }
+                    Err(error) => {
+                        self.last_error =
+                            Some(format!("could not save status-line layout: {error}"));
+                    }
+                }
+                self.force_full_redraw = true;
+                self.render(buffer)?;
+            }
+            Action::CancelStatuslineLayout(statusline) => {
+                add_to_history = false;
+                self.config.statusline = statusline.clone();
+                self.current_dialog = None;
+                self.last_error = None;
+                self.force_full_redraw = true;
                 self.render(buffer)?;
             }
             Action::ConfigDiagnostics => {
@@ -24163,6 +24214,64 @@ builtin = "rust"
                 vec![Action::PluginCommand("CancelScratch".to_string())]
             );
         }
+    }
+
+    #[test]
+    fn statusline_colon_command_opens_the_manager() {
+        let mut editor = test_editor(40, 10);
+        let runtime = Runtime::new();
+
+        assert_eq!(
+            editor.handle_command("statusline", &runtime),
+            vec![Action::OpenStatuslineManager]
+        );
+    }
+
+    #[tokio::test]
+    async fn statusline_layout_panel_opens_previews_and_cancels_without_quitting() {
+        let mut editor = test_editor(80, 16);
+        let mut runtime = Runtime::new();
+        let mut buffer = RenderBuffer::new(80, 16, &Style::default());
+        let original = editor.config.statusline.clone();
+
+        let quit = editor
+            .execute(&Action::OpenStatuslineManager, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(!quit);
+        assert!(editor.current_dialog.is_some());
+        let frame = render_text_rows(&buffer).join("\n");
+        assert!(frame.contains("Statusline Layout"));
+        assert!(frame.contains("Available"));
+        assert!(frame.contains("Git branch"));
+
+        let mut preview = original.clone();
+        preview.left.swap(0, 1);
+
+        let quit = editor
+            .execute(
+                &Action::PreviewStatuslineLayout(preview.clone()),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+
+        assert!(!quit);
+        assert_eq!(editor.config.statusline, preview);
+        assert!(editor.current_dialog.is_some());
+
+        editor
+            .execute(
+                &Action::CancelStatuslineLayout(original.clone()),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        assert_eq!(editor.config.statusline, original);
+        assert!(editor.current_dialog.is_none());
     }
 
     #[tokio::test]

--- a/src/editor/agent_manager.rs
+++ b/src/editor/agent_manager.rs
@@ -102,6 +102,10 @@ impl AgentManager {
         self.active_sessions.contains(session_id)
     }
 
+    pub fn has_active_sessions(&self) -> bool {
+        !self.active_sessions.is_empty()
+    }
+
     pub fn clear_active_sessions(&mut self) {
         self.active_sessions.clear();
     }

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -30,7 +30,7 @@ use crate::{
     lsp::Diagnostic,
     plugin::DecorationAnchor,
     splash,
-    theme::{SelectionForegroundPriority, Style},
+    theme::{SelectionForegroundPriority, Style, Theme},
     ui::IconCatalog,
     undo::TextPosition,
     unicode_utils::{
@@ -120,14 +120,12 @@ struct StatuslineContext {
 fn statusline_segment(
     section: StatuslineSection,
     context: &StatuslineContext,
-    base_style: &Style,
-    context_style: &Style,
-    prominent_style: &Style,
+    style: &Style,
     icon_style: PickerIconStyle,
     color_icons: bool,
 ) -> Option<StatuslineSegment> {
     let (text, style, icon) = match section {
-        StatuslineSection::Mode => (format!(" {} ", context.mode), prominent_style.clone(), None),
+        StatuslineSection::Mode => (format!(" {} ", context.mode), style.clone(), None),
         StatuslineSection::GitBranch => {
             let branch = context.git_branch.as_deref()?;
             let glyph = match icon_style {
@@ -136,15 +134,9 @@ fn statusline_segment(
                 PickerIconStyle::Ascii => "git",
                 PickerIconStyle::None => "",
             };
-            (
-                statusline_icon_label(glyph, branch),
-                context_style.clone(),
-                None,
-            )
+            (statusline_icon_label(glyph, branch), style.clone(), None)
         }
-        StatuslineSection::Filename => {
-            (format!(" {} ", context.filename), base_style.clone(), None)
-        }
+        StatuslineSection::Filename => (format!(" {} ", context.filename), style.clone(), None),
         StatuslineSection::Syntax => {
             let syntax = context.syntax.as_deref()?;
             let icon = IconCatalog::file(
@@ -160,11 +152,11 @@ fn statusline_segment(
                 });
             (
                 statusline_icon_label(icon.glyph, syntax),
-                context_style.clone(),
+                style.clone(),
                 icon_override,
             )
         }
-        StatuslineSection::Position => (context.position.clone(), prominent_style.clone(), None),
+        StatuslineSection::Position => (context.position.clone(), style.clone(), None),
     };
 
     Some(StatuslineSegment { text, style, icon })
@@ -175,6 +167,16 @@ fn statusline_icon_label(glyph: &str, label: &str) -> String {
         format!(" {label} ")
     } else {
         format!(" {glyph} {label} ")
+    }
+}
+
+pub(crate) fn statusline_slot_style(theme: &Theme, index: usize) -> Style {
+    let base = &theme.statusline_style.inner_style;
+    let prominent = &theme.statusline_style.outer_style;
+    match index {
+        0 => prominent.clone(),
+        1 => statusline_context_style(base, prominent),
+        _ => base.clone(),
     }
 }
 
@@ -2187,37 +2189,24 @@ impl Editor {
         };
 
         let base_style = self.theme.statusline_style.inner_style.clone();
-        let prominent_style = self.theme.statusline_style.outer_style.clone();
-        let context_style = statusline_context_style(&base_style, &prominent_style);
         let icons = self.config.statusline.icons;
         let left = left_sections
             .into_iter()
-            .filter_map(|section| {
-                statusline_segment(
-                    section,
-                    &context,
-                    &base_style,
-                    &context_style,
-                    &prominent_style,
-                    icons.style,
-                    icons.color,
-                )
+            .enumerate()
+            .filter_map(|(index, section)| {
+                let style = statusline_slot_style(&self.theme, index);
+                statusline_segment(section, &context, &style, icons.style, icons.color)
             })
             .collect::<Vec<_>>();
-        let right = right_sections
+        let mut right = right_sections
             .into_iter()
-            .filter_map(|section| {
-                statusline_segment(
-                    section,
-                    &context,
-                    &base_style,
-                    &context_style,
-                    &prominent_style,
-                    icons.style,
-                    icons.color,
-                )
+            .enumerate()
+            .filter_map(|(index, section)| {
+                let style = statusline_slot_style(&self.theme, index);
+                statusline_segment(section, &context, &style, icons.style, icons.color)
             })
             .collect::<Vec<_>>();
+        right.reverse();
 
         let left_separator = self.theme.statusline_style.outer_chars[1];
         let right_separator = self.theme.statusline_style.outer_chars[2];
@@ -2719,7 +2708,7 @@ mod tests {
     fn configurable_statusline_sections_render_in_the_requested_sides() {
         let mut config = Config::default();
         config.statusline.left = vec![StatuslineSection::Syntax, StatuslineSection::Mode];
-        config.statusline.right = vec![StatuslineSection::Filename, StatuslineSection::Position];
+        config.statusline.right = vec![StatuslineSection::Position, StatuslineSection::Filename];
         config.statusline.icons.style = PickerIconStyle::Ascii;
         let lsp = Box::new(LspManager::new(config.lsp.clone()));
         let source = Buffer::new(
@@ -2774,6 +2763,44 @@ mod tests {
     }
 
     #[test]
+    fn statusline_colors_are_assigned_by_edge_position() {
+        let mut theme = Theme::default();
+        theme.statusline_style.inner_style = Style {
+            fg: Some(Color::Rgb {
+                r: 220,
+                g: 220,
+                b: 220,
+            }),
+            bg: Some(Color::Rgb {
+                r: 20,
+                g: 30,
+                b: 40,
+            }),
+            ..Style::default()
+        };
+        theme.statusline_style.outer_style = Style {
+            fg: Some(Color::Rgb { r: 0, g: 0, b: 0 }),
+            bg: Some(Color::Rgb {
+                r: 80,
+                g: 180,
+                b: 220,
+            }),
+            ..Style::default()
+        };
+
+        let edge = statusline_slot_style(&theme, 0);
+        let second = statusline_slot_style(&theme, 1);
+        let third = statusline_slot_style(&theme, 2);
+        let fourth = statusline_slot_style(&theme, 3);
+
+        assert_eq!(edge, theme.statusline_style.outer_style);
+        assert_ne!(second.bg, edge.bg);
+        assert_ne!(second.bg, third.bg);
+        assert_eq!(third, theme.statusline_style.inner_style);
+        assert_eq!(fourth, theme.statusline_style.inner_style);
+    }
+
+    #[test]
     fn git_branch_reads_regular_and_worktree_head_files() {
         let repository = tempfile::tempdir().unwrap();
         fs::create_dir(repository.path().join(".git")).unwrap();
@@ -2817,7 +2844,7 @@ mod tests {
     fn statusline_preserves_the_edge_position_on_a_narrow_terminal() {
         let mut config = Config::default();
         config.statusline.left = vec![StatuslineSection::Mode, StatuslineSection::Filename];
-        config.statusline.right = vec![StatuslineSection::Syntax, StatuslineSection::Position];
+        config.statusline.right = vec![StatuslineSection::Position, StatuslineSection::Syntax];
         let lsp = Box::new(LspManager::new(config.lsp.clone()));
         let source = Buffer::new(
             Some("config.toml".to_string()),

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -11,12 +11,15 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    ffi::OsStr,
     fs,
     io::{self, Write as _},
     path::{Path, PathBuf},
+    process::Command,
     time::{Duration, Instant},
 };
 
+use chrono::Local;
 use crossterm::{
     cursor::{self, MoveTo},
     style, terminal, QueueableCommand as _,
@@ -27,7 +30,7 @@ use crate::{
     color::{blend_color, ensure_minimum_contrast, Color},
     config::{CursorShape, KeyAction, PickerIconStyle, StatuslineSection},
     editor::RenderCommand,
-    lsp::Diagnostic,
+    lsp::{Diagnostic, DiagnosticSeverity},
     plugin::DecorationAnchor,
     splash,
     theme::{SelectionForegroundPriority, Style, Theme},
@@ -37,12 +40,13 @@ use crate::{
         char_prefix, display_width, display_width_with_tabs, fit_display_width,
         grapheme_to_column_with_tabs, trim_line_ending, truncate_display_width,
     },
-    utils::expand_user_path,
+    utils::{expand_user_path, get_workspace_path},
 };
 
 use super::{
     adjust_color_brightness, display_layout::DisplayLayout, render_buffer::Change, Editor, Mode,
-    Point, Rect, RenderBuffer, StyleCursor, GUTTER_SIGN_COLUMN_WIDTH, MAX_HIGHLIGHT_SLICE_BYTES,
+    Point, Rect, RenderBuffer, StatuslineGitChanges, StyleCursor, GUTTER_SIGN_COLUMN_WIDTH,
+    MAX_HIGHLIGHT_SLICE_BYTES,
 };
 
 fn diagnostic_row(diagnostics: &[&Diagnostic], available_width: usize) -> Option<String> {
@@ -114,6 +118,26 @@ struct StatuslineContext {
     position: String,
     syntax: Option<String>,
     git_branch: Option<String>,
+    diagnostics: Option<(usize, usize)>,
+    git_changes: Option<StatuslineGitChanges>,
+    lsp_status: Option<String>,
+    current_symbol: Option<String>,
+    selection: Option<String>,
+    recording: Option<char>,
+    search_matches: Option<(usize, usize)>,
+    indentation: String,
+    encoding: &'static str,
+    line_endings: &'static str,
+    read_only: bool,
+    modified: bool,
+    workspace: String,
+    relative_path: Option<String>,
+    buffer_index: String,
+    window_index: String,
+    file_size: String,
+    agent_activity: Option<String>,
+    formatter: Option<&'static str>,
+    clock: String,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -157,9 +181,275 @@ fn statusline_segment(
             )
         }
         StatuslineSection::Position => (context.position.clone(), style.clone(), None),
+        StatuslineSection::Diagnostics => {
+            let (errors, warnings) = context.diagnostics?;
+            let text = statusline_diagnostics_label(errors, warnings, icon_style);
+            (format!(" {text} "), style.clone(), None)
+        }
+        StatuslineSection::GitChanges => {
+            let changes = context.git_changes?;
+            let text = format!(
+                "+{} ~{} -{}",
+                changes.added, changes.modified, changes.deleted
+            );
+            (
+                statusline_icon_label(
+                    statusline_section_icon(StatuslineSection::GitChanges, icon_style),
+                    &text,
+                ),
+                style.clone(),
+                None,
+            )
+        }
+        StatuslineSection::LspStatus => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::LspStatus, icon_style),
+                context.lsp_status.as_deref()?,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::CurrentSymbol => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::CurrentSymbol, icon_style),
+                context.current_symbol.as_deref()?,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::Selection => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::Selection, icon_style),
+                context.selection.as_deref()?,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::Recording => {
+            let label = format!("recording @{}", context.recording?);
+            (
+                statusline_icon_label(
+                    statusline_section_icon(StatuslineSection::Recording, icon_style),
+                    &label,
+                ),
+                style.clone(),
+                None,
+            )
+        }
+        StatuslineSection::SearchMatches => {
+            let (current, total) = context.search_matches?;
+            let label = format!("{current}/{total}");
+            (
+                statusline_icon_label(
+                    statusline_section_icon(StatuslineSection::SearchMatches, icon_style),
+                    &label,
+                ),
+                style.clone(),
+                None,
+            )
+        }
+        StatuslineSection::Indentation => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::Indentation, icon_style),
+                &context.indentation,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::Encoding => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::Encoding, icon_style),
+                context.encoding,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::LineEndings => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::LineEndings, icon_style),
+                context.line_endings,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::ReadOnly => {
+            if !context.read_only {
+                return None;
+            }
+            (
+                statusline_icon_label(
+                    statusline_section_icon(StatuslineSection::ReadOnly, icon_style),
+                    "RO",
+                ),
+                style.clone(),
+                None,
+            )
+        }
+        StatuslineSection::Modified => {
+            if !context.modified {
+                return None;
+            }
+            (
+                statusline_icon_label(
+                    statusline_section_icon(StatuslineSection::Modified, icon_style),
+                    "modified",
+                ),
+                style.clone(),
+                None,
+            )
+        }
+        StatuslineSection::Workspace => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::Workspace, icon_style),
+                &context.workspace,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::RelativePath => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::RelativePath, icon_style),
+                context.relative_path.as_deref()?,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::BufferIndex => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::BufferIndex, icon_style),
+                &context.buffer_index,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::WindowIndex => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::WindowIndex, icon_style),
+                &context.window_index,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::FileSize => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::FileSize, icon_style),
+                &context.file_size,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::AgentActivity => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::AgentActivity, icon_style),
+                context.agent_activity.as_deref()?,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::Formatter => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::Formatter, icon_style),
+                context.formatter?,
+            ),
+            style.clone(),
+            None,
+        ),
+        StatuslineSection::Clock => (
+            statusline_icon_label(
+                statusline_section_icon(StatuslineSection::Clock, icon_style),
+                &context.clock,
+            ),
+            style.clone(),
+            None,
+        ),
     };
 
     Some(StatuslineSegment { text, style, icon })
+}
+
+pub(crate) fn statusline_section_icon(
+    section: StatuslineSection,
+    style: PickerIconStyle,
+) -> &'static str {
+    if style == PickerIconStyle::None {
+        return "";
+    }
+    match (section, style) {
+        (StatuslineSection::Mode, _) => "N",
+        (StatuslineSection::GitBranch, PickerIconStyle::NerdFont) => "",
+        (StatuslineSection::GitBranch, PickerIconStyle::Unicode) => "⑂",
+        (StatuslineSection::GitBranch, PickerIconStyle::Ascii) => "git",
+        (StatuslineSection::Diagnostics, PickerIconStyle::NerdFont) => "󰒡",
+        (StatuslineSection::Diagnostics, PickerIconStyle::Unicode) => "⚠",
+        (StatuslineSection::Diagnostics, PickerIconStyle::Ascii) => "diag",
+        (StatuslineSection::GitChanges, PickerIconStyle::NerdFont) => "󰊢",
+        (StatuslineSection::GitChanges, PickerIconStyle::Unicode) => "Δ",
+        (StatuslineSection::GitChanges, PickerIconStyle::Ascii) => "git",
+        (StatuslineSection::LspStatus, PickerIconStyle::NerdFont) => "",
+        (StatuslineSection::LspStatus, PickerIconStyle::Unicode) => "⚙",
+        (StatuslineSection::LspStatus, PickerIconStyle::Ascii) => "lsp",
+        (StatuslineSection::CurrentSymbol, _) => "ƒ",
+        (StatuslineSection::Selection, PickerIconStyle::NerdFont) => "󰒉",
+        (StatuslineSection::Selection, PickerIconStyle::Unicode) => "↔",
+        (StatuslineSection::Selection, PickerIconStyle::Ascii) => "sel",
+        (StatuslineSection::Recording, PickerIconStyle::NerdFont) => "󰑊",
+        (StatuslineSection::Recording, PickerIconStyle::Unicode) => "●",
+        (StatuslineSection::Recording, PickerIconStyle::Ascii) => "rec",
+        (StatuslineSection::SearchMatches, PickerIconStyle::NerdFont) => "",
+        (StatuslineSection::SearchMatches, PickerIconStyle::Unicode) => "⌕",
+        (StatuslineSection::SearchMatches, PickerIconStyle::Ascii) => "find",
+        (StatuslineSection::Indentation, PickerIconStyle::NerdFont) => "󰌒",
+        (StatuslineSection::Indentation, PickerIconStyle::Unicode) => "⇥",
+        (StatuslineSection::Indentation, PickerIconStyle::Ascii) => "spc",
+        (StatuslineSection::Encoding, PickerIconStyle::NerdFont) => "󰅩",
+        (StatuslineSection::Encoding, PickerIconStyle::Unicode) => "文",
+        (StatuslineSection::Encoding, PickerIconStyle::Ascii) => "enc",
+        (StatuslineSection::LineEndings, PickerIconStyle::NerdFont) => "󰌑",
+        (StatuslineSection::LineEndings, PickerIconStyle::Unicode) => "↵",
+        (StatuslineSection::LineEndings, PickerIconStyle::Ascii) => "eol",
+        (StatuslineSection::ReadOnly, PickerIconStyle::NerdFont) => "",
+        (StatuslineSection::ReadOnly, PickerIconStyle::Unicode) => "🔒",
+        (StatuslineSection::ReadOnly, PickerIconStyle::Ascii) => "ro",
+        (StatuslineSection::Modified, PickerIconStyle::Ascii) => "+",
+        (StatuslineSection::Modified, _) => "●",
+        (StatuslineSection::Workspace, PickerIconStyle::NerdFont) => "󰉋",
+        (StatuslineSection::Workspace, PickerIconStyle::Unicode) => "▣",
+        (StatuslineSection::Workspace, PickerIconStyle::Ascii) => "ws",
+        (StatuslineSection::RelativePath, PickerIconStyle::NerdFont) => "󰈔",
+        (StatuslineSection::RelativePath, PickerIconStyle::Unicode) => "↳",
+        (StatuslineSection::RelativePath, PickerIconStyle::Ascii) => "path",
+        (StatuslineSection::BufferIndex, PickerIconStyle::NerdFont) => "󰓩",
+        (StatuslineSection::BufferIndex, PickerIconStyle::Unicode) => "▤",
+        (StatuslineSection::BufferIndex, PickerIconStyle::Ascii) => "buf",
+        (StatuslineSection::WindowIndex, PickerIconStyle::NerdFont) => "󰖲",
+        (StatuslineSection::WindowIndex, PickerIconStyle::Unicode) => "□",
+        (StatuslineSection::WindowIndex, PickerIconStyle::Ascii) => "win",
+        (StatuslineSection::FileSize, PickerIconStyle::NerdFont) => "󰉉",
+        (StatuslineSection::FileSize, PickerIconStyle::Unicode) => "≋",
+        (StatuslineSection::FileSize, PickerIconStyle::Ascii) => "size",
+        (StatuslineSection::AgentActivity, PickerIconStyle::NerdFont) => "󰚩",
+        (StatuslineSection::AgentActivity, PickerIconStyle::Unicode) => "✦",
+        (StatuslineSection::AgentActivity, PickerIconStyle::Ascii) => "agent",
+        (StatuslineSection::Formatter, PickerIconStyle::NerdFont) => "󰉼",
+        (StatuslineSection::Formatter, PickerIconStyle::Unicode) => "≡",
+        (StatuslineSection::Formatter, PickerIconStyle::Ascii) => "fmt",
+        (StatuslineSection::Clock, PickerIconStyle::NerdFont) => "",
+        (StatuslineSection::Clock, PickerIconStyle::Unicode) => "◷",
+        (StatuslineSection::Clock, PickerIconStyle::Ascii) => "time",
+        (StatuslineSection::Position, PickerIconStyle::NerdFont) => "󰆤",
+        (StatuslineSection::Position, PickerIconStyle::Unicode) => "⌖",
+        (StatuslineSection::Position, PickerIconStyle::Ascii) => "pos",
+        (StatuslineSection::Filename | StatuslineSection::Syntax, _) => "",
+        (_, PickerIconStyle::None) => "",
+    }
+}
+
+fn statusline_diagnostics_label(errors: usize, warnings: usize, style: PickerIconStyle) -> String {
+    match style {
+        PickerIconStyle::NerdFont => format!(" {errors}   {warnings}"),
+        PickerIconStyle::Unicode => format!("● {errors}  ▲ {warnings}"),
+        PickerIconStyle::Ascii | PickerIconStyle::None => format!("E{errors} W{warnings}"),
+    }
 }
 
 fn statusline_icon_label(glyph: &str, label: &str) -> String {
@@ -406,6 +696,171 @@ fn compact_git_branch(branch: &str) -> String {
         compact.push('…');
         compact
     }
+}
+
+fn git_repository_root(search_dir: &Path) -> Option<PathBuf> {
+    search_dir
+        .ancestors()
+        .find(|ancestor| ancestor.join(".git").exists())
+        .map(Path::to_path_buf)
+}
+
+fn git_changes_from_status(repository_root: &Path) -> Option<StatuslineGitChanges> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repository_root)
+        .args(["status", "--porcelain=v1", "--untracked-files=normal"])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| git_changes_from_porcelain(&String::from_utf8_lossy(&output.stdout)))
+        .flatten()
+}
+
+fn git_changes_from_porcelain(status: &str) -> Option<StatuslineGitChanges> {
+    let mut changes = StatuslineGitChanges::default();
+    for line in status.lines() {
+        let bytes = line.as_bytes();
+        if bytes.len() < 2 {
+            continue;
+        }
+        let (index, worktree) = (bytes[0], bytes[1]);
+        if (index == b'?' && worktree == b'?') || index == b'A' || worktree == b'A' {
+            changes.added += 1;
+        } else if index == b'D' || worktree == b'D' {
+            changes.deleted += 1;
+        } else {
+            changes.modified += 1;
+        }
+    }
+    (changes.added + changes.modified + changes.deleted > 0).then_some(changes)
+}
+
+fn statusline_relative_path(file: Option<&str>, workspace_root: &Path) -> Option<String> {
+    let file = file?;
+    let path = expand_user_path(file).ok()?;
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        get_workspace_path().join(path)
+    };
+    Some(
+        absolute
+            .strip_prefix(workspace_root)
+            .unwrap_or(&absolute)
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+fn statusline_workspace_name(workspace_root: &Path) -> String {
+    workspace_root
+        .file_name()
+        .and_then(OsStr::to_str)
+        .filter(|name| !name.is_empty())
+        .unwrap_or("workspace")
+        .to_string()
+}
+
+fn statusline_file_is_read_only(file: Option<&str>) -> bool {
+    file.and_then(|file| expand_user_path(file).ok())
+        .and_then(|path| fs::metadata(path).ok())
+        .is_some_and(|metadata| metadata.permissions().readonly())
+}
+
+fn statusline_file_size(bytes: usize) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let bytes = bytes as f64;
+    if bytes >= GIB {
+        format!("{:.1} GB", bytes / GIB)
+    } else if bytes >= MIB {
+        format!("{:.1} MB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{:.1} KB", bytes / KIB)
+    } else {
+        format!("{} B", bytes as usize)
+    }
+}
+
+fn statusline_symbol_at(buffer: &crate::buffer::Buffer, cursor_line: usize) -> Option<String> {
+    let first_line = cursor_line.saturating_sub(199);
+    (first_line..=cursor_line)
+        .rev()
+        .filter_map(|line| buffer.get(line))
+        .find_map(|line| statusline_symbol_from_declaration(trim_line_ending(&line)))
+}
+
+fn statusline_symbol_from_declaration(line: &str) -> Option<String> {
+    let mut declaration = line.trim_start();
+    if let Some(heading) = declaration.strip_prefix('#') {
+        let heading = heading.trim_start_matches('#').trim();
+        return (!heading.is_empty()).then(|| heading.to_string());
+    }
+    for prefix in ["pub(crate) ", "pub(super) ", "pub ", "export ", "default "] {
+        if let Some(rest) = declaration.strip_prefix(prefix) {
+            declaration = rest;
+            break;
+        }
+    }
+    if let Some(rest) = declaration.strip_prefix("const fn ") {
+        declaration = rest;
+        let name = declaration
+            .split(|character: char| {
+                !(character.is_alphanumeric() || matches!(character, '_' | ':' | '-'))
+            })
+            .next()
+            .unwrap_or_default();
+        return (!name.is_empty()).then(|| name.to_string());
+    }
+    for prefix in ["async ", "unsafe "] {
+        if let Some(rest) = declaration.strip_prefix(prefix) {
+            declaration = rest;
+        }
+    }
+    for keyword in [
+        "fn ",
+        "def ",
+        "function ",
+        "class ",
+        "struct ",
+        "enum ",
+        "trait ",
+        "interface ",
+        "type ",
+        "mod ",
+    ] {
+        if let Some(rest) = declaration.strip_prefix(keyword) {
+            let name = rest
+                .split(|character: char| {
+                    !(character.is_alphanumeric() || matches!(character, '_' | ':' | '-'))
+                })
+                .next()
+                .unwrap_or_default();
+            return (!name.is_empty()).then(|| name.to_string());
+        }
+    }
+    if let Some(rest) = declaration.strip_prefix("impl ") {
+        let name = rest
+            .split(|character: char| matches!(character, '{' | '<') || character.is_whitespace())
+            .next()
+            .unwrap_or_default();
+        return (!name.is_empty()).then(|| format!("impl {name}"));
+    }
+    for keyword in ["const ", "let ", "var "] {
+        let Some(rest) = declaration.strip_prefix(keyword) else {
+            continue;
+        };
+        let (name, value) = rest.split_once('=')?;
+        if value.contains("=>") || value.trim_start().starts_with("function") {
+            let name = name.trim();
+            return (!name.is_empty()).then(|| name.to_string());
+        }
+    }
+    None
 }
 
 fn decoration_local_x(
@@ -2123,12 +2578,30 @@ impl Editor {
             return;
         }
 
-        let (filename, file_path, dirty, position, buffer_index) =
-            if let Some(window) = self.window_manager.active_window() {
-                let window_buffer = &self.buffer_manager[window.buffer_index];
-                let dirty = window_buffer.is_dirty();
-                let window_count = self.window_manager.window_count();
-                let window_indicator = if window_count > 1 {
+        let left_sections = self.config.statusline.left.clone();
+        let right_sections = self.config.statusline.right.clone();
+        let configured = |candidate| {
+            left_sections
+                .iter()
+                .chain(&right_sections)
+                .any(|section| *section == candidate)
+        };
+
+        let (
+            filename,
+            file_path,
+            dirty,
+            position,
+            buffer_index,
+            cursor_line,
+            byte_len,
+            line_endings,
+        ) = if let Some(window) = self.window_manager.active_window() {
+            let window_buffer = &self.buffer_manager[window.buffer_index];
+            let dirty = window_buffer.is_dirty();
+            let window_count = self.window_manager.window_count();
+            let window_indicator =
+                if window_count > 1 && !configured(StatuslineSection::WindowIndex) {
                     format!(
                         " [{}/{}] ",
                         self.window_manager.active_window_id() + 1,
@@ -2137,47 +2610,114 @@ impl Editor {
                 } else {
                     " ".to_string()
                 };
-                (
-                    statusline_file_name(window_buffer.name()).to_string(),
-                    window_buffer.file.clone(),
-                    dirty,
-                    format!(
-                        " {}:{}{}",
-                        window.vtop + window.cy + 1,
-                        window.cx + 1,
-                        window_indicator
-                    ),
-                    window.buffer_index,
-                )
-            } else {
-                let current = self.current_buffer();
-                (
-                    statusline_file_name(current.name()).to_string(),
-                    current.file.clone(),
-                    current.is_dirty(),
-                    format!(" {}:{} ", self.vtop + self.cy + 1, self.cx + 1),
-                    self.buffer_manager.active_index(),
-                )
-            };
+            (
+                statusline_file_name(window_buffer.name()).to_string(),
+                window_buffer.file.clone(),
+                dirty,
+                format!(
+                    " {}:{}{}",
+                    window.vtop + window.cy + 1,
+                    window.cx + 1,
+                    window_indicator
+                ),
+                window.buffer_index,
+                window.vtop + window.cy,
+                window_buffer.byte_len(),
+                if window_buffer
+                    .get(0)
+                    .is_some_and(|line| line.ends_with("\r\n"))
+                {
+                    "CRLF"
+                } else {
+                    "LF"
+                },
+            )
+        } else {
+            let current = self.current_buffer();
+            (
+                statusline_file_name(current.name()).to_string(),
+                current.file.clone(),
+                current.is_dirty(),
+                format!(" {}:{} ", self.vtop + self.cy + 1, self.cx + 1),
+                self.buffer_manager.active_index(),
+                self.vtop + self.cy,
+                current.byte_len(),
+                if current.get(0).is_some_and(|line| line.ends_with("\r\n")) {
+                    "CRLF"
+                } else {
+                    "LF"
+                },
+            )
+        };
 
         let term_width = self.size.0 as usize;
         let y = self.size.1 as usize - 2;
         let clear_line = " ".repeat(term_width);
         buffer.set_text(0, y, &clear_line, &self.theme.statusline_style.inner_style);
 
-        let left_sections = self.config.statusline.left.clone();
-        let right_sections = self.config.statusline.right.clone();
-        let wants_git = left_sections
-            .iter()
-            .chain(&right_sections)
-            .any(|section| *section == StatuslineSection::GitBranch);
-        let git_branch = wants_git
-            .then(|| self.statusline_git_branch(file_path.as_deref()))
+        let wants_git = configured(StatuslineSection::GitBranch)
+            || configured(StatuslineSection::GitChanges)
+            || configured(StatuslineSection::Workspace)
+            || configured(StatuslineSection::RelativePath);
+        if wants_git {
+            self.refresh_statusline_git(
+                file_path.as_deref(),
+                configured(StatuslineSection::GitChanges),
+            );
+        }
+        let workspace_root = self
+            .statusline_git_cache
+            .repository_root
+            .clone()
+            .or_else(|| {
+                file_path
+                    .as_deref()
+                    .and_then(|file| self.lsp.workspace_root_for_file(file))
+            })
+            .unwrap_or_else(get_workspace_path);
+        let diagnostics = configured(StatuslineSection::Diagnostics)
+            .then(|| self.statusline_diagnostic_counts(buffer_index))
             .flatten();
-        let syntax = self.highlight_language_id_for_buffer_index(buffer_index);
+        let current_symbol = configured(StatuslineSection::CurrentSymbol)
+            .then(|| statusline_symbol_at(&self.buffer_manager[buffer_index], cursor_line))
+            .flatten();
+        let selection = configured(StatuslineSection::Selection)
+            .then(|| self.statusline_selection_label())
+            .flatten();
+        let search_matches = configured(StatuslineSection::SearchMatches)
+            .then(|| self.statusline_search_position())
+            .flatten();
+        let lsp_status = configured(StatuslineSection::LspStatus)
+            .then(|| {
+                file_path
+                    .as_deref()
+                    .and_then(|file| self.lsp.server_name_for_file(file))
+            })
+            .flatten();
+        let formatter = configured(StatuslineSection::Formatter)
+            .then(|| {
+                let file = file_path.as_deref()?;
+                self.lsp.server_capabilities_for_file(file).map(|_| {
+                    if self.lsp.supports_document_formatting(file) {
+                        "fmt"
+                    } else {
+                        "no fmt"
+                    }
+                })
+            })
+            .flatten();
+        let agent_activity = configured(StatuslineSection::AgentActivity)
+            .then(|| self.statusline_agent_activity())
+            .flatten();
+        let syntax = configured(StatuslineSection::Syntax)
+            .then(|| self.highlight_language_id_for_buffer_index(buffer_index))
+            .flatten();
+        let show_modified_separately = configured(StatuslineSection::Modified);
+        let read_only = statusline_file_is_read_only(file_path.as_deref());
+        let relative_path = statusline_relative_path(file_path.as_deref(), &workspace_root);
         let context = StatuslineContext {
             mode: format_mode_name(&self.mode).to_string(),
-            filename: if dirty {
+            filename: if dirty && !show_modified_separately {
                 format!("{filename} [+]")
             } else {
                 filename
@@ -2185,7 +2725,34 @@ impl Editor {
             file_path,
             position,
             syntax,
-            git_branch,
+            git_branch: self.statusline_git_cache.branch.clone(),
+            diagnostics,
+            git_changes: self.statusline_git_cache.changes,
+            lsp_status,
+            current_symbol,
+            selection,
+            recording: self
+                .macro_recording
+                .as_ref()
+                .map(|recording| recording.register),
+            search_matches,
+            indentation: format!("spaces:{}", self.indentation().shift_width),
+            encoding: "utf-8",
+            line_endings,
+            read_only,
+            modified: dirty,
+            workspace: statusline_workspace_name(&workspace_root),
+            relative_path,
+            buffer_index: format!("{}/{}", buffer_index + 1, self.buffer_manager.len().max(1)),
+            window_index: format!(
+                "{}/{}",
+                self.window_manager.active_window_id() + 1,
+                self.window_manager.window_count().max(1)
+            ),
+            file_size: statusline_file_size(byte_len),
+            agent_activity,
+            formatter,
+            clock: Local::now().format("%H:%M").to_string(),
         };
 
         let base_style = self.theme.statusline_style.inner_style.clone();
@@ -2215,8 +2782,8 @@ impl Editor {
         draw_statusline_left(buffer, y, right_start, &left, &base_style, left_separator);
     }
 
-    fn statusline_git_branch(&mut self, file: Option<&str>) -> Option<String> {
-        const CACHE_TTL: Duration = Duration::from_secs(1);
+    fn refresh_statusline_git(&mut self, file: Option<&str>, load_changes: bool) {
+        const CACHE_TTL: Duration = Duration::from_secs(2);
 
         let search_dir = statusline_git_search_dir(file);
         let now = Instant::now();
@@ -2224,16 +2791,92 @@ impl Editor {
             && self
                 .statusline_git_cache
                 .refreshed_at
-                .is_some_and(|refreshed| now.duration_since(refreshed) < CACHE_TTL);
+                .is_some_and(|refreshed| now.duration_since(refreshed) < CACHE_TTL)
+            && (!load_changes || self.statusline_git_cache.changes_loaded);
         if cache_is_fresh {
-            return self.statusline_git_cache.branch.clone();
+            return;
         }
 
+        let repository_root = git_repository_root(&search_dir);
         let branch = git_branch_from_head(&search_dir);
+        let changes = load_changes
+            .then(|| repository_root.as_deref().and_then(git_changes_from_status))
+            .flatten();
         self.statusline_git_cache.search_dir = Some(search_dir);
-        self.statusline_git_cache.branch = branch.clone();
+        self.statusline_git_cache.repository_root = repository_root;
+        self.statusline_git_cache.branch = branch;
+        self.statusline_git_cache.changes = changes;
+        self.statusline_git_cache.changes_loaded = load_changes;
         self.statusline_git_cache.refreshed_at = Some(now);
-        branch
+    }
+
+    fn statusline_diagnostic_counts(&self, buffer_index: usize) -> Option<(usize, usize)> {
+        let uri = self
+            .buffer_manager
+            .get(buffer_index)?
+            .uri()
+            .ok()
+            .flatten()?;
+        let diagnostics = self.diagnostics.get(&uri)?;
+        let (mut errors, mut warnings) = (0, 0);
+        for diagnostic in diagnostics {
+            match diagnostic.severity.as_ref() {
+                Some(DiagnosticSeverity::Error) => errors += 1,
+                Some(DiagnosticSeverity::Warning) => warnings += 1,
+                _ => {}
+            }
+        }
+        (errors + warnings > 0).then_some((errors, warnings))
+    }
+
+    fn statusline_selection_label(&self) -> Option<String> {
+        let selection = self.selection?;
+        let (_, y0, _, y1) = selection.into();
+        if self.mode == Mode::VisualLine || y0 != y1 {
+            return Some(format!("{} lines", y0.abs_diff(y1) + 1));
+        }
+        self.selected_text()
+            .map(|text| format!("{} chars", text.chars().count()))
+    }
+
+    fn statusline_search_position(&mut self) -> Option<(usize, usize)> {
+        let active_search = self.active_search.clone();
+        let pattern = active_search
+            .as_ref()
+            .map(|search| search.draft.as_str())
+            .filter(|pattern| !pattern.is_empty())
+            .or_else(|| (!self.search_term.is_empty()).then_some(self.search_term.as_str()))?
+            .to_string();
+        let matches = self.search_matches(&pattern).ok()?;
+        if matches.is_empty() {
+            return None;
+        }
+        let current = active_search
+            .and_then(|search| search.preview)
+            .map(|preview| (preview.start_y, preview.start_x))
+            .unwrap_or((
+                self.buffer_line(),
+                self.grapheme_to_char_on_line(self.cx, self.buffer_line()),
+            ));
+        let index = matches
+            .partition_point(|match_| (match_.start_y, match_.start_x) < current)
+            .min(matches.len().saturating_sub(1));
+        Some((index + 1, matches.len()))
+    }
+
+    fn statusline_agent_activity(&self) -> Option<String> {
+        if self.agent_manager.has_active_sessions() {
+            return Some("working".to_string());
+        }
+        if self
+            .agent_manager
+            .workspace()
+            .and_then(|workspace| workspace.try_lock().ok())
+            .is_some_and(|workspace| workspace.has_pending_files())
+        {
+            return Some("changes ready".to_string());
+        }
+        self.agent_manager.has_bridge().then(|| "idle".to_string())
     }
 
     pub fn draw_commandline(&mut self, buffer: &mut RenderBuffer) {
@@ -2593,6 +3236,51 @@ mod tests {
         assert_eq!(by_line[&4].len(), 2);
         assert_eq!(by_line[&4][0].message, "first visible");
         assert_eq!(by_line[&4][1].message, "second visible");
+    }
+
+    #[test]
+    fn git_porcelain_changes_are_grouped_for_the_statusline() {
+        let changes = git_changes_from_porcelain(
+            " M src/editor.rs\nA  src/new.rs\nD  src/old.rs\n?? notes.txt\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            changes,
+            StatuslineGitChanges {
+                added: 2,
+                modified: 1,
+                deleted: 1,
+            }
+        );
+        assert_eq!(git_changes_from_porcelain(""), None);
+    }
+
+    #[test]
+    fn current_symbol_recognizes_common_declarations() {
+        assert_eq!(
+            statusline_symbol_from_declaration("pub async fn render_frame() {"),
+            Some("render_frame".to_string())
+        );
+        assert_eq!(
+            statusline_symbol_from_declaration("const fn capacity() -> usize {"),
+            Some("capacity".to_string())
+        );
+        assert_eq!(
+            statusline_symbol_from_declaration("const openPanel = () => {}"),
+            Some("openPanel".to_string())
+        );
+        assert_eq!(
+            statusline_symbol_from_declaration("## Configuration"),
+            Some("Configuration".to_string())
+        );
+    }
+
+    #[test]
+    fn file_sizes_use_compact_binary_units() {
+        assert_eq!(statusline_file_size(42), "42 B");
+        assert_eq!(statusline_file_size(1536), "1.5 KB");
+        assert_eq!(statusline_file_size(2 * 1024 * 1024), "2.0 MB");
     }
 
     #[test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -11,7 +11,10 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    fs,
     io::{self, Write as _},
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
 };
 
 use crossterm::{
@@ -21,18 +24,20 @@ use crossterm::{
 use unicode_segmentation::UnicodeSegmentation as _;
 
 use crate::{
-    color::{blend_color, Color},
-    config::{CursorShape, KeyAction},
+    color::{blend_color, ensure_minimum_contrast, Color},
+    config::{CursorShape, KeyAction, PickerIconStyle, StatuslineSection},
     editor::RenderCommand,
     lsp::Diagnostic,
     plugin::DecorationAnchor,
     splash,
     theme::{SelectionForegroundPriority, Style},
+    ui::IconCatalog,
     undo::TextPosition,
     unicode_utils::{
         char_prefix, display_width, display_width_with_tabs, fit_display_width,
         grapheme_to_column_with_tabs, trim_line_ending, truncate_display_width,
     },
+    utils::expand_user_path,
 };
 
 use super::{
@@ -87,6 +92,318 @@ fn diagnostics_by_visible_line(
 
 fn statusline_file_name(name: &str) -> &str {
     name.strip_prefix("./").unwrap_or(name)
+}
+
+#[derive(Clone)]
+struct StatuslineSegment {
+    text: String,
+    style: Style,
+    icon: Option<StatuslineIcon>,
+}
+
+#[derive(Clone)]
+struct StatuslineIcon {
+    glyph: String,
+    color: Color,
+}
+
+struct StatuslineContext {
+    mode: String,
+    filename: String,
+    file_path: Option<String>,
+    position: String,
+    syntax: Option<String>,
+    git_branch: Option<String>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn statusline_segment(
+    section: StatuslineSection,
+    context: &StatuslineContext,
+    base_style: &Style,
+    context_style: &Style,
+    prominent_style: &Style,
+    icon_style: PickerIconStyle,
+    color_icons: bool,
+) -> Option<StatuslineSegment> {
+    let (text, style, icon) = match section {
+        StatuslineSection::Mode => (format!(" {} ", context.mode), prominent_style.clone(), None),
+        StatuslineSection::GitBranch => {
+            let branch = context.git_branch.as_deref()?;
+            let glyph = match icon_style {
+                PickerIconStyle::NerdFont => "",
+                PickerIconStyle::Unicode => "⑂",
+                PickerIconStyle::Ascii => "git",
+                PickerIconStyle::None => "",
+            };
+            (
+                statusline_icon_label(glyph, branch),
+                context_style.clone(),
+                None,
+            )
+        }
+        StatuslineSection::Filename => {
+            (format!(" {} ", context.filename), base_style.clone(), None)
+        }
+        StatuslineSection::Syntax => {
+            let syntax = context.syntax.as_deref()?;
+            let icon = IconCatalog::file(
+                context.file_path.as_deref().unwrap_or(&context.filename),
+                icon_style,
+            );
+            let icon_override = (color_icons && !icon.glyph.is_empty())
+                .then_some(icon.color)
+                .flatten()
+                .map(|color| StatuslineIcon {
+                    glyph: icon.glyph.to_string(),
+                    color,
+                });
+            (
+                statusline_icon_label(icon.glyph, syntax),
+                context_style.clone(),
+                icon_override,
+            )
+        }
+        StatuslineSection::Position => (context.position.clone(), prominent_style.clone(), None),
+    };
+
+    Some(StatuslineSegment { text, style, icon })
+}
+
+fn statusline_icon_label(glyph: &str, label: &str) -> String {
+    if glyph.is_empty() {
+        format!(" {label} ")
+    } else {
+        format!(" {glyph} {label} ")
+    }
+}
+
+fn statusline_context_style(base: &Style, prominent: &Style) -> Style {
+    let (Some(base_bg), Some(accent)) = (base.bg, prominent.bg) else {
+        return base.clone();
+    };
+    let Color::Rgb { r, g, b } = blend_color(accent, base_bg) else {
+        unreachable!("blend_color always normalizes its result to RGB");
+    };
+    let bg = blend_color(Color::Rgba { r, g, b, a: 58 }, base_bg);
+    let fg = ensure_minimum_contrast(accent, bg, 3.0);
+    Style {
+        fg: Some(fg),
+        bg: Some(bg),
+        bold: true,
+        ..base.clone()
+    }
+}
+
+fn draw_statusline_left(
+    buffer: &mut RenderBuffer,
+    y: usize,
+    limit: usize,
+    segments: &[StatuslineSegment],
+    base_style: &Style,
+    separator: char,
+) {
+    let separator = separator.to_string();
+    let separator_width = display_width(&separator);
+    let mut x = 0;
+
+    for (index, segment) in segments.iter().enumerate() {
+        if x >= limit {
+            break;
+        }
+        let next_style = segments
+            .get(index + 1)
+            .map(|next| &next.style)
+            .unwrap_or(base_style);
+        let has_separator = segment.style.bg != next_style.bg;
+        let text_width = display_width(&segment.text);
+        let desired_width = text_width + if has_separator { separator_width } else { 0 };
+        let remaining = limit - x;
+        if desired_width > remaining {
+            let text = truncate_display_width(&segment.text, remaining);
+            let visible_width = display_width(&text);
+            draw_statusline_segment(buffer, x, y, &text, visible_width, segment);
+            break;
+        }
+
+        draw_statusline_segment(buffer, x, y, &segment.text, text_width, segment);
+        x += text_width;
+        if has_separator {
+            let transition = Style {
+                fg: segment.style.bg,
+                bg: next_style.bg,
+                ..Default::default()
+            };
+            buffer.set_text(x, y, &separator, &transition);
+            x += separator_width;
+        }
+    }
+}
+
+fn draw_statusline_right(
+    buffer: &mut RenderBuffer,
+    y: usize,
+    width: usize,
+    mut segments: Vec<StatuslineSegment>,
+    base_style: &Style,
+    separator: char,
+) -> usize {
+    let separator = separator.to_string();
+    let separator_width = display_width(&separator);
+    while segments.len() > 1
+        && statusline_right_width(&segments, base_style, separator_width) > width
+    {
+        segments.remove(0);
+    }
+    if let Some(segment) = segments.first_mut() {
+        let leading_width = if segment.style.bg != base_style.bg {
+            separator_width
+        } else {
+            0
+        };
+        let available_text = width.saturating_sub(leading_width);
+        if display_width(&segment.text) > available_text {
+            segment.text = truncate_display_width(&segment.text, available_text);
+        }
+    }
+
+    let total_width = statusline_right_width(&segments, base_style, separator_width).min(width);
+    let start = width - total_width;
+    let mut x = start;
+    let mut previous_style = base_style;
+    for segment in &segments {
+        if segment.style.bg != previous_style.bg {
+            let transition = Style {
+                fg: segment.style.bg,
+                bg: previous_style.bg,
+                ..Default::default()
+            };
+            buffer.set_text(x, y, &separator, &transition);
+            x += separator_width;
+        }
+        let text_width = display_width(&segment.text);
+        draw_statusline_segment(buffer, x, y, &segment.text, text_width, segment);
+        x += text_width;
+        previous_style = &segment.style;
+    }
+    start
+}
+
+fn statusline_right_width(
+    segments: &[StatuslineSegment],
+    base_style: &Style,
+    separator_width: usize,
+) -> usize {
+    let mut previous_style = base_style;
+    segments.iter().fold(0, |width, segment| {
+        let transition = if segment.style.bg != previous_style.bg {
+            separator_width
+        } else {
+            0
+        };
+        previous_style = &segment.style;
+        width + transition + display_width(&segment.text)
+    })
+}
+
+fn draw_statusline_segment(
+    buffer: &mut RenderBuffer,
+    x: usize,
+    y: usize,
+    text: &str,
+    visible_width: usize,
+    segment: &StatuslineSegment,
+) {
+    buffer.set_text(x, y, text, &segment.style);
+    let Some(icon) = &segment.icon else {
+        return;
+    };
+    let icon_x = x + 1;
+    if icon_x + display_width(&icon.glyph) > x + visible_width {
+        return;
+    }
+    let icon_style = Style {
+        fg: Some(icon.color),
+        ..segment.style.clone()
+    };
+    buffer.set_text(icon_x, y, &icon.glyph, &icon_style);
+}
+
+fn statusline_git_search_dir(file: Option<&str>) -> PathBuf {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let Some(file) = file else {
+        return cwd;
+    };
+    let path = expand_user_path(file).unwrap_or_else(|_| PathBuf::from(file));
+    let path = if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    };
+    let search_dir = if path.is_dir() {
+        path
+    } else {
+        path.parent().unwrap_or(&path).to_path_buf()
+    };
+    search_dir.canonicalize().unwrap_or(search_dir)
+}
+
+fn git_head_path(search_dir: &Path) -> Option<PathBuf> {
+    for ancestor in search_dir.ancestors() {
+        let dot_git = ancestor.join(".git");
+        if dot_git.is_dir() {
+            return Some(dot_git.join("HEAD"));
+        }
+        let Ok(contents) = fs::read_to_string(&dot_git) else {
+            continue;
+        };
+        let Some(git_dir) = contents.trim().strip_prefix("gitdir:") else {
+            continue;
+        };
+        let git_dir = PathBuf::from(git_dir.trim());
+        let git_dir = if git_dir.is_absolute() {
+            git_dir
+        } else {
+            ancestor.join(git_dir)
+        };
+        return Some(git_dir.join("HEAD"));
+    }
+    None
+}
+
+fn git_branch_from_head(search_dir: &Path) -> Option<String> {
+    let head = fs::read_to_string(git_head_path(search_dir)?).ok()?;
+    let head = head.trim();
+    let branch = head
+        .strip_prefix("ref: refs/heads/")
+        .or_else(|| head.strip_prefix("ref: "))
+        .unwrap_or_else(|| head.get(..head.len().min(8)).unwrap_or(head));
+    (!branch.is_empty()).then(|| compact_git_branch(branch))
+}
+
+fn compact_git_branch(branch: &str) -> String {
+    const MAX_WIDTH: usize = 25;
+    if display_width(branch) <= MAX_WIDTH {
+        return branch.to_string();
+    }
+    let parts = branch.split('/').collect::<Vec<_>>();
+    let compact = if parts.len() >= 3 {
+        parts[..parts.len() - 1]
+            .iter()
+            .map(|part| part.chars().next().unwrap_or('?').to_string())
+            .chain(std::iter::once(parts[parts.len() - 1].to_string()))
+            .collect::<Vec<_>>()
+            .join("/")
+    } else {
+        branch.to_string()
+    };
+    if display_width(&compact) <= MAX_WIDTH {
+        compact
+    } else {
+        let mut compact = truncate_display_width(&compact, MAX_WIDTH - 1);
+        compact.push('…');
+        compact
+    }
 }
 
 fn decoration_local_x(
@@ -1804,105 +2121,130 @@ impl Editor {
             return;
         }
 
-        let mode = format_mode_name(&self.mode);
-        let mode = format!(" {mode} ");
-
-        // Get information from the active window
-        let active_window = self.window_manager.active_window();
-        let (file, pos, window_indicator) = if let Some(window) = active_window {
-            let window_buffer = &self.buffer_manager[window.buffer_index];
-            let dirty = if window_buffer.is_dirty() {
-                " [+] "
-            } else {
-                ""
-            };
-            let file = format!(" {}{}", statusline_file_name(window_buffer.name()), dirty);
-            let pos = format!(" {}:{} ", window.vtop + window.cy + 1, window.cx + 1);
-
-            // Add window indicator if there are multiple windows
-            let window_count = self.window_manager.window_count();
-            let window_indicator = if window_count > 1 {
-                format!(
-                    " [{}/{}]",
-                    self.window_manager.active_window_id() + 1,
-                    window_count
+        let (filename, file_path, dirty, position, buffer_index) =
+            if let Some(window) = self.window_manager.active_window() {
+                let window_buffer = &self.buffer_manager[window.buffer_index];
+                let dirty = window_buffer.is_dirty();
+                let window_count = self.window_manager.window_count();
+                let window_indicator = if window_count > 1 {
+                    format!(
+                        " [{}/{}] ",
+                        self.window_manager.active_window_id() + 1,
+                        window_count
+                    )
+                } else {
+                    " ".to_string()
+                };
+                (
+                    statusline_file_name(window_buffer.name()).to_string(),
+                    window_buffer.file.clone(),
+                    dirty,
+                    format!(
+                        " {}:{}{}",
+                        window.vtop + window.cy + 1,
+                        window.cx + 1,
+                        window_indicator
+                    ),
+                    window.buffer_index,
                 )
             } else {
-                String::new()
+                let current = self.current_buffer();
+                (
+                    statusline_file_name(current.name()).to_string(),
+                    current.file.clone(),
+                    current.is_dirty(),
+                    format!(" {}:{} ", self.vtop + self.cy + 1, self.cx + 1),
+                    self.buffer_manager.active_index(),
+                )
             };
-
-            (file, pos, window_indicator)
-        } else {
-            // Fallback to global state if no active window
-            let dirty = if self.current_buffer().is_dirty() {
-                " [+] "
-            } else {
-                ""
-            };
-            let file = format!(
-                " {}{}",
-                statusline_file_name(self.current_buffer().name()),
-                dirty
-            );
-            let pos = format!(" {}:{} ", self.vtop + self.cy + 1, self.cx + 1);
-            (file, pos, String::new())
-        };
 
         let term_width = self.size.0 as usize;
         let y = self.size.1 as usize - 2;
-
-        let transition_style = Style {
-            fg: self.theme.statusline_style.outer_style.bg,
-            bg: self.theme.statusline_style.inner_style.bg,
-            ..Default::default()
-        };
-
         let clear_line = " ".repeat(term_width);
         buffer.set_text(0, y, &clear_line, &self.theme.statusline_style.inner_style);
 
-        let left_transition = self.theme.statusline_style.outer_chars[1].to_string();
-        let right_transition = self.theme.statusline_style.outer_chars[2].to_string();
-        let position = format!("{}{}", pos, window_indicator);
+        let left_sections = self.config.statusline.left.clone();
+        let right_sections = self.config.statusline.right.clone();
+        let wants_git = left_sections
+            .iter()
+            .chain(&right_sections)
+            .any(|section| *section == StatuslineSection::GitBranch);
+        let git_branch = wants_git
+            .then(|| self.statusline_git_branch(file_path.as_deref()))
+            .flatten();
+        let syntax = self.highlight_language_id_for_buffer_index(buffer_index);
+        let context = StatuslineContext {
+            mode: format_mode_name(&self.mode).to_string(),
+            filename: if dirty {
+                format!("{filename} [+]")
+            } else {
+                filename
+            },
+            file_path,
+            position,
+            syntax,
+            git_branch,
+        };
 
-        let mode_width = display_width(&mode);
-        let left_transition_width = display_width(&left_transition);
-        let right_transition_width = display_width(&right_transition);
-        let position_width = display_width(&position);
-        let position_start = term_width.saturating_sub(position_width);
-        let right_transition_start = position_start.saturating_sub(right_transition_width);
-        let file_start = mode_width + left_transition_width;
-        let file_width = right_transition_start.saturating_sub(file_start);
+        let base_style = self.theme.statusline_style.inner_style.clone();
+        let prominent_style = self.theme.statusline_style.outer_style.clone();
+        let context_style = statusline_context_style(&base_style, &prominent_style);
+        let icons = self.config.statusline.icons;
+        let left = left_sections
+            .into_iter()
+            .filter_map(|section| {
+                statusline_segment(
+                    section,
+                    &context,
+                    &base_style,
+                    &context_style,
+                    &prominent_style,
+                    icons.style,
+                    icons.color,
+                )
+            })
+            .collect::<Vec<_>>();
+        let right = right_sections
+            .into_iter()
+            .filter_map(|section| {
+                statusline_segment(
+                    section,
+                    &context,
+                    &base_style,
+                    &context_style,
+                    &prominent_style,
+                    icons.style,
+                    icons.color,
+                )
+            })
+            .collect::<Vec<_>>();
 
-        buffer.set_text(0, y, &mode, &self.theme.statusline_style.outer_style);
+        let left_separator = self.theme.statusline_style.outer_chars[1];
+        let right_separator = self.theme.statusline_style.outer_chars[2];
+        let right_start =
+            draw_statusline_right(buffer, y, term_width, right, &base_style, right_separator);
+        draw_statusline_left(buffer, y, right_start, &left, &base_style, left_separator);
+    }
 
-        buffer.set_text(mode_width, y, &left_transition, &transition_style);
+    fn statusline_git_branch(&mut self, file: Option<&str>) -> Option<String> {
+        const CACHE_TTL: Duration = Duration::from_secs(1);
 
-        if file_width > 0 {
-            buffer.set_text(
-                file_start,
-                y,
-                &format!("{:<width$}", file, width = file_width),
-                &self.theme.statusline_style.inner_style,
-            );
+        let search_dir = statusline_git_search_dir(file);
+        let now = Instant::now();
+        let cache_is_fresh = self.statusline_git_cache.search_dir.as_ref() == Some(&search_dir)
+            && self
+                .statusline_git_cache
+                .refreshed_at
+                .is_some_and(|refreshed| now.duration_since(refreshed) < CACHE_TTL);
+        if cache_is_fresh {
+            return self.statusline_git_cache.branch.clone();
         }
 
-        if right_transition_start < term_width {
-            buffer.set_text(
-                right_transition_start,
-                y,
-                &right_transition,
-                &transition_style,
-            );
-        }
-
-        if position_start < term_width {
-            buffer.set_text(
-                position_start,
-                y,
-                &position,
-                &self.theme.statusline_style.outer_style,
-            );
-        }
+        let branch = git_branch_from_head(&search_dir);
+        self.statusline_git_cache.search_dir = Some(search_dir);
+        self.statusline_git_cache.branch = branch.clone();
+        self.statusline_git_cache.refreshed_at = Some(now);
+        branch
     }
 
     pub fn draw_commandline(&mut self, buffer: &mut RenderBuffer) {
@@ -2371,6 +2713,123 @@ mod tests {
             "/Users/fcoury/code/red/src/color.rs"
         );
         assert_eq!(statusline_file_name("[No Name]"), "[No Name]");
+    }
+
+    #[test]
+    fn configurable_statusline_sections_render_in_the_requested_sides() {
+        let mut config = Config::default();
+        config.statusline.left = vec![StatuslineSection::Syntax, StatuslineSection::Mode];
+        config.statusline.right = vec![StatuslineSection::Filename, StatuslineSection::Position];
+        config.statusline.icons.style = PickerIconStyle::Ascii;
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let source = Buffer::new(
+            Some("config.toml".to_string()),
+            "theme = 'red'\n".to_string(),
+        );
+        let mut editor =
+            Editor::with_size(lsp, 60, 12, config, Theme::default(), vec![source]).unwrap();
+        let row = editor.test_statusline_row();
+
+        let syntax = row.find("T toml").expect("syntax belongs on the left");
+        let mode = row.find("NORMAL").expect("mode belongs after syntax");
+        let filename = row
+            .find("config.toml")
+            .expect("filename belongs on the right");
+        let position = row.rfind("1:1").expect("position belongs at the edge");
+        assert!(syntax < mode);
+        assert!(mode < filename);
+        assert!(filename < position);
+    }
+
+    #[test]
+    fn contextual_statusline_color_is_between_base_and_prominent_bands() {
+        let base = Style {
+            fg: Some(Color::Rgb {
+                r: 220,
+                g: 220,
+                b: 220,
+            }),
+            bg: Some(Color::Rgb {
+                r: 20,
+                g: 30,
+                b: 40,
+            }),
+            ..Style::default()
+        };
+        let prominent = Style {
+            fg: Some(Color::Rgb { r: 0, g: 0, b: 0 }),
+            bg: Some(Color::Rgb {
+                r: 80,
+                g: 180,
+                b: 220,
+            }),
+            ..Style::default()
+        };
+
+        let contextual = statusline_context_style(&base, &prominent);
+
+        assert_ne!(contextual.bg, base.bg);
+        assert_ne!(contextual.bg, prominent.bg);
+        assert!(contextual.bold);
+    }
+
+    #[test]
+    fn git_branch_reads_regular_and_worktree_head_files() {
+        let repository = tempfile::tempdir().unwrap();
+        fs::create_dir(repository.path().join(".git")).unwrap();
+        fs::write(
+            repository.path().join(".git/HEAD"),
+            "ref: refs/heads/feature/statusline\n",
+        )
+        .unwrap();
+        let nested = repository.path().join("src/editor");
+        fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(
+            git_branch_from_head(&nested).as_deref(),
+            Some("feature/statusline")
+        );
+
+        let worktree = tempfile::tempdir().unwrap();
+        let git_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            worktree.path().join(".git"),
+            format!("gitdir: {}\n", git_dir.path().display()),
+        )
+        .unwrap();
+        fs::write(git_dir.path().join("HEAD"), "0123456789abcdef\n").unwrap();
+
+        assert_eq!(
+            git_branch_from_head(worktree.path()).as_deref(),
+            Some("01234567")
+        );
+    }
+
+    #[test]
+    fn long_git_branch_keeps_hierarchy_and_identity_compact() {
+        assert_eq!(
+            compact_git_branch("feature/frontend/configurable-statusline-with-icons"),
+            "f/f/configurable-statusl…"
+        );
+    }
+
+    #[test]
+    fn statusline_preserves_the_edge_position_on_a_narrow_terminal() {
+        let mut config = Config::default();
+        config.statusline.left = vec![StatuslineSection::Mode, StatuslineSection::Filename];
+        config.statusline.right = vec![StatuslineSection::Syntax, StatuslineSection::Position];
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let source = Buffer::new(
+            Some("config.toml".to_string()),
+            "value = true\n".to_string(),
+        );
+        let mut editor =
+            Editor::with_size(lsp, 8, 5, config, Theme::default(), vec![source]).unwrap();
+
+        let row = editor.test_statusline_row();
+
+        assert_eq!(display_width(&row), 8);
+        assert!(row.ends_with(" 1:1 "), "{row:?}");
     }
 
     #[test]

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -727,6 +727,15 @@ impl LspClient for LspManager {
             .get_server_capabilities()
     }
 
+    fn server_name_for_file(&self, file: &str) -> Option<String> {
+        let key = self.document_clients.get(file).cloned().or_else(|| {
+            self.resolve_document(file)
+                .map(|document| client_key(&document))
+        })?;
+        let (server_name, _) = client_source_from_key(&key, &self.config);
+        Some(server_name.to_string())
+    }
+
     fn supports_document_formatting(&self, file: &str) -> bool {
         if let Some(key) = self.document_clients.get(file) {
             return self

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -476,6 +476,11 @@ pub trait LspClient: std::any::Any + Send {
         self.get_server_capabilities()
     }
 
+    /// Returns the configured server name associated with `file`.
+    fn server_name_for_file(&self, _file: &str) -> Option<String> {
+        None
+    }
+
     /// Reports whether the server associated with `file` supports formatting.
     fn supports_document_formatting(&self, _file: &str) -> bool {
         true

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -139,11 +139,7 @@ fn full_block(version: &str) -> Vec<Line> {
         Role::Epigraph,
         width,
     ));
-    lines.push(centered(
-        "everything else included",
-        Role::Epigraph,
-        width,
-    ));
+    lines.push(centered("everything else included", Role::Epigraph, width));
     lines
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -24,6 +24,7 @@ mod prompt_buffer;
 mod rich_text;
 mod selection;
 mod spinner;
+mod statusline_layout;
 
 pub use action_bar::{
     ActionBar, ActionBarLayout, ActionBarRole, ActionBarSpan, ActionMode, ActionPriority, UiAction,
@@ -52,6 +53,7 @@ pub(crate) use prompt_buffer::{
 pub(crate) use rich_text::paint_rich_text;
 pub(crate) use selection::{FollowTailViewport, SelectionViewport};
 pub(crate) use spinner::{spinner_frame, SPINNER_FRAME_INTERVAL_MS};
+pub use statusline_layout::StatuslineLayoutPanel;
 
 use crate::{
     config::KeyAction,

--- a/src/ui/statusline_layout.rs
+++ b/src/ui/statusline_layout.rs
@@ -1,0 +1,574 @@
+//! Three-bucket terminal panel for arranging status-line sections with live preview.
+
+use crossterm::event::{Event, KeyCode, KeyModifiers};
+
+use crate::{
+    config::{KeyAction, PickerIconStyle, StatuslineConfig, StatuslineSection},
+    editor::{rendering::statusline_slot_style, Action, Editor, RenderBuffer},
+    theme::{SelectionForegroundPriority, Style, Theme},
+    unicode_utils::truncate_display_width,
+};
+
+use super::{
+    dialog::{BorderStyle, Dialog, SurfaceRole},
+    Component, IconCatalog,
+};
+
+const WIDE_LAYOUT_MIN_WIDTH: usize = 72;
+const DESIRED_WIDTH: usize = 96;
+const BODY_ROWS: usize = 7;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Bucket {
+    Available,
+    Left,
+    Right,
+}
+
+impl Bucket {
+    const ALL: [Self; 3] = [Self::Available, Self::Left, Self::Right];
+
+    const fn index(self) -> usize {
+        match self {
+            Self::Available => 0,
+            Self::Left => 1,
+            Self::Right => 2,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Available => "Available",
+            Self::Left => "Left · edge → center",
+            Self::Right => "Right · edge → center",
+        }
+    }
+}
+
+/// Editor-owned modal that edits a draft while the real status line previews it.
+pub struct StatuslineLayoutPanel {
+    dialog: Dialog,
+    original: StatuslineConfig,
+    draft: StatuslineConfig,
+    focus: Bucket,
+    selected: [usize; 3],
+    theme: Theme,
+}
+
+impl StatuslineLayoutPanel {
+    pub fn new(editor: &Editor) -> Self {
+        let (width, height) = panel_size(editor.vwidth(), editor.vheight());
+        let x = editor.vwidth().saturating_sub(width + 2) / 2;
+        let y = editor.vheight().saturating_sub(height + 2) / 2;
+        let style = editor.theme.ui_style.dialog.clone();
+        let mut dialog = Dialog::new(
+            Some("Statusline Layout · live preview below".to_string()),
+            x,
+            y,
+            width,
+            height,
+            &style,
+            BorderStyle::Rounded,
+            &editor.theme,
+        )
+        .with_surface_theme(&editor.theme, SurfaceRole::Dialog);
+        dialog.set_footer(Some(
+            "h/l focus · j/k select · H left · L right · K/J reorder · x remove · s save · esc cancel"
+                .to_string(),
+        ));
+
+        let original = editor.statusline_config().clone();
+        let has_available = StatuslineSection::ALL
+            .into_iter()
+            .any(|section| !original.left.contains(&section) && !original.right.contains(&section));
+        Self {
+            dialog,
+            draft: original.clone(),
+            original,
+            focus: if has_available {
+                Bucket::Available
+            } else {
+                Bucket::Left
+            },
+            selected: [0; 3],
+            theme: editor.theme.clone(),
+        }
+    }
+
+    fn sections(&self, bucket: Bucket) -> Vec<StatuslineSection> {
+        match bucket {
+            Bucket::Available => StatuslineSection::ALL
+                .into_iter()
+                .filter(|section| {
+                    !self.draft.left.contains(section) && !self.draft.right.contains(section)
+                })
+                .collect(),
+            Bucket::Left => self.draft.left.clone(),
+            Bucket::Right => self.draft.right.clone(),
+        }
+    }
+
+    fn selected_section(&self) -> Option<StatuslineSection> {
+        self.sections(self.focus)
+            .get(self.selected[self.focus.index()])
+            .copied()
+    }
+
+    fn clamp_selection(&mut self, bucket: Bucket) {
+        let len = self.sections(bucket).len();
+        let selected = &mut self.selected[bucket.index()];
+        *selected = (*selected).min(len.saturating_sub(1));
+    }
+
+    fn focus_by(&mut self, delta: isize) {
+        let next = (self.focus.index() as isize + delta).clamp(0, 2) as usize;
+        self.focus = Bucket::ALL[next];
+        self.clamp_selection(self.focus);
+    }
+
+    fn select_by(&mut self, delta: isize) {
+        let len = self.sections(self.focus).len();
+        if len == 0 {
+            self.selected[self.focus.index()] = 0;
+            return;
+        }
+        let current = self.selected[self.focus.index()] as isize;
+        self.selected[self.focus.index()] = (current + delta).clamp(0, len as isize - 1) as usize;
+    }
+
+    fn move_to(&mut self, target: Bucket) -> bool {
+        let Some(section) = self.selected_section() else {
+            return false;
+        };
+        let previous = self.draft.clone();
+        self.draft.left.retain(|candidate| *candidate != section);
+        self.draft.right.retain(|candidate| *candidate != section);
+        match target {
+            Bucket::Available => {}
+            Bucket::Left => self.draft.left.push(section),
+            Bucket::Right => self.draft.right.push(section),
+        }
+        self.focus = target;
+        let target_len = self.sections(target).len();
+        self.selected[target.index()] = target_len.saturating_sub(1);
+        for bucket in Bucket::ALL {
+            self.clamp_selection(bucket);
+        }
+        self.draft != previous
+    }
+
+    fn reorder(&mut self, delta: isize) -> bool {
+        let selected = self.selected[self.focus.index()];
+        let list = match self.focus {
+            Bucket::Available => return false,
+            Bucket::Left => &mut self.draft.left,
+            Bucket::Right => &mut self.draft.right,
+        };
+        if list.len() < 2 {
+            return false;
+        }
+        let next = (selected as isize + delta).clamp(0, list.len() as isize - 1) as usize;
+        if next == selected {
+            return false;
+        }
+        list.swap(selected, next);
+        self.selected[self.focus.index()] = next;
+        true
+    }
+
+    fn preview_action(&self) -> Option<KeyAction> {
+        Some(KeyAction::Single(Action::PreviewStatuslineLayout(
+            self.draft.clone(),
+        )))
+    }
+
+    const fn refresh_action() -> Option<KeyAction> {
+        Some(KeyAction::Single(Action::Refresh))
+    }
+
+    fn draw_wide(&self, buffer: &mut RenderBuffer, x: usize, y: usize, width: usize, rows: usize) {
+        let available = width.saturating_sub(2);
+        let first_width = available / 3;
+        let second_width = available / 3;
+        let third_width = available.saturating_sub(first_width + second_width);
+        let panes = [
+            (Bucket::Available, x, first_width),
+            (Bucket::Left, x + first_width + 1, second_width),
+            (
+                Bucket::Right,
+                x + first_width + second_width + 2,
+                third_width,
+            ),
+        ];
+
+        for separator_x in [x + first_width, x + first_width + second_width + 1] {
+            buffer.fill_rect(
+                separator_x,
+                y,
+                1,
+                rows,
+                '│',
+                &self.theme.ui_style.dialog_border,
+                &self.theme,
+            );
+        }
+        for (bucket, pane_x, pane_width) in panes {
+            self.draw_pane(buffer, bucket, pane_x, y, pane_width, rows);
+        }
+    }
+
+    fn draw_narrow(
+        &self,
+        buffer: &mut RenderBuffer,
+        x: usize,
+        y: usize,
+        width: usize,
+        rows: usize,
+    ) {
+        let tab_width = width / Bucket::ALL.len();
+        for (index, bucket) in Bucket::ALL.into_iter().enumerate() {
+            let tab_x = x + index * tab_width;
+            let current_width = if index + 1 == Bucket::ALL.len() {
+                width.saturating_sub(index * tab_width)
+            } else {
+                tab_width
+            };
+            let label = match bucket {
+                Bucket::Available => "Available",
+                Bucket::Left => "Left",
+                Bucket::Right => "Right",
+            };
+            let style = if bucket == self.focus {
+                self.theme.selected_style(
+                    &self.theme.ui_style.dialog,
+                    &self.theme.ui_style.picker_selected_item,
+                    SelectionForegroundPriority::Selection,
+                )
+            } else {
+                self.theme.ui_style.muted.clone()
+            };
+            buffer.fill_rect(tab_x, y, current_width, 1, ' ', &style, &self.theme);
+            buffer.set_text(
+                tab_x,
+                y,
+                &truncate_display_width(&format!(" {label}"), current_width),
+                &style,
+            );
+        }
+        self.draw_rows(buffer, self.focus, x, y + 1, width, rows.saturating_sub(1));
+    }
+
+    fn draw_pane(
+        &self,
+        buffer: &mut RenderBuffer,
+        bucket: Bucket,
+        x: usize,
+        y: usize,
+        width: usize,
+        rows: usize,
+    ) {
+        let focused = bucket == self.focus;
+        let style = if focused {
+            Style {
+                bold: true,
+                ..self.theme.ui_style.dialog_title.clone()
+            }
+        } else {
+            self.theme.ui_style.muted.clone()
+        };
+        buffer.set_text(
+            x,
+            y,
+            &truncate_display_width(&format!(" {}", bucket.label()), width),
+            &style,
+        );
+        self.draw_rows(buffer, bucket, x, y + 1, width, rows.saturating_sub(1));
+    }
+
+    fn draw_rows(
+        &self,
+        buffer: &mut RenderBuffer,
+        bucket: Bucket,
+        x: usize,
+        y: usize,
+        width: usize,
+        rows: usize,
+    ) {
+        if rows == 0 {
+            return;
+        }
+        let sections = self.sections(bucket);
+        if sections.is_empty() {
+            buffer.set_text(
+                x + usize::from(width > 1),
+                y,
+                &truncate_display_width("(empty)", width.saturating_sub(1)),
+                &self.theme.ui_style.muted,
+            );
+            return;
+        }
+
+        for (index, section) in sections.into_iter().enumerate().take(rows) {
+            let row_y = y + index;
+            let selected = bucket == self.focus && self.selected[bucket.index()] == index;
+            let row_style = if selected {
+                self.theme.selected_style(
+                    &self.theme.ui_style.dialog,
+                    &self.theme.ui_style.picker_selected_item,
+                    SelectionForegroundPriority::Selection,
+                )
+            } else {
+                self.theme.ui_style.dialog.clone()
+            };
+            buffer.fill_rect(x, row_y, width, 1, ' ', &row_style, &self.theme);
+
+            let slot = if bucket == Bucket::Available {
+                "+".to_string()
+            } else {
+                (index + 1).to_string()
+            };
+            let slot_style = if bucket == Bucket::Available {
+                self.theme.ui_style.muted.clone().with_bg(row_style.bg)
+            } else {
+                statusline_slot_style(&self.theme, index)
+            };
+            let tag = format!(" {slot} ");
+            buffer.set_text(x, row_y, &tag, &slot_style);
+
+            let text_x = x + 3;
+            let text = section_label(section, self.draft.icons.style);
+            buffer.set_text(
+                text_x,
+                row_y,
+                &truncate_display_width(&text, width.saturating_sub(3)),
+                &row_style,
+            );
+        }
+    }
+}
+
+impl Component for StatuslineLayoutPanel {
+    fn set_theme(&mut self, theme: &Theme) {
+        self.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
+    }
+
+    fn resize(&mut self, viewport_width: usize, viewport_height: usize) -> bool {
+        let (width, height) = panel_size(viewport_width, viewport_height);
+        self.dialog.width = width;
+        self.dialog.height = height;
+        self.dialog.x = viewport_width.saturating_sub(width + 2) / 2;
+        self.dialog.y = viewport_height.saturating_sub(height + 2) / 2;
+        true
+    }
+
+    fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.dialog.draw(buffer)?;
+        let x = self.dialog.x + 1;
+        let y = self.dialog.y + 1;
+        if self.dialog.width >= WIDE_LAYOUT_MIN_WIDTH {
+            self.draw_wide(buffer, x, y, self.dialog.width, self.dialog.height);
+        } else {
+            self.draw_narrow(buffer, x, y, self.dialog.width, self.dialog.height);
+        }
+        Ok(())
+    }
+
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        let Event::Key(key) = event else {
+            return None;
+        };
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => Some(
+                KeyAction::Single(Action::CancelStatuslineLayout(self.original.clone())),
+            ),
+            (KeyCode::Char('s'), _) => Some(KeyAction::Single(Action::SaveStatuslineLayout(
+                self.draft.clone(),
+            ))),
+            (KeyCode::Left | KeyCode::Char('h') | KeyCode::BackTab, _) => {
+                self.focus_by(-1);
+                Self::refresh_action()
+            }
+            (KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab, _) => {
+                self.focus_by(1);
+                Self::refresh_action()
+            }
+            (KeyCode::Up | KeyCode::Char('k'), _) => {
+                self.select_by(-1);
+                Self::refresh_action()
+            }
+            (KeyCode::Down | KeyCode::Char('j'), _) => {
+                self.select_by(1);
+                Self::refresh_action()
+            }
+            (KeyCode::Char('H'), _) => {
+                if self.move_to(Bucket::Left) {
+                    self.preview_action()
+                } else {
+                    Self::refresh_action()
+                }
+            }
+            (KeyCode::Char('L'), _) => {
+                if self.move_to(Bucket::Right) {
+                    self.preview_action()
+                } else {
+                    Self::refresh_action()
+                }
+            }
+            (KeyCode::Char('x'), _) => {
+                if self.move_to(Bucket::Available) {
+                    self.preview_action()
+                } else {
+                    Self::refresh_action()
+                }
+            }
+            (KeyCode::Char('K'), _) => {
+                if self.reorder(-1) {
+                    self.preview_action()
+                } else {
+                    Self::refresh_action()
+                }
+            }
+            (KeyCode::Char('J'), _) => {
+                if self.reorder(1) {
+                    self.preview_action()
+                } else {
+                    Self::refresh_action()
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+fn panel_size(viewport_width: usize, viewport_height: usize) -> (usize, usize) {
+    (
+        DESIRED_WIDTH.min(viewport_width.saturating_sub(2)).max(1),
+        BODY_ROWS.min(viewport_height.saturating_sub(2)).max(1),
+    )
+}
+
+fn section_label(section: StatuslineSection, icon_style: PickerIconStyle) -> String {
+    let icon = match section {
+        StatuslineSection::Mode => "N",
+        StatuslineSection::GitBranch => match icon_style {
+            PickerIconStyle::NerdFont => "",
+            PickerIconStyle::Unicode => "⑂",
+            PickerIconStyle::Ascii => "git",
+            PickerIconStyle::None => "",
+        },
+        StatuslineSection::Filename => IconCatalog::file("src/editor.rs", icon_style).glyph,
+        StatuslineSection::Syntax => IconCatalog::file("src/lib.rs", icon_style).glyph,
+        StatuslineSection::Position => match icon_style {
+            PickerIconStyle::NerdFont => "󰆤",
+            PickerIconStyle::Unicode => "⌖",
+            PickerIconStyle::Ascii => "pos",
+            PickerIconStyle::None => "",
+        },
+    };
+    if icon.is_empty() {
+        section.label().to_string()
+    } else {
+        format!("{icon}  {}", section.label())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyEvent, KeyModifiers};
+
+    use super::*;
+    use crate::{buffer::Buffer, config::Config, lsp::LspManager};
+
+    fn editor(width: usize, height: usize) -> Editor {
+        editor_with_config(width, height, Config::default())
+    }
+
+    fn editor_with_config(width: usize, height: usize, config: Config) -> Editor {
+        Editor::with_size(
+            Box::new(LspManager::new(config.lsp.clone())),
+            width,
+            height,
+            config,
+            Theme::default(),
+            vec![Buffer::new(Some("src/lib.rs".to_string()), String::new())],
+        )
+        .unwrap()
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn rendered_text(buffer: &RenderBuffer) -> String {
+        buffer
+            .cells
+            .chunks(buffer.width)
+            .map(|row| row.iter().map(|cell| cell.c).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn moving_an_available_field_to_the_right_previews_edge_to_center_order() {
+        let mut config = Config::default();
+        config
+            .statusline
+            .left
+            .retain(|section| *section != StatuslineSection::GitBranch);
+        let editor = editor_with_config(100, 18, config);
+        let mut panel = StatuslineLayoutPanel::new(&editor);
+
+        let action = panel.handle_event(&key(KeyCode::Char('L'))).unwrap();
+
+        let KeyAction::Single(Action::PreviewStatuslineLayout(config)) = action else {
+            panic!("expected a live-preview action");
+        };
+        assert_eq!(config.right.last(), Some(&StatuslineSection::GitBranch));
+        assert_eq!(panel.focus, Bucket::Right);
+    }
+
+    #[test]
+    fn reorder_and_remove_update_the_draft_without_touching_the_original() {
+        let editor = editor(100, 18);
+        let mut panel = StatuslineLayoutPanel::new(&editor);
+        let original = panel.original.clone();
+        panel.focus = Bucket::Left;
+        panel.selected[Bucket::Left.index()] = 1;
+
+        assert!(matches!(
+            panel.handle_event(&key(KeyCode::Char('K'))),
+            Some(KeyAction::Single(Action::PreviewStatuslineLayout(_)))
+        ));
+        assert_eq!(panel.draft.left[0], StatuslineSection::GitBranch);
+        assert!(matches!(
+            panel.handle_event(&key(KeyCode::Char('x'))),
+            Some(KeyAction::Single(Action::PreviewStatuslineLayout(_)))
+        ));
+        assert_eq!(panel.original, original);
+        assert!(!panel.draft.left.contains(&StatuslineSection::GitBranch));
+    }
+
+    #[test]
+    fn wide_and_narrow_layouts_keep_all_three_buckets_reachable() {
+        let wide_editor = editor(100, 18);
+        let wide = StatuslineLayoutPanel::new(&wide_editor);
+        let mut wide_buffer = RenderBuffer::new(100, 18, &Style::default());
+        wide.draw(&mut wide_buffer).unwrap();
+        let wide_text = rendered_text(&wide_buffer);
+        assert!(wide_text.contains("Available"));
+        assert!(wide_text.contains("Left · edge → center"));
+        assert!(wide_text.contains("Right · edge → center"));
+
+        let narrow_editor = editor(42, 14);
+        let mut narrow = StatuslineLayoutPanel::new(&narrow_editor);
+        narrow.focus = Bucket::Right;
+        let mut narrow_buffer = RenderBuffer::new(42, 14, &Style::default());
+        narrow.draw(&mut narrow_buffer).unwrap();
+        let narrow_text = rendered_text(&narrow_buffer);
+        assert!(narrow_text.contains("Available"));
+        assert!(narrow_text.contains("Left"));
+        assert!(narrow_text.contains("Right"));
+        assert!(narrow_text.contains("Cursor position"));
+    }
+}

--- a/src/ui/statusline_layout.rs
+++ b/src/ui/statusline_layout.rs
@@ -4,7 +4,10 @@ use crossterm::event::{Event, KeyCode, KeyModifiers};
 
 use crate::{
     config::{KeyAction, PickerIconStyle, StatuslineConfig, StatuslineSection},
-    editor::{rendering::statusline_slot_style, Action, Editor, RenderBuffer},
+    editor::{
+        rendering::{statusline_section_icon, statusline_slot_style},
+        Action, Editor, RenderBuffer,
+    },
     theme::{SelectionForegroundPriority, Style, Theme},
     unicode_utils::truncate_display_width,
 };
@@ -52,6 +55,7 @@ pub struct StatuslineLayoutPanel {
     draft: StatuslineConfig,
     focus: Bucket,
     selected: [usize; 3],
+    scroll: [usize; 3],
     theme: Theme,
 }
 
@@ -91,6 +95,7 @@ impl StatuslineLayoutPanel {
                 Bucket::Left
             },
             selected: [0; 3],
+            scroll: [0; 3],
             theme: editor.theme.clone(),
         }
     }
@@ -118,6 +123,24 @@ impl StatuslineLayoutPanel {
         let len = self.sections(bucket).len();
         let selected = &mut self.selected[bucket.index()];
         *selected = (*selected).min(len.saturating_sub(1));
+        self.ensure_selection_visible(bucket);
+    }
+
+    fn visible_rows(&self) -> usize {
+        self.dialog.height.saturating_sub(1).max(1)
+    }
+
+    fn ensure_selection_visible(&mut self, bucket: Bucket) {
+        let rows = self.visible_rows();
+        let index = bucket.index();
+        let selected = self.selected[index];
+        let len = self.sections(bucket).len();
+        if selected < self.scroll[index] {
+            self.scroll[index] = selected;
+        } else if selected >= self.scroll[index] + rows {
+            self.scroll[index] = selected + 1 - rows;
+        }
+        self.scroll[index] = self.scroll[index].min(len.saturating_sub(rows));
     }
 
     fn focus_by(&mut self, delta: isize) {
@@ -134,6 +157,7 @@ impl StatuslineLayoutPanel {
         }
         let current = self.selected[self.focus.index()] as isize;
         self.selected[self.focus.index()] = (current + delta).clamp(0, len as isize - 1) as usize;
+        self.ensure_selection_visible(self.focus);
     }
 
     fn move_to(&mut self, target: Bucket) -> bool {
@@ -173,6 +197,7 @@ impl StatuslineLayoutPanel {
         }
         list.swap(selected, next);
         self.selected[self.focus.index()] = next;
+        self.ensure_selection_visible(self.focus);
         true
     }
 
@@ -308,8 +333,15 @@ impl StatuslineLayoutPanel {
             return;
         }
 
-        for (index, section) in sections.into_iter().enumerate().take(rows) {
-            let row_y = y + index;
+        let scroll = self.scroll[bucket.index()];
+        for (display_index, (index, section)) in sections
+            .into_iter()
+            .enumerate()
+            .skip(scroll)
+            .take(rows)
+            .enumerate()
+        {
+            let row_y = y + display_index;
             let selected = bucket == self.focus && self.selected[bucket.index()] == index;
             let row_style = if selected {
                 self.theme.selected_style(
@@ -359,6 +391,9 @@ impl Component for StatuslineLayoutPanel {
         self.dialog.height = height;
         self.dialog.x = viewport_width.saturating_sub(width + 2) / 2;
         self.dialog.y = viewport_height.saturating_sub(height + 2) / 2;
+        for bucket in Bucket::ALL {
+            self.ensure_selection_visible(bucket);
+        }
         true
     }
 
@@ -450,21 +485,9 @@ fn panel_size(viewport_width: usize, viewport_height: usize) -> (usize, usize) {
 
 fn section_label(section: StatuslineSection, icon_style: PickerIconStyle) -> String {
     let icon = match section {
-        StatuslineSection::Mode => "N",
-        StatuslineSection::GitBranch => match icon_style {
-            PickerIconStyle::NerdFont => "",
-            PickerIconStyle::Unicode => "⑂",
-            PickerIconStyle::Ascii => "git",
-            PickerIconStyle::None => "",
-        },
         StatuslineSection::Filename => IconCatalog::file("src/editor.rs", icon_style).glyph,
         StatuslineSection::Syntax => IconCatalog::file("src/lib.rs", icon_style).glyph,
-        StatuslineSection::Position => match icon_style {
-            PickerIconStyle::NerdFont => "󰆤",
-            PickerIconStyle::Unicode => "⌖",
-            PickerIconStyle::Ascii => "pos",
-            PickerIconStyle::None => "",
-        },
+        _ => statusline_section_icon(section, icon_style),
     };
     if icon.is_empty() {
         section.label().to_string()
@@ -570,5 +593,23 @@ mod tests {
         assert!(narrow_text.contains("Left"));
         assert!(narrow_text.contains("Right"));
         assert!(narrow_text.contains("Cursor position"));
+    }
+
+    #[test]
+    fn repository_scrolls_to_keep_late_fields_visible() {
+        let editor = editor(100, 18);
+        let mut panel = StatuslineLayoutPanel::new(&editor);
+        assert_eq!(panel.focus, Bucket::Available);
+
+        for _ in 0..StatuslineSection::ALL.len() {
+            panel.handle_event(&key(KeyCode::Down));
+        }
+
+        let mut buffer = RenderBuffer::new(100, 18, &Style::default());
+        panel.draw(&mut buffer).unwrap();
+        let text = rendered_text(&buffer);
+
+        assert!(panel.scroll[Bucket::Available.index()] > 0);
+        assert!(text.contains("Clock"));
     }
 }


### PR DESCRIPTION
The status line was fixed in place and exposed only a small amount of context. This adds a terminal-native manager for composing both sides from a broad field catalog while keeping the real status line visible as an immediate preview.

## Summary

- add a responsive Available / Left / Right terminal panel opened through :statusline or the command palette
- preview moves and reordering immediately, persist only on save, and restore the opening layout on cancel
- offer 25 fields covering mode, file and cursor context, Git, diagnostics, LSP and formatter state, symbols, selection, macros, search, indentation and encoding, buffers and windows, agent activity, and time
- hide conditional fields such as diagnostics, selection, recording, modified, and agent activity when they have no useful value
- render each side by edge position with accent, middle, and base theme shades plus Nerd Font, Unicode, ASCII, and icon-free presentation
- scroll long field lists while keeping the active choice visible on wide and narrow terminal layouts
- cache opt-in Git status work and preserve unrelated config.toml settings when saving

## How to Test

1. Open a file inside a Git repository, run :statusline, and confirm the panel appears while the real status line remains visible below it.
2. Use h/l and j/k to navigate. Scroll the Available repository through the final Clock field, then use H/L to add fields and K/J to reorder them. Confirm the status line updates immediately and slot 1 remains the strongest edge color on both sides.
3. Add Diagnostics, Git changes, LSP status, Current symbol, Selection, Macro recording, Search matches, Modified, and Agent activity. Exercise the matching editor state and confirm each conditional field appears and disappears appropriately.
4. Press Esc after making changes and confirm the opening layout is restored. Reopen the panel, make a change, press s, and confirm it persists after restarting Red without rewriting unrelated user configuration.
5. Resize below 72 columns and confirm the panel switches to Available / Left / Right tabs and continues scrolling the focused list.
6. Run cargo test statusline --all-features for focused config, renderer, panel, scrolling, and cancel-flow coverage.