### PR TITLE
feat(lsp): add diagnostic navigation

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -323,10 +323,12 @@ Esc = { EnterMode = "Normal" }
 
 [keys.normal."["]
 "%" = "MatchitPreviousUnmatched"
+"d" = "PreviousDiagnostic"
 "h" = { PluginCommand = "GitHunkPrevious" }
 
 [keys.normal."]"]
 "%" = "MatchitNextUnmatched"
+"d" = "NextDiagnostic"
 "h" = { PluginCommand = "GitHunkNext" }
 
 [keys.normal."Ctrl-w"]

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -807,6 +807,24 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Action::ShowLineDiagnostics,
         ),
         builtin(
+            "lsp.next_diagnostic",
+            "Go to next diagnostic",
+            "LSP",
+            "Move to the next diagnostic in the current buffer",
+            None,
+            &["next error", "next warning"],
+            Action::NextDiagnostic,
+        ),
+        builtin(
+            "lsp.previous_diagnostic",
+            "Go to previous diagnostic",
+            "LSP",
+            "Move to the previous diagnostic in the current buffer",
+            None,
+            &["previous error", "previous warning"],
+            Action::PreviousDiagnostic,
+        ),
+        builtin(
             "lsp.format",
             "Format document",
             "LSP",
@@ -1055,6 +1073,8 @@ fn action_label(action: &Action) -> String {
         Action::StartRename => "Rename symbol".to_string(),
         Action::Hover => "Show hover documentation".to_string(),
         Action::ShowLineDiagnostics => "Show line diagnostics".to_string(),
+        Action::NextDiagnostic => "Go to next diagnostic".to_string(),
+        Action::PreviousDiagnostic => "Go to previous diagnostic".to_string(),
         Action::SignatureHelp => "Show signature help".to_string(),
         Action::ClearSearchHighlight => "Clear search highlights".to_string(),
         Action::ToggleWrap => "Toggle line wrapping".to_string(),
@@ -1527,6 +1547,24 @@ mod tests {
 
         assert_eq!(diagnostics.action, Action::ShowLineDiagnostics);
         assert_eq!(diagnostics.shortcuts, vec!["D"]);
+    }
+
+    #[test]
+    fn diagnostic_navigation_commands_expose_default_shortcuts() {
+        let commands = entries(&default_keys(), &[]);
+        let next = commands
+            .iter()
+            .find(|entry| entry.id == "lsp.next_diagnostic")
+            .expect("next diagnostic command");
+        let previous = commands
+            .iter()
+            .find(|entry| entry.id == "lsp.previous_diagnostic")
+            .expect("previous diagnostic command");
+
+        assert_eq!(next.action, Action::NextDiagnostic);
+        assert_eq!(next.shortcuts, vec!["] d"]);
+        assert_eq!(previous.action, Action::PreviousDiagnostic);
+        assert_eq!(previous.shortcuts, vec!["[ d"]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3237,6 +3237,27 @@ env = { NO_BROWSER = "1" }
     }
 
     #[test]
+    fn default_config_maps_diagnostic_navigation() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        let Some(KeyAction::Nested(previous)) = config.keys.normal.get("[") else {
+            panic!("expected [ prefix");
+        };
+        assert_eq!(
+            previous.get("d"),
+            Some(&KeyAction::Single(Action::PreviousDiagnostic))
+        );
+
+        let Some(KeyAction::Nested(next)) = config.keys.normal.get("]") else {
+            panic!("expected ] prefix");
+        };
+        assert_eq!(
+            next.get("d"),
+            Some(&KeyAction::Single(Action::NextDiagnostic))
+        );
+    }
+
+    #[test]
     fn default_config_maps_neovim_style_search_keys() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2021,6 +2021,8 @@ pub enum Action {
     RefreshDiagnostics,
     Refresh,
     ShowLineDiagnostics,
+    NextDiagnostic,
+    PreviousDiagnostic,
     Hover,
     ExecuteLspCommand(Box<LspCommand>),
     FormatDocument,
@@ -5881,6 +5883,8 @@ impl Editor {
                 | Action::RefreshDiagnostics
                 | Action::Refresh
                 | Action::ShowLineDiagnostics
+                | Action::NextDiagnostic
+                | Action::PreviousDiagnostic
                 | Action::Hover
                 | Action::FormatDocument
                 | Action::CodeAction
@@ -9887,6 +9891,46 @@ impl Editor {
             .cloned()
             .collect::<Vec<_>>();
         (!diagnostics.is_empty()).then_some(diagnostics)
+    }
+
+    fn diagnostic_navigation_target(&self, forward: bool) -> Option<TextPosition> {
+        let uri = self.current_buffer().uri().ok().flatten()?;
+        let cursor = self.cursor_lsp_position();
+        let cursor = (cursor.line, cursor.character);
+        let positions = self
+            .diagnostics
+            .get(&uri)?
+            .iter()
+            .map(|diagnostic| {
+                (
+                    diagnostic.range.start.line,
+                    diagnostic.range.start.character,
+                )
+            })
+            .filter(|(line, _)| self.current_buffer().get(*line).is_some())
+            .collect::<Vec<_>>();
+
+        let target = if forward {
+            positions
+                .iter()
+                .copied()
+                .filter(|position| *position > cursor)
+                .min()
+                .or_else(|| positions.iter().copied().min())
+        } else {
+            positions
+                .iter()
+                .copied()
+                .filter(|position| *position < cursor)
+                .max()
+                .or_else(|| positions.iter().copied().max())
+        }?;
+        let line = self.current_buffer().get(target.0)?;
+        let line = line.trim_end_matches(['\r', '\n']);
+        Some(TextPosition::new(
+            target.0,
+            utf16_to_grapheme(line, target.1),
+        ))
     }
 
     fn process_progress(&mut self, progress_params: &ProgressParams) -> Option<Action> {
@@ -16652,6 +16696,18 @@ impl Editor {
                     self.render(buffer)?;
                 }
             }
+            Action::NextDiagnostic | Action::PreviousDiagnostic => {
+                let forward = matches!(action, Action::NextDiagnostic);
+                if let Some(target) = self.diagnostic_navigation_target(forward) {
+                    self.execute_with_tracking(
+                        &Action::MoveTo(target.character, target.line + 1),
+                        buffer,
+                        runtime,
+                        false,
+                    )
+                    .await?;
+                }
+            }
             Action::ExecuteLspCommand(command) => {
                 self.execute_lsp_command(command, None).await?;
             }
@@ -18403,6 +18459,8 @@ impl Editor {
                 | Action::MatchitBackward
                 | Action::MatchitPreviousUnmatched
                 | Action::MatchitNextUnmatched
+                | Action::NextDiagnostic
+                | Action::PreviousDiagnostic
                 | Action::MoveTo(_, _)
                 | Action::MoveToFilePos(_, _, _)
                 | Action::JumpToMark { .. }
@@ -30847,6 +30905,99 @@ builtin = "rust"
 
         assert!(editor.current_dialog.is_none());
         assert_eq!(editor.current_buffer().contents(), original);
+    }
+
+    #[tokio::test]
+    async fn diagnostic_navigation_orders_utf16_positions_and_wraps() {
+        let root = tempfile::tempdir().unwrap();
+        let file = root.path().join("main.rs");
+        let mut editor = lsp_test_editor(vec![Buffer::new(
+            Some(file.to_string_lossy().into_owned()),
+            "zero\n😀 alpha beta\ntwo\nthree".to_string(),
+        )]);
+        let uri = crate::lsp::file_uri(&file).unwrap();
+        editor.add_diagnostics(
+            Some(&uri),
+            &[
+                line_diagnostic((3, 0), (3, 1), DiagnosticSeverity::Hint, "last", None),
+                line_diagnostic(
+                    (1, 8),
+                    (1, 9),
+                    DiagnosticSeverity::Warning,
+                    "same line later",
+                    None,
+                ),
+                line_diagnostic(
+                    (99, 0),
+                    (99, 1),
+                    DiagnosticSeverity::Error,
+                    "outside the buffer",
+                    None,
+                ),
+                line_diagnostic((0, 0), (0, 1), DiagnosticSeverity::Error, "first", None),
+                line_diagnostic(
+                    (1, 2),
+                    (1, 3),
+                    DiagnosticSeverity::Information,
+                    "after emoji",
+                    None,
+                ),
+            ],
+        );
+        let mut buffer = RenderBuffer::new(60, 12, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .execute(&Action::NextDiagnostic, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!((editor.cx, editor.buffer_line()), (1, 1));
+
+        editor
+            .execute(&Action::NextDiagnostic, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!((editor.cx, editor.buffer_line()), (7, 1));
+
+        editor
+            .execute(&Action::NextDiagnostic, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!((editor.cx, editor.buffer_line()), (0, 3));
+
+        editor
+            .execute(&Action::NextDiagnostic, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!((editor.cx, editor.buffer_line()), (0, 0));
+
+        editor
+            .execute(&Action::PreviousDiagnostic, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!((editor.cx, editor.buffer_line()), (0, 3));
+    }
+
+    #[tokio::test]
+    async fn diagnostic_navigation_is_a_safe_noop_without_diagnostics() {
+        let mut editor =
+            lsp_test_editor(vec![Buffer::new(None, "first\nsecond\nthird".to_string())]);
+        editor.cy = 1;
+        editor.cx = 2;
+        let mut buffer = RenderBuffer::new(60, 12, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .execute(&Action::NextDiagnostic, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        editor
+            .execute(&Action::PreviousDiagnostic, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert_eq!((editor.cx, editor.buffer_line()), (2, 1));
+        assert!(editor.last_error.is_none());
     }
 
     fn diagnostic_at(


### PR DESCRIPTION
Diagnostics are visible throughout the editor, but moving between them currently requires opening a picker or navigating manually. This adds familiar keyboard motions so diagnostic review can stay in the normal-mode flow.

- Add `]d` and `[d` for the next and previous diagnostic in the current buffer.
- Order locations by LSP start position, wrap at either end, and translate UTF-16 columns to editor grapheme positions.
- Record diagnostic moves in jump history and safely ignore diagnostics outside the current buffer.
- Expose both actions in the command palette with their default shortcuts.

## How to Test

1. Open a file with multiple LSP diagnostics and press `]d` repeatedly. Verify the cursor visits each diagnostic and wraps from the last back to the first.
2. Press `[d` repeatedly. Verify navigation runs in reverse and wraps from the first to the last.
3. Verify diagnostics on the same line, including after non-BMP Unicode characters, land on the correct visual column.
4. Open a file without diagnostics and verify both mappings are safe no-ops.

Focused automated coverage: `cargo test --lib diagnostic_navigation`.