### PR TITLE
feat(lsp): add diagnostics picker

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -358,6 +358,8 @@ Esc = { EnterMode = "Normal" }
 "t" = { PluginCommand = "ThemeBrowser" }
 "w" = { PluginCommand = "LspWorkspaceSymbols" }
 "k" = { PluginCommand = "LspReferences" }
+"d" = "OpenDiagnosticsPicker"
+"e" = "OpenErrorDiagnosticsPicker"
 "f" = "FormatDocument"
 "." = "CodeAction"
 "r" = "StartRename"
@@ -366,14 +368,6 @@ Esc = { EnterMode = "Normal" }
 "?" = "CommandPalette"
 "h" = { "s" = { PluginCommand = "GitHunkStage" }, "u" = { PluginCommand = "GitHunkUnstage" }, "r" = { PluginCommand = "GitHunkReset" } }
 "c" = { "c" = { PluginCommand = "GitSubmitMessage" }, "q" = { PluginCommand = "GitCancelMessage" } }
-
-[keys.normal." "."d"]
-"b" = "DumpBuffer"
-"i" = "DumpDiagnostics"
-"c" = "DumpCapabilities"
-"h" = "DumpHistory"
-"l" = "ViewLogs"
-"p" = "ListPlugins"
 
 [keys.normal."d"]
 "d" = "DeleteCurrentLine"

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -751,6 +751,24 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Action::MaximizeWindow,
         ),
         builtin(
+            "lsp.diagnostics",
+            "Diagnostics",
+            "LSP",
+            "Browse all known language-server diagnostics",
+            None,
+            &["problems", "warnings", "errors"],
+            Action::OpenDiagnosticsPicker,
+        ),
+        builtin(
+            "lsp.errors",
+            "Errors",
+            "LSP",
+            "Browse language-server errors",
+            None,
+            &["problems", "diagnostics"],
+            Action::OpenErrorDiagnosticsPicker,
+        ),
+        builtin(
             "lsp.definition",
             "Go to definition",
             "LSP",
@@ -994,6 +1012,8 @@ fn action_label(action: &Action) -> String {
     match action {
         Action::CommandPalette => "All commands".to_string(),
         Action::ConfigDiagnostics => "Configuration diagnostics".to_string(),
+        Action::OpenDiagnosticsPicker => "Diagnostics".to_string(),
+        Action::OpenErrorDiagnosticsPicker => "Errors".to_string(),
         Action::OpenStatuslineManager => "Configure status line".to_string(),
         Action::PluginCommand(name) => humanize_identifier(name),
         Action::Save => "Save file".to_string(),
@@ -1059,7 +1079,6 @@ fn group_label(prefix: &[String], key: &str) -> String {
     match (prefix.as_str(), display_key(key)) {
         ("Space", "h") => "Git hunks".to_string(),
         ("Space", "c") => "Commit message".to_string(),
-        ("Space", "d") => "Debug".to_string(),
         (_, "Ctrl-w") => "Windows".to_string(),
         (_, "g") => "Go to".to_string(),
         (_, "z") => "View".to_string(),
@@ -1149,6 +1168,20 @@ mod tests {
             .shortcuts
             .iter()
             .any(|shortcut| shortcut == "Space f"));
+
+        let diagnostics = entries
+            .iter()
+            .find(|entry| entry.id == "lsp.diagnostics")
+            .unwrap();
+        assert_eq!(diagnostics.action, Action::OpenDiagnosticsPicker);
+        assert_eq!(diagnostics.shortcuts, ["Space d"]);
+
+        let errors = entries
+            .iter()
+            .find(|entry| entry.id == "lsp.errors")
+            .unwrap();
+        assert_eq!(errors.action, Action::OpenErrorDiagnosticsPicker);
+        assert_eq!(errors.shortcuts, ["Space e"]);
 
         let save = entries
             .iter()
@@ -1469,6 +1502,12 @@ mod tests {
         assert!(hints
             .iter()
             .any(|hint| hint.key == "a" && hint.label == "Select all"));
+        assert!(hints
+            .iter()
+            .any(|hint| { hint.key == "d" && hint.label == "Diagnostics" && !hint.is_group }));
+        assert!(hints
+            .iter()
+            .any(|hint| hint.key == "e" && hint.label == "Errors" && !hint.is_group));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3606,7 +3606,7 @@ groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
     }
 
     #[test]
-    fn default_config_maps_ctrl_t_to_lsp_document_symbols() {
+    fn default_config_maps_lsp_navigation_and_actions() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 
         assert_eq!(
@@ -3642,6 +3642,14 @@ groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
             Some(&KeyAction::Single(Action::PluginCommand(
                 "LspReferences".to_string()
             )))
+        );
+        assert_eq!(
+            leader.get("d"),
+            Some(&KeyAction::Single(Action::OpenDiagnosticsPicker))
+        );
+        assert_eq!(
+            leader.get("e"),
+            Some(&KeyAction::Single(Action::OpenErrorDiagnosticsPicker))
         );
         assert_eq!(
             leader.get("f"),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -17,6 +17,7 @@
 
 mod agent_manager;
 mod buffer_manager;
+mod diagnostics_picker;
 mod display_layout;
 mod lsp_coordinator;
 pub(crate) mod perf;
@@ -1937,6 +1938,8 @@ pub enum Action {
     OpenSyntaxPicker,
     SetSyntax(String),
     OpenStatuslineManager,
+    OpenDiagnosticsPicker,
+    OpenErrorDiagnosticsPicker,
     PreviewStatuslineLayout(StatuslineConfig),
     SaveStatuslineLayout(StatuslineConfig),
     CancelStatuslineLayout(StatuslineConfig),
@@ -11304,6 +11307,8 @@ impl Editor {
             | Action::FilePicker
             | Action::CommandPalette
             | Action::OpenStatuslineManager
+            | Action::OpenDiagnosticsPicker
+            | Action::OpenErrorDiagnosticsPicker
             | Action::ConfigDiagnostics
             | Action::Suspend
             | Action::ViewLogs
@@ -17408,6 +17413,16 @@ impl Editor {
             Action::OpenStatuslineManager => {
                 self.release_current_dialog_callbacks(runtime);
                 self.current_dialog = Some(Box::new(StatuslineLayoutPanel::new(self)));
+                self.render(buffer)?;
+            }
+            Action::OpenDiagnosticsPicker => {
+                self.release_current_dialog_callbacks(runtime);
+                self.open_diagnostics_picker(diagnostics_picker::DiagnosticFilter::All);
+                self.render(buffer)?;
+            }
+            Action::OpenErrorDiagnosticsPicker => {
+                self.release_current_dialog_callbacks(runtime);
+                self.open_diagnostics_picker(diagnostics_picker::DiagnosticFilter::Errors);
                 self.render(buffer)?;
             }
             Action::PreviewStatuslineLayout(statusline) => {

--- a/src/editor/diagnostics_picker.rs
+++ b/src/editor/diagnostics_picker.rs
@@ -1,0 +1,434 @@
+//! Editor-owned diagnostics picker built from the latest URI-keyed LSP snapshot.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use serde_json::json;
+
+use crate::{
+    lsp::{normalized_file_path, Diagnostic, DiagnosticSeverity},
+    plugin::{LocationColumnEncoding, OpenLocationTarget, PluginLocation},
+    ui::{Picker, PickerItem, PickerPreview},
+    unicode_utils::grapheme_to_byte,
+    utils::get_workspace_path,
+};
+
+use super::{utf16_to_grapheme, Action, Editor};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DiagnosticFilter {
+    All,
+    Errors,
+}
+
+impl DiagnosticFilter {
+    fn includes(self, diagnostic: &Diagnostic) -> bool {
+        match self {
+            Self::All => true,
+            Self::Errors => matches!(
+                diagnostic.severity.as_ref(),
+                Some(DiagnosticSeverity::Error)
+            ),
+        }
+    }
+
+    fn title(self) -> &'static str {
+        match self {
+            Self::All => "Diagnostics",
+            Self::Errors => "Errors",
+        }
+    }
+
+    fn placeholder(self) -> &'static str {
+        match self {
+            Self::All => "Filter diagnostics",
+            Self::Errors => "Filter errors",
+        }
+    }
+
+    fn empty_message(self) -> &'static str {
+        match self {
+            Self::All => "No diagnostics",
+            Self::Errors => "No errors",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DiagnosticEntry {
+    path: PathBuf,
+    display_path: String,
+    diagnostic: Diagnostic,
+}
+
+struct DiagnosticPickerModel {
+    items: Vec<PickerItem>,
+    actions: HashMap<String, Action>,
+}
+
+impl Editor {
+    pub(super) fn open_diagnostics_picker(&mut self, filter: DiagnosticFilter) {
+        let preview_contents = self
+            .buffer_manager
+            .iter()
+            .filter_map(|buffer| {
+                let uri = buffer.uri().ok().flatten()?;
+                let path = normalized_file_path(&uri).ok()?;
+                Some((path, buffer.contents()))
+            })
+            .collect::<HashMap<_, _>>();
+        let model = diagnostic_picker_model(
+            &self.diagnostics,
+            filter,
+            &get_workspace_path(),
+            &preview_contents,
+        );
+        let actions = model.actions;
+        let mut picker = Picker::builder()
+            .title(filter.title())
+            .structured_items(model.items)
+            .filter_action(diagnostic_filter_score)
+            .placeholder(filter.placeholder())
+            .history_key(match filter {
+                DiagnosticFilter::All => "diagnostics",
+                DiagnosticFilter::Errors => "diagnostic-errors",
+            })
+            .location_preview_contents(preview_contents)
+            .select_action(move |item| {
+                actions.get(&item).cloned().unwrap_or_else(|| {
+                    Action::Print("diagnostic is no longer available".to_string())
+                })
+            })
+            .build(self);
+        picker.set_empty_message(Some(filter.empty_message().to_string()));
+        self.current_dialog = Some(Box::new(picker));
+    }
+}
+
+fn diagnostic_picker_model(
+    diagnostics_by_uri: &HashMap<String, Vec<Diagnostic>>,
+    filter: DiagnosticFilter,
+    workspace: &Path,
+    preview_contents: &HashMap<String, String>,
+) -> DiagnosticPickerModel {
+    let mut entries = diagnostics_by_uri
+        .iter()
+        .filter_map(|(uri, diagnostics)| {
+            normalized_file_path(uri)
+                .ok()
+                .map(|path| (PathBuf::from(path), diagnostics))
+        })
+        .flat_map(|(path, diagnostics)| {
+            let display_path = path
+                .strip_prefix(workspace)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned();
+            diagnostics
+                .iter()
+                .filter(move |diagnostic| filter.includes(diagnostic))
+                .cloned()
+                .map(move |diagnostic| DiagnosticEntry {
+                    path: path.clone(),
+                    display_path: display_path.clone(),
+                    diagnostic,
+                })
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        severity_rank(left.diagnostic.severity.as_ref())
+            .cmp(&severity_rank(right.diagnostic.severity.as_ref()))
+            .then_with(|| left.display_path.cmp(&right.display_path))
+            .then_with(|| {
+                left.diagnostic
+                    .range
+                    .start
+                    .line
+                    .cmp(&right.diagnostic.range.start.line)
+            })
+            .then_with(|| {
+                left.diagnostic
+                    .range
+                    .start
+                    .character
+                    .cmp(&right.diagnostic.range.start.character)
+            })
+            .then_with(|| left.diagnostic.message.cmp(&right.diagnostic.message))
+    });
+
+    let mut items = Vec::with_capacity(entries.len());
+    let mut actions = HashMap::with_capacity(entries.len());
+    for (index, entry) in entries.into_iter().enumerate() {
+        let id = index.to_string();
+        let path = entry.path.to_string_lossy().into_owned();
+        let line = entry.diagnostic.range.start.line;
+        let column = entry.diagnostic.range.start.character;
+        let severity = severity_label(entry.diagnostic.severity.as_ref());
+        let origin = diagnostic_origin(&entry.diagnostic);
+        let display_column = preview_contents
+            .get(&path)
+            .and_then(|contents| diagnostic_display_column(contents, &entry.diagnostic))
+            .unwrap_or(column);
+        let location = format!("{}:{}:{}", entry.display_path, line + 1, display_column + 1);
+        let annotation = origin.as_ref().map_or_else(
+            || location.clone(),
+            |origin| format!("{origin}  {location}"),
+        );
+        let message = entry.diagnostic.message.replace(['\r', '\n'], " ");
+        let search_text = format!(
+            "{} {} {} {}",
+            message,
+            entry.display_path,
+            origin.as_deref().unwrap_or_default(),
+            severity
+        );
+        let matches = preview_contents
+            .get(&path)
+            .map(|contents| diagnostic_preview_matches(contents, &entry.diagnostic))
+            .unwrap_or_default();
+
+        items.push(PickerItem {
+            id: id.clone(),
+            icon: None,
+            label: message.clone(),
+            kind: Some(severity.to_string()),
+            annotation: Some(annotation),
+            detail: None,
+            data: json!({
+                "search_text": search_text,
+                "location": {
+                    "path": path,
+                    "line": line,
+                    "column": column,
+                },
+                "annotation_align": "right",
+                "compact_annotation": location,
+            }),
+            matches: Vec::new(),
+            detail_matches: Vec::new(),
+            preview: Some(PickerPreview::Location {
+                path: path.clone(),
+                line: Some(line),
+                column: Some(column),
+                matches,
+            }),
+        });
+        actions.insert(
+            id,
+            Action::OpenLocation(
+                PluginLocation {
+                    path,
+                    line,
+                    column,
+                    column_encoding: LocationColumnEncoding::Utf16,
+                },
+                OpenLocationTarget::Current,
+            ),
+        );
+    }
+
+    DiagnosticPickerModel { items, actions }
+}
+
+fn diagnostic_filter_score(item: &PickerItem, query: &str) -> Option<i64> {
+    if query.trim().is_empty() {
+        return Some(0);
+    }
+    let matcher = SkimMatcherV2::default();
+    let search_text = item
+        .data
+        .get("search_text")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(&item.label);
+    query.split_whitespace().try_fold(0_i64, |total, token| {
+        matcher
+            .fuzzy_match(search_text, token)
+            .map(|score| total.saturating_add(score))
+    })
+}
+
+fn diagnostic_preview_matches(contents: &str, diagnostic: &Diagnostic) -> Vec<[usize; 2]> {
+    let range = &diagnostic.range;
+    let Some(line) = contents.split('\n').nth(range.start.line) else {
+        return Vec::new();
+    };
+    let start = grapheme_to_byte(line, utf16_to_grapheme(line, range.start.character));
+    let end = if range.end.line == range.start.line {
+        grapheme_to_byte(line, utf16_to_grapheme(line, range.end.character))
+    } else {
+        line.len()
+    };
+    (start < end).then_some([start, end]).into_iter().collect()
+}
+
+fn diagnostic_display_column(contents: &str, diagnostic: &Diagnostic) -> Option<usize> {
+    let start = &diagnostic.range.start;
+    let line = contents.split('\n').nth(start.line)?;
+    Some(utf16_to_grapheme(line, start.character))
+}
+
+fn severity_rank(severity: Option<&DiagnosticSeverity>) -> u8 {
+    match severity {
+        Some(DiagnosticSeverity::Error) => 0,
+        Some(DiagnosticSeverity::Warning) => 1,
+        Some(DiagnosticSeverity::Information) => 2,
+        Some(DiagnosticSeverity::Hint) => 3,
+        None => 4,
+    }
+}
+
+fn severity_label(severity: Option<&DiagnosticSeverity>) -> &'static str {
+    match severity {
+        Some(DiagnosticSeverity::Error) => "Error",
+        Some(DiagnosticSeverity::Warning) => "Warning",
+        Some(DiagnosticSeverity::Information) => "Info",
+        Some(DiagnosticSeverity::Hint) => "Hint",
+        None => "Diagnostic",
+    }
+}
+
+fn diagnostic_origin(diagnostic: &Diagnostic) -> Option<String> {
+    let code = diagnostic.code.as_ref().map(|code| code.as_string());
+    match (diagnostic.source.as_deref(), code) {
+        (Some(source), Some(code)) => Some(format!("{source} ({code})")),
+        (Some(source), None) => Some(source.to_string()),
+        (None, Some(code)) => Some(code),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lsp::{file_uri, DiagnosticCode, Position, Range};
+
+    fn diagnostic(
+        message: &str,
+        severity: Option<DiagnosticSeverity>,
+        line: usize,
+        start: usize,
+        end: usize,
+    ) -> Diagnostic {
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line,
+                    character: start,
+                },
+                end: Position {
+                    line,
+                    character: end,
+                },
+            },
+            severity,
+            code: None,
+            source: None,
+            message: message.to_string(),
+            related_information: None,
+            data: None,
+            tags: None,
+        }
+    }
+
+    #[test]
+    fn all_diagnostics_sort_by_severity_path_and_position() {
+        let workspace = tempfile::tempdir().unwrap();
+        let alpha = workspace.path().join("alpha.py");
+        let beta = workspace.path().join("beta.py");
+        let diagnostics = HashMap::from([
+            (
+                file_uri(&beta).unwrap(),
+                vec![diagnostic(
+                    "warning",
+                    Some(DiagnosticSeverity::Warning),
+                    0,
+                    0,
+                    1,
+                )],
+            ),
+            (
+                file_uri(&alpha).unwrap(),
+                vec![
+                    diagnostic("hint", Some(DiagnosticSeverity::Hint), 1, 0, 1),
+                    diagnostic("error", Some(DiagnosticSeverity::Error), 2, 0, 1),
+                ],
+            ),
+        ]);
+
+        let model = diagnostic_picker_model(
+            &diagnostics,
+            DiagnosticFilter::All,
+            workspace.path(),
+            &HashMap::new(),
+        );
+
+        assert_eq!(
+            model
+                .items
+                .iter()
+                .map(|item| (item.kind.as_deref(), item.label.as_str()))
+                .collect::<Vec<_>>(),
+            [
+                (Some("Error"), "error"),
+                (Some("Warning"), "warning"),
+                (Some("Hint"), "hint"),
+            ]
+        );
+    }
+
+    #[test]
+    fn errors_filter_excludes_other_severities_and_keeps_source_code_searchable() {
+        let workspace = tempfile::tempdir().unwrap();
+        let file = workspace.path().join("main.py");
+        let mut error = diagnostic(
+            "Do not assign a lambda",
+            Some(DiagnosticSeverity::Error),
+            8,
+            3,
+            9,
+        );
+        error.source = Some("Ruff".to_string());
+        error.code = Some(DiagnosticCode::String("E731".to_string()));
+        let diagnostics = HashMap::from([(
+            file_uri(&file).unwrap(),
+            vec![
+                error,
+                diagnostic("unused", Some(DiagnosticSeverity::Warning), 0, 0, 1),
+            ],
+        )]);
+
+        let model = diagnostic_picker_model(
+            &diagnostics,
+            DiagnosticFilter::Errors,
+            workspace.path(),
+            &HashMap::new(),
+        );
+
+        assert_eq!(model.items.len(), 1);
+        assert_eq!(
+            model.items[0].annotation.as_deref(),
+            Some("Ruff (E731)  main.py:9:4")
+        );
+        assert!(diagnostic_filter_score(&model.items[0], "ruff e731").is_some());
+        assert_eq!(model.actions.len(), 1);
+        let Action::OpenLocation(location, OpenLocationTarget::Current) = &model.actions["0"]
+        else {
+            panic!("diagnostic selection should open its source location");
+        };
+        assert_eq!(location.path, file.to_string_lossy());
+        assert_eq!(location.line, 8);
+        assert_eq!(location.column, 3);
+        assert_eq!(location.column_encoding, LocationColumnEncoding::Utf16);
+    }
+
+    #[test]
+    fn preview_matches_convert_utf16_offsets_to_utf8_bytes() {
+        let diagnostic = diagnostic("emoji", Some(DiagnosticSeverity::Error), 0, 1, 3);
+
+        assert_eq!(diagnostic_preview_matches("a😀z\n", &diagnostic), [[1, 5]]);
+        assert_eq!(diagnostic_display_column("a😀z\n", &diagnostic), Some(1));
+    }
+}

--- a/src/editor/diagnostics_picker.rs
+++ b/src/editor/diagnostics_picker.rs
@@ -1,17 +1,19 @@
 //! Editor-owned diagnostics picker built from the latest URI-keyed LSP snapshot.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use ropey::Rope;
 use serde_json::json;
 
 use crate::{
+    buffer::Buffer,
     lsp::{normalized_file_path, Diagnostic, DiagnosticSeverity},
     plugin::{LocationColumnEncoding, OpenLocationTarget, PluginLocation},
-    ui::{Picker, PickerItem, PickerPreview},
+    ui::{Picker, PickerItem, PickerPreview, MAX_UNFOCUSED_PREVIEW_BYTES},
     unicode_utils::grapheme_to_byte,
     utils::get_workspace_path,
 };
@@ -71,15 +73,8 @@ struct DiagnosticPickerModel {
 
 impl Editor {
     pub(super) fn open_diagnostics_picker(&mut self, filter: DiagnosticFilter) {
-        let preview_contents = self
-            .buffer_manager
-            .iter()
-            .filter_map(|buffer| {
-                let uri = buffer.uri().ok().flatten()?;
-                let path = normalized_file_path(&uri).ok()?;
-                Some((path, buffer.contents()))
-            })
-            .collect::<HashMap<_, _>>();
+        let diagnostic_paths = filtered_diagnostic_paths(&self.diagnostics, filter);
+        let preview_contents = diagnostic_preview_contents(&self.buffer_manager, &diagnostic_paths);
         let model = diagnostic_picker_model(
             &self.diagnostics,
             filter,
@@ -108,11 +103,42 @@ impl Editor {
     }
 }
 
+fn filtered_diagnostic_paths(
+    diagnostics_by_uri: &HashMap<String, Vec<Diagnostic>>,
+    filter: DiagnosticFilter,
+) -> HashSet<String> {
+    diagnostics_by_uri
+        .iter()
+        .filter(|(_, diagnostics)| {
+            diagnostics
+                .iter()
+                .any(|diagnostic| filter.includes(diagnostic))
+        })
+        .filter_map(|(uri, _)| normalized_file_path(uri).ok())
+        .collect()
+}
+
+fn diagnostic_preview_contents(
+    buffers: &[Buffer],
+    diagnostic_paths: &HashSet<String>,
+) -> HashMap<String, Rope> {
+    buffers
+        .iter()
+        .filter_map(|buffer| {
+            let uri = buffer.uri().ok().flatten()?;
+            let path = normalized_file_path(&uri).ok()?;
+            diagnostic_paths
+                .contains(&path)
+                .then(|| (path, buffer.contents_snapshot()))
+        })
+        .collect()
+}
+
 fn diagnostic_picker_model(
     diagnostics_by_uri: &HashMap<String, Vec<Diagnostic>>,
     filter: DiagnosticFilter,
     workspace: &Path,
-    preview_contents: &HashMap<String, String>,
+    preview_contents: &HashMap<String, Rope>,
 ) -> DiagnosticPickerModel {
     let mut entries = diagnostics_by_uri
         .iter()
@@ -168,9 +194,12 @@ fn diagnostic_picker_model(
         let column = entry.diagnostic.range.start.character;
         let severity = severity_label(entry.diagnostic.severity.as_ref());
         let origin = diagnostic_origin(&entry.diagnostic);
-        let display_column = preview_contents
+        let preview_line = preview_contents
             .get(&path)
-            .and_then(|contents| diagnostic_display_column(contents, &entry.diagnostic))
+            .and_then(|contents| diagnostic_preview_line(contents, &entry.diagnostic));
+        let display_column = preview_line
+            .as_deref()
+            .and_then(|line| diagnostic_display_column(line, &entry.diagnostic))
             .unwrap_or(column);
         let location = format!("{}:{}:{}", entry.display_path, line + 1, display_column + 1);
         let annotation = origin.as_ref().map_or_else(
@@ -185,9 +214,9 @@ fn diagnostic_picker_model(
             origin.as_deref().unwrap_or_default(),
             severity
         );
-        let matches = preview_contents
-            .get(&path)
-            .map(|contents| diagnostic_preview_matches(contents, &entry.diagnostic))
+        let matches = preview_line
+            .as_deref()
+            .map(|line| diagnostic_preview_matches(line, &entry.diagnostic))
             .unwrap_or_default();
 
         items.push(PickerItem {
@@ -250,11 +279,23 @@ fn diagnostic_filter_score(item: &PickerItem, query: &str) -> Option<i64> {
     })
 }
 
-fn diagnostic_preview_matches(contents: &str, diagnostic: &Diagnostic) -> Vec<[usize; 2]> {
+fn diagnostic_preview_line(contents: &Rope, diagnostic: &Diagnostic) -> Option<String> {
+    let line = contents.get_line(diagnostic.range.start.line)?;
+    if u64::try_from(line.len_bytes()).unwrap_or(u64::MAX) > MAX_UNFOCUSED_PREVIEW_BYTES {
+        return None;
+    }
+    let mut line = line.to_string();
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+    Some(line)
+}
+
+fn diagnostic_preview_matches(line: &str, diagnostic: &Diagnostic) -> Vec<[usize; 2]> {
     let range = &diagnostic.range;
-    let Some(line) = contents.split('\n').nth(range.start.line) else {
-        return Vec::new();
-    };
     let start = grapheme_to_byte(line, utf16_to_grapheme(line, range.start.character));
     let end = if range.end.line == range.start.line {
         grapheme_to_byte(line, utf16_to_grapheme(line, range.end.character))
@@ -264,9 +305,8 @@ fn diagnostic_preview_matches(contents: &str, diagnostic: &Diagnostic) -> Vec<[u
     (start < end).then_some([start, end]).into_iter().collect()
 }
 
-fn diagnostic_display_column(contents: &str, diagnostic: &Diagnostic) -> Option<usize> {
+fn diagnostic_display_column(line: &str, diagnostic: &Diagnostic) -> Option<usize> {
     let start = &diagnostic.range.start;
-    let line = contents.split('\n').nth(start.line)?;
     Some(utf16_to_grapheme(line, start.character))
 }
 
@@ -428,7 +468,65 @@ mod tests {
     fn preview_matches_convert_utf16_offsets_to_utf8_bytes() {
         let diagnostic = diagnostic("emoji", Some(DiagnosticSeverity::Error), 0, 1, 3);
 
-        assert_eq!(diagnostic_preview_matches("a😀z\n", &diagnostic), [[1, 5]]);
-        assert_eq!(diagnostic_display_column("a😀z\n", &diagnostic), Some(1));
+        assert_eq!(diagnostic_preview_matches("a😀z", &diagnostic), [[1, 5]]);
+        assert_eq!(diagnostic_display_column("a😀z", &diagnostic), Some(1));
+    }
+
+    #[test]
+    fn preview_snapshots_only_include_buffers_with_filtered_diagnostics() {
+        let workspace = tempfile::tempdir().unwrap();
+        let error_path = workspace.path().join("error.py");
+        let warning_path = workspace.path().join("warning.py");
+        let unrelated_path = workspace.path().join("unrelated.py");
+        let diagnostics = HashMap::from([
+            (
+                file_uri(&error_path).unwrap(),
+                vec![diagnostic(
+                    "error",
+                    Some(DiagnosticSeverity::Error),
+                    0,
+                    0,
+                    1,
+                )],
+            ),
+            (
+                file_uri(&warning_path).unwrap(),
+                vec![diagnostic(
+                    "warning",
+                    Some(DiagnosticSeverity::Warning),
+                    0,
+                    0,
+                    1,
+                )],
+            ),
+        ]);
+        let buffers = vec![
+            Buffer::new(
+                Some(error_path.to_string_lossy().into_owned()),
+                "unsaved error\n".to_string(),
+            ),
+            Buffer::new(
+                Some(warning_path.to_string_lossy().into_owned()),
+                "unsaved warning\n".to_string(),
+            ),
+            Buffer::new(
+                Some(unrelated_path.to_string_lossy().into_owned()),
+                "x".repeat(MAX_UNFOCUSED_PREVIEW_BYTES as usize * 2),
+            ),
+        ];
+
+        let paths = filtered_diagnostic_paths(&diagnostics, DiagnosticFilter::Errors);
+        let snapshots = diagnostic_preview_contents(&buffers, &paths);
+
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(
+            snapshots
+                .get(&error_path.to_string_lossy().into_owned())
+                .map(ToString::to_string)
+                .as_deref(),
+            Some("unsaved error\n")
+        );
+        assert!(!snapshots.contains_key(&warning_path.to_string_lossy().into_owned()));
+        assert!(!snapshots.contains_key(&unrelated_path.to_string_lossy().into_owned()));
     }
 }

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -3163,6 +3163,7 @@ mod tests {
             },
             severity: None,
             code: None,
+            source: None,
             message: message.to_string(),
             related_information: None,
             data: None,

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1959,6 +1959,7 @@ mod test {
         let diag = &msg.diagnostics[0];
         let code = diag.code.as_ref().unwrap();
         assert_eq!(code.as_string(), "dead_code");
+        assert_eq!(diag.source.as_deref(), Some("rustc"));
     }
 
     #[tokio::test]

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -33,7 +33,7 @@ pub struct Diagnostic {
     pub severity: Option<DiagnosticSeverity>,
     pub code: Option<DiagnosticCode>,
     // pub code_description: Option<DiagnosticCodeDescription>,
-    // pub source: Option<String>,
+    pub source: Option<String>,
     pub message: String,
     pub related_information: Option<Vec<DiagnosticRelatedInformation>>,
     pub data: Option<Value>,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -43,6 +43,7 @@ pub use info::Info;
 pub use input_prompt::InputPrompt;
 pub(crate) use keymap_hints::draw_keymap_hints;
 use list::List;
+pub(crate) use picker::MAX_UNFOCUSED_PREVIEW_BYTES;
 pub use picker::{
     LegacyPickerOptions, Picker, PickerIcon, PickerItem, PickerOptions, PickerPresentation,
     PickerPreview, PickerUpdate,

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -17,7 +17,7 @@ use std::{
     borrow::Cow,
     cell::{Cell, RefCell},
     cmp::Reverse,
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     io::{self, BufRead as _, BufReader, Read as _, Seek as _, SeekFrom},
     path::PathBuf,
     sync::Arc,
@@ -313,6 +313,7 @@ pub struct Picker {
     preview_scroll: isize,
     preview_highlighter: PreviewHighlighter,
     preview_text_cache: RefCell<VecDeque<Arc<CachedLocationPreview>>>,
+    location_preview_overrides: HashMap<String, Arc<CachedLocationPreview>>,
     history_key: Option<String>,
     history: Vec<String>,
     history_navigation: Option<PickerHistoryNavigation>,
@@ -480,6 +481,7 @@ impl Picker {
             preview_scroll: 0,
             preview_highlighter: PreviewHighlighter::new(&editor.theme, editor.language_registry()),
             preview_text_cache: RefCell::new(VecDeque::new()),
+            location_preview_overrides: HashMap::new(),
             history_key: None,
             history: Vec::new(),
             history_navigation: None,
@@ -1148,6 +1150,13 @@ impl Picker {
                     "peekViewResult.fileForeground",
                 ])
                 .or_else(|| Some(self.theme.ui_style.picker_prompt.clone())),
+            "hint" => self
+                .color_style(&[
+                    "editorHint.foreground",
+                    "notificationsInfoIcon.foreground",
+                    "editorInfo.foreground",
+                ])
+                .or_else(|| Some(self.theme.ui_style.muted.clone())),
             "gitbranch" | "gitremote" => self
                 .color_style(&[
                     "gitDecoration.submoduleResourceForeground",
@@ -2097,6 +2106,9 @@ impl Picker {
         preview_scroll: isize,
         preview_height: usize,
     ) -> Arc<CachedLocationPreview> {
+        if let Some(preview) = self.location_preview_overrides.get(path) {
+            return Arc::clone(preview);
+        }
         let metadata = std::fs::metadata(path).ok();
         let modified = metadata
             .as_ref()
@@ -2554,6 +2566,9 @@ fn unicode_picker_kind_icon(kind: &str) -> &'static str {
         "Preferred" | "Proceed" | "Success" | "Added" | "Created" | "Staged" => "✓",
         "Warning" | "Warn" | "Modified" | "Permission" | "Amend" => "⚠",
         "Error" | "Failed" | "Deleted" | "Conflict" | "Destructive" => "✗",
+        "Info" => "ℹ",
+        "Hint" => "◆",
+        "Diagnostic" => "●",
         "Cancel" | "Close" => "×",
         "GitCommit" => "●",
         "GitBranch" => "⌁",
@@ -2604,6 +2619,9 @@ fn nerd_font_picker_kind_icon(kind: &str) -> &'static str {
         "Preferred" | "Proceed" | "Success" | "Added" | "Created" | "Staged" => "",
         "Warning" | "Warn" | "Modified" | "Permission" | "Amend" => "",
         "Error" | "Failed" | "Deleted" | "Conflict" | "Destructive" => "",
+        "Info" => "",
+        "Hint" => "",
+        "Diagnostic" => "",
         "Cancel" | "Close" => "󰅖",
         "GitCommit" => "",
         "GitBranch" => "",
@@ -2639,6 +2657,9 @@ fn ascii_picker_kind_icon(kind: &str) -> &'static str {
         "Preferred" | "Proceed" | "Success" | "Added" | "Created" | "Staged" => "+",
         "Warning" | "Warn" | "Modified" | "Permission" | "Amend" => "!",
         "Error" | "Failed" | "Deleted" | "Conflict" | "Destructive" => "x",
+        "Info" => "i",
+        "Hint" => "h",
+        "Diagnostic" => "d",
         "Cancel" | "Close" => "x",
         "GitCommit" => "o",
         "GitBranch" => "b",
@@ -3264,6 +3285,7 @@ pub struct PickerBuilder {
     status: Option<String>,
     busy: bool,
     history_key: Option<String>,
+    location_preview_contents: HashMap<String, String>,
     content_sizing: Option<PickerContentSizing>,
     status_on_query_line: bool,
 }
@@ -3289,6 +3311,7 @@ impl PickerBuilder {
             status: None,
             busy: false,
             history_key: None,
+            location_preview_contents: HashMap::new(),
             content_sizing: None,
             status_on_query_line: false,
         }
@@ -3371,6 +3394,12 @@ impl PickerBuilder {
         self
     }
 
+    /// Uses editor snapshots instead of disk contents for matching location previews.
+    pub(crate) fn location_preview_contents(mut self, contents: HashMap<String, String>) -> Self {
+        self.location_preview_contents = contents;
+        self
+    }
+
     /// Fits an editor-owned picker to its rows while retaining a bounded, readable width.
     pub(crate) fn content_sized(mut self, max_width: usize, max_rows: usize) -> Self {
         self.content_sizing = Some(PickerContentSizing {
@@ -3412,6 +3441,7 @@ impl PickerBuilder {
         let status = self.status;
         let busy = self.busy;
         let history_key = self.history_key;
+        let location_preview_contents = self.location_preview_contents;
         let content_sizing = self.content_sizing;
         let status_on_query_line = self.status_on_query_line;
 
@@ -3434,6 +3464,25 @@ impl PickerBuilder {
             let history = editor.picker_history(&history_key).to_vec();
             picker.set_history(history_key, history);
         }
+        picker.location_preview_overrides = location_preview_contents
+            .into_iter()
+            .map(|(path, contents)| {
+                let text = Arc::<str>::from(contents);
+                let preview = Arc::new(CachedLocationPreview {
+                    path: path.clone(),
+                    modified: None,
+                    len: u64::try_from(text.len()).unwrap_or(u64::MAX),
+                    line_starts: preview_line_starts(&text),
+                    text,
+                    first_line: 0,
+                    source_offset: 0,
+                    requested_start: 0,
+                    requested_height: 0,
+                    complete: true,
+                });
+                (path, preview)
+            })
+            .collect();
         picker.content_sizing = content_sizing;
         picker.status_on_query_line = status_on_query_line;
         picker.resize_to_viewport(editor.vwidth(), editor.vheight());
@@ -3444,15 +3493,20 @@ impl PickerBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
     };
 
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
     use serde_json::json;
 
-    use super::{picker_file_icon, picker_file_icon_color, PickerFilterHighlights};
+    use super::{
+        picker_file_icon, picker_file_icon_color, picker_kind_icon, PickerFilterHighlights,
+    };
     use crate::{
         buffer::Buffer,
         color::{contrast_ratio, Color},
@@ -4529,6 +4583,31 @@ mod tests {
         assert_eq!(border.style.fg, Some(border_fg));
         assert_eq!(prompt.style.fg, Some(prompt_fg));
         assert_eq!(picker.dialog.style.bg, Some(popup_bg));
+    }
+
+    #[test]
+    fn location_preview_can_use_an_unsaved_buffer_snapshot() {
+        let editor = test_editor();
+        let path = "/tmp/red-unsaved-preview.py".to_string();
+        let contents = "value = 'unsaved'\n".to_string();
+        let picker = Picker::builder()
+            .structured_items(vec![dynamic_item("diagnostic", "diagnostic")])
+            .location_preview_contents(HashMap::from([(path.clone(), contents.clone())]))
+            .build(&editor);
+
+        let preview = picker.location_preview(&path, Some(0), 0, 10);
+
+        assert_eq!(preview.text.as_ref(), contents);
+        assert!(preview.complete);
+        assert_eq!(preview.first_line, 0);
+    }
+
+    #[test]
+    fn diagnostic_kinds_have_icons_in_every_visible_icon_style() {
+        assert_eq!(picker_kind_icon("Info", PickerIconStyle::Unicode), "ℹ");
+        assert_eq!(picker_kind_icon("Hint", PickerIconStyle::NerdFont), "");
+        assert_eq!(picker_kind_icon("Diagnostic", PickerIconStyle::Ascii), "d");
+        assert_eq!(picker_kind_icon("Error", PickerIconStyle::None), "");
     }
 
     #[test]

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -11,6 +11,7 @@
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
+use ropey::{Rope, RopeSlice};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{
@@ -48,7 +49,7 @@ type FilterTieBreaker = Box<dyn Fn(&PickerItem) -> usize + Send>;
 type FilterHighlightAction = Box<dyn Fn(&PickerItem, &str) -> PickerFilterHighlights + Send>;
 const MIN_HORIZONTAL_PREVIEW_PANE_WIDTH: usize = 40;
 const MAX_PREVIEW_HIGHLIGHT_BYTES: usize = 64 * 1024;
-const MAX_UNFOCUSED_PREVIEW_BYTES: u64 = 256 * 1024;
+pub(crate) const MAX_UNFOCUSED_PREVIEW_BYTES: u64 = 256 * 1024;
 const MAX_LOCATION_PREVIEW_SCAN_BYTES: usize = 8 * 1024 * 1024;
 const LOCATION_PREVIEW_CACHE_CAPACITY: usize = 8;
 const COMMAND_COLUMN_GAP: usize = 2;
@@ -313,7 +314,7 @@ pub struct Picker {
     preview_scroll: isize,
     preview_highlighter: PreviewHighlighter,
     preview_text_cache: RefCell<VecDeque<Arc<CachedLocationPreview>>>,
-    location_preview_overrides: HashMap<String, Arc<CachedLocationPreview>>,
+    location_preview_overrides: HashMap<String, Rope>,
     history_key: Option<String>,
     history: Vec<String>,
     history_navigation: Option<PickerHistoryNavigation>,
@@ -2106,19 +2107,23 @@ impl Picker {
         preview_scroll: isize,
         preview_height: usize,
     ) -> Arc<CachedLocationPreview> {
-        if let Some(preview) = self.location_preview_overrides.get(path) {
-            return Arc::clone(preview);
-        }
-        let metadata = std::fs::metadata(path).ok();
+        let override_contents = self.location_preview_overrides.get(path);
+        let metadata = override_contents
+            .is_none()
+            .then(|| std::fs::metadata(path).ok())
+            .flatten();
         let modified = metadata
             .as_ref()
             .and_then(|metadata| metadata.modified().ok());
-        let len = metadata.as_ref().map_or(0, std::fs::Metadata::len);
+        let len = override_contents.map_or_else(
+            || metadata.as_ref().map_or(0, std::fs::Metadata::len),
+            |contents| u64::try_from(contents.len_bytes()).unwrap_or(u64::MAX),
+        );
         let requested_start = location_preview_start(
             focus_line,
             preview_scroll,
             preview_height,
-            /*line_count*/ None,
+            override_contents.map(rope_preview_line_count),
         );
         let mut cache = self.preview_text_cache.borrow_mut();
         let cached_index = cache.iter().position(|cached| {
@@ -2136,33 +2141,48 @@ impl Picker {
         }
 
         let complete = len <= MAX_UNFOCUSED_PREVIEW_BYTES;
-        let checkpoint = cache
-            .iter()
-            .filter(|cached| {
-                modified.is_some()
-                    && cached.path == path
-                    && cached.modified == modified
-                    && cached.len == len
-                    && cached.first_line <= requested_start
-                    && (cached.first_line == 0 || cached.source_offset > 0)
-            })
-            .max_by_key(|cached| cached.first_line)
-            .map(|cached| (cached.first_line, cached.source_offset));
-        let (text, first_line, source_offset) = read_location_preview(
-            path,
-            complete,
-            focus_line,
-            preview_scroll,
-            preview_height,
-            checkpoint,
-        )
-        .unwrap_or_else(|error| {
-            (
-                format!("Unable to preview {path}: {error}"),
-                requested_start,
-                0,
-            )
+        let checkpoint = override_contents.is_none().then(|| {
+            cache
+                .iter()
+                .filter(|cached| {
+                    modified.is_some()
+                        && cached.path == path
+                        && cached.modified == modified
+                        && cached.len == len
+                        && cached.first_line <= requested_start
+                        && (cached.first_line == 0 || cached.source_offset > 0)
+                })
+                .max_by_key(|cached| cached.first_line)
+                .map(|cached| (cached.first_line, cached.source_offset))
         });
+        let (text, first_line, source_offset) = override_contents.map_or_else(
+            || {
+                read_location_preview(
+                    path,
+                    complete,
+                    focus_line,
+                    preview_scroll,
+                    preview_height,
+                    checkpoint.flatten(),
+                )
+                .unwrap_or_else(|error| {
+                    (
+                        format!("Unable to preview {path}: {error}"),
+                        requested_start,
+                        0,
+                    )
+                })
+            },
+            |contents| {
+                read_rope_location_preview(
+                    contents,
+                    complete,
+                    focus_line,
+                    preview_scroll,
+                    preview_height,
+                )
+            },
+        );
         let text = Arc::<str>::from(text);
         let line_starts = preview_line_starts(&text);
         let preview = Arc::new(CachedLocationPreview {
@@ -2177,7 +2197,7 @@ impl Picker {
             requested_height: preview_height,
             complete,
         });
-        if metadata.is_some() {
+        if override_contents.is_some() || metadata.is_some() {
             cache.retain(|cached| {
                 cached.path != path || (cached.modified == modified && cached.len == len)
             });
@@ -2744,6 +2764,63 @@ fn location_preview_start(
     max_start.map_or(start, |max_start| start.min(max_start))
 }
 
+fn rope_preview_line_count(contents: &Rope) -> usize {
+    if contents.len_chars() == 0 {
+        return 0;
+    }
+    contents
+        .len_lines()
+        .saturating_sub(usize::from(contents.char(contents.len_chars() - 1) == '\n'))
+}
+
+fn read_rope_location_preview(
+    contents: &Rope,
+    complete: bool,
+    focus_line: Option<usize>,
+    preview_scroll: isize,
+    preview_height: usize,
+) -> (String, usize, u64) {
+    if complete {
+        return (contents.to_string(), 0, 0);
+    }
+
+    let line_count = rope_preview_line_count(contents);
+    let start_line =
+        location_preview_start(focus_line, preview_scroll, preview_height, Some(line_count));
+    let max_lines = preview_height
+        .max(1)
+        .min(MAX_UNFOCUSED_PREVIEW_BYTES as usize);
+    let max_line_bytes = (MAX_UNFOCUSED_PREVIEW_BYTES as usize / max_lines).saturating_sub(1);
+    let mut text = String::new();
+    for line_index in start_line..start_line.saturating_add(max_lines).min(line_count) {
+        push_bounded_rope_line(&mut text, contents.line(line_index), max_line_bytes);
+    }
+    let source_offset = if start_line < contents.len_lines() {
+        u64::try_from(contents.line_to_byte(start_line)).unwrap_or(u64::MAX)
+    } else {
+        u64::try_from(contents.len_bytes()).unwrap_or(u64::MAX)
+    };
+    (text, start_line, source_offset)
+}
+
+fn push_bounded_rope_line(text: &mut String, line: RopeSlice<'_>, max_line_bytes: usize) {
+    let has_line_ending = line
+        .get_char(line.len_chars().saturating_sub(1))
+        .is_some_and(|character| character == '\n');
+    let mut copied: usize = 0;
+    for character in line.chars().take_while(|character| *character != '\n') {
+        let character_bytes = character.len_utf8();
+        if copied.saturating_add(character_bytes) > max_line_bytes {
+            break;
+        }
+        text.push(character);
+        copied += character_bytes;
+    }
+    if has_line_ending {
+        text.push('\n');
+    }
+}
+
 fn read_location_preview(
     path: &str,
     complete: bool,
@@ -3285,7 +3362,7 @@ pub struct PickerBuilder {
     status: Option<String>,
     busy: bool,
     history_key: Option<String>,
-    location_preview_contents: HashMap<String, String>,
+    location_preview_contents: HashMap<String, Rope>,
     content_sizing: Option<PickerContentSizing>,
     status_on_query_line: bool,
 }
@@ -3394,8 +3471,8 @@ impl PickerBuilder {
         self
     }
 
-    /// Uses editor snapshots instead of disk contents for matching location previews.
-    pub(crate) fn location_preview_contents(mut self, contents: HashMap<String, String>) -> Self {
+    /// Uses structurally shared editor snapshots instead of disk contents for location previews.
+    pub(crate) fn location_preview_contents(mut self, contents: HashMap<String, Rope>) -> Self {
         self.location_preview_contents = contents;
         self
     }
@@ -3464,25 +3541,7 @@ impl PickerBuilder {
             let history = editor.picker_history(&history_key).to_vec();
             picker.set_history(history_key, history);
         }
-        picker.location_preview_overrides = location_preview_contents
-            .into_iter()
-            .map(|(path, contents)| {
-                let text = Arc::<str>::from(contents);
-                let preview = Arc::new(CachedLocationPreview {
-                    path: path.clone(),
-                    modified: None,
-                    len: u64::try_from(text.len()).unwrap_or(u64::MAX),
-                    line_starts: preview_line_starts(&text),
-                    text,
-                    first_line: 0,
-                    source_offset: 0,
-                    requested_start: 0,
-                    requested_height: 0,
-                    complete: true,
-                });
-                (path, preview)
-            })
-            .collect();
+        picker.location_preview_overrides = location_preview_contents;
         picker.content_sizing = content_sizing;
         picker.status_on_query_line = status_on_query_line;
         picker.resize_to_viewport(editor.vwidth(), editor.vheight());
@@ -3502,6 +3561,7 @@ mod tests {
     };
 
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+    use ropey::Rope;
     use serde_json::json;
 
     use super::{
@@ -4592,7 +4652,7 @@ mod tests {
         let contents = "value = 'unsaved'\n".to_string();
         let picker = Picker::builder()
             .structured_items(vec![dynamic_item("diagnostic", "diagnostic")])
-            .location_preview_contents(HashMap::from([(path.clone(), contents.clone())]))
+            .location_preview_contents(HashMap::from([(path.clone(), Rope::from_str(&contents))]))
             .build(&editor);
 
         let preview = picker.location_preview(&path, Some(0), 0, 10);
@@ -4600,6 +4660,34 @@ mod tests {
         assert_eq!(preview.text.as_ref(), contents);
         assert!(preview.complete);
         assert_eq!(preview.first_line, 0);
+    }
+
+    #[test]
+    fn unsaved_buffer_snapshot_keeps_large_location_preview_bounded() {
+        const FOCUS_LINE: usize = 4_000;
+
+        let editor = test_editor();
+        let path = "/tmp/red-large-unsaved-preview.py".to_string();
+        let mut contents = String::new();
+        for line in 0..5_000 {
+            if line == FOCUS_LINE {
+                contents.push_str("unsaved diagnostic location\n");
+            } else {
+                contents.push_str(&format!("line {line:04} {}\n", "x".repeat(64)));
+            }
+        }
+        assert!(contents.len() > super::MAX_UNFOCUSED_PREVIEW_BYTES as usize);
+        let picker = Picker::builder()
+            .structured_items(vec![dynamic_item("diagnostic", "diagnostic")])
+            .location_preview_contents(HashMap::from([(path.clone(), Rope::from_str(&contents))]))
+            .build(&editor);
+
+        let preview = picker.location_preview(&path, Some(FOCUS_LINE), 0, 10);
+
+        assert!(!preview.complete);
+        assert!(preview.text.len() <= super::MAX_UNFOCUSED_PREVIEW_BYTES as usize);
+        assert!(preview.text.contains("unsaved diagnostic location"));
+        assert_eq!(preview.first_line, FOCUS_LINE - 5);
     }
 
     #[test]

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -5746,8 +5746,8 @@ async fn focused_agent_panel_keeps_global_leader_until_the_composer_is_focused()
     let Some(KeyAction::Nested(leader)) = action else {
         panic!("expected Space to start the leader sequence from the conversation, got {action:?}");
     };
-    assert_eq!(leader.len(), 5);
-    for global in ["A", "?", "d", "P", "s"] {
+    assert_eq!(leader.len(), 6);
+    for global in ["A", "?", "d", "e", "P", "s"] {
         assert!(
             leader.contains_key(global),
             "global leader branch {global:?} must remain available"


### PR DESCRIPTION
LSP diagnostics are visible inline, but Red has not provided a workspace-level way to scan, filter, preview, and navigate them. The default `Space d` prefix was also reserved for developer dump actions instead of this frequent editing workflow.

This change adds structured pickers for all known diagnostics and errors only. Results are ordered by severity and location, searchable by message, path, source, and code, and paired with a source preview that prefers unsaved editor contents. Selecting a result navigates using the original UTF-16 LSP location.

The default keymap now opens diagnostics with `Space d` and errors with `Space e`; both actions are also discoverable through the command palette. The underlying debug commands remain available through command discovery without occupying a default leader prefix.

## How to Test

1. Open a file with language-server errors and warnings, then press `Space d`. Expect all known diagnostics to appear with severity icons, locations, and a source preview.
2. Filter by message, file path, diagnostic source, or code. Select a result and expect Red to jump to its exact source location.
3. Press `Space e`. Expect warnings, hints, and informational diagnostics to be excluded.
4. Open either picker when no matching diagnostics exist. Expect the picker to remain usable and show `No diagnostics` or `No errors`.
5. Run `cargo test --all-features` and `cargo clippy --all-targets --all-features -- -D warnings`.
