### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to Red are documented in this file.
 
+## [0.5.0](https://github.com/codersauce/red/compare/v0.4.0...v0.5.0)
+
+### Features
+
+- **completion:** Add compact async completion menu ([#188](https://github.com/codersauce/red/issues/188)) ([21d16ba](https://github.com/codersauce/red/commit/21d16ba889cc44b97d3ba9ca41412fc280f03c60))
+- **editor:** Add language-aware autoindent ([#184](https://github.com/codersauce/red/issues/184)) ([e72f7d2](https://github.com/codersauce/red/commit/e72f7d2db37d75fd564bc4d52c02edc458139afc))
+- **completion:** Add buffer and automatic suggestions ([f987558](https://github.com/codersauce/red/commit/f987558706604314ab2f8ba9ce4be229bf77b67e))
+
+### Bug Fixes
+
+- **completion:** Exit insert mode on escape ([#187](https://github.com/codersauce/red/issues/187)) ([e10465a](https://github.com/codersauce/red/commit/e10465ae1b6ca40688b0858e31df5bac21ccf0f7))
+- **completion:** Keep autocomplete valid while typing ([#186](https://github.com/codersauce/red/issues/186)) ([9d89583](https://github.com/codersauce/red/commit/9d89583e69afcb34810c9418725d1c926b3d295b))
+- **completion:** Filter by existing identifier prefix ([1a15171](https://github.com/codersauce/red/commit/1a151719a82630600bbb28423970821345ca833e))
+- **completion:** Insert newline when no matches remain ([#182](https://github.com/codersauce/red/issues/182)) ([b2cabfe](https://github.com/codersauce/red/commit/b2cabfe5e1bee01f6893604d724ba95a11b974cb))
+- **editor:** Refresh cursor after inserting tab ([7fa7fcd](https://github.com/codersauce/red/commit/7fa7fcda312849b3d4c3a63a028a25436135fca7))
+
+### Refactoring
+
+- **languages:** Move Python support to official pack ([#185](https://github.com/codersauce/red/issues/185)) ([a152c33](https://github.com/codersauce/red/commit/a152c33db75472b6c63ddb6a6a379cee63c8b1e5))
+
+### Continuous Integration
+
+- **windows:** Pin ripgrep release archive ([96795fe](https://github.com/codersauce/red/commit/96795fe0e63f2582e51294578e010ff1b224d591))
+- **windows:** Retry ripgrep installation ([11912e0](https://github.com/codersauce/red/commit/11912e060c47b64e0cf6d337d503e2c8d445ec9e))
+
+### Other
+
+- Update completion and CI validation ([59334f2](https://github.com/codersauce/red/commit/59334f2f59b57ea5693a0b74cea1eebb17c93824))
+- Improve guide and cli navigation ([e2f2371](https://github.com/codersauce/red/commit/e2f2371110bf0da0d5327322778077b16d04bead))
+- Improve wiki navigation and stale claims ([334c507](https://github.com/codersauce/red/commit/334c507bf3fefa2d2f06b97a79665c2b37615ef0))
+- Refresh plugin api and graph links ([04b7e79](https://github.com/codersauce/red/commit/04b7e796a8515a4d84d60964b3216b95642de691))
+- Document statusline defaults ([b080dbd](https://github.com/codersauce/red/commit/b080dbd5d470bf9358eb5c67b772668f8fafd32c))
+
 ## [0.4.0](https://github.com/codersauce/red/compare/v0.3.0...v0.4.0)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "red"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 default-run = "red"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ files stay yours.
 [Documentation](#documentation) ·
 [Community](https://discord.gg/5PWvAUNRHU)
 
-<!-- current-release: 0.4.0 -->
+<!-- current-release: 0.5.0 -->
 The current documented release is
-[v0.4.0](https://github.com/codersauce/red/releases/tag/v0.4.0).
+[v0.5.0](https://github.com/codersauce/red/releases/tag/v0.5.0).
 
 ![Red editing its Rust rendering pipeline with the project tree open](docs/images/editor-overview.jpg)
 
@@ -64,7 +64,7 @@ The PowerShell installer verifies the release checksum, installs to
 To pin a release or choose another directory:
 
 ```shell
-RED_VERSION=0.4.0 RED_INSTALL_DIR="$HOME/bin" \
+RED_VERSION=0.5.0 RED_INSTALL_DIR="$HOME/bin" \
   sh -c "$(curl --proto '=https' --tlsv1.2 -fsSL https://getred.dev/install.sh)"
 ```
 


### PR DESCRIPTION
## Why

Prepare Red 0.5.0 for review. This release centers on immediate, Neovim-style completion and language-aware indentation, with an important migration for existing Python users.

## What changed

- Updated `Cargo.toml`, `Cargo.lock`, and the README release references to `0.5.0`.
- Prepended the git-cliff-generated `0.5.0` section to `CHANGELOG.md`.
- Includes automatic buffer-backed completion, asynchronous LSP enrichment, compact fuzzy rendering, Neovim-style completion controls, and completion lifecycle fixes.
- Includes language-aware autoindent with Python suite, continuation, branch, stop-statement, and soft-tab behavior.
- Moves Python highlighting, commenting, LSP routing, and indentation configuration to the released `python-language` catalog pack. Existing Python users should install it with:

  ```shell
  red plugin install --catalog python-language --trust-native-grammars
  ```

## How to test

1. Confirm the package, lockfile, README release link, and installer pin all use `0.5.0`.
2. Review every generated changelog group and entry against `v0.4.0...v0.5.0`.
3. Confirm the released `python-language` catalog pack is available and its documented install command succeeds.
4. Confirm CI passes, including Clippy, all platform test/build jobs, changelog verification, and the bundled runtime self-check.

Merging this PR does not publish the release. After merge, create and push the annotated `v0.5.0` tag to start the release workflow and produce a draft GitHub release for separate review.
