### PR TITLE
feat(agent): add keyboard-first selectable conversations

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -11343,6 +11343,36 @@ impl Editor {
         {
             return Self::panel_event_key_action(event);
         }
+        let count = usize::from(self.repeater.unwrap_or(1));
+        if let Some(input) = self.panel_manager.handle_focused_scrollback_input(
+            ev,
+            usize::from(self.size.1.saturating_sub(2)),
+            usize::from(self.size.0),
+            count,
+        ) {
+            self.repeater = None;
+            return Some(match input {
+                plugin::panel::TextPanelScrollbackInput::Handled => {
+                    KeyAction::Single(Action::Refresh)
+                }
+                plugin::panel::TextPanelScrollbackInput::Yank(yank) => {
+                    let length = yank.text.graphemes(true).count();
+                    let lines = yank.text.lines().count();
+                    let content = if yank.linewise {
+                        Content::linewise(yank.text)
+                    } else {
+                        Content::charwise(yank.text)
+                    };
+                    self.set_default_register(content);
+                    self.last_error = Some(if yank.linewise {
+                        format!("{} lines yanked", lines.max(1))
+                    } else {
+                        format!("{length} characters yanked")
+                    });
+                    KeyAction::Single(Action::Refresh)
+                }
+            });
+        }
         match ev {
             Event::Key(event) => {
                 if matches!(event.code, KeyCode::Char('y') | KeyCode::Char('Y')) {
@@ -11358,13 +11388,21 @@ impl Editor {
                     }
                 }
                 if matches!(event.code, KeyCode::Tab | KeyCode::BackTab) {
+                    if self.panel_manager.focused_text_input_active()
+                        && self
+                            .panel_manager
+                            .focus_focused_text_scrollback(usize::from(self.size.0))
+                    {
+                        return Some(KeyAction::Single(Action::Refresh));
+                    }
                     let panel_height = usize::from(self.size.1.saturating_sub(2));
                     let forward = event.code == KeyCode::Tab;
-                    if self.panel_manager.select_focused_text_link(
+                    let selected = self.panel_manager.select_focused_text_link(
                         forward,
                         panel_height,
                         usize::from(self.size.0),
-                    ) {
+                    );
+                    if selected || !self.panel_manager.focused_row_panel() {
                         return Some(KeyAction::Single(Action::Refresh));
                     }
                 }
@@ -11410,7 +11448,7 @@ impl Editor {
                     }
                     KeyCode::Char('H') => "history",
                     KeyCode::Char('N') => "new",
-                    KeyCode::Char('a') if !self.panel_manager.focused_row_panel() => {
+                    KeyCode::Char('a' | 'i') if !self.panel_manager.focused_row_panel() => {
                         "composer_focus"
                     }
                     KeyCode::Char('x') if !self.panel_manager.focused_row_panel() => "clear",
@@ -11532,16 +11570,29 @@ impl Editor {
 
         match event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
-                if let Some(target) = self
-                    .panel_manager
-                    .text_link_at_position(x, y, width, height)
+                if event
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::SUPER)
                 {
-                    return Some(self.follow_text_panel_link(target));
+                    if let Some(target) = self
+                        .panel_manager
+                        .text_link_at_position(x, y, width, height)
+                    {
+                        return Some(self.follow_text_panel_link(target));
+                    }
                 }
                 self.panel_manager
                     .focus_panel_at_position(x, y, width, height)
                     .and_then(Self::panel_event_key_action)
             }
+            MouseEventKind::Drag(MouseButton::Left) => self
+                .panel_manager
+                .drag_focused_text_selection(x, y, width, height)
+                .then_some(KeyAction::Single(Action::Refresh)),
+            MouseEventKind::Up(MouseButton::Left) => self
+                .panel_manager
+                .finish_focused_text_selection()
+                .then_some(KeyAction::Single(Action::Refresh)),
             MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
                 let placement = self.panel_manager.panel_at_position(x, y, width, height)?;
                 let scroll_lines = isize::try_from(self.config.mouse_scroll_lines.unwrap_or(3))
@@ -24402,6 +24453,16 @@ impl Editor {
         self.restore_panel_layout(id);
         self.apply_panel_layout();
         self.sync_with_window();
+    }
+
+    #[doc(hidden)]
+    pub fn test_update_text_panel(&mut self, id: &str, blocks: Vec<plugin::TextPanelBlock>) {
+        self.panel_manager.update_text_panel(
+            id,
+            blocks,
+            usize::from(self.size.1.saturating_sub(2)),
+            usize::from(self.size.0),
+        );
     }
 
     #[doc(hidden)]

--- a/src/plugin/markdown.rs
+++ b/src/plugin/markdown.rs
@@ -27,6 +27,14 @@ pub(crate) enum TextPanelSpanStyle {
     Muted,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) enum TextPanelSpanSelection {
+    #[default]
+    Content,
+    Chrome,
+    CopySeparator(String),
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CodeBlockChrome {
     Framed,
@@ -39,12 +47,21 @@ pub(crate) struct RenderedTextSpan {
     pub(crate) style: TextPanelSpanStyle,
     pub(crate) syntax_style: Option<Style>,
     pub(crate) link: Option<TextPanelLink>,
+    pub(crate) selection: TextPanelSpanSelection,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct RenderedTextLine {
     pub(crate) spans: Vec<RenderedTextSpan>,
     pub(crate) break_after: RenderedTextLineBreak,
+    pub(crate) selection: TextPanelLineSelection,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum TextPanelLineSelection {
+    #[default]
+    Semantic,
+    Chrome,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -63,8 +80,24 @@ impl RenderedTextLine {
                 style,
                 syntax_style: None,
                 link: None,
+                selection: TextPanelSpanSelection::Content,
             }],
             break_after: RenderedTextLineBreak::Hard,
+            selection: TextPanelLineSelection::Semantic,
+        }
+    }
+
+    pub(crate) fn chrome(text: String, style: TextPanelSpanStyle) -> Self {
+        Self {
+            spans: vec![RenderedTextSpan {
+                text,
+                style,
+                syntax_style: None,
+                link: None,
+                selection: TextPanelSpanSelection::Chrome,
+            }],
+            break_after: RenderedTextLineBreak::Hard,
+            selection: TextPanelLineSelection::Chrome,
         }
     }
 
@@ -219,8 +252,9 @@ impl<'a> MarkdownRenderer<'a> {
                 let mut line = RenderedTextLine {
                     spans: prefix,
                     break_after: RenderedTextLineBreak::Hard,
+                    selection: TextPanelLineSelection::Chrome,
                 };
-                push_span(
+                push_chrome_span(
                     &mut line.spans,
                     "─".repeat(rule_width),
                     TextPanelSpanStyle::Muted,
@@ -240,7 +274,7 @@ impl<'a> MarkdownRenderer<'a> {
             Tag::Heading { .. } => {
                 self.flush_current();
                 self.blank_line();
-                self.append("▍ ", TextPanelSpanStyle::Heading);
+                self.append_chrome("▍ ", TextPanelSpanStyle::Heading);
                 self.styles.push(TextPanelSpanStyle::Heading);
             }
             Tag::BlockQuote(_) => {
@@ -274,6 +308,7 @@ impl<'a> MarkdownRenderer<'a> {
                         style: TextPanelSpanStyle::Muted,
                         syntax_style: None,
                         link: None,
+                        selection: TextPanelSpanSelection::Chrome,
                     }];
                     self.lines
                         .extend(wrap_spans(&spans, self.width, &prefix, &continuation));
@@ -367,19 +402,26 @@ impl<'a> MarkdownRenderer<'a> {
                 let (_, continuation) = self.take_prefixes();
                 let mut code_prefix = continuation.clone();
                 if self.code_block_chrome == CodeBlockChrome::Framed {
-                    push_span(
+                    push_chrome_span(
                         &mut code_prefix,
                         "│ ".to_string(),
                         TextPanelSpanStyle::Muted,
                     );
                 }
                 for spans in code_lines {
+                    let semantic_blank = spans.iter().all(|span| span.text.is_empty());
+                    let first_line = self.lines.len();
                     self.lines.extend(wrap_verbatim(
                         &spans,
                         self.width,
                         &code_prefix,
                         &code_prefix,
                     ));
+                    if semantic_blank {
+                        for line in &mut self.lines[first_line..] {
+                            line.selection = TextPanelLineSelection::Semantic;
+                        }
+                    }
                 }
                 if self.code_block_chrome == CodeBlockChrome::Framed {
                     let (_, continuation) = self.take_prefixes();
@@ -389,6 +431,7 @@ impl<'a> MarkdownRenderer<'a> {
                             style: TextPanelSpanStyle::Muted,
                             syntax_style: None,
                             link: None,
+                            selection: TextPanelSpanSelection::Chrome,
                         }],
                         self.width,
                         &continuation,
@@ -463,6 +506,13 @@ impl<'a> MarkdownRenderer<'a> {
         self.append_with_link(text, style, self.links.last().cloned().flatten());
     }
 
+    fn append_chrome(&mut self, text: &str, style: TextPanelSpanStyle) {
+        if text.is_empty() {
+            return;
+        }
+        push_chrome_span(&mut self.current, text.to_string(), style);
+    }
+
     fn append_linkified(&mut self, text: &str, style: TextPanelSpanStyle) {
         if let Some(link) = self.links.last().cloned().flatten() {
             self.append_with_link(text, style, Some(link));
@@ -520,8 +570,8 @@ impl<'a> MarkdownRenderer<'a> {
         let mut first = Vec::new();
         let mut continuation = Vec::new();
         for _ in 0..self.quote_depth {
-            push_span(&mut first, "│ ".to_string(), TextPanelSpanStyle::Quote);
-            push_span(
+            push_chrome_span(&mut first, "│ ".to_string(), TextPanelSpanStyle::Quote);
+            push_chrome_span(
                 &mut continuation,
                 "│ ".to_string(),
                 TextPanelSpanStyle::Quote,
@@ -535,7 +585,7 @@ impl<'a> MarkdownRenderer<'a> {
                 item.continuation.clone()
             };
             push_span(&mut first, prefix, TextPanelSpanStyle::User);
-            push_span(
+            push_chrome_span(
                 &mut continuation,
                 item.continuation.clone(),
                 TextPanelSpanStyle::Text,
@@ -551,6 +601,7 @@ impl<'a> MarkdownRenderer<'a> {
         self.lines.push(RenderedTextLine {
             spans: Vec::new(),
             break_after: RenderedTextLineBreak::Hard,
+            selection: TextPanelLineSelection::Semantic,
         });
     }
 }
@@ -583,6 +634,7 @@ fn linkified_spans(
             style,
             syntax_style: None,
             link: None,
+            selection: TextPanelSpanSelection::Content,
         }];
     }
     linkify_source_locations(text)
@@ -605,6 +657,7 @@ fn linkified_spans(
                 },
                 syntax_style: None,
                 link,
+                selection: TextPanelSpanSelection::Content,
             }
         })
         .collect()
@@ -710,8 +763,10 @@ fn wrap_spans(
     }
     let tokens = styled_tokens(spans);
     if tokens.is_empty() {
+        let spans = fit_prefix(first_prefix, width);
         return vec![RenderedTextLine {
-            spans: fit_prefix(first_prefix, width),
+            selection: line_selection(&spans),
+            spans,
             break_after: RenderedTextLineBreak::Hard,
         }];
     }
@@ -724,10 +779,14 @@ fn wrap_spans(
     for token in tokens {
         if token.whitespace {
             if content_width > 0 {
-                pending_space = token
-                    .spans
-                    .first()
-                    .map(|span| (span.style, span.syntax_style.clone(), span.link.clone()));
+                pending_space = token.spans.first().map(|span| {
+                    (
+                        span.style,
+                        span.syntax_style.clone(),
+                        span.link.clone(),
+                        span.selection.clone(),
+                    )
+                });
             }
             continue;
         }
@@ -735,6 +794,7 @@ fn wrap_spans(
         let available = width.saturating_sub(prefix_width).max(1);
         let space_width = usize::from(pending_space.is_some() && content_width > 0);
         if content_width > 0 && content_width + space_width + token.width > available {
+            let selection = line_selection(&prefix);
             lines.push(RenderedTextLine {
                 spans: prefix,
                 break_after: if pending_space.is_some() {
@@ -742,14 +802,22 @@ fn wrap_spans(
                 } else {
                     RenderedTextLineBreak::Soft
                 },
+                selection,
             });
             prefix = fit_prefix(continuation_prefix, width.saturating_sub(1));
             content_width = 0;
             pending_space = None;
         }
-        if let Some((style, syntax_style, link)) = pending_space.take() {
+        if let Some((style, syntax_style, link, selection)) = pending_space.take() {
             if content_width > 0 {
-                push_rendered_span(&mut prefix, " ".to_string(), style, syntax_style, link);
+                push_rendered_span(
+                    &mut prefix,
+                    " ".to_string(),
+                    style,
+                    syntax_style,
+                    link,
+                    selection,
+                );
                 content_width += 1;
             }
         }
@@ -763,6 +831,7 @@ fn wrap_spans(
                     span.style,
                     span.syntax_style,
                     span.link,
+                    span.selection,
                 );
             }
             content_width += token.width;
@@ -774,9 +843,11 @@ fn wrap_spans(
                 let prefix_width = spans_width(&prefix).saturating_sub(content_width);
                 let available = width.saturating_sub(prefix_width).max(1);
                 if content_width > 0 && content_width + grapheme_width > available {
+                    let selection = line_selection(&prefix);
                     lines.push(RenderedTextLine {
                         spans: prefix,
                         break_after: RenderedTextLineBreak::Soft,
+                        selection,
                     });
                     prefix = fit_prefix(continuation_prefix, width.saturating_sub(1));
                     content_width = 0;
@@ -792,6 +863,7 @@ fn wrap_spans(
                         span.style,
                         span.syntax_style.clone(),
                         span.link.clone(),
+                        span.selection.clone(),
                     );
                     content_width += 1;
                 } else {
@@ -801,15 +873,18 @@ fn wrap_spans(
                         span.style,
                         span.syntax_style.clone(),
                         span.link.clone(),
+                        span.selection.clone(),
                     );
                     content_width += grapheme_width;
                 }
             }
         }
     }
+    let selection = line_selection(&prefix);
     lines.push(RenderedTextLine {
         spans: prefix,
         break_after: RenderedTextLineBreak::Hard,
+        selection,
     });
     lines
 }
@@ -832,9 +907,11 @@ fn wrap_verbatim(
             let prefix_width = spans_width(&current).saturating_sub(content_width);
             let available = width.saturating_sub(prefix_width).max(1);
             if content_width > 0 && content_width + grapheme_width > available {
+                let selection = line_selection(&current);
                 lines.push(RenderedTextLine {
                     spans: current,
                     break_after: RenderedTextLineBreak::Soft,
+                    selection,
                 });
                 current = fit_prefix(continuation_prefix, width.saturating_sub(1));
                 content_width = 0;
@@ -850,6 +927,7 @@ fn wrap_verbatim(
                     span.style,
                     span.syntax_style.clone(),
                     span.link.clone(),
+                    span.selection.clone(),
                 );
                 content_width += 1;
             } else {
@@ -859,14 +937,17 @@ fn wrap_verbatim(
                     span.style,
                     span.syntax_style.clone(),
                     span.link.clone(),
+                    span.selection.clone(),
                 );
                 content_width += grapheme_width;
             }
         }
     }
+    let selection = line_selection(&current);
     lines.push(RenderedTextLine {
         spans: current,
         break_after: RenderedTextLineBreak::Hard,
+        selection,
     });
     lines
 }
@@ -893,6 +974,7 @@ fn styled_tokens(spans: &[RenderedTextSpan]) -> Vec<StyledToken> {
                     span.style,
                     span.syntax_style.clone(),
                     span.link.clone(),
+                    span.selection.clone(),
                 );
                 token.width += display_width(grapheme);
             }
@@ -967,9 +1049,9 @@ fn render_table(
     let mut separator = fit_prefix(continuation_prefix, width);
     for (index, column_width) in widths.iter().enumerate() {
         if index > 0 {
-            push_span(&mut separator, " ".repeat(gap), TextPanelSpanStyle::Muted);
+            push_chrome_span(&mut separator, " ".repeat(gap), TextPanelSpanStyle::Muted);
         }
-        push_span(
+        push_chrome_span(
             &mut separator,
             "━".repeat(*column_width),
             TextPanelSpanStyle::Muted,
@@ -978,6 +1060,7 @@ fn render_table(
     lines.push(RenderedTextLine {
         spans: separator,
         break_after: RenderedTextLineBreak::Hard,
+        selection: TextPanelLineSelection::Chrome,
     });
     for row in &table.rows {
         push_table_row(
@@ -1015,6 +1098,7 @@ fn push_table_row(
                     style: default_style,
                     syntax_style: None,
                     link: None,
+                    selection: TextPanelSpanSelection::Content,
                 }]
             } else if cell.spans.is_empty() {
                 vec![RenderedTextSpan {
@@ -1022,6 +1106,7 @@ fn push_table_row(
                     style: default_style,
                     syntax_style: None,
                     link: None,
+                    selection: TextPanelSpanSelection::Content,
                 }]
             } else {
                 cell.spans.clone()
@@ -1038,7 +1123,12 @@ fn push_table_row(
         };
         for (column, column_width) in widths.iter().enumerate() {
             if column > 0 {
-                push_span(&mut output, "  ".to_string(), TextPanelSpanStyle::Muted);
+                push_copy_separator(
+                    &mut output,
+                    "  ".to_string(),
+                    "\t",
+                    TextPanelSpanStyle::Muted,
+                );
             }
             let spans = wrapped[column]
                 .get(row_line)
@@ -1051,7 +1141,7 @@ fn push_table_row(
                 Alignment::Right => (remaining, 0),
                 Alignment::Left | Alignment::None => (0, remaining),
             };
-            push_span(&mut output, " ".repeat(left), TextPanelSpanStyle::Text);
+            push_chrome_span(&mut output, " ".repeat(left), TextPanelSpanStyle::Text);
             for span in spans {
                 push_rendered_span(
                     &mut output,
@@ -1059,15 +1149,18 @@ fn push_table_row(
                     span.style,
                     span.syntax_style.clone(),
                     span.link.clone(),
+                    span.selection.clone(),
                 );
             }
             if column + 1 < widths.len() {
-                push_span(&mut output, " ".repeat(right), TextPanelSpanStyle::Text);
+                push_chrome_span(&mut output, " ".repeat(right), TextPanelSpanStyle::Text);
             }
         }
+        let selection = line_selection(&output);
         lines.push(RenderedTextLine {
             spans: output,
             break_after: RenderedTextLineBreak::Hard,
+            selection,
         });
     }
 }
@@ -1098,6 +1191,7 @@ fn render_table_records(
                     style: TextPanelSpanStyle::Heading,
                     syntax_style: None,
                     link: None,
+                    selection: TextPanelSpanSelection::Content,
                 }],
                 width,
                 prefix,
@@ -1105,7 +1199,7 @@ fn render_table_records(
             ));
 
             let mut value_prefix = continuation_prefix.to_vec();
-            push_span(
+            push_chrome_span(
                 &mut value_prefix,
                 "  ".to_string(),
                 TextPanelSpanStyle::Text,
@@ -1116,6 +1210,7 @@ fn render_table_records(
                     style: TextPanelSpanStyle::Muted,
                     syntax_style: None,
                     link: None,
+                    selection: TextPanelSpanSelection::Content,
                 }]
             } else {
                 value.spans.clone()
@@ -1130,7 +1225,7 @@ fn render_table_records(
         if row_index + 1 < table.rows.len() {
             let mut separator = fit_prefix(continuation_prefix, width);
             let remaining = width.saturating_sub(spans_width(&separator));
-            push_span(
+            push_chrome_span(
                 &mut separator,
                 "─".repeat(remaining),
                 TextPanelSpanStyle::Muted,
@@ -1138,6 +1233,7 @@ fn render_table_records(
             lines.push(RenderedTextLine {
                 spans: separator,
                 break_after: RenderedTextLineBreak::Hard,
+                selection: TextPanelLineSelection::Chrome,
             });
         }
     }
@@ -1159,6 +1255,18 @@ fn spans_width(spans: &[RenderedTextSpan]) -> usize {
     spans.iter().map(|span| display_width(&span.text)).sum()
 }
 
+fn line_selection(spans: &[RenderedTextSpan]) -> TextPanelLineSelection {
+    if !spans.is_empty()
+        && spans
+            .iter()
+            .all(|span| !matches!(span.selection, TextPanelSpanSelection::Content))
+    {
+        TextPanelLineSelection::Chrome
+    } else {
+        TextPanelLineSelection::Semantic
+    }
+}
+
 fn fit_prefix(spans: &[RenderedTextSpan], width: usize) -> Vec<RenderedTextSpan> {
     let mut out = Vec::new();
     let mut used = 0usize;
@@ -1174,6 +1282,7 @@ fn fit_prefix(spans: &[RenderedTextSpan], width: usize) -> Vec<RenderedTextSpan>
                 span.style,
                 span.syntax_style.clone(),
                 span.link.clone(),
+                span.selection.clone(),
             );
             used += grapheme_width;
         }
@@ -1185,13 +1294,47 @@ fn push_span(spans: &mut Vec<RenderedTextSpan>, text: String, style: TextPanelSp
     push_span_with_link(spans, text, style, None);
 }
 
+fn push_chrome_span(spans: &mut Vec<RenderedTextSpan>, text: String, style: TextPanelSpanStyle) {
+    push_rendered_span(
+        spans,
+        text,
+        style,
+        None,
+        None,
+        TextPanelSpanSelection::Chrome,
+    );
+}
+
+fn push_copy_separator(
+    spans: &mut Vec<RenderedTextSpan>,
+    display: String,
+    copy: impl Into<String>,
+    style: TextPanelSpanStyle,
+) {
+    push_rendered_span(
+        spans,
+        display,
+        style,
+        None,
+        None,
+        TextPanelSpanSelection::CopySeparator(copy.into()),
+    );
+}
+
 fn push_span_with_link(
     spans: &mut Vec<RenderedTextSpan>,
     text: String,
     style: TextPanelSpanStyle,
     link: Option<TextPanelLink>,
 ) {
-    push_rendered_span(spans, text, style, None, link);
+    push_rendered_span(
+        spans,
+        text,
+        style,
+        None,
+        link,
+        TextPanelSpanSelection::Content,
+    );
 }
 
 fn push_rendered_span(
@@ -1200,12 +1343,17 @@ fn push_rendered_span(
     style: TextPanelSpanStyle,
     syntax_style: Option<Style>,
     link: Option<TextPanelLink>,
+    selection: TextPanelSpanSelection,
 ) {
     if text.is_empty() {
         return;
     }
     if let Some(last) = spans.last_mut() {
-        if last.style == style && last.syntax_style == syntax_style && last.link == link {
+        if last.style == style
+            && last.syntax_style == syntax_style
+            && last.link == link
+            && last.selection == selection
+        {
             last.text.push_str(&text);
             return;
         }
@@ -1215,6 +1363,7 @@ fn push_rendered_span(
         style,
         syntax_style,
         link,
+        selection,
     });
 }
 
@@ -1226,7 +1375,14 @@ fn push_span_with_syntax(
     if text.is_empty() {
         return;
     }
-    push_rendered_span(spans, text, TextPanelSpanStyle::Code, syntax_style, None);
+    push_rendered_span(
+        spans,
+        text,
+        TextPanelSpanStyle::Code,
+        syntax_style,
+        None,
+        TextPanelSpanSelection::Content,
+    );
 }
 
 #[cfg(test)]

--- a/src/plugin/markdown.rs
+++ b/src/plugin/markdown.rs
@@ -44,6 +44,15 @@ pub(crate) struct RenderedTextSpan {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct RenderedTextLine {
     pub(crate) spans: Vec<RenderedTextSpan>,
+    pub(crate) break_after: RenderedTextLineBreak,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum RenderedTextLineBreak {
+    Soft,
+    SoftSpace,
+    #[default]
+    Hard,
 }
 
 impl RenderedTextLine {
@@ -55,6 +64,7 @@ impl RenderedTextLine {
                 syntax_style: None,
                 link: None,
             }],
+            break_after: RenderedTextLineBreak::Hard,
         }
     }
 
@@ -206,7 +216,10 @@ impl<'a> MarkdownRenderer<'a> {
                 self.blank_line();
                 let (prefix, _) = self.take_prefixes();
                 let rule_width = self.width.saturating_sub(spans_width(&prefix));
-                let mut line = RenderedTextLine { spans: prefix };
+                let mut line = RenderedTextLine {
+                    spans: prefix,
+                    break_after: RenderedTextLineBreak::Hard,
+                };
                 push_span(
                     &mut line.spans,
                     "─".repeat(rule_width),
@@ -535,7 +548,10 @@ impl<'a> MarkdownRenderer<'a> {
         if self.lines.is_empty() || self.lines.last().is_some_and(RenderedTextLine::is_empty) {
             return;
         }
-        self.lines.push(RenderedTextLine { spans: Vec::new() });
+        self.lines.push(RenderedTextLine {
+            spans: Vec::new(),
+            break_after: RenderedTextLineBreak::Hard,
+        });
     }
 }
 
@@ -696,6 +712,7 @@ fn wrap_spans(
     if tokens.is_empty() {
         return vec![RenderedTextLine {
             spans: fit_prefix(first_prefix, width),
+            break_after: RenderedTextLineBreak::Hard,
         }];
     }
 
@@ -718,7 +735,14 @@ fn wrap_spans(
         let available = width.saturating_sub(prefix_width).max(1);
         let space_width = usize::from(pending_space.is_some() && content_width > 0);
         if content_width > 0 && content_width + space_width + token.width > available {
-            lines.push(RenderedTextLine { spans: prefix });
+            lines.push(RenderedTextLine {
+                spans: prefix,
+                break_after: if pending_space.is_some() {
+                    RenderedTextLineBreak::SoftSpace
+                } else {
+                    RenderedTextLineBreak::Soft
+                },
+            });
             prefix = fit_prefix(continuation_prefix, width.saturating_sub(1));
             content_width = 0;
             pending_space = None;
@@ -750,7 +774,10 @@ fn wrap_spans(
                 let prefix_width = spans_width(&prefix).saturating_sub(content_width);
                 let available = width.saturating_sub(prefix_width).max(1);
                 if content_width > 0 && content_width + grapheme_width > available {
-                    lines.push(RenderedTextLine { spans: prefix });
+                    lines.push(RenderedTextLine {
+                        spans: prefix,
+                        break_after: RenderedTextLineBreak::Soft,
+                    });
                     prefix = fit_prefix(continuation_prefix, width.saturating_sub(1));
                     content_width = 0;
                 }
@@ -780,7 +807,10 @@ fn wrap_spans(
             }
         }
     }
-    lines.push(RenderedTextLine { spans: prefix });
+    lines.push(RenderedTextLine {
+        spans: prefix,
+        break_after: RenderedTextLineBreak::Hard,
+    });
     lines
 }
 
@@ -802,7 +832,10 @@ fn wrap_verbatim(
             let prefix_width = spans_width(&current).saturating_sub(content_width);
             let available = width.saturating_sub(prefix_width).max(1);
             if content_width > 0 && content_width + grapheme_width > available {
-                lines.push(RenderedTextLine { spans: current });
+                lines.push(RenderedTextLine {
+                    spans: current,
+                    break_after: RenderedTextLineBreak::Soft,
+                });
                 current = fit_prefix(continuation_prefix, width.saturating_sub(1));
                 content_width = 0;
             }
@@ -831,7 +864,10 @@ fn wrap_verbatim(
             }
         }
     }
-    lines.push(RenderedTextLine { spans: current });
+    lines.push(RenderedTextLine {
+        spans: current,
+        break_after: RenderedTextLineBreak::Hard,
+    });
     lines
 }
 
@@ -939,7 +975,10 @@ fn render_table(
             TextPanelSpanStyle::Muted,
         );
     }
-    lines.push(RenderedTextLine { spans: separator });
+    lines.push(RenderedTextLine {
+        spans: separator,
+        break_after: RenderedTextLineBreak::Hard,
+    });
     for row in &table.rows {
         push_table_row(
             &mut lines,
@@ -1026,7 +1065,10 @@ fn push_table_row(
                 push_span(&mut output, " ".repeat(right), TextPanelSpanStyle::Text);
             }
         }
-        lines.push(RenderedTextLine { spans: output });
+        lines.push(RenderedTextLine {
+            spans: output,
+            break_after: RenderedTextLineBreak::Hard,
+        });
     }
 }
 
@@ -1093,7 +1135,10 @@ fn render_table_records(
                 "─".repeat(remaining),
                 TextPanelSpanStyle::Muted,
             );
-            lines.push(RenderedTextLine { spans: separator });
+            lines.push(RenderedTextLine {
+                spans: separator,
+                break_after: RenderedTextLineBreak::Hard,
+            });
         }
     }
     lines

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -17,7 +17,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use super::markdown::{
     render_markdown_lines, wrap_plain_text, RenderedTextLine, RenderedTextLineBreak,
-    RenderedTextSpan, TextPanelSpanStyle,
+    RenderedTextSpan, TextPanelLineSelection, TextPanelSpanSelection, TextPanelSpanStyle,
 };
 use super::text_link::{TextPanelLink, TextPanelLinkTarget};
 use crate::{
@@ -271,6 +271,7 @@ enum ScrollbackFindDirection {
 #[derive(Debug, Clone)]
 struct TextPanelLayoutCell {
     text: String,
+    copy_prefix: String,
     column: usize,
     width: usize,
     link: Option<TextPanelLink>,
@@ -283,7 +284,7 @@ struct TextPanelLayoutLine {
     cells: Vec<TextPanelLayoutCell>,
     break_after: RenderedTextLineBreak,
     selectable: bool,
-    chrome_prefix_graphemes: usize,
+    chrome_only: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -606,7 +607,7 @@ impl TextPanel {
                         lines.push(turn_separator(width));
                     }
                 }
-                lines.push(RenderedTextLine::plain(
+                lines.push(RenderedTextLine::chrome(
                     "▎ You".to_string(),
                     TextPanelSpanStyle::User,
                 ));
@@ -629,7 +630,7 @@ impl TextPanel {
                 lines.extend(block_lines.into_iter().map(user_accented));
             } else {
                 if let Some((label, style)) = block_label(&block.kind) {
-                    lines.push(RenderedTextLine::plain(label.to_string(), style));
+                    lines.push(RenderedTextLine::chrome(label.to_string(), style));
                 }
 
                 let style = block_style(&block.kind);
@@ -658,6 +659,7 @@ impl TextPanel {
                     style: TextPanelSpanStyle::User,
                     syntax_style: None,
                     link: None,
+                    selection: TextPanelSpanSelection::Chrome,
                 });
             }
         }
@@ -674,54 +676,52 @@ impl TextPanelLayout {
                 let first = next;
                 let mut column = 0usize;
                 let mut cells = Vec::new();
-                let text = line
-                    .spans
-                    .iter()
-                    .map(|span| span.text.as_str())
-                    .collect::<String>();
-                let selectable =
-                    !text.is_empty() && !text.chars().all(|character| character == '─');
-                let chrome_prefix_graphemes = line.spans.first().map_or(0, |span| {
-                    usize::from(
-                        span.style == TextPanelSpanStyle::User && span.text.as_str() == "▎ ",
-                    ) * span.text.graphemes(true).count()
-                });
-                if selectable {
-                    let mut grapheme_index = 0usize;
-                    for span in &line.spans {
-                        for grapheme in span.text.graphemes(true) {
-                            let width = display_width(grapheme).max(1);
-                            if grapheme_index >= chrome_prefix_graphemes {
+                let mut pending_copy_separator = String::new();
+                for span in &line.spans {
+                    match &span.selection {
+                        TextPanelSpanSelection::Chrome => {
+                            column = column.saturating_add(display_width(&span.text));
+                        }
+                        TextPanelSpanSelection::CopySeparator(copy) => {
+                            pending_copy_separator.clone_from(copy);
+                            column = column.saturating_add(display_width(&span.text));
+                        }
+                        TextPanelSpanSelection::Content => {
+                            for grapheme in span.text.graphemes(true) {
+                                let width = display_width(grapheme).max(1);
                                 cells.push(TextPanelLayoutCell {
                                     text: grapheme.to_string(),
+                                    copy_prefix: std::mem::take(&mut pending_copy_separator),
                                     column,
                                     width,
                                     link: span.link.clone(),
                                     virtual_space: false,
                                 });
                                 next = next.saturating_add(1);
+                                column = column.saturating_add(width);
                             }
-                            column = column.saturating_add(width);
-                            grapheme_index = grapheme_index.saturating_add(1);
                         }
                     }
-                    if line.break_after == RenderedTextLineBreak::SoftSpace {
-                        cells.push(TextPanelLayoutCell {
-                            text: " ".to_string(),
-                            column,
-                            width: 0,
-                            link: None,
-                            virtual_space: true,
-                        });
-                        next = next.saturating_add(1);
-                    }
                 }
+                if !cells.is_empty() && line.break_after == RenderedTextLineBreak::SoftSpace {
+                    cells.push(TextPanelLayoutCell {
+                        text: " ".to_string(),
+                        copy_prefix: String::new(),
+                        column,
+                        width: 0,
+                        link: None,
+                        virtual_space: true,
+                    });
+                    next = next.saturating_add(1);
+                }
+                let selectable = !cells.is_empty();
+                let chrome_only = line.selection == TextPanelLineSelection::Chrome;
                 TextPanelLayoutLine {
                     first,
                     cells,
                     break_after: line.break_after,
                     selectable,
-                    chrome_prefix_graphemes,
+                    chrome_only,
                 }
             })
             .collect();
@@ -879,7 +879,7 @@ impl TextPanelLayout {
         };
         let mut output = String::new();
         for row in start_row..=end_row {
-            if row > start_row {
+            if row > start_row && !self.lines[row - 1].chrome_only {
                 match self.lines[row - 1].break_after {
                     RenderedTextLineBreak::Soft => {}
                     RenderedTextLineBreak::SoftSpace => {}
@@ -887,10 +887,15 @@ impl TextPanelLayout {
                 }
             }
             let line = &self.lines[row];
+            let mut wrote_selected_cell = false;
             for (index, cell) in line.cells.iter().enumerate() {
                 let offset = line.first.saturating_add(index);
                 if offset >= start && offset <= end {
+                    if wrote_selected_cell {
+                        output.push_str(&cell.copy_prefix);
+                    }
                     output.push_str(&cell.text);
+                    wrote_selected_cell = true;
                 }
             }
         }
@@ -3012,10 +3017,6 @@ fn render_text_panel(
             layout
                 .lines
                 .get(line_index)
-                .map_or(0, |line| line.chrome_prefix_graphemes),
-            layout
-                .lines
-                .get(line_index)
                 .is_some_and(|line| line.selectable)
                 .then_some(selection)
                 .flatten(),
@@ -3257,14 +3258,12 @@ fn render_text_spans(
     width: usize,
     line: &RenderedTextLine,
     line_first: usize,
-    chrome_prefix_graphemes: usize,
     selection: Option<(usize, usize)>,
     selected_link: Option<u64>,
     theme: &Theme,
 ) {
     let mut column = 0usize;
     let mut offset = line_first;
-    let mut grapheme_index = 0usize;
     for span in &line.spans {
         let base_style = text_panel_span_style(span.style, theme);
         let mut style = if let Some(syntax_style) = &span.syntax_style {
@@ -3291,7 +3290,7 @@ fn render_text_spans(
                 return;
             }
             let mut grapheme_style = style.clone();
-            let selectable = grapheme_index >= chrome_prefix_graphemes;
+            let selectable = matches!(span.selection, TextPanelSpanSelection::Content);
             if selectable && selection.is_some_and(|(start, end)| offset >= start && offset <= end)
             {
                 let selected = theme.list_selection_style();
@@ -3306,7 +3305,6 @@ fn render_text_spans(
             if selectable {
                 offset = offset.saturating_add(1);
             }
-            grapheme_index = grapheme_index.saturating_add(1);
         }
     }
 }
@@ -3401,19 +3399,25 @@ fn block_style(kind: &TextPanelBlockKind) -> TextPanelSpanStyle {
 }
 
 fn turn_separator(width: usize) -> RenderedTextLine {
-    RenderedTextLine::plain("─".repeat(width.max(1)), TextPanelSpanStyle::Muted)
+    RenderedTextLine::chrome("─".repeat(width.max(1)), TextPanelSpanStyle::Muted)
 }
 
 fn user_accented(line: RenderedTextLine) -> RenderedTextLine {
     let break_after = line.break_after;
+    let selection = line.selection;
     let mut spans = vec![RenderedTextSpan {
         text: "▎ ".to_string(),
         style: TextPanelSpanStyle::User,
         syntax_style: None,
         link: None,
+        selection: TextPanelSpanSelection::Chrome,
     }];
     spans.extend(line.spans);
-    RenderedTextLine { spans, break_after }
+    RenderedTextLine {
+        spans,
+        break_after,
+        selection,
+    }
 }
 
 fn render_row_segments(
@@ -4187,6 +4191,7 @@ mod tests {
                         ..Style::default()
                     }),
                     link: None,
+                    selection: TextPanelSpanSelection::Content,
                 },
                 RenderedTextSpan {
                     text: "b".to_string(),
@@ -4196,13 +4201,15 @@ mod tests {
                         ..Style::default()
                     }),
                     link: None,
+                    selection: TextPanelSpanSelection::Content,
                 },
             ],
             break_after: RenderedTextLineBreak::Hard,
+            selection: TextPanelLineSelection::Semantic,
         };
         let mut buffer = RenderBuffer::new(2, 1, &theme.style);
 
-        render_text_spans(&mut buffer, 0, 0, 2, &line, 0, 0, None, None, &theme);
+        render_text_spans(&mut buffer, 0, 0, 2, &line, 0, None, None, &theme);
 
         assert_eq!(
             buffer.cells[0].style,
@@ -4222,6 +4229,40 @@ mod tests {
                 italic: false,
             }
         );
+    }
+
+    #[test]
+    fn scrollback_highlight_skips_display_chrome() {
+        let theme = Theme::default();
+        let line = RenderedTextLine {
+            spans: vec![
+                RenderedTextSpan {
+                    text: "│ ".to_string(),
+                    style: TextPanelSpanStyle::Muted,
+                    syntax_style: None,
+                    link: None,
+                    selection: TextPanelSpanSelection::Chrome,
+                },
+                RenderedTextSpan {
+                    text: "x".to_string(),
+                    style: TextPanelSpanStyle::Code,
+                    syntax_style: None,
+                    link: None,
+                    selection: TextPanelSpanSelection::Content,
+                },
+            ],
+            break_after: RenderedTextLineBreak::Hard,
+            selection: TextPanelLineSelection::Semantic,
+        };
+        let mut normal = RenderBuffer::new(3, 1, &theme.style);
+        let mut selected = RenderBuffer::new(3, 1, &theme.style);
+
+        render_text_spans(&mut normal, 0, 0, 3, &line, 0, None, None, &theme);
+        render_text_spans(&mut selected, 0, 0, 3, &line, 0, Some((0, 0)), None, &theme);
+
+        assert_eq!(normal.cells[0].style, selected.cells[0].style);
+        assert_eq!(normal.cells[1].style, selected.cells[1].style);
+        assert_ne!(normal.cells[2].style, selected.cells[2].style);
     }
 
     #[test]
@@ -5569,8 +5610,160 @@ mod tests {
         assert_eq!(narrow_user.len, wide_user.len);
         assert_eq!(
             narrow_user.selected_text(0, narrow_user.len - 1, false),
-            "▎ You\nalpha beta gamma\nsecond line"
+            "alpha beta gamma\nsecond line"
         );
+    }
+
+    #[test]
+    fn markdown_selection_omits_code_frames_and_preserves_code_blank_lines() {
+        let mut panel = TextPanel::new("agent".to_string(), PanelConfig::default());
+        panel.blocks = vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Markdown,
+            text: "```bash\n/game\n\npwd\n```".to_string(),
+        }];
+
+        let layout = panel.layout(40);
+        let copied = layout.selected_text(0, layout.len - 1, false);
+
+        assert_eq!(copied, "/game\n\npwd");
+        assert!(!copied.contains("bash"));
+        assert!(!copied.contains(['┌', '│', '└']));
+        assert_eq!(layout.len, "/gamepwd".graphemes(true).count());
+        assert!(layout.lines.iter().any(|line| line.chrome_only));
+    }
+
+    #[test]
+    fn markdown_selection_omits_heading_quote_rule_and_role_chrome() {
+        let mut panel = TextPanel::new("agent".to_string(), PanelConfig::default());
+        panel.blocks = vec![
+            TextPanelBlock {
+                id: "user".to_string(),
+                kind: TextPanelBlockKind::User,
+                format: TextPanelBlockFormat::Markdown,
+                text: "# Heading\n\n> quoted **strong** and `inline`".to_string(),
+            },
+            TextPanelBlock {
+                id: "agent".to_string(),
+                kind: TextPanelBlockKind::Agent,
+                format: TextPanelBlockFormat::Markdown,
+                text: "---\n\nAfter".to_string(),
+            },
+        ];
+
+        let layout = panel.layout(60);
+        let copied = layout.selected_text(0, layout.len - 1, false);
+
+        for content in ["Heading", "quoted strong and inline", "After"] {
+            assert!(
+                copied.contains(content),
+                "missing semantic content {content:?}"
+            );
+        }
+        for chrome in ["▎ You", "◆ Agent", "▍", "│", "─"] {
+            assert!(!copied.contains(chrome), "copied display chrome {chrome:?}");
+        }
+    }
+
+    #[test]
+    fn markdown_selection_keeps_list_structure_and_link_labels() {
+        let mut panel = TextPanel::new("agent".to_string(), PanelConfig::default());
+        panel.blocks = vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Markdown,
+            text: "- item\n- [x] done\n\n1. numbered\n\n[label](https://example.com)".to_string(),
+        }];
+
+        let layout = panel.layout(50);
+        let copied = layout.selected_text(0, layout.len - 1, false);
+
+        assert!(copied.contains("• item"));
+        assert!(copied.contains("• ☑ done"));
+        assert!(copied.contains("1. numbered"));
+        assert!(copied.contains("label"));
+        assert!(!copied.contains("https://example.com"));
+    }
+
+    #[test]
+    fn markdown_table_selection_uses_tabs_and_omits_grid_padding() {
+        let mut panel = TextPanel::new("agent".to_string(), PanelConfig::default());
+        panel.blocks = vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Markdown,
+            text: "| Name | Value |\n|---|---|\n| one | 1 |".to_string(),
+        }];
+
+        let layout = panel.layout(40);
+        let copied = layout.selected_text(0, layout.len - 1, false);
+
+        assert_eq!(copied, "Name\tValue\none\t1");
+        assert!(!copied.contains('━'));
+        assert!(!copied.contains("  "));
+    }
+
+    #[test]
+    fn markdown_selection_is_stable_across_wrapping_and_unicode() {
+        let mut panel = TextPanel::new("agent".to_string(), PanelConfig::default());
+        panel.blocks = vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Markdown,
+            text: "# Café 👩‍💻\n\n- outer item with enough words to wrap\n   - nested e\u{301} item\n\n> quoted words that also wrap\n\n```bash\necho 👩‍💻-abcdefghijk\n```"
+                .to_string(),
+        }];
+
+        let narrow = panel.layout(14);
+        let wide = panel.layout(80);
+        let narrow_copy = narrow.selected_text(0, narrow.len - 1, false);
+        let wide_copy = wide.selected_text(0, wide.len - 1, false);
+
+        assert_eq!(narrow.len, wide.len);
+        assert_eq!(narrow_copy, wide_copy);
+        assert!(narrow_copy.contains("Café 👩‍💻"));
+        assert!(narrow_copy.contains("  • nested e\u{301} item"));
+        assert!(narrow_copy.contains("echo 👩‍💻-abcdefghijk"));
+        assert!(!narrow_copy.contains(['▍', '│', '┌', '└']));
+    }
+
+    #[test]
+    fn markdown_selection_keeps_visible_html_and_image_alt_text() {
+        let mut panel = TextPanel::new("agent".to_string(), PanelConfig::default());
+        panel.blocks = vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Markdown,
+            text: "Press <kbd>Ctrl</kbd> beside ![diagram](https://example.com/image.png)."
+                .to_string(),
+        }];
+
+        let layout = panel.layout(80);
+        let copied = layout.selected_text(0, layout.len - 1, false);
+
+        assert_eq!(copied, "Press <kbd>Ctrl</kbd> beside diagram.");
+        assert!(!copied.contains("https://example.com/image.png"));
+    }
+
+    #[test]
+    fn narrow_markdown_table_selection_omits_record_chrome() {
+        let mut panel = TextPanel::new("agent".to_string(), PanelConfig::default());
+        panel.blocks = vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Markdown,
+            text: "| Name | Value |\n|---|---|\n| one | 1 |\n| two | 2 |".to_string(),
+        }];
+
+        let layout = panel.layout(10);
+        let copied = layout.selected_text(0, layout.len - 1, false);
+
+        for content in ["Name", "Value", "one", "1", "two", "2"] {
+            assert!(copied.contains(content));
+        }
+        assert!(!copied.contains(['─', '━']));
+        assert!(!copied.lines().any(|line| line.starts_with("  ")));
     }
 
     #[test]

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -13,17 +13,19 @@ use std::{collections::HashMap, time::Instant};
 
 use crossterm::event::{Event, KeyCode, KeyModifiers};
 use serde::{Deserialize, Serialize};
+use unicode_segmentation::UnicodeSegmentation;
 
 use super::markdown::{
-    render_markdown_lines, wrap_plain_text, RenderedTextLine, RenderedTextSpan, TextPanelSpanStyle,
+    render_markdown_lines, wrap_plain_text, RenderedTextLine, RenderedTextLineBreak,
+    RenderedTextSpan, TextPanelSpanStyle,
 };
 use super::text_link::{TextPanelLink, TextPanelLinkTarget};
 use crate::{
     editor::{render_buffer::RenderBuffer, Point},
     theme::{SelectionForegroundPriority, Style, Theme, ThemeStyleSpec},
     ui::{
-        normalize_prompt_newlines, paint_rich_text, wrap_text, FollowTailViewport, PromptBuffer,
-        PromptInput, PROMPT_MAX_BYTES,
+        normalize_prompt_newlines, wrap_text, FollowTailViewport, PromptBuffer, PromptInput,
+        PROMPT_MAX_BYTES,
     },
     unicode_utils::{display_width, fit_display_width, truncate_display_width},
 };
@@ -221,6 +223,111 @@ pub struct TextPanel {
     status: Option<TextPanelStatus>,
     busy_since: Option<Instant>,
     selected_link: Option<u64>,
+    scrollback: TextPanelScrollback,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum TextPanelScrollbackMode {
+    #[default]
+    Normal,
+    Visual,
+    VisualLine,
+}
+
+#[derive(Debug, Clone, Default)]
+struct TextPanelScrollback {
+    focused: bool,
+    initialized: bool,
+    mode: TextPanelScrollbackMode,
+    cursor: usize,
+    preferred_column: Option<usize>,
+    selection_anchor: Option<usize>,
+    mouse_anchor: Option<usize>,
+    mouse_dragging: bool,
+    pending_find: Option<PendingScrollbackFind>,
+    last_find: Option<ScrollbackFind>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingScrollbackFind {
+    direction: ScrollbackFindDirection,
+    till: bool,
+    count: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScrollbackFind {
+    direction: ScrollbackFindDirection,
+    till: bool,
+    target: char,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ScrollbackFindDirection {
+    Forward,
+    Backward,
+}
+
+#[derive(Debug, Clone)]
+struct TextPanelLayoutCell {
+    text: String,
+    column: usize,
+    width: usize,
+    link: Option<TextPanelLink>,
+    virtual_space: bool,
+}
+
+#[derive(Debug, Clone)]
+struct TextPanelLayoutLine {
+    first: usize,
+    cells: Vec<TextPanelLayoutCell>,
+    break_after: RenderedTextLineBreak,
+    selectable: bool,
+    chrome_prefix_graphemes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct TextPanelLayout {
+    rendered: Vec<RenderedTextLine>,
+    lines: Vec<TextPanelLayoutLine>,
+    len: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TextPanelYank {
+    pub(crate) text: String,
+    pub(crate) linewise: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TextPanelScrollbackInput {
+    Handled,
+    Yank(TextPanelYank),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TextPanelMotion {
+    Left,
+    Right,
+    Up,
+    Down,
+    LineStart,
+    FirstNonBlank,
+    LineEnd,
+    NextWord,
+    PreviousWord,
+    WordEnd,
+    PreviousParagraph,
+    NextParagraph,
+    PageUp,
+    PageDown,
+    HalfPageUp,
+    HalfPageDown,
+    ViewportTop,
+    ViewportMiddle,
+    ViewportBottom,
+    Top,
+    Bottom,
 }
 
 const TEXT_PANEL_SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -286,6 +393,7 @@ impl TextPanel {
             status: None,
             busy_since: None,
             selected_link: None,
+            scrollback: TextPanelScrollback::default(),
         }
     }
 
@@ -319,6 +427,11 @@ impl TextPanel {
         } else {
             self.clamp_scroll(panel_height, panel_width);
         }
+        let layout = self.layout(panel_width);
+        self.scrollback.cursor = layout.clamp(self.scrollback.cursor);
+        if layout.len == 0 {
+            self.scrollback.initialized = false;
+        }
     }
 
     fn append_delta(
@@ -344,6 +457,8 @@ impl TextPanel {
         } else {
             self.clamp_scroll(panel_height, panel_width);
         }
+        let layout = self.layout(panel_width);
+        self.scrollback.cursor = layout.clamp(self.scrollback.cursor);
     }
 
     fn move_scroll(&mut self, delta: isize, panel_height: usize, panel_width: usize) {
@@ -455,6 +570,13 @@ impl TextPanel {
         };
         let (link, line) = &links[index];
         self.selected_link = Some(link.id);
+        self.scrollback.focused = true;
+        self.scrollback.mode = TextPanelScrollbackMode::Normal;
+        self.scrollback.selection_anchor = None;
+        let layout = self.layout(width);
+        if let Some(offset) = layout.link_offset(link.id) {
+            self.scrollback.cursor = offset;
+        }
         self.viewport.restore(self.scroll, self.follow_tail);
         self.viewport.reveal(*line, self.visible_rows(panel_height));
         self.scroll = self.viewport.offset();
@@ -541,6 +663,600 @@ impl TextPanel {
         }
         lines
     }
+}
+
+impl TextPanelLayout {
+    fn new(rendered: Vec<RenderedTextLine>) -> Self {
+        let mut next = 0usize;
+        let lines = rendered
+            .iter()
+            .map(|line| {
+                let first = next;
+                let mut column = 0usize;
+                let mut cells = Vec::new();
+                let text = line
+                    .spans
+                    .iter()
+                    .map(|span| span.text.as_str())
+                    .collect::<String>();
+                let selectable =
+                    !text.is_empty() && !text.chars().all(|character| character == '─');
+                let chrome_prefix_graphemes = line.spans.first().map_or(0, |span| {
+                    usize::from(
+                        span.style == TextPanelSpanStyle::User && span.text.as_str() == "▎ ",
+                    ) * span.text.graphemes(true).count()
+                });
+                if selectable {
+                    let mut grapheme_index = 0usize;
+                    for span in &line.spans {
+                        for grapheme in span.text.graphemes(true) {
+                            let width = display_width(grapheme).max(1);
+                            if grapheme_index >= chrome_prefix_graphemes {
+                                cells.push(TextPanelLayoutCell {
+                                    text: grapheme.to_string(),
+                                    column,
+                                    width,
+                                    link: span.link.clone(),
+                                    virtual_space: false,
+                                });
+                                next = next.saturating_add(1);
+                            }
+                            column = column.saturating_add(width);
+                            grapheme_index = grapheme_index.saturating_add(1);
+                        }
+                    }
+                    if line.break_after == RenderedTextLineBreak::SoftSpace {
+                        cells.push(TextPanelLayoutCell {
+                            text: " ".to_string(),
+                            column,
+                            width: 0,
+                            link: None,
+                            virtual_space: true,
+                        });
+                        next = next.saturating_add(1);
+                    }
+                }
+                TextPanelLayoutLine {
+                    first,
+                    cells,
+                    break_after: line.break_after,
+                    selectable,
+                    chrome_prefix_graphemes,
+                }
+            })
+            .collect();
+        Self {
+            rendered,
+            lines,
+            len: next,
+        }
+    }
+
+    fn clamp(&self, offset: usize) -> usize {
+        offset.min(self.len.saturating_sub(1))
+    }
+
+    fn position(&self, offset: usize) -> Option<(usize, usize, usize)> {
+        if self.len == 0 {
+            return None;
+        }
+        let offset = self.clamp(offset);
+        self.lines.iter().enumerate().find_map(|(row, line)| {
+            let index = offset.checked_sub(line.first)?;
+            let cell = line.cells.get(index)?;
+            Some((row, index, cell.column))
+        })
+    }
+
+    fn offset_at(&self, row: usize, column: usize) -> Option<usize> {
+        let line = self.lines.get(row)?;
+        line.cells
+            .iter()
+            .enumerate()
+            .filter(|(_, cell)| !cell.virtual_space)
+            .min_by_key(|(_, cell)| {
+                let end = cell.column.saturating_add(cell.width.saturating_sub(1));
+                if column < cell.column {
+                    cell.column - column
+                } else {
+                    column.saturating_sub(end)
+                }
+            })
+            .map(|(index, _)| line.first.saturating_add(index))
+    }
+
+    fn nearest_offset_on_row(&self, row: usize, column: usize) -> Option<usize> {
+        if let Some(offset) = self.offset_at(row, column) {
+            return Some(offset);
+        }
+        (1..self.lines.len()).find_map(|distance| {
+            row.checked_sub(distance)
+                .and_then(|candidate| self.offset_at(candidate, column))
+                .or_else(|| self.offset_at(row.saturating_add(distance), column))
+        })
+    }
+
+    fn offset_at_or_after(&self, row: usize, column: usize) -> Option<usize> {
+        (row..self.lines.len()).find_map(|candidate| self.offset_at(candidate, column))
+    }
+
+    fn offset_at_or_before(&self, row: usize, column: usize) -> Option<usize> {
+        (0..=row.min(self.lines.len().saturating_sub(1)))
+            .rev()
+            .find_map(|candidate| self.offset_at(candidate, column))
+    }
+
+    fn line_bounds(&self, row: usize) -> Option<(usize, usize)> {
+        let line = self.lines.get(row)?;
+        let first = line.cells.iter().position(|cell| !cell.virtual_space)?;
+        let last = line.cells.iter().rposition(|cell| !cell.virtual_space)?;
+        Some((
+            line.first.saturating_add(first),
+            line.first.saturating_add(last),
+        ))
+    }
+
+    fn logical_line_bounds(&self, row: usize) -> Option<(usize, usize)> {
+        let mut first_row = row.min(self.lines.len().saturating_sub(1));
+        while first_row > 0 && self.lines[first_row - 1].break_after != RenderedTextLineBreak::Hard
+        {
+            first_row -= 1;
+        }
+        let mut last_row = row.min(self.lines.len().saturating_sub(1));
+        while last_row + 1 < self.lines.len()
+            && self.lines[last_row].break_after != RenderedTextLineBreak::Hard
+        {
+            last_row += 1;
+        }
+        let start = (first_row..=last_row)
+            .find_map(|candidate| self.line_bounds(candidate))?
+            .0;
+        let end = (first_row..=last_row)
+            .rev()
+            .find_map(|candidate| self.line_bounds(candidate))?
+            .1;
+        Some((start, end))
+    }
+
+    fn first_non_blank(&self, row: usize) -> Option<usize> {
+        let line = self.lines.get(row)?;
+        line.cells
+            .iter()
+            .position(|cell| !cell.text.chars().all(char::is_whitespace))
+            .map(|index| line.first.saturating_add(index))
+            .or_else(|| self.line_bounds(row).map(|(first, _)| first))
+    }
+
+    fn link_at(&self, offset: usize) -> Option<TextPanelLinkTarget> {
+        let (row, index, _) = self.position(offset)?;
+        self.lines
+            .get(row)?
+            .cells
+            .get(index)?
+            .link
+            .as_ref()
+            .map(|link| link.target.clone())
+    }
+
+    fn link_offset(&self, id: u64) -> Option<usize> {
+        self.lines.iter().find_map(|line| {
+            line.cells
+                .iter()
+                .position(|cell| cell.link.as_ref().is_some_and(|link| link.id == id))
+                .map(|index| line.first.saturating_add(index))
+        })
+    }
+
+    fn selected_text(&self, start: usize, end: usize, linewise: bool) -> String {
+        if self.len == 0 {
+            return String::new();
+        }
+        let mut start = self.clamp(start);
+        let mut end = self.clamp(end);
+        if start > end {
+            std::mem::swap(&mut start, &mut end);
+        }
+        if linewise {
+            let Some((start_row, _, _)) = self.position(start) else {
+                return String::new();
+            };
+            let Some((end_row, _, _)) = self.position(end) else {
+                return String::new();
+            };
+            if let Some((line_start, _)) = self.logical_line_bounds(start_row) {
+                start = line_start;
+            }
+            if let Some((_, line_end)) = self.logical_line_bounds(end_row) {
+                end = line_end;
+            }
+        }
+
+        let Some((start_row, _, _)) = self.position(start) else {
+            return String::new();
+        };
+        let Some((end_row, _, _)) = self.position(end) else {
+            return String::new();
+        };
+        let mut output = String::new();
+        for row in start_row..=end_row {
+            if row > start_row {
+                match self.lines[row - 1].break_after {
+                    RenderedTextLineBreak::Soft => {}
+                    RenderedTextLineBreak::SoftSpace => {}
+                    RenderedTextLineBreak::Hard => output.push('\n'),
+                }
+            }
+            let line = &self.lines[row];
+            for (index, cell) in line.cells.iter().enumerate() {
+                let offset = line.first.saturating_add(index);
+                if offset >= start && offset <= end {
+                    output.push_str(&cell.text);
+                }
+            }
+        }
+        if linewise && !output.ends_with('\n') {
+            output.push('\n');
+        }
+        output
+    }
+}
+
+impl TextPanel {
+    fn layout(&self, width: usize) -> TextPanelLayout {
+        let mut layout = TextPanelLayout::new(self.rendered_lines(width.max(1)));
+        if self.status.as_ref().is_some_and(|status| status.stream) {
+            if let Some(line) = layout.lines.last_mut() {
+                if line.cells.last().is_some_and(|cell| cell.text == "▌") {
+                    line.cells.pop();
+                    layout.len = layout.len.saturating_sub(1);
+                }
+            }
+        }
+        layout
+    }
+
+    fn focus_scrollback(&mut self, width: usize) {
+        if let Some(composer) = self.composer.as_mut() {
+            composer.focused = false;
+        }
+        self.scrollback.focused = true;
+        self.scrollback.mode = TextPanelScrollbackMode::Normal;
+        self.scrollback.selection_anchor = None;
+        let layout = self.layout(width);
+        if !self.scrollback.initialized {
+            self.scrollback.cursor = (self.scroll..layout.lines.len())
+                .find_map(|row| layout.offset_at(row, 0))
+                .unwrap_or_else(|| layout.clamp(self.scrollback.cursor));
+            self.scrollback.initialized = layout.len > 0;
+        } else {
+            self.scrollback.cursor = layout.clamp(self.scrollback.cursor);
+        }
+    }
+
+    fn blur_scrollback(&mut self) {
+        self.scrollback.focused = false;
+        self.scrollback.mode = TextPanelScrollbackMode::Normal;
+        self.scrollback.selection_anchor = None;
+        self.scrollback.mouse_anchor = None;
+        self.scrollback.mouse_dragging = false;
+    }
+
+    fn selection_bounds(&self, layout: &TextPanelLayout) -> Option<(usize, usize)> {
+        let anchor = self.scrollback.selection_anchor?;
+        let mut start = layout.clamp(anchor);
+        let mut end = layout.clamp(self.scrollback.cursor);
+        if start > end {
+            std::mem::swap(&mut start, &mut end);
+        }
+        if self.scrollback.mode == TextPanelScrollbackMode::VisualLine {
+            let (start_row, _, _) = layout.position(start)?;
+            let (end_row, _, _) = layout.position(end)?;
+            start = layout.logical_line_bounds(start_row)?.0;
+            end = layout.logical_line_bounds(end_row)?.1;
+        }
+        Some((start, end))
+    }
+
+    fn reveal_scrollback_cursor(&mut self, layout: &TextPanelLayout, panel_height: usize) {
+        let Some((row, _, _)) = layout.position(self.scrollback.cursor) else {
+            return;
+        };
+        self.viewport.restore(self.scroll, self.follow_tail);
+        self.viewport.reveal(row, self.visible_rows(panel_height));
+        self.scroll = self.viewport.offset();
+        self.follow_tail = self.viewport.is_following();
+    }
+
+    fn move_scrollback(
+        &mut self,
+        motion: TextPanelMotion,
+        count: usize,
+        panel_height: usize,
+        width: usize,
+    ) {
+        let layout = self.layout(width);
+        if layout.len == 0 {
+            self.scrollback.cursor = 0;
+            return;
+        }
+        self.scrollback.cursor = layout.clamp(self.scrollback.cursor);
+        let count = count.max(1);
+        let (row, _, column) = layout.position(self.scrollback.cursor).unwrap_or_default();
+        let visible_rows = self.visible_rows(panel_height).max(1);
+        let target = match motion {
+            TextPanelMotion::Left => self.scrollback.cursor.saturating_sub(count),
+            TextPanelMotion::Right => self
+                .scrollback
+                .cursor
+                .saturating_add(count)
+                .min(layout.len - 1),
+            TextPanelMotion::Up | TextPanelMotion::Down => {
+                let goal = self.scrollback.preferred_column.unwrap_or(column);
+                self.scrollback.preferred_column = Some(goal);
+                let target_row = if matches!(motion, TextPanelMotion::Up) {
+                    row.saturating_sub(count)
+                } else {
+                    row.saturating_add(count)
+                        .min(layout.lines.len().saturating_sub(1))
+                };
+                if matches!(motion, TextPanelMotion::Up) {
+                    layout.offset_at_or_before(target_row, goal)
+                } else {
+                    layout.offset_at_or_after(target_row, goal)
+                }
+                .unwrap_or(self.scrollback.cursor)
+            }
+            TextPanelMotion::LineStart => layout.line_bounds(row).map_or(0, |bounds| bounds.0),
+            TextPanelMotion::FirstNonBlank => layout
+                .first_non_blank(row)
+                .unwrap_or(self.scrollback.cursor),
+            TextPanelMotion::LineEnd => layout
+                .line_bounds(row)
+                .map_or(self.scrollback.cursor, |bounds| bounds.1),
+            TextPanelMotion::NextWord => {
+                word_motion(&layout, self.scrollback.cursor, count, WordMotion::Next)
+            }
+            TextPanelMotion::PreviousWord => {
+                word_motion(&layout, self.scrollback.cursor, count, WordMotion::Previous)
+            }
+            TextPanelMotion::WordEnd => {
+                word_motion(&layout, self.scrollback.cursor, count, WordMotion::End)
+            }
+            TextPanelMotion::PreviousParagraph | TextPanelMotion::NextParagraph => {
+                let mut target_row = row;
+                for _ in 0..count {
+                    target_row = if matches!(motion, TextPanelMotion::PreviousParagraph) {
+                        (0..target_row)
+                            .rev()
+                            .find(|candidate| {
+                                !layout.lines[*candidate].cells.is_empty()
+                                    && (*candidate == 0
+                                        || layout.lines[candidate.saturating_sub(1)]
+                                            .cells
+                                            .is_empty())
+                            })
+                            .unwrap_or(0)
+                    } else {
+                        ((target_row + 1)..layout.lines.len())
+                            .find(|candidate| {
+                                !layout.lines[*candidate].cells.is_empty()
+                                    && layout.lines[candidate.saturating_sub(1)].cells.is_empty()
+                            })
+                            .unwrap_or(layout.lines.len().saturating_sub(1))
+                    };
+                }
+                layout
+                    .nearest_offset_on_row(target_row, column)
+                    .unwrap_or(self.scrollback.cursor)
+            }
+            TextPanelMotion::PageUp | TextPanelMotion::HalfPageUp => {
+                let amount = if matches!(motion, TextPanelMotion::PageUp) {
+                    visible_rows
+                } else {
+                    visible_rows.div_ceil(2)
+                };
+                let target_row = row.saturating_sub(amount.saturating_mul(count));
+                layout
+                    .offset_at_or_before(target_row, column)
+                    .or_else(|| layout.offset_at_or_after(target_row, column))
+                    .unwrap_or(self.scrollback.cursor)
+            }
+            TextPanelMotion::PageDown | TextPanelMotion::HalfPageDown => {
+                let amount = if matches!(motion, TextPanelMotion::PageDown) {
+                    visible_rows
+                } else {
+                    visible_rows.div_ceil(2)
+                };
+                let target_row = row
+                    .saturating_add(amount.saturating_mul(count))
+                    .min(layout.lines.len().saturating_sub(1));
+                layout
+                    .offset_at_or_after(target_row, column)
+                    .or_else(|| layout.offset_at_or_before(target_row, column))
+                    .unwrap_or(self.scrollback.cursor)
+            }
+            TextPanelMotion::ViewportTop => layout
+                .offset_at_or_after(self.scroll, column)
+                .or_else(|| layout.offset_at_or_before(self.scroll, column))
+                .unwrap_or(self.scrollback.cursor),
+            TextPanelMotion::ViewportMiddle => layout
+                .nearest_offset_on_row(self.scroll.saturating_add(visible_rows / 2), column)
+                .unwrap_or(self.scrollback.cursor),
+            TextPanelMotion::ViewportBottom => layout
+                .offset_at_or_before(
+                    self.scroll
+                        .saturating_add(visible_rows.saturating_sub(1))
+                        .min(layout.lines.len().saturating_sub(1)),
+                    column,
+                )
+                .or_else(|| layout.offset_at_or_after(self.scroll, column))
+                .unwrap_or(self.scrollback.cursor),
+            TextPanelMotion::Top => 0,
+            TextPanelMotion::Bottom => layout.len - 1,
+        };
+        self.scrollback.cursor = layout.clamp(target);
+        if !matches!(motion, TextPanelMotion::Up | TextPanelMotion::Down) {
+            self.scrollback.preferred_column = None;
+        }
+        if matches!(motion, TextPanelMotion::Bottom) {
+            self.scroll_to_bottom(panel_height, width);
+        } else {
+            self.follow_tail = false;
+            self.reveal_scrollback_cursor(&layout, panel_height);
+        }
+        self.selected_link = None;
+    }
+
+    fn yank_scrollback(&mut self, width: usize) -> Option<TextPanelYank> {
+        let layout = self.layout(width);
+        let (start, end) = self.selection_bounds(&layout)?;
+        let linewise = self.scrollback.mode == TextPanelScrollbackMode::VisualLine;
+        let text = layout.selected_text(start, end, linewise);
+        if text.is_empty() {
+            return None;
+        }
+        self.scrollback.cursor = start;
+        self.scrollback.mode = TextPanelScrollbackMode::Normal;
+        self.scrollback.selection_anchor = None;
+        Some(TextPanelYank { text, linewise })
+    }
+
+    fn find_in_scrollback(
+        &mut self,
+        find: ScrollbackFind,
+        count: usize,
+        panel_height: usize,
+        width: usize,
+    ) {
+        let layout = self.layout(width);
+        let Some((row, _, _)) = layout.position(self.scrollback.cursor) else {
+            return;
+        };
+        let Some((line_start, line_end)) = layout.line_bounds(row) else {
+            return;
+        };
+        let cells = layout_cells(&layout);
+        let matches_target = |offset: usize| {
+            cells
+                .get(offset)
+                .is_some_and(|cell| cell.text.starts_with(find.target))
+        };
+        let target = match find.direction {
+            ScrollbackFindDirection::Forward => ((self.scrollback.cursor + 1)..=line_end)
+                .filter(|offset| matches_target(*offset))
+                .nth(count.saturating_sub(1))
+                .map(|offset| {
+                    if find.till {
+                        offset.saturating_sub(1)
+                    } else {
+                        offset
+                    }
+                }),
+            ScrollbackFindDirection::Backward => (line_start..self.scrollback.cursor)
+                .rev()
+                .filter(|offset| matches_target(*offset))
+                .nth(count.saturating_sub(1))
+                .map(|offset| {
+                    if find.till {
+                        offset.saturating_add(1).min(line_end)
+                    } else {
+                        offset
+                    }
+                }),
+        };
+        if let Some(target) = target {
+            self.scrollback.cursor = target;
+            self.scrollback.preferred_column = None;
+            self.follow_tail = false;
+            self.reveal_scrollback_cursor(&layout, panel_height);
+            self.selected_link = None;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WordClass {
+    Whitespace,
+    Word,
+    Punctuation,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum WordMotion {
+    Next,
+    Previous,
+    End,
+}
+
+fn word_class(cell: &TextPanelLayoutCell) -> WordClass {
+    let mut chars = cell.text.chars();
+    let Some(character) = chars.next() else {
+        return WordClass::Whitespace;
+    };
+    if character.is_whitespace() {
+        WordClass::Whitespace
+    } else if character.is_alphanumeric() || character == '_' {
+        WordClass::Word
+    } else {
+        WordClass::Punctuation
+    }
+}
+
+fn layout_cells(layout: &TextPanelLayout) -> Vec<&TextPanelLayoutCell> {
+    layout.lines.iter().flat_map(|line| &line.cells).collect()
+}
+
+fn word_motion(layout: &TextPanelLayout, offset: usize, count: usize, motion: WordMotion) -> usize {
+    let cells = layout_cells(layout);
+    if cells.is_empty() {
+        return 0;
+    }
+    let mut cursor = offset.min(cells.len() - 1);
+    for _ in 0..count.max(1) {
+        cursor = match motion {
+            WordMotion::Next => {
+                let class = word_class(cells[cursor]);
+                let mut next = cursor.saturating_add(1);
+                while next < cells.len() && word_class(cells[next]) == class {
+                    next += 1;
+                }
+                while next < cells.len() && word_class(cells[next]) == WordClass::Whitespace {
+                    next += 1;
+                }
+                next.min(cells.len() - 1)
+            }
+            WordMotion::Previous => {
+                let mut previous = cursor.saturating_sub(1);
+                while previous > 0 && word_class(cells[previous]) == WordClass::Whitespace {
+                    previous -= 1;
+                }
+                let class = word_class(cells[previous]);
+                while previous > 0 && word_class(cells[previous - 1]) == class {
+                    previous -= 1;
+                }
+                previous
+            }
+            WordMotion::End => {
+                let mut end = cursor;
+                if end + 1 < cells.len() {
+                    end += 1;
+                }
+                while end < cells.len() && word_class(cells[end]) == WordClass::Whitespace {
+                    end += 1;
+                }
+                if end >= cells.len() {
+                    cells.len() - 1
+                } else {
+                    let class = word_class(cells[end]);
+                    while end + 1 < cells.len() && word_class(cells[end + 1]) == class {
+                        end += 1;
+                    }
+                    end
+                }
+            }
+        };
+    }
+    cursor
 }
 
 fn namespace_block_links(lines: &mut [RenderedTextLine], block_index: usize) {
@@ -950,6 +1666,10 @@ impl PanelManager {
             && (self.panels.contains_key(id) || self.text_panels.contains_key(id))
         {
             self.focused = Some(id.to_string());
+            if let Some(panel) = self.text_panels.get_mut(id) {
+                let width = effective_panel_width(&panel.config, usize::MAX);
+                panel.focus_scrollback(width);
+            }
             true
         } else {
             false
@@ -970,6 +1690,9 @@ impl PanelManager {
                 .and_then(|panel| panel.composer.as_mut())
             {
                 composer.focused = false;
+            }
+            if let Some(panel) = self.text_panels.get_mut(id) {
+                panel.blur_scrollback();
             }
         }
         self.focused = None;
@@ -1084,6 +1807,14 @@ impl PanelManager {
                 }
                 "top" => panel.scroll_to_top(),
                 "bottom" => panel.scroll_to_bottom(panel_height, width),
+                "composer_focus" => {
+                    panel.blur_scrollback();
+                    if let Some(composer) = panel.composer.as_mut() {
+                        if composer.enabled {
+                            composer.focused = true;
+                        }
+                    }
+                }
                 _ => {}
             }
             return Some(PanelEvent {
@@ -1115,6 +1846,171 @@ impl PanelManager {
         })
     }
 
+    pub(crate) fn handle_focused_scrollback_input(
+        &mut self,
+        event: &Event,
+        panel_height: usize,
+        terminal_width: usize,
+        count: usize,
+    ) -> Option<TextPanelScrollbackInput> {
+        let focused = self.focused.clone()?;
+        let panel = self.text_panels.get_mut(&focused)?;
+        if !panel.scrollback.focused {
+            return None;
+        }
+        let Event::Key(key) = event else {
+            return None;
+        };
+        let width = effective_panel_width(&panel.config, terminal_width);
+        let panel_height = effective_panel_height(&panel.config, panel_height);
+
+        if let Some(pending) = panel.scrollback.pending_find.take() {
+            if key.code == KeyCode::Esc {
+                return Some(TextPanelScrollbackInput::Handled);
+            }
+            let KeyCode::Char(target) = key.code else {
+                return Some(TextPanelScrollbackInput::Handled);
+            };
+            let find = ScrollbackFind {
+                direction: pending.direction,
+                till: pending.till,
+                target,
+            };
+            panel.find_in_scrollback(find, pending.count, panel_height, width);
+            panel.scrollback.last_find = Some(find);
+            return Some(TextPanelScrollbackInput::Handled);
+        }
+
+        if key.code == KeyCode::Esc && panel.scrollback.mode != TextPanelScrollbackMode::Normal {
+            panel.scrollback.mode = TextPanelScrollbackMode::Normal;
+            panel.scrollback.selection_anchor = None;
+            return Some(TextPanelScrollbackInput::Handled);
+        }
+        if key.code == KeyCode::Esc {
+            let composer_enabled = panel
+                .composer
+                .as_ref()
+                .is_some_and(|composer| composer.enabled);
+            if composer_enabled {
+                panel.blur_scrollback();
+                if let Some(composer) = panel.composer.as_mut() {
+                    composer.focused = true;
+                }
+                return Some(TextPanelScrollbackInput::Handled);
+            }
+            return None;
+        }
+        if key.modifiers.is_empty() && matches!(key.code, KeyCode::Char('i' | 'a')) {
+            let composer_enabled = panel
+                .composer
+                .as_ref()
+                .is_some_and(|composer| composer.enabled);
+            if composer_enabled {
+                panel.blur_scrollback();
+                if let Some(composer) = panel.composer.as_mut() {
+                    composer.focused = true;
+                    composer.prompt.set_mode(crate::editor::Mode::Normal);
+                    let _ = composer
+                        .prompt
+                        .handle_event(event, width.saturating_sub(2).max(1));
+                }
+                return Some(TextPanelScrollbackInput::Handled);
+            }
+        }
+        if !key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+        {
+            match key.code {
+                KeyCode::Char('v') => {
+                    panel.scrollback.mode =
+                        if panel.scrollback.mode == TextPanelScrollbackMode::Visual {
+                            TextPanelScrollbackMode::Normal
+                        } else {
+                            TextPanelScrollbackMode::Visual
+                        };
+                    panel.scrollback.selection_anchor = (panel.scrollback.mode
+                        != TextPanelScrollbackMode::Normal)
+                        .then_some(panel.scrollback.cursor);
+                    return Some(TextPanelScrollbackInput::Handled);
+                }
+                KeyCode::Char('V') => {
+                    panel.scrollback.mode =
+                        if panel.scrollback.mode == TextPanelScrollbackMode::VisualLine {
+                            TextPanelScrollbackMode::Normal
+                        } else {
+                            TextPanelScrollbackMode::VisualLine
+                        };
+                    panel.scrollback.selection_anchor = (panel.scrollback.mode
+                        != TextPanelScrollbackMode::Normal)
+                        .then_some(panel.scrollback.cursor);
+                    return Some(TextPanelScrollbackInput::Handled);
+                }
+                KeyCode::Char('y') if panel.scrollback.mode != TextPanelScrollbackMode::Normal => {
+                    return panel
+                        .yank_scrollback(width)
+                        .map(TextPanelScrollbackInput::Yank);
+                }
+                KeyCode::Char('f' | 'F' | 't' | 'T') => {
+                    panel.scrollback.pending_find = Some(PendingScrollbackFind {
+                        direction: if matches!(key.code, KeyCode::Char('F' | 'T')) {
+                            ScrollbackFindDirection::Backward
+                        } else {
+                            ScrollbackFindDirection::Forward
+                        },
+                        till: matches!(key.code, KeyCode::Char('t' | 'T')),
+                        count,
+                    });
+                    return Some(TextPanelScrollbackInput::Handled);
+                }
+                KeyCode::Char(';' | ',') => {
+                    let Some(mut find) = panel.scrollback.last_find else {
+                        return Some(TextPanelScrollbackInput::Handled);
+                    };
+                    if key.code == KeyCode::Char(',') {
+                        find.direction = match find.direction {
+                            ScrollbackFindDirection::Forward => ScrollbackFindDirection::Backward,
+                            ScrollbackFindDirection::Backward => ScrollbackFindDirection::Forward,
+                        };
+                    }
+                    panel.find_in_scrollback(find, count, panel_height, width);
+                    return Some(TextPanelScrollbackInput::Handled);
+                }
+                _ => {}
+            }
+        }
+
+        let control = key.modifiers.contains(KeyModifiers::CONTROL);
+        let motion = match key.code {
+            KeyCode::Left | KeyCode::Char('h') if !control => TextPanelMotion::Left,
+            KeyCode::Right | KeyCode::Char('l') if !control => TextPanelMotion::Right,
+            KeyCode::Up | KeyCode::Char('k') if !control => TextPanelMotion::Up,
+            KeyCode::Down | KeyCode::Char('j') if !control => TextPanelMotion::Down,
+            KeyCode::Home | KeyCode::Char('0') if !control => TextPanelMotion::LineStart,
+            KeyCode::Char('^') if !control => TextPanelMotion::FirstNonBlank,
+            KeyCode::End | KeyCode::Char('$') if !control => TextPanelMotion::LineEnd,
+            KeyCode::Char('w' | 'W') if !control => TextPanelMotion::NextWord,
+            KeyCode::Char('b' | 'B') if !control => TextPanelMotion::PreviousWord,
+            KeyCode::Char('e' | 'E') if !control => TextPanelMotion::WordEnd,
+            KeyCode::Char('{') if !control => TextPanelMotion::PreviousParagraph,
+            KeyCode::Char('}') if !control => TextPanelMotion::NextParagraph,
+            KeyCode::PageUp => TextPanelMotion::PageUp,
+            KeyCode::PageDown => TextPanelMotion::PageDown,
+            KeyCode::Char('b') if control => TextPanelMotion::PageUp,
+            KeyCode::Char('f') if control => TextPanelMotion::PageDown,
+            KeyCode::Char('u') if control => TextPanelMotion::HalfPageUp,
+            KeyCode::Char('d') if control => TextPanelMotion::HalfPageDown,
+            KeyCode::Char('H') if !control => TextPanelMotion::ViewportTop,
+            KeyCode::Char('M') if !control => TextPanelMotion::ViewportMiddle,
+            KeyCode::Char('L') if !control => TextPanelMotion::ViewportBottom,
+            KeyCode::Char('g') if !control => TextPanelMotion::Top,
+            KeyCode::Char('G') if !control => TextPanelMotion::Bottom,
+            _ => return None,
+        };
+        panel.move_scrollback(motion, count, panel_height, width);
+        Some(TextPanelScrollbackInput::Handled)
+    }
+
     pub fn handle_mouse_scroll(
         &mut self,
         id: &str,
@@ -1128,6 +2024,22 @@ impl PanelManager {
             let width = effective_panel_width(&panel.config, terminal_width);
             let panel_height = effective_panel_height(&panel.config, panel_height);
             panel.move_scroll(delta, panel_height, width);
+            if panel.scrollback.focused {
+                let layout = panel.layout(width);
+                if let Some((row, _, column)) = layout.position(panel.scrollback.cursor) {
+                    let visible = panel.visible_rows(panel_height);
+                    let first = panel.scroll;
+                    let last = first
+                        .saturating_add(visible.saturating_sub(1))
+                        .min(layout.lines.len().saturating_sub(1));
+                    let target_row = row.clamp(first, last);
+                    if target_row != row {
+                        if let Some(offset) = layout.nearest_offset_on_row(target_row, column) {
+                            panel.scrollback.cursor = offset;
+                        }
+                    }
+                }
+            }
             return Some(PanelEvent {
                 panel_id: panel.id.clone(),
                 action: action.to_string(),
@@ -1168,13 +2080,29 @@ impl PanelManager {
         panel.select_link(forward, panel_height, width)
     }
 
+    pub(crate) fn focus_focused_text_scrollback(&mut self, terminal_width: usize) -> bool {
+        let Some(focused) = self.focused.clone() else {
+            return false;
+        };
+        let Some(panel) = self.text_panels.get_mut(&focused) else {
+            return false;
+        };
+        let width = effective_panel_width(&panel.config, terminal_width);
+        panel.focus_scrollback(width);
+        true
+    }
+
     pub(crate) fn focused_text_link_target(
         &self,
         terminal_width: usize,
     ) -> Option<TextPanelLinkTarget> {
         let panel = self.text_panels.get(self.focused.as_deref()?)?;
         let width = effective_panel_width(&panel.config, terminal_width);
-        panel.selected_link_target(width)
+        if panel.scrollback.focused {
+            panel.layout(width).link_at(panel.scrollback.cursor)
+        } else {
+            panel.selected_link_target(width)
+        }
     }
 
     pub(crate) fn text_link_at_position(
@@ -1237,17 +2165,17 @@ impl PanelManager {
         if !self.z_order.iter().any(|panel_id| panel_id == id) {
             return false;
         }
-        let Some(composer) = self
-            .text_panels
-            .get_mut(id)
-            .and_then(|panel| panel.composer.as_mut())
-        else {
+        let Some(panel) = self.text_panels.get_mut(id) else {
+            return false;
+        };
+        let Some(composer) = panel.composer.as_mut() else {
             return false;
         };
         if !composer.enabled {
             return false;
         }
         composer.focused = true;
+        panel.blur_scrollback();
         self.focused = Some(id.to_string());
         true
     }
@@ -1349,6 +2277,7 @@ impl PanelManager {
                 if (composer.prompt.mode() == crate::editor::Mode::Normal
                     && key.modifiers.is_empty()
                     && matches!(key.code, KeyCode::Char('j' | 'k') | KeyCode::Up | KeyCode::Down))
+                    || matches!(key.code, KeyCode::Tab | KeyCode::BackTab)
                     || (key.modifiers.contains(KeyModifiers::CONTROL)
                         && matches!(key.code, KeyCode::Char('h' | 'j' | 'k' | 'g' | 'G' | 'w')))
         );
@@ -1387,6 +2316,11 @@ impl PanelManager {
             },
             PromptInput::Cancel => {
                 composer.focused = false;
+                panel.scrollback.focused = true;
+                panel.scrollback.mode = TextPanelScrollbackMode::Normal;
+                panel.scrollback.selection_anchor = None;
+                let layout = panel.layout(panel_width);
+                panel.scrollback.cursor = layout.clamp(panel.scrollback.cursor);
                 ("composer_blur", None)
             }
             PromptInput::Unhandled
@@ -1410,6 +2344,13 @@ impl PanelManager {
     /// Returns the prompt-local editor mode while the docked composer owns focus.
     pub(crate) fn focused_text_panel_cursor_mode(&self) -> Option<crate::editor::Mode> {
         let panel = self.text_panels.get(self.focused.as_deref()?)?;
+        if panel.scrollback.focused {
+            return Some(match panel.scrollback.mode {
+                TextPanelScrollbackMode::Normal => crate::editor::Mode::Normal,
+                TextPanelScrollbackMode::Visual => crate::editor::Mode::Visual,
+                TextPanelScrollbackMode::VisualLine => crate::editor::Mode::VisualLine,
+            });
+        }
         let composer = panel.composer.as_ref()?;
         (composer.focused && composer.enabled).then(|| composer.prompt.mode())
     }
@@ -1421,14 +2362,36 @@ impl PanelManager {
     ) -> Option<(usize, usize)> {
         let id = self.focused.as_deref()?;
         let panel = self.text_panels.get(id)?;
-        let composer = panel.composer.as_ref()?;
-        if !composer.focused || !composer.enabled {
-            return None;
-        }
         let placement = self
             .panel_placements(terminal_width, terminal_height)
             .into_iter()
             .find(|placement| placement.id == id)?;
+        if panel.scrollback.focused {
+            let title_rows = usize::from(
+                panel.config.title.is_some() || !panel.config.header_actions.is_empty(),
+            );
+            let visible_rows = panel.visible_rows(placement.height);
+            let layout = panel.layout(placement.width);
+            let max_scroll = layout.lines.len().saturating_sub(visible_rows);
+            let scroll = panel.viewport.visible_offset(max_scroll);
+            let (row, _, column) = layout
+                .position(panel.scrollback.cursor)
+                .unwrap_or((scroll, 0, 0));
+            if row < scroll || row >= scroll.saturating_add(visible_rows) {
+                return None;
+            }
+            return Some((
+                placement.x.saturating_add(column),
+                placement
+                    .y
+                    .saturating_add(title_rows)
+                    .saturating_add(row.saturating_sub(scroll)),
+            ));
+        }
+        let composer = panel.composer.as_ref()?;
+        if !composer.focused || !composer.enabled {
+            return None;
+        }
         let content_width = placement.width.saturating_sub(2).max(1);
         let wrapped = wrap_text(&composer.prompt.text(), content_width);
         let (row, column) = wrapped
@@ -1506,10 +2469,33 @@ impl PanelManager {
                         composer.prompt.set_cursor(index);
                     }
                 }
+                panel.blur_scrollback();
                 "composer_focus"
             } else {
-                if let Some(composer) = panel.composer.as_mut() {
-                    composer.focused = false;
+                panel.focus_scrollback(placement.width);
+                let title_rows = usize::from(
+                    panel.config.title.is_some() || !panel.config.header_actions.is_empty(),
+                );
+                let content_height = placement
+                    .height
+                    .saturating_sub(panel.composer_height())
+                    .saturating_sub(panel.status_height());
+                let screen_row = y.saturating_sub(placement.y);
+                if screen_row >= title_rows && screen_row < content_height {
+                    let layout = panel.layout(placement.width);
+                    let visible_rows = content_height.saturating_sub(title_rows);
+                    let max_scroll = layout.lines.len().saturating_sub(visible_rows);
+                    let scroll = panel.viewport.visible_offset(max_scroll);
+                    let row = scroll.saturating_add(screen_row.saturating_sub(title_rows));
+                    let column = x.saturating_sub(placement.x);
+                    if let Some(offset) = layout.nearest_offset_on_row(row, column) {
+                        panel.scrollback.cursor = offset;
+                        panel.scrollback.mouse_anchor = Some(offset);
+                        panel.scrollback.mouse_dragging = true;
+                        panel.scrollback.mode = TextPanelScrollbackMode::Normal;
+                        panel.scrollback.selection_anchor = None;
+                        panel.selected_link = None;
+                    }
                 }
                 "select"
             };
@@ -1532,6 +2518,88 @@ impl PanelManager {
             row: panel.selected_row(),
             text: None,
         })
+    }
+
+    pub(crate) fn drag_focused_text_selection(
+        &mut self,
+        x: usize,
+        y: usize,
+        terminal_width: usize,
+        terminal_height: usize,
+    ) -> bool {
+        let Some(id) = self.focused.clone() else {
+            return false;
+        };
+        let Some(placement) = self
+            .panel_placements(terminal_width, terminal_height)
+            .into_iter()
+            .find(|placement| placement.id == id)
+        else {
+            return false;
+        };
+        let Some(panel) = self.text_panels.get_mut(&id) else {
+            return false;
+        };
+        let Some(anchor) = panel.scrollback.mouse_anchor else {
+            return false;
+        };
+        if !panel.scrollback.mouse_dragging {
+            return false;
+        }
+        let title_rows =
+            usize::from(panel.config.title.is_some() || !panel.config.header_actions.is_empty());
+        let content_height = placement
+            .height
+            .saturating_sub(panel.composer_height())
+            .saturating_sub(panel.status_height());
+        if content_height <= title_rows {
+            return false;
+        }
+        let top = placement.y.saturating_add(title_rows);
+        let bottom = placement.y.saturating_add(content_height.saturating_sub(1));
+        if y < top {
+            panel.move_scroll(-1, placement.height, placement.width);
+        } else if y > bottom {
+            panel.move_scroll(1, placement.height, placement.width);
+        }
+        let layout = panel.layout(placement.width);
+        let visible_rows = content_height.saturating_sub(title_rows);
+        let max_scroll = layout.lines.len().saturating_sub(visible_rows);
+        let scroll = panel.viewport.visible_offset(max_scroll);
+        let screen_row = y.clamp(top, bottom).saturating_sub(top);
+        let row = scroll.saturating_add(screen_row);
+        let column = x
+            .clamp(
+                placement.x,
+                placement
+                    .x
+                    .saturating_add(placement.width.saturating_sub(1)),
+            )
+            .saturating_sub(placement.x);
+        let Some(offset) = layout.nearest_offset_on_row(row, column) else {
+            return false;
+        };
+        panel.scrollback.cursor = offset;
+        if offset != anchor {
+            panel.scrollback.mode = TextPanelScrollbackMode::Visual;
+            panel.scrollback.selection_anchor = Some(anchor);
+            panel.follow_tail = false;
+        }
+        true
+    }
+
+    pub(crate) fn finish_focused_text_selection(&mut self) -> bool {
+        let Some(panel) = self
+            .focused
+            .as_deref()
+            .and_then(|id| self.text_panels.get_mut(id))
+        else {
+            return false;
+        };
+        let dragging = panel.scrollback.mouse_dragging;
+        panel.scrollback.mouse_dragging = false;
+        panel.scrollback.mouse_anchor = None;
+        dragging
     }
 
     pub fn panel_at_position(
@@ -1922,16 +2990,35 @@ fn render_text_panel(
         .saturating_sub(composer_height)
         .saturating_sub(status_height);
     let visible_rows = content_height.saturating_sub(title_rows);
-    let lines = panel.rendered_lines(width);
-    let max_scroll = lines.len().saturating_sub(visible_rows);
+    let layout = panel.layout(width);
+    let max_scroll = layout.lines.len().saturating_sub(visible_rows);
     let scroll = panel.viewport.visible_offset(max_scroll);
-    for (offset, line) in lines.iter().skip(scroll).take(visible_rows).enumerate() {
+    let selection = panel.selection_bounds(&layout);
+    for (offset, line) in layout
+        .rendered
+        .iter()
+        .skip(scroll)
+        .take(visible_rows)
+        .enumerate()
+    {
+        let line_index = scroll.saturating_add(offset);
         render_text_spans(
             buffer,
             position.x,
             position.y.saturating_add(title_rows + offset),
             width,
             line,
+            layout.lines.get(line_index).map_or(0, |line| line.first),
+            layout
+                .lines
+                .get(line_index)
+                .map_or(0, |line| line.chrome_prefix_graphemes),
+            layout
+                .lines
+                .get(line_index)
+                .is_some_and(|line| line.selectable)
+                .then_some(selection)
+                .flatten(),
             panel.selected_link,
             theme,
         );
@@ -1959,6 +3046,7 @@ fn render_text_panel(
         render_text_panel_composer(
             buffer,
             composer,
+            &panel.scrollback,
             position,
             width,
             content_height + status_height,
@@ -1976,9 +3064,11 @@ enum TextPanelOverflow {
     Both,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_text_panel_composer(
     buffer: &mut RenderBuffer,
     composer: &TextPanelComposer,
+    scrollback: &TextPanelScrollback,
     position: Point,
     width: usize,
     top: usize,
@@ -2030,7 +3120,19 @@ fn render_text_panel_composer(
             style,
         );
     }
-    let hints = if composer.focused && composer.prompt.mode() == crate::editor::Mode::Normal {
+    let hints = if scrollback.focused {
+        match scrollback.mode {
+            TextPanelScrollbackMode::Normal => {
+                "SCROLLBACK NORMAL · hjkl/arrows move · v/V select · y copy · a edit"
+            }
+            TextPanelScrollbackMode::Visual => {
+                "SCROLLBACK VISUAL · motions extend · y copy · Esc cancel"
+            }
+            TextPanelScrollbackMode::VisualLine => {
+                "SCROLLBACK VISUAL LINE · motions extend · y copy · Esc cancel"
+            }
+        }
+    } else if composer.focused && composer.prompt.mode() == crate::editor::Mode::Normal {
         "NORMAL · j/k ↑/↓ scroll · i/a edit · Enter send · Esc nav"
     } else if composer.focused {
         "INSERT · ^J/^K scroll · ^g/^G ends · Ctrl+Enter send · Esc normal"
@@ -2147,16 +3249,23 @@ fn text_panel_header_action_at(config: &PanelConfig, width: usize, x: usize) -> 
         .map(|(_, action, _)| action)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_text_spans(
     buffer: &mut RenderBuffer,
     x: usize,
     y: usize,
     width: usize,
     line: &RenderedTextLine,
+    line_first: usize,
+    chrome_prefix_graphemes: usize,
+    selection: Option<(usize, usize)>,
     selected_link: Option<u64>,
     theme: &Theme,
 ) {
-    paint_rich_text(buffer, x, y, width, line, |span| {
+    let mut column = 0usize;
+    let mut offset = line_first;
+    let mut grapheme_index = 0usize;
+    for span in &line.spans {
         let base_style = text_panel_span_style(span.style, theme);
         let mut style = if let Some(syntax_style) = &span.syntax_style {
             Style {
@@ -2176,8 +3285,30 @@ fn render_text_spans(
             let selection = theme.list_selection_style();
             style = theme.selected_style(&style, &selection, SelectionForegroundPriority::Content);
         }
-        style
-    });
+        for grapheme in span.text.graphemes(true) {
+            let grapheme_width = display_width(grapheme).max(1);
+            if column.saturating_add(grapheme_width) > width {
+                return;
+            }
+            let mut grapheme_style = style.clone();
+            let selectable = grapheme_index >= chrome_prefix_graphemes;
+            if selectable && selection.is_some_and(|(start, end)| offset >= start && offset <= end)
+            {
+                let selected = theme.list_selection_style();
+                grapheme_style = theme.selected_style(
+                    &grapheme_style,
+                    &selected,
+                    SelectionForegroundPriority::Content,
+                );
+            }
+            buffer.set_text(x.saturating_add(column), y, grapheme, &grapheme_style);
+            column = column.saturating_add(grapheme_width);
+            if selectable {
+                offset = offset.saturating_add(1);
+            }
+            grapheme_index = grapheme_index.saturating_add(1);
+        }
+    }
 }
 
 fn text_panel_span_style(style: TextPanelSpanStyle, theme: &Theme) -> Style {
@@ -2274,6 +3405,7 @@ fn turn_separator(width: usize) -> RenderedTextLine {
 }
 
 fn user_accented(line: RenderedTextLine) -> RenderedTextLine {
+    let break_after = line.break_after;
     let mut spans = vec![RenderedTextSpan {
         text: "▎ ".to_string(),
         style: TextPanelSpanStyle::User,
@@ -2281,7 +3413,7 @@ fn user_accented(line: RenderedTextLine) -> RenderedTextLine {
         link: None,
     }];
     spans.extend(line.spans);
-    RenderedTextLine { spans }
+    RenderedTextLine { spans, break_after }
 }
 
 fn render_row_segments(
@@ -3066,10 +4198,11 @@ mod tests {
                     link: None,
                 },
             ],
+            break_after: RenderedTextLineBreak::Hard,
         };
         let mut buffer = RenderBuffer::new(2, 1, &theme.style);
 
-        render_text_spans(&mut buffer, 0, 0, 2, &line, None, &theme);
+        render_text_spans(&mut buffer, 0, 0, 2, &line, 0, 0, None, None, &theme);
 
         assert_eq!(
             buffer.cells[0].style,
@@ -3948,7 +5081,7 @@ mod tests {
             .map(|row| row_text(&buffer, row))
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(top.contains("↓ more · j/k scroll · G latest"));
+        assert!(top.contains("SCROLLBACK NORMAL · hjkl/arrows move"));
 
         manager.handle_focused_key("bottom", 15, 80, 0).unwrap();
         let mut buffer = RenderBuffer::new(80, 15, &theme.style);
@@ -3957,7 +5090,7 @@ mod tests {
             .map(|row| row_text(&buffer, row))
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(bottom.contains("↑ history · j/k scroll · g oldest"));
+        assert!(bottom.contains("SCROLLBACK NORMAL · hjkl/arrows move"));
     }
 
     #[test]
@@ -4404,5 +5537,403 @@ mod tests {
         render_panel(&mut buffer, &panel, Point::new(0, 0), 6, &theme);
 
         assert_eq!(row_text(&buffer, 0), "abc M ");
+    }
+
+    #[test]
+    fn scrollback_selection_copy_ignores_soft_wraps_and_preserves_hard_breaks() {
+        let mut panel = TextPanel::new("agent".to_string(), PanelConfig::default());
+        panel.blocks = vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Plain,
+            text: "alpha beta gamma\nsecond line".to_string(),
+        }];
+
+        let layout = panel.layout(7);
+        assert!(layout.lines.len() > 2);
+        assert_eq!(
+            layout.selected_text(0, layout.len - 1, false),
+            "alpha beta gamma\nsecond line"
+        );
+
+        let wide = panel.layout(40);
+        assert_eq!(layout.len, wide.len);
+        assert_eq!(
+            layout.selected_text(6, 9, false),
+            wide.selected_text(6, 9, false)
+        );
+
+        panel.blocks[0].kind = TextPanelBlockKind::User;
+        let narrow_user = panel.layout(7);
+        let wide_user = panel.layout(40);
+        assert_eq!(narrow_user.len, wide_user.len);
+        assert_eq!(
+            narrow_user.selected_text(0, narrow_user.len - 1, false),
+            "▎ You\nalpha beta gamma\nsecond line"
+        );
+    }
+
+    #[test]
+    fn scrollback_focus_starts_on_the_first_visible_row_so_j_moves_down() {
+        use crossterm::event::KeyEvent;
+
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "agent".to_string(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 20,
+                title: Some("Agent".to_string()),
+                composer: Some(TextPanelComposerConfig {
+                    placeholder: "Ask".to_string(),
+                    rows: 2,
+                }),
+                ..PanelConfig::default()
+            },
+        );
+        manager.update_text_panel(
+            "agent",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Text,
+                format: TextPanelBlockFormat::Plain,
+                text: (1..=30)
+                    .map(|line| format!("line {line}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            }],
+            8,
+            80,
+        );
+        assert!(manager.focus_text_panel_composer("agent"));
+        assert!(manager.focus_focused_text_scrollback(80));
+
+        let panel = &manager.text_panels["agent"];
+        assert!(panel.scroll > 0);
+        let before_row = panel
+            .layout(20)
+            .position(panel.scrollback.cursor)
+            .unwrap()
+            .0;
+        assert_eq!(before_row, panel.scroll);
+
+        manager
+            .handle_focused_scrollback_input(
+                &Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+                8,
+                80,
+                1,
+            )
+            .unwrap();
+
+        let panel = &manager.text_panels["agent"];
+        let after_row = panel
+            .layout(20)
+            .position(panel.scrollback.cursor)
+            .unwrap()
+            .0;
+        assert_eq!(after_row, before_row + 1);
+    }
+
+    #[test]
+    fn scrollback_j_moves_forward_across_empty_rows() {
+        use crossterm::event::KeyEvent;
+
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "agent".to_string(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 20,
+                ..PanelConfig::default()
+            },
+        );
+        manager.update_text_panel(
+            "agent",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Text,
+                format: TextPanelBlockFormat::Plain,
+                text: "first\n\nthird".to_string(),
+            }],
+            10,
+            80,
+        );
+        assert!(manager.focus_panel("agent"));
+        manager
+            .handle_focused_scrollback_input(
+                &Event::Key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+                10,
+                80,
+                1,
+            )
+            .unwrap();
+
+        let before = manager.text_panels["agent"].scrollback.cursor;
+        manager
+            .handle_focused_scrollback_input(
+                &Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+                10,
+                80,
+                1,
+            )
+            .unwrap();
+
+        let panel = &manager.text_panels["agent"];
+        assert!(panel.scrollback.cursor > before);
+        let layout = panel.layout(20);
+        let (row, _, _) = layout.position(panel.scrollback.cursor).unwrap();
+        assert_eq!(
+            layout.selected_text(panel.scrollback.cursor, panel.scrollback.cursor, false),
+            "t"
+        );
+        assert_eq!(row, 2);
+    }
+
+    #[test]
+    fn scrollback_escape_i_and_a_return_to_the_composer_in_one_keypress() {
+        use crossterm::event::KeyEvent;
+
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "agent".to_string(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 30,
+                composer: Some(TextPanelComposerConfig {
+                    placeholder: "Ask".to_string(),
+                    rows: 2,
+                }),
+                ..PanelConfig::default()
+            },
+        );
+        manager.update_text_panel(
+            "agent",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Text,
+                format: TextPanelBlockFormat::Plain,
+                text: "answer".to_string(),
+            }],
+            10,
+            80,
+        );
+        assert!(manager.focus_text_panel_composer("agent"));
+        manager.handle_focused_text_input(&Event::Paste("abcd".to_string()), 80);
+
+        assert!(manager.focus_focused_text_scrollback(80));
+        manager
+            .handle_focused_scrollback_input(
+                &Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+                10,
+                80,
+                1,
+            )
+            .unwrap();
+        assert_eq!(
+            manager.focused_text_panel_cursor_mode(),
+            Some(crate::editor::Mode::Insert)
+        );
+
+        for (key, expected_cursor) in [('i', 1), ('a', 2)] {
+            let composer = manager
+                .text_panels
+                .get_mut("agent")
+                .unwrap()
+                .composer
+                .as_mut()
+                .unwrap();
+            composer.prompt.set_cursor(1);
+            composer.prompt.set_mode(crate::editor::Mode::Insert);
+            assert!(manager.focus_focused_text_scrollback(80));
+
+            manager
+                .handle_focused_scrollback_input(
+                    &Event::Key(KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)),
+                    10,
+                    80,
+                    1,
+                )
+                .unwrap();
+
+            let panel = &manager.text_panels["agent"];
+            let composer = panel.composer.as_ref().unwrap();
+            assert!(composer.focused);
+            assert!(!panel.scrollback.focused);
+            assert_eq!(composer.prompt.mode(), crate::editor::Mode::Insert);
+            assert_eq!(composer.prompt.cursor(), expected_cursor);
+        }
+    }
+
+    #[test]
+    fn scrollback_visual_line_yank_is_unicode_safe_and_linewise() {
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "agent".to_string(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 20,
+                ..PanelConfig::default()
+            },
+        );
+        manager.update_text_panel(
+            "agent",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Text,
+                format: TextPanelBlockFormat::Plain,
+                text: "a👨‍👩‍👧‍👦e\u{301}\nsecond".to_string(),
+            }],
+            10,
+            80,
+        );
+        assert!(manager.focus_panel("agent"));
+        manager
+            .handle_focused_scrollback_input(
+                &Event::Key(crossterm::event::KeyEvent::new(
+                    KeyCode::Char('g'),
+                    KeyModifiers::NONE,
+                )),
+                10,
+                80,
+                1,
+            )
+            .unwrap();
+        manager
+            .handle_focused_scrollback_input(
+                &Event::Key(crossterm::event::KeyEvent::new(
+                    KeyCode::Char('V'),
+                    KeyModifiers::SHIFT,
+                )),
+                10,
+                80,
+                1,
+            )
+            .unwrap();
+        let yank = manager
+            .handle_focused_scrollback_input(
+                &Event::Key(crossterm::event::KeyEvent::new(
+                    KeyCode::Char('y'),
+                    KeyModifiers::NONE,
+                )),
+                10,
+                80,
+                1,
+            )
+            .unwrap();
+
+        assert_eq!(
+            yank,
+            TextPanelScrollbackInput::Yank(TextPanelYank {
+                text: "a👨‍👩‍👧‍👦e\u{301}\n".to_string(),
+                linewise: true,
+            })
+        );
+    }
+
+    #[test]
+    fn scrollback_character_find_extends_visual_selection() {
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "agent".to_string(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 20,
+                ..PanelConfig::default()
+            },
+        );
+        manager.update_text_panel(
+            "agent",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Text,
+                format: TextPanelBlockFormat::Plain,
+                text: "alpha beta".to_string(),
+            }],
+            10,
+            80,
+        );
+        assert!(manager.focus_panel("agent"));
+        let mut outcome = None;
+        for key in ['g', 'v', 'f', 'b', 'y'] {
+            outcome = manager.handle_focused_scrollback_input(
+                &Event::Key(crossterm::event::KeyEvent::new(
+                    KeyCode::Char(key),
+                    KeyModifiers::NONE,
+                )),
+                10,
+                80,
+                1,
+            );
+        }
+
+        let panel = &manager.text_panels["agent"];
+        assert_eq!(panel.scrollback.mode, TextPanelScrollbackMode::Normal);
+        assert_eq!(panel.scrollback.cursor, 0);
+        assert_eq!(
+            outcome,
+            Some(TextPanelScrollbackInput::Yank(TextPanelYank {
+                text: "alpha b".to_string(),
+                linewise: false,
+            }))
+        );
+    }
+
+    #[test]
+    fn streaming_append_does_not_expand_an_active_scrollback_selection() {
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "agent".to_string(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 20,
+                ..PanelConfig::default()
+            },
+        );
+        manager.update_text_panel(
+            "agent",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Text,
+                format: TextPanelBlockFormat::Plain,
+                text: "alpha beta".to_string(),
+            }],
+            10,
+            80,
+        );
+        assert!(manager.focus_panel("agent"));
+        for key in ['g', 'v', 'e'] {
+            manager
+                .handle_focused_scrollback_input(
+                    &Event::Key(crossterm::event::KeyEvent::new(
+                        KeyCode::Char(key),
+                        KeyModifiers::NONE,
+                    )),
+                    10,
+                    80,
+                    1,
+                )
+                .unwrap();
+        }
+        manager.append_text_panel("agent", "answer", " gamma", 10, 80);
+
+        let yank = manager
+            .handle_focused_scrollback_input(
+                &Event::Key(crossterm::event::KeyEvent::new(
+                    KeyCode::Char('y'),
+                    KeyModifiers::NONE,
+                )),
+                10,
+                80,
+                1,
+            )
+            .unwrap();
+        assert_eq!(
+            yank,
+            TextPanelScrollbackInput::Yank(TextPanelYank {
+                text: "alpha".to_string(),
+                linewise: false,
+            })
+        );
     }
 }

--- a/src/ui/rich_text.rs
+++ b/src/ui/rich_text.rs
@@ -37,7 +37,9 @@ pub(crate) fn paint_rich_text(
 mod tests {
     use crate::{
         editor::RenderBuffer,
-        plugin::markdown::{RenderedTextLine, RenderedTextSpan, TextPanelSpanStyle},
+        plugin::markdown::{
+            RenderedTextLine, RenderedTextLineBreak, RenderedTextSpan, TextPanelSpanStyle,
+        },
         theme::Style,
     };
 
@@ -62,6 +64,7 @@ mod tests {
                     link: None,
                 },
             ],
+            break_after: RenderedTextLineBreak::Hard,
         };
 
         paint_rich_text(&mut buffer, 1, 0, 5, &line, |_| style.clone());

--- a/src/ui/rich_text.rs
+++ b/src/ui/rich_text.rs
@@ -38,7 +38,8 @@ mod tests {
     use crate::{
         editor::RenderBuffer,
         plugin::markdown::{
-            RenderedTextLine, RenderedTextLineBreak, RenderedTextSpan, TextPanelSpanStyle,
+            RenderedTextLine, RenderedTextLineBreak, RenderedTextSpan, TextPanelLineSelection,
+            TextPanelSpanSelection, TextPanelSpanStyle,
         },
         theme::Style,
     };
@@ -56,15 +57,18 @@ mod tests {
                     style: TextPanelSpanStyle::Text,
                     syntax_style: None,
                     link: None,
+                    selection: TextPanelSpanSelection::Content,
                 },
                 RenderedTextSpan {
                     text: "世z".to_string(),
                     style: TextPanelSpanStyle::Strong,
                     syntax_style: None,
                     link: None,
+                    selection: TextPanelSpanSelection::Content,
                 },
             ],
             break_after: RenderedTextLineBreak::Hard,
+            selection: TextPanelLineSelection::Semantic,
         };
 
         paint_rich_text(&mut buffer, 1, 0, 5, &line, |_| style.clone());

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -17,8 +17,8 @@ use red::{
     editor::{Action, Content, Editor, Mode, SearchDirection},
     lsp::LspClient,
     plugin::{
-        PanelConfig, PanelRow, PanelRowKind, PanelSegment, PanelSide, Runtime,
-        TextPanelComposerConfig,
+        PanelConfig, PanelRow, PanelRowKind, PanelSegment, PanelSide, Runtime, TextPanelBlock,
+        TextPanelBlockFormat, TextPanelBlockKind, TextPanelComposerConfig,
     },
     preferences::PreferencesStore,
     theme::{Style, Theme},
@@ -5840,6 +5840,125 @@ async fn focused_agent_panel_keeps_global_leader_until_the_composer_is_focused()
 }
 
 #[test]
+fn agent_scrollback_tab_focuses_a_cursor_and_visual_yank_uses_the_clipboard() {
+    let buffer = Buffer::new(None, "abcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    let clipboard_text = Arc::new(Mutex::new(None));
+    harness
+        .editor
+        .test_set_clipboard(Box::new(MemoryClipboardProvider::from(
+            clipboard_text.clone(),
+        )));
+    harness.editor.test_create_text_panel(
+        "agent",
+        PanelConfig {
+            side: PanelSide::Right,
+            width: 24,
+            title: Some("Agent".to_string()),
+            composer: Some(TextPanelComposerConfig {
+                placeholder: "Ask".to_string(),
+                rows: 2,
+            }),
+            ..PanelConfig::default()
+        },
+    );
+    harness.editor.test_update_text_panel(
+        "agent",
+        vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Plain,
+            text: "alpha beta gamma".to_string(),
+        }],
+    );
+    assert!(harness.editor.test_focus_text_panel_composer("agent"));
+
+    harness
+        .editor
+        .test_handle_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)))
+        .unwrap();
+    assert!(harness.render_cursor_position().is_some());
+
+    for key in ['g', 'w', 'v', 'e', 'y'] {
+        harness
+            .editor
+            .test_handle_event(Event::Key(KeyEvent::new(
+                KeyCode::Char(key),
+                KeyModifiers::NONE,
+            )))
+            .unwrap();
+    }
+
+    assert_eq!(clipboard_text.lock().unwrap().as_deref(), Some("beta"));
+    assert_eq!(harness.last_error(), Some("4 characters yanked"));
+    assert!(harness.render_cursor_position().is_some());
+}
+
+#[test]
+fn mouse_drag_selects_agent_scrollback_text_for_visual_yank() {
+    let buffer = Buffer::new(None, "abcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    let clipboard_text = Arc::new(Mutex::new(None));
+    harness
+        .editor
+        .test_set_clipboard(Box::new(MemoryClipboardProvider::from(
+            clipboard_text.clone(),
+        )));
+    harness.editor.test_create_text_panel(
+        "agent",
+        PanelConfig {
+            side: PanelSide::Right,
+            width: 24,
+            title: Some("Agent".to_string()),
+            composer: Some(TextPanelComposerConfig {
+                placeholder: "Ask".to_string(),
+                rows: 2,
+            }),
+            ..PanelConfig::default()
+        },
+    );
+    harness.editor.test_update_text_panel(
+        "agent",
+        vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Text,
+            format: TextPanelBlockFormat::Plain,
+            text: "alpha beta gamma".to_string(),
+        }],
+    );
+
+    for kind in [
+        MouseEventKind::Down(MouseButton::Left),
+        MouseEventKind::Drag(MouseButton::Left),
+        MouseEventKind::Up(MouseButton::Left),
+    ] {
+        let column = if matches!(kind, MouseEventKind::Down(_)) {
+            56
+        } else {
+            60
+        };
+        harness
+            .editor
+            .test_handle_event(Event::Mouse(MouseEvent {
+                kind,
+                column,
+                row: 1,
+                modifiers: KeyModifiers::NONE,
+            }))
+            .unwrap();
+    }
+    harness
+        .editor
+        .test_handle_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('y'),
+            KeyModifiers::NONE,
+        )))
+        .unwrap();
+
+    assert_eq!(clipboard_text.lock().unwrap().as_deref(), Some("alpha"));
+}
+
+#[test]
 fn focused_agent_composer_routes_control_navigation_to_the_conversation() {
     let buffer = Buffer::new(None, "abcdef".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());
@@ -7011,7 +7130,7 @@ async fn ctrl_w_w_focuses_agent_composer_and_makes_cursor_visible() {
             ))
     ));
     assert_eq!(harness.editor.test_focused_panel_id(), Some("agent"));
-    assert_eq!(harness.render_cursor_position(), None);
+    assert!(harness.render_cursor_position().is_some());
 }
 
 #[tokio::test]

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -5895,6 +5895,56 @@ fn agent_scrollback_tab_focuses_a_cursor_and_visual_yank_uses_the_clipboard() {
 }
 
 #[test]
+fn agent_scrollback_visual_yank_copies_code_without_markdown_frame() {
+    let buffer = Buffer::new(None, "abcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    let clipboard_text = Arc::new(Mutex::new(None));
+    harness
+        .editor
+        .test_set_clipboard(Box::new(MemoryClipboardProvider::from(
+            clipboard_text.clone(),
+        )));
+    harness.editor.test_create_text_panel(
+        "agent",
+        PanelConfig {
+            side: PanelSide::Right,
+            width: 24,
+            title: Some("Agent".to_string()),
+            composer: Some(TextPanelComposerConfig {
+                placeholder: "Ask".to_string(),
+                rows: 2,
+            }),
+            ..PanelConfig::default()
+        },
+    );
+    harness.editor.test_update_text_panel(
+        "agent",
+        vec![TextPanelBlock {
+            id: "answer".to_string(),
+            kind: TextPanelBlockKind::Agent,
+            format: TextPanelBlockFormat::Markdown,
+            text: "```bash\n/game\n```".to_string(),
+        }],
+    );
+    assert!(harness.editor.test_focus_text_panel_composer("agent"));
+
+    for code in [
+        KeyCode::Tab,
+        KeyCode::Char('g'),
+        KeyCode::Char('v'),
+        KeyCode::Char('G'),
+        KeyCode::Char('y'),
+    ] {
+        harness
+            .editor
+            .test_handle_event(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
+            .unwrap();
+    }
+
+    assert_eq!(clipboard_text.lock().unwrap().as_deref(), Some("/game"));
+}
+
+#[test]
 fn mouse_drag_selects_agent_scrollback_text_for_visual_yank() {
     let buffer = Buffer::new(None, "abcdef".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());


### PR DESCRIPTION
## Why

The agent conversation introduced in #197 can be navigated as a viewport, but transcript text still cannot be addressed precisely with a cursor, selected with keyboard or mouse, or copied without rendered Markdown decoration.

Depends on #197.

## What Changed

- Focus scrollback with Tab and expose a visible Normal-mode cursor.
- Support arrow/Vim motions, counts, paging, viewport motions, word/paragraph motions, and character finds.
- Add Visual and Visual Line selection, mouse drag selection, and clipboard yanks.
- Make Esc return from Normal scrollback to the composer, and make i/a focus the composer and enter Insert mode in one keypress.
- Separate semantic Markdown content from display chrome so code frames, language labels, heading/quote bars, role labels, rules, streaming cursors, and table padding are neither highlighted nor copied.
- Preserve code blank lines, list/task structure, link labels, image alt text, visible HTML, Unicode, and logical wrapping; grid tables copy with tab-separated columns.

## How to Test

1. Check out this branch with #197 beneath it, run `cargo run`, and open an agent conversation with enough content to scroll.
2. Focus the composer, then press Tab. Move with j/k, arrows, counts, paging, and word motions; the cursor should cross blank rows without changing the composer draft.
3. Press v or V, extend with normal motions, and press y. Paste elsewhere and confirm only highlighted conversation content was copied. Repeat with a mouse drag followed by y.
4. Select a fenced Bash block. Its command should highlight and copy, while the `bash` title and `┌─`, `│`, `└─` frame glyphs should not.
5. From Normal scrollback, verify Esc returns to the composer. Re-enter scrollback and verify i and a each enter composer Insert mode with one keypress.
6. Regression: resize the pane and append streaming content while a selection exists; the logical selection should remain stable.
