### PR TITLE
fix(completion): exit insert mode on escape

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -28919,6 +28919,48 @@ builtin = "rust"
     }
 
     #[tokio::test]
+    async fn escape_after_completion_filters_out_exits_insert_mode() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(
+            Some("bigram.py".to_string()),
+            "torch.manual_seed(1337".to_string(),
+        );
+        let mut editor =
+            Editor::with_size(lsp, 40, 10, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+        editor.mode = Mode::Insert;
+        editor.cx = "torch.manual_seed(1337".chars().count();
+        editor.refresh_cursor_goal();
+        editor.sync_to_window();
+
+        let mut completion = CompletionUI::new();
+        completion.show(vec![completion_item("manual_seed")], 0, 0);
+        editor.current_dialog = Some(Box::new(completion));
+
+        let mut render_buffer = RenderBuffer::new(40, 10, &Style::default());
+        let mut runtime = Runtime::new();
+        for code in [KeyCode::Char(')'), KeyCode::Esc] {
+            editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(code, KeyModifiers::NONE)),
+                    &mut render_buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            editor.current_buffer().contents(),
+            "torch.manual_seed(1337)"
+        );
+        assert_eq!(editor.mode, Mode::Normal);
+        assert!(editor.current_dialog.is_none());
+    }
+
+    #[tokio::test]
     async fn completion_dialog_redraws_typed_text_in_active_window() {
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -10,7 +10,7 @@ use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
 use crate::{
     config::KeyAction,
-    editor::{Action, RenderBuffer},
+    editor::{Action, Mode, RenderBuffer},
     lsp::types::{CompletionItemKind, CompletionResponseItem, Documentation},
     theme::{SelectionForegroundPriority, Style, Theme, UiStyle},
     unicode_utils::{
@@ -588,7 +588,10 @@ impl Component for CompletionUI {
             }
             Event::Key(KeyEvent {
                 code: KeyCode::Esc, ..
-            }) => Some(KeyAction::Single(Action::CloseDialog)),
+            }) => Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::EnterMode(Mode::Normal),
+            ])),
             Event::Key(KeyEvent {
                 code: KeyCode::Char(c),
                 ..
@@ -923,6 +926,34 @@ mod tests {
         assert_eq!(
             ui.handle_event(&key(KeyCode::Backspace, KeyModifiers::NONE)),
             None
+        );
+    }
+
+    #[test]
+    fn escape_closes_completion_and_leaves_insert_mode() {
+        let mut ui = CompletionUI::new();
+        ui.show(
+            vec![item("manual_seed", Some(CompletionItemKind::Text))],
+            0,
+            0,
+        );
+
+        assert_eq!(
+            ui.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::EnterMode(Mode::Normal),
+            ]))
+        );
+
+        ui.set_filter("manual_seed(1337)");
+        assert!(ui.selected_item().is_none());
+        assert_eq!(
+            ui.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::EnterMode(Mode::Normal),
+            ]))
         );
     }
 


### PR DESCRIPTION
Autocomplete can remain the active dialog after filtering removes every candidate. The popup then renders nothing, but still intercepts Esc to close only the hidden dialog, requiring a second Esc to leave Insert mode.

Make completion Esc handling close the dialog and enter Normal mode as one action. This keeps the modal editing contract consistent whether completion candidates are visible or have filtered down to zero, and adds production-event coverage for the reported Python call sequence.

## How to Test

1. Run Red on a Python file containing a symbol such as manual_seed.
2. In Insert mode, type torch.manual and wait for completion to appear.
3. Finish typing _seed(1337) so the candidates disappear, then press Esc once.
4. Verify the statusline changes directly to NORMAL and the completed text remains intact.
5. With completion still visibly open, press Esc once and verify it also closes the popup and enters Normal mode.

Automated coverage:
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings