### PR TITLE
feat(editor): add language-aware autoindent

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -85,6 +85,7 @@ use crate::{
     },
     dispatcher::Dispatcher,
     highlighter::{Highlighter, LanguageRegistry},
+    indent::{self, IndentDecision},
     log,
     lsp::{
         apply_workspace_resource_operations, file_path as lsp_file_path, get_client_capabilities,
@@ -2536,6 +2537,9 @@ pub struct Editor {
     /// Cursor position where the current insert session began.
     insert_entry_cursor: Option<CursorSnapshot>,
 
+    /// Whitespace created by auto-indent that is still removable as a blank line.
+    generated_indent: Option<GeneratedIndent>,
+
     /// Partial command being entered
     waiting_command: Option<String>,
 
@@ -3177,19 +3181,37 @@ impl HistoryEntry {
 #[derive(Debug, Clone, Copy)]
 struct Indentation {
     shift_width: usize,
-    // TODO: use fields
-    // soft_tab_stop: usize,
-    // expand_tab: bool,
+    soft_tab_stop: usize,
+    tab_width: usize,
+    expand_tab: bool,
 }
 
 impl Indentation {
-    fn new(shift_width: usize, _soft_tab_stop: usize, _expand_tab: bool) -> Self {
+    fn new(shift_width: usize, soft_tab_stop: usize, expand_tab: bool) -> Self {
         Self {
             shift_width,
-            // soft_tab_stop,
-            // expand_tab,
+            soft_tab_stop,
+            tab_width: shift_width,
+            expand_tab,
         }
     }
+
+    fn whitespace_for_columns(self, columns: usize) -> String {
+        if self.expand_tab {
+            return " ".repeat(columns);
+        }
+
+        let tab_width = self.tab_width.max(1);
+        let tabs = columns / tab_width;
+        let spaces = columns % tab_width;
+        format!("{}{}", "\t".repeat(tabs), " ".repeat(spaces))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GeneratedIndent {
+    buffer_id: BufferId,
+    line: usize,
 }
 
 impl ServerCapabilities {
@@ -3771,6 +3793,7 @@ impl Editor {
             vx,
             mode: Mode::Normal,
             insert_entry_cursor: None,
+            generated_indent: None,
             waiting_command: None,
             waiting_key_action: None,
             keymap_hint_prefix: Vec::new(),
@@ -4466,7 +4489,7 @@ impl Editor {
 
     fn tab_width_for_buffer_index(&self, buffer_index: usize) -> usize {
         self.indentation_for_buffer_index(buffer_index)
-            .shift_width
+            .tab_width
             .max(1)
     }
 
@@ -4483,7 +4506,7 @@ impl Editor {
             enabled: self.config.breakindent.unwrap_or(true),
             tab_width: self
                 .indentation_for_buffer_index(buffer_index)
-                .shift_width
+                .tab_width
                 .max(1),
         }
     }
@@ -4665,7 +4688,7 @@ impl Editor {
                 };
                 let text = text.trim_end_matches(['\r', '\n']);
                 let indent_width =
-                    leading_whitespace_display_width(text, indentation.shift_width.max(1));
+                    leading_whitespace_display_width(text, indentation.tab_width.max(1));
                 json!({
                     "screen_row": segment.row,
                     "line": segment.line,
@@ -4701,7 +4724,7 @@ impl Editor {
             },
             "indentation": {
                 "shift_width": indentation.shift_width,
-                "tab_width": indentation.shift_width,
+                "tab_width": indentation.tab_width,
             },
             "line_count": buffer.navigable_line_count(),
             "revision": buffer.revision(),
@@ -14152,24 +14175,108 @@ impl Editor {
         self.current_buffer().get(self.buffer_line())
     }
 
-    fn leading_indentation(line: &str) -> usize {
-        line.trim_end_matches(&['\r', '\n'][..])
-            .chars()
-            .take_while(|c| c.is_whitespace())
-            .count()
+    fn leading_indentation_text(line: &str) -> &str {
+        let line = line.trim_end_matches(&['\r', '\n'][..]);
+        let end = line
+            .char_indices()
+            .find(|(_, character)| !character.is_whitespace())
+            .map_or(line.len(), |(index, _)| index);
+        &line[..end]
     }
 
-    fn previous_line_indentation(&self) -> usize {
-        if self.buffer_line() > 0 {
-            Self::leading_indentation(
-                &self
-                    .current_buffer()
-                    .get(self.buffer_line() - 1)
-                    .unwrap_or_default(),
+    fn leading_indentation(line: &str) -> usize {
+        Self::leading_indentation_text(line).chars().count()
+    }
+
+    fn indentation_columns_for_line(&self, line: usize) -> usize {
+        let indentation = self.indentation();
+        self.current_buffer().get(line).map_or(0, |contents| {
+            display_width_with_tabs(
+                Self::leading_indentation_text(&contents),
+                indentation.tab_width.max(1),
             )
-        } else {
-            0
+        })
+    }
+
+    fn indentation_decision_for_line(&self, line: usize) -> IndentDecision {
+        let indentation = self.indentation();
+        let language =
+            self.highlight_language_id_for_buffer_index(self.buffer_manager.active_index());
+        indent::indent_for_line(
+            language.as_deref(),
+            &self.current_buffer().contents(),
+            line,
+            indentation.shift_width,
+            indentation.tab_width,
+        )
+    }
+
+    /// Applies a display-column indentation target and preserves the cursor's
+    /// offset into non-whitespace content when the target is the active line.
+    fn apply_indentation_to_line(&mut self, line: usize, decision: IndentDecision) -> usize {
+        let IndentDecision::Columns(columns) = decision else {
+            return self.indentation_columns_for_line(line);
+        };
+        let Some(contents) = self.current_buffer().get(line) else {
+            return 0;
+        };
+        let old_indentation = Self::leading_indentation_text(&contents).to_string();
+        let new_indentation = self.indentation().whitespace_for_columns(columns);
+        let old_graphemes = grapheme_len(&old_indentation);
+        let cursor_offset =
+            (self.buffer_line() == line).then(|| self.cx.saturating_sub(old_graphemes));
+
+        if old_indentation != new_indentation {
+            self.replace_range(
+                TextRange::new(
+                    TextPosition::new(line, 0),
+                    TextPosition::new(line, old_indentation.chars().count()),
+                ),
+                &new_indentation,
+            );
         }
+
+        if let Some(cursor_offset) = cursor_offset {
+            self.cx = grapheme_len(&new_indentation) + cursor_offset;
+        }
+        columns
+    }
+
+    fn mark_generated_indent(&mut self, line: usize, columns: usize) {
+        self.generated_indent = (columns > 0).then(|| GeneratedIndent {
+            buffer_id: self.current_buffer().id(),
+            line,
+        });
+    }
+
+    /// Removes untouched auto-indent whitespace. Callers must already own the
+    /// active insert transaction so cleanup remains part of the user's change.
+    fn cleanup_generated_indent(&mut self) -> bool {
+        let Some(generated) = self.generated_indent.take() else {
+            return false;
+        };
+        if generated.buffer_id != self.current_buffer().id() {
+            return false;
+        }
+        let Some(contents) = self.current_buffer().get(generated.line) else {
+            return false;
+        };
+        let line = contents.trim_end_matches(&['\r', '\n'][..]);
+        if line.is_empty() || !line.chars().all(char::is_whitespace) {
+            return false;
+        }
+
+        self.replace_range(
+            TextRange::new(
+                TextPosition::new(generated.line, 0),
+                TextPosition::new(generated.line, line.chars().count()),
+            ),
+            "",
+        );
+        if self.buffer_line() == generated.line {
+            self.cx = 0;
+        }
+        true
     }
 
     fn current_line_indentation(&self) -> usize {
@@ -14527,6 +14634,7 @@ impl Editor {
                 }
 
                 if matches!(old_mode, Mode::Insert) && matches!(new_mode, Mode::Normal) {
+                    let cleaned_generated_indent = self.cleanup_generated_indent();
                     if self.insert_entry_cursor.is_some_and(|entry| {
                         let y = self.buffer_line();
                         y > entry.y || (y == entry.y && self.cx > entry.x)
@@ -14540,6 +14648,9 @@ impl Editor {
                     let after_cursor = self.cursor_snapshot();
                     self.commit_transaction(after_cursor);
                     self.cancel_transaction_if_empty();
+                    if cleaned_generated_indent {
+                        self.notify_change(runtime).await?;
+                    }
                 }
 
                 if matches!(new_mode, Mode::Search) {
@@ -14581,16 +14692,30 @@ impl Editor {
                 let line = self.buffer_line();
                 let cx = self.cx;
                 let char_cx = self.grapheme_to_char_on_line(cx, line);
+                self.generated_indent = None;
 
                 self.replace_range(
                     TextRange::insertion(TextPosition::new(line, char_cx)),
                     &c.to_string(),
                 );
                 drop(replace_span);
-                self.notify_change(runtime).await?;
 
                 // Move cursor by one character position (not display width)
                 self.cx += grapheme_len(&c.to_string());
+                let language =
+                    self.highlight_language_id_for_buffer_index(self.buffer_manager.active_index());
+                let should_reindent = self.current_line_contents().is_some_and(|contents| {
+                    indent::should_reindent_after(
+                        language.as_deref(),
+                        *c,
+                        contents.trim_end_matches(&['\r', '\n'][..]),
+                    )
+                });
+                if should_reindent {
+                    let decision = self.indentation_decision_for_line(line);
+                    self.apply_indentation_to_line(line, decision);
+                }
+                self.notify_change(runtime).await?;
                 self.refresh_cursor_goal();
                 if started_transaction {
                     self.commit_transaction(self.cursor_snapshot());
@@ -14942,7 +15067,9 @@ impl Editor {
                 if started_transaction {
                     self.begin_transaction("insert newline");
                 }
-                let spaces = self.current_line_indentation();
+                let source_line = self.buffer_line();
+                let fallback_columns = self.indentation_columns_for_line(source_line);
+                self.cleanup_generated_indent();
 
                 let current_line = self.current_line_contents().unwrap_or_default();
                 let current_line_without_ending = current_line.trim_end_matches(&['\r', '\n'][..]);
@@ -14961,17 +15088,23 @@ impl Editor {
                 let after_cursor = char_suffix(current_line_for_split, cursor_char).to_string();
 
                 let line = self.buffer_line();
+                let fallback_indent = self.indentation().whitespace_for_columns(fallback_columns);
                 self.replace_range(
                     TextRange::new(
                         TextPosition::new(line, 0),
                         TextPosition::new(line, current_line_without_ending.chars().count()),
                     ),
-                    &format!("{}\n{}{}", before_cursor, " ".repeat(spaces), after_cursor),
+                    &format!("{}\n{}{}", before_cursor, fallback_indent, after_cursor),
                 );
-                self.notify_change(runtime).await?;
 
-                self.cx = spaces;
+                self.cx = grapheme_len(&fallback_indent);
                 self.cy += 1;
+
+                let target_line = line + 1;
+                let decision = self.indentation_decision_for_line(target_line);
+                let target_columns = self.apply_indentation_to_line(target_line, decision);
+                self.mark_generated_indent(target_line, target_columns);
+                self.notify_change(runtime).await?;
 
                 if self.cy >= self.vheight() {
                     self.vtop += 1;
@@ -15286,13 +15419,14 @@ impl Editor {
                 self.render(buffer)?;
             }
             Action::InsertLineBelowCursor => {
-                let leading_spaces = self.current_line_indentation();
+                let leading_columns = self.indentation_columns_for_line(self.buffer_line());
                 let line = self.buffer_line();
+                let fallback_indent = self.indentation().whitespace_for_columns(leading_columns);
 
                 log!(
-                    "InsertLineBelowCursor - line: {}, leading_spaces: {}, current cx: {}, cy: {}",
+                    "InsertLineBelowCursor - line: {}, leading_columns: {}, current cx: {}, cy: {}",
                     line,
-                    leading_spaces,
+                    leading_columns,
                     self.cx,
                     self.cy
                 );
@@ -15303,13 +15437,17 @@ impl Editor {
                 }
                 self.replace_range(
                     TextRange::insertion(TextPosition::new(line + 1, 0)),
-                    &format!("{}\n", " ".repeat(leading_spaces)),
+                    &format!("{fallback_indent}\n"),
                 );
-                self.notify_change(runtime).await?;
                 self.cy += 1;
-                self.cx = leading_spaces;
+                self.cx = grapheme_len(&fallback_indent);
                 self.mode = Mode::Insert;
                 self.insert_entry_cursor = Some(self.cursor_snapshot());
+                let target_line = line + 1;
+                let decision = self.indentation_decision_for_line(target_line);
+                let target_columns = self.apply_indentation_to_line(target_line, decision);
+                self.mark_generated_indent(target_line, target_columns);
+                self.notify_change(runtime).await?;
                 self.refresh_cursor_goal();
 
                 if self.cy >= self.vheight() {
@@ -15321,29 +15459,35 @@ impl Editor {
             }
             Action::InsertLineAtCursor => {
                 // if the current line is empty, let's use the indentation from the line above
-                let leading_spaces = if let Some(line) = self.current_line_contents() {
-                    if line.is_empty() {
-                        self.previous_line_indentation()
+                let leading_columns = if let Some(contents) = self.current_line_contents() {
+                    if contents.is_empty() {
+                        let previous_line = self.buffer_line().saturating_sub(1);
+                        self.indentation_columns_for_line(previous_line)
                     } else {
-                        self.current_line_indentation()
+                        self.indentation_columns_for_line(self.buffer_line())
                     }
                 } else {
-                    self.previous_line_indentation()
+                    let previous_line = self.buffer_line().saturating_sub(1);
+                    self.indentation_columns_for_line(previous_line)
                 };
 
                 let line = self.buffer_line();
+                let fallback_indent = self.indentation().whitespace_for_columns(leading_columns);
                 let started_transaction = !self.transaction_active();
                 if started_transaction {
                     self.begin_transaction("insert line above");
                 }
                 self.replace_range(
                     TextRange::insertion(TextPosition::new(line, 0)),
-                    &format!("{}\n", " ".repeat(leading_spaces)),
+                    &format!("{fallback_indent}\n"),
                 );
-                self.notify_change(runtime).await?;
-                self.cx = leading_spaces;
+                self.cx = grapheme_len(&fallback_indent);
                 self.mode = Mode::Insert;
                 self.insert_entry_cursor = Some(self.cursor_snapshot());
+                let decision = self.indentation_decision_for_line(line);
+                let target_columns = self.apply_indentation_to_line(line, decision);
+                self.mark_generated_indent(line, target_columns);
+                self.notify_change(runtime).await?;
                 self.refresh_cursor_goal();
                 self.render(buffer)?;
             }
@@ -15388,27 +15532,43 @@ impl Editor {
                 }
 
                 if self.cx > 0 {
-                    // Get the current line to find the previous grapheme boundary
                     if let Some(line) = self.current_line_contents() {
                         let line = line.trim_end_matches('\n');
-                        let prev_grapheme_idx = self.cx - 1;
-
-                        if let Some((start_char, end_char)) =
-                            grapheme_char_range(line, prev_grapheme_idx)
-                        {
-                            let line_num = self.buffer_line();
+                        let prefix = line.graphemes(true).take(self.cx).collect::<String>();
+                        let line_num = self.buffer_line();
+                        if prefix.chars().all(char::is_whitespace) {
+                            let indentation = self.indentation();
+                            let current_column =
+                                display_width_with_tabs(&prefix, indentation.tab_width.max(1));
+                            let stop = indentation.soft_tab_stop.max(1);
+                            let target_column = current_column.saturating_sub(1) / stop * stop;
+                            let replacement = indentation.whitespace_for_columns(target_column);
                             self.replace_range(
                                 TextRange::new(
-                                    TextPosition::new(line_num, start_char),
-                                    TextPosition::new(line_num, end_char),
+                                    TextPosition::new(line_num, 0),
+                                    TextPosition::new(line_num, prefix.chars().count()),
                                 ),
-                                "",
+                                &replacement,
                             );
-                            self.cx = prev_grapheme_idx;
-
-                            self.notify_change(runtime).await?;
-                            self.render_edited_window_rows(buffer)?;
+                            self.cx = grapheme_len(&replacement);
+                        } else {
+                            let prev_grapheme_idx = self.cx - 1;
+                            if let Some((start_char, end_char)) =
+                                grapheme_char_range(line, prev_grapheme_idx)
+                            {
+                                self.replace_range(
+                                    TextRange::new(
+                                        TextPosition::new(line_num, start_char),
+                                        TextPosition::new(line_num, end_char),
+                                    ),
+                                    "",
+                                );
+                                self.cx = prev_grapheme_idx;
+                            }
                         }
+
+                        self.notify_change(runtime).await?;
+                        self.render_edited_window_rows(buffer)?;
                     }
                 } else if self.buffer_line() > 0 {
                     let line_num = self.buffer_line();
@@ -16098,7 +16258,11 @@ impl Editor {
                     let indentation = self.indentation();
                     let request_id = self
                         .lsp
-                        .format_document_with_options(&file, indentation.shift_width, true)
+                        .format_document_with_options(
+                            &file,
+                            indentation.tab_width,
+                            indentation.expand_tab,
+                        )
                         .await?;
                     if request_id > 0 {
                         self.pending_lsp_edit_requests.insert(request_id, pending);
@@ -16618,10 +16782,21 @@ impl Editor {
                 }
             }
             Action::InsertTab => {
-                // TODO: Tab configuration
-                let tabsize = 4;
+                let indentation = self.indentation();
                 let cx = self.cx;
                 let line = self.buffer_line();
+                let contents = self.current_line_contents().unwrap_or_default();
+                let contents = contents.trim_end_matches(&['\r', '\n'][..]);
+                let current_column =
+                    grapheme_to_column_with_tabs(contents, cx, indentation.tab_width.max(1));
+                let stop = indentation.soft_tab_stop.max(1);
+                let target_column = (current_column / stop + 1) * stop;
+                let inserted_columns = target_column - current_column;
+                let inserted = if indentation.expand_tab {
+                    " ".repeat(inserted_columns)
+                } else {
+                    "\t".to_string()
+                };
                 let char_cx = self.grapheme_to_char_on_line(cx, line);
                 let started_transaction = !self.transaction_active();
                 if started_transaction {
@@ -16629,10 +16804,11 @@ impl Editor {
                 }
                 self.replace_range(
                     TextRange::insertion(TextPosition::new(line, char_cx)),
-                    &" ".repeat(tabsize),
+                    &inserted,
                 );
+                self.generated_indent = None;
                 self.notify_change(runtime).await?;
-                self.cx += tabsize;
+                self.cx += grapheme_len(&inserted);
                 self.refresh_cursor_goal();
                 if started_transaction {
                     self.commit_transaction(self.cursor_snapshot());
@@ -17638,6 +17814,19 @@ impl Editor {
                     self.sync_with_window();
                     self.render(buffer)?;
                 }
+            }
+        }
+
+        if let Some(generated) = self.generated_indent {
+            if generated.buffer_id != self.current_buffer().id() {
+                self.generated_indent = None;
+            } else if self.is_insert()
+                && self.buffer_line() != generated.line
+                && self.transaction_active()
+                && self.cleanup_generated_indent()
+            {
+                self.notify_change(runtime).await?;
+                self.render(buffer)?;
             }
         }
 
@@ -21944,7 +22133,7 @@ impl Editor {
         let indentation = self.indentation();
         let request = self
             .lsp
-            .format_document_with_options(&file, indentation.shift_width, true)
+            .format_document_with_options(&file, indentation.tab_width, indentation.expand_tab)
             .await;
         let request_id = match request {
             Ok(request_id) => request_id,
@@ -26399,8 +26588,8 @@ builtin = "rust"
             ('I', "    hello", (8, 0), (4, 0)),
             ('a', "hello", (2, 0), (2, 0)),
             ('A', "hello", (2, 0), (4, 0)),
-            ('o', "    one\nnext", (2, 0), (3, 1)),
-            ('O', "one\n    two", (2, 1), (3, 1)),
+            ('o', "    one\nnext", (2, 0), (0, 1)),
+            ('O', "one\n    two", (2, 1), (0, 1)),
         ];
 
         for (key, contents, start, expected) in cases {

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -1,0 +1,426 @@
+//! Language-aware indentation decisions for newly created and reindented lines.
+//!
+//! Providers are deliberately pure: they inspect a document snapshot and return a
+//! display-column target. The editor remains responsible for applying whitespace
+//! through its undoable text-mutation boundary.
+
+use crate::unicode_utils::display_width_with_tabs;
+
+const PYTHON_BRACKET_LOOKBACK_LINES: usize = 50;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IndentDecision {
+    Keep,
+    Columns(usize),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OpenBracket {
+    character: char,
+    line: usize,
+    char_index: usize,
+    column: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct QuoteState {
+    delimiter: char,
+    triple: bool,
+    escaped: bool,
+}
+
+#[derive(Debug, Default)]
+struct PythonLineAnalysis {
+    code: String,
+    starts_in_multiline_string: bool,
+    stack_before: Vec<OpenBracket>,
+    last_closed_opener: Option<OpenBracket>,
+}
+
+/// Returns the language-specific indentation for `target_line`.
+///
+/// `Keep` means the editor should retain its ordinary auto-indent fallback.
+pub(crate) fn indent_for_line(
+    language_id: Option<&str>,
+    document: &str,
+    target_line: usize,
+    shift_width: usize,
+    tab_width: usize,
+) -> IndentDecision {
+    match language_id {
+        Some("python") => python_indent_for_line(document, target_line, shift_width, tab_width),
+        _ => IndentDecision::Keep,
+    }
+}
+
+/// Mirrors the useful parts of Vim's `indentkeys` for the bundled providers.
+pub(crate) fn should_reindent_after(
+    language_id: Option<&str>,
+    inserted: char,
+    current_line: &str,
+) -> bool {
+    if language_id != Some("python") {
+        return false;
+    }
+
+    if matches!(inserted, ':' | ')' | ']' | '}') {
+        return true;
+    }
+
+    let line = current_line.trim();
+    matches!(line, "elif" | "except")
+}
+
+fn python_indent_for_line(
+    document: &str,
+    target_line: usize,
+    shift_width: usize,
+    tab_width: usize,
+) -> IndentDecision {
+    let shift_width = shift_width.max(1);
+    let tab_width = tab_width.max(1);
+    // `split` preserves the implicit final empty line after a trailing newline,
+    // which is exactly the line `o` or Enter asks us to indent at EOF.
+    let lines = document
+        .split('\n')
+        .map(|line| line.trim_end_matches('\r'))
+        .collect::<Vec<_>>();
+    if target_line >= lines.len() {
+        return IndentDecision::Keep;
+    }
+
+    let analysis = analyze_python(&lines, tab_width);
+    let target = &analysis[target_line];
+    if target.starts_in_multiline_string {
+        return IndentDecision::Keep;
+    }
+
+    let target_indent = indentation_columns(lines[target_line], tab_width);
+    let Some(previous_line) = (0..target_line)
+        .rev()
+        .find(|line| !lines[*line].trim().is_empty())
+    else {
+        return IndentDecision::Columns(0);
+    };
+    let previous_indent = indentation_columns(lines[previous_line], tab_width);
+    let previous_code = analysis[previous_line].code.trim_end();
+
+    // Explicit backslash continuations use two shift widths for their first line,
+    // then retain that continuation indentation.
+    if previous_code.ends_with('\\') {
+        let previous_previous = (0..previous_line)
+            .rev()
+            .find(|line| !lines[*line].trim().is_empty());
+        if previous_previous.is_some_and(|line| analysis[line].code.trim_end().ends_with('\\')) {
+            return IndentDecision::Columns(previous_indent);
+        }
+        return IndentDecision::Columns(previous_indent + shift_width * 2);
+    }
+
+    // Work from the unmatched opener visible immediately before the target line.
+    // The bounded lookup follows Vim's Python indent script and prevents malformed
+    // documents from turning Enter into an unbounded scan.
+    let opener =
+        target.stack_before.iter().rev().find(|opener| {
+            target_line.saturating_sub(opener.line) <= PYTHON_BRACKET_LOOKBACK_LINES
+        });
+    if let Some(opener) = opener {
+        if target
+            .code
+            .trim_start()
+            .chars()
+            .next()
+            .is_some_and(|character| matching_brackets(opener.character, character))
+        {
+            return preserve_manual_dedent(
+                target_indent,
+                indentation_columns(lines[opener.line], tab_width),
+                shift_width,
+            );
+        }
+
+        let opener_line = &analysis[opener.line].code;
+        let content_after_opener = opener_line
+            .chars()
+            .skip(opener.char_index + 1)
+            .any(|character| !character.is_whitespace());
+        if content_after_opener {
+            return IndentDecision::Columns(opener.column + 1);
+        }
+
+        if previous_line > opener.line {
+            return IndentDecision::Columns(previous_indent);
+        }
+
+        let opener_indent = indentation_columns(lines[opener.line], tab_width);
+        let continuation = if target.stack_before.len() > 1 {
+            shift_width
+        } else {
+            shift_width * 2
+        };
+        return IndentDecision::Columns(opener_indent + continuation);
+    }
+
+    // A colon in code opens a Python suite. Comments and strings were blanked by
+    // the lexical pass, so `# note:` and `"value:"` do not trigger this rule.
+    if previous_code.ends_with(':') {
+        return IndentDecision::Columns(previous_indent + shift_width);
+    }
+
+    let target_code = target.code.trim_start();
+    if starts_with_any_keyword(target_code, &["except", "finally"]) {
+        for line in (0..target_line).rev() {
+            let code = analysis[line].code.trim_start();
+            if starts_with_any_keyword(code, &["try", "except"]) {
+                let expected = indentation_columns(lines[line], tab_width);
+                return preserve_manual_dedent(target_indent, expected, shift_width);
+            }
+        }
+        return IndentDecision::Keep;
+    }
+
+    if starts_with_any_keyword(target_code, &["elif", "else"]) {
+        if starts_with_any_keyword(previous_code.trim_start(), &["for", "if", "elif", "try"]) {
+            return IndentDecision::Columns(previous_indent);
+        }
+        return preserve_manual_dedent(
+            target_indent,
+            previous_indent.saturating_sub(shift_width),
+            shift_width,
+        );
+    }
+
+    if starts_with_any_keyword(
+        previous_code.trim_start(),
+        &["break", "continue", "raise", "return", "pass"],
+    ) {
+        return preserve_manual_dedent(
+            target_indent,
+            previous_indent.saturating_sub(shift_width),
+            shift_width,
+        );
+    }
+
+    if let Some(opener) = analysis[previous_line].last_closed_opener {
+        if previous_code
+            .chars()
+            .last()
+            .is_some_and(|character| matching_brackets(opener.character, character))
+        {
+            return preserve_manual_dedent(
+                target_indent,
+                indentation_columns(lines[opener.line], tab_width),
+                shift_width,
+            );
+        }
+    }
+
+    IndentDecision::Keep
+}
+
+fn preserve_manual_dedent(current: usize, expected: usize, shift_width: usize) -> IndentDecision {
+    if current == expected || current + shift_width <= expected {
+        IndentDecision::Keep
+    } else {
+        IndentDecision::Columns(expected)
+    }
+}
+
+fn indentation_columns(line: &str, tab_width: usize) -> usize {
+    let whitespace = line
+        .char_indices()
+        .find(|(_, character)| !character.is_whitespace())
+        .map_or(line, |(index, _)| &line[..index]);
+    display_width_with_tabs(whitespace, tab_width)
+}
+
+fn starts_with_any_keyword(line: &str, keywords: &[&str]) -> bool {
+    keywords.iter().any(|keyword| {
+        line.strip_prefix(keyword).is_some_and(|suffix| {
+            suffix
+                .chars()
+                .next()
+                .is_none_or(|character| !is_identifier(character))
+        })
+    })
+}
+
+fn is_identifier(character: char) -> bool {
+    character == '_' || character.is_alphanumeric()
+}
+
+fn matching_brackets(open: char, close: char) -> bool {
+    matches!((open, close), ('(', ')') | ('[', ']') | ('{', '}'))
+}
+
+fn analyze_python(lines: &[&str], tab_width: usize) -> Vec<PythonLineAnalysis> {
+    let mut analyses = Vec::with_capacity(lines.len());
+    let mut stack = Vec::<OpenBracket>::new();
+    let mut quote = None::<QuoteState>;
+
+    for (line_index, line) in lines.iter().enumerate() {
+        let starts_in_multiline_string = quote.is_some_and(|state| state.triple);
+        let stack_before = stack.clone();
+        let characters = line.chars().collect::<Vec<_>>();
+        let mut code = String::with_capacity(line.len());
+        let mut last_closed_opener = None;
+        let mut index = 0;
+
+        while index < characters.len() {
+            let character = characters[index];
+            if let Some(mut state) = quote {
+                if state.escaped {
+                    state.escaped = false;
+                    quote = Some(state);
+                    code.push(' ');
+                    index += 1;
+                    continue;
+                }
+                if character == '\\' {
+                    state.escaped = true;
+                    quote = Some(state);
+                    code.push(' ');
+                    index += 1;
+                    continue;
+                }
+                if state.triple
+                    && character == state.delimiter
+                    && characters.get(index + 1) == Some(&state.delimiter)
+                    && characters.get(index + 2) == Some(&state.delimiter)
+                {
+                    code.push_str("   ");
+                    quote = None;
+                    index += 3;
+                    continue;
+                }
+                if !state.triple && character == state.delimiter {
+                    quote = None;
+                } else {
+                    quote = Some(state);
+                }
+                code.push(' ');
+                index += 1;
+                continue;
+            }
+
+            if character == '#' {
+                code.extend(std::iter::repeat_n(' ', characters.len() - index));
+                break;
+            }
+
+            if matches!(character, '\'' | '"') {
+                let triple = characters.get(index + 1) == Some(&character)
+                    && characters.get(index + 2) == Some(&character);
+                quote = Some(QuoteState {
+                    delimiter: character,
+                    triple,
+                    escaped: false,
+                });
+                if triple {
+                    code.push_str("   ");
+                    index += 3;
+                } else {
+                    code.push(' ');
+                    index += 1;
+                }
+                continue;
+            }
+
+            if matches!(character, '(' | '[' | '{') {
+                let prefix = characters[..index].iter().collect::<String>();
+                stack.push(OpenBracket {
+                    character,
+                    line: line_index,
+                    char_index: index,
+                    column: display_width_with_tabs(&prefix, tab_width),
+                });
+            } else if matches!(character, ')' | ']' | '}')
+                && stack
+                    .last()
+                    .is_some_and(|open| matching_brackets(open.character, character))
+            {
+                last_closed_opener = stack.pop();
+            }
+
+            code.push(character);
+            index += 1;
+        }
+
+        if quote.is_some_and(|state| !state.triple) {
+            quote = None;
+        }
+        analyses.push(PythonLineAnalysis {
+            code,
+            starts_in_multiline_string,
+            stack_before,
+            last_closed_opener,
+        });
+    }
+
+    analyses
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{indent_for_line, should_reindent_after, IndentDecision};
+
+    fn python(document: &str, line: usize) -> IndentDecision {
+        indent_for_line(Some("python"), document, line, 4, 4)
+    }
+
+    #[test]
+    fn python_suite_colons_indent_but_comment_and_string_colons_do_not() {
+        assert_eq!(
+            python("def something(x):\n    ", 1),
+            IndentDecision::Columns(4)
+        );
+        assert_eq!(python("value = 1  # note:\n", 1), IndentDecision::Keep);
+        assert_eq!(python("value = \"note:\"\n", 1), IndentDecision::Keep);
+    }
+
+    #[test]
+    fn python_continuations_align_or_use_hanging_indent() {
+        assert_eq!(python("call(first,\n     ", 1), IndentDecision::Columns(5));
+        assert_eq!(
+            python("values = [\n        ", 1),
+            IndentDecision::Columns(8)
+        );
+        assert_eq!(
+            python("value = first + \\\n        ", 1),
+            IndentDecision::Columns(8)
+        );
+    }
+
+    #[test]
+    fn python_stop_statements_and_branch_headers_dedent() {
+        assert_eq!(
+            python("if ready:\n    return value\n    ", 2),
+            IndentDecision::Columns(0)
+        );
+        assert_eq!(
+            python("if ready:\n    work()\n    else:", 2),
+            IndentDecision::Columns(0)
+        );
+        assert_eq!(
+            python("try:\n    work()\n    except:", 2),
+            IndentDecision::Columns(0)
+        );
+    }
+
+    #[test]
+    fn python_preserves_an_existing_manual_dedent() {
+        assert_eq!(
+            python("if ready:\n    return value\n", 2),
+            IndentDecision::Keep
+        );
+    }
+
+    #[test]
+    fn python_indent_triggers_match_vim_style_keys() {
+        assert!(should_reindent_after(Some("python"), ':', "    else:"));
+        assert!(should_reindent_after(Some("python"), 'f', "    elif"));
+        assert!(should_reindent_after(Some("python"), 't', "    except"));
+        assert!(!should_reindent_after(Some("python"), 'x', "value = x"));
+        assert!(!should_reindent_after(Some("rust"), ':', "label:"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod dispatcher;
 pub mod editor;
 pub mod headless;
 pub mod highlighter;
+mod indent;
 pub mod language;
 pub mod logger;
 pub mod lsp;

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -425,6 +425,11 @@ fn comment_harness(file: &str, contents: &str) -> EditorHarness {
     EditorHarness::with_config(buffer, default_key_config())
 }
 
+fn python_harness(contents: &str) -> EditorHarness {
+    let buffer = Buffer::new(Some("sample.py".to_string()), contents.to_string());
+    EditorHarness::with_config(buffer, default_key_config())
+}
+
 #[tokio::test]
 async fn comment_gcc_toggles_the_current_line() {
     let mut harness = comment_harness("main.rs", "    let value = 1;");
@@ -2522,7 +2527,7 @@ async fn test_open_line_below() {
 }
 
 #[tokio::test]
-async fn test_enter_on_opened_indented_blank_line_preserves_indentation() {
+async fn test_enter_on_opened_indented_blank_line_moves_generated_indentation() {
     let mut harness = EditorHarness::with_content("fn name() {\n    let a = 1;\n}");
 
     harness.execute_action(Action::MoveDown).await.unwrap();
@@ -2535,7 +2540,226 @@ async fn test_enter_on_opened_indented_blank_line_preserves_indentation() {
     harness.execute_action(Action::InsertNewLine).await.unwrap();
 
     harness.assert_cursor_at(4, 3);
-    harness.assert_buffer_contents("fn name() {\n    let a = 1;\n    \n    \n}");
+    harness.assert_buffer_contents("fn name() {\n    let a = 1;\n\n    \n}");
+}
+
+#[tokio::test]
+async fn python_enter_indents_a_suite_and_dedents_after_return() {
+    let mut harness = python_harness("");
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    harness.type_text("def something(x):").await.unwrap();
+    harness.execute_action(Action::InsertNewLine).await.unwrap();
+    harness.assert_cursor_at(4, 1);
+    harness.type_text("return x").await.unwrap();
+    harness.execute_action(Action::InsertNewLine).await.unwrap();
+
+    harness.assert_cursor_at(0, 2);
+    harness.assert_buffer_contents("def something(x):\n    return x\n");
+}
+
+#[tokio::test]
+async fn python_ignores_colons_in_comments_and_strings() {
+    for source in ["value = 1  # note:", "value = \"note:\""] {
+        let mut harness = python_harness(source);
+        harness
+            .execute_action(Action::EnterMode(Mode::Insert))
+            .await
+            .unwrap();
+        harness.execute_action(Action::MoveToLineEnd).await.unwrap();
+        harness.execute_action(Action::MoveRight).await.unwrap();
+        harness.execute_action(Action::InsertNewLine).await.unwrap();
+        harness.assert_cursor_at(0, 1);
+    }
+}
+
+#[tokio::test]
+async fn python_continuations_align_and_use_hanging_indent() {
+    let mut aligned = python_harness("call(first,");
+    aligned
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    aligned.assert_cursor_at(5, 1);
+    aligned.type_text("second").await.unwrap();
+    aligned.assert_buffer_contents("call(first,\n     second");
+
+    let mut hanging = python_harness("values = [");
+    hanging
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    hanging.assert_cursor_at(8, 1);
+}
+
+#[tokio::test]
+async fn python_typing_else_and_except_reindents_the_current_line() {
+    let mut else_harness = python_harness("if ready:\n    work()\n    ");
+    else_harness
+        .execute_action(Action::MoveToBottom)
+        .await
+        .unwrap();
+    else_harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    else_harness
+        .execute_action(Action::MoveToLineEnd)
+        .await
+        .unwrap();
+    else_harness
+        .execute_action(Action::MoveRight)
+        .await
+        .unwrap();
+    else_harness.type_text("else:").await.unwrap();
+    else_harness.assert_buffer_contents("if ready:\n    work()\nelse:");
+    else_harness.assert_cursor_at(5, 2);
+
+    let mut except_harness = python_harness("try:\n    work()\n    ");
+    except_harness
+        .execute_action(Action::MoveToBottom)
+        .await
+        .unwrap();
+    except_harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    except_harness
+        .execute_action(Action::MoveToLineEnd)
+        .await
+        .unwrap();
+    except_harness
+        .execute_action(Action::MoveRight)
+        .await
+        .unwrap();
+    except_harness.type_text("except:").await.unwrap();
+    except_harness.assert_buffer_contents("try:\n    work()\nexcept:");
+}
+
+#[tokio::test]
+async fn backspace_uses_soft_tab_stops_inside_leading_indentation() {
+    let mut harness = python_harness("values = [");
+    harness
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(8, 1);
+
+    harness
+        .execute_action(Action::DeletePreviousChar)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(4, 1);
+    harness
+        .execute_action(Action::DeletePreviousChar)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(0, 1);
+    harness.type_text("value").await.unwrap();
+    harness.assert_buffer_contents("values = [\nvalue");
+}
+
+#[tokio::test]
+async fn tab_advances_to_the_next_soft_tab_stop() {
+    let mut harness = python_harness("  value");
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::SetCursor(2, 0))
+        .await
+        .unwrap();
+    harness.execute_action(Action::InsertTab).await.unwrap();
+
+    harness.assert_cursor_at(4, 0);
+    harness.assert_buffer_contents("    value");
+}
+
+#[tokio::test]
+async fn untouched_generated_indent_is_removed_on_escape_and_carried_across_enter() {
+    let mut escaped = python_harness("def something(x):");
+    escaped
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    escaped
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    escaped.assert_buffer_contents("def something(x):\n");
+
+    let mut carried = python_harness("def something(x):");
+    carried
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    carried.execute_action(Action::InsertNewLine).await.unwrap();
+    carried.type_text("value").await.unwrap();
+    carried.assert_buffer_contents("def something(x):\n\n    value");
+}
+
+#[tokio::test]
+async fn python_open_above_and_forced_syntax_use_the_same_provider() {
+    let mut above = python_harness("def something(x):\n    value");
+    above.execute_action(Action::MoveDown).await.unwrap();
+    above
+        .execute_action(Action::InsertLineAtCursor)
+        .await
+        .unwrap();
+    above.assert_cursor_at(4, 1);
+    above.type_text("other").await.unwrap();
+    above.assert_buffer_contents("def something(x):\n    other\n    value");
+
+    let buffer = Buffer::new(
+        Some("notes.txt".to_string()),
+        "def something(x):".to_string(),
+    );
+    let mut forced = EditorHarness::with_config(buffer, default_key_config());
+    forced
+        .execute_action(Action::SetSyntax("python".to_string()))
+        .await
+        .unwrap();
+    forced
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    forced.assert_cursor_at(4, 1);
+}
+
+#[tokio::test]
+async fn generated_indent_cleans_up_when_insert_mode_moves_to_another_line() {
+    let mut harness = python_harness("def something(x):\nnext");
+    harness
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("def something(x):\n    \nnext");
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.assert_buffer_contents("def something(x):\n\nnext");
+}
+
+#[tokio::test]
+async fn python_autoindent_and_inserted_text_undo_as_one_change() {
+    let mut harness = python_harness("def something(x):\nnext");
+    harness
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    harness.type_text("value").await.unwrap();
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("def something(x):\n    value\nnext");
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("def something(x):\nnext");
+    harness.execute_action(Action::Redo).await.unwrap();
+    harness.assert_buffer_contents("def something(x):\n    value\nnext");
 }
 
 #[tokio::test]

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -194,8 +194,8 @@ async fn test_tab_after_zwj_grapheme_preserves_emoji() {
     h.execute_action(Action::MoveRight).await.unwrap();
     h.execute_action(Action::InsertTab).await.unwrap();
 
-    h.assert_buffer_contents("👨‍👩‍👧‍👦    x");
-    h.assert_cursor_at(5, 0);
+    h.assert_buffer_contents("👨‍👩‍👧‍👦  x");
+    h.assert_cursor_at(3, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

Red previously copied the current line's whitespace when opening or splitting lines, without considering the active language. In Python, that left users manually indenting suites and continuations, dedenting branch and stop statements, and removing automatic indentation one character at a time.

## What Changed

- Add a language-specific indentation provider and a Python implementation for suites, bracket and backslash continuations, closing brackets, branch headers, and stop statements while ignoring comments and strings.
- Apply indentation on Enter, `o`, and `O`, and reindent Python branch headers as their trigger text is completed.
- Track untouched generated indentation so blank whitespace is removed on Escape or cursor movement and carried correctly across another Enter.
- Make Backspace move to the previous soft tab stop within leading whitespace and Tab advance to the next stop using display columns.
- Keep indentation changes inside editor transactions so text edits, cursor state, undo/redo, and change notifications stay synchronized.

## How to Test

1. Open a Python buffer, type `def something(x):`, and press Enter. Expect the next line to begin at four columns. Type `return x` and press Enter again; expect the new line to dedent to column zero.
2. Open a line containing `values = [`, use `o`, and expect an eight-column hanging indent. Press Backspace twice and expect the cursor to move first to column four and then column zero.
3. Press Enter after `value = "note:"` or `value = 1  # note:`. Expect no extra indentation. Open an automatically indented blank line and press Escape; expect no trailing whitespace to remain.
4. Run `cargo test python_enter_indents_a_suite_and_dedents_after_return` and `cargo test backspace_uses_soft_tab_stops_inside_leading_indentation`; expect both targeted regressions to pass.
