### PR TITLE
fix(agent): focus composer on first toggle

### DIFF
--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -387,8 +387,10 @@ fn toggle_conversation() {
         ensure_conversation_panel();
         if !was_created {
             render_conversation();
+            red::execute("FocusTextPanelComposer", "agent-conversation");
+        } else {
+            red::execute("RestorePanelFocus", "agent-conversation");
         }
-        red::execute("RestorePanelFocus", "agent-conversation");
     }
 }
 

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -7306,7 +7306,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bundled_agent_toggle_creates_hides_and_reopens_the_same_panel() {
+    async fn bundled_agent_toggle_focuses_new_composer_and_restores_reopened_panel() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
         let mut runtime = Runtime::new();
@@ -7326,7 +7326,7 @@ mod tests {
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
-            PluginRequest::RestorePanelFocus { id } if id == "agent-conversation"
+            PluginRequest::FocusTextPanelComposer { id } if id == "agent-conversation"
         ));
         assert!(ACTION_DISPATCHER.try_recv_request().is_none());
 


### PR DESCRIPTION
Opening the agent pane for the first time with Alt+A currently lands in scrollback, forcing an extra focus step before the user can type. The restored-focus behavior is useful after the pane has already been used, but a new pane has no meaningful prior region to restore.

Focus the conversation composer when AgentToggle creates the panel for the first time. Continue restoring the last-used composer or scrollback region when reopening an existing panel.

## How to Test

1. Start with the agent pane unopened and press Alt+A. Confirm the pane opens with the composer focused and ready for input.
2. Focus scrollback, close the pane with Alt+A, then reopen it. Confirm scrollback focus is restored rather than forced back to the composer.
3. Run `cargo test bundled_agent_toggle_focuses_new_composer_and_restores_reopened_panel` and confirm the first-open and reopen request paths pass.