### PR TITLE
fix(git): make dashboard staging reliable

### DIFF
--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -276,6 +276,8 @@ struct GitPluginState {
     detail_rendered_section: String,
     detail_timer: String,
     pending_detail_row: Option<GitWorkspaceRow>,
+    row_action_process: String,
+    row_action_error: String,
     safe_sync_pending: bool,
     confirm_mode: String,
     confirm_args: [String],
@@ -369,6 +371,8 @@ fn initial_state() -> GitPluginState {
         detail_rendered_section: "",
         detail_timer: "",
         pending_detail_row: None,
+        row_action_process: "",
+        row_action_error: "",
         safe_sync_pending: false,
         confirm_mode: "",
         confirm_args: [],
@@ -670,7 +674,7 @@ fn update_status(output: String) {
         refresh_selected_detail(false);
     }
     let safe_sync_pending = plugin_state().safe_sync_pending;
-    if changed {
+    if changed || forced {
         render_dashboard();
     }
     if changed || forced {
@@ -1472,7 +1476,11 @@ fn finish_detail() {
     red::state_patch(GitPluginState { detail_rendered_path: path });
     red::state_patch(GitPluginState { detail_rendered_section: section });
     if output == "" {
-        red::state_patch(GitPluginState { detail: [[PanelSegment { text: "No textual diff available.", style: muted_style() }]] });
+        let message = "No textual diff available.";
+        if section == "untracked" {
+            message = "Empty file.";
+        }
+        red::state_patch(GitPluginState { detail: [[PanelSegment { text: message, style: muted_style() }]] });
         red::state_patch(GitPluginState { detail_document: None });
     } else {
         red::state_patch(GitPluginState {
@@ -1533,7 +1541,56 @@ fn run_row_action(row: Option<GitWorkspaceRow>, action: String) {
         args: args,
         cwd: red::string(plugin_state().root, "."),
     });
-    red::on("process:" + process_id, action_finished);
+    red::state_patch(GitPluginState {
+        row_action_process: process_id,
+        row_action_error: "",
+    });
+    red::on("process:" + process_id, row_action_finished);
+}
+
+fn row_action_finished(event: ProcessEvent) {
+    match event {
+        ProcessEvent::Stderr { process_id, line, plugin_name } => {
+            if process_id == plugin_state().row_action_process && plugin_state().row_action_error == "" {
+                red::state_patch(GitPluginState {
+                    row_action_error: line,
+                });
+            }
+        }
+        ProcessEvent::Error { process_id, message, plugin_name } => {
+            if process_id == plugin_state().row_action_process {
+                red::state_patch(GitPluginState {
+                    row_action_process: "",
+                    row_action_error: "",
+                });
+                red::execute("Print", "Git action failed: " + message);
+            }
+        }
+        ProcessEvent::Exit { process_id, code, plugin_name } => {
+            if process_id != plugin_state().row_action_process {
+                return;
+            }
+            let error = red::trim(plugin_state().row_action_error);
+            red::state_patch(GitPluginState {
+                row_action_process: "",
+                row_action_error: "",
+            });
+            let exit_code = 0;
+            if let Some(value) = code {
+                exit_code = value;
+            }
+            if exit_code != 0 {
+                if error != "" {
+                    red::execute("Print", error);
+                } else {
+                    red::execute("Print", "Git action failed with exit code " + exit_code);
+                }
+                return;
+            }
+            force_refresh();
+        }
+        ProcessEvent::Stdout { process_id, line, plugin_name } => {}
+    }
 }
 
 fn run_detail_action(event: GitWorkspaceEvent) {

--- a/plugins/git_core/src/commands.hk
+++ b/plugins/git_core/src/commands.hk
@@ -50,6 +50,19 @@ pub fn sign_diff_args(staged: bool, paths: [String]) -> [String] {
 }
 
 pub fn detail_diff_args(section: String, path: String) -> [String] {
+    if section == "untracked" {
+        return [
+            "diff",
+            "--no-index",
+            "--no-ext-diff",
+            "--color=never",
+            "--src-prefix=a/",
+            "--dst-prefix=b/",
+            "--",
+            "/dev/null",
+            path,
+        ];
+    }
     let target = diff_target(section);
     let mut args = ["diff"];
     match target {
@@ -175,6 +188,7 @@ fn builds_bounded_noninteractive_status_and_diff_commands() {
     assert(sign_diff_args(true, ["src/a.rs", "src/b.rs"]).join(" ") == "-c core.quotePath=false diff --cached --no-ext-diff --no-prefix --unified=0 -- src/a.rs src/b.rs");
     assert(detail_diff_args("staged", "src/a.rs").join(" ") == "diff --cached --no-ext-diff --color=never -- src/a.rs");
     assert(detail_diff_args("unstaged", "src/a.rs").join(" ") == "diff --no-ext-diff --color=never -- src/a.rs");
+    assert(detail_diff_args("untracked", "src/new file.rs").join(" ") == "diff --no-index --no-ext-diff --color=never --src-prefix=a/ --dst-prefix=b/ -- /dev/null src/new file.rs");
 }
 
 #[test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -11300,6 +11300,184 @@ mod tests {
 
     #[cfg(not(windows))]
     #[tokio::test]
+    async fn git_dashboard_renders_untracked_file_contents() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(
+            root.join("new-file.txt"),
+            "first new line\nsecond new line\n",
+        )
+        .unwrap();
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let document = loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut document = None;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::UpdateWorkspace { model, .. } = request {
+                    if let Some(detail) = model.detail_document {
+                        document = Some(detail);
+                    }
+                }
+            }
+            if let Some(document) = document {
+                break document;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "untracked file contents did not render"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(document.path, "new-file.txt");
+        let added = document
+            .lines
+            .iter()
+            .filter(|line| line.kind == "added")
+            .map(|line| line.text.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(added, ["first new line", "second new line"]);
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_dashboard_reopens_with_unchanged_status() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(root.join("new-file.txt"), "new contents\n").unwrap();
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        let wait_for_row = async |runtime: &mut Runtime, failure: &str| {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                pump_process_events(runtime).await.unwrap();
+                let mut found = false;
+                while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                    if let PluginRequest::UpdateWorkspace { model, .. } = request {
+                        found = model
+                            .rows
+                            .iter()
+                            .any(|row| row.id == "untracked:new-file.txt");
+                    }
+                }
+                if found {
+                    break;
+                }
+                assert!(Instant::now() < deadline, "{failure}");
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        };
+        wait_for_row(&mut runtime, "first Git dashboard did not render").await;
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "q", "row": null }),
+            )
+            .await
+            .unwrap();
+        drain_requests();
+        runtime.execute_command("GitDashboard").await.unwrap();
+        wait_for_row(
+            &mut runtime,
+            "reopened Git dashboard did not restore unchanged status",
+        )
+        .await;
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_dashboard_reports_failed_row_actions() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(root.join("new-file.txt"), "new contents\n").unwrap();
+
+        let mut runtime = load_git_runtime(root).await;
+        fs::write(root.join(".git/index.lock"), "").unwrap();
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({
+                    "action": "s",
+                    "focus": "rows",
+                    "row": {
+                        "id": "untracked:new-file.txt",
+                        "selectable": true,
+                        "depth": 1,
+                        "path": "new-file.txt",
+                        "segments": [],
+                        "right_segments": [],
+                        "data": {
+                            "section": "untracked",
+                            "path": "new-file.txt",
+                            "entry": null
+                        }
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let error = loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut error = None;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::Action(Action::Print(message)) = request {
+                    error = Some(message);
+                }
+            }
+            if let Some(error) = error {
+                break error;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "failed Git row action did not report its error"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert!(
+            error.contains("index.lock"),
+            "unexpected Git error: {error}"
+        );
+        assert!(Command::new("git")
+            .args(["status", "--short"])
+            .current_dir(root)
+            .output()
+            .unwrap()
+            .stdout
+            .starts_with(b"?? new-file.txt"));
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
     async fn git_dashboard_renders_structured_diff_and_stages_one_selected_line() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -348,6 +348,10 @@ impl PluginWorkspace {
         theme: &Theme,
         registry: &Arc<LanguageRegistry>,
     ) {
+        if model.detail_document.is_none() {
+            self.focus = WorkspaceFocus::Rows;
+            self.detail_selection_anchor = None;
+        }
         let selected_id = self
             .model
             .rows
@@ -827,7 +831,9 @@ impl WorkspaceManager {
         let workspace = self.active.as_mut()?;
         let layout = WorkspaceLayout::calculate(workspace, height, width);
         if let Some(focus) = layout.focus_at(column, row) {
-            workspace.focus = focus;
+            if focus == WorkspaceFocus::Rows || workspace.model.detail_document.is_some() {
+                workspace.focus = focus;
+            }
         }
         let visible_rows = layout.visible_rows(workspace.focus);
         match action {
@@ -1699,6 +1705,72 @@ mod tests {
             .unwrap();
         assert_eq!(event.focus, WorkspaceFocus::Detail);
         assert_eq!(event.detail_index, 3);
+    }
+
+    #[test]
+    fn passive_detail_preview_keeps_actions_focused_on_the_selected_row() {
+        let theme = Theme::default();
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update(
+            "git",
+            WorkspaceModel {
+                rows: vec![row("untracked:new-file.txt", true)],
+                detail: vec![vec![PanelSegment {
+                    text: "No textual diff available.".to_string(),
+                    style: None,
+                    semantic: None,
+                }]],
+                ..WorkspaceModel::default()
+            },
+            &theme,
+        );
+
+        let layout = WorkspaceLayout::calculate(manager.active.as_ref().unwrap(), 24, 100);
+        let detail = layout
+            .detail
+            .expect("wide workspace should show the preview pane");
+        let click = manager
+            .handle_mouse("mouse_click", detail.x + 2, detail.y + 1, 24, 100)
+            .unwrap();
+        assert_eq!(click.focus, WorkspaceFocus::Rows);
+
+        let stage = manager.handle_action("s".to_string(), 24, 100).unwrap();
+        assert_eq!(stage.focus, WorkspaceFocus::Rows);
+        assert_eq!(stage.row.unwrap().id, "untracked:new-file.txt");
+        assert!(stage.detail_line.is_none());
+    }
+
+    #[test]
+    fn losing_the_detail_document_returns_focus_to_rows() {
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update("git", model_with_document(), &Theme::default());
+        assert_eq!(
+            manager
+                .handle_action("toggle".to_string(), 20, 100)
+                .unwrap()
+                .focus,
+            WorkspaceFocus::Detail
+        );
+
+        manager.update(
+            "git",
+            WorkspaceModel {
+                rows: vec![row("file", true)],
+                detail: vec![vec![]],
+                ..WorkspaceModel::default()
+            },
+            &Theme::default(),
+        );
+
+        assert_eq!(
+            manager
+                .handle_action("s".to_string(), 20, 100)
+                .unwrap()
+                .focus,
+            WorkspaceFocus::Rows
+        );
     }
 
     #[test]


### PR DESCRIPTION
Staging an untracked file could appear to do nothing when the passive preview held focus or when Git rejected the command, and reopening the dashboard with unchanged status could leave the new workspace blank. Untracked files also lacked a useful content preview.

This change keeps row actions focused on the selected file when no interactive diff exists, reports row-action failures, renders untracked text files as complete additions, and redraws cached status on forced refresh so reopening restores the dashboard.

## How to Test

1. Create a new text file, open the Git dashboard with `Space G`, and select it. Expect the detail pane to show every line as an addition; focus Changes and press `s`, then expect the file to move to Staged.
2. Close the dashboard with `q` and reopen it without changing the repository. Expect the same staged and untracked sections to appear instead of a blank Changes pane.
3. In a disposable repository, create `.git/index.lock` and try to stage an untracked file. Expect Red to show the Git lock error and leave the file untracked.

Focused automated coverage: `cargo test git_dashboard_`, `cargo test plugin::workspace::tests`, and `cargo run -p husk-cli -- test --locked plugins/git_core`.