### PR TITLE
fix(session): restore clean workspaces on restart

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -433,6 +433,7 @@ inlay_hints = "inlay_hints.hk"
 lsp_symbols = "lsp_symbols.hk"
 neotree = "neotree.hk"
 project_search = "project_search.hk"
+session_restore = "session_restore.hk"
 theme_browser = "theme_browser.hk"
 
 # Breadcrumb text uses theme colors; file icons use nvim-web-devicons' light/dark palette.

--- a/docs/SESSION_RECOVERY.md
+++ b/docs/SESSION_RECOVERY.md
@@ -1,5 +1,12 @@
 # Session recovery
 
+On a normal clean exit, Red's bundled `session_restore` plugin remembers clean,
+file-backed buffers, cursor positions, viewports, and split layout. Starting
+`red` again without file arguments in the same working directory restores that
+lightweight workspace automatically. Supplying files starts the requested
+workspace instead, and dirty buffers remain the responsibility of core crash
+recovery.
+
 Red's core writes versioned recovery snapshots under `sessions/<owner>/latest.json` in the configuration directory. Each editor and named detached owner has an independent namespace, so concurrent sessions cannot replace one another's recovery point. Run `red --resume` after a crash to restore the newest valid snapshot containing dirty buffers, falling back to the newest clean snapshot when no work is pending; legacy `sessions/latest.json` snapshots remain supported. An interactive resume continues the selected owner namespace so a subsequent clean save replaces the stale dirty recovery point. Recovery is deliberately separate from opening files: restored dirty contents remain in memory and Red never writes them to disk until an explicit save. Do not resume an editor that is still running, since interactive owners do not currently hold an exclusive recovery lock.
 
 The snapshot includes open buffers and unsaved contents, the window tree and cursors, registers, marks, jumplist, per-buffer undo trees with attribution, and the agent conversation. New agent snapshots bind Red's clean structured transcript projection to a persisted Codex thread ID. On recovery, the Agent composer stays disabled until a replacement app-server rejoins that thread and reconciles the panel with the returned turns. Legacy flat transcripts and conversations whose Codex thread is missing are shown as archived context; their next prompt starts a visibly new session with bounded recovered context.

--- a/plugins/session_restore.hk
+++ b/plugins/session_restore.hk
@@ -13,6 +13,10 @@ struct StringConfigValue {
     value: String,
 }
 
+struct BooleanConfigValue {
+    value: bool,
+}
+
 struct SessionBuffer {
     path: String,
     dirty: bool,
@@ -54,6 +58,13 @@ fn state() -> SessionRestoreState {
 
 #[red::on("editor:ready")]
 fn ready(event: EmptyEvent) {
+    red::request("GetConfig", startup_resume_loaded, "startup_session_resumed");
+}
+
+fn startup_resume_loaded(event: BooleanConfigValue) {
+    if red::bool(event.value, false) {
+        return;
+    }
     red::request("GetConfig", startup_count_loaded, "startup_file_count");
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -297,6 +297,9 @@ pub struct Config {
     /// Number of files supplied at startup; runtime-only context.
     #[serde(default, skip_serializing)]
     pub startup_file_count: usize,
+    /// Whether startup already restored a core-owned recovery snapshot.
+    #[serde(default, skip_serializing)]
+    pub startup_session_resumed: bool,
 }
 
 /// Direct Codex CLI launch configuration.
@@ -3957,6 +3960,16 @@ max_buffer_words = 20
         let permissions = config.plugin_permissions.get("project_search").unwrap();
         assert_eq!(permissions.process, vec!["rg".to_string()]);
         assert_eq!(config.log_file.as_deref(), Some("red.log"));
+    }
+
+    #[test]
+    fn default_config_enables_session_restore() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.plugins.get("session_restore").map(String::as_str),
+            Some("session_restore.hk")
+        );
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8364,6 +8364,9 @@ impl Editor {
                             "diagnostics" => json!(self.config.diagnostics),
                             "show_diagnostics" => json!(self.config.show_diagnostics),
                             "startup_file_count" => json!(self.config.startup_file_count),
+                            "startup_session_resumed" => {
+                                json!(self.config.startup_session_resumed)
+                            }
                             "cwd" => json!(std::env::current_dir()
                                 .ok()
                                 .map(|path| path.to_string_lossy().to_string())),
@@ -8386,6 +8389,7 @@ impl Editor {
                             "diagnostics": self.config.diagnostics,
                             "show_diagnostics": self.config.show_diagnostics,
                             "startup_file_count": self.config.startup_file_count,
+                            "startup_session_resumed": self.config.startup_session_resumed,
                             "cwd": std::env::current_dir().ok().map(|path| path.to_string_lossy().to_string()),
                             "executable": std::env::current_exe().ok().map(|path| path.to_string_lossy().to_string()),
                             "keys": self.config.keys,

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,7 @@ async fn run() -> anyhow::Result<()> {
     let preferences = PreferencesStore::load(Config::path("preferences.json"));
 
     loaded.config.startup_file_count = args.files.len();
+    loaded.config.startup_session_resumed = args.resume;
 
     if let Some(root) = &args.root {
         // change to root directory

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -12196,6 +12196,17 @@ mod tests {
             .notify("editor:ready", serde_json::json!({}))
             .await
             .unwrap();
+        let resumed_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetConfig { request_id, key } => {
+                assert_eq!(key.as_deref(), Some("startup_session_resumed"));
+                request_id
+            }
+            _ => panic!("unexpected plugin request"),
+        };
+        runtime
+            .resolve_request(resumed_request_id, serde_json::json!({ "value": false }))
+            .await
+            .unwrap();
         let startup_request_id = match ACTION_DISPATCHER.recv_request() {
             PluginRequest::GetConfig { request_id, key } => {
                 assert_eq!(key.as_deref(), Some("startup_file_count"));
@@ -12263,6 +12274,39 @@ mod tests {
             }
             _ => panic!("unexpected plugin request"),
         }
+    }
+
+    #[tokio::test]
+    async fn session_restore_does_not_override_core_recovery() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin(
+                "session_restore",
+                include_str!("../../plugins/session_restore.hk"),
+            )
+            .await
+            .unwrap();
+
+        runtime
+            .notify("editor:ready", serde_json::json!({}))
+            .await
+            .unwrap();
+        let resumed_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetConfig { request_id, key } => {
+                assert_eq!(key.as_deref(), Some("startup_session_resumed"));
+                request_id
+            }
+            _ => panic!("unexpected plugin request"),
+        };
+        runtime
+            .resolve_request(resumed_request_id, serde_json::json!({ "value": true }))
+            .await
+            .unwrap();
+
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
     }
 
     #[tokio::test]

--- a/tests/self_check.rs
+++ b/tests/self_check.rs
@@ -46,6 +46,7 @@ fn self_check_reports_every_bundled_plugin_and_finishes_with_success() {
         "lsp_symbols",
         "neotree",
         "project_search",
+        "session_restore",
         "theme_browser",
     ];
     for plugin in expected {


### PR DESCRIPTION
## Why

Red still embeds the `session_restore` plugin, but it stopped enabling the plugin by default when core crash recovery was introduced. Normal clean restarts therefore opened an empty workspace even though the plugin lifecycle and saved state remained available.

## What changed

- enable the bundled `session_restore` plugin by default so a bare `red` launch in the same working directory restores clean file-backed buffers, cursor positions, viewports, and split layout
- expose whether startup already loaded a core recovery snapshot and skip the plugin restore after `red --resume`, keeping dirty-buffer crash recovery authoritative
- document the clean-restart versus crash-recovery boundary and cover the default configuration, plugin lifecycle, and production self-check

## How to Test

1. Run `red src/main.rs`, create a split, move the cursor, and exit with `:q`.
2. Run bare `red` from the same directory. The file, cursor, active pane, and split layout should be restored.
3. Create a newer core snapshot for a different file and run `red --resume`. The core-recovered file should remain active instead of being replaced by the older plugin workspace.

Targeted coverage: `session_restore_loads_matching_snapshot_and_saves_only_clean_buffers`, `session_restore_does_not_override_core_recovery`, and the bundled runtime self-check.

Also validated with `cargo test --all-targets --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check`.