### PR TITLE
Improve Git commit editor workflow

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -186,6 +186,8 @@ workspace. Open it with `Space G`.
 - `[h` and `]h` move between hunks.
 - `Space h s`, `Space h u`, and `Space h r` stage, unstage, or reset a hunk.
 - `Space c c` submits a commit message; `Space c q` cancels it.
+- The commit editor shows branch and working-tree status followed by the staged diff.
+  `:w` or `:wq` submits the message and returns to the workspace; `:q` cancels.
 
 The workspace covers staged, unstaged, untracked, and conflicted files with an
 adaptive diff pane. It also exposes synchronization, branch, remote, tag,

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.7.0` is defined by
+Red host API version `0.8.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -24,9 +24,18 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 annotations use `HUSK-A0004`. `--no-typecheck` is an unsupported development
 escape hatch; compatibility guarantees do not apply while it is enabled.
 
-Red `0.7.0` retains the complete `0.4.0` and `0.6.0` contracts, so existing
-packages that declare either minor continue to load. New packages should target
-`"red_api_version": "^0.7.0"` to use global command scope.
+Red `0.8.0` retains the complete `0.4.0`, `0.6.0`, and `0.7.0` contracts, so existing
+packages that declare those minors continue to load. New packages should target
+`"red_api_version": "^0.8.0"`.
+
+## Scratch-buffer workflows
+
+`OpenScratchBuffer(callback, name, text, commands?)` accepts optional `submit` and
+`cancel` plugin command names. In a managed scratch buffer, `:w` and `:wq` invoke the
+submit command without writing the display name to disk, while `:q` and `:q!` invoke
+the cancel command without quitting Red. `Save`, `Quit`, and configured key bindings
+follow the same routing. The options were added in host API `0.8.0`; calls using the
+original three required arguments remain compatible.
 
 ## External package primitives
 

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.7.0",
+  "api_version": "0.8.0",
   "changes": [
+    {
+      "version": "0.8.0",
+      "kind": "introduced",
+      "symbols": ["OpenScratchBuffer.commands"],
+      "migration_note": "docs/PLUGIN_API.md#scratch-buffer-workflows"
+    },
     {
       "version": "0.7.0",
       "kind": "introduced",

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -141,6 +141,11 @@ struct GitScratchOpenedEvent {
     buffer_index: i32,
 }
 
+struct ScratchBufferOptions {
+    submit: String,
+    cancel: String,
+}
+
 struct GitRestoreResult {
     restored: bool,
     warnings: [String],
@@ -248,6 +253,9 @@ struct GitPluginState {
     commit_snapshot: Json,
     commit_buffer: i32,
     commit_retry_text: String,
+    commit_draft_text: String,
+    commit_context_process: String,
+    commit_context_output: String,
     signs: [GitGutterSign],
     sign_jobs: [SignJob],
     prompt_kind: String,
@@ -335,6 +343,9 @@ fn initial_state() -> GitPluginState {
         commit_snapshot: red::null(),
         commit_buffer: -1,
         commit_retry_text: "",
+        commit_draft_text: "",
+        commit_context_process: "",
+        commit_context_output: "",
         signs: [],
         sign_jobs: [],
         prompt_kind: "",
@@ -2557,7 +2568,51 @@ fn commit_snapshot_loaded(snapshot: Json) {
     red::state_patch(GitPluginState { commit_snapshot: snapshot });
     let text = red::string(plugin_state().commit_retry_text, "");
     red::state_patch(GitPluginState { commit_retry_text: "" });
-    red::request("OpenScratchBuffer", commit_scratch_opened, "[Git Commit].gitcommit", text);
+    red::state_patch(GitPluginState { commit_draft_text: text });
+    red::state_patch(GitPluginState { commit_context_output: "" });
+    let process_id = red::execute("SpawnProcess", Process {
+        command: "git",
+        args: ["diff", "--cached", "--stat", "--patch", "--no-ext-diff", "--color=never"],
+        env: Json { GIT_PAGER: "cat", LC_ALL: "C" },
+        raw_output: true,
+        cwd: red::string(plugin_state().root, "."),
+    });
+    red::state_patch(GitPluginState { commit_context_process: process_id });
+    red::on("process:" + process_id, commit_context_event);
+}
+
+fn commit_context_event(event: ProcessEvent) {
+    match event {
+        ProcessEvent::Stdout { process_id, line, plugin_name } => {
+            if process_id == plugin_state().commit_context_process {
+                red::state_patch(GitPluginState {
+                    commit_context_output: plugin_state().commit_context_output + line,
+                });
+            }
+        }
+        ProcessEvent::Exit { process_id, code, plugin_name } => finish_commit_context(process_id),
+        ProcessEvent::Error { process_id, message, plugin_name } => finish_commit_context(process_id),
+        ProcessEvent::Stderr { process_id, line, plugin_name } => {}
+    }
+}
+
+fn finish_commit_context(process_id: String) {
+    if process_id != plugin_state().commit_context_process {
+        return;
+    }
+    red::state_patch(GitPluginState { commit_context_process: "" });
+    let text = commit_editor_text(
+        red::string(plugin_state().commit_draft_text, ""),
+        red::string(plugin_state().commit_context_output, "")
+    );
+    red::state_patch(GitPluginState { commit_draft_text: "" });
+    red::request(
+        "OpenScratchBuffer",
+        commit_scratch_opened,
+        "[Git Commit].gitcommit",
+        text,
+        ScratchBufferOptions { submit: "GitSubmitMessage", cancel: "GitCancelMessage" }
+    );
 }
 
 fn commit_scratch_opened(event: GitScratchOpenedEvent) {
@@ -2590,7 +2645,7 @@ fn finish_commit_scratch(submit: bool, text: String) {
     }
     red::state_patch(GitPluginState { commit_buffer: -1 });
     if submit {
-        let message = red::trim(text);
+        let message = commit_message(text);
         if message != "" {
             let mode = red::string(plugin_state().commit_mode, "");
             if mode == "amend" {
@@ -2600,6 +2655,78 @@ fn finish_commit_scratch(submit: bool, text: String) {
             }
         }
     }
+}
+
+fn commit_context_marker() -> String {
+    return "# --- Red commit context (not part of the commit message) ---";
+}
+
+fn commit_message(text: String) -> String {
+    let message_lines = [];
+    for line in red::split(text, "\n") {
+        if line == commit_context_marker() {
+            break;
+        }
+        message_lines = red::push(message_lines, line);
+    }
+    return red::trim(red::join(message_lines, "\n"));
+}
+
+fn commit_editor_text(message: String, staged_diff: String) -> String {
+    let text = message;
+    if text != "" && !red::ends_with(text, "\n") {
+        text = text + "\n";
+    }
+    text = text + "\n" + commit_context_marker() + "\n";
+    text = text + "# Write the commit message above. :w or :wq submits; :q cancels.\n#\n";
+
+    let state = plugin_state().state;
+    let branch = red::string(state.head, "");
+    if branch != "" {
+        text = text + "# On branch " + branch + "\n";
+    }
+    text = append_commit_status(text, "Changes to be committed", state.staged);
+    text = append_commit_status(text, "Changes not staged for commit", state.unstaged);
+    text = append_commit_status(text, "Unmerged paths", state.conflicted);
+    text = append_commit_status(text, "Untracked files", state.untracked);
+
+    if red::trim(staged_diff) != "" {
+        text = text + "#\n# Staged diff:\n#\n" + commented_diff(staged_diff);
+    }
+    return text;
+}
+
+fn append_commit_status(text: String, title: String, entries: [GitEntry]) -> String {
+    if red::len(entries) == 0 {
+        return text;
+    }
+    text = text + "#\n# " + title + ":\n#\n";
+    for entry in entries {
+        let status = red::string(entry.x, "?");
+        if status == " " || status == "?" {
+            status = red::string(entry.y, "?");
+        }
+        let path = entry.path;
+        if let Some(original) = entry.original_path {
+            path = original + " -> " + path;
+        }
+        text = text + "#   " + status + "  " + path + "\n";
+    }
+    return text;
+}
+
+fn commented_diff(diff: String) -> String {
+    let commented = [];
+    let lines = red::split(diff, "\n");
+    let index = 0;
+    while index < red::len(lines) && index < 2000 {
+        commented = red::push(commented, "# " + lines[index]);
+        index = index + 1;
+    }
+    if index < red::len(lines) {
+        commented = red::push(commented, "# … staged diff truncated after 2000 lines");
+    }
+    return red::join(commented, "\n") + "\n";
 }
 
 fn run_commit(mode: String, message: String) {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1287,6 +1287,8 @@ pub enum PluginRequest {
         request_id: RequestId,
         name: String,
         text: String,
+        submit_command: Option<String>,
+        cancel_command: Option<String>,
     },
     CloseScratchBuffer {
         buffer_index: usize,
@@ -2343,6 +2345,9 @@ pub struct Editor {
     /// Domain sub-controller managing open buffers and tab selection.
     buffer_manager: buffer_manager::BufferManager,
 
+    /// Plugin-owned scratch buffers and the commands that finish their workflows.
+    scratch_buffers: HashMap<BufferId, ScratchBufferCommands>,
+
     /// Domain sub-controller managing session recovery and snapshots
     session_manager: session_manager::SessionManager,
 
@@ -3116,6 +3121,12 @@ struct PendingLspFormatSave {
     previous_file: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct ScratchBufferCommands {
+    submit: Option<String>,
+    cancel: Option<String>,
+}
+
 enum FormatOnSaveRequest {
     Pending,
     Save { warning: Option<String> },
@@ -3675,6 +3686,7 @@ impl Editor {
 
         Ok(Editor {
             buffer_manager,
+            scratch_buffers: HashMap::new(),
             session_manager,
             lsp_coordinator,
             agent_manager,
@@ -7779,9 +7791,18 @@ impl Editor {
                     request_id,
                     name,
                     text,
+                    submit_command,
+                    cancel_command,
                 } => {
-                    self.buffer_manager
-                        .push_buffer(Buffer::new(Some(name), text));
+                    let scratch_buffer = Buffer::new(Some(name), text);
+                    self.scratch_buffers.insert(
+                        scratch_buffer.id(),
+                        ScratchBufferCommands {
+                            submit: submit_command,
+                            cancel: cancel_command,
+                        },
+                    );
+                    self.buffer_manager.push_buffer(scratch_buffer);
                     let buffer_index = self.buffer_manager.len() - 1;
                     self.set_current_buffer(buffer, buffer_index).await?;
                     self.plugin_registry
@@ -11301,6 +11322,17 @@ impl Editor {
         self.repeater = None;
         self.last_error = None;
 
+        if let Some(commands) = self.scratch_buffers.get(&self.current_buffer().id()) {
+            let routed = match cmd.trim() {
+                "w" | "w!" | "write" | "write!" | "wq" | "wq!" => commands.submit.as_ref(),
+                "q" | "q!" | "quit" | "quit!" => commands.cancel.as_ref(),
+                _ => None,
+            };
+            if let Some(command) = routed {
+                return vec![Action::PluginCommand(command.clone())];
+            }
+        }
+
         if let Ok(line) = cmd.parse::<usize>() {
             return vec![Action::GoToLine(line)];
         }
@@ -14177,18 +14209,27 @@ impl Editor {
 
         match action {
             Action::Quit(force) => {
-                if *force {
-                    return Ok(true);
+                let scratch_command = self
+                    .scratch_buffers
+                    .get(&self.current_buffer().id())
+                    .and_then(|commands| commands.cancel.clone());
+                if let Some(command) = scratch_command {
+                    add_to_history = false;
+                    self.plugin_registry.execute(runtime, &command).await?;
+                } else {
+                    if *force {
+                        return Ok(true);
+                    }
+                    let modified_buffers = self.modified_buffers();
+                    if modified_buffers.is_empty() {
+                        return Ok(true);
+                    }
+                    self.last_error = Some(format!(
+                        "The following buffers have unwritten changes: {}",
+                        modified_buffers.join(", ")
+                    ));
+                    return Ok(false);
                 }
-                let modified_buffers = self.modified_buffers();
-                if modified_buffers.is_empty() {
-                    return Ok(true);
-                }
-                self.last_error = Some(format!(
-                    "The following buffers have unwritten changes: {}",
-                    modified_buffers.join(", ")
-                ));
-                return Ok(false);
             }
             Action::MoveUp => {
                 if self.cy == 0 {
@@ -16570,6 +16611,14 @@ impl Editor {
                 }
             }
             Action::Save => {
+                let scratch_command = self
+                    .scratch_buffers
+                    .get(&self.current_buffer().id())
+                    .and_then(|commands| commands.submit.clone());
+                if let Some(command) = scratch_command {
+                    self.plugin_registry.execute(runtime, &command).await?;
+                    return Ok(false);
+                }
                 let resume_insert_transaction = self.commit_active_transaction_before_save();
                 let format_warning = if self.config.lsp.format_on_save {
                     let request = self.request_format_on_save(None).await;
@@ -16619,6 +16668,15 @@ impl Editor {
                 }
             }
             Action::SaveAs(new_file_name) => {
+                if self
+                    .scratch_buffers
+                    .contains_key(&self.current_buffer().id())
+                {
+                    self.last_error = Some(
+                        "Scratch buffers cannot be written to disk; use :w to submit".to_string(),
+                    );
+                    return Ok(false);
+                }
                 let previous_uri = self.current_buffer().uri()?;
                 let previous_file = self.current_buffer().file.clone();
                 let resume_insert_transaction = self.commit_active_transaction_before_save();
@@ -18526,6 +18584,7 @@ impl Editor {
 
         self.sync_to_window();
         let removed_id = self.current_buffer().id();
+        self.scratch_buffers.remove(&removed_id);
         let removed_uri = self.current_buffer().uri()?;
         if let Some(uri) = removed_uri.as_deref() {
             let still_open = self
@@ -24067,6 +24126,32 @@ builtin = "rust"
         );
         assert!(editor.handle_command("plugins extra", &runtime).is_empty());
         assert_eq!(editor.last_error.as_deref(), Some("usage: plugins"));
+    }
+
+    #[test]
+    fn managed_scratch_buffers_route_write_and_quit_commands_to_their_owner() {
+        let mut editor = test_editor(40, 10);
+        let runtime = Runtime::new();
+        editor.scratch_buffers.insert(
+            editor.current_buffer().id(),
+            ScratchBufferCommands {
+                submit: Some("SubmitScratch".to_string()),
+                cancel: Some("CancelScratch".to_string()),
+            },
+        );
+
+        for command in ["w", "write", "wq", "wq!"] {
+            assert_eq!(
+                editor.handle_command(command, &runtime),
+                vec![Action::PluginCommand("SubmitScratch".to_string())]
+            );
+        }
+        for command in ["q", "q!", "quit"] {
+            assert_eq!(
+                editor.handle_command(command, &runtime),
+                vec![Action::PluginCommand("CancelScratch".to_string())]
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.0",
+  "version": "0.8.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },
@@ -87,7 +87,7 @@
     { "name": "GetBufferText", "kind": "request", "signature": "(callback: fn(Json), start_line?: i32, end_line?: i32)", "introduced": "0.1.0" },
     { "name": "GetSelection", "kind": "request", "signature": "(callback: fn(Json))", "introduced": "0.1.0" },
     { "name": "GetAgentContext", "kind": "request", "signature": "(callback: fn(Json))", "introduced": "0.2.0" },
-    { "name": "OpenScratchBuffer", "kind": "request", "signature": "(callback: fn(Json), name: String, text: String)", "introduced": "0.1.0" },
+    { "name": "OpenScratchBuffer", "kind": "request", "signature": "(callback: fn(Json), name: String, text: String, commands?: Json)", "introduced": "0.1.0" },
     { "name": "GetConfig", "kind": "request", "signature": "(callback: fn(Json), key?: String)", "introduced": "0.1.0" },
     { "name": "GetStorage", "kind": "request", "signature": "(callback: fn(Json), key: String)", "introduced": "0.1.0" },
     { "name": "GetEditorState", "kind": "request", "signature": "(callback: fn(Json))", "introduced": "0.1.0" },

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -33,8 +33,9 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.7.0";
-pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &["0.4.0", "0.6.0", RED_HOST_API_VERSION];
+pub const RED_HOST_API_VERSION: &str = "0.8.0";
+pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] =
+    &["0.4.0", "0.6.0", "0.7.0", RED_HOST_API_VERSION];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PluginModification {

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1916,11 +1916,25 @@ impl RedHost {
             }
             "GetSelection" => PluginRequest::GetSelection { request_id },
             "GetAgentContext" => PluginRequest::GetAgentContext { request_id },
-            "OpenScratchBuffer" => PluginRequest::OpenScratchBuffer {
-                request_id,
-                name: args.first().map(value_to_string).unwrap_or_default(),
-                text: args.get(1).map(value_to_string).unwrap_or_default(),
-            },
+            "OpenScratchBuffer" => {
+                let commands = args
+                    .get(2)
+                    .map(value_to_json)
+                    .unwrap_or(serde_json::Value::Null);
+                PluginRequest::OpenScratchBuffer {
+                    request_id,
+                    name: args.first().map(value_to_string).unwrap_or_default(),
+                    text: args.get(1).map(value_to_string).unwrap_or_default(),
+                    submit_command: commands
+                        .get("submit")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
+                    cancel_command: commands
+                        .get("cancel")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
+                }
+            }
             "GetConfig" => PluginRequest::GetConfig {
                 request_id,
                 key: args.first().and_then(Value::as_str).map(str::to_string),
@@ -4038,6 +4052,48 @@ mod tests {
 
     fn drain_requests() {
         while ACTION_DISPATCHER.try_recv_request().is_some() {}
+    }
+
+    #[tokio::test]
+    async fn scratch_buffer_requests_preserve_submit_and_cancel_commands() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin(
+                "scratch_owner",
+                r#"
+                    struct ScratchCommands { submit: String, cancel: String }
+                    pub fn activate() {
+                        red::request(
+                            "OpenScratchBuffer",
+                            opened,
+                            "[Prompt].txt",
+                            "draft",
+                            ScratchCommands { submit: "SubmitPrompt", cancel: "CancelPrompt" }
+                        );
+                    }
+                    fn opened(event: Json) {}
+                "#,
+            )
+            .await
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenScratchBuffer {
+                name,
+                text,
+                submit_command,
+                cancel_command,
+                ..
+            } => {
+                assert_eq!(name, "[Prompt].txt");
+                assert_eq!(text, "draft");
+                assert_eq!(submit_command.as_deref(), Some("SubmitPrompt"));
+                assert_eq!(cancel_command.as_deref(), Some("CancelPrompt"));
+            }
+            _ => panic!("expected a managed scratch-buffer request"),
+        }
     }
 
     fn recv_agent_composer() -> (ComposerHandle, Option<String>, String, Vec<String>) {
@@ -10719,6 +10775,118 @@ mod tests {
                     .any(|item| item.label == "git switch -c feature/readable-pickers"));
             }
             _ => panic!("expected callback-backed command log"),
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_commit_scratch_includes_status_diff_and_managed_commands() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(root.join("staged.txt"), "hello\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "staged.txt"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut staged_visible = false;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::UpdateWorkspace { model, .. } = request {
+                    staged_visible = model.rows.iter().any(|row| row.id == "staged:staged.txt");
+                }
+            }
+            if staged_visible {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "staged Git status did not render"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "c", "row": null }),
+            )
+            .await
+            .unwrap();
+        let (picker, create) = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackPicker {
+                handle,
+                title,
+                items,
+                ..
+            } => {
+                assert_eq!(title.as_deref(), Some("Commit"));
+                let create = items
+                    .into_iter()
+                    .find(|item| item.id == "create")
+                    .expect("commit picker should contain Create commit");
+                (handle, create)
+            }
+            _ => panic!("expected the commit picker"),
+        };
+        runtime
+            .notify_picker(picker, PickerCallback::Selected(create))
+            .unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetEditorState { request_id } => request_id,
+            _ => panic!("expected an editor snapshot request"),
+        };
+        runtime
+            .resolve_request(request_id, serde_json::json!({ "version": 1 }))
+            .await
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut scratch = None;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::OpenScratchBuffer {
+                    name,
+                    text,
+                    submit_command,
+                    cancel_command,
+                    ..
+                } = request
+                {
+                    scratch = Some((name, text, submit_command, cancel_command));
+                }
+            }
+            if let Some((name, text, submit, cancel)) = scratch {
+                assert_eq!(name, "[Git Commit].gitcommit");
+                assert_eq!(submit.as_deref(), Some("GitSubmitMessage"));
+                assert_eq!(cancel.as_deref(), Some("GitCancelMessage"));
+                assert!(text.contains("# --- Red commit context"));
+                assert!(text.contains("# Changes to be committed:"));
+                assert!(text.contains("staged.txt"));
+                assert!(text.contains("# Staged diff:"));
+                assert!(text.contains("# +hello"));
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "commit scratch buffer did not open"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
 


### PR DESCRIPTION
## Why

The Git commit workflow currently opens `[Git Commit].gitcommit` as a file-backed buffer. Saving with `:wq` therefore writes that synthetic filename into the repository and then quits Red, while the editor gives the user no staged context to review alongside the message.

## What Changed

- Added optional submit and cancel commands to managed plugin scratch buffers.
- Routed `:w`, `:wq`, and editor save actions to the owning plugin without writing the scratch-buffer display name to disk.
- Routed `:q`, `:q!`, and editor quit actions to cancellation without quitting Red.
- Updated the bundled Git plugin to show branch state, staged and unstaged paths, conflicts, untracked files, and a commented staged diff below the editable commit message.
- Strip the informational footer before creating the commit and cap displayed diffs at 2,000 lines.
- Documented the additive scratch-buffer contract in host API `0.8.0` while retaining support for previous API minors.

## How to Test

1. Build and start Red in a Git repository with at least one staged change.
2. Open the Git workspace with `Space G`, then start a commit with `Space c c`.
3. Confirm that the editable message is at the top and that commented branch, status, and staged-diff context appears below it.
4. Enter a message and run `:w` or `:wq`; confirm that the commit is created, Red remains open, and no `[Git Commit].gitcommit` file is written.
5. Start another commit and run `:q` or `:q!`; confirm that the workflow is cancelled without creating a commit or quitting Red.

Targeted tests:

- `cargo test managed_scratch_buffers_route_write_and_quit_commands_to_their_owner`
- `cargo test scratch_buffer_requests_preserve_submit_and_cancel_commands`
- `cargo test git_commit_scratch_includes_status_diff_and_managed_commands`