### PR TITLE
feat(git): highlight commit message buffers

### DIFF
--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -30,12 +30,14 @@ packages that declare those minors continue to load. New packages should target
 
 ## Scratch-buffer workflows
 
-`OpenScratchBuffer(callback, name, text, commands?)` accepts optional `submit` and
-`cancel` plugin command names. In a managed scratch buffer, `:w` and `:wq` invoke the
-submit command without writing the display name to disk, while `:q` and `:q!` invoke
-the cancel command without quitting Red. `Save`, `Quit`, and configured key bindings
-follow the same routing. The options were added in host API `0.8.0`; calls using the
-original three required arguments remain compatible.
+`OpenScratchBuffer(callback, name, text, commands?)` accepts an optional `syntax`
+language name plus optional `submit` and `cancel` plugin command names. The syntax
+selection is local to the scratch buffer and falls back to automatic filename
+detection when omitted or unknown. In a managed scratch buffer, `:w` and `:wq` invoke
+the submit command without writing the display name to disk, while `:q` and `:q!`
+invoke the cancel command without quitting Red. `Save`, `Quit`, and configured key
+bindings follow the same routing. The options were added in host API `0.8.0`; calls
+using the original three required arguments remain compatible.
 
 ## External package primitives
 

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -147,6 +147,7 @@ struct GitScratchOpenedEvent {
 }
 
 struct ScratchBufferOptions {
+    syntax: String,
     submit: String,
     cancel: String,
 }
@@ -2833,7 +2834,11 @@ fn open_commit_editor(message: String) {
         commit_scratch_opened,
         "[Git Commit].gitcommit",
         text,
-        ScratchBufferOptions { submit: "GitSubmitMessage", cancel: "GitCancelMessage" }
+        ScratchBufferOptions {
+            syntax: "gitcommit",
+            submit: "GitSubmitMessage",
+            cancel: "GitCancelMessage"
+        }
     );
 }
 
@@ -2896,7 +2901,9 @@ fn commit_message(text: String) -> String {
 
 fn commit_editor_text(message: String, staged_diff: String) -> String {
     let text = message;
-    if text != "" && !red::ends_with(text, "\n") {
+    if text == "" {
+        text = "\n";
+    } else if !red::ends_with(text, "\n") {
         text = text + "\n";
     }
     text = text + "\n" + commit_context_marker() + "\n";

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1519,6 +1519,7 @@ pub enum PluginRequest {
         request_id: RequestId,
         name: String,
         text: String,
+        syntax: Option<String>,
         submit_command: Option<String>,
         cancel_command: Option<String>,
     },
@@ -8367,10 +8368,19 @@ impl Editor {
                     request_id,
                     name,
                     text,
+                    syntax,
                     submit_command,
                     cancel_command,
                 } => {
-                    let scratch_buffer = Buffer::new(Some(name), text);
+                    let syntax = syntax.and_then(|name| {
+                        self.highlighter
+                            .language_id_for_name(&name)
+                            .map(ToString::to_string)
+                    });
+                    let mut scratch_buffer = Buffer::new(Some(name), text);
+                    if let Some(language) = syntax {
+                        scratch_buffer.set_syntax_selection(SyntaxSelection::Language(language));
+                    }
                     self.scratch_buffers.insert(
                         scratch_buffer.id(),
                         ScratchBufferCommands {

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -31,9 +31,17 @@ use crate::{
 struct BundledLanguageDefinition {
     id: &'static str,
     extensions: &'static [&'static str],
-    language: fn() -> Language,
+    filenames: &'static [&'static str],
+    language: Option<fn() -> Language>,
     highlight_queries: &'static [&'static str],
     injection_query: Option<&'static str>,
+    specialized: Option<SpecializedHighlighter>,
+}
+
+#[derive(Clone, Copy)]
+enum SpecializedHighlighter {
+    Husk,
+    GitCommit,
 }
 
 #[derive(Clone)]
@@ -57,6 +65,7 @@ struct RuntimeLanguageDefinition {
     grammar: Option<GrammarSource>,
     highlight_queries: Vec<String>,
     injection_query: Option<String>,
+    specialized: Option<SpecializedHighlighter>,
 }
 
 /// Immutable language routing and grammar definitions shared by all render surfaces.
@@ -86,19 +95,24 @@ impl LanguageRegistry {
                     .iter()
                     .map(ToString::to_string)
                     .collect(),
-                filenames: Vec::new(),
+                filenames: definition
+                    .filenames
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
                 aliases: LANGUAGE_NAMES
                     .iter()
                     .filter(|(_, language)| *language == definition.id)
                     .map(|(alias, _)| (*alias).to_string())
                     .collect(),
-                grammar: Some(GrammarSource::Bundled(definition.language)),
+                grammar: definition.language.map(GrammarSource::Bundled),
                 highlight_queries: definition
                     .highlight_queries
                     .iter()
                     .map(ToString::to_string)
                     .collect(),
                 injection_query: definition.injection_query.map(ToString::to_string),
+                specialized: definition.specialized,
             });
         }
         registry
@@ -142,6 +156,7 @@ impl LanguageRegistry {
             grammar: None,
             highlight_queries: Vec::new(),
             injection_query: None,
+            specialized: None,
         });
         if !config.extensions.is_empty() {
             definition.extensions = config
@@ -167,6 +182,7 @@ impl LanguageRegistry {
                 definition
                     .injection_query
                     .clone_from(&bundled.injection_query);
+                definition.specialized = None;
             }
             if let Some(path) = grammar_path(grammar, config_dir)? {
                 let trust = GrammarTrustStore::new(config_dir);
@@ -180,6 +196,7 @@ impl LanguageRegistry {
                     &symbol,
                     grammar.trusted,
                 )?);
+                definition.specialized = None;
             }
             if !grammar.highlights.is_empty() {
                 definition.highlight_queries = grammar
@@ -327,6 +344,7 @@ pub struct Highlighter {
     registry: Arc<LanguageRegistry>,
     theme: Theme,
     husk_styles: HuskStyles,
+    git_commit_styles: GitCommitStyles,
 }
 
 struct HuskStyles {
@@ -351,6 +369,34 @@ impl HuskStyles {
             string: theme.get_style("string"),
             type_builtin: theme.get_style("type.builtin"),
             operator: theme.get_style("operator"),
+        }
+    }
+}
+
+struct GitCommitStyles {
+    comment: Option<Style>,
+    heading: Option<Style>,
+    reference: Option<Style>,
+    status: Option<Style>,
+    inserted: Option<Style>,
+    deleted: Option<Style>,
+    changed: Option<Style>,
+}
+
+impl GitCommitStyles {
+    fn new(theme: &Theme) -> Self {
+        Self {
+            comment: theme.get_style("comment"),
+            heading: theme
+                .get_style("markup.heading")
+                .or_else(|| theme.get_style("keyword")),
+            reference: theme.get_style("string"),
+            status: theme.get_style("keyword"),
+            inserted: theme.get_style("markup.inserted.diff"),
+            deleted: theme.get_style("markup.deleted.diff"),
+            changed: theme
+                .get_style("markup.changed.diff")
+                .or_else(|| theme.get_style("keyword")),
         }
     }
 }
@@ -385,6 +431,9 @@ const LANGUAGE_NAMES: &[(&str, &str)] = &[
     ("lua", "lua"),
     ("hk", "husk"),
     ("husk", "husk"),
+    ("gitcommit", "gitcommit"),
+    ("git-commit", "gitcommit"),
+    ("commit", "gitcommit"),
 ];
 
 const YAML_ADDITIONAL_HIGHLIGHTS_QUERY: &str = r#"
@@ -409,6 +458,7 @@ impl Highlighter {
             registry,
             theme: theme.clone(),
             husk_styles: HuskStyles::new(theme),
+            git_commit_styles: GitCommitStyles::new(theme),
         })
     }
 
@@ -518,13 +568,17 @@ impl Highlighter {
         code: &str,
         depth: usize,
     ) -> anyhow::Result<Vec<StyleInfo>> {
-        if language_id == "husk" {
-            return Ok(highlight_husk(code, &self.husk_styles));
-        }
-
         let Some(definition) = self.registry.languages.get(language_id).cloned() else {
             return Ok(Vec::new());
         };
+        if let Some(specialized) = definition.specialized {
+            return Ok(match specialized {
+                SpecializedHighlighter::Husk => highlight_husk(code, &self.husk_styles),
+                SpecializedHighlighter::GitCommit => {
+                    highlight_git_commit(code, &self.git_commit_styles)
+                }
+            });
+        }
         let Some(grammar) = &definition.grammar else {
             return Ok(Vec::new());
         };
@@ -704,105 +758,263 @@ fn language_definitions() -> Vec<BundledLanguageDefinition> {
         BundledLanguageDefinition {
             id: "rust",
             extensions: &["rs"],
-            language: || tree_sitter_rust::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_rust::LANGUAGE.into()),
             highlight_queries: &[tree_sitter_rust::HIGHLIGHTS_QUERY],
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "markdown",
             extensions: &["md", "markdown"],
-            language: || tree_sitter_md::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_md::LANGUAGE.into()),
             highlight_queries: &[MARKDOWN_HIGHLIGHT_QUERY],
             injection_query: Some(MARKDOWN_INJECTION_QUERY),
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "javascript",
             extensions: &["js", "mjs", "cjs"],
-            language: || tree_sitter_javascript::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_javascript::LANGUAGE.into()),
             highlight_queries: JAVASCRIPT_HIGHLIGHT_QUERIES,
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "jsx",
             extensions: &["jsx"],
-            language: || tree_sitter_javascript::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_javascript::LANGUAGE.into()),
             highlight_queries: JSX_HIGHLIGHT_QUERIES,
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "typescript",
             extensions: &["ts"],
-            language: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
             highlight_queries: TYPESCRIPT_HIGHLIGHT_QUERIES,
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "tsx",
             extensions: &["tsx"],
-            language: || tree_sitter_typescript::LANGUAGE_TSX.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_typescript::LANGUAGE_TSX.into()),
             highlight_queries: TSX_HIGHLIGHT_QUERIES,
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "json",
             extensions: &["json"],
-            language: || tree_sitter_json::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_json::LANGUAGE.into()),
             highlight_queries: &[tree_sitter_json::HIGHLIGHTS_QUERY],
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "toml",
             extensions: &["toml"],
-            language: || tree_sitter_toml_ng::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_toml_ng::LANGUAGE.into()),
             highlight_queries: &[tree_sitter_toml_ng::HIGHLIGHTS_QUERY],
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "yaml",
             extensions: &["yml", "yaml"],
-            language: || tree_sitter_yaml::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_yaml::LANGUAGE.into()),
             highlight_queries: &[
                 tree_sitter_yaml::HIGHLIGHTS_QUERY,
                 YAML_ADDITIONAL_HIGHLIGHTS_QUERY,
             ],
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "bash",
             extensions: &["sh", "bash", "zsh"],
-            language: || tree_sitter_bash::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_bash::LANGUAGE.into()),
             highlight_queries: &[tree_sitter_bash::HIGHLIGHT_QUERY],
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "fish",
             extensions: &["fish"],
-            language: tree_sitter_fish::language,
+            filenames: &[],
+            language: Some(tree_sitter_fish::language),
             highlight_queries: &[tree_sitter_fish::HIGHLIGHTS_QUERY],
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "powershell",
             extensions: &["ps1", "psm1", "psd1"],
-            language: || tree_sitter_powershell::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_powershell::LANGUAGE.into()),
             highlight_queries: &[tree_sitter_powershell::HIGHLIGHTS_QUERY],
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "lua",
             extensions: &["lua"],
-            language: || tree_sitter_lua::LANGUAGE.into(),
+            filenames: &[],
+            language: Some(|| tree_sitter_lua::LANGUAGE.into()),
             highlight_queries: &[tree_sitter_lua::HIGHLIGHTS_QUERY],
             injection_query: None,
+            specialized: None,
         },
         BundledLanguageDefinition {
             id: "husk",
             extensions: &["hk", "husk"],
-            language: || tree_sitter_rust::LANGUAGE.into(),
+            filenames: &[],
+            language: None,
             highlight_queries: &[],
             injection_query: None,
+            specialized: Some(SpecializedHighlighter::Husk),
+        },
+        BundledLanguageDefinition {
+            id: "gitcommit",
+            extensions: &["gitcommit"],
+            filenames: &["COMMIT_EDITMSG", "MERGE_MSG", "SQUASH_MSG", "TAG_EDITMSG"],
+            language: None,
+            highlight_queries: &[],
+            injection_query: None,
+            specialized: Some(SpecializedHighlighter::GitCommit),
         },
     ]
+}
+
+fn highlight_git_commit(code: &str, theme: &GitCommitStyles) -> Vec<StyleInfo> {
+    let mut styles = Vec::new();
+    let mut offset = 0;
+
+    for line_with_ending in code.split_inclusive('\n') {
+        let line = line_with_ending.trim_end_matches(['\r', '\n']);
+        if let Some(comment) = line.strip_prefix('#') {
+            let line_end = offset + line.len();
+            push_style(theme.comment.as_ref(), offset..line_end, &mut styles);
+
+            let leading = comment.len() - comment.trim_start().len();
+            let body = comment.trim_start();
+            let body_start = offset + 1 + leading;
+            highlight_git_commit_comment(body, body_start, theme, &mut styles);
+        }
+        offset += line_with_ending.len();
+    }
+
+    styles
+}
+
+fn highlight_git_commit_comment(
+    body: &str,
+    body_start: usize,
+    theme: &GitCommitStyles,
+    styles: &mut Vec<StyleInfo>,
+) {
+    if body.is_empty() {
+        return;
+    }
+
+    if body == "--- Red commit context (not part of the commit message) ---"
+        || body == "Commands:"
+        || body == "Staged diff:"
+        || body.ends_with("files:")
+        || body.ends_with("paths:")
+        || body.ends_with("committed:")
+        || body.ends_with("commit:")
+    {
+        push_style(
+            theme.heading.as_ref(),
+            body_start..body_start + body.len(),
+            styles,
+        );
+    }
+
+    if let Some(branch) = body.strip_prefix("On branch ") {
+        let prefix_len = "On branch ".len();
+        push_style(
+            theme.status.as_ref(),
+            body_start..body_start + prefix_len,
+            styles,
+        );
+        push_style(
+            theme.reference.as_ref(),
+            body_start + prefix_len..body_start + prefix_len + branch.len(),
+            styles,
+        );
+    }
+
+    for prefix in ["new file:", "modified:", "deleted:", "renamed:"] {
+        if let Some(path) = body.strip_prefix(prefix) {
+            let path_leading = path.len() - path.trim_start().len();
+            push_style(
+                theme.status.as_ref(),
+                body_start..body_start + prefix.len(),
+                styles,
+            );
+            push_style(
+                theme.reference.as_ref(),
+                body_start + prefix.len() + path_leading..body_start + body.len(),
+                styles,
+            );
+        }
+    }
+
+    if let Some((status, path)) = body.split_once("  ") {
+        if matches!(status, "A" | "M" | "D" | "R" | "C" | "U" | "??") && !path.is_empty() {
+            push_style(
+                theme.status.as_ref(),
+                body_start..body_start + status.len(),
+                styles,
+            );
+            push_style(
+                theme.reference.as_ref(),
+                body_start + status.len() + 2..body_start + body.len(),
+                styles,
+            );
+        }
+    }
+
+    for quoted in body.match_indices('\'') {
+        let quote_start = quoted.0;
+        let rest = &body[quote_start + 1..];
+        if let Some(relative_end) = rest.find('\'') {
+            push_style(
+                theme.reference.as_ref(),
+                body_start + quote_start..body_start + quote_start + relative_end + 2,
+                styles,
+            );
+            break;
+        }
+    }
+
+    let diff_style = if body.starts_with('+') && !body.starts_with("+++") {
+        theme.inserted.as_ref()
+    } else if body.starts_with('-') && !body.starts_with("---") {
+        theme.deleted.as_ref()
+    } else if body.starts_with("diff --git ")
+        || body.starts_with("index ")
+        || body.starts_with("@@")
+        || body.starts_with("--- ")
+        || body.starts_with("+++ ")
+    {
+        theme.changed.as_ref()
+    } else {
+        None
+    };
+    push_style(diff_style, body_start..body_start + body.len(), styles);
 }
 
 fn highlight_husk(code: &str, theme: &HuskStyles) -> Vec<StyleInfo> {
@@ -1207,8 +1419,77 @@ mod tests {
             highlighter.language_id_for_file(Some("plugin.hk")),
             Some("husk")
         );
+        assert_eq!(
+            highlighter.language_id_for_file(Some("[Git Commit].gitcommit")),
+            Some("gitcommit")
+        );
+        assert_eq!(
+            highlighter.language_id_for_file(Some(".git/COMMIT_EDITMSG")),
+            Some("gitcommit")
+        );
+        assert_eq!(
+            highlighter.language_id_for_file(Some(".git/MERGE_MSG")),
+            Some("gitcommit")
+        );
+        assert_eq!(
+            highlighter.language_id_for_name("commit"),
+            Some("gitcommit")
+        );
         assert_eq!(highlighter.language_id_for_file(Some("main.py")), None);
         assert_eq!(highlighter.language_id_for_file(Some("LICENSE")), None);
+    }
+
+    #[test]
+    fn git_commit_highlighter_styles_comments_and_semantic_details() {
+        let theme = theme_with_scopes(&[
+            "comment",
+            "markup.heading",
+            "string",
+            "keyword",
+            "markup.inserted.diff",
+            "markup.deleted.diff",
+            "markup.changed.diff",
+        ]);
+        let mut highlighter = Highlighter::new(&theme).unwrap();
+        let code = "feat(git): keep café readable\n\n\
+# --- Red commit context (not part of the commit message) ---\n\
+# On branch fëat/commit-style\n\
+# Changes to be committed:\n\
+#   A  src/café.rs\n\
+# diff --git a/src/café.rs b/src/café.rs\n\
+# +let ready = true;\n\
+# -let ready = false;\n";
+
+        let styles = highlighter.highlight("gitcommit", code).unwrap();
+
+        assert!(effective_style_at(&styles, 0).is_none());
+        for token in [
+            "# --- Red commit context (not part of the commit message) ---",
+            "fëat/commit-style",
+            "Changes to be committed:",
+            "A",
+            "src/café.rs",
+            "diff --git a/src/café.rs b/src/café.rs",
+            "+let ready = true;",
+            "-let ready = false;",
+        ] {
+            assert_token_highlighted(&styles, code, token);
+        }
+
+        for token in [
+            "fëat/commit-style",
+            "src/café.rs",
+            "+let ready = true;",
+            "-let ready = false;",
+        ] {
+            let start = code.find(token).unwrap();
+            assert!(
+                styles
+                    .iter()
+                    .any(|style| style.start == start && style.end == start + token.len()),
+                "`{token}` should have a precise semantic highlight span"
+            );
+        }
     }
 
     #[test]
@@ -1553,6 +1834,7 @@ mod tests {
             vec![
                 "bash",
                 "fish",
+                "gitcommit",
                 "husk",
                 "javascript",
                 "json",

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1935,6 +1935,10 @@ impl RedHost {
                     request_id,
                     name: args.first().map(value_to_string).unwrap_or_default(),
                     text: args.get(1).map(value_to_string).unwrap_or_default(),
+                    syntax: commands
+                        .get("syntax")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
                     submit_command: commands
                         .get("submit")
                         .and_then(serde_json::Value::as_str)
@@ -4066,7 +4070,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scratch_buffer_requests_preserve_submit_and_cancel_commands() {
+    async fn scratch_buffer_requests_preserve_syntax_submit_and_cancel_commands() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
         let mut runtime = Runtime::new();
@@ -4074,14 +4078,18 @@ mod tests {
             .load_plugin(
                 "scratch_owner",
                 r#"
-                    struct ScratchCommands { submit: String, cancel: String }
+                    struct ScratchCommands { syntax: String, submit: String, cancel: String }
                     pub fn activate() {
                         red::request(
                             "OpenScratchBuffer",
                             opened,
                             "[Prompt].txt",
                             "draft",
-                            ScratchCommands { submit: "SubmitPrompt", cancel: "CancelPrompt" }
+                            ScratchCommands {
+                                syntax: "gitcommit",
+                                submit: "SubmitPrompt",
+                                cancel: "CancelPrompt"
+                            }
                         );
                     }
                     fn opened(event: Json) {}
@@ -4094,12 +4102,14 @@ mod tests {
             PluginRequest::OpenScratchBuffer {
                 name,
                 text,
+                syntax,
                 submit_command,
                 cancel_command,
                 ..
             } => {
                 assert_eq!(name, "[Prompt].txt");
                 assert_eq!(text, "draft");
+                assert_eq!(syntax.as_deref(), Some("gitcommit"));
                 assert_eq!(submit_command.as_deref(), Some("SubmitPrompt"));
                 assert_eq!(cancel_command.as_deref(), Some("CancelPrompt"));
             }
@@ -11232,18 +11242,27 @@ mod tests {
                     request_id,
                     name,
                     text,
+                    syntax,
                     submit_command,
                     cancel_command,
                 } = request
                 {
-                    scratch = Some((request_id, name, text, submit_command, cancel_command));
+                    scratch = Some((
+                        request_id,
+                        name,
+                        text,
+                        syntax,
+                        submit_command,
+                        cancel_command,
+                    ));
                 }
             }
-            if let Some((request_id, name, text, submit, cancel)) = scratch {
+            if let Some((request_id, name, text, syntax, submit, cancel)) = scratch {
                 assert_eq!(name, "[Git Commit].gitcommit");
+                assert_eq!(syntax.as_deref(), Some("gitcommit"));
                 assert_eq!(submit.as_deref(), Some("GitSubmitMessage"));
                 assert_eq!(cancel.as_deref(), Some("GitCancelMessage"));
-                assert!(text.starts_with("feat(git): describe staged files\n"));
+                assert!(text.starts_with("feat(git): describe staged files\n\n#"));
                 assert!(text.contains("# --- Red commit context"));
                 assert!(text.contains("# Changes to be committed:"));
                 assert!(text.contains("staged.txt"));


### PR DESCRIPTION
## Why

The commit editor introduced by the generated-message flow contains useful branch, status, and staged-diff context, but it currently renders as visually flat text. That makes the ignored comment block harder to distinguish from the editable message and makes the embedded diff difficult to scan.

Depends on #213, which adds generated commit drafts and the managed Git commit scratch buffer this branch styles.

## What Changed

- Add a reusable specialized-highlighter dispatch path alongside Tree-sitter, and migrate Husk's existing lexer-backed highlighting onto it.
- Register `gitcommit` for `.gitcommit` buffers and Git's exact commit-message filenames, with aliases for explicit syntax selection.
- Highlight comment lines, context headings, branch and path references, status codes, diff metadata, additions, and deletions with existing semantic theme scopes while leaving the editable message unstyled.
- Let plugins request a buffer-local syntax for scratch buffers and have the Git plugin explicitly request `gitcommit`.
- Keep an empty separator row between the editable message and generated comments, including for blank manual drafts.

## How to Test

1. Stage a file, open the Git dashboard with `Space G`, press `c`, and choose `Write message`. Expect two writable blank rows before the comment block and `gitcommit` in the status line.
2. Confirm the context comments are muted, headings and diff metadata are accented, branch/path references are distinct, and added/deleted diff lines use insertion/deletion colors.
3. Choose the default `Generate message` action. Expect the generated draft to remain unstyled above one empty separator row, with the same highlighted context below it.
4. Run `cargo test --all-targets --all-features`.
5. Run `cargo clippy --all-targets --all-features -- -D warnings`.
