### PR TITLE
fix(completion): insert newline when no matches remain

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -28183,6 +28183,54 @@ builtin = "rust"
     }
 
     #[tokio::test]
+    async fn enter_after_python_call_with_filtered_out_completion_inserts_newline() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(Some("example.py".to_string()), "get".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        editor.mode = Mode::Insert;
+        editor.cx = 3;
+        editor.refresh_cursor_goal();
+        editor.sync_to_window();
+
+        let mut completion = CompletionUI::new();
+        completion.show(vec![completion_item("getattr")], 0, 0);
+        editor.current_dialog = Some(Box::new(completion));
+
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+        let mut runtime = Runtime::new();
+        for character in "(\"something\")".chars() {
+            editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE)),
+                    &mut render_buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(editor.current_buffer().contents(), "get(\"something\")");
+        assert!(editor.current_dialog.is_some());
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert!(editor.current_dialog.is_none());
+        assert_eq!(editor.current_buffer().contents(), "get(\"something\")\n");
+        assert_eq!((editor.cx, editor.buffer_line()), (0, 1));
+    }
+
+    #[tokio::test]
     async fn completion_dialog_redraws_typed_text_in_active_window() {
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -581,7 +581,10 @@ impl Component for CompletionUI {
                         Action::CloseDialog,
                     ]))
                 } else {
-                    Some(KeyAction::Single(Action::CloseDialog))
+                    Some(KeyAction::Multiple(vec![
+                        Action::CloseDialog,
+                        Action::InsertNewLine,
+                    ]))
                 }
             }
             Event::Key(KeyEvent {


### PR DESCRIPTION
When an insert-mode completion popup filtered down to zero matches, it stopped drawing but remained active. Pressing Enter then closed the invisible popup and consumed the key, leaving the cursor on the same line.

When no completion item is selectable, Enter now closes the completion dialog and inserts a newline in the same action. Enter continues to accept the selected item whenever matches remain. A regression test types the reported Python call through an active completion popup and verifies the dialog closes, the line splits, and the cursor moves to the new line.

## How to Test

1. Run cargo test enter_after_python_call_with_filtered_out_completion_inserts_newline -- --nocapture and confirm it passes.
2. Run cargo test completion -- --nocapture and confirm the completion unit and integration tests pass.
3. In a Python buffer with completion enabled, type get("something") and press Enter after the closing parenthesis. Confirm the cursor immediately moves to the next line.
4. Open completion while a selectable match remains and press Enter. Confirm the selected completion is still accepted instead of inserting a newline.