### PR TITLE
fix(neotree): highlight newly created files

### DIFF
--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -73,6 +73,7 @@ struct FileOperationResult {
     ok: bool,
     error: Option<String>,
     undo_supported: bool,
+    created: [String],
 }
 
 struct PathOperation {
@@ -155,6 +156,7 @@ struct NeoTreeState {
     pending_extension: String,
     pending_source: String,
     pending_parent: String,
+    select_created_file: bool,
     reveal_target: String,
     reveal_parts: [String],
     reveal_index: i32,
@@ -187,6 +189,7 @@ fn initial_state() -> NeoTreeState {
         pending_extension: "",
         pending_source: "",
         pending_parent: ".",
+        select_created_file: false,
         reveal_target: "",
         reveal_parts: [],
         reveal_index: 0,
@@ -411,6 +414,7 @@ fn open_path_prompt(kind: String, title: String, initial: String, source: String
 
 fn path_prompt_cancelled(event: ComposerCancelled) {
     red::state_patch(NeoTreeState { pending_kind: "" });
+    red::state_patch(NeoTreeState { select_created_file: false });
 }
 
 fn path_prompt_submitted(value: String) {
@@ -427,6 +431,7 @@ fn path_prompt_submitted(value: String) {
         if kind == "create" && red::ends_with(query, "/") {
             create_kind = "create_directory";
         }
+        red::state_patch(NeoTreeState { select_created_file: create_kind == "create" });
         request_path_operation(PathOperation {
             kind: create_kind,
             path: path_join(parent, query),
@@ -464,10 +469,15 @@ fn request_paths_operation(operation: PathsOperation) {
 fn operation_loaded(result: FileOperationResult) {
     let kind = red::string(state().pending_kind, "operation");
     if !red::bool(result.ok, false) {
+        red::state_patch(NeoTreeState { select_created_file: false });
         red::execute("Print", "Neo-tree " + kind + " failed: " + optional_text(result.error, "unknown error"));
         return;
     }
 
+    let created_file = "";
+    if red::bool(state().select_created_file, false) && red::len(result.created) > 0 {
+        created_file = result.created[0];
+    }
     if kind == "trash" && red::bool(result.undo_supported, false) {
         red::state_patch(NeoTreeState { trash_history: red::push(state().trash_history, TrashBatch {
             paths: state().pending_paths,
@@ -475,8 +485,13 @@ fn operation_loaded(result: FileOperationResult) {
     }
     red::state_patch(NeoTreeState { selected: [] });
     red::state_patch(NeoTreeState { pending_kind: "" });
+    red::state_patch(NeoTreeState { select_created_file: false });
     red::execute("Print", "Neo-tree " + kind + " complete");
-    reset_tree();
+    if created_file != "" {
+        reset_tree_revealing(created_file);
+    } else {
+        reset_tree();
+    }
 }
 
 fn selected_paths(row: TreePanelRow) -> [String] {
@@ -676,6 +691,10 @@ fn show_help() {
 }
 
 fn reset_tree() {
+    reset_tree_revealing("");
+}
+
+fn reset_tree_revealing(path: String) {
     for watch in state().watches {
         red::execute("UnwatchDirectory", watch.id);
     }
@@ -683,6 +702,9 @@ fn reset_tree() {
     red::state_patch(NeoTreeState { children: [] });
     red::state_patch(NeoTreeState { expanded: ["."] });
     clear_reveal();
+    if path != "" {
+        prepare_reveal(path);
+    }
     request_directory(".");
     request_git_status();
 }
@@ -814,17 +836,25 @@ fn tree_path_for_file(file: String, cwd: String) -> String {
 }
 
 fn start_reveal(tree_path: String) {
+    if !prepare_reveal(tree_path) {
+        return;
+    }
+
+    add_expanded(".");
+    continue_reveal();
+}
+
+fn prepare_reveal(tree_path: String) -> bool {
     let parts = red::neotree_core("reveal_parts", tree_path);
     if red::len(parts) == 0 {
-        return;
+        return false;
     }
 
     red::state_patch(NeoTreeState { reveal_target: tree_path });
     red::state_patch(NeoTreeState { reveal_parts: parts });
     red::state_patch(NeoTreeState { reveal_index: 0 });
     red::state_patch(NeoTreeState { reveal_parent: "." });
-    add_expanded(".");
-    continue_reveal();
+    return true;
 }
 
 fn continue_reveal() {

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -12170,6 +12170,134 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn neotree_selects_a_new_file_after_refreshing_its_parent() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("neotree", include_str!("../../plugins/neotree.hk"))
+            .await
+            .unwrap();
+
+        runtime
+            .notify(
+                "panel:event:neotree",
+                serde_json::json!({
+                    "action": "a",
+                    "row": { "path": "./src", "kind": "directory" },
+                }),
+            )
+            .await
+            .unwrap();
+        let create_handle = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackInput { handle, .. } => handle,
+            _ => panic!("expected Neo-tree create prompt"),
+        };
+        runtime
+            .notify_composer(
+                create_handle,
+                ComposerCallback::Submitted("generated.rs".to_string()),
+            )
+            .unwrap();
+        let operation_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::FileOperation {
+                operation,
+                request_id,
+            } => {
+                assert_eq!(
+                    operation,
+                    serde_json::json!({
+                        "kind": "create",
+                        "path": "./src/generated.rs",
+                    })
+                );
+                request_id
+            }
+            _ => panic!("expected Neo-tree create file operation"),
+        };
+
+        runtime
+            .resolve_request(
+                operation_request_id,
+                serde_json::json!({
+                    "ok": true,
+                    "error": null,
+                    "undo_supported": false,
+                    "created": ["src/generated.rs"],
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::Action(Action::Print(message))
+                if message == "Neo-tree create complete"
+        ));
+        let root_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::ListDirectory { path, request_id } => {
+                assert_eq!(path, ".");
+                request_id
+            }
+            _ => panic!("expected Neo-tree root refresh"),
+        };
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::GetGitStatus { path, .. } if path == "."
+        ));
+
+        runtime
+            .resolve_request(
+                root_request_id,
+                serde_json::json!({
+                    "path": ".",
+                    "entries": [
+                        { "name": "src", "path": "./src", "kind": "directory" },
+                    ],
+                    "error": null,
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::WatchDirectory { path, .. } if path == "."
+        ));
+        let src_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::ListDirectory { path, request_id } => {
+                assert_eq!(path, "./src");
+                request_id
+            }
+            _ => panic!("expected created file parent refresh"),
+        };
+
+        runtime
+            .resolve_request(
+                src_request_id,
+                serde_json::json!({
+                    "path": "./src",
+                    "entries": [
+                        { "name": "generated.rs", "path": "./src/generated.rs", "kind": "file" },
+                    ],
+                    "error": null,
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::WatchDirectory { path, .. } if path == "./src"
+        ));
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::SelectPanelRow { id, row_id } => {
+                assert_eq!(id, "neotree");
+                assert_eq!(row_id, "./src/generated.rs");
+            }
+            _ => panic!("expected Neo-tree to select the created file"),
+        }
+    }
+
+    #[tokio::test]
     async fn neotree_handles_optional_selection_and_nullable_file_operation_errors() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();


### PR DESCRIPTION
Creating a file from Neo-tree refreshes the filesystem tree but previously left the cursor on its old row, making the newly created entry easy to lose.

This change carries the canonical path returned by a successful file operation into Neo-tree’s existing reveal flow. The refresh expands the necessary parent directories and selects the new file row once it appears. Cancelled and failed creates clear the pending selection intent, while directory creation keeps its existing refresh behavior.

## How to Test

1. Open Neo-tree with `Ctrl-e`, select the workspace root or a directory, press `a`, and create a file. Expect the refreshed tree to highlight the new file.
2. Create a file inside a nested path. Expect Neo-tree to expand its parents and keep the created file visible and selected.
3. Create a directory with a trailing `/`. Expect the directory to be created without treating it as a file-selection target.
4. Attempt a create that fails. Expect the error to be reported without a stale highlight appearing after a later refresh.
5. Run `cargo test plugin::runtime::tests::neotree_selects_a_new_file_after_refreshing_its_parent --all-features`.