### PR TITLE
feat(editor): restore and indent visual selections

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -402,6 +402,7 @@ Esc = { EnterMode = "Normal" }
 "P" = [ "PasteBefore", { EnterMode = "Normal" } ]
 "I" = "InsertBlock"
 ">" = { IndentSelection = 1 }
+"<" = { UnindentSelection = 1 }
 "J" = [ { JoinLines = 2 }, { EnterMode = "Normal" } ]
 "g" = { "c" = [ "ToggleCommentSelection", { EnterMode = "Normal" } ], "J" = [ { JoinLinesKeepSpaces = 2 }, { EnterMode = "Normal" } ], "v" = "RestoreLastVisualSelection" }
 "u" = [ { TransformSelection = "Lower" }, { EnterMode = "Normal" } ]

--- a/default_config.toml
+++ b/default_config.toml
@@ -246,7 +246,7 @@ Esc = { EnterMode = "Normal" }
 "o" = "InsertLineBelowCursor"
 "O" = "InsertLineAtCursor"
 "G" = "MoveToBottom"
-"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "c" = { StartCommentOperator = 1 }, "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd", "e" = "MoveToPreviousWordEnd", "E" = "MoveToPreviousBigWordEnd", "J" = { JoinLinesKeepSpaces = 2 }, "W" = "ToggleWrap", "u" = { StartLowercaseOperator = 1 }, "U" = { StartUppercaseOperator = 1 }, "~" = { StartToggleCaseOperator = 1 }, "-" = "SelectPreviousUndoBranch", "+" = "SelectNextUndoBranch" }
+"g" = { "g" = "MoveToTop", "%" = "MatchitBackward", "c" = { StartCommentOperator = 1 }, "d" = "GoToDefinition", "j" = "MoveScreenLineDown", "k" = "MoveScreenLineUp", "0" = "MoveToScreenLineStart", "^" = "MoveToScreenLineFirstNonBlank", "$" = "MoveToScreenLineEnd", "e" = "MoveToPreviousWordEnd", "E" = "MoveToPreviousBigWordEnd", "J" = { JoinLinesKeepSpaces = 2 }, "W" = "ToggleWrap", "v" = "RestoreLastVisualSelection", "u" = { StartLowercaseOperator = 1 }, "U" = { StartUppercaseOperator = 1 }, "~" = { StartToggleCaseOperator = 1 }, "-" = "SelectPreviousUndoBranch", "+" = "SelectNextUndoBranch" }
 "u" = "Undo"
 "U" = "Redo"
 "Ctrl-r" = "Redo"
@@ -401,8 +401,9 @@ Esc = { EnterMode = "Normal" }
 "p" = [ "Paste", { EnterMode = "Normal" } ]
 "P" = [ "PasteBefore", { EnterMode = "Normal" } ]
 "I" = "InsertBlock"
+">" = { IndentSelection = 1 }
 "J" = [ { JoinLines = 2 }, { EnterMode = "Normal" } ]
-"g" = { "c" = [ "ToggleCommentSelection", { EnterMode = "Normal" } ], "J" = [ { JoinLinesKeepSpaces = 2 }, { EnterMode = "Normal" } ] }
+"g" = { "c" = [ "ToggleCommentSelection", { EnterMode = "Normal" } ], "J" = [ { JoinLinesKeepSpaces = 2 }, { EnterMode = "Normal" } ], "v" = "RestoreLastVisualSelection" }
 "u" = [ { TransformSelection = "Lower" }, { EnterMode = "Normal" } ]
 "U" = [ { TransformSelection = "Upper" }, { EnterMode = "Normal" } ]
 "~" = [ { TransformSelection = "Toggle" }, { EnterMode = "Normal" } ]

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -1,7 +1,7 @@
 # Red Vim compatibility matrix
 
-**Matrix version:** 1.3
-**Validated against:** Red 0.2.4, July 2026
+**Matrix version:** 1.4
+**Validated against:** Red 0.5.0, August 2026
 **Status vocabulary:** **supported**, **intentional difference**, **not yet supported**
 
 “Real Vim keys” means the rows marked **supported** below. It does not mean complete
@@ -44,6 +44,8 @@ the corresponding integration tests.
 | Visual character | **supported** | Motions, supported text objects, yank/delete/change/paste, and Unicode selections. |
 | Visual line | **supported** | Linewise yank/delete/change/paste, including whole-document and interior replacements. |
 | Visual block | **supported** | Block delete/change/insert, one-transaction replay, undo/redo, and dot-repeat for block insert. |
+| Restore Visual selection | **supported** | `gv` restores the previous buffer-local Visual area with its character, line, or block shape and original direction. In Visual mode it exchanges the current and previous areas. Selection metadata survives session recovery, while `<` and `>` continue to track edits. |
+| Visual indent | **supported** | `[count]>` shifts every covered line by `count × shiftwidth` in one undoable transaction for character, line, and block selections. Empty lines remain empty, and `gv` restores the shifted range. |
 | Visual `r` replace and case changes | **supported** | Visual `r{char}`, `u`, `U`, and `~` replace/change the selection in one transaction, including shifted terminal key events and Visual-line/block selections. |
 | Wrapped-line motions | **supported** | `gj`, `gk`, `g0`, `g^`, and `g$`; scroll and cursor state are window-local. |
 

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -45,7 +45,7 @@ the corresponding integration tests.
 | Visual line | **supported** | Linewise yank/delete/change/paste, including whole-document and interior replacements. |
 | Visual block | **supported** | Block delete/change/insert, one-transaction replay, undo/redo, and dot-repeat for block insert. |
 | Restore Visual selection | **supported** | `gv` restores the previous buffer-local Visual area with its character, line, or block shape and original direction. In Visual mode it exchanges the current and previous areas. Selection metadata survives session recovery, while `<` and `>` continue to track edits. |
-| Visual indent | **supported** | `[count]>` shifts every covered line by `count × shiftwidth` in one undoable transaction for character, line, and block selections. Empty lines remain empty, and `gv` restores the shifted range. |
+| Visual indent | **supported** | `[count]>` and `[count]<` shift every covered line right or left by `count × shiftwidth` in one undoable transaction for character, line, and block selections. Empty lines remain empty, indentation saturates at column zero, and `gv` restores the shifted range. |
 | Visual `r` replace and case changes | **supported** | Visual `r{char}`, `u`, `U`, and `~` replace/change the selection in one transaction, including shifted terminal key events and Visual-line/block selections. |
 | Wrapped-line motions | **supported** | `gj`, `gk`, `g0`, `g^`, and `g$`; scroll and cursor state are window-local. |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3523,6 +3523,25 @@ input_position = "left"
     }
 
     #[test]
+    fn default_config_maps_last_visual_restore_and_visual_indent() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+        let Some(KeyAction::Nested(normal_g)) = config.keys.normal.get("g") else {
+            panic!("default config should map normal g to nested actions");
+        };
+        let Some(KeyAction::Nested(visual_g)) = config.keys.visual.get("g") else {
+            panic!("default config should map visual g to nested actions");
+        };
+
+        let restore = Some(&KeyAction::Single(Action::RestoreLastVisualSelection));
+        assert_eq!(normal_g.get("v"), restore);
+        assert_eq!(visual_g.get("v"), restore);
+        assert_eq!(
+            config.keys.visual.get(">"),
+            Some(&KeyAction::Single(Action::IndentSelection(1)))
+        );
+    }
+
+    #[test]
     fn default_config_maps_matchit_keys() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3539,6 +3539,10 @@ input_position = "left"
             config.keys.visual.get(">"),
             Some(&KeyAction::Single(Action::IndentSelection(1)))
         );
+        assert_eq!(
+            config.keys.visual.get("<"),
+            Some(&KeyAction::Single(Action::UnindentSelection(1)))
+        );
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2033,6 +2033,7 @@ pub enum Action {
     IndentLine,
     IndentSelection(u16),
     UnindentLine,
+    UnindentSelection(u16),
 
     GoToLine(usize),
     GoToDefinition,
@@ -14664,6 +14665,44 @@ impl Editor {
         self.commit_transaction(self.cursor_snapshot())
     }
 
+    fn unindent_selection(&mut self, count: u16) -> bool {
+        let Some(selection) = self.selection else {
+            return false;
+        };
+        let first_line = selection.y0.min(selection.y1);
+        let last_line = selection.y0.max(selection.y1);
+        let indentation = self.indentation();
+        let columns = indentation
+            .shift_width
+            .saturating_mul(usize::from(count.max(1)));
+
+        self.begin_transaction("unindent selection");
+        for line in first_line..=last_line {
+            let Some(contents) = self.current_buffer().get(line) else {
+                continue;
+            };
+            let old_indentation = Self::leading_indentation_text(&contents).to_string();
+            if old_indentation.is_empty() {
+                continue;
+            }
+            let old_columns =
+                display_width_with_tabs(&old_indentation, indentation.tab_width.max(1));
+            let new_indentation =
+                indentation.whitespace_for_columns(old_columns.saturating_sub(columns));
+            self.replace_range(
+                TextRange::new(
+                    TextPosition::new(line, 0),
+                    TextPosition::new(line, old_indentation.chars().count()),
+                ),
+                &new_indentation,
+            );
+        }
+        self.move_to_text_position(TextPosition::new(first_line, 0));
+        self.selection = None;
+        self.selection_start = None;
+        self.commit_transaction(self.cursor_snapshot())
+    }
+
     /// Executes a single editor action
     ///
     /// This is the core action dispatcher that:
@@ -18046,6 +18085,15 @@ impl Editor {
                 self.notify_change(runtime).await?;
                 self.render(buffer)?;
             }
+            Action::UnindentSelection(count) => {
+                self.capture_last_visual_selection();
+                let changed = self.unindent_selection(*count);
+                if changed {
+                    self.notify_change(runtime).await?;
+                }
+                self.execute(&Action::EnterMode(Mode::Normal), buffer, runtime)
+                    .await?;
+            }
             Action::JumpBack => {
                 add_to_history = false;
                 if let Some(entry) = self.jump_back_entry() {
@@ -20249,6 +20297,9 @@ impl Editor {
                     }
                     KeyAction::Single(Action::IndentSelection(_)) => {
                         KeyAction::Single(Action::IndentSelection(count))
+                    }
+                    KeyAction::Single(Action::UnindentSelection(_)) => {
+                        KeyAction::Single(Action::UnindentSelection(count))
                     }
                     KeyAction::Single(Action::StartUppercaseOperator(_)) => {
                         KeyAction::Single(Action::StartUppercaseOperator(count))

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -110,7 +110,8 @@ use crate::{
     session::{
         capture_session_disk_fingerprint, detect_disk_divergence, read_session_disk_contents,
         RecoveryDivergence, SessionAnchorAffinity, SessionBufferSnapshot, SessionDiskFingerprint,
-        SessionJump, SessionMark, SessionSnapshot, SessionStore, SESSION_SCHEMA_VERSION,
+        SessionJump, SessionMark, SessionSnapshot, SessionStore, SessionVisualMode,
+        SessionVisualSelection, SESSION_SCHEMA_VERSION,
     },
     theme::{parse_vscode_theme, parse_vscode_theme_contents, Style, Theme},
     ui::{
@@ -1870,6 +1871,7 @@ pub enum Action {
     Save,
     SaveAs(String),
     EnterMode(Mode),
+    RestoreLastVisualSelection,
     EnterSearch(SearchDirection),
 
     Undo,
@@ -2029,6 +2031,7 @@ pub enum Action {
     ReplaceLineAt(usize, String),
 
     IndentLine,
+    IndentSelection(u16),
     UnindentLine,
 
     GoToLine(usize),
@@ -2247,7 +2250,7 @@ impl Default for CursorGoal {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 /// Editor interaction mode used by keymaps, cursor styling, and selection.
 pub enum Mode {
     /// Command-oriented navigation mode.
@@ -2410,6 +2413,12 @@ struct Rect {
     y0: usize,
     x1: usize,
     y1: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LastVisualSelection {
+    mode: Mode,
+    anchor_at_start: bool,
 }
 
 impl Rect {
@@ -2738,6 +2747,7 @@ pub struct Editor {
     local_marks: HashMap<BufferId, HashMap<char, EditAnchor>>,
     global_marks: HashMap<char, EditAnchor>,
     special_marks: HashMap<(BufferId, char), EditAnchor>,
+    last_visual_selections: HashMap<BufferId, LastVisualSelection>,
     substitute_confirmation: Option<SubstituteConfirmation>,
 
     /// Current command line content
@@ -3949,6 +3959,7 @@ impl Editor {
             local_marks: HashMap::new(),
             global_marks: HashMap::new(),
             special_marks: HashMap::new(),
+            last_visual_selections: HashMap::new(),
             substitute_confirmation: None,
             command: String::new(),
             preferences,
@@ -14625,6 +14636,34 @@ impl Editor {
         Self::leading_indentation(&self.current_line_contents().unwrap_or_default())
     }
 
+    fn indent_selection(&mut self, count: u16) -> bool {
+        let Some(selection) = self.selection else {
+            return false;
+        };
+        let first_line = selection.y0.min(selection.y1);
+        let last_line = selection.y0.max(selection.y1);
+        let indentation = self.indentation();
+        let columns = indentation
+            .shift_width
+            .saturating_mul(usize::from(count.max(1)));
+        let prefix = indentation.whitespace_for_columns(columns);
+
+        self.begin_transaction("indent selection");
+        for line in first_line..=last_line {
+            let Some(contents) = self.current_buffer().get(line) else {
+                continue;
+            };
+            if trim_line_ending(&contents).is_empty() {
+                continue;
+            }
+            self.replace_range(TextRange::insertion(TextPosition::new(line, 0)), &prefix);
+        }
+        self.move_to_text_position(TextPosition::new(first_line, 0));
+        self.selection = None;
+        self.selection_start = None;
+        self.commit_transaction(self.cursor_snapshot())
+    }
+
     /// Executes a single editor action
     ///
     /// This is the core action dispatcher that:
@@ -14947,6 +14986,15 @@ impl Editor {
                 self.begin_search(*direction);
                 self.render(buffer)?;
             }
+            Action::RestoreLastVisualSelection => {
+                add_to_history = false;
+                if self.restore_last_visual_selection() {
+                    self.render(buffer)?;
+                } else {
+                    self.last_error = Some("last visual selection is not set".to_string());
+                    self.draw_commandline(buffer);
+                }
+            }
             Action::EnterMode(new_mode) => {
                 add_to_history = false;
                 let old_mode = self.mode;
@@ -14957,7 +15005,7 @@ impl Editor {
                     new_mode,
                     Mode::Visual | Mode::VisualLine | Mode::VisualBlock
                 ) {
-                    self.capture_last_visual_marks();
+                    self.capture_last_visual_selection();
                 }
                 self.selection = None;
                 self.pending_visual_text_object_scope = None;
@@ -17972,6 +18020,15 @@ impl Editor {
                 self.notify_change(runtime).await?;
                 self.render(buffer)?;
             }
+            Action::IndentSelection(count) => {
+                self.capture_last_visual_selection();
+                let changed = self.indent_selection(*count);
+                if changed {
+                    self.notify_change(runtime).await?;
+                }
+                self.execute(&Action::EnterMode(Mode::Normal), buffer, runtime)
+                    .await?;
+            }
             Action::UnindentLine => {
                 let spaces = self.current_line_indentation();
                 let chars_to_remove = std::cmp::min(spaces, self.indentation().shift_width);
@@ -20190,6 +20247,9 @@ impl Editor {
                     KeyAction::Single(Action::ToggleCommentLines(_)) => {
                         KeyAction::Single(Action::ToggleCommentLines(count))
                     }
+                    KeyAction::Single(Action::IndentSelection(_)) => {
+                        KeyAction::Single(Action::IndentSelection(count))
+                    }
                     KeyAction::Single(Action::StartUppercaseOperator(_)) => {
                         KeyAction::Single(Action::StartUppercaseOperator(count))
                     }
@@ -20298,17 +20358,87 @@ impl Editor {
         self.special_marks.insert((anchor.buffer_id, mark), anchor);
     }
 
-    fn capture_last_visual_marks(&mut self) {
+    fn capture_last_visual_selection(&mut self) {
+        if !self.is_visual() {
+            return;
+        }
         let Some(selection) = self.selection else {
             return;
         };
         let (x0, y0, x1, y1) = selection.into();
-        let start = TextPosition::new(y0, self.grapheme_to_char_on_line(x0, y0));
-        let end = TextPosition::new(y1, self.grapheme_to_char_on_line(x1, y1));
+        let first = Point::new(x0, y0);
+        let second = Point::new(x1, y1);
+        let (start_point, end_point) = if first <= second {
+            (first, second)
+        } else {
+            (second, first)
+        };
+        let start = TextPosition::new(
+            start_point.y,
+            self.grapheme_to_char_on_line(start_point.x, start_point.y),
+        );
+        let end = TextPosition::new(
+            end_point.y,
+            self.grapheme_to_char_on_line(end_point.x, end_point.y),
+        );
         let start_char = self.current_buffer().position_to_char_idx(start);
         let end_char = self.current_buffer().position_to_char_idx(end);
         self.set_special_mark_at_char('<', start_char, AnchorAffinity::Left);
         self.set_special_mark_at_char('>', end_char, AnchorAffinity::Right);
+        self.last_visual_selections.insert(
+            self.current_buffer().id(),
+            LastVisualSelection {
+                mode: self.mode,
+                anchor_at_start: self.selection_start == Some(start_point),
+            },
+        );
+    }
+
+    fn restore_last_visual_selection(&mut self) -> bool {
+        let buffer_id = self.current_buffer().id();
+        let Some(selection) = self.last_visual_selections.get(&buffer_id).copied() else {
+            return false;
+        };
+        let Some(start_anchor) = self.special_marks.get(&(buffer_id, '<')).cloned() else {
+            return false;
+        };
+        let Some(end_anchor) = self.special_marks.get(&(buffer_id, '>')).cloned() else {
+            return false;
+        };
+
+        if self.is_visual() {
+            self.capture_last_visual_selection();
+        }
+
+        let start_position = self
+            .current_buffer()
+            .char_idx_to_position(start_anchor.char_index);
+        let end_position = self
+            .current_buffer()
+            .char_idx_to_position(end_anchor.char_index);
+        let start = self.point_for_text_position(start_position);
+        let end = self.point_for_text_position(end_position);
+        let (anchor, cursor) = if selection.anchor_at_start {
+            (start, end)
+        } else {
+            (end, start)
+        };
+
+        self.mode = selection.mode;
+        self.selection_start = Some(anchor);
+        self.set_selection(start, end);
+        self.move_to_text_position(if selection.anchor_at_start {
+            end_position
+        } else {
+            start_position
+        });
+        self.pending_visual_text_object_scope = None;
+        self.pending_operator = None;
+        self.pending_character_motion = None;
+        self.refresh_cursor_goal();
+        self.selection_start = Some(anchor);
+        self.update_selection_end(cursor);
+        true
     }
 
     fn transform_anchor_for_edit(
@@ -21097,6 +21227,7 @@ impl Editor {
         self.local_marks.clear();
         self.global_marks.clear();
         self.special_marks.clear();
+        self.last_visual_selections.clear();
         for mark in &snapshot.local_marks {
             if let Some(anchor) = self.restore_session_mark(mark, &buffer_map) {
                 self.local_marks
@@ -21115,6 +21246,26 @@ impl Editor {
                 self.special_marks
                     .insert((anchor.buffer_id, mark.name), anchor);
             }
+        }
+        for selection in &snapshot.last_visual_selections {
+            let Some(buffer_position) = buffer_map.get(&selection.buffer_index).copied() else {
+                continue;
+            };
+            let Some(buffer_id) = self.buffer_manager.get(buffer_position).map(Buffer::id) else {
+                continue;
+            };
+            let mode = match selection.mode {
+                SessionVisualMode::Character => Mode::Visual,
+                SessionVisualMode::Line => Mode::VisualLine,
+                SessionVisualMode::Block => Mode::VisualBlock,
+            };
+            self.last_visual_selections.insert(
+                buffer_id,
+                LastVisualSelection {
+                    mode,
+                    anchor_at_start: selection.anchor_at_start,
+                },
+            );
         }
         self.agent_manager.set_workspace(
             snapshot
@@ -21338,6 +21489,24 @@ impl Editor {
             .iter()
             .filter_map(|((_, name), anchor)| self.snapshot_mark(*name, anchor, &buffer_indices))
             .collect();
+        let last_visual_selections = self
+            .last_visual_selections
+            .iter()
+            .filter_map(|(buffer_id, selection)| {
+                let buffer_index = *buffer_indices.get(buffer_id)?;
+                let mode = match selection.mode {
+                    Mode::Visual => SessionVisualMode::Character,
+                    Mode::VisualLine => SessionVisualMode::Line,
+                    Mode::VisualBlock => SessionVisualMode::Block,
+                    Mode::Normal | Mode::Insert | Mode::Command | Mode::Search => return None,
+                };
+                Some(SessionVisualSelection {
+                    buffer_index,
+                    mode,
+                    anchor_at_start: selection.anchor_at_start,
+                })
+            })
+            .collect();
         let agent_workspace = self
             .agent_manager
             .workspace()
@@ -21371,6 +21540,7 @@ impl Editor {
                 local_marks,
                 global_marks,
                 special_marks,
+                last_visual_selections,
                 agent_transcript,
                 agent_workspace,
                 agent_session_resumable: false,

--- a/src/session.rs
+++ b/src/session.rs
@@ -103,6 +103,9 @@ pub struct SessionSnapshot {
     /// Editor-managed special marks.
     #[serde(default)]
     pub special_marks: Vec<SessionMark>,
+    /// Buffer-local metadata needed to reconstruct the last Visual selection.
+    #[serde(default)]
+    pub last_visual_selections: Vec<SessionVisualSelection>,
     /// Human-readable agent transcript retained across recovery.
     #[serde(default)]
     pub agent_transcript: Option<String>,
@@ -190,6 +193,29 @@ pub struct SessionMark {
     pub fallback: TextPosition,
     /// Insertion-side behavior at the exact anchor.
     pub affinity: SessionAnchorAffinity,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+/// Visual selection shape retained across session recovery.
+pub enum SessionVisualMode {
+    /// Characterwise selection.
+    Character,
+    /// Linewise selection.
+    Line,
+    /// Rectangular selection.
+    Block,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+/// Durable metadata paired with the `<` and `>` special marks.
+pub struct SessionVisualSelection {
+    /// Buffer index used when the selection was captured.
+    pub buffer_index: usize,
+    /// Shape of the previous Visual selection.
+    pub mode: SessionVisualMode,
+    /// Whether the selection anchor is the earlier `<` endpoint.
+    pub anchor_at_start: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2263,6 +2289,7 @@ mod tests {
             local_marks: Vec::new(),
             global_marks: Vec::new(),
             special_marks: Vec::new(),
+            last_visual_selections: Vec::new(),
             agent_transcript: None,
             agent_workspace: None,
             agent_session_resumable: false,

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -4663,6 +4663,43 @@ async fn visual_indent_supports_character_block_and_counted_selections() {
 }
 
 #[tokio::test]
+async fn visual_unindent_shifts_all_selected_lines_as_one_change() {
+    let buffer = Buffer::new(None, "    one\n\n      two\n       ".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    type_normal_keys(&mut harness, "Vjjj<").await;
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_buffer_contents("one\n\n  two\n   ");
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("    one\n\n      two\n       ");
+}
+
+#[tokio::test]
+async fn visual_unindent_supports_character_block_and_counted_selections() {
+    for mode in [Mode::Visual, Mode::VisualBlock] {
+        let buffer = Buffer::new(None, "    one\n    two".to_string());
+        let mut harness = EditorHarness::with_config(buffer, default_key_config());
+        harness
+            .execute_action(Action::EnterMode(mode))
+            .await
+            .unwrap();
+        harness.execute_action(Action::MoveDown).await.unwrap();
+        type_normal_keys(&mut harness, "<").await;
+
+        harness.assert_mode(Mode::Normal);
+        harness.assert_buffer_contents("one\ntwo");
+    }
+
+    let buffer = Buffer::new(None, "        one\n    two".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    type_normal_keys(&mut harness, "Vj2<").await;
+    harness.assert_buffer_contents("one\ntwo");
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("        one\n    two");
+}
+
+#[tokio::test]
 async fn gv_reselects_lines_after_visual_indent() {
     let buffer = Buffer::new(None, "one\ntwo\nthree".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());
@@ -4675,6 +4712,21 @@ async fn gv_reselects_lines_after_visual_indent() {
         Some((0, 1))
     );
     harness.assert_buffer_contents("    one\n    two\nthree");
+}
+
+#[tokio::test]
+async fn gv_reselects_lines_after_visual_unindent() {
+    let buffer = Buffer::new(None, "    one\n    two\nthree".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    type_normal_keys(&mut harness, "Vj<gv").await;
+
+    harness.assert_mode(Mode::VisualLine);
+    assert_eq!(
+        harness.selection().map(|(_, y0, _, y1)| (y0, y1)),
+        Some((0, 1))
+    );
+    harness.assert_buffer_contents("one\ntwo\nthree");
 }
 
 #[tokio::test]

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1046,6 +1046,73 @@ async fn last_change_and_last_visual_marks_are_available() {
 }
 
 #[tokio::test]
+async fn gv_restores_the_last_visual_area_mode_and_direction() {
+    let buffer = Buffer::new(None, "abcdef\nsecond".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    type_normal_keys(&mut harness, "llvh").await;
+    command_key(&mut harness, KeyCode::Esc).await;
+    type_normal_keys(&mut harness, "Ggv").await;
+
+    harness.assert_mode(Mode::Visual);
+    assert_eq!(harness.selection(), Some((1, 0, 2, 0)));
+    harness.assert_cursor_at(1, 0);
+
+    harness.execute_action(Action::MoveLeft).await.unwrap();
+    assert_eq!(harness.selection(), Some((0, 0, 2, 0)));
+}
+
+#[tokio::test]
+async fn gv_in_visual_mode_exchanges_current_and_previous_areas() {
+    let buffer = Buffer::new(None, "abcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    type_normal_keys(&mut harness, "vl").await;
+    command_key(&mut harness, KeyCode::Esc).await;
+    type_normal_keys(&mut harness, "llvl").await;
+    assert_eq!(harness.selection(), Some((3, 0, 4, 0)));
+
+    type_normal_keys(&mut harness, "gv").await;
+    assert_eq!(harness.selection(), Some((0, 0, 1, 0)));
+
+    type_normal_keys(&mut harness, "gv").await;
+    assert_eq!(harness.selection(), Some((3, 0, 4, 0)));
+}
+
+#[tokio::test]
+async fn gv_restores_line_and_block_modes_after_session_recovery() {
+    for mode in [Mode::VisualLine, Mode::VisualBlock] {
+        let contents = "one\ntwo\nthree";
+        let buffer = Buffer::new(None, contents.to_string());
+        let mut source = EditorHarness::with_config(buffer, default_key_config());
+        source
+            .execute_action(Action::EnterMode(mode))
+            .await
+            .unwrap();
+        source.execute_action(Action::MoveDown).await.unwrap();
+        source
+            .execute_action(Action::EnterMode(Mode::Normal))
+            .await
+            .unwrap();
+        let snapshot = source.editor.test_session_snapshot();
+
+        let buffer = Buffer::new(None, contents.to_string());
+        let mut restored = EditorHarness::with_config(buffer, default_key_config());
+        restored.editor.restore_session_snapshot(&snapshot).unwrap();
+        restored
+            .execute_action(Action::RestoreLastVisualSelection)
+            .await
+            .unwrap();
+
+        restored.assert_mode(mode);
+        assert_eq!(
+            restored.selection().map(|(_, y0, _, y1)| (y0, y1)),
+            Some((0, 1))
+        );
+    }
+}
+
+#[tokio::test]
 async fn global_mark_reopens_a_closed_file_buffer() {
     let marked_path = temp_file_path("global-mark");
     let other_path = temp_file_path("global-mark-other");
@@ -4556,6 +4623,58 @@ async fn test_undo_indent_and_unindent() {
     harness.assert_buffer_contents("line");
     harness.execute_action(Action::Undo).await.unwrap();
     harness.assert_buffer_contents("    line");
+}
+
+#[tokio::test]
+async fn visual_indent_shifts_all_selected_lines_as_one_change() {
+    let buffer = Buffer::new(None, "one\n\n  two\n   ".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    type_normal_keys(&mut harness, "Vjjj>").await;
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_buffer_contents("    one\n\n      two\n       ");
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("one\n\n  two\n   ");
+}
+
+#[tokio::test]
+async fn visual_indent_supports_character_block_and_counted_selections() {
+    for mode in [Mode::Visual, Mode::VisualBlock] {
+        let buffer = Buffer::new(None, "one\ntwo".to_string());
+        let mut harness = EditorHarness::with_config(buffer, default_key_config());
+        harness
+            .execute_action(Action::EnterMode(mode))
+            .await
+            .unwrap();
+        harness.execute_action(Action::MoveDown).await.unwrap();
+        type_normal_keys(&mut harness, ">").await;
+
+        harness.assert_mode(Mode::Normal);
+        harness.assert_buffer_contents("    one\n    two");
+    }
+
+    let buffer = Buffer::new(None, "one\ntwo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+    type_normal_keys(&mut harness, "Vj2>").await;
+    harness.assert_buffer_contents("        one\n        two");
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("one\ntwo");
+}
+
+#[tokio::test]
+async fn gv_reselects_lines_after_visual_indent() {
+    let buffer = Buffer::new(None, "one\ntwo\nthree".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    type_normal_keys(&mut harness, "Vj>gv").await;
+
+    harness.assert_mode(Mode::VisualLine);
+    assert_eq!(
+        harness.selection().map(|(_, y0, _, y1)| (y0, y1)),
+        Some((0, 1))
+    );
+    harness.assert_buffer_contents("    one\n    two\nthree");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

Red tracked the `<` and `>` marks for the most recent Visual selection, but it did not retain the selection shape or expose Vim's `gv` command. Visual selections also could not be shifted with `>` or `<`, leaving two common Vim editing workflows incomplete.

Closes #198.
Closes #199.

## What Changed

- Retain buffer-local Visual mode and direction alongside edit-aware selection marks, including across session recovery.
- Map `gv` in Normal and Visual modes to restore or exchange the previous character-, line-, or blockwise area.
- Add counted Visual indentation and unindentation across every covered line as one undoable transaction, while leaving empty lines unchanged and clamping left shifts at column zero.
- Document the supported behavior and add configuration, session-recovery, and editing coverage.

## How to Test

1. Open a buffer, make characterwise, linewise, and blockwise Visual selections, press Escape, and then press `gv`.
   - Expected: Red restores the same area, Visual mode, and selection direction.
2. While already in Visual mode, select a different area and press `gv` twice.
   - Expected: the current and previous areas exchange each time.
3. Select multiple lines with `V`, press `2>`, and then press `u` followed by `gv`.
   - Expected: each non-empty selected line shifts right by two `shiftwidth` units in one undo step, undo restores all lines together, and `gv` reselects the range.
4. Select lines with different indentation depths, including one indented by less than two `shiftwidth` units, and press `2<`.
   - Expected: each selected line shifts left by up to two `shiftwidth` units in one undo step, and shallower lines stop at column zero.
5. Recover a session after recording a linewise or blockwise selection, then press `gv`.
   - Expected: Red restores the recovered selection shape and bounds.

Targeted automated coverage is included in `tests/editing.rs` and `src/config.rs`. `cargo test --all-features` and `cargo clippy --all-targets --all-features -- -D warnings` pass.
