### PR TITLE
feat(git): report operation progress

### DIFF
--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -292,6 +292,13 @@ struct GitPluginState {
     pending_detail_row: Option<GitWorkspaceRow>,
     row_action_process: String,
     row_action_error: String,
+    git_task_process: String,
+    git_task_error: String,
+    git_task_operation: String,
+    git_task_start_message: String,
+    git_task_success_message: String,
+    git_task_busy_timer: String,
+    git_task_done_timer: String,
     safe_sync_pending: bool,
     push_preview_process: String,
     push_preview_stage: String,
@@ -406,6 +413,13 @@ fn initial_state() -> GitPluginState {
         pending_detail_row: None,
         row_action_process: "",
         row_action_error: "",
+        git_task_process: "",
+        git_task_error: "",
+        git_task_operation: "",
+        git_task_start_message: "",
+        git_task_success_message: "",
+        git_task_busy_timer: "",
+        git_task_done_timer: "",
         safe_sync_pending: false,
         push_preview_process: "",
         push_preview_stage: "",
@@ -529,6 +543,18 @@ fn schedule_refresh(event: EmptyEvent) {
 
 #[red::on("timeout:callback")]
 fn timeout_callback(event: TimerEvent) {
+    if event.timer_id == plugin_state().git_task_busy_timer {
+        red::state_patch(GitPluginState { git_task_busy_timer: "" });
+        if red::string(plugin_state().git_task_process, "") != "" {
+            show_git_progress(red::string(plugin_state().git_task_start_message, "Working…"));
+        }
+        return;
+    }
+    if event.timer_id == plugin_state().git_task_done_timer {
+        red::state_patch(GitPluginState { git_task_done_timer: "" });
+        red::execute("RemoveOverlay", "git-operation-progress");
+        return;
+    }
     if event.timer_id == plugin_state().push_done_timer {
         red::state_patch(GitPluginState { push_done_timer: "" });
         red::execute("RemoveOverlay", "git-push-progress");
@@ -1783,13 +1809,7 @@ fn action_finished(event: ProcessEvent) {
 }
 
 fn run_simple_git(args: [String]) {
-    record_command(args);
-    let process_id = red::execute("SpawnProcess", Process {
-        command: "git",
-        args: args,
-        cwd: red::string(plugin_state().root, "."),
-    });
-    red::on("process:" + process_id, action_finished);
+    run_git_task(args, Json { LC_ALL: "C" });
 }
 
 fn record_command(args: [String]) {
@@ -1799,16 +1819,205 @@ fn record_command(args: [String]) {
 }
 
 fn run_operation_git(operation: String, action: String) {
-    let process = Process {
-        command: "git",
-        args: [operation, "--" + action],
-        cwd: red::string(plugin_state().root, "."),
-    };
+    let args = [operation, "--" + action];
+    let env = Json { LC_ALL: "C" };
     if operation == "rebase" {
-        process.env = Json { GIT_EDITOR: "true" };
+        env = Json { GIT_EDITOR: "true", LC_ALL: "C" };
     }
-    let process_id = red::execute("SpawnProcess", process);
-    red::on("process:" + process_id, action_finished);
+    run_git_task(args, env);
+}
+
+fn run_git_task(args: [String], env: Json) {
+    if red::string(plugin_state().git_task_process, "") != "" ||
+        red::string(plugin_state().commit_process, "") != "" {
+        red::execute("Print", "A Git operation is already in progress");
+        return;
+    }
+    cancel_git_progress_timers();
+    record_command(args);
+    let process_id = red::execute("SpawnProcess", Process {
+        command: "git",
+        args: args,
+        cwd: red::string(plugin_state().root, "."),
+        env: env,
+    });
+    red::state_patch(GitPluginState {
+        git_task_process: process_id,
+        git_task_error: "",
+        git_task_operation: if red::len(args) > 0 { args[0] } else { "git" },
+        git_task_start_message: git_task_start_message(args),
+        git_task_success_message: git_task_success_message(args),
+        git_task_busy_timer: red::execute("SetTimeout", 180),
+    });
+    red::on("process:" + process_id, git_task_event);
+}
+
+fn git_task_event(event: ProcessEvent) {
+    match event {
+        ProcessEvent::Stderr { process_id, line, plugin_name } => {
+            if process_id == plugin_state().git_task_process {
+                red::state_patch(GitPluginState {
+                    git_task_error: plugin_state().git_task_error + line + "\n",
+                });
+            }
+        }
+        ProcessEvent::Error { process_id, message, plugin_name } => {
+            finish_git_task(process_id, false, message);
+        }
+        ProcessEvent::Exit { process_id, code, plugin_name } => {
+            if process_id != plugin_state().git_task_process { return; }
+            let exit_code = 1;
+            if let Some(value) = code { exit_code = value; }
+            finish_git_task(
+                process_id,
+                exit_code == 0,
+                "git exited with code " + exit_code
+            );
+        }
+        ProcessEvent::Stdout { process_id, line, plugin_name } => {
+            if process_id == plugin_state().git_task_process {
+                red::state_patch(GitPluginState {
+                    git_task_error: plugin_state().git_task_error + line + "\n",
+                });
+            }
+        }
+    }
+}
+
+fn finish_git_task(process_id: String, succeeded: bool, fallback: String) {
+    if process_id != plugin_state().git_task_process { return; }
+    let error = red::trim(red::string(plugin_state().git_task_error, ""));
+    let operation = red::string(plugin_state().git_task_operation, "git");
+    let success_message = red::string(plugin_state().git_task_success_message, "✓ Git operation completed");
+    red::state_patch(GitPluginState {
+        git_task_process: "",
+        git_task_error: "",
+        git_task_operation: "",
+        git_task_start_message: "",
+        git_task_success_message: "",
+    });
+    if succeeded {
+        complete_git_progress(success_message, true);
+    } else {
+        if error == "" { error = fallback; }
+        red::state_patch(GitPluginState { safe_sync_pending: false });
+        let compact_error = bounded_git_error(error);
+        let failure_message = "Git operation failed: " + compact_error;
+        if red::len(red::split(error, "CONFLICT")) > 1 {
+            if operation == "merge" { failure_message = "Merge stopped: resolve conflicts"; }
+            if operation == "rebase" { failure_message = "Rebase stopped: resolve conflicts"; }
+            if operation == "cherry-pick" { failure_message = "Cherry-pick stopped: resolve conflicts"; }
+            if operation == "revert" { failure_message = "Revert stopped: resolve conflicts"; }
+        }
+        complete_git_progress(failure_message, false);
+        if compact_error != error {
+            red::execute("Print", "Git operation details: " + error);
+        }
+    }
+    force_refresh();
+}
+
+fn cancel_git_progress_timers() {
+    let busy_timer = red::string(plugin_state().git_task_busy_timer, "");
+    if busy_timer != "" { red::execute("CancelTimeout", busy_timer); }
+    let done_timer = red::string(plugin_state().git_task_done_timer, "");
+    if done_timer != "" { red::execute("CancelTimeout", done_timer); }
+    red::state_patch(GitPluginState {
+        git_task_busy_timer: "",
+        git_task_done_timer: "",
+    });
+}
+
+fn create_git_progress_overlay() {
+    red::execute("CreateOverlay", "git-operation-progress", OverlayConfig {
+        align: "bottom",
+        x_padding: 1,
+        y_padding: 0,
+        relative: "editor",
+    });
+}
+
+fn show_git_progress(message: String) {
+    create_git_progress_overlay();
+    red::execute("UpdateOverlay", "git-operation-progress", [(message, heading_style())]);
+    red::execute("UpdateOverlayBusy", "git-operation-progress", true);
+}
+
+fn begin_git_progress(message: String) {
+    cancel_git_progress_timers();
+    show_git_progress(message);
+}
+
+fn update_git_progress(message: String) {
+    create_git_progress_overlay();
+    red::execute("UpdateOverlay", "git-operation-progress", [(message, heading_style())]);
+    red::execute("UpdateOverlayBusy", "git-operation-progress", true);
+}
+
+fn complete_git_progress(message: String, succeeded: bool) {
+    cancel_git_progress_timers();
+    create_git_progress_overlay();
+    red::execute("UpdateOverlayBusy", "git-operation-progress", false);
+    if succeeded {
+        red::execute("UpdateOverlay", "git-operation-progress", [(message, success_style())]);
+        red::state_patch(GitPluginState { git_task_done_timer: red::execute("SetTimeout", 2500) });
+    } else {
+        red::execute("UpdateOverlay", "git-operation-progress", [(message, warning_style())]);
+        red::state_patch(GitPluginState { git_task_done_timer: red::execute("SetTimeout", 5000) });
+    }
+    red::execute("Print", message);
+}
+
+fn dismiss_git_progress() {
+    cancel_git_progress_timers();
+    red::execute("RemoveOverlay", "git-operation-progress");
+}
+
+fn git_task_target(args: [String]) -> String {
+    if red::len(args) <= 1 { return ""; }
+    return args[red::len(args) - 1];
+}
+
+fn git_task_start_message(args: [String]) -> String {
+    if red::len(args) == 0 { return "Running Git operation…"; }
+    let operation = args[0];
+    let target = git_task_target(args);
+    if operation == "fetch" { return "Fetching remote changes…"; }
+    if operation == "pull" { return "Pulling remote changes…"; }
+    if operation == "push" { return "Pushing tags…"; }
+    if operation == "switch" { return "Switching to " + target + "…"; }
+    if operation == "merge" { return "Merging " + target + "…"; }
+    if operation == "rebase" { return "Rebasing " + target + "…"; }
+    if operation == "cherry-pick" { return "Cherry-picking " + target + "…"; }
+    if operation == "revert" { return "Reverting " + target + "…"; }
+    if operation == "reset" { return "Resetting to " + target + "…"; }
+    if operation == "stash" { return "Updating stash…"; }
+    if operation == "worktree" { return "Updating worktrees…"; }
+    if operation == "branch" { return "Updating branches…"; }
+    if operation == "tag" { return "Updating tags…"; }
+    if operation == "remote" { return "Updating remotes…"; }
+    return "Running git " + operation + "…";
+}
+
+fn git_task_success_message(args: [String]) -> String {
+    if red::len(args) == 0 { return "✓ Git operation completed"; }
+    let operation = args[0];
+    let target = git_task_target(args);
+    if operation == "fetch" { return "✓ Fetch completed"; }
+    if operation == "pull" { return "✓ Pull completed"; }
+    if operation == "push" { return "✓ Tags pushed"; }
+    if operation == "switch" { return "✓ Switched to " + target; }
+    if operation == "merge" { return "✓ Merged " + target; }
+    if operation == "rebase" { return "✓ Rebase completed"; }
+    if operation == "cherry-pick" { return "✓ Cherry-picked " + target; }
+    if operation == "revert" { return "✓ Reverted " + target; }
+    if operation == "reset" { return "✓ Reset completed"; }
+    if operation == "stash" { return "✓ Stash updated"; }
+    if operation == "worktree" { return "✓ Worktrees updated"; }
+    if operation == "branch" { return "✓ Branches updated"; }
+    if operation == "tag" { return "✓ Tags updated"; }
+    if operation == "remote" { return "✓ Remotes updated"; }
+    return "✓ Git " + operation + " completed";
 }
 
 fn safe_sync() {
@@ -1819,20 +2028,25 @@ fn safe_sync() {
 fn safe_sync_after_refresh() {
     let state = plugin_state().state;
     if red::len(state.staged) + red::len(state.unstaged) + red::len(state.untracked) + red::len(state.conflicted) > 0 {
+        complete_git_progress("Safe sync stopped: working tree is dirty", false);
         render_error("Safe sync stopped: working tree is dirty");
         return;
     }
     if red::string(state.upstream, "") == "" {
+        dismiss_git_progress();
         push_menu();
         return;
     }
     if red::int(state.ahead, 0) > 0 && red::int(state.behind, 0) > 0 {
+        complete_git_progress("Safe sync stopped: branch histories diverged", false);
         render_error("Safe sync stopped: branch histories diverged");
     } else if red::int(state.behind, 0) > 0 {
         run_simple_git(["pull", "--ff-only"]);
     } else if red::int(state.ahead, 0) > 0 {
-        run_simple_git(["push"]);
+        dismiss_git_progress();
+        push_menu();
     } else {
+        complete_git_progress("✓ Already up to date", true);
         render_dashboard();
     }
 }
@@ -1957,7 +2171,7 @@ fn fail_push_preview(process_id: String, fallback: String) {
     red::state_patch(GitPluginState { push_preview_process: "" });
     let error = red::trim(red::string(plugin_state().push_preview_error, ""));
     if error == "" { error = fallback; }
-    red::execute("Print", "Could not prepare push: " + bounded_push_error(error));
+    red::execute("Print", "Could not prepare push: " + bounded_git_error(error));
 }
 
 fn show_push_confirmation(output: String) {
@@ -2011,6 +2225,7 @@ fn show_push_confirmation(output: String) {
 
 fn push_confirmed(item: PickerItem) {
     if item.id != "accept" { return; }
+    dismiss_git_progress();
     let done_timer = red::string(plugin_state().push_done_timer, "");
     if done_timer != "" {
         red::execute("CancelTimeout", done_timer);
@@ -2076,14 +2291,14 @@ fn finish_push(process_id: String, succeeded: bool, fallback: String) {
     } else {
         let error = red::trim(red::string(plugin_state().push_error, ""));
         if error == "" { error = fallback; }
-        let message = "Push failed: " + bounded_push_error(error);
+        let message = "Push failed: " + bounded_git_error(error);
         red::execute("UpdateOverlay", "git-push-progress", [(message, warning_style())]);
         red::execute("Print", message);
         red::state_patch(GitPluginState { push_done_timer: red::execute("SetTimeout", 5000) });
     }
 }
 
-fn bounded_push_error(error: String) -> String {
+fn bounded_git_error(error: String) -> String {
     let compact = red::trim(red::split(error, "\n")[0]);
     if red::len(compact) <= 240 { return compact; }
     return red::slice(compact, 0, 237) + "…";
@@ -2548,17 +2763,13 @@ fn show_rebase_choice() {
 
 fn run_rebase_todo() {
     let todo = red::join(plugin_state().rebase_todo, "\n") + "\n";
-    let process_id = red::execute("SpawnProcess", Process {
-        command: "git",
-        args: ["rebase", "-i", red::string(plugin_state().rebase_base, "HEAD~5")],
-        cwd: red::string(plugin_state().root, "."),
-        env: Json {
-            GIT_SEQUENCE_EDITOR: red::string(plugin_state().executable, "red") + " --process-editor-replace",
-            GIT_EDITOR: "true",
-            RED_PROCESS_EDITOR_CONTENT: todo,
-        },
+    let args = ["rebase", "-i", red::string(plugin_state().rebase_base, "HEAD~5")];
+    run_git_task(args, Json {
+        GIT_SEQUENCE_EDITOR: red::string(plugin_state().executable, "red") + " --process-editor-replace",
+        GIT_EDITOR: "true",
+        RED_PROCESS_EDITOR_CONTENT: todo,
+        LC_ALL: "C",
     });
-    red::on("process:" + process_id, action_finished);
 }
 
 fn menu_selected(item: PickerItem) {
@@ -2921,6 +3132,9 @@ fn commit_choice(item: PickerItem) {
     if generate { mode = "create"; }
     red::state_patch(GitPluginState { commit_mode: mode });
     red::state_patch(GitPluginState { commit_generate_message: generate });
+    if generate {
+        begin_git_progress("Preparing commit message context…");
+    }
     red::request("GetEditorState", commit_snapshot_loaded);
 }
 
@@ -2984,6 +3198,9 @@ fn fail_commit_context(process_id: String, fallback: String) {
     red::state_patch(GitPluginState { commit_context_process: "" });
     let error = red::trim(red::string(plugin_state().commit_context_error, ""));
     if error == "" { error = fallback; }
+    if red::bool(plugin_state().commit_generate_message, false) {
+        complete_git_progress("Commit message preparation failed: " + bounded_git_error(error), false);
+    }
     red::execute("Print", "Could not read staged changes: " + error);
     open_commit_editor(red::string(plugin_state().commit_draft_text, ""));
 }
@@ -2995,6 +3212,7 @@ fn finish_commit_context(process_id: String) {
     red::state_patch(GitPluginState { commit_context_process: "" });
     if red::bool(plugin_state().commit_generate_message, false) {
         if red::trim(red::string(plugin_state().commit_context_output, "")) == "" {
+            complete_git_progress("No staged changes to describe", false);
             red::execute("Print", "No staged changes to describe; opening a blank commit message");
             open_commit_editor("");
             return;
@@ -3004,6 +3222,7 @@ fn finish_commit_context(process_id: String) {
             request_generated_commit_message();
             return;
         }
+        update_git_progress("Generating commit message with Codex…");
         red::execute("Print", "Generating commit message with Codex…");
         let process_id = red::execute("SpawnProcess", Process {
             command: "git",
@@ -3086,7 +3305,10 @@ fn commit_message_generated(result: Json) {
     let message = red::trim(red::string(result.message, ""));
     let error = red::trim(red::string(result.error, ""));
     if error != "" {
+        complete_git_progress("Commit message generation failed: " + bounded_git_error(error), false);
         red::execute("Print", "Codex could not generate a commit message: " + error);
+    } else {
+        complete_git_progress("✓ Commit message generated", true);
     }
     open_commit_editor(message);
 }
@@ -3229,6 +3451,17 @@ fn commented_diff(diff: String) -> String {
 }
 
 fn run_commit(mode: String, message: String) {
+    if red::string(plugin_state().git_task_process, "") != "" ||
+        red::string(plugin_state().commit_process, "") != "" {
+        red::execute("Print", "A Git operation is already in progress");
+        return;
+    }
+    red::state_patch(GitPluginState { commit_mode: mode });
+    if mode == "amend" || mode == "--amend" {
+        begin_git_progress("Amending commit…");
+    } else {
+        begin_git_progress("Creating commit…");
+    }
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
         args: red::git_core("commit_args", mode),
@@ -3263,9 +3496,9 @@ fn commit_finished(event: ProcessEvent) {
                 red::state_patch(GitPluginState { commit_error: "" });
                 red::state_patch(GitPluginState { commit_retry_text: "" });
                 if mode == "amend" || mode == "--amend" {
-                    red::execute("Print", "Commit amended successfully");
+                    complete_git_progress("✓ Commit amended successfully", true);
                 } else {
-                    red::execute("Print", "Commit created successfully");
+                    complete_git_progress("✓ Commit created successfully", true);
                 }
                 force_refresh();
             } else {
@@ -3282,7 +3515,11 @@ fn fail_commit(process_id: String, fallback: String) {
     if error == "" { error = fallback; }
     red::state_patch(GitPluginState { commit_process: "" });
     red::state_patch(GitPluginState { commit_error: "" });
-    red::execute("Print", "Git commit failed: " + error);
+    let compact_error = bounded_git_error(error);
+    complete_git_progress("Git commit failed: " + compact_error, false);
+    if compact_error != error {
+        red::execute("Print", "Git commit details: " + error);
+    }
     red::request("GetEditorState", commit_snapshot_loaded);
 }
 
@@ -3547,6 +3784,22 @@ fn deactivate() {
     if push_done_timer != "" {
         red::execute("CancelTimeout", push_done_timer);
     }
+    let git_task_busy_timer = red::string(plugin_state().git_task_busy_timer, "");
+    if git_task_busy_timer != "" {
+        red::execute("CancelTimeout", git_task_busy_timer);
+    }
+    let git_task_done_timer = red::string(plugin_state().git_task_done_timer, "");
+    if git_task_done_timer != "" {
+        red::execute("CancelTimeout", git_task_done_timer);
+    }
+    for process_id in [
+        red::string(plugin_state().git_task_process, ""),
+        red::string(plugin_state().commit_process, ""),
+        red::string(plugin_state().commit_context_process, ""),
+        red::string(plugin_state().commit_history_process, ""),
+    ] {
+        if process_id != "" { red::execute("KillProcess", process_id); }
+    }
     let push_preview_process = red::string(plugin_state().push_preview_process, "");
     if push_preview_process != "" {
         red::execute("KillProcess", push_preview_process);
@@ -3558,10 +3811,13 @@ fn deactivate() {
     red::state_patch(GitPluginState { refresh_timer: "" });
     red::state_patch(GitPluginState { poll_timer: "" });
     red::state_patch(GitPluginState { push_done_timer: "" });
+    red::state_patch(GitPluginState { git_task_busy_timer: "" });
+    red::state_patch(GitPluginState { git_task_done_timer: "" });
     if red::string(plugin_state().watch_path, "") != "" {
         red::execute("UnwatchDirectory", 1502);
     }
     red::execute("ClearGutterSigns", "git-signs");
     red::execute("CloseWorkspace", "git-dashboard");
     red::execute("RemoveOverlay", "git-push-progress");
+    red::execute("RemoveOverlay", "git-operation-progress");
 }

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -11156,11 +11156,11 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
-        let open_push_confirmation = async |runtime: &mut Runtime| {
+        let open_push_confirmation = async |runtime: &mut Runtime, action: &str| {
             runtime
                 .notify(
                     "workspace:event:git-dashboard",
-                    serde_json::json!({ "action": "p", "row": null }),
+                    serde_json::json!({ "action": action, "row": null }),
                 )
                 .await
                 .unwrap();
@@ -11195,7 +11195,7 @@ mod tests {
             }
         };
 
-        let cancel_handle = open_push_confirmation(&mut runtime).await;
+        let cancel_handle = open_push_confirmation(&mut runtime, "y").await;
         runtime
             .notify_picker(cancel_handle, PickerCallback::Cancelled)
             .unwrap();
@@ -11208,7 +11208,7 @@ mod tests {
             .stdout;
         assert_eq!(remote_after_cancel, remote_before);
 
-        let accept_handle = open_push_confirmation(&mut runtime).await;
+        let accept_handle = open_push_confirmation(&mut runtime, "p").await;
         let accept = serde_json::from_value(serde_json::json!({
             "id": "accept",
             "label": "Push",
@@ -11451,6 +11451,12 @@ mod tests {
             .status()
             .unwrap()
             .success());
+        assert!(Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
         fs::write(root.join("staged.txt"), "hello\n").unwrap();
         assert!(Command::new("git")
             .args(["add", "staged.txt"])
@@ -11512,10 +11518,22 @@ mod tests {
         runtime
             .notify_picker(picker, PickerCallback::Selected(generate))
             .unwrap();
-        let request_id = match ACTION_DISPATCHER.recv_request() {
-            PluginRequest::GetEditorState { request_id } => request_id,
-            _ => panic!("expected an editor snapshot request"),
+        let mut generation_progress = false;
+        let request_id = loop {
+            match ACTION_DISPATCHER.recv_request() {
+                PluginRequest::UpdateOverlayBusy { id, busy }
+                    if id == "git-operation-progress" && busy =>
+                {
+                    generation_progress = true;
+                }
+                PluginRequest::GetEditorState { request_id } => break request_id,
+                _ => {}
+            }
         };
+        assert!(
+            generation_progress,
+            "commit generation should show progress"
+        );
         let editor_snapshot = serde_json::json!({
             "version": 1,
             "cwd": root.display().to_string(),
@@ -11665,6 +11683,9 @@ mod tests {
 
         let deadline = Instant::now() + Duration::from_secs(5);
         let mut failure_reported = false;
+        let mut failure_overlay = false;
+        let mut commit_started = false;
+        let mut commit_busy = false;
         let mut retry_requested = false;
         loop {
             pump_process_events(&mut runtime).await.unwrap();
@@ -11687,6 +11708,22 @@ mod tests {
                     {
                         failure_reported = true;
                     }
+                    PluginRequest::CreateOverlay { id, .. } if id == "git-operation-progress" => {
+                        commit_started = true;
+                    }
+                    PluginRequest::UpdateOverlayBusy { id, busy }
+                        if id == "git-operation-progress" && busy =>
+                    {
+                        commit_busy = true;
+                    }
+                    PluginRequest::UpdateOverlay { id, lines }
+                        if id == "git-operation-progress"
+                            && lines.iter().any(|(line, _)| {
+                                line == "Git commit failed: blocked by commit feedback test"
+                            }) =>
+                    {
+                        failure_overlay = true;
+                    }
                     PluginRequest::GetEditorState { request_id } => {
                         runtime
                             .resolve_request(request_id, editor_snapshot.clone())
@@ -11697,7 +11734,12 @@ mod tests {
                     _ => {}
                 }
             }
-            if failure_reported && retry_requested {
+            if failure_reported
+                && failure_overlay
+                && commit_started
+                && commit_busy
+                && retry_requested
+            {
                 break;
             }
             assert!(Instant::now() < deadline, "commit failure was not reported");
@@ -11754,6 +11796,7 @@ mod tests {
 
         let deadline = Instant::now() + Duration::from_secs(5);
         let mut restored = false;
+        let mut success_overlay = false;
         let success = loop {
             pump_process_events(&mut runtime).await.unwrap();
             let mut success = false;
@@ -11773,9 +11816,17 @@ mod tests {
                         restored = true;
                     }
                     PluginRequest::Action(Action::Print(message))
-                        if message == "Commit created successfully" =>
+                        if message == "✓ Commit created successfully" =>
                     {
                         success = true;
+                    }
+                    PluginRequest::UpdateOverlay { id, lines }
+                        if id == "git-operation-progress"
+                            && lines
+                                .iter()
+                                .any(|(line, _)| line == "✓ Commit created successfully") =>
+                    {
+                        success_overlay = true;
                     }
                     _ => {}
                 }
@@ -11787,6 +11838,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         };
         assert!(success);
+        assert!(success_overlay);
         assert!(restored);
         assert_eq!(
             String::from_utf8(
@@ -11800,6 +11852,249 @@ mod tests {
             .unwrap()
             .trim(),
             "feat(git): describe staged files"
+        );
+
+        runtime.execute_command("GitDashboard").await.unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut rendered = false;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if matches!(request, PluginRequest::UpdateWorkspace { .. }) {
+                    rendered = true;
+                }
+            }
+            if rendered {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "Git dashboard did not reopen for amend"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "c", "row": null }),
+            )
+            .await
+            .unwrap();
+        let (commit_picker, no_edit) = loop {
+            if let PluginRequest::OpenCallbackPicker {
+                handle,
+                title,
+                items,
+                ..
+            } = ACTION_DISPATCHER.recv_request()
+            {
+                if title.as_deref() == Some("Commit") {
+                    let no_edit = items
+                        .into_iter()
+                        .find(|item| item.id == "no-edit")
+                        .expect("commit picker should contain amend without editing");
+                    break (handle, no_edit);
+                }
+            }
+        };
+        runtime
+            .notify_picker(commit_picker, PickerCallback::Selected(no_edit))
+            .unwrap();
+        let (confirmation, proceed) = loop {
+            if let PluginRequest::OpenCallbackPicker {
+                handle,
+                title,
+                items,
+                ..
+            } = ACTION_DISPATCHER.recv_request()
+            {
+                if title.as_deref() == Some("Amend commit") {
+                    let proceed = items
+                        .into_iter()
+                        .find(|item| item.id == "proceed")
+                        .expect("amend confirmation should contain proceed");
+                    break (handle, proceed);
+                }
+            }
+        };
+        runtime
+            .notify_picker(confirmation, PickerCallback::Selected(proceed))
+            .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut amend_started = false;
+        let mut amend_busy = false;
+        let mut amend_succeeded = false;
+        while !amend_started || !amend_busy || !amend_succeeded {
+            pump_process_events(&mut runtime).await.unwrap();
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                match request {
+                    PluginRequest::UpdateOverlay { id, lines }
+                        if id == "git-operation-progress"
+                            && lines.iter().any(|(line, _)| line == "Amending commit…") =>
+                    {
+                        amend_started = true;
+                    }
+                    PluginRequest::UpdateOverlayBusy { id, busy }
+                        if id == "git-operation-progress" && busy =>
+                    {
+                        amend_busy = true;
+                    }
+                    PluginRequest::UpdateOverlay { id, lines }
+                        if id == "git-operation-progress"
+                            && lines
+                                .iter()
+                                .any(|(line, _)| line == "✓ Commit amended successfully") =>
+                    {
+                        amend_succeeded = true;
+                    }
+                    _ => {}
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "amend progress was not reported: started={amend_started} busy={amend_busy} succeeded={amend_succeeded}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            String::from_utf8(
+                Command::new("git")
+                    .args(["rev-list", "--count", "HEAD"])
+                    .current_dir(root)
+                    .output()
+                    .unwrap()
+                    .stdout
+            )
+            .unwrap()
+            .trim(),
+            "2"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_user_operations_report_success_failure_and_cleanup() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        assert!(Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(root.join("tracked.txt"), "one\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "tracked.txt"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "-c",
+                "user.name=Red Test",
+                "-c",
+                "user.email=red@example.test",
+                "commit",
+                "-qm",
+                "feat: initial",
+            ])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            let mut rendered = false;
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if matches!(request, PluginRequest::UpdateWorkspace { .. }) {
+                    rendered = true;
+                }
+            }
+            if rendered {
+                break;
+            }
+            assert!(Instant::now() < deadline, "Git dashboard did not render");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "f", "row": null }),
+            )
+            .await
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut fetch_succeeded = false;
+        let mut fetch_stopped_busy = false;
+        while !fetch_succeeded || !fetch_stopped_busy {
+            pump_process_events(&mut runtime).await.unwrap();
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                match request {
+                    PluginRequest::UpdateOverlay { id, lines }
+                        if id == "git-operation-progress"
+                            && lines.iter().any(|(line, _)| line == "✓ Fetch completed") =>
+                    {
+                        fetch_succeeded = true;
+                    }
+                    PluginRequest::UpdateOverlayBusy { id, busy }
+                        if id == "git-operation-progress" && !busy =>
+                    {
+                        fetch_stopped_busy = true;
+                    }
+                    _ => {}
+                }
+            }
+            assert!(Instant::now() < deadline, "fetch success was not reported");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "P", "row": null }),
+            )
+            .await
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut pull_failed = false;
+        while !pull_failed {
+            pump_process_events(&mut runtime).await.unwrap();
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::UpdateOverlay { id, lines } = request {
+                    if id == "git-operation-progress"
+                        && lines
+                            .iter()
+                            .any(|(line, _)| line.starts_with("Git operation failed:"))
+                    {
+                        pull_failed = true;
+                    }
+                }
+            }
+            assert!(Instant::now() < deadline, "pull failure was not reported");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        runtime.deactivate_all().await.unwrap();
+        let mut removed = false;
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            if let PluginRequest::RemoveOverlay { id } = request {
+                if id == "git-operation-progress" {
+                    removed = true;
+                }
+            }
+        }
+        assert!(
+            removed,
+            "Git operation overlay was not removed on deactivation"
         );
     }
 


### PR DESCRIPTION
Most user-triggered Git operations in the dashboard refreshed silently, so slow commands could look stalled and failures were easy to miss. Safe Sync could also push an ahead branch directly, bypassing the confirmation flow added for normal pushes.

This change:

- adds a shared transient progress lifecycle for Git operations, with delayed busy state, success and failure outcomes, bounded error summaries, conflict-aware messages, and teardown cleanup
- applies that lifecycle to commit creation, amend, generated commit messages, fetch, pull, branch, tag, stash, worktree, remote, merge, rebase, cherry-pick, revert, and reset actions
- routes Safe Sync pushes through the existing push preview and confirmation flow
- keeps background refreshes and hunk application quiet
- expands runtime integration coverage for commit generation, retry after hook failure, create and amend success, operation success and failure, push confirmation, and overlay cleanup

## How to Test

1. Stage a change, open the Git dashboard, and create a commit. With a slow passing pre-commit hook, verify that Creating commit… appears while the hook runs, then changes to ✓ Commit created successfully and restores the previous editor.
2. Repeat with a failing pre-commit hook. Verify that the warning includes the first Git error line and the original commit message reopens for retry.
3. Run Fetch and Pull from the dashboard. Verify successful commands show a transient success result and failures show a warning without hiding full multiline details.
4. Run Safe Sync on an ahead branch. Verify it opens the push preview and still requires explicit confirmation.

Automated coverage completed successfully:

- cargo test --all-features -p red plugin::runtime::tests::git_ -- --nocapture (14 passed)
- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- cargo run --all-features -- --self-check