### PR TITLE
ci(release): generate contributor-friendly release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,15 @@ jobs:
         env:
           OUTPUT: changelog-preview.md
 
+      - name: Validate GitHub release notes configuration
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5
+        with:
+          version: v2.13.1
+          config: cliff.release.toml
+          args: --unreleased
+        env:
+          OUTPUT: release-notes-preview.md
+
       - name: Read release PR version
         if: startsWith(github.head_ref, 'release/v')
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,18 @@ jobs:
           normalize_markdown generated-release-changes.md > normalized-generated-release-changes.md
           diff -u normalized-release-changes.md normalized-generated-release-changes.md
 
+      - name: Generate GitHub release notes
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5
+        with:
+          version: v2.13.1
+          config: cliff.release.toml
+          args: --current --github-repo ${{ github.repository }}
+          github_token: ${{ github.token }}
+        env:
+          OUTPUT: RELEASE_NOTES.md
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+
       - name: Generate checksums
         run: |
           set -euo pipefail
@@ -264,9 +276,7 @@ jobs:
             changelog_url="https://github.com/${{ github.repository }}/compare/${previous_tag}...${tag}"
           fi
 
-          {
-          cat release-changes.md
-          cat <<EOF
+          cat <<EOF >> RELEASE_NOTES.md
 
           ## Installation
 
@@ -304,7 +314,6 @@ jobs:
 
           ${changelog_url}
           EOF
-          } > RELEASE_NOTES.md
 
           {
             echo "tag_name=$tag"

--- a/cliff.release.toml
+++ b/cliff.release.toml
@@ -1,0 +1,51 @@
+[changelog]
+header = """
+## What's Changed
+
+"""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+{% set message = commit.message | split(pat="\n") | first | trim -%}
+{% if commit.remote.pr_number -%}
+{% set pr_suffix = " (#" ~ commit.remote.pr_number ~ ")" -%}
+{% set message = message | replace(from=pr_suffix, to="") -%}
+{% endif -%}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ message | upper_first }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{% endif %}
+{%- endfor %}
+
+{% endfor %}
+{% if github.contributors %}
+## Contributors
+{% for contributor in github.contributors %}
+- @{{ contributor.username }}{% if contributor.pr_number %} in #{{ contributor.pr_number }}{% endif %}{% if contributor.is_first_time %} (first-time contributor){% endif %}
+{%- endfor %}
+{% endif %}
+"""
+trim = true
+postprocessors = [
+  { pattern = ' by @[^[:space:]]+\[bot\]', replace = "" },
+  { pattern = '\n- @[^[:space:]]+\[bot\][^\n]*', replace = "" },
+]
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"
+
+commit_parsers = [
+  { message = "^Merge", skip = true },
+  { message = "^chore\\(release\\): prepare v", skip = true },
+  { message = "^almanac", skip = true },
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^test", group = "Tests" },
+  { message = "^chore", group = "Maintenance" },
+  { message = ".*", group = "Other" },
+]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -16,6 +16,10 @@ The release workflow uses the repository `GITHUB_TOKEN` to create a draft
 release, so `.github/workflows/release.yml` grants `contents: write` only to
 the release publishing job.
 
+`cliff.toml` generates the versioned `CHANGELOG.md` embedded in Red as an
+offline fallback. `cliff.release.toml` separately generates the public GitHub
+release notes, including pull request authors and first-time contributors.
+
 ## Release Process
 
 1. Choose the next semantic version, for example `0.2.0`.
@@ -50,12 +54,15 @@ the release publishing job.
 
 6. Watch the **Release** workflow in GitHub Actions. It verifies the package version
    and matching `CHANGELOG.md` section, builds all four archives, and runs the
-   extracted editor's embedded-runtime self-check on each target platform.
+   extracted editor's embedded-runtime self-check on each target platform. It also
+   generates GitHub release notes with grouped changes, pull request authors, and a
+   contributors section that identifies first-time contributors.
 7. Review the draft GitHub release and confirm:
    - all four archives are attached
    - `SHA256SUMS.txt` is attached
    - `install.sh` and `install.ps1` are attached
    - install instructions match the release tag
+   - change authors, pull requests, and first-time contributors are credited correctly
 8. Publish the draft release.
 9. Watch the **Release** workflow run triggered by the `release.published`
    event. This updates `Formula/red.rb` in `codersauce/homebrew-tap`.

--- a/scripts/discord_release.py
+++ b/scripts/discord_release.py
@@ -48,6 +48,9 @@ def release_sections(body: str) -> dict[str, list[str]]:
     for line in body.splitlines():
         if line.startswith("## Installation"):
             break
+        if line.startswith("## "):
+            current = None
+            continue
         heading = SECTION.match(line)
         if heading:
             current = heading.group(1)

--- a/src/whats_new.rs
+++ b/src/whats_new.rs
@@ -332,7 +332,7 @@ mod tests {
         let fallback = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", Some("0.3.0"));
         let payload = serde_json::json!({
             "tag_name": "v0.5.0",
-            "body": "## [0.5.0](https://example.test)\n\n### Features\n\n- Published improvement\n\n## Installation\n\nDo not show this.",
+            "body": "## What's Changed\n\n### Features\n\n- Published improvement by @contributor in #42\n\n## Contributors\n\n- @contributor in #42 (first-time contributor)\n\n## Installation\n\nDo not show this.",
             "html_url": "https://github.com/codersauce/red/releases/tag/v0.5.0",
             "published_at": "2026-08-13T21:03:28Z",
             "draft": false
@@ -346,8 +346,12 @@ mod tests {
         .unwrap();
 
         assert!(notes.markdown.contains("Published improvement"));
+        assert!(notes.markdown.contains("first-time contributor"));
         assert!(notes.markdown.contains("Previous thing"));
         assert!(!notes.markdown.contains("Do not show this"));
+        let highlights = notes.highlights_markdown();
+        assert!(highlights.contains("Published improvement"));
+        assert!(!highlights.contains("first-time contributor"));
         assert_eq!(notes.published_at.as_deref(), Some("Aug 13, 2026"));
     }
 

--- a/tests/test_discord_release.py
+++ b/tests/test_discord_release.py
@@ -12,7 +12,7 @@ RELEASE = {
     "tagName": "v0.2.4",
     "url": "https://github.com/codersauce/red/releases/tag/v0.2.4",
     "publishedAt": "2026-07-25T14:05:22Z",
-    "body": """## [0.2.4]
+    "body": """## What's Changed
 
 ### Features
 
@@ -22,6 +22,10 @@ RELEASE = {
 ### Bug Fixes
 
 - **lsp:** Prevent pathological batching hangs ([7b126be](https://example.test/commit))
+
+## Contributors
+
+- @new-contributor in #138 (first-time contributor)
 
 ## Installation
 
@@ -45,6 +49,7 @@ class DiscordReleaseTest(unittest.TestCase):
             sections["Bug Fixes"],
             ["**lsp:** Prevent pathological batching hangs"],
         )
+        self.assertNotIn("new-contributor", str(sections))
         self.assertNotIn("This must not", str(sections))
 
     def test_builds_a_branded_safe_embed(self) -> None:


### PR DESCRIPTION
## Why

Red release pages currently expose the commit-oriented changelog but do not credit pull request authors or welcome first-time contributors. The tsql release format is easier to scan and makes contributor recognition part of every release.

## What changed

- add a dedicated `cliff.release.toml` for GitHub release pages with grouped changes, PR authors, PR numbers, contributors, and first-time contributor labels
- keep `cliff.toml` and the versioned `CHANGELOG.md` unchanged as the embedded offline fallback
- generate the enriched notes in the existing draft release workflow before appending installation and checksum guidance
- prevent contributor bullets from being counted as Discord highlights and cover the same format in the in-app release-note tests
- validate both git-cliff configurations in CI and document the distinction in `docs/RELEASING.md`

## How to Test

1. Run git-cliff 2.13.1 with `cliff.release.toml`, `--unreleased`, and `--github-repo codersauce/red`. Confirm the preview starts with `What’s Changed`, groups changes, adds `by @author in #PR`, and ends with a Contributors section.
2. Run `python3 -m unittest tests.test_discord_release`. Confirm a first-time contributor entry is not counted as a feature or fix.
3. Run `cargo test --locked whats_new --lib`. Confirm the in-app notes retain contributor credit while the Highlights view only contains product changes.

Also validated with the full 1,393-test library suite, actionlint 1.7.12, `cargo fmt --all -- --check`, and `cargo clippy --all-targets --all-features -- -D warnings`.