### PR TITLE
feat(editor): show release notes after version upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ The current release includes:
 See the [latest release notes](https://github.com/codersauce/red/releases/latest)
 or the [complete changelog](CHANGELOG.md) for details.
 
+After installing a new version, Red opens a themed **What’s new** panel once.
+Reopen it whenever you like with `:whats-new`, `:changelog`, or the command
+palette. Release notes are bundled for offline use and refreshed from the exact
+matching GitHub release in the background.
+
 ## Configuration
 
 Red layers your settings over embedded defaults, so a configuration file can
@@ -171,6 +176,9 @@ contain only the values you want to change:
 # ~/.config/red/config.toml
 theme = "red.json"
 scrolloff = 8
+# Disable the automatic release panel or its optional GitHub refresh:
+# show_whats_new = false
+# fetch_release_notes = false
 
 [search]
 ignorecase = true

--- a/default_config.toml
+++ b/default_config.toml
@@ -39,6 +39,12 @@ sidescrolloff = 0
 # disappears on the first edit, file open, or window split.
 splash = true
 
+# Present a themed release announcement once after installing a new version.
+show_whats_new = true
+
+# Refresh bundled release notes from GitHub without delaying editor startup.
+fetch_release_notes = true
+
 # Path to the log file. Relative paths are resolved from Red's config
 # directory. If the log file is not present, Red will create it; if it is
 # present, Red will append to it.

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -48,6 +48,8 @@ pub(crate) const BUILTIN_COLON_COMMANDS: &[&str] = &[
 const SPECIAL_BUILTIN_COLON_COMMANDS: &[&str] = &[
     "commands",
     "command-palette",
+    "whats-new",
+    "changelog",
     "db",
     "dh",
     "di",
@@ -371,6 +373,15 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Some(":config-diagnostics"),
             &[],
             Action::ConfigDiagnostics,
+        ),
+        builtin(
+            "editor.whats_new",
+            "What’s new in Red",
+            "Editor",
+            "Read highlights and release notes for the installed version",
+            Some(":whats-new"),
+            &[":changelog", "release notes", "what's new", "updates"],
+            Action::OpenWhatsNew,
         ),
         builtin(
             "editor.statusline_manager",
@@ -1021,6 +1032,7 @@ fn action_label(action: &Action) -> String {
     match action {
         Action::CommandPalette => "All commands".to_string(),
         Action::ConfigDiagnostics => "Configuration diagnostics".to_string(),
+        Action::OpenWhatsNew => "What’s new in Red".to_string(),
         Action::OpenDiagnosticsPicker => "Diagnostics".to_string(),
         Action::OpenErrorDiagnosticsPicker => "Errors".to_string(),
         Action::OpenStatuslineManager => "Configure status line".to_string(),
@@ -1111,6 +1123,8 @@ fn colon_name_is_builtin(name: &str) -> bool {
         name,
         "commands"
             | "command-palette"
+            | "whats-new"
+            | "changelog"
             | "db"
             | "dh"
             | "di"
@@ -1206,6 +1220,14 @@ mod tests {
             .unwrap();
         assert_eq!(statusline.colon.as_deref(), Some(":statusline"));
         assert_eq!(statusline.action, Action::OpenStatuslineManager);
+
+        let whats_new = entries
+            .iter()
+            .find(|entry| entry.id == "editor.whats_new")
+            .unwrap();
+        assert_eq!(whats_new.colon.as_deref(), Some(":whats-new"));
+        assert!(whats_new.aliases.iter().any(|alias| alias == ":changelog"));
+        assert_eq!(whats_new.action, Action::OpenWhatsNew);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,6 +238,14 @@ pub struct Config {
     /// Show the startup splash when red opens without file arguments.
     /// Defaults to on.
     pub splash: Option<bool>,
+    /// Announce each newly installed Red release once after interactive startup.
+    /// Defaults to on.
+    #[serde(default)]
+    pub show_whats_new: Option<bool>,
+    /// Refresh bundled release notes from the matching published GitHub release.
+    /// Defaults to on.
+    #[serde(default)]
+    pub fetch_release_notes: Option<bool>,
     /// Interactive search behavior.
     #[serde(default)]
     pub search: SearchConfig,
@@ -1754,6 +1762,8 @@ fn known_top_level_field(field: &str) -> bool {
             | "sidescroll"
             | "sidescrolloff"
             | "splash"
+            | "show_whats_new"
+            | "fetch_release_notes"
             | "search"
             | "completion"
             | "picker"
@@ -3751,6 +3761,8 @@ groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
     fn default_config_maps_command_palette_entrypoints_and_enables_key_hints() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 
+        assert_eq!(config.show_whats_new, Some(true));
+        assert_eq!(config.fetch_release_notes, Some(true));
         assert_eq!(
             config.keys.normal.get("F1"),
             Some(&KeyAction::Single(Action::CommandPalette))

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -112,10 +112,11 @@ use crate::{
     ui::{
         AgentComposer, CompletionUI, Component, Confirmation, DiagnosticInfo, FilePicker,
         HoverInfo, HoverInfoFormat, Info, InputPrompt, LegacyPickerOptions, Picker, PickerItem,
-        PickerOptions, PickerPreview, PickerUpdate, StatuslineLayoutPanel,
+        PickerOptions, PickerPreview, PickerUpdate, StatuslineLayoutPanel, WhatsNewPanel,
     },
     undo::{AppliedTextEdit, CursorSnapshot, EditOrigin, RevertEdit, TextPosition, TextRange},
     utils::{expand_user_path, get_workspace_path},
+    whats_new::ReleaseNotes,
     window::{WindowDivider, WindowId, WindowManager, WindowManagerSnapshot},
 };
 
@@ -2005,6 +2006,7 @@ pub enum Action {
     CommandPalette,
     OpenSyntaxPicker,
     SetSyntax(String),
+    OpenWhatsNew,
     OpenStatuslineManager,
     OpenDiagnosticsPicker,
     OpenErrorDiagnosticsPicker,
@@ -2680,6 +2682,15 @@ pub struct Editor {
     /// Persistent preferences, including command-line history.
     preferences: PreferencesStore,
 
+    /// A release has changed, but no visible client has seen its announcement yet.
+    whats_new_startup_pending: bool,
+
+    /// Set only after an interactive terminal or authenticated detached client exists.
+    whats_new_auto_presentation_enabled: bool,
+
+    /// The announcement was prepared and still needs a successful rendered-frame claim.
+    whats_new_needs_persistence: bool,
+
     /// Active command-history navigation state.
     command_history_navigation: Option<CommandHistoryNavigation>,
 
@@ -2978,6 +2989,21 @@ impl DetachedEditorCore {
 
     pub fn clear_pending_paste(&mut self) {
         self.pending_paste.clear();
+    }
+
+    /// Prepares a pending release modal only after a client authenticates.
+    pub fn prepare_startup_whats_new(&mut self) -> anyhow::Result<bool> {
+        if !self.editor.prepare_startup_whats_new() {
+            return Ok(false);
+        }
+        self.editor.render(&mut self.render_buffer)?;
+        self.finish_render()?;
+        Ok(true)
+    }
+
+    /// Claims the version only after its first frame reaches an attached client.
+    pub fn mark_whats_new_presented(&mut self) {
+        self.editor.mark_whats_new_presented();
     }
 
     pub async fn shutdown(&mut self) {
@@ -3850,6 +3876,9 @@ impl Editor {
         let buffer_manager = buffer_manager::BufferManager::with_buffers(buffers);
         let session_manager = session_manager::SessionManager::new();
         let agent_manager = agent_manager::AgentManager::new();
+        let whats_new_startup_pending = preferences.is_persistent()
+            && config.show_whats_new.unwrap_or(true)
+            && preferences.last_seen_version() != Some(env!("CARGO_PKG_VERSION"));
 
         Ok(Editor {
             buffer_manager,
@@ -3940,6 +3969,9 @@ impl Editor {
             substitute_confirmation: None,
             command: String::new(),
             preferences,
+            whats_new_startup_pending,
+            whats_new_auto_presentation_enabled: false,
+            whats_new_needs_persistence: false,
             command_history_navigation: None,
             command_completion: None,
             search_term: String::new(),
@@ -4016,6 +4048,57 @@ impl Editor {
             buffers,
             preferences,
         )
+    }
+
+    /// Defers release announcements while crash recovery owns the first frame.
+    pub fn suppress_startup_whats_new(&mut self) {
+        self.whats_new_startup_pending = false;
+    }
+
+    fn open_whats_new_panel(&mut self) -> bool {
+        if !WhatsNewPanel::fits(self.vwidth(), self.vheight()) {
+            return false;
+        }
+
+        let version = env!("CARGO_PKG_VERSION");
+        let notes = ReleaseNotes::bundled(version, self.preferences.last_seen_version());
+        let refresh = if self.config.fetch_release_notes.unwrap_or(true) {
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            let fallback = notes.clone();
+            tokio::spawn(async move {
+                let result = ReleaseNotes::fetch(version, &fallback)
+                    .await
+                    .map_err(|error| format!("{error:#}"));
+                let _ = sender.send(result);
+            });
+            Some(receiver)
+        } else {
+            None
+        };
+
+        self.current_dialog = Some(Box::new(WhatsNewPanel::new(self, notes, refresh)));
+        self.whats_new_startup_pending = false;
+        self.whats_new_needs_persistence = true;
+        true
+    }
+
+    fn prepare_startup_whats_new(&mut self) -> bool {
+        self.whats_new_auto_presentation_enabled = true;
+        self.whats_new_startup_pending
+            && self.current_dialog.is_none()
+            && self.open_whats_new_panel()
+    }
+
+    fn mark_whats_new_presented(&mut self) {
+        if !std::mem::take(&mut self.whats_new_needs_persistence) {
+            return;
+        }
+        if let Err(error) = self
+            .preferences
+            .set_last_seen_version(env!("CARGO_PKG_VERSION"))
+        {
+            log!("could not persist the displayed release version: {error}");
+        }
     }
 
     /// Synchronizes the editor's state with the active window
@@ -6950,7 +7033,9 @@ impl Editor {
         self.ensure_current_buffer_lsp_opened().await?;
         let (columns, rows) = terminal::size()?;
         self.resize_terminal_surface(columns, rows, &mut buffer);
+        self.prepare_startup_whats_new();
         self.render(&mut buffer)?;
+        self.mark_whats_new_presented();
         drop(interactive_startup);
         let mut pending_events = VecDeque::new();
         let mut last_terminal_size_reconciliation = Instant::now();
@@ -7226,6 +7311,14 @@ impl Editor {
             false
         };
 
+        let startup_release_changed = if self.whats_new_auto_presentation_enabled
+            && self.whats_new_startup_pending
+            && self.current_dialog.is_none()
+        {
+            self.open_whats_new_panel()
+        } else {
+            false
+        };
         let dialog_changed = if let Some(current_dialog) = &mut self.current_dialog {
             current_dialog.tick()?
         } else {
@@ -7239,8 +7332,16 @@ impl Editor {
             self.keymap_hints_visible = true;
         }
         let panel_animation_changed = self.panel_manager.poll_animation();
-        if completion_changed || dialog_changed || keymap_hints_changed || panel_animation_changed {
+        if completion_changed
+            || startup_release_changed
+            || dialog_changed
+            || keymap_hints_changed
+            || panel_animation_changed
+        {
             self.render(buffer)?;
+            if startup_release_changed {
+                self.mark_whats_new_presented();
+            }
         }
 
         // if self.sync_state.should_notify() {
@@ -11683,6 +11784,9 @@ impl Editor {
 
         if matches!(cmd, "commands" | "command-palette") {
             return vec![Action::CommandPalette];
+        }
+        if matches!(cmd, "whats-new" | "changelog") {
+            return vec![Action::OpenWhatsNew];
         }
         if cmd == "config-diagnostics" {
             return vec![Action::ConfigDiagnostics];
@@ -17556,6 +17660,16 @@ impl Editor {
                 self.force_full_redraw = true;
                 self.last_error = Some(format!("syntax: {label}"));
                 self.render(buffer)?;
+            }
+            Action::OpenWhatsNew => {
+                self.release_current_dialog_callbacks(runtime);
+                if self.open_whats_new_panel() {
+                    self.render(buffer)?;
+                    self.mark_whats_new_presented();
+                } else {
+                    self.last_error = Some("terminal is too small for release notes".to_string());
+                    self.render(buffer)?;
+                }
             }
             Action::OpenStatuslineManager => {
                 self.release_current_dialog_callbacks(runtime);
@@ -25189,6 +25303,198 @@ builtin = "rust"
             editor.handle_command("statusline", &runtime),
             vec![Action::OpenStatuslineManager]
         );
+    }
+
+    #[test]
+    fn release_note_colon_commands_open_the_same_branded_panel() {
+        let mut editor = test_editor(80, 24);
+        let runtime = Runtime::new();
+
+        assert_eq!(
+            editor.handle_command("whats-new", &runtime),
+            vec![Action::OpenWhatsNew]
+        );
+        assert_eq!(
+            editor.handle_command("changelog", &runtime),
+            vec![Action::OpenWhatsNew]
+        );
+    }
+
+    #[tokio::test]
+    async fn manual_release_notes_action_renders_without_waiting_for_github() {
+        let mut editor = test_editor(90, 24);
+        editor.config.fetch_release_notes = Some(false);
+        let mut runtime = Runtime::new();
+        let mut buffer = RenderBuffer::new(90, 24, &Style::default());
+
+        let quit = editor
+            .execute(&Action::OpenWhatsNew, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(!quit);
+        assert!(editor.current_dialog.is_some());
+        let frame = render_text_rows(&buffer).join("\n");
+        assert!(frame.contains("WHAT’S NEW"));
+        assert!(frame.contains("What’s new in Red"));
+        assert!(frame.contains(&format!("v{}", env!("CARGO_PKG_VERSION"))));
+    }
+
+    #[tokio::test]
+    async fn startup_release_is_claimed_only_after_its_frame_is_rendered() {
+        let directory =
+            std::env::temp_dir().join(format!("red-whats-new-{}", uuid::Uuid::new_v4()));
+        let path = directory.join("preferences.json");
+        let preferences = PreferencesStore::load(&path);
+        let config = Config {
+            fetch_release_notes: Some(false),
+            ..Config::default()
+        };
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size_and_preferences(
+            lsp,
+            90,
+            24,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+            preferences,
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        let mut buffer = RenderBuffer::new(90, 24, &Style::default());
+
+        assert!(editor.prepare_startup_whats_new());
+        assert_eq!(editor.preferences.last_seen_version(), None);
+        editor.render(&mut buffer).unwrap();
+        editor.mark_whats_new_presented();
+
+        let reloaded = PreferencesStore::load(&path);
+        assert_eq!(
+            reloaded.last_seen_version(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+
+        let config = Config {
+            fetch_release_notes: Some(false),
+            ..Config::default()
+        };
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut reopened = Editor::with_size_and_preferences(
+            lsp,
+            90,
+            24,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+            reloaded,
+        )
+        .unwrap();
+        assert!(!reopened.prepare_startup_whats_new());
+        fs::remove_dir_all(directory).ok();
+    }
+
+    #[tokio::test]
+    async fn detached_release_waits_for_a_client_and_a_successful_frame() {
+        let directory =
+            std::env::temp_dir().join(format!("red-whats-new-detached-{}", uuid::Uuid::new_v4()));
+        let path = directory.join("preferences.json");
+        let preferences = PreferencesStore::load(&path);
+        let config = Config {
+            fetch_release_notes: Some(false),
+            ..Config::default()
+        };
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let editor = Editor::with_size_and_preferences(
+            lsp,
+            90,
+            24,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+            preferences,
+        )
+        .unwrap();
+        let mut core = DetachedEditorCore::new(editor).await.unwrap();
+
+        assert!(!core
+            .snapshot(None)
+            .lines
+            .iter()
+            .any(|line| line.text.contains("WHAT’S NEW")));
+        assert_eq!(core.editor.preferences.last_seen_version(), None);
+
+        assert!(core.prepare_startup_whats_new().unwrap());
+        assert_eq!(core.editor.preferences.last_seen_version(), None);
+        assert!(core
+            .snapshot(None)
+            .lines
+            .iter()
+            .any(|line| line.text.contains("WHAT’S NEW")));
+        core.mark_whats_new_presented();
+
+        assert_eq!(
+            PreferencesStore::load(&path).last_seen_version(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        fs::remove_dir_all(directory).ok();
+    }
+
+    #[tokio::test]
+    async fn crash_recovery_defers_the_release_announcement() {
+        let directory =
+            std::env::temp_dir().join(format!("red-whats-new-recovery-{}", uuid::Uuid::new_v4()));
+        let path = directory.join("preferences.json");
+        let preferences = PreferencesStore::load(&path);
+        let config = Config {
+            fetch_release_notes: Some(false),
+            ..Config::default()
+        };
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size_and_preferences(
+            lsp,
+            90,
+            24,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+            preferences,
+        )
+        .unwrap();
+
+        editor.suppress_startup_whats_new();
+
+        assert!(!editor.prepare_startup_whats_new());
+        assert_eq!(editor.preferences.last_seen_version(), None);
+        fs::remove_dir_all(directory).ok();
+    }
+
+    #[test]
+    fn disabled_release_announcements_remain_available_on_demand() {
+        let directory =
+            std::env::temp_dir().join(format!("red-whats-new-disabled-{}", uuid::Uuid::new_v4()));
+        let path = directory.join("preferences.json");
+        let preferences = PreferencesStore::load(&path);
+        let config = Config {
+            show_whats_new: Some(false),
+            fetch_release_notes: Some(false),
+            ..Config::default()
+        };
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size_and_preferences(
+            lsp,
+            90,
+            24,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+            preferences,
+        )
+        .unwrap();
+
+        assert!(!editor.prepare_startup_whats_new());
+        assert!(editor.open_whats_new_panel());
+        fs::remove_dir_all(directory).ok();
     }
 
     #[tokio::test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -25335,7 +25335,7 @@ builtin = "rust"
         assert!(!quit);
         assert!(editor.current_dialog.is_some());
         let frame = render_text_rows(&buffer).join("\n");
-        assert!(frame.contains("WHAT’S NEW"));
+        assert!(frame.contains("RELEASE NOTES"));
         assert!(frame.contains("What’s new in Red"));
         assert!(frame.contains(&format!("v{}", env!("CARGO_PKG_VERSION"))));
     }
@@ -25421,7 +25421,7 @@ builtin = "rust"
             .snapshot(None)
             .lines
             .iter()
-            .any(|line| line.text.contains("WHAT’S NEW")));
+            .any(|line| line.text.contains("RELEASE NOTES")));
         assert_eq!(core.editor.preferences.last_seen_version(), None);
 
         assert!(core.prepare_startup_whats_new().unwrap());
@@ -25430,7 +25430,7 @@ builtin = "rust"
             .snapshot(None)
             .lines
             .iter()
-            .any(|line| line.text.contains("WHAT’S NEW")));
+            .any(|line| line.text.contains("RELEASE NOTES")));
         core.mark_whats_new_presented();
 
         assert_eq!(

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -797,12 +797,13 @@ async fn serve_editor_connection(
         return Ok(false);
     }
     validate_terminal_size(columns, rows)?;
-    {
+    let displayed_whats_new = {
         let mut core = core.lock().await;
         core.clear_pending_paste();
         core.resize(columns, rows).await?;
         core.focus(focused).await?;
-    }
+        core.prepare_startup_whats_new()?
+    };
     let render = core.lock().await.snapshot(last_revision);
     let mut client_revision = render.revision;
     write_frame(
@@ -813,6 +814,9 @@ async fn serve_editor_connection(
         },
     )
     .await?;
+    if displayed_whats_new {
+        core.lock().await.mark_whats_new_presented();
+    }
 
     loop {
         let message = tokio::time::timeout(CLIENT_HEARTBEAT_LEASE, read_frame(&mut reader)).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub mod ui;
 pub mod undo;
 pub mod unicode_utils;
 pub mod utils;
+pub mod whats_new;
 pub mod window;
 
 // Test utilities for integration tests

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,6 +246,7 @@ async fn run() -> anyhow::Result<()> {
     editor.set_language_reload_source(config_file, args.config_overrides.clone());
     editor.set_config_diagnostics(diagnostics, recovery);
     if let Some(snapshot) = &resumed_session {
+        editor.suppress_startup_whats_new();
         for divergence in editor.restore_session_snapshot(snapshot)? {
             eprintln!(
                 "Recovered {} with external disk changes:\n{}",

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -28,6 +28,8 @@ pub struct Preferences {
     picker_history: HashMap<String, Vec<String>>,
     #[serde(default)]
     plugin_storage: HashMap<String, serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_seen_version: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +46,12 @@ impl PreferencesStore {
             path: None,
             preferences: Preferences::default(),
         }
+    }
+
+    /// Whether the store can remember a release across separate editor sessions.
+    #[must_use]
+    pub fn is_persistent(&self) -> bool {
+        self.path.is_some()
     }
 
     /// Loads preferences, falling back to empty state on any read or parse error.
@@ -82,6 +90,21 @@ impl PreferencesStore {
             .get(key)
             .map(Vec::as_slice)
             .unwrap_or(&[])
+    }
+
+    /// Returns the most recent Red release successfully presented to the user.
+    #[must_use]
+    pub fn last_seen_version(&self) -> Option<&str> {
+        self.preferences.last_seen_version.as_deref()
+    }
+
+    /// Records a release only after its announcement has actually been rendered.
+    pub fn set_last_seen_version(&mut self, version: &str) -> anyhow::Result<()> {
+        if self.last_seen_version() == Some(version) {
+            return Ok(());
+        }
+        self.preferences.last_seen_version = Some(version.to_string());
+        self.save()
     }
 
     /// Appends a non-empty command unless it duplicates the newest entry.
@@ -380,6 +403,34 @@ mod tests {
         let store = PreferencesStore::load(path);
 
         assert!(store.command_history().is_empty());
+        assert_eq!(store.last_seen_version(), None);
+    }
+
+    #[test]
+    fn seen_release_version_survives_a_preferences_reload() {
+        let dir = unique_temp_dir("release-preferences");
+        let path = dir.join("preferences.json");
+        let mut store = PreferencesStore::load(&path);
+
+        store.set_last_seen_version("0.5.0").unwrap();
+
+        let reloaded = PreferencesStore::load(&path);
+        assert_eq!(reloaded.last_seen_version(), Some("0.5.0"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn older_preferences_without_a_seen_release_remain_compatible() {
+        let dir = unique_temp_dir("legacy-release-preferences");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("preferences.json");
+        fs::write(&path, r#"{"command_history":["write"]}"#).unwrap();
+
+        let store = PreferencesStore::load(&path);
+
+        assert_eq!(store.command_history(), ["write"]);
+        assert_eq!(store.last_seen_version(), None);
+        fs::remove_dir_all(dir).ok();
     }
 
     #[test]

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -18,6 +18,7 @@ pub struct Dialog {
     footer: Option<String>,
     actions: Vec<UiAction>,
     action_width: Option<usize>,
+    action_inset: usize,
     left_aligned_title: bool,
     pub x: usize,
     pub y: usize,
@@ -76,6 +77,7 @@ impl Dialog {
             footer: None,
             actions: Vec::new(),
             action_width: None,
+            action_inset: 0,
             left_aligned_title: false,
             x,
             y,
@@ -161,6 +163,11 @@ impl Dialog {
     pub fn set_actions(&mut self, actions: Vec<UiAction>) {
         self.set_footer(None);
         self.actions = actions;
+    }
+
+    /// Keeps responsive footer actions a consistent distance from both borders.
+    pub(crate) fn set_action_inset(&mut self, inset: usize) {
+        self.action_inset = inset;
     }
 }
 
@@ -302,8 +309,15 @@ impl Component for Dialog {
             .y
             .saturating_add(height.saturating_sub(inset.saturating_add(1)));
         if !self.actions.is_empty() && inner_width > 0 {
-            let action_width = self.action_width.unwrap_or(inner_width).min(inner_width);
-            let action_x = footer_x.saturating_add(inner_width.saturating_sub(action_width));
+            let action_inset = self.action_inset.min(inner_width.saturating_sub(1) / 2);
+            let available_width = inner_width.saturating_sub(action_inset.saturating_mul(2));
+            let action_width = self
+                .action_width
+                .unwrap_or(available_width)
+                .min(available_width);
+            let action_x = footer_x
+                .saturating_add(action_inset)
+                .saturating_add(available_width.saturating_sub(action_width));
             ActionBar::new(&self.actions).render_right_aligned(
                 buffer,
                 action_x,

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -130,7 +130,6 @@ impl Dialog {
 
     /// Places a modal title inside the left edge of its top border.
     #[must_use]
-    #[cfg(test)]
     pub(crate) const fn with_left_aligned_title(mut self) -> Self {
         self.left_aligned_title = true;
         self
@@ -149,7 +148,6 @@ impl Dialog {
     }
 
     /// Sets compact, right-aligned metadata in the dialog header.
-    #[cfg(test)]
     pub(crate) fn set_header_status(&mut self, status: Option<String>) {
         self.header_status = status;
     }

--- a/src/ui/hover_info.rs
+++ b/src/ui/hover_info.rs
@@ -513,7 +513,7 @@ fn render_line(
     });
 }
 
-fn hover_span_style(span: &RenderedTextSpan, theme: &Theme) -> Style {
+pub(crate) fn hover_span_style(span: &RenderedTextSpan, theme: &Theme) -> Style {
     let base = &theme.ui_style.dialog;
     let code_background = theme
         .colors

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -26,6 +26,7 @@ mod rich_text;
 mod selection;
 mod spinner;
 mod statusline_layout;
+mod whats_new;
 
 pub use action_bar::{
     ActionBar, ActionBarLayout, ActionBarRole, ActionBarSpan, ActionMode, ActionPriority, UiAction,
@@ -57,6 +58,7 @@ pub(crate) use rich_text::paint_rich_text;
 pub(crate) use selection::{FollowTailViewport, SelectionViewport};
 pub(crate) use spinner::{spinner_frame, SPINNER_FRAME_INTERVAL_MS};
 pub use statusline_layout::StatuslineLayoutPanel;
+pub use whats_new::WhatsNewPanel;
 
 use crate::{
     config::KeyAction,

--- a/src/ui/whats_new.rs
+++ b/src/ui/whats_new.rs
@@ -1,0 +1,598 @@
+//! Branded, responsive release announcements over the existing Markdown renderer.
+
+use std::sync::Arc;
+
+use crossterm::event::{Event, KeyCode, KeyModifiers, MouseEventKind};
+use tokio::sync::oneshot;
+
+use crate::{
+    config::KeyAction,
+    editor::{Action, Editor, RenderBuffer},
+    highlighter::{Highlighter, LanguageRegistry},
+    log,
+    plugin::{
+        markdown::{render_markdown_lines_with_highlighter, RenderedTextLine, RenderedTextSpan},
+        TextPanelLinkTarget,
+    },
+    splash::{self, Role},
+    theme::{Style, Theme},
+    unicode_utils::{display_width, truncate_display_width},
+    whats_new::ReleaseNotes,
+};
+
+use super::{
+    dialog::{BorderStyle, Dialog, SurfaceRole},
+    hover_info::hover_span_style,
+    paint_rich_text, ActionPriority, Component, UiAction,
+};
+
+const MAX_PANEL_WIDTH: usize = 100;
+const MAX_PANEL_HEIGHT: usize = 30;
+const MIN_PANEL_WIDTH: usize = 26;
+const MIN_PANEL_HEIGHT: usize = 9;
+const HERO_ROWS: usize = 5;
+
+type ReleaseRefresh = oneshot::Receiver<Result<ReleaseNotes, String>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReleaseView {
+    Highlights,
+    Changelog,
+}
+
+/// Theme-aware modal for one exact installed release.
+pub struct WhatsNewPanel {
+    dialog: Dialog,
+    notes: ReleaseNotes,
+    view: ReleaseView,
+    lines: Vec<RenderedTextLine>,
+    scroll: usize,
+    selected_link: Option<usize>,
+    links: Vec<(u64, TextPanelLinkTarget, usize)>,
+    theme: Theme,
+    registry: Arc<LanguageRegistry>,
+    viewport_width: usize,
+    viewport_height: usize,
+    refresh: Option<ReleaseRefresh>,
+}
+
+impl WhatsNewPanel {
+    /// The compact version still needs a readable body and usable close action.
+    #[must_use]
+    pub(crate) const fn fits(viewport_width: usize, viewport_height: usize) -> bool {
+        viewport_width >= MIN_PANEL_WIDTH && viewport_height >= MIN_PANEL_HEIGHT
+    }
+
+    pub(crate) fn new(
+        editor: &Editor,
+        notes: ReleaseNotes,
+        refresh: Option<ReleaseRefresh>,
+    ) -> Self {
+        let viewport_width = editor.vwidth();
+        let viewport_height = editor.vheight();
+        let (x, y, width, height) = geometry(viewport_width, viewport_height);
+        let theme = editor.theme.clone();
+        let style = theme.ui_style.dialog.clone();
+        let mut dialog = Dialog::new(
+            Some("WHAT’S NEW".to_string()),
+            x,
+            y,
+            width,
+            height,
+            &style,
+            BorderStyle::Rounded,
+            &theme,
+        )
+        .with_surface_theme(&theme, SurfaceRole::Dialog)
+        .with_left_aligned_title();
+        dialog.set_header_status(Some(format!("v{}", notes.version)));
+
+        let mut panel = Self {
+            dialog,
+            notes,
+            view: ReleaseView::Highlights,
+            lines: Vec::new(),
+            scroll: 0,
+            selected_link: None,
+            links: Vec::new(),
+            theme,
+            registry: editor.language_registry(),
+            viewport_width,
+            viewport_height,
+            refresh,
+        };
+        panel.reflow();
+        panel
+    }
+
+    fn body_height(&self) -> usize {
+        self.dialog.height.saturating_sub(HERO_ROWS + 1)
+    }
+
+    fn max_scroll(&self) -> usize {
+        self.lines.len().saturating_sub(self.body_height())
+    }
+
+    fn reflow(&mut self) {
+        let markdown = match self.view {
+            ReleaseView::Highlights => self.notes.highlights_markdown(),
+            ReleaseView::Changelog => self.notes.markdown.clone(),
+        };
+        let width = self.dialog.width.saturating_sub(4);
+        let mut highlighter =
+            Highlighter::with_registry(&self.theme, Arc::clone(&self.registry)).ok();
+        self.lines = render_markdown_lines_with_highlighter(&markdown, width, highlighter.as_mut());
+        self.links.clear();
+        for (line_index, line) in self.lines.iter().enumerate() {
+            for span in &line.spans {
+                let Some(link) = &span.link else {
+                    continue;
+                };
+                if self.links.iter().any(|(id, _, _)| *id == link.id) {
+                    continue;
+                }
+                self.links.push((link.id, link.target.clone(), line_index));
+            }
+        }
+        self.selected_link = (!self.links.is_empty()).then_some(0);
+        self.scroll = self.scroll.min(self.max_scroll());
+        self.update_chrome();
+    }
+
+    fn update_chrome(&mut self) {
+        let metadata = self.notes.published_at.as_ref().map_or_else(
+            || format!("v{}", self.notes.version),
+            |date| format!("v{} · {date}", self.notes.version),
+        );
+        self.dialog.set_header_status(Some(metadata));
+
+        let mut actions = vec![
+            UiAction::new("close", "Esc", "Close").with_priority(ActionPriority::Essential),
+            UiAction::new("view", "Tab", "Changelog").with_priority(ActionPriority::Essential),
+            UiAction::new("github", "o", "GitHub"),
+        ];
+        if self.max_scroll() > 0 {
+            actions.push(UiAction::new("scroll", "j/k", "Scroll"));
+        }
+        if !self.links.is_empty() {
+            actions.push(UiAction::new("link", "Enter", "Open link"));
+        }
+        self.dialog.set_actions(actions);
+    }
+
+    fn switch_view(&mut self) {
+        self.view = match self.view {
+            ReleaseView::Highlights => ReleaseView::Changelog,
+            ReleaseView::Changelog => ReleaseView::Highlights,
+        };
+        self.scroll = 0;
+        self.reflow();
+    }
+
+    fn scroll_by(&mut self, delta: isize) {
+        self.scroll = self
+            .scroll
+            .saturating_add_signed(delta)
+            .min(self.max_scroll());
+    }
+
+    fn select_link(&mut self, delta: isize) {
+        if self.links.is_empty() {
+            return;
+        }
+        let current = self.selected_link.unwrap_or(0) as isize;
+        let count = self.links.len() as isize;
+        let next = (current + delta).rem_euclid(count) as usize;
+        self.selected_link = Some(next);
+        let line = self.links[next].2;
+        let body_height = self.body_height().max(1);
+        if line < self.scroll {
+            self.scroll = line;
+        } else if line >= self.scroll + body_height {
+            self.scroll = line + 1 - body_height;
+        }
+        self.scroll = self.scroll.min(self.max_scroll());
+    }
+
+    fn selected_link_id(&self) -> Option<u64> {
+        self.selected_link
+            .and_then(|selected| self.links.get(selected))
+            .map(|(id, _, _)| *id)
+    }
+
+    fn open_selected_link(&self) -> Option<KeyAction> {
+        let (_, target, _) = self.links.get(self.selected_link?)?;
+        match target {
+            TextPanelLinkTarget::ExternalUrl(url) => {
+                Some(KeyAction::Single(Action::OpenExternalUrl(url.to_string())))
+            }
+            TextPanelLinkTarget::File { .. } => None,
+        }
+    }
+
+    fn centered_text(&self, buffer: &mut RenderBuffer, row: usize, text: &str, style: &Style) {
+        let available = self.dialog.width.saturating_sub(4);
+        let text = truncate_display_width(text, available);
+        let x = self.dialog.x + 1 + self.dialog.width.saturating_sub(display_width(&text)) / 2;
+        buffer.set_text(x, self.dialog.y + 1 + row, &text, style);
+    }
+
+    fn draw_hero(&self, buffer: &mut RenderBuffer) {
+        let palette = splash::palette(&self.theme);
+        let brand = "red";
+        let brand_width = display_width(brand) + 2;
+        let x = self.dialog.x + 1 + self.dialog.width.saturating_sub(brand_width) / 2;
+        let y = self.dialog.y + 1;
+        buffer.set_text(x, y, brand, palette.style(Role::Mark));
+        buffer.set_text(
+            x + display_width(brand) + 1,
+            y,
+            "●",
+            palette.style(Role::Dot),
+        );
+
+        let title_style = Style {
+            bold: true,
+            ..self.theme.ui_style.dialog_title.clone()
+        };
+        self.centered_text(buffer, 1, "What’s new in Red", &title_style);
+        self.centered_text(
+            buffer,
+            2,
+            "everything your fingers expect — and a little more",
+            palette.style(Role::Muted),
+        );
+
+        let (first, second) = if self.dialog.width >= 34 {
+            (" Highlights ", " Full changelog ")
+        } else {
+            (" New ", " Changes ")
+        };
+        let tabs_width = display_width(first) + display_width(second) + 3;
+        let tabs_x = self.dialog.x + 1 + self.dialog.width.saturating_sub(tabs_width) / 2;
+        let active = palette.style(Role::Key).with_bg(self.dialog.style.bg);
+        let inactive = palette.style(Role::Muted).with_bg(self.dialog.style.bg);
+        let first_style = if self.view == ReleaseView::Highlights {
+            &active
+        } else {
+            &inactive
+        };
+        let second_style = if self.view == ReleaseView::Changelog {
+            &active
+        } else {
+            &inactive
+        };
+        let y = self.dialog.y + 4;
+        buffer.set_text(tabs_x, y, first, first_style);
+        buffer.set_text(tabs_x + display_width(first), y, " · ", &inactive);
+        buffer.set_text(tabs_x + display_width(first) + 3, y, second, second_style);
+
+        let rule_width = self.dialog.width.saturating_sub(4);
+        buffer.set_text(
+            self.dialog.x + 3,
+            self.dialog.y + HERO_ROWS,
+            &"─".repeat(rule_width),
+            palette.style(Role::Rule),
+        );
+    }
+
+    fn draw_body(&self, buffer: &mut RenderBuffer) {
+        let x = self.dialog.x + 3;
+        let y = self.dialog.y + HERO_ROWS + 1;
+        let width = self.dialog.width.saturating_sub(4);
+        let selected_link_id = self.selected_link_id();
+
+        for (offset, line) in self
+            .lines
+            .iter()
+            .skip(self.scroll)
+            .take(self.body_height())
+            .enumerate()
+        {
+            paint_rich_text(
+                buffer,
+                x,
+                y + offset,
+                width,
+                line,
+                |span: &RenderedTextSpan| {
+                    let mut style = hover_span_style(span, &self.theme);
+                    if span
+                        .link
+                        .as_ref()
+                        .is_some_and(|link| Some(link.id) == selected_link_id)
+                    {
+                        style.bold = true;
+                    }
+                    style
+                },
+            );
+        }
+    }
+
+    fn link_at(&self, column: usize, row: usize) -> Option<usize> {
+        let first_x = self.dialog.x + 3;
+        let first_y = self.dialog.y + HERO_ROWS + 1;
+        if column < first_x || row < first_y {
+            return None;
+        }
+        let line = self.lines.get(self.scroll + row - first_y)?;
+        let mut x = first_x;
+        for span in &line.spans {
+            let end = x + display_width(&span.text);
+            if (x..end).contains(&column) {
+                let link_id = span.link.as_ref()?.id;
+                return self.links.iter().position(|(id, _, _)| *id == link_id);
+            }
+            x = end;
+        }
+        None
+    }
+}
+
+impl Component for WhatsNewPanel {
+    fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.dialog.draw(buffer)?;
+        self.draw_hero(buffer);
+        self.draw_body(buffer);
+        Ok(())
+    }
+
+    fn tick(&mut self) -> anyhow::Result<bool> {
+        let Some(refresh) = &mut self.refresh else {
+            return Ok(false);
+        };
+        match refresh.try_recv() {
+            Ok(Ok(notes)) => {
+                self.refresh = None;
+                self.notes = notes;
+                self.reflow();
+                Ok(true)
+            }
+            Ok(Err(error)) => {
+                self.refresh = None;
+                log!("could not refresh release notes: {error}");
+                Ok(false)
+            }
+            Err(oneshot::error::TryRecvError::Empty) => Ok(false),
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.refresh = None;
+                Ok(false)
+            }
+        }
+    }
+
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        let refresh = || Some(KeyAction::Single(Action::Refresh));
+        match event {
+            Event::Key(key) => match (key.code, key.modifiers) {
+                (KeyCode::Esc | KeyCode::Char('q'), _) => {
+                    Some(KeyAction::Single(Action::CloseDialog))
+                }
+                (KeyCode::Char('o'), _) => Some(KeyAction::Single(Action::OpenExternalUrl(
+                    self.notes.release_url.clone(),
+                ))),
+                (KeyCode::Tab | KeyCode::BackTab, _) => {
+                    self.switch_view();
+                    refresh()
+                }
+                (KeyCode::Down | KeyCode::Char('j'), _) => {
+                    self.scroll_by(1);
+                    refresh()
+                }
+                (KeyCode::Up | KeyCode::Char('k'), _) => {
+                    self.scroll_by(-1);
+                    refresh()
+                }
+                (KeyCode::PageDown, _) | (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
+                    self.scroll_by(self.body_height().max(1) as isize);
+                    refresh()
+                }
+                (KeyCode::PageUp, _) | (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
+                    self.scroll_by(-(self.body_height().max(1) as isize));
+                    refresh()
+                }
+                (KeyCode::Home | KeyCode::Char('g'), _) => {
+                    self.scroll = 0;
+                    refresh()
+                }
+                (KeyCode::End | KeyCode::Char('G'), _) => {
+                    self.scroll = self.max_scroll();
+                    refresh()
+                }
+                (KeyCode::Char(']'), _) => {
+                    self.select_link(1);
+                    refresh()
+                }
+                (KeyCode::Char('['), _) => {
+                    self.select_link(-1);
+                    refresh()
+                }
+                (KeyCode::Enter, _) => self.open_selected_link(),
+                _ => None,
+            },
+            Event::Mouse(mouse) => match mouse.kind {
+                MouseEventKind::ScrollDown => {
+                    self.scroll_by(3);
+                    refresh()
+                }
+                MouseEventKind::ScrollUp => {
+                    self.scroll_by(-3);
+                    refresh()
+                }
+                MouseEventKind::Down(_) => {
+                    if let Some(link) = self.link_at(mouse.column as usize, mouse.row as usize) {
+                        self.selected_link = Some(link);
+                        self.open_selected_link()
+                    } else if !(self.dialog.x..self.dialog.x + self.dialog.width + 2)
+                        .contains(&(mouse.column as usize))
+                        || !(self.dialog.y..self.dialog.y + self.dialog.height + 2)
+                            .contains(&(mouse.row as usize))
+                    {
+                        Some(KeyAction::Single(Action::CloseDialog))
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn resize(&mut self, viewport_width: usize, viewport_height: usize) -> bool {
+        self.viewport_width = viewport_width;
+        self.viewport_height = viewport_height;
+        let (x, y, width, height) = geometry(viewport_width, viewport_height);
+        self.dialog.x = x;
+        self.dialog.y = y;
+        self.dialog.width = width;
+        self.dialog.height = height;
+        self.reflow();
+        true
+    }
+
+    fn set_theme(&mut self, theme: &Theme) {
+        self.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
+        self.reflow();
+    }
+}
+
+fn geometry(viewport_width: usize, viewport_height: usize) -> (usize, usize, usize, usize) {
+    let width = viewport_width.saturating_sub(4).min(MAX_PANEL_WIDTH);
+    let height = viewport_height.saturating_sub(3).min(MAX_PANEL_HEIGHT);
+    let x = viewport_width.saturating_sub(width + 2) / 2;
+    let y = viewport_height.saturating_sub(height + 2) / 2;
+    (x, y, width, height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{buffer::Buffer, config::Config, lsp::LspManager};
+
+    fn editor(width: usize, height: usize) -> Editor {
+        let config = Config::default();
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        Editor::with_size(
+            lsp,
+            width,
+            height,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+        )
+        .unwrap()
+    }
+
+    fn rendered_text(buffer: &RenderBuffer) -> String {
+        buffer
+            .cells
+            .chunks(buffer.width)
+            .map(|row| row.iter().map(|cell| cell.c).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn release_panel_renders_brand_version_and_markdown_highlights() {
+        let editor = editor(100, 28);
+        let notes = ReleaseNotes::bundled(env!("CARGO_PKG_VERSION"), None);
+        let panel = WhatsNewPanel::new(&editor, notes, None);
+        let mut buffer = RenderBuffer::new(100, 28, &Style::default());
+
+        panel.draw(&mut buffer).unwrap();
+
+        let text = rendered_text(&buffer);
+        assert!(text.contains("WHAT’S NEW"));
+        assert!(text.contains("What’s new in Red"));
+        assert!(text.contains(&format!("v{}", env!("CARGO_PKG_VERSION"))));
+        assert!(text.contains("●"));
+        assert!(text.contains("Highlights"));
+    }
+
+    #[test]
+    fn tab_switches_between_highlights_and_the_complete_changelog() {
+        let editor = editor(90, 26);
+        let notes = ReleaseNotes {
+            version: "1.0.0".to_string(),
+            markdown:
+                "## [1.0.0](https://example.test)\n\n### Features\n\n- Visible feature\n\n### Refactoring\n\n- Full detail"
+                    .to_string(),
+            release_url: "https://github.com/codersauce/red/releases/tag/v1.0.0".to_string(),
+            published_at: None,
+        };
+        let mut panel = WhatsNewPanel::new(&editor, notes, None);
+
+        assert!(!panel
+            .lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .any(|span| span.text.contains("Full detail")));
+        panel.handle_event(&Event::Key(crossterm::event::KeyEvent::new(
+            KeyCode::Tab,
+            KeyModifiers::NONE,
+        )));
+
+        assert!(panel
+            .lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .any(|span| span.text.contains("Full detail")));
+    }
+
+    #[test]
+    fn release_panel_reflows_after_resize_without_overflowing() {
+        let editor = editor(100, 30);
+        let notes = ReleaseNotes::bundled(env!("CARGO_PKG_VERSION"), None);
+        let mut panel = WhatsNewPanel::new(&editor, notes, None);
+
+        panel.resize(38, 12);
+
+        assert!(panel.dialog.x + panel.dialog.width + 2 <= 38);
+        assert!(panel.dialog.y + panel.dialog.height + 2 <= 12);
+        let mut buffer = RenderBuffer::new(38, 12, &Style::default());
+        panel.draw(&mut buffer).unwrap();
+    }
+
+    #[test]
+    fn compact_release_panel_preserves_both_rounded_border_corners() {
+        let editor = editor(26, 10);
+        let notes = ReleaseNotes::bundled(env!("CARGO_PKG_VERSION"), None);
+        let panel = WhatsNewPanel::new(&editor, notes, None);
+        let mut buffer = RenderBuffer::new(26, 10, &Style::default());
+
+        panel.draw(&mut buffer).unwrap();
+
+        let first = panel.dialog.y * buffer.width + panel.dialog.x;
+        let last = first + panel.dialog.width + 1;
+        assert_eq!(buffer.cells[first].c, '╭');
+        assert_eq!(buffer.cells[last].c, '╮');
+        let text = rendered_text(&buffer);
+        assert!(text.contains("New"));
+        assert!(text.contains("Changes"));
+    }
+
+    #[test]
+    fn background_release_refresh_reflows_the_existing_panel() {
+        let editor = editor(90, 26);
+        let initial = ReleaseNotes::bundled(env!("CARGO_PKG_VERSION"), None);
+        let (sender, receiver) = oneshot::channel();
+        let mut panel = WhatsNewPanel::new(&editor, initial.clone(), Some(receiver));
+        let updated = ReleaseNotes {
+            markdown: "### Features\n\n- Fresh GitHub release".to_string(),
+            published_at: Some("Aug 13, 2026".to_string()),
+            ..initial
+        };
+        sender.send(Ok(updated)).unwrap();
+
+        assert!(panel.tick().unwrap());
+        assert!(panel
+            .lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .any(|span| span.text.contains("Fresh GitHub release")));
+        assert_eq!(panel.notes.published_at.as_deref(), Some("Aug 13, 2026"));
+    }
+}

--- a/src/ui/whats_new.rs
+++ b/src/ui/whats_new.rs
@@ -30,7 +30,8 @@ const MAX_PANEL_WIDTH: usize = 100;
 const MAX_PANEL_HEIGHT: usize = 30;
 const MIN_PANEL_WIDTH: usize = 26;
 const MIN_PANEL_HEIGHT: usize = 9;
-const HERO_ROWS: usize = 5;
+const MIN_COMFORTABLE_PANEL_HEIGHT: usize = 20;
+const SPACIOUS_CHROME_HEIGHT: usize = 10;
 
 type ReleaseRefresh = oneshot::Receiver<Result<ReleaseNotes, String>>;
 
@@ -38,6 +39,62 @@ type ReleaseRefresh = oneshot::Receiver<Result<ReleaseNotes, String>>;
 enum ReleaseView {
     Highlights,
     Changelog,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PanelLayout {
+    brand_row: usize,
+    title_row: usize,
+    tagline_row: Option<usize>,
+    tabs_row: usize,
+    body_row: usize,
+    bottom_padding: usize,
+}
+
+impl PanelLayout {
+    const fn for_height(height: usize) -> Self {
+        if height >= 18 {
+            Self {
+                brand_row: 2,
+                title_row: 3,
+                tagline_row: Some(4),
+                tabs_row: 6,
+                body_row: 8,
+                bottom_padding: 2,
+            }
+        } else if height >= 11 {
+            Self {
+                brand_row: 1,
+                title_row: 2,
+                tagline_row: Some(3),
+                tabs_row: 4,
+                body_row: 6,
+                bottom_padding: 1,
+            }
+        } else {
+            Self {
+                brand_row: 1,
+                title_row: 2,
+                tagline_row: None,
+                tabs_row: 3,
+                body_row: 5,
+                bottom_padding: 0,
+            }
+        }
+    }
+
+    const fn body_height(self, height: usize) -> usize {
+        height.saturating_sub(self.body_row + self.bottom_padding)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TabsLayout {
+    x: usize,
+    y: usize,
+    first_width: usize,
+    second_x: usize,
+    second_width: usize,
 }
 
 /// Theme-aware modal for one exact installed release.
@@ -70,11 +127,11 @@ impl WhatsNewPanel {
     ) -> Self {
         let viewport_width = editor.vwidth();
         let viewport_height = editor.vheight();
-        let (x, y, width, height) = geometry(viewport_width, viewport_height);
+        let (x, y, width, height) = geometry(viewport_width, viewport_height, 0);
         let theme = editor.theme.clone();
         let style = theme.ui_style.dialog.clone();
         let mut dialog = Dialog::new(
-            Some("WHAT’S NEW".to_string()),
+            Some("RELEASE NOTES".to_string()),
             x,
             y,
             width,
@@ -101,12 +158,17 @@ impl WhatsNewPanel {
             viewport_height,
             refresh,
         };
+        panel.normalize_surface();
         panel.reflow();
         panel
     }
 
+    fn layout(&self) -> PanelLayout {
+        PanelLayout::for_height(self.dialog.height)
+    }
+
     fn body_height(&self) -> usize {
-        self.dialog.height.saturating_sub(HERO_ROWS + 1)
+        self.layout().body_height(self.dialog.height)
     }
 
     fn max_scroll(&self) -> usize {
@@ -114,14 +176,24 @@ impl WhatsNewPanel {
     }
 
     fn reflow(&mut self) {
+        let width = geometry(self.viewport_width, self.viewport_height, 0).2;
+        self.dialog.width = width;
         let markdown = match self.view {
             ReleaseView::Highlights => self.notes.highlights_markdown(),
             ReleaseView::Changelog => self.notes.markdown.clone(),
         };
-        let width = self.dialog.width.saturating_sub(4);
+        let width = width.saturating_sub(4);
         let mut highlighter =
             Highlighter::with_registry(&self.theme, Arc::clone(&self.registry)).ok();
         self.lines = render_markdown_lines_with_highlighter(&markdown, width, highlighter.as_mut());
+
+        let (x, y, width, height) =
+            geometry(self.viewport_width, self.viewport_height, self.lines.len());
+        self.dialog.x = x;
+        self.dialog.y = y;
+        self.dialog.width = width;
+        self.dialog.height = height;
+
         self.links.clear();
         for (line_index, line) in self.lines.iter().enumerate() {
             for span in &line.spans {
@@ -139,6 +211,17 @@ impl WhatsNewPanel {
         self.update_chrome();
     }
 
+    fn normalize_surface(&mut self) {
+        let background = self.dialog.style.bg;
+        self.dialog.border_draw_style = self.dialog.border_draw_style.with_bg(background);
+        self.dialog.title_style = self.dialog.title_style.with_bg(background);
+        self.dialog.footer_style = self.dialog.footer_style.with_bg(background);
+    }
+
+    fn surface_style(&self, style: &Style) -> Style {
+        style.with_bg(self.dialog.style.bg)
+    }
+
     fn update_chrome(&mut self) {
         let metadata = self.notes.published_at.as_ref().map_or_else(
             || format!("v{}", self.notes.version),
@@ -146,18 +229,31 @@ impl WhatsNewPanel {
         );
         self.dialog.set_header_status(Some(metadata));
 
+        let destination = match self.view {
+            ReleaseView::Highlights => "Changelog",
+            ReleaseView::Changelog => "Highlights",
+        };
         let mut actions = vec![
             UiAction::new("close", "Esc", "Close").with_priority(ActionPriority::Essential),
-            UiAction::new("view", "Tab", "Changelog").with_priority(ActionPriority::Essential),
+            UiAction::new("view", "Tab", destination).with_priority(ActionPriority::Essential),
             UiAction::new("github", "o", "GitHub"),
         ];
         if self.max_scroll() > 0 {
-            actions.push(UiAction::new("scroll", "j/k", "Scroll"));
+            actions.push(
+                UiAction::new("scroll", "j/k", "Scroll").with_priority(ActionPriority::Secondary),
+            );
         }
         if !self.links.is_empty() {
+            if self.links.len() > 1 {
+                actions.push(
+                    UiAction::new("links", "[ ]", "Links").with_priority(ActionPriority::Secondary),
+                );
+            }
             actions.push(UiAction::new("link", "Enter", "Open link"));
         }
         self.dialog.set_actions(actions);
+        self.dialog
+            .set_action_inset(if self.dialog.width >= 40 { 2 } else { 1 });
     }
 
     fn switch_view(&mut self) {
@@ -214,44 +310,79 @@ impl WhatsNewPanel {
         let available = self.dialog.width.saturating_sub(4);
         let text = truncate_display_width(text, available);
         let x = self.dialog.x + 1 + self.dialog.width.saturating_sub(display_width(&text)) / 2;
-        buffer.set_text(x, self.dialog.y + 1 + row, &text, style);
+        buffer.set_text(x, self.dialog.y + row, &text, &self.surface_style(style));
+    }
+
+    fn tab_labels(&self) -> (&'static str, &'static str) {
+        if self.dialog.width >= 34 {
+            (" Highlights ", " Full changelog ")
+        } else {
+            (" New ", " Changes ")
+        }
+    }
+
+    fn tabs_layout(&self) -> TabsLayout {
+        let (first, second) = self.tab_labels();
+        let first_width = display_width(first);
+        let second_width = display_width(second);
+        let tabs_width = first_width + second_width + 3;
+        let x = self.dialog.x + 1 + self.dialog.width.saturating_sub(tabs_width) / 2;
+        TabsLayout {
+            x,
+            y: self.dialog.y + self.layout().tabs_row,
+            first_width,
+            second_x: x + first_width + 3,
+            second_width,
+        }
+    }
+
+    fn tab_at(&self, column: usize, row: usize) -> Option<ReleaseView> {
+        let tabs = self.tabs_layout();
+        if row != tabs.y {
+            return None;
+        }
+        if (tabs.x..tabs.x + tabs.first_width).contains(&column) {
+            Some(ReleaseView::Highlights)
+        } else if (tabs.second_x..tabs.second_x + tabs.second_width).contains(&column) {
+            Some(ReleaseView::Changelog)
+        } else {
+            None
+        }
     }
 
     fn draw_hero(&self, buffer: &mut RenderBuffer) {
         let palette = splash::palette(&self.theme);
+        let layout = self.layout();
         let brand = "red";
         let brand_width = display_width(brand) + 2;
         let x = self.dialog.x + 1 + self.dialog.width.saturating_sub(brand_width) / 2;
-        let y = self.dialog.y + 1;
-        buffer.set_text(x, y, brand, palette.style(Role::Mark));
+        let y = self.dialog.y + layout.brand_row;
+        buffer.set_text(x, y, brand, &self.surface_style(palette.style(Role::Mark)));
         buffer.set_text(
             x + display_width(brand) + 1,
             y,
             "●",
-            palette.style(Role::Dot),
+            &self.surface_style(palette.style(Role::Dot)),
         );
 
         let title_style = Style {
             bold: true,
             ..self.theme.ui_style.dialog_title.clone()
         };
-        self.centered_text(buffer, 1, "What’s new in Red", &title_style);
-        self.centered_text(
-            buffer,
-            2,
-            "everything your fingers expect — and a little more",
-            palette.style(Role::Muted),
-        );
+        self.centered_text(buffer, layout.title_row, "What’s new in Red", &title_style);
+        if let Some(tagline_row) = layout.tagline_row {
+            self.centered_text(
+                buffer,
+                tagline_row,
+                "the editor that respects your muscle memory",
+                palette.style(Role::Muted),
+            );
+        }
 
-        let (first, second) = if self.dialog.width >= 34 {
-            (" Highlights ", " Full changelog ")
-        } else {
-            (" New ", " Changes ")
-        };
-        let tabs_width = display_width(first) + display_width(second) + 3;
-        let tabs_x = self.dialog.x + 1 + self.dialog.width.saturating_sub(tabs_width) / 2;
-        let active = palette.style(Role::Key).with_bg(self.dialog.style.bg);
-        let inactive = palette.style(Role::Muted).with_bg(self.dialog.style.bg);
+        let (first, second) = self.tab_labels();
+        let tabs = self.tabs_layout();
+        let active = self.surface_style(palette.style(Role::Key));
+        let inactive = self.surface_style(palette.style(Role::Muted));
         let first_style = if self.view == ReleaseView::Highlights {
             &active
         } else {
@@ -262,23 +393,14 @@ impl WhatsNewPanel {
         } else {
             &inactive
         };
-        let y = self.dialog.y + 4;
-        buffer.set_text(tabs_x, y, first, first_style);
-        buffer.set_text(tabs_x + display_width(first), y, " · ", &inactive);
-        buffer.set_text(tabs_x + display_width(first) + 3, y, second, second_style);
-
-        let rule_width = self.dialog.width.saturating_sub(4);
-        buffer.set_text(
-            self.dialog.x + 3,
-            self.dialog.y + HERO_ROWS,
-            &"─".repeat(rule_width),
-            palette.style(Role::Rule),
-        );
+        buffer.set_text(tabs.x, tabs.y, first, first_style);
+        buffer.set_text(tabs.x + tabs.first_width, tabs.y, " · ", &inactive);
+        buffer.set_text(tabs.second_x, tabs.y, second, second_style);
     }
 
     fn draw_body(&self, buffer: &mut RenderBuffer) {
         let x = self.dialog.x + 3;
-        let y = self.dialog.y + HERO_ROWS + 1;
+        let y = self.dialog.y + self.layout().body_row;
         let width = self.dialog.width.saturating_sub(4);
         let selected_link_id = self.selected_link_id();
 
@@ -310,9 +432,37 @@ impl WhatsNewPanel {
         }
     }
 
+    fn draw_scroll_indicator(&self, buffer: &mut RenderBuffer) {
+        if self.max_scroll() == 0 || self.layout().bottom_padding == 0 {
+            return;
+        }
+
+        let first = self.scroll + 1;
+        let last = (self.scroll + self.body_height()).min(self.lines.len());
+        let indicator = format!("{first}–{last} of {}", self.lines.len());
+        let available = self.dialog.width.saturating_sub(4);
+        if display_width(&indicator) > available {
+            return;
+        }
+
+        let x = self
+            .dialog
+            .x
+            .saturating_add(self.dialog.width)
+            .saturating_sub(display_width(&indicator) + 1);
+        let y = self.dialog.y + self.dialog.height.saturating_sub(1);
+        let palette = splash::palette(&self.theme);
+        buffer.set_text(
+            x,
+            y,
+            &indicator,
+            &self.surface_style(palette.style(Role::Muted)),
+        );
+    }
+
     fn link_at(&self, column: usize, row: usize) -> Option<usize> {
         let first_x = self.dialog.x + 3;
-        let first_y = self.dialog.y + HERO_ROWS + 1;
+        let first_y = self.dialog.y + self.layout().body_row;
         if column < first_x || row < first_y {
             return None;
         }
@@ -335,6 +485,7 @@ impl Component for WhatsNewPanel {
         self.dialog.draw(buffer)?;
         self.draw_hero(buffer);
         self.draw_body(buffer);
+        self.draw_scroll_indicator(buffer);
         Ok(())
     }
 
@@ -421,7 +572,16 @@ impl Component for WhatsNewPanel {
                     refresh()
                 }
                 MouseEventKind::Down(_) => {
-                    if let Some(link) = self.link_at(mouse.column as usize, mouse.row as usize) {
+                    let column = mouse.column as usize;
+                    let row = mouse.row as usize;
+                    if let Some(view) = self.tab_at(column, row) {
+                        if self.view != view {
+                            self.view = view;
+                            self.scroll = 0;
+                            self.reflow();
+                        }
+                        refresh()
+                    } else if let Some(link) = self.link_at(column, row) {
                         self.selected_link = Some(link);
                         self.open_selected_link()
                     } else if !(self.dialog.x..self.dialog.x + self.dialog.width + 2)
@@ -443,11 +603,6 @@ impl Component for WhatsNewPanel {
     fn resize(&mut self, viewport_width: usize, viewport_height: usize) -> bool {
         self.viewport_width = viewport_width;
         self.viewport_height = viewport_height;
-        let (x, y, width, height) = geometry(viewport_width, viewport_height);
-        self.dialog.x = x;
-        self.dialog.y = y;
-        self.dialog.width = width;
-        self.dialog.height = height;
         self.reflow();
         true
     }
@@ -455,13 +610,22 @@ impl Component for WhatsNewPanel {
     fn set_theme(&mut self, theme: &Theme) {
         self.theme = theme.clone();
         self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
+        self.normalize_surface();
         self.reflow();
     }
 }
 
-fn geometry(viewport_width: usize, viewport_height: usize) -> (usize, usize, usize, usize) {
+fn geometry(
+    viewport_width: usize,
+    viewport_height: usize,
+    content_lines: usize,
+) -> (usize, usize, usize, usize) {
     let width = viewport_width.saturating_sub(4).min(MAX_PANEL_WIDTH);
-    let height = viewport_height.saturating_sub(3).min(MAX_PANEL_HEIGHT);
+    let available_height = viewport_height.saturating_sub(3).min(MAX_PANEL_HEIGHT);
+    let preferred_height = content_lines
+        .saturating_add(SPACIOUS_CHROME_HEIGHT)
+        .max(MIN_COMFORTABLE_PANEL_HEIGHT);
+    let height = preferred_height.min(available_height);
     let x = viewport_width.saturating_sub(width + 2) / 2;
     let y = viewport_height.saturating_sub(height + 2) / 2;
     (x, y, width, height)
@@ -505,11 +669,15 @@ mod tests {
         panel.draw(&mut buffer).unwrap();
 
         let text = rendered_text(&buffer);
-        assert!(text.contains("WHAT’S NEW"));
+        assert!(text.contains("RELEASE NOTES"));
         assert!(text.contains("What’s new in Red"));
+        assert!(text.contains("the editor that respects your muscle memory"));
         assert!(text.contains(&format!("v{}", env!("CARGO_PKG_VERSION"))));
         assert!(text.contains("●"));
         assert!(text.contains("Highlights"));
+        assert!(text.contains("New features"));
+        assert!(text.contains("Fixes"));
+        assert!(!text.contains("everything your fingers expect — and a little more"));
     }
 
     #[test]
@@ -540,6 +708,152 @@ mod tests {
             .iter()
             .flat_map(|line| &line.spans)
             .any(|span| span.text.contains("Full detail")));
+
+        let mut buffer = RenderBuffer::new(90, 26, &Style::default());
+        panel.draw(&mut buffer).unwrap();
+        assert!(rendered_text(&buffer).contains("Tab Highlights"));
+    }
+
+    #[test]
+    fn mouse_clicks_switch_between_release_views() {
+        let editor = editor(100, 35);
+        let notes = ReleaseNotes::bundled(env!("CARGO_PKG_VERSION"), None);
+        let mut panel = WhatsNewPanel::new(&editor, notes, None);
+        let tabs = panel.tabs_layout();
+
+        let result = panel.handle_event(&Event::Mouse(crossterm::event::MouseEvent {
+            kind: MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            column: tabs.second_x as u16,
+            row: tabs.y as u16,
+            modifiers: KeyModifiers::NONE,
+        }));
+
+        assert!(matches!(result, Some(KeyAction::Single(Action::Refresh))));
+        assert_eq!(panel.view, ReleaseView::Changelog);
+
+        let tabs = panel.tabs_layout();
+        panel.handle_event(&Event::Mouse(crossterm::event::MouseEvent {
+            kind: MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            column: tabs.x as u16,
+            row: tabs.y as u16,
+            modifiers: KeyModifiers::NONE,
+        }));
+
+        assert_eq!(panel.view, ReleaseView::Highlights);
+    }
+
+    #[test]
+    fn spacious_layout_leaves_balanced_header_and_body_padding() {
+        let editor = editor(180, 70);
+        let notes = ReleaseNotes::bundled(env!("CARGO_PKG_VERSION"), None);
+        let panel = WhatsNewPanel::new(&editor, notes, None);
+        let layout = panel.layout();
+        let mut buffer = RenderBuffer::new(180, 70, &Style::default());
+
+        panel.draw(&mut buffer).unwrap();
+
+        assert_eq!(panel.dialog.width, MAX_PANEL_WIDTH);
+        assert!(panel.dialog.height >= MIN_COMFORTABLE_PANEL_HEIGHT);
+        assert!(panel.dialog.height < MAX_PANEL_HEIGHT);
+        assert_eq!(layout.brand_row, 2);
+        assert!(layout.body_row > layout.tabs_row + 1);
+        assert_eq!(layout.bottom_padding, 2);
+
+        let gap_row = panel.dialog.y + layout.tabs_row + 1;
+        let first = gap_row * buffer.width + panel.dialog.x + 1;
+        let last = first + panel.dialog.width;
+        assert!(buffer.cells[first..last].iter().all(|cell| cell.c == ' '));
+
+        let footer_row = panel.dialog.y + panel.dialog.height;
+        let last_action_cell = footer_row * buffer.width + panel.dialog.x + panel.dialog.width - 1;
+        assert_eq!(buffer.cells[last_action_cell].c, ' ');
+    }
+
+    #[test]
+    fn every_plain_release_cell_retains_the_dialog_background() {
+        let editor = editor(120, 40);
+        let notes = ReleaseNotes {
+            version: "1.0.0".to_string(),
+            markdown: "### Features\n\n- A readable improvement".to_string(),
+            release_url: "https://github.com/codersauce/red/releases/tag/v1.0.0".to_string(),
+            published_at: Some("Aug 13, 2026".to_string()),
+        };
+        let mut panel = WhatsNewPanel::new(&editor, notes, None);
+
+        for theme_path in ["themes/red.json", "themes/github-light.json"] {
+            let theme = crate::theme::parse_vscode_theme(theme_path).unwrap();
+            panel.set_theme(&theme);
+            let mut buffer = RenderBuffer::new(120, 40, &Style::default());
+            panel.draw(&mut buffer).unwrap();
+
+            for y in panel.dialog.y..=panel.dialog.y + panel.dialog.height + 1 {
+                for x in panel.dialog.x..=panel.dialog.x + panel.dialog.width + 1 {
+                    let cell = &buffer.cells[y * buffer.width + x];
+                    assert_eq!(
+                        cell.style.bg, panel.dialog.style.bg,
+                        "{theme_path} paints an inconsistent background at {x},{y}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn long_changelogs_grow_within_bounds_and_show_scroll_progress() {
+        let editor = editor(160, 70);
+        let entries = (1..=45)
+            .map(|index| format!("- Improvement number {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let notes = ReleaseNotes {
+            version: "1.0.0".to_string(),
+            markdown: format!("### Features\n\n{entries}"),
+            release_url: "https://github.com/codersauce/red/releases/tag/v1.0.0".to_string(),
+            published_at: None,
+        };
+        let mut panel = WhatsNewPanel::new(&editor, notes, None);
+        panel.switch_view();
+
+        assert_eq!(panel.dialog.height, MAX_PANEL_HEIGHT);
+        assert!(panel.max_scroll() > 0);
+
+        let mut buffer = RenderBuffer::new(160, 70, &Style::default());
+        panel.draw(&mut buffer).unwrap();
+        let expected = format!("1–{} of {}", panel.body_height(), panel.lines.len());
+        assert!(rendered_text(&buffer).contains(&expected));
+
+        panel.handle_event(&Event::Key(crossterm::event::KeyEvent::new(
+            KeyCode::Char('j'),
+            KeyModifiers::NONE,
+        )));
+        let mut buffer = RenderBuffer::new(160, 70, &Style::default());
+        panel.draw(&mut buffer).unwrap();
+        let expected = format!("2–{} of {}", panel.body_height() + 1, panel.lines.len());
+        assert!(rendered_text(&buffer).contains(&expected));
+    }
+
+    #[test]
+    fn multiple_release_links_advertise_keyboard_navigation() {
+        let editor = editor(120, 35);
+        let notes = ReleaseNotes {
+            version: "1.0.0".to_string(),
+            markdown: "### Features\n\n- [First change](https://example.test/first)\n- [Second change](https://example.test/second)".to_string(),
+            release_url: "https://github.com/codersauce/red/releases/tag/v1.0.0".to_string(),
+            published_at: None,
+        };
+        let mut panel = WhatsNewPanel::new(&editor, notes, None);
+        let mut buffer = RenderBuffer::new(120, 35, &Style::default());
+        panel.draw(&mut buffer).unwrap();
+
+        assert!(rendered_text(&buffer).contains("[ ] Links"));
+        assert_eq!(panel.selected_link, Some(0));
+
+        panel.handle_event(&Event::Key(crossterm::event::KeyEvent::new(
+            KeyCode::Char(']'),
+            KeyModifiers::NONE,
+        )));
+
+        assert_eq!(panel.selected_link, Some(1));
     }
 
     #[test]

--- a/src/whats_new.rs
+++ b/src/whats_new.rs
@@ -1,0 +1,390 @@
+//! Exact-version release notes with an immediate embedded changelog fallback.
+//!
+//! A release announcement must never delay startup or describe a version other
+//! than the binary the user actually launched. The checked-in changelog is
+//! therefore embedded into every binary; GitHub can enrich it asynchronously.
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use regex::Regex;
+use semver::Version;
+use serde::Deserialize;
+
+const EMBEDDED_CHANGELOG: &str = include_str!("../CHANGELOG.md");
+const REPOSITORY: &str = "codersauce/red";
+const MAX_RELEASE_NOTES_BYTES: usize = 128 * 1024;
+const RELEASE_REQUEST_TIMEOUT: Duration = Duration::from_secs(4);
+const MAX_HIGHLIGHTS_PER_SECTION: usize = 5;
+
+/// One version-specific release announcement ready for terminal presentation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReleaseNotes {
+    /// Exact package version embedded in the running binary.
+    pub version: String,
+    /// One or more relevant changelog sections, newest first.
+    pub markdown: String,
+    /// Canonical browser destination for the matching release.
+    pub release_url: String,
+    /// Human-readable publication date when GitHub supplies one.
+    pub published_at: Option<String>,
+}
+
+#[derive(Debug)]
+struct ChangelogSection {
+    version: Version,
+    markdown: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    body: Option<String>,
+    html_url: Option<String>,
+    published_at: Option<String>,
+    #[serde(default)]
+    draft: bool,
+}
+
+impl ReleaseNotes {
+    /// Returns the bundled notes for this version and any skipped releases.
+    #[must_use]
+    pub fn bundled(version: &str, last_seen_version: Option<&str>) -> Self {
+        Self::from_changelog(EMBEDDED_CHANGELOG, version, last_seen_version)
+    }
+
+    fn from_changelog(changelog: &str, version: &str, last_seen_version: Option<&str>) -> Self {
+        let current = Version::parse(version).ok();
+        let previous = last_seen_version.and_then(|value| Version::parse(value).ok());
+        let previous = match (&current, previous) {
+            (Some(current), Some(previous)) if previous < *current => Some(previous),
+            _ => None,
+        };
+        let sections = changelog_sections(changelog)
+            .into_iter()
+            .filter(|section| {
+                current.as_ref().is_some_and(|current| {
+                    section.version <= *current
+                        && previous
+                            .as_ref()
+                            .map_or(section.version == *current, |previous| {
+                                section.version > *previous
+                            })
+                })
+            })
+            .map(|section| section.markdown)
+            .collect::<Vec<_>>();
+        let release_url = format!("https://github.com/{REPOSITORY}/releases/tag/v{version}");
+        let markdown = if sections.is_empty() {
+            format!("## Red v{version}\n\n[Read the release notes on GitHub]({release_url}).")
+        } else {
+            sections.join("\n\n")
+        };
+
+        Self {
+            version: version.to_string(),
+            markdown,
+            release_url,
+            published_at: None,
+        }
+    }
+
+    /// Reduces the full changelog to the most useful user-visible changes.
+    #[must_use]
+    pub fn highlights_markdown(&self) -> String {
+        let commit_link = Regex::new(
+            r"\s*\(\[[0-9a-f]{7,40}\]\(https://github\.com/[^)]+/commit/[0-9a-f]{7,40}\)\)",
+        )
+        .expect("release commit-link expression is valid");
+        let mut sections = Vec::new();
+
+        for (heading, label) in [
+            ("Features", "What’s new"),
+            ("Performance", "Faster and smoother"),
+            ("Bug Fixes", "Fixed"),
+        ] {
+            let mut in_section = false;
+            let mut changes = Vec::new();
+            for line in self.markdown.lines() {
+                if let Some(section) = line.strip_prefix("### ") {
+                    in_section = section.trim().eq_ignore_ascii_case(heading);
+                    continue;
+                }
+                if line.starts_with("## ") {
+                    in_section = false;
+                    continue;
+                }
+                if in_section && line.starts_with("- ") {
+                    let cleaned = commit_link.replace_all(line, "").trim().to_string();
+                    changes.push(cleaned);
+                    if changes.len() == MAX_HIGHLIGHTS_PER_SECTION {
+                        break;
+                    }
+                }
+            }
+            if !changes.is_empty() {
+                sections.push(format!("## {label}\n\n{}", changes.join("\n")));
+            }
+        }
+
+        if sections.is_empty() {
+            self.markdown.clone()
+        } else {
+            sections.join("\n\n")
+        }
+    }
+
+    /// Retrieves and validates the published release for the running version.
+    pub async fn fetch(version: &str, fallback: &Self) -> Result<Self> {
+        let url = format!("https://api.github.com/repos/{REPOSITORY}/releases/tags/v{version}");
+        let client = reqwest::Client::builder()
+            .timeout(RELEASE_REQUEST_TIMEOUT)
+            .user_agent(format!("red/{version}"))
+            .build()
+            .context("failed to configure the GitHub release client")?;
+        let response = client
+            .get(url)
+            .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+            .send()
+            .await
+            .context("failed to retrieve the GitHub release")?
+            .error_for_status()
+            .context("GitHub rejected the release request")?;
+
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_RELEASE_NOTES_BYTES as u64)
+        {
+            anyhow::bail!("GitHub release notes exceed the permitted response size");
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .context("failed to read GitHub release notes")?;
+        anyhow::ensure!(
+            bytes.len() <= MAX_RELEASE_NOTES_BYTES,
+            "GitHub release notes exceed the permitted response size"
+        );
+        Self::from_github_json(&bytes, version, fallback)
+    }
+
+    fn from_github_json(bytes: &[u8], version: &str, fallback: &Self) -> Result<Self> {
+        let release: GitHubRelease =
+            serde_json::from_slice(bytes).context("failed to decode GitHub release metadata")?;
+        let expected_tag = format!("v{version}");
+        anyhow::ensure!(
+            release.tag_name == expected_tag,
+            "GitHub returned release {}, expected {expected_tag}",
+            release.tag_name
+        );
+        anyhow::ensure!(
+            !release.draft,
+            "the requested GitHub release is unpublished"
+        );
+        let markdown = release
+            .body
+            .as_deref()
+            .map(strip_release_boilerplate)
+            .filter(|body| !body.trim().is_empty())
+            .ok_or_else(|| anyhow!("the GitHub release contains no changelog"))?;
+
+        let skipped_releases = trailing_release_sections(&fallback.markdown);
+        let markdown = if skipped_releases.is_empty() {
+            markdown
+        } else {
+            format!("{markdown}\n\n{skipped_releases}")
+        };
+
+        let published_at = release.published_at.and_then(|value| {
+            chrono::DateTime::parse_from_rfc3339(&value)
+                .ok()
+                .map(|date| date.format("%b %e, %Y").to_string().replace("  ", " "))
+        });
+
+        Ok(Self {
+            version: version.to_string(),
+            markdown,
+            release_url: release
+                .html_url
+                .unwrap_or_else(|| fallback.release_url.clone()),
+            published_at,
+        })
+    }
+}
+
+fn changelog_sections(changelog: &str) -> Vec<ChangelogSection> {
+    let mut sections = Vec::new();
+    let mut current_version = None;
+    let mut current_lines = Vec::new();
+
+    for line in changelog.lines() {
+        if let Some(version) = release_heading_version(line) {
+            if let Some(previous) = current_version.replace(version) {
+                sections.push(ChangelogSection {
+                    version: previous,
+                    markdown: current_lines.join("\n").trim().to_string(),
+                });
+                current_lines.clear();
+            }
+            current_lines.push(line.to_string());
+        } else if current_version.is_some() {
+            current_lines.push(line.to_string());
+        }
+    }
+
+    if let Some(version) = current_version {
+        sections.push(ChangelogSection {
+            version,
+            markdown: current_lines.join("\n").trim().to_string(),
+        });
+    }
+
+    sections
+}
+
+fn release_heading_version(line: &str) -> Option<Version> {
+    let heading = line.strip_prefix("## [")?;
+    let (version, _) = heading.split_once(']')?;
+    Version::parse(version.trim_start_matches('v')).ok()
+}
+
+fn strip_release_boilerplate(markdown: &str) -> String {
+    let mut lines = Vec::new();
+    for line in markdown.lines() {
+        if matches!(
+            line.trim(),
+            "## Installation" | "## Checksums" | "## Full Changelog"
+        ) {
+            break;
+        }
+        lines.push(line);
+    }
+    lines.join("\n").trim().to_string()
+}
+
+fn trailing_release_sections(markdown: &str) -> String {
+    let mut headings_seen = 0_usize;
+    let mut lines = Vec::new();
+    for line in markdown.lines() {
+        if release_heading_version(line).is_some() {
+            headings_seen += 1;
+        }
+        if headings_seen >= 2 {
+            lines.push(line);
+        }
+    }
+    lines.join("\n").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHANGELOG: &str = "# Changelog\n\n## [0.5.0](https://example.test/0.5)\n\n### Features\n\n- **editor:** New thing ([#2](https://github.com/codersauce/red/issues/2)) ([abcdef0](https://github.com/codersauce/red/commit/abcdef0123456789))\n\n### Bug Fixes\n\n- Fix old thing\n\n## [0.4.0](https://example.test/0.4)\n\n### Features\n\n- Previous thing\n\n## [0.3.0](https://example.test/0.3)\n\n### Features\n\n- Old thing\n";
+
+    #[test]
+    fn bundles_only_the_installed_version_for_a_first_launch() {
+        let notes = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", None);
+
+        assert!(notes.markdown.contains("New thing"));
+        assert!(!notes.markdown.contains("Previous thing"));
+    }
+
+    #[test]
+    fn includes_every_version_skipped_since_the_previous_seen_release() {
+        let notes = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", Some("0.3.0"));
+
+        assert!(notes.markdown.contains("New thing"));
+        assert!(notes.markdown.contains("Previous thing"));
+        assert!(!notes.markdown.contains("Old thing"));
+    }
+
+    #[test]
+    fn downgrades_show_only_the_running_release() {
+        let notes = ReleaseNotes::from_changelog(CHANGELOG, "0.4.0", Some("0.5.0"));
+
+        assert!(notes.markdown.contains("Previous thing"));
+        assert!(!notes.markdown.contains("Old thing"));
+    }
+
+    #[test]
+    fn unavailable_embedded_versions_still_offer_a_release_link() {
+        let notes = ReleaseNotes::from_changelog(CHANGELOG, "0.9.0", None);
+
+        assert!(notes.markdown.contains("Red v0.9.0"));
+        assert!(notes.markdown.contains("releases/tag/v0.9.0"));
+    }
+
+    #[test]
+    fn highlights_keep_issue_links_and_remove_commit_noise() {
+        let notes = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", None);
+        let highlights = notes.highlights_markdown();
+
+        assert!(highlights.contains("## What’s new"));
+        assert!(highlights.contains("## Fixed"));
+        assert!(highlights.contains("issues/2"));
+        assert!(!highlights.contains("commit/abcdef"));
+    }
+
+    #[test]
+    fn github_release_replaces_current_notes_and_keeps_skipped_versions() {
+        let fallback = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", Some("0.3.0"));
+        let payload = serde_json::json!({
+            "tag_name": "v0.5.0",
+            "body": "## [0.5.0](https://example.test)\n\n### Features\n\n- Published improvement\n\n## Installation\n\nDo not show this.",
+            "html_url": "https://github.com/codersauce/red/releases/tag/v0.5.0",
+            "published_at": "2026-08-13T21:03:28Z",
+            "draft": false
+        });
+
+        let notes = ReleaseNotes::from_github_json(
+            &serde_json::to_vec(&payload).unwrap(),
+            "0.5.0",
+            &fallback,
+        )
+        .unwrap();
+
+        assert!(notes.markdown.contains("Published improvement"));
+        assert!(notes.markdown.contains("Previous thing"));
+        assert!(!notes.markdown.contains("Do not show this"));
+        assert_eq!(notes.published_at.as_deref(), Some("Aug 13, 2026"));
+    }
+
+    #[test]
+    fn rejects_wrong_or_unpublished_github_releases() {
+        let fallback = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", None);
+        let wrong = serde_json::json!({
+            "tag_name": "v0.6.0",
+            "body": "### Features\n- Wrong version",
+            "draft": false
+        });
+        let draft = serde_json::json!({
+            "tag_name": "v0.5.0",
+            "body": "### Features\n- Unpublished",
+            "draft": true
+        });
+
+        assert!(ReleaseNotes::from_github_json(
+            &serde_json::to_vec(&wrong).unwrap(),
+            "0.5.0",
+            &fallback,
+        )
+        .is_err());
+        assert!(ReleaseNotes::from_github_json(
+            &serde_json::to_vec(&draft).unwrap(),
+            "0.5.0",
+            &fallback,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn actual_embedded_changelog_contains_the_current_package_release() {
+        let notes = ReleaseNotes::bundled(env!("CARGO_PKG_VERSION"), None);
+
+        assert!(notes
+            .markdown
+            .contains(&format!("## [{}]", env!("CARGO_PKG_VERSION"))));
+    }
+}

--- a/src/whats_new.rs
+++ b/src/whats_new.rs
@@ -99,9 +99,9 @@ impl ReleaseNotes {
         let mut sections = Vec::new();
 
         for (heading, label) in [
-            ("Features", "What’s new"),
+            ("Features", "New features"),
             ("Performance", "Faster and smoother"),
-            ("Bug Fixes", "Fixed"),
+            ("Bug Fixes", "Fixes"),
         ] {
             let mut in_section = false;
             let mut changes = Vec::new();
@@ -321,8 +321,8 @@ mod tests {
         let notes = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", None);
         let highlights = notes.highlights_markdown();
 
-        assert!(highlights.contains("## What’s new"));
-        assert!(highlights.contains("## Fixed"));
+        assert!(highlights.contains("## New features"));
+        assert!(highlights.contains("## Fixes"));
         assert!(highlights.contains("issues/2"));
         assert!(!highlights.contains("commit/abcdef"));
     }


### PR DESCRIPTION
Red users currently have to discover release changes outside the editor, and there is no persistent way to announce a newly installed version once without interrupting every launch.

## What changed

- Open a branded, responsive What’s New panel once for each installed version, and record the version only after its first frame reaches an interactive or authenticated detached client.
- Render the exact bundled `CHANGELOG.md` section immediately, refresh the matching GitHub release asynchronously, preserve skipped releases, and fall back safely when the network or release is unavailable.
- Add highlights/full-changelog views with clickable tabs, keyboard and mouse scrolling, link navigation, theme-correct surfaces, responsive spacing, and scroll progress.
- Expose `:whats-new`, `:changelog`, and a command-palette entry, plus `show_whats_new` and `fetch_release_notes` configuration toggles.
- Preserve crash recovery, detached-session authentication, legacy preferences compatibility, compact terminals, and the shared dialog footer behavior.

## How to Test

1. Launch Red with a fresh configuration directory or remove `last_seen_version` from `~/.config/red/preferences.json`; confirm the release panel appears immediately with the current version, Red branding, and bundled highlights.
2. Close the panel and restart the same version; confirm it does not reappear, then run `:whats-new` and `:changelog` to reopen it manually.
3. Press `Tab` or click each tab; confirm the full changelog opens, the footer changes to `Tab Highlights`, links remain navigable with `[` / `]`, and long notes show scrolling progress.
4. Set `show_whats_new = false` and restart; confirm automatic presentation is suppressed while `:whats-new` still works. Set `fetch_release_notes = false` to verify offline bundled notes.
5. Resize to a compact terminal and switch between the Red and GitHub Light themes; confirm the modal stays inside the viewport and every non-code cell retains the same dialog background.

## Verification

- `cargo test -p red --target-dir /private/tmp/red-whats-new-target --quiet` — 1,360 library tests and all integration suites passed.
- `CARGO_TARGET_DIR=/private/tmp/red-whats-new-target cargo clippy --all-targets --all-features -- -D warnings` — passed without warnings.
- Interactive, detached, live GitHub-release, dark-theme, light-theme, full-changelog, and compact-terminal tmux smoke tests passed.
