### PR TITLE
fix(editor): refresh cursor after inserting tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,22 +80,27 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $maxAttempts = 3
-          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-            Write-Host "Installing ripgrep (attempt $attempt of $maxAttempts)"
-            choco install ripgrep --yes --no-progress
+          $version = "15.2.0"
+          $archive = Join-Path $env:RUNNER_TEMP "ripgrep.zip"
+          $extractRoot = Join-Path $env:RUNNER_TEMP "ripgrep"
+          $url = "https://github.com/BurntSushi/ripgrep/releases/download/$version/ripgrep-$version-x86_64-pc-windows-msvc.zip"
+          $expectedSha256 = "71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5"
 
-            if (Get-Command rg -ErrorAction SilentlyContinue) {
-              rg --version
-              exit 0
-            }
-
-            if ($attempt -lt $maxAttempts) {
-              Start-Sleep -Seconds (15 * $attempt)
-            }
+          Invoke-WebRequest -Uri $url -OutFile $archive
+          $actualSha256 = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualSha256 -ne $expectedSha256) {
+            throw "ripgrep archive checksum mismatch: expected $expectedSha256, got $actualSha256"
           }
 
-          throw "ripgrep was not available after $maxAttempts installation attempts"
+          Expand-Archive -Path $archive -DestinationPath $extractRoot -Force
+          $installDir = Join-Path $extractRoot "ripgrep-$version-x86_64-pc-windows-msvc"
+          $executable = Join-Path $installDir "rg.exe"
+          if (-not (Test-Path $executable)) {
+            throw "ripgrep executable was not found at $executable"
+          }
+
+          $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & $executable --version
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,24 @@ jobs:
 
       - name: Install ripgrep (Windows)
         if: runner.os == 'Windows'
-        run: choco install ripgrep --yes --no-progress
+        shell: pwsh
+        run: |
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Installing ripgrep (attempt $attempt of $maxAttempts)"
+            choco install ripgrep --yes --no-progress
+
+            if (Get-Command rg -ErrorAction SilentlyContinue) {
+              rg --version
+              exit 0
+            }
+
+            if ($attempt -lt $maxAttempts) {
+              Start-Sleep -Seconds (15 * $attempt)
+            }
+          }
+
+          throw "ripgrep was not available after $maxAttempts installation attempts"
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -16633,6 +16633,7 @@ impl Editor {
                 );
                 self.notify_change(runtime).await?;
                 self.cx += tabsize;
+                self.refresh_cursor_goal();
                 if started_transaction {
                     self.commit_transaction(self.cursor_snapshot());
                 }
@@ -31639,6 +31640,40 @@ while True:
                 "insert {inserted:?} in {contents:?} left the terminal cursor movement queued"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn tab_key_renders_cursor_at_its_new_display_column() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, String::new());
+        let mut editor =
+            Editor::with_size(lsp, 20, 5, config, Theme::default(), vec![buffer]).unwrap();
+        editor.mode = Mode::Insert;
+        editor.refresh_cursor_goal();
+        editor.sync_to_window();
+        let (initial_screen_x, expected_screen_y) = editor.render_cursor_position().unwrap();
+        let mut render_buffer = RenderBuffer::new(20, 5, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        let expected_position = (initial_screen_x + 4, expected_screen_y);
+        assert_eq!(editor.current_buffer().contents(), "    \n");
+        assert_eq!(editor.cx, 4);
+        assert_eq!(editor.render_cursor_position(), Some(expected_position));
+        assert_eq!(
+            editor.last_rendered_cursor_position,
+            Some(expected_position)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Pressing Tab in insert mode inserted the configured spaces, but the editor rendered before refreshing the cursor display-column goal. The inserted whitespace was present while the painted cursor stayed at its previous position until another character was typed.

Windows CI also relies on ripgrep for the project-search integration test. Chocolatey can report success after a feed timeout while installing zero packages, which lets the workflow continue to a misleading `rg: program not found` test failure.

Refresh the cursor goal immediately after advancing the logical cursor for `InsertTab`, before rendering or committing the final cursor state. Add a regression test that checks the inserted whitespace, logical cursor, calculated render position, and last painted cursor position. On Windows, install ripgrep from its pinned official release archive, verify the published SHA-256 checksum, and add the executable to `PATH` before tests.

## How to Test

1. Run `cargo test tab_key_renders_cursor_at_its_new_display_column -- --nocapture` and confirm the regression test passes.
2. Open an empty buffer, enter insert mode, and press Tab. Confirm four spaces are inserted and the cursor moves four columns immediately.
3. In the Windows CI job, confirm the ripgrep step verifies the archive checksum, prints `rg --version`, and the project-search integration test passes.