### PR TITLE
feat(session): restore plugin pane state

### DIFF
--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -36,6 +36,15 @@ struct AgentPanelEvent {
     text: String,
 }
 
+struct RestoredPane {
+    id: String,
+    visible: bool,
+}
+
+struct RestoredPanesEvent {
+    panels: [RestoredPane],
+}
+
 struct AgentTranscriptEvent {
     transcript: String,
 }
@@ -402,6 +411,20 @@ fn ensure_conversation_panel() {
     if !state().panel_open {
         red::execute("SetPanelVisible", "agent-conversation", true);
         red::state_patch(AgentState { panel_open: true });
+    }
+}
+
+#[red::on("editor:panes_restore")]
+fn restore_conversation_pane(event: RestoredPanesEvent) {
+    for pane in event.panels {
+        if pane.id == "agent-conversation" && red::bool(pane.visible, false) {
+            let was_created = state().panel_created;
+            ensure_conversation_panel();
+            if !was_created {
+                render_conversation();
+            }
+            return;
+        }
     }
 }
 

--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -30,6 +30,24 @@ struct NeoTreePanelEvent {
     row: Option<TreePanelRow>,
 }
 
+struct RestoredPane {
+    id: String,
+    visible: bool,
+}
+
+struct RestoredPanesEvent {
+    panels: [RestoredPane],
+}
+
+struct NeoTreeStoredSession {
+    expanded: [String],
+    selected: [String],
+}
+
+struct NeoTreeStoredSessionEvent {
+    value: Option<NeoTreeStoredSession>,
+}
+
 struct DirectoryEntry {
     name: String,
     path: String,
@@ -219,6 +237,10 @@ fn neotree() {
 }
 
 fn show() {
+    show_panel(true);
+}
+
+fn show_panel(focus: bool) {
     red::state_patch(NeoTreeState { created: true });
     red::execute("CreatePanel", "neotree", PanelConfig {
         side: "left",
@@ -233,12 +255,32 @@ fn show() {
         },
     });
     red::execute("UpdatePanel", "neotree", loading_rows());
-    red::execute("FocusPanel", "neotree");
+    if focus {
+        red::execute("FocusPanel", "neotree");
+    }
 
     red::request("GetConfig", cwd_loaded, "cwd");
     red::request("GetWindows", windows_loaded);
     request_directory(".");
     request_git_status();
+}
+
+#[red::on("editor:panes_restore")]
+fn restore_neotree_pane(event: RestoredPanesEvent) {
+    for pane in event.panels {
+        if pane.id == "neotree" && red::bool(pane.visible, false) {
+            red::request("GetStorage", neotree_session_loaded, "pane_session");
+            return;
+        }
+    }
+}
+
+fn neotree_session_loaded(event: NeoTreeStoredSessionEvent) {
+    if let Some(saved) = event.value {
+        red::state_patch(NeoTreeState { expanded: saved.expanded });
+        red::state_patch(NeoTreeState { selected: saved.selected });
+    }
+    show_panel(false);
 }
 
 fn close() {
@@ -258,6 +300,14 @@ fn close() {
 #[red::lifecycle("deactivate")]
 fn deactivate() {
     close();
+}
+
+#[red::lifecycle("before_exit")]
+fn before_exit(snapshot: Json) {
+    red::execute("SetStorage", "pane_session", NeoTreeStoredSession {
+        expanded: state().expanded,
+        selected: state().selected,
+    });
 }
 
 #[red::on("panel:event:neotree")]

--- a/plugins/project_search.hk
+++ b/plugins/project_search.hk
@@ -35,6 +35,30 @@ struct ProjectSearchPanelEvent {
     row: ProjectSearchPanelRow,
 }
 
+struct RestoredPane {
+    id: String,
+    visible: bool,
+}
+
+struct RestoredPanesEvent {
+    panels: [RestoredPane],
+}
+
+struct ProjectSearchStoredPanel {
+    items: [ProjectSearchItem],
+    query: String,
+    hidden: bool,
+    ignored: bool,
+    follow: bool,
+    regex: bool,
+    preview: bool,
+    truncated: bool,
+}
+
+struct ProjectSearchStoredPanelEvent {
+    value: Option<ProjectSearchStoredPanel>,
+}
+
 struct ProjectSearchItem {
     id: String,
     label: String,
@@ -70,6 +94,7 @@ struct ProjectSearchState {
     regex: bool,
     preview: bool,
     truncated: bool,
+    panel_open: bool,
 }
 
 #[red::state]
@@ -96,6 +121,7 @@ fn initial_state() -> ProjectSearchState {
         regex: true,
         preview: true,
         truncated: false,
+        panel_open: false,
     };
 }
 
@@ -571,6 +597,10 @@ fn rebuild_items() {
 }
 
 fn export_results() {
+    export_results_panel(true);
+}
+
+fn export_results_panel(focus: bool) {
     let rows = [];
     for item in state().items {
         rows = red::push(rows, PanelRow {
@@ -593,13 +623,42 @@ fn export_results() {
         title: "Project Search Results",
     });
     red::execute("UpdatePanel", "project-search-results", rows);
-    red::execute("FocusPanel", "project-search-results");
+    red::state_patch(ProjectSearchState { panel_open: true });
+    if focus {
+        red::execute("FocusPanel", "project-search-results");
+    }
+}
+
+#[red::on("editor:panes_restore")]
+fn restore_project_search_pane(event: RestoredPanesEvent) {
+    for pane in event.panels {
+        if pane.id == "project-search-results" && red::bool(pane.visible, false) {
+            red::request("GetStorage", project_search_panel_loaded, "exported_panel");
+            return;
+        }
+    }
+}
+
+fn project_search_panel_loaded(event: ProjectSearchStoredPanelEvent) {
+    let Some(saved) = event.value else {
+        return;
+    };
+    red::state_patch(ProjectSearchState { items: saved.items });
+    red::state_patch(ProjectSearchState { query: saved.query });
+    red::state_patch(ProjectSearchState { hidden: saved.hidden });
+    red::state_patch(ProjectSearchState { ignored: saved.ignored });
+    red::state_patch(ProjectSearchState { follow: saved.follow });
+    red::state_patch(ProjectSearchState { regex: saved.regex });
+    red::state_patch(ProjectSearchState { preview: saved.preview });
+    red::state_patch(ProjectSearchState { truncated: saved.truncated });
+    export_results_panel(false);
 }
 
 #[red::on("panel:event:project-search-results")]
 fn export_panel_event(event: ProjectSearchPanelEvent) {
     if event.action == "close" {
         red::execute("ClosePanel", "project-search-results");
+        red::state_patch(ProjectSearchState { panel_open: false });
         return;
     }
     if event.action != "activate" || event.row == red::null() {
@@ -633,4 +692,22 @@ fn deactivate() {
     cancel_process();
     cancel_timers();
     red::execute("ClosePanel", "project-search-results");
+}
+
+#[red::lifecycle("before_exit")]
+fn before_exit(snapshot: Json) {
+    if !state().panel_open {
+        red::execute("SetStorage", "exported_panel", red::null());
+        return;
+    }
+    red::execute("SetStorage", "exported_panel", ProjectSearchStoredPanel {
+        items: state().items,
+        query: state().query,
+        hidden: state().hidden,
+        ignored: state().ignored,
+        follow: state().follow,
+        regex: state().regex,
+        preview: state().preview,
+        truncated: state().truncated,
+    });
 }

--- a/plugins/session_restore.hk
+++ b/plugins/session_restore.hk
@@ -26,6 +26,7 @@ struct SessionSnapshot {
     version: i32,
     cwd: String,
     buffers: [SessionBuffer],
+    panels: Option<Json>,
 }
 
 struct StoredSessionSnapshot {
@@ -77,8 +78,15 @@ fn startup_count_loaded(event: IntegerConfigValue) {
 
 fn snapshot_loaded(event: StoredSessionSnapshot) {
     let snapshot = event.value;
-    if snapshot == red::null() || red::int(snapshot.version, 0) != 1 {
+    if snapshot == red::null() {
         return;
+    }
+    let version = red::int(snapshot.version, 0);
+    if version != 1 && version != 2 {
+        return;
+    }
+    if version == 1 {
+        snapshot.panels = Some(Json { panels: [], focused: red::null() });
     }
     red::state_patch(SessionRestoreState { snapshot: Some(snapshot) });
     red::request("GetConfig", cwd_loaded, "cwd");

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3062,6 +3062,7 @@ impl DetachedEditorCore {
             .notify(&mut runtime, "editor:ready", json!({}))
             .await?;
         editor.restore_agent_plugin_state(&mut runtime).await?;
+        editor.notify_pane_restore_intents(&mut runtime).await?;
         editor.ensure_current_buffer_lsp_opened().await?;
         let mut render_buffer = RenderBuffer::new(
             editor.size.0 as usize,
@@ -7598,6 +7599,7 @@ impl Editor {
                 .notify(&mut runtime, "editor:ready", json!({}))
                 .await?;
             self.restore_agent_plugin_state(&mut runtime).await?;
+            self.notify_pane_restore_intents(&mut runtime).await?;
             drop(plugin_startup);
         }
 
@@ -7795,6 +7797,20 @@ impl Editor {
                 .await?;
         }
         Ok(())
+    }
+
+    async fn notify_pane_restore_intents(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
+        let snapshot = self.panel_manager.pending_restore_snapshot();
+        if snapshot.panels.is_empty() {
+            return Ok(());
+        }
+        self.plugin_registry
+            .notify(
+                runtime,
+                "editor:panes_restore",
+                serde_json::to_value(snapshot)?,
+            )
+            .await
     }
 
     async fn finish_agent_bridge(&mut self, fallback: &str) -> String {
@@ -9006,6 +9022,7 @@ impl Editor {
                         self.plugin_registry
                             .notify(runtime, "editor:state_restored", restored_payload)
                             .await?;
+                        self.notify_pane_restore_intents(runtime).await?;
                     }
                     let payload = match result {
                         Ok(result) => serde_json::to_value(result)?,
@@ -9367,16 +9384,23 @@ impl Editor {
                 PluginRequest::CreatePanel { id, config } => {
                     self.panel_manager.create_panel(id.clone(), config);
                     self.restore_panel_layout(&id);
+                    self.panel_manager.apply_pending_shell_restore(&id);
                     self.apply_panel_layout();
                     needs_render = true;
                 }
                 PluginRequest::UpdatePanel { id, rows } => {
                     self.panel_manager.update_panel(&id, rows);
+                    self.panel_manager.apply_pending_content_restore(
+                        &id,
+                        usize::from(self.size.1.saturating_sub(2)),
+                        usize::from(self.size.0),
+                    );
                     needs_render = true;
                 }
                 PluginRequest::CreateTextPanel { id, config } => {
                     self.panel_manager.create_text_panel(id.clone(), config);
                     self.restore_panel_layout(&id);
+                    self.panel_manager.apply_pending_shell_restore(&id);
                     self.apply_panel_layout();
                     needs_render = true;
                 }
@@ -9384,6 +9408,11 @@ impl Editor {
                     self.panel_manager.update_text_panel(
                         &id,
                         blocks,
+                        usize::from(self.size.1.saturating_sub(2)),
+                        usize::from(self.size.0),
+                    );
+                    self.panel_manager.apply_pending_content_restore(
+                        &id,
                         usize::from(self.size.1.saturating_sub(2)),
                         usize::from(self.size.0),
                     );
@@ -21927,6 +21956,7 @@ impl Editor {
                 (self.size.0 as usize, self.size.1 as usize),
             )
         });
+        self.panel_manager.stage_restore(snapshot.panels.clone());
         self.registers = snapshot.registers.clone();
         self.jump_list = snapshot
             .jumps
@@ -22237,6 +22267,7 @@ impl Editor {
                 buffers,
                 current_buffer_index: self.buffer_manager.active_index(),
                 window_layout: self.window_manager.snapshot(),
+                panels: self.panel_manager.snapshot(usize::from(self.size.0)),
                 registers: self.registers.clone(),
                 jumps: self
                     .jump_list
@@ -22428,12 +22459,13 @@ impl Editor {
             .collect();
 
         EditorStateSnapshot {
-            version: 1,
+            version: 2,
             cwd,
             saved_at,
             buffers,
             current_buffer_index: self.buffer_manager.active_index(),
             window_layout: self.window_manager.snapshot(),
+            panels: self.panel_manager.snapshot(usize::from(self.size.0)),
         }
     }
 
@@ -22442,7 +22474,7 @@ impl Editor {
         snapshot: EditorStateSnapshot,
         render_buffer: &mut RenderBuffer,
     ) -> anyhow::Result<RestoreResult> {
-        if snapshot.version != 1 {
+        if !matches!(snapshot.version, 1 | 2) {
             return Ok(RestoreResult {
                 restored: false,
                 opened_files: Vec::new(),
@@ -22453,6 +22485,13 @@ impl Editor {
                 )],
             });
         }
+
+        let has_panel_restore = !snapshot.panels.panels.is_empty();
+        self.panel_manager.stage_restore(snapshot.panels.clone());
+        self.panel_manager.apply_pending_to_existing(
+            usize::from(self.size.1.saturating_sub(2)),
+            usize::from(self.size.0),
+        );
 
         let mut opened_files = Vec::new();
         let mut skipped_files = Vec::new();
@@ -22495,12 +22534,24 @@ impl Editor {
             }
         }
 
-        if restored_buffers.is_empty() {
+        if restored_buffers.is_empty() && !has_panel_restore {
             return Ok(RestoreResult {
                 restored: false,
                 opened_files,
                 skipped_files,
                 warnings: vec!["No saved files could be restored".to_string()],
+            });
+        }
+
+        if restored_buffers.is_empty() {
+            self.apply_panel_layout();
+            self.sync_with_window();
+            self.render(render_buffer)?;
+            return Ok(RestoreResult {
+                restored: true,
+                opened_files,
+                skipped_files,
+                warnings: Vec::new(),
             });
         }
 
@@ -24297,6 +24348,9 @@ pub struct EditorStateSnapshot {
     /// Split layout and per-window viewport state.
     #[serde(alias = "windowLayout")]
     pub window_layout: WindowManagerSnapshot,
+    /// Stable plugin panes and editor-owned interaction state.
+    #[serde(default)]
+    pub panels: plugin::PanelManagerSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31885,6 +31939,44 @@ builtin = "rust"
         assert!(result.restored);
         assert_eq!(editor.buffer_manager[0].file.as_deref(), restored.to_str());
         assert!(editor.gutter_sign_manager.visible_sign(0, 0).is_none());
+    }
+
+    #[tokio::test]
+    async fn restoring_editor_state_accepts_a_pane_only_clean_workspace() {
+        let mut source = lsp_test_editor(vec![Buffer::new(None, String::new())]);
+        source.panel_manager.create_text_panel(
+            "agent-conversation".to_string(),
+            plugin::PanelConfig {
+                side: plugin::PanelSide::Right,
+                width: 42,
+                composer: Some(plugin::TextPanelComposerConfig {
+                    placeholder: "Ask".to_string(),
+                    rows: 3,
+                }),
+                ..plugin::PanelConfig::default()
+            },
+        );
+        let snapshot = source.editor_state_snapshot();
+        assert!(snapshot.buffers.is_empty());
+        assert_eq!(snapshot.panels.panels.len(), 1);
+
+        let mut restored = lsp_test_editor(vec![Buffer::new(None, String::new())]);
+        let mut render_buffer = RenderBuffer::new(60, 12, &Style::default());
+        let result = restored
+            .restore_editor_state(snapshot, &mut render_buffer)
+            .await
+            .unwrap();
+
+        assert!(result.restored);
+        assert_eq!(
+            restored
+                .panel_manager
+                .pending_restore_snapshot()
+                .panels
+                .first()
+                .map(|panel| panel.id.as_str()),
+            Some("agent-conversation")
+        );
     }
 
     #[tokio::test]

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -38,9 +38,10 @@ pub use location::{LocationColumnEncoding, OpenLocationTarget, PluginLocation};
 pub use metadata::PluginMetadata;
 pub use overlay::{OverlayAlignment, OverlayConfig, OverlayManager};
 pub use panel::{
-    PanelConfig, PanelManager, PanelRow, PanelRowKind, PanelSegment, PanelSide, TextPanelBlock,
-    TextPanelBlockFormat, TextPanelBlockKind, TextPanelComposerConfig, TextPanelHeaderAction,
-    TextPanelStatus,
+    PanelConfig, PanelManager, PanelManagerSnapshot, PanelRow, PanelRowKind, PanelSegment,
+    PanelSessionSnapshot, PanelSide, PanelSnapshotKind, TextPanelBlock, TextPanelBlockFormat,
+    TextPanelBlockKind, TextPanelComposerConfig, TextPanelComposerSnapshot, TextPanelHeaderAction,
+    TextPanelSessionSnapshot, TextPanelSnapshotFocus, TextPanelStatus,
 };
 pub use registry::{PluginRegistry, PluginStatus, RED_HOST_API_VERSION};
 pub use runtime::{

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -44,6 +44,76 @@ pub enum PanelSide {
     Bottom,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PanelSnapshotKind {
+    Row,
+    Text,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TextPanelSnapshotFocus {
+    #[default]
+    Scrollback,
+    Composer,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TextPanelComposerSnapshot {
+    pub text: String,
+    pub cursor: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TextPanelSessionSnapshot {
+    #[serde(default)]
+    pub follow_tail: bool,
+    #[serde(default)]
+    pub scroll_anchor: Option<usize>,
+    #[serde(default)]
+    pub cursor: usize,
+    #[serde(default)]
+    pub focus: TextPanelSnapshotFocus,
+    #[serde(default)]
+    pub composer: Option<TextPanelComposerSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PanelSessionSnapshot {
+    pub id: String,
+    pub kind: PanelSnapshotKind,
+    #[serde(default)]
+    pub visible: bool,
+    #[serde(default)]
+    pub z_index: Option<usize>,
+    pub side: PanelSide,
+    #[serde(default)]
+    pub vertical_size: Option<usize>,
+    #[serde(default)]
+    pub horizontal_size: Option<usize>,
+    #[serde(default)]
+    pub selected_row_id: Option<String>,
+    #[serde(default)]
+    pub row_scroll: usize,
+    #[serde(default)]
+    pub text: Option<TextPanelSessionSnapshot>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PanelManagerSnapshot {
+    #[serde(default)]
+    pub panels: Vec<PanelSessionSnapshot>,
+    #[serde(default)]
+    pub focused: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingPanelRestore {
+    snapshot: PanelSessionSnapshot,
+    shell_applied: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PanelConfig {
@@ -1663,9 +1733,259 @@ pub struct PanelManager {
     z_order: Vec<String>,
     focused: Option<String>,
     animation_state: Vec<(String, u8, u64)>,
+    pending_restore: HashMap<String, PendingPanelRestore>,
+    pending_focused: Option<String>,
 }
 
 impl PanelManager {
+    /// Captures durable, plugin-independent pane state by stable resource ID.
+    pub fn snapshot(&self, terminal_width: usize) -> PanelManagerSnapshot {
+        let panels = self
+            .panel_ids()
+            .into_iter()
+            .filter_map(|id| {
+                let config = self.panel_config(&id)?;
+                let visible = self.z_order.iter().position(|candidate| candidate == &id);
+                let sizes = self.preferred_sizes.get(&id).copied().unwrap_or_default();
+                let vertical_size = sizes.vertical.preferred.or_else(|| {
+                    matches!(config.side, PanelSide::Left | PanelSide::Right)
+                        .then_some(config.width)
+                });
+                let horizontal_size = sizes.horizontal.preferred.or_else(|| {
+                    matches!(config.side, PanelSide::Top | PanelSide::Bottom)
+                        .then_some(config.width)
+                });
+
+                if let Some(panel) = self.panels.get(&id) {
+                    return Some(PanelSessionSnapshot {
+                        id,
+                        kind: PanelSnapshotKind::Row,
+                        visible: visible.is_some(),
+                        z_index: visible,
+                        side: config.side,
+                        vertical_size,
+                        horizontal_size,
+                        selected_row_id: panel.selected_row().map(|row| row.id),
+                        row_scroll: panel.scroll,
+                        text: None,
+                    });
+                }
+
+                let panel = self.text_panels.get(&id)?;
+                let width = effective_panel_width(&panel.config, terminal_width);
+                let layout = panel.layout(width);
+                let scroll_anchor = (!panel.follow_tail).then(|| {
+                    (panel.scroll..layout.lines.len())
+                        .find_map(|row| layout.offset_at(row, 0))
+                        .unwrap_or(0)
+                });
+                let focus = if panel
+                    .composer
+                    .as_ref()
+                    .is_some_and(|composer| composer.focused)
+                    || panel.last_focused_region == TextPanelFocusRegion::Composer
+                {
+                    TextPanelSnapshotFocus::Composer
+                } else {
+                    TextPanelSnapshotFocus::Scrollback
+                };
+                let composer = panel
+                    .composer
+                    .as_ref()
+                    .map(|composer| TextPanelComposerSnapshot {
+                        text: composer.prompt.text(),
+                        cursor: composer.prompt.cursor(),
+                    });
+                Some(PanelSessionSnapshot {
+                    id,
+                    kind: PanelSnapshotKind::Text,
+                    visible: visible.is_some(),
+                    z_index: visible,
+                    side: config.side,
+                    vertical_size,
+                    horizontal_size,
+                    selected_row_id: None,
+                    row_scroll: 0,
+                    text: Some(TextPanelSessionSnapshot {
+                        follow_tail: panel.follow_tail,
+                        scroll_anchor,
+                        cursor: panel.scrollback.cursor,
+                        focus,
+                        composer,
+                    }),
+                })
+            })
+            .collect();
+        PanelManagerSnapshot {
+            panels,
+            focused: self.focused.clone(),
+        }
+    }
+
+    /// Stages pane state until the owning plugins recreate their resources.
+    pub fn stage_restore(&mut self, snapshot: PanelManagerSnapshot) {
+        self.pending_restore = snapshot
+            .panels
+            .into_iter()
+            .map(|snapshot| {
+                (
+                    snapshot.id.clone(),
+                    PendingPanelRestore {
+                        snapshot,
+                        shell_applied: false,
+                    },
+                )
+            })
+            .collect();
+        self.pending_focused = snapshot.focused;
+        self.focus_editor();
+    }
+
+    /// Returns the still-unclaimed restoration intents sent to plugin owners.
+    pub fn pending_restore_snapshot(&self) -> PanelManagerSnapshot {
+        let mut panels = self
+            .pending_restore
+            .values()
+            .map(|pending| pending.snapshot.clone())
+            .collect::<Vec<_>>();
+        panels.sort_by(|left, right| left.id.cmp(&right.id));
+        PanelManagerSnapshot {
+            panels,
+            focused: self.pending_focused.clone(),
+        }
+    }
+
+    /// Applies layout, visibility, and stacking after a plugin recreates a pane.
+    pub fn apply_pending_shell_restore(&mut self, id: &str) -> bool {
+        let Some(pending) = self.pending_restore.get(id) else {
+            return false;
+        };
+        let snapshot = pending.snapshot.clone();
+        let live_kind = if self.panels.contains_key(id) {
+            PanelSnapshotKind::Row
+        } else if self.text_panels.contains_key(id) {
+            PanelSnapshotKind::Text
+        } else {
+            return false;
+        };
+        if live_kind != snapshot.kind {
+            self.pending_restore.remove(id);
+            return false;
+        }
+
+        let size = if matches!(snapshot.side, PanelSide::Left | PanelSide::Right) {
+            snapshot.vertical_size
+        } else {
+            snapshot.horizontal_size
+        }
+        .or_else(|| self.panel_layout(id).map(|(_, size)| size))
+        .unwrap_or_default();
+        self.restore_panel_layout(
+            id,
+            snapshot.side,
+            size,
+            snapshot.vertical_size,
+            snapshot.horizontal_size,
+        );
+
+        self.z_order.retain(|candidate| candidate != id);
+        if snapshot.visible {
+            let index = snapshot.z_index.unwrap_or(self.z_order.len());
+            self.z_order
+                .insert(index.min(self.z_order.len()), id.to_string());
+        }
+        if let Some(pending) = self.pending_restore.get_mut(id) {
+            pending.shell_applied = true;
+        }
+        true
+    }
+
+    /// Applies content-relative state once the plugin has repopulated the pane.
+    pub fn apply_pending_content_restore(
+        &mut self,
+        id: &str,
+        panel_height: usize,
+        terminal_width: usize,
+    ) -> bool {
+        let Some(pending) = self.pending_restore.get(id) else {
+            return false;
+        };
+        if !pending.shell_applied {
+            return false;
+        }
+        let snapshot = pending.snapshot.clone();
+
+        let applied = match snapshot.kind {
+            PanelSnapshotKind::Row => {
+                let Some(panel) = self.panels.get_mut(id) else {
+                    return false;
+                };
+                if let Some(row_id) = snapshot.selected_row_id.as_deref() {
+                    if !panel.select_row_by_id(row_id, panel_height) {
+                        return false;
+                    }
+                }
+                panel.scroll = snapshot.row_scroll.min(panel.selected);
+                true
+            }
+            PanelSnapshotKind::Text => {
+                let Some(saved) = snapshot.text else {
+                    return false;
+                };
+                let Some(panel) = self.text_panels.get_mut(id) else {
+                    return false;
+                };
+                let width = effective_panel_width(&panel.config, terminal_width);
+                let panel_height = effective_panel_height(&panel.config, panel_height);
+                if let (Some(composer), Some(saved_composer)) =
+                    (panel.composer.as_mut(), saved.composer)
+                {
+                    composer.prompt.set_text(&saved_composer.text);
+                    composer.prompt.set_cursor(saved_composer.cursor);
+                }
+
+                let layout = panel.layout(width);
+                panel.scrollback.mode = TextPanelScrollbackMode::Normal;
+                panel.scrollback.selection_anchor = None;
+                panel.scrollback.cursor = layout.clamp(saved.cursor);
+                panel.last_focused_region = match saved.focus {
+                    TextPanelSnapshotFocus::Scrollback => TextPanelFocusRegion::Scrollback,
+                    TextPanelSnapshotFocus::Composer => TextPanelFocusRegion::Composer,
+                };
+                if saved.follow_tail {
+                    panel.scroll_to_bottom(panel_height, width);
+                } else {
+                    let row = saved
+                        .scroll_anchor
+                        .and_then(|anchor| layout.position(layout.clamp(anchor)))
+                        .map_or(0, |(row, _, _)| row);
+                    panel.scroll = row;
+                    panel.follow_tail = false;
+                    panel.clamp_scroll(panel_height, width);
+                }
+                true
+            }
+        };
+
+        if applied {
+            let should_focus = self.pending_focused.as_deref() == Some(id);
+            self.pending_restore.remove(id);
+            if should_focus {
+                self.pending_focused = None;
+                self.restore_panel_focus(id);
+            }
+        }
+        applied
+    }
+
+    /// Applies a staged snapshot to resources that were already live when it loaded.
+    pub fn apply_pending_to_existing(&mut self, panel_height: usize, terminal_width: usize) {
+        for id in self.panel_ids() {
+            self.apply_pending_shell_restore(&id);
+            self.apply_pending_content_restore(&id, panel_height, terminal_width);
+        }
+    }
+
     pub fn create_panel(&mut self, id: String, config: PanelConfig) {
         self.default_layouts
             .insert(id.clone(), (config.side, config.width));
@@ -4165,6 +4485,97 @@ mod tests {
             assert_eq!(config.side, side);
             assert_eq!(serde_json::to_value(&config).unwrap()["side"], name);
         }
+    }
+
+    #[test]
+    fn pane_snapshot_restores_deferred_visibility_focus_selection_and_draft() {
+        let mut original = PanelManager::default();
+        original.create_panel(
+            "tree".to_string(),
+            PanelConfig {
+                side: PanelSide::Left,
+                width: 24,
+                ..PanelConfig::default()
+            },
+        );
+        original.update_panel("tree", vec![row("src"), row("tests")]);
+        assert!(original.select_row_by_id("tree", "tests", 20));
+        assert!(original.set_panel_visible("tree", false));
+
+        let agent_config = PanelConfig {
+            side: PanelSide::Right,
+            width: 42,
+            composer: Some(TextPanelComposerConfig {
+                placeholder: "Ask".to_string(),
+                rows: 3,
+            }),
+            ..PanelConfig::default()
+        };
+        original.create_text_panel("agent".to_string(), agent_config.clone());
+        original.update_text_panel(
+            "agent",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Agent,
+                format: TextPanelBlockFormat::Markdown,
+                text: "restored answer".to_string(),
+            }],
+            20,
+            100,
+        );
+        let composer = original
+            .text_panels
+            .get_mut("agent")
+            .unwrap()
+            .composer
+            .as_mut()
+            .unwrap();
+        assert!(composer.prompt.set_text("keep this draft"));
+        composer.prompt.set_cursor(5);
+        assert!(original.focus_text_panel_composer("agent"));
+
+        let encoded = serde_json::to_vec(&original.snapshot(100)).unwrap();
+        let snapshot: PanelManagerSnapshot = serde_json::from_slice(&encoded).unwrap();
+        let mut restored = PanelManager::default();
+        restored.stage_restore(snapshot);
+
+        restored.create_text_panel("agent".to_string(), agent_config);
+        assert!(restored.apply_pending_shell_restore("agent"));
+        restored.update_text_panel(
+            "agent",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Agent,
+                format: TextPanelBlockFormat::Markdown,
+                text: "restored answer".to_string(),
+            }],
+            20,
+            100,
+        );
+        assert!(restored.apply_pending_content_restore("agent", 20, 100));
+
+        restored.create_panel(
+            "tree".to_string(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 10,
+                ..PanelConfig::default()
+            },
+        );
+        assert!(restored.apply_pending_shell_restore("tree"));
+        restored.update_panel("tree", vec![row("src")]);
+        assert!(!restored.apply_pending_content_restore("tree", 20, 100));
+        restored.update_panel("tree", vec![row("src"), row("tests")]);
+        assert!(restored.apply_pending_content_restore("tree", 20, 100));
+
+        assert_eq!(restored.focused.as_deref(), Some("agent"));
+        assert!(!restored.z_order.iter().any(|id| id == "tree"));
+        assert_eq!(restored.panels["tree"].selected_row().unwrap().id, "tests");
+        assert_eq!(restored.panel_layout("tree"), Some((PanelSide::Left, 24)));
+        let composer = restored.text_panels["agent"].composer.as_ref().unwrap();
+        assert_eq!(composer.prompt.text(), "keep this draft");
+        assert_eq!(composer.prompt.cursor(), 5);
+        assert!(composer.focused);
     }
 
     #[test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -8704,6 +8704,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bundled_agent_plugin_recreates_only_a_visible_restored_pane() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+
+        runtime
+            .notify(
+                "editor:panes_restore",
+                serde_json::json!({
+                    "panels": [{ "id": "agent-conversation", "visible": false }]
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+
+        runtime
+            .notify(
+                "editor:panes_restore",
+                serde_json::json!({
+                    "panels": [{ "id": "agent-conversation", "visible": true }]
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::CreateTextPanel { id, .. } if id == "agent-conversation"
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdateTextPanel { id, .. } if id == "agent-conversation"
+        ));
+    }
+
+    #[tokio::test]
     async fn bundled_agent_plugin_restores_a_truncated_leading_response_as_markdown() {
         let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
         drain_requests();
@@ -10307,6 +10347,70 @@ mod tests {
         assert!(!runtime
             .notify_picker(handle, PickerCallback::Query("stale".to_string()))
             .unwrap());
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+    }
+
+    #[tokio::test]
+    async fn project_search_recreates_a_restored_export_without_stealing_focus() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin(
+                "project_search",
+                include_str!("../../plugins/project_search.hk"),
+            )
+            .await
+            .unwrap();
+
+        runtime
+            .notify(
+                "editor:panes_restore",
+                serde_json::json!({
+                    "panels": [{ "id": "project-search-results", "visible": true }]
+                }),
+            )
+            .await
+            .unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetPluginStorage {
+                plugin,
+                key,
+                request_id,
+            } => {
+                assert_eq!(plugin, "project_search");
+                assert_eq!(key, "exported_panel");
+                request_id
+            }
+            _ => panic!("expected exported-panel storage request"),
+        };
+        runtime
+            .resolve_request(
+                request_id,
+                serde_json::json!({
+                    "value": {
+                        "items": [],
+                        "query": "needle",
+                        "hidden": false,
+                        "ignored": false,
+                        "follow": false,
+                        "regex": true,
+                        "preview": true,
+                        "truncated": false
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::CreatePanel { id, .. } if id == "project-search-results"
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePanel { id, .. } if id == "project-search-results"
+        ));
         assert!(ACTION_DISPATCHER.try_recv_request().is_none());
     }
 
@@ -12818,7 +12922,7 @@ mod tests {
         drain_requests();
 
         let snapshot = serde_json::json!({
-            "version": 1,
+            "version": 2,
             "cwd": "/tmp/project",
             "saved_at": 1,
             "buffers": [
@@ -12849,6 +12953,16 @@ mod tests {
                     "cy": 0,
                     "vx": 0,
                 }
+            },
+            "panels": {
+                "panels": [{
+                    "id": "agent-conversation",
+                    "kind": "text",
+                    "visible": true,
+                    "z_index": 0,
+                    "side": "right"
+                }],
+                "focused": "agent-conversation"
             }
         });
         let mut runtime = Runtime::new();
@@ -12926,6 +13040,7 @@ mod tests {
             } => {
                 assert!(request_id.get() > 0);
                 assert_eq!(snapshot.buffers.len(), 2);
+                assert_eq!(snapshot.panels.panels.len(), 1);
             }
             _ => panic!("unexpected plugin request"),
         }
@@ -12939,6 +13054,7 @@ mod tests {
                 assert_eq!(key, "latest");
                 assert_eq!(value["buffers"].as_array().unwrap().len(), 1);
                 assert_eq!(value["buffers"][0]["path"], "src/main.rs");
+                assert_eq!(value["panels"]["panels"][0]["id"], "agent-conversation");
             }
             _ => panic!("unexpected plugin request"),
         }
@@ -13185,6 +13301,61 @@ mod tests {
             PluginRequest::FocusEditor => {}
             _ => panic!("unexpected plugin request"),
         }
+    }
+
+    #[tokio::test]
+    async fn neotree_recreates_a_restored_pane_without_stealing_focus() {
+        let _lock = PLUGIN_DISPATCHER_TEST_LOCK.lock().await;
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("neotree", include_str!("../../plugins/neotree.hk"))
+            .await
+            .unwrap();
+
+        runtime
+            .notify(
+                "editor:panes_restore",
+                serde_json::json!({
+                    "panels": [{ "id": "neotree", "visible": true }]
+                }),
+            )
+            .await
+            .unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::GetPluginStorage {
+                plugin,
+                key,
+                request_id,
+            } => {
+                assert_eq!(plugin, "neotree");
+                assert_eq!(key, "pane_session");
+                request_id
+            }
+            _ => panic!("expected Neo-tree storage request"),
+        };
+        runtime
+            .resolve_request(
+                request_id,
+                serde_json::json!({
+                    "value": { "expanded": [".", "src"], "selected": [] }
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::CreatePanel { id, .. } if id == "neotree"
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePanel { id, .. } if id == "neotree"
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::GetConfig { .. }
+        ));
     }
 
     #[tokio::test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     agent_conversation::AgentConversationSnapshot,
     editor::Content,
+    plugin::PanelManagerSnapshot,
     undo::{TextPosition, UndoHistory},
     window::WindowManagerSnapshot,
 };
@@ -85,6 +86,9 @@ pub struct SessionSnapshot {
     pub current_buffer_index: usize,
     /// Split tree, focused window, and per-window view state.
     pub window_layout: WindowManagerSnapshot,
+    /// Plugin pane shells and editor-owned interaction state, keyed by stable IDs.
+    #[serde(default)]
+    pub panels: PanelManagerSnapshot,
     /// Named editor registers.
     #[serde(default)]
     pub registers: HashMap<char, Content>,
@@ -2281,6 +2285,7 @@ mod tests {
                     vx: 0,
                 },
             },
+            panels: PanelManagerSnapshot::default(),
             registers: HashMap::new(),
             jumps: Vec::new(),
             jump_index: 0,
@@ -2317,6 +2322,16 @@ mod tests {
             encoded.get("former_plugin"),
             Some(&serde_json::json!({ "version": 1, "reviews": [1, 2] }))
         );
+    }
+
+    #[test]
+    fn older_session_snapshots_default_missing_pane_state() {
+        let mut value = serde_json::to_value(snapshot("source")).unwrap();
+        value.as_object_mut().unwrap().remove("panels");
+
+        let restored: SessionSnapshot = serde_json::from_value(value).unwrap();
+
+        assert_eq!(restored.panels, PanelManagerSnapshot::default());
     }
 
     #[test]


### PR DESCRIPTION
Pane layout preferences already preserved dock placement and size, but clean restarts and crash recovery lost whether plugin panes were visible and all editor-owned pane interaction state. This left restored agent transcripts without their conversation pane and discarded unsent composer drafts.

This change adds a versioned pane snapshot shared by clean restart and durable recovery. Red stages restored pane state by stable resource ID, lets the owning plugin recreate its resource, then reapplies visibility, stacking, layout, focus, row selection and scroll, text scroll and follow-tail, and composer draft and cursor state. The bundled agent, Neo-tree, and project-search plugins now recreate their visible panes and restore the plugin-owned data needed to repopulate them. Older session snapshots continue to load with empty pane state.

## How to Test

1. Open a file, open the Agent pane, enter an unsent composer draft, then quit Red.
2. Restart Red without file arguments in the same workspace.
3. Confirm the file, Agent pane, pane layout, focus region, and unsent draft are restored.
4. Hide the Agent pane, quit, and restart again; confirm the pane remains hidden.
5. Open Neo-tree or export project-search results, restart, and confirm the visible pane is recreated without stealing editor focus.

Automated coverage includes pane snapshot round-trips, pane-only clean-workspace restore, legacy snapshot compatibility, and bundled plugin recreation handlers. `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` pass.