### PR TITLE
feat(formatting): support language pack formatters

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -146,6 +146,13 @@ waiting = "steady_underscore"
 # [lsp]
 # format_on_save = true
 #
+# `lsp.format_on_save` remains supported. New configurations can select an
+# external language-pack formatter, LSP formatting, or automatic fallback:
+#
+# [formatting]
+# on_save = true
+# provider = "auto" # "auto", "external", or "lsp"
+#
 # [lsp.servers.rust]
 # command = "rust-analyzer"
 # args = ["-v"]

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.9.0` is defined by
+Red host API version `0.10.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -24,9 +24,33 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 annotations use `HUSK-A0004`. `--no-typecheck` is an unsupported development
 escape hatch; compatibility guarantees do not apply while it is enabled.
 
-Red `0.9.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, and `0.8.0` contracts, so existing
-packages that declare those minors continue to load. New packages should target
-`"red_api_version": "^0.9.0"`.
+Red `0.10.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, and `0.9.0`
+contracts, so existing packages that declare those minors continue to load. New
+packages should target `"red_api_version": "^0.10.0"`.
+
+## Language-pack formatters
+
+Host API `0.10.0` adds an optional `formatter` table to each language definition:
+
+```toml
+[languages.python.formatter]
+name = "Black"
+command = "black"
+args = ["--quiet", "--stdin-filename", "{file}", "-"]
+root_markers = ["pyproject.toml", ".git"]
+```
+
+Red launches the command directly, sends the document on standard input, and replaces
+the document with UTF-8 standard output. `{file}` and `{workspace}` placeholders are
+expanded in arguments and environment values. Project-local executables under
+`node_modules/.bin`, `.venv/bin`, `venv/bin`, and `vendor/bin` take precedence over
+`PATH`.
+
+The global `[formatting]` table supports `on_save` and a `provider` of `auto`,
+`external`, or `lsp`. `auto` prefers an installed language-pack formatter and falls
+back to LSP when the formatter is absent; a formatter that starts and fails does not
+silently switch engines. The legacy `lsp.format_on_save` flag remains accepted as an
+on-save enablement alias.
 
 ## Scratch-buffer workflows
 

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.9.0",
+  "api_version": "0.10.0",
   "changes": [
+    {
+      "version": "0.10.0",
+      "kind": "introduced",
+      "symbols": ["languages.*.formatter", "formatting.on_save", "formatting.provider"],
+      "migration_note": "docs/PLUGIN_API.md#language-pack-formatters"
+    },
     {
       "version": "0.9.0",
       "kind": "introduced",

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -868,8 +868,8 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
         builtin(
             "lsp.format",
             "Format document",
-            "LSP",
-            "Format the current document",
+            "Editing",
+            "Format the current document with its configured formatter",
             None,
             &["formatter"],
             Action::FormatDocument,
@@ -1250,7 +1250,7 @@ mod tests {
             .iter()
             .find(|entry| entry.id == "lsp.format")
             .unwrap();
-        assert_eq!(format.category, "LSP");
+        assert_eq!(format.category, "Editing");
         assert_eq!(format.title, "Format document");
         assert!(format
             .shortcuts
@@ -1531,7 +1531,7 @@ mod tests {
         assert_eq!(
             format.icon,
             Some(PickerIcon::Symbol {
-                kind: "CommandLsp".to_string(),
+                kind: "Command".to_string(),
                 role: Some("Command".to_string()),
             })
         );
@@ -1543,14 +1543,14 @@ mod tests {
             })
         );
         assert_eq!(format.label, "Format document");
-        assert_eq!(format.annotation.as_deref().map(str::trim), Some("LSP"));
+        assert_eq!(format.annotation.as_deref().map(str::trim), Some("Editing"));
         assert!(format
             .detail
             .as_deref()
             .is_some_and(|detail| detail.contains("Space f")));
         assert_eq!(
             format.data["description"].as_str(),
-            Some("Format the current document")
+            Some("Format the current document with its configured formatter")
         );
         assert_eq!(save.data["colon"].as_str(), Some(":w"));
         assert_eq!(format.data["primary_shortcut"].as_str(), Some("Space f"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -267,6 +267,9 @@ pub struct Config {
     /// Language-server routing and behavior.
     #[serde(default)]
     pub lsp: LspConfig,
+    /// Document formatting behavior shared by language servers and external tools.
+    #[serde(default)]
+    pub formatting: FormattingConfig,
     /// User-defined syntax, grammar, formatting, and language-server definitions.
     #[serde(default)]
     pub languages: HashMap<String, LanguageConfig>,
@@ -875,6 +878,31 @@ pub struct LspConfig {
     pub servers: HashMap<String, LanguageServerConfig>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+/// Selects the formatting backend used for explicit and save-time formatting.
+pub enum FormattingProvider {
+    /// Prefer a configured external formatter and otherwise ask the language server.
+    #[default]
+    Auto,
+    /// Use only the language pack's external formatter.
+    External,
+    /// Use only language-server formatting.
+    Lsp,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+/// Global document formatting behavior.
+pub struct FormattingConfig {
+    /// Format supported documents immediately before saving them.
+    #[serde(default)]
+    pub on_save: bool,
+    /// Backend selected for explicit and save-time formatting.
+    #[serde(default)]
+    pub provider: FormattingProvider,
+}
+
 /// One configurable language shared by highlighting, editing, and LSP routing.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -900,6 +928,28 @@ pub struct LanguageConfig {
     /// Language-server launch and settings associated with this language.
     #[serde(default)]
     pub lsp: Option<LanguageLspConfig>,
+    /// External stdin-to-stdout formatter supplied by the language pack.
+    #[serde(default)]
+    pub formatter: Option<LanguageFormatterConfig>,
+}
+
+/// One external formatter launched directly with the document on stdin.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LanguageFormatterConfig {
+    /// Human-readable formatter name shown in editor feedback.
+    pub name: String,
+    /// Formatter executable launched without a shell.
+    pub command: String,
+    /// Arguments with optional `{file}` and `{workspace}` placeholders.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Files or directories searched upward to select the working directory.
+    #[serde(default)]
+    pub root_markers: Vec<String>,
+    /// Environment additions supplied only to the formatter process.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
 }
 
 /// Source, highlighting queries, and platform artifacts for one grammar.
@@ -1774,6 +1824,7 @@ fn known_top_level_field(field: &str) -> bool {
             | "key_hints"
             | "clipboard"
             | "lsp"
+            | "formatting"
             | "languages"
             | "commenting"
             | "matchit"
@@ -1937,6 +1988,7 @@ fn known_schema_path(path: &[String]) -> bool {
             matches!(*field, "enabled" | "sync_on_yank" | "sync_on_paste")
         }
         ["lsp", field] => matches!(*field, "enabled" | "format_on_save" | "servers"),
+        ["formatting", field] => matches!(*field, "on_save" | "provider"),
         ["lsp", "servers", _] => true,
         ["lsp", "servers", _, field] => matches!(
             *field,
@@ -1958,7 +2010,14 @@ fn known_schema_path(path: &[String]) -> bool {
         ["languages", _] => true,
         ["languages", _, field] => matches!(
             *field,
-            "extensions" | "filenames" | "aliases" | "comment" | "indent_width" | "grammar" | "lsp"
+            "extensions"
+                | "filenames"
+                | "aliases"
+                | "comment"
+                | "indent_width"
+                | "grammar"
+                | "lsp"
+                | "formatter"
         ),
         ["languages", _, "grammar", field] => matches!(
             *field,
@@ -1982,6 +2041,10 @@ fn known_schema_path(path: &[String]) -> bool {
         ["languages", _, "lsp", "env", _]
         | ["languages", _, "lsp", "initialization_options", ..]
         | ["languages", _, "lsp", "settings", ..] => true,
+        ["languages", _, "formatter", field] => {
+            matches!(*field, "name" | "command" | "args" | "root_markers" | "env")
+        }
+        ["languages", _, "formatter", "env", _] => true,
         ["commenting", "languages"] | ["commenting", "languages", _] => true,
         ["matchit", field] => matches!(*field, "enabled" | "pairs" | "languages"),
         ["matchit", "languages", _] | ["matchit", "languages", _, "groups"] => true,
@@ -4147,6 +4210,46 @@ workspace_name = "frontend"
         assert_eq!(server.documents()[0].file_extensions, vec!["ts", "tsx"]);
         assert_eq!(server.root_markers, vec!["package.json", ".git"]);
         assert_eq!(server.workspace_name.as_deref(), Some("frontend"));
+    }
+
+    #[test]
+    fn formatting_config_accepts_external_language_formatter() {
+        let config: Config = toml::from_str(
+            r#"
+theme = "theme/nightfox.json"
+
+[keys]
+
+[formatting]
+on_save = true
+provider = "external"
+
+[languages.python]
+extensions = ["py"]
+
+[languages.python.formatter]
+name = "Black"
+command = "black"
+args = ["--quiet", "--stdin-filename", "{file}", "-"]
+root_markers = ["pyproject.toml", ".git"]
+
+[languages.python.formatter.env]
+BLACK_CACHE_DIR = "{workspace}/.cache/black"
+"#,
+        )
+        .unwrap();
+
+        assert!(config.formatting.on_save);
+        assert_eq!(config.formatting.provider, FormattingProvider::External);
+        let formatter = config.languages["python"].formatter.as_ref().unwrap();
+        assert_eq!(formatter.name, "Black");
+        assert_eq!(formatter.command, "black");
+        assert_eq!(
+            formatter.args,
+            ["--quiet", "--stdin-filename", "{file}", "-"]
+        );
+        assert_eq!(formatter.root_markers, ["pyproject.toml", ".git"]);
+        assert_eq!(formatter.env["BLACK_CACHE_DIR"], "{workspace}/.cache/black");
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -52,6 +52,7 @@ use crossterm::{
     },
     terminal, ExecutableCommand,
 };
+use futures::future::BoxFuture;
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 #[cfg(unix)]
 use nix::sys::signal::{self, Signal};
@@ -79,8 +80,8 @@ use crate::{
     command, command_palette,
     comment::CommentSyntax,
     config::{
-        Config, ConfigDiagnostic, ConfigDiagnosticSource, ConfigRecovery, KeyAction,
-        PickerIconStyle, StatuslineConfig,
+        Config, ConfigDiagnostic, ConfigDiagnosticSource, ConfigRecovery, FormattingProvider,
+        KeyAction, LanguageFormatterConfig, PickerIconStyle, StatuslineConfig,
     },
     dispatcher::Dispatcher,
     editing::{
@@ -3540,6 +3541,19 @@ enum FormatOnSaveRequest {
     Cancelled,
 }
 
+enum ExternalFormatOutcome {
+    NotConfigured,
+    Unavailable { name: String },
+    Unchanged { name: String },
+    Applied { name: String },
+}
+
+struct ExternalFormatOnSave {
+    use_lsp: bool,
+    warning: Option<String>,
+    changed: bool,
+}
+
 impl HistoryEntry {
     fn new(file: Option<String>, x: usize, y: usize) -> Self {
         Self { file, x, y }
@@ -3834,6 +3848,7 @@ impl Editor {
         let count = loaded.config.languages.len();
         self.config.languages = loaded.config.languages;
         self.config.lsp = loaded.config.lsp;
+        self.config.formatting = loaded.config.formatting;
         self.config.commenting = loaded.config.commenting;
         self.config_diagnostics = loaded.diagnostics;
         self.config_diagnostics_acknowledged = self.config_diagnostics.is_empty();
@@ -17377,32 +17392,7 @@ impl Editor {
                 self.execute_lsp_command(command, None).await?;
             }
             Action::FormatDocument => {
-                if let Some(file) = self.current_buffer().file.clone() {
-                    let Some(uri) = self.current_buffer().uri()? else {
-                        return Ok(false);
-                    };
-                    let pending = PendingLspEdit {
-                        buffer_id: self.current_buffer().id(),
-                        revision: self.current_buffer().revision(),
-                        uri,
-                    };
-                    self.ensure_current_buffer_lsp_opened().await?;
-                    let indentation = self.indentation();
-                    let request_id = self
-                        .lsp
-                        .format_document_with_options(
-                            &file,
-                            indentation.tab_width,
-                            indentation.expand_tab,
-                        )
-                        .await?;
-                    if request_id > 0 {
-                        self.pending_lsp_edit_requests.insert(request_id, pending);
-                    } else {
-                        self.last_error =
-                            Some("no language server is available for this file".to_string());
-                    }
-                }
+                self.format_document_action(buffer, runtime).await?;
             }
             Action::CodeAction => {
                 if let Some(file) = self.current_buffer().file.clone() {
@@ -17957,167 +17947,13 @@ impl Editor {
                 }
             }
             Action::Save => {
-                let scratch_command = self
-                    .scratch_buffers
-                    .get(&self.current_buffer().id())
-                    .and_then(|commands| commands.submit.clone());
-                if let Some(command) = scratch_command {
-                    self.plugin_registry.execute(runtime, &command).await?;
+                if !self.save_action(buffer, runtime).await? {
                     return Ok(false);
-                }
-                let resume_insert_transaction = self.commit_active_transaction_before_save();
-                let format_warning = if self.config.lsp.format_on_save {
-                    let request = self.request_format_on_save(None).await;
-                    let request = match request {
-                        Ok(request) => request,
-                        Err(error) => {
-                            self.resume_insert_transaction_after_save(resume_insert_transaction);
-                            return Err(error);
-                        }
-                    };
-                    match request {
-                        FormatOnSaveRequest::Pending => {
-                            self.resume_insert_transaction_after_save(resume_insert_transaction);
-                            return Ok(false);
-                        }
-                        FormatOnSaveRequest::Save { warning } => warning,
-                        FormatOnSaveRequest::Cancelled => {
-                            self.resume_insert_transaction_after_save(resume_insert_transaction);
-                            return Ok(false);
-                        }
-                    }
-                } else {
-                    None
-                };
-                let save_result = self.current_buffer_mut().save();
-                self.resume_insert_transaction_after_save(resume_insert_transaction);
-
-                match save_result {
-                    Ok(msg) => {
-                        // TODO: use last_message instead of last_error
-                        self.last_error = Some(format_warning.unwrap_or(msg));
-
-                        // Notify plugins about file save
-                        if let Some(file) = &self.current_buffer().file {
-                            let save_info = serde_json::json!({
-                                "file": file,
-                                "buffer_index": self.buffer_manager.active_index()
-                            });
-                            self.plugin_registry
-                                .notify(runtime, "file:saved", save_info)
-                                .await?;
-                        }
-                    }
-                    Err(e) => {
-                        self.last_error = Some(e.to_string());
-                    }
                 }
             }
             Action::SaveAs(new_file_name) => {
-                if self
-                    .scratch_buffers
-                    .contains_key(&self.current_buffer().id())
-                {
-                    self.last_error = Some(
-                        "Scratch buffers cannot be written to disk; use :w to submit".to_string(),
-                    );
+                if !self.save_as_action(new_file_name, buffer, runtime).await? {
                     return Ok(false);
-                }
-                let previous_uri = self.current_buffer().uri()?;
-                let previous_file = self.current_buffer().file.clone();
-                let resume_insert_transaction = self.commit_active_transaction_before_save();
-                let format_warning = if self.config.lsp.format_on_save {
-                    let request = self
-                        .request_format_on_save(Some(new_file_name.clone()))
-                        .await;
-                    let request = match request {
-                        Ok(request) => request,
-                        Err(error) => {
-                            self.resume_insert_transaction_after_save(resume_insert_transaction);
-                            return Err(error);
-                        }
-                    };
-                    match request {
-                        FormatOnSaveRequest::Pending => {
-                            self.resume_insert_transaction_after_save(resume_insert_transaction);
-                            return Ok(false);
-                        }
-                        FormatOnSaveRequest::Save { warning } => warning,
-                        FormatOnSaveRequest::Cancelled => {
-                            self.resume_insert_transaction_after_save(resume_insert_transaction);
-                            return Ok(false);
-                        }
-                    }
-                } else {
-                    None
-                };
-                let save_result = self.current_buffer_mut().save_as(new_file_name);
-                self.resume_insert_transaction_after_save(resume_insert_transaction);
-
-                match save_result {
-                    Ok(msg) => {
-                        // TODO: use last_message instead of last_error
-                        self.last_error = Some(format_warning.unwrap_or(msg));
-                        if let Err(error) = self
-                            .sync_lsp_document_identity(
-                                previous_uri.as_deref(),
-                                self.buffer_manager.active_index(),
-                            )
-                            .await
-                        {
-                            if !self.config.lsp.format_on_save
-                                || !matches!(
-                                    error.downcast_ref::<crate::lsp::LspError>(),
-                                    Some(
-                                        crate::lsp::LspError::ProtocolError(_)
-                                            | crate::lsp::LspError::RequestTimeout(_)
-                                    )
-                                )
-                            {
-                                return Err(error);
-                            }
-                            log!(
-                                "{}",
-                                json!({
-                                    "event": "lsp_format_on_save_fallback",
-                                    "level": "warn",
-                                    "service": "red",
-                                    "stage": "sync_document_identity",
-                                    "error": error.to_string(),
-                                })
-                            );
-                            self.last_error = Some(format!(
-                                "format-on-save unavailable; saved unformatted: {error}"
-                            ));
-                        }
-                        let saved_file = self
-                            .current_buffer()
-                            .file
-                            .clone()
-                            .unwrap_or_else(|| new_file_name.clone());
-
-                        // Notify plugins about file save
-                        let save_info = serde_json::json!({
-                            "file": saved_file,
-                            "buffer_index": self.buffer_manager.active_index()
-                        });
-                        self.plugin_registry
-                            .notify(runtime, "file:saved", save_info)
-                            .await?;
-                    }
-                    Err(e) => {
-                        if self.config.lsp.format_on_save {
-                            if let Some(target_uri) = self.current_buffer().uri()? {
-                                self.restore_lsp_format_save_identity(
-                                    self.current_buffer().id(),
-                                    &target_uri,
-                                    previous_file,
-                                )
-                                .await;
-                            }
-                        }
-                        self.last_error = Some(e.to_string());
-                    }
                 }
             }
             Action::CommitSearch => {
@@ -23714,6 +23550,442 @@ impl Editor {
             runtime,
         )
         .await
+    }
+
+    #[inline(never)]
+    fn save_action<'a>(
+        &'a mut self,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<bool>> {
+        Box::pin(self.save_action_impl(buffer, runtime))
+    }
+
+    async fn save_action_impl(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        let scratch_command = self
+            .scratch_buffers
+            .get(&self.current_buffer().id())
+            .and_then(|commands| commands.submit.clone());
+        if let Some(command) = scratch_command {
+            self.plugin_registry.execute(runtime, &command).await?;
+            return Ok(false);
+        }
+        let resume_insert_transaction = self.commit_active_transaction_before_save();
+        let format_on_save = self.config.formatting.on_save || self.config.lsp.format_on_save;
+        let mut format_warning = None;
+        let mut use_lsp = format_on_save;
+        if format_on_save && self.config.formatting.provider != FormattingProvider::Lsp {
+            let file = self.current_buffer().file.clone();
+            let external = self.external_format_on_save(file.as_deref(), runtime).await;
+            use_lsp = external.use_lsp;
+            format_warning = external.warning;
+            if external.changed {
+                self.render(buffer)?;
+            }
+        }
+        if format_on_save && use_lsp {
+            let request = self.request_format_on_save(None).await;
+            let request = match request {
+                Ok(request) => request,
+                Err(error) => {
+                    self.resume_insert_transaction_after_save(resume_insert_transaction);
+                    return Err(error);
+                }
+            };
+            match request {
+                FormatOnSaveRequest::Pending => {
+                    self.resume_insert_transaction_after_save(resume_insert_transaction);
+                    return Ok(false);
+                }
+                FormatOnSaveRequest::Save { warning } => {
+                    format_warning = warning.or(format_warning);
+                }
+                FormatOnSaveRequest::Cancelled => {
+                    self.resume_insert_transaction_after_save(resume_insert_transaction);
+                    return Ok(false);
+                }
+            }
+        }
+        let save_result = self.current_buffer_mut().save();
+        self.resume_insert_transaction_after_save(resume_insert_transaction);
+
+        match save_result {
+            Ok(msg) => {
+                // TODO: use last_message instead of last_error
+                self.last_error = Some(format_warning.unwrap_or(msg));
+
+                // Notify plugins about file save
+                if let Some(file) = &self.current_buffer().file {
+                    let save_info = serde_json::json!({
+                        "file": file,
+                        "buffer_index": self.buffer_manager.active_index()
+                    });
+                    self.plugin_registry
+                        .notify(runtime, "file:saved", save_info)
+                        .await?;
+                }
+            }
+            Err(e) => {
+                self.last_error = Some(e.to_string());
+            }
+        }
+        Ok(true)
+    }
+
+    #[inline(never)]
+    fn save_as_action<'a>(
+        &'a mut self,
+        new_file_name: &'a str,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<bool>> {
+        Box::pin(self.save_as_action_impl(new_file_name, buffer, runtime))
+    }
+
+    async fn save_as_action_impl(
+        &mut self,
+        new_file_name: &str,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        if self
+            .scratch_buffers
+            .contains_key(&self.current_buffer().id())
+        {
+            self.last_error =
+                Some("Scratch buffers cannot be written to disk; use :w to submit".to_string());
+            return Ok(false);
+        }
+        let previous_uri = self.current_buffer().uri()?;
+        let previous_file = self.current_buffer().file.clone();
+        let resume_insert_transaction = self.commit_active_transaction_before_save();
+        let format_on_save = self.config.formatting.on_save || self.config.lsp.format_on_save;
+        let mut format_warning = None;
+        let mut use_lsp = format_on_save;
+        if format_on_save && self.config.formatting.provider != FormattingProvider::Lsp {
+            let external = self
+                .external_format_on_save(Some(new_file_name), runtime)
+                .await;
+            use_lsp = external.use_lsp;
+            format_warning = external.warning;
+            if external.changed {
+                self.render(buffer)?;
+            }
+        }
+        if format_on_save && use_lsp {
+            let request = self
+                .request_format_on_save(Some(new_file_name.to_string()))
+                .await;
+            let request = match request {
+                Ok(request) => request,
+                Err(error) => {
+                    self.resume_insert_transaction_after_save(resume_insert_transaction);
+                    return Err(error);
+                }
+            };
+            match request {
+                FormatOnSaveRequest::Pending => {
+                    self.resume_insert_transaction_after_save(resume_insert_transaction);
+                    return Ok(false);
+                }
+                FormatOnSaveRequest::Save { warning } => {
+                    format_warning = warning.or(format_warning);
+                }
+                FormatOnSaveRequest::Cancelled => {
+                    self.resume_insert_transaction_after_save(resume_insert_transaction);
+                    return Ok(false);
+                }
+            }
+        }
+        let save_result = self.current_buffer_mut().save_as(new_file_name);
+        self.resume_insert_transaction_after_save(resume_insert_transaction);
+
+        match save_result {
+            Ok(msg) => {
+                // TODO: use last_message instead of last_error
+                self.last_error = Some(format_warning.unwrap_or(msg));
+                if let Err(error) = self
+                    .sync_lsp_document_identity(
+                        previous_uri.as_deref(),
+                        self.buffer_manager.active_index(),
+                    )
+                    .await
+                {
+                    if !format_on_save
+                        || !use_lsp
+                        || !matches!(
+                            error.downcast_ref::<crate::lsp::LspError>(),
+                            Some(
+                                crate::lsp::LspError::ProtocolError(_)
+                                    | crate::lsp::LspError::RequestTimeout(_)
+                            )
+                        )
+                    {
+                        return Err(error);
+                    }
+                    log!(
+                        "{}",
+                        json!({
+                            "event": "lsp_format_on_save_fallback",
+                            "level": "warn",
+                            "service": "red",
+                            "stage": "sync_document_identity",
+                            "error": error.to_string(),
+                        })
+                    );
+                    self.last_error = Some(format!(
+                        "format-on-save unavailable; saved unformatted: {error}"
+                    ));
+                }
+                let saved_file = self
+                    .current_buffer()
+                    .file
+                    .clone()
+                    .unwrap_or_else(|| new_file_name.to_string());
+
+                // Notify plugins about file save
+                let save_info = serde_json::json!({
+                    "file": saved_file,
+                    "buffer_index": self.buffer_manager.active_index()
+                });
+                self.plugin_registry
+                    .notify(runtime, "file:saved", save_info)
+                    .await?;
+            }
+            Err(e) => {
+                if format_on_save && use_lsp {
+                    if let Some(target_uri) = self.current_buffer().uri()? {
+                        self.restore_lsp_format_save_identity(
+                            self.current_buffer().id(),
+                            &target_uri,
+                            previous_file,
+                        )
+                        .await;
+                    }
+                }
+                self.last_error = Some(e.to_string());
+            }
+        }
+        Ok(true)
+    }
+
+    #[inline(never)]
+    fn format_document_action<'a>(
+        &'a mut self,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(self.format_document_action_impl(buffer, runtime))
+    }
+
+    async fn format_document_action_impl(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let Some(file) = self.current_buffer().file.clone() else {
+            return Ok(());
+        };
+        let provider = self.config.formatting.provider;
+        if provider != FormattingProvider::Lsp {
+            match self
+                .format_current_buffer_with_external(&file, runtime)
+                .await
+            {
+                Ok(ExternalFormatOutcome::Applied { name }) => {
+                    self.last_error = Some(format!("formatted with {name}"));
+                    self.render(buffer)?;
+                    return Ok(());
+                }
+                Ok(ExternalFormatOutcome::Unchanged { name }) => {
+                    self.last_error = Some(format!("already formatted with {name}"));
+                    return Ok(());
+                }
+                Ok(ExternalFormatOutcome::Unavailable { name })
+                    if provider == FormattingProvider::External =>
+                {
+                    self.last_error = Some(format!(
+                        "formatter {name} is not installed or not executable"
+                    ));
+                    return Ok(());
+                }
+                Ok(ExternalFormatOutcome::NotConfigured)
+                    if provider == FormattingProvider::External =>
+                {
+                    self.last_error =
+                        Some("no external formatter is configured for this language".to_string());
+                    return Ok(());
+                }
+                Err(error) => {
+                    self.last_error = Some(error.to_string());
+                    return Ok(());
+                }
+                Ok(
+                    ExternalFormatOutcome::Unavailable { .. }
+                    | ExternalFormatOutcome::NotConfigured,
+                ) => {}
+            }
+        }
+        let Some(uri) = self.current_buffer().uri()? else {
+            return Ok(());
+        };
+        let pending = PendingLspEdit {
+            buffer_id: self.current_buffer().id(),
+            revision: self.current_buffer().revision(),
+            uri,
+        };
+        self.ensure_current_buffer_lsp_opened().await?;
+        let indentation = self.indentation();
+        let request_id = self
+            .lsp
+            .format_document_with_options(&file, indentation.tab_width, indentation.expand_tab)
+            .await?;
+        if request_id > 0 {
+            self.pending_lsp_edit_requests.insert(request_id, pending);
+        } else {
+            self.last_error = Some("no language server is available for this file".to_string());
+        }
+        Ok(())
+    }
+
+    fn formatter_definition_for_file(&self, file: &str) -> Option<&LanguageFormatterConfig> {
+        let language = self
+            .highlighter
+            .language_id_for_file(Some(file))
+            .map(str::to_string)
+            .or_else(|| self.current_language_id())?;
+        self.config
+            .languages
+            .get(&language)
+            .and_then(|definition| definition.formatter.as_ref())
+    }
+
+    fn formatter_for_file(&self, file: &str) -> Option<LanguageFormatterConfig> {
+        self.formatter_definition_for_file(file).cloned()
+    }
+
+    async fn format_current_buffer_with_external(
+        &mut self,
+        file: &str,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<ExternalFormatOutcome> {
+        let Some(definition) = self.formatter_for_file(file) else {
+            return Ok(ExternalFormatOutcome::NotConfigured);
+        };
+        let name = if definition.name.trim().is_empty() {
+            definition.command.clone()
+        } else {
+            definition.name.clone()
+        };
+        let file_path = expand_user_path(file)?;
+        let revision = self.current_buffer().revision();
+        let contents = self.current_buffer().contents();
+        let Some(formatted) =
+            crate::formatter::format_document(&definition, &file_path, &contents).await?
+        else {
+            return Ok(ExternalFormatOutcome::Unavailable { name });
+        };
+        anyhow::ensure!(
+            self.current_buffer().revision() == revision,
+            "formatter result is stale because the document changed"
+        );
+        if formatted.contents == contents {
+            return Ok(ExternalFormatOutcome::Unchanged {
+                name: formatted.name,
+            });
+        }
+
+        let end = self.current_buffer().char_idx_to_position(usize::MAX);
+        self.begin_transaction_with_origin(
+            format!("format with {}", formatted.name),
+            EditOrigin::Formatter {
+                name: formatted.name.clone(),
+            },
+        );
+        self.replace_range(
+            TextRange::new(TextPosition::new(0, 0), end),
+            &formatted.contents,
+        );
+        self.check_bounds();
+        self.refresh_cursor_goal();
+        self.commit_transaction(self.cursor_snapshot());
+        self.notify_change(runtime).await?;
+        Ok(ExternalFormatOutcome::Applied {
+            name: formatted.name,
+        })
+    }
+
+    async fn external_format_on_save(
+        &mut self,
+        file: Option<&str>,
+        runtime: &mut Runtime,
+    ) -> ExternalFormatOnSave {
+        let provider = self.config.formatting.provider;
+        let outcome = match file {
+            Some(file) => {
+                self.format_current_buffer_with_external(file, runtime)
+                    .await
+            }
+            None => Ok(ExternalFormatOutcome::NotConfigured),
+        };
+        match outcome {
+            Ok(ExternalFormatOutcome::Applied { .. }) => ExternalFormatOnSave {
+                use_lsp: false,
+                warning: None,
+                changed: true,
+            },
+            Ok(ExternalFormatOutcome::Unchanged { .. }) => ExternalFormatOnSave {
+                use_lsp: false,
+                warning: None,
+                changed: false,
+            },
+            Ok(ExternalFormatOutcome::Unavailable { name }) => {
+                if provider == FormattingProvider::Auto {
+                    ExternalFormatOnSave {
+                        use_lsp: true,
+                        warning: None,
+                        changed: false,
+                    }
+                } else {
+                    ExternalFormatOnSave {
+                        use_lsp: false,
+                        warning: Some(format!(
+                            "format-on-save unavailable; saved unformatted: formatter {name} is not installed or not executable"
+                        )),
+                        changed: false,
+                    }
+                }
+            }
+            Ok(ExternalFormatOutcome::NotConfigured) => {
+                if provider == FormattingProvider::Auto {
+                    ExternalFormatOnSave {
+                        use_lsp: true,
+                        warning: None,
+                        changed: false,
+                    }
+                } else {
+                    ExternalFormatOnSave {
+                        use_lsp: false,
+                        warning: Some(
+                            "format-on-save unavailable; saved unformatted: no external formatter is configured for this language"
+                                .to_string(),
+                        ),
+                        changed: false,
+                    }
+                }
+            }
+            Err(error) => ExternalFormatOnSave {
+                use_lsp: false,
+                warning: Some(format!(
+                    "format-on-save unavailable; saved unformatted: {error}"
+                )),
+                changed: false,
+            },
+        }
     }
 
     async fn request_format_on_save(
@@ -31481,6 +31753,120 @@ builtin = "rust"
         let mut editor = Editor::with_size(lsp, 60, 12, config, Theme::default(), buffers).unwrap();
         editor.test_disable_terminal_output();
         editor
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn external_formatter_is_undoable_and_runs_before_save() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("document.testfmt");
+        std::fs::write(&path, "hello\n").unwrap();
+        let formatter = root.path().join("uppercase-format");
+        std::fs::write(&formatter, "#!/bin/sh\ntr 'a-z' 'A-Z'\n").unwrap();
+        let mut permissions = std::fs::metadata(&formatter).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&formatter, permissions).unwrap();
+
+        let mut config = Config::default();
+        config.lsp.enabled = false;
+        config.languages.insert(
+            "testfmt".to_string(),
+            crate::config::LanguageConfig {
+                extensions: vec!["testfmt".to_string()],
+                formatter: Some(LanguageFormatterConfig {
+                    name: "Uppercase".to_string(),
+                    command: formatter.to_string_lossy().into_owned(),
+                    root_markers: vec![],
+                    args: vec![],
+                    env: Default::default(),
+                }),
+                ..Default::default()
+            },
+        );
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(
+            Some(path.to_string_lossy().into_owned()),
+            "hello\n".to_string(),
+        );
+        let mut editor =
+            Editor::with_size(lsp, 60, 12, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+
+        editor
+            .test_execute_production_action(Action::FormatDocument)
+            .await
+            .unwrap();
+        assert_eq!(editor.current_buffer().contents(), "HELLO\n");
+        assert_eq!(
+            editor.last_error.as_deref(),
+            Some("formatted with Uppercase")
+        );
+
+        editor
+            .test_execute_production_action(Action::Undo)
+            .await
+            .unwrap();
+        assert_eq!(editor.current_buffer().contents(), "hello\n");
+
+        editor.config.formatting.on_save = true;
+        editor
+            .test_execute_production_action(Action::Save)
+            .await
+            .unwrap();
+        assert_eq!(editor.current_buffer().contents(), "HELLO\n");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "HELLO\n");
+        assert!(!editor.current_buffer().is_dirty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failing_external_formatter_saves_unformatted_without_lsp_fallback() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("document.testfmt");
+        std::fs::write(&path, "disk\n").unwrap();
+        let formatter = root.path().join("failing-format");
+        std::fs::write(&formatter, "#!/bin/sh\necho 'invalid syntax' >&2\nexit 7\n").unwrap();
+        let mut permissions = std::fs::metadata(&formatter).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&formatter, permissions).unwrap();
+
+        let mut config = Config::default();
+        config.lsp.enabled = false;
+        config.formatting.on_save = true;
+        config.languages.insert(
+            "testfmt".to_string(),
+            crate::config::LanguageConfig {
+                extensions: vec!["testfmt".to_string()],
+                formatter: Some(LanguageFormatterConfig {
+                    name: "Failing".to_string(),
+                    command: formatter.to_string_lossy().into_owned(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(
+            Some(path.to_string_lossy().into_owned()),
+            "unformatted\n".to_string(),
+        );
+        let mut editor =
+            Editor::with_size(lsp, 60, 12, config, Theme::default(), vec![buffer]).unwrap();
+        editor.test_disable_terminal_output();
+
+        editor
+            .test_execute_production_action(Action::Save)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "unformatted\n");
+        assert!(editor.last_error.as_deref().is_some_and(|message| {
+            message.contains("saved unformatted") && message.contains("invalid syntax")
+        }));
     }
 
     fn line_diagnostic(

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -28,7 +28,7 @@ use unicode_segmentation::UnicodeSegmentation as _;
 
 use crate::{
     color::{blend_color, ensure_minimum_contrast, Color},
-    config::{CursorShape, KeyAction, PickerIconStyle, StatuslineSection},
+    config::{CursorShape, FormattingProvider, KeyAction, PickerIconStyle, StatuslineSection},
     editor::RenderCommand,
     lsp::{Diagnostic, DiagnosticSeverity},
     plugin::DecorationAnchor,
@@ -121,7 +121,7 @@ struct StatuslineAccent {
     minimum_contrast: Option<f32>,
 }
 
-struct StatuslineContext {
+struct StatuslineContext<'a> {
     mode: String,
     filename: String,
     file_path: Option<String>,
@@ -146,13 +146,13 @@ struct StatuslineContext {
     window_index: String,
     file_size: String,
     agent_activity: Option<String>,
-    formatter: Option<&'static str>,
+    formatter: Option<&'a str>,
     clock: String,
 }
 
 fn statusline_segment(
     section: StatuslineSection,
-    context: &StatuslineContext,
+    context: &StatuslineContext<'_>,
     theme: &Theme,
     icon_style: PickerIconStyle,
     color_icons: bool,
@@ -525,7 +525,7 @@ pub(crate) fn statusline_slot_style(theme: &Theme, index: usize) -> Style {
 
 fn statusline_segments(
     sections: impl IntoIterator<Item = StatuslineSection>,
-    context: &StatuslineContext,
+    context: &StatuslineContext<'_>,
     theme: &Theme,
     icon_style: PickerIconStyle,
     color_icons: bool,
@@ -2804,6 +2804,21 @@ impl Editor {
         let formatter = configured(StatuslineSection::Formatter)
             .then(|| {
                 let file = file_path.as_deref()?;
+                if self.config.formatting.provider != FormattingProvider::Lsp {
+                    if let Some(definition) = self.formatter_definition_for_file(file) {
+                        let path = expand_user_path(file).ok()?;
+                        if crate::formatter::is_available(definition, &path) {
+                            return Some(if definition.name.trim().is_empty() {
+                                definition.command.as_str()
+                            } else {
+                                definition.name.as_str()
+                            });
+                        }
+                        if self.config.formatting.provider == FormattingProvider::External {
+                            return Some("no fmt");
+                        }
+                    }
+                }
                 self.lsp.server_capabilities_for_file(file).map(|_| {
                     if self.lsp.supports_document_formatting(file) {
                         "fmt"

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,0 +1,272 @@
+//! External document formatter discovery and execution.
+//!
+//! Language packs describe stdin-to-stdout tools. Red resolves project-local
+//! executables before `PATH`, launches them without a shell, and bounds each run.
+
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use anyhow::{anyhow, Context};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    process::Command,
+    time::timeout,
+};
+
+use crate::config::LanguageFormatterConfig;
+
+const FORMAT_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_FORMATTED_BYTES: usize = 16 * 1024 * 1024;
+const MAX_ERROR_BYTES: usize = 64 * 1024;
+
+#[derive(Debug)]
+pub struct FormattedDocument {
+    pub name: String,
+    pub contents: String,
+}
+
+/// Returns the workspace used for formatter discovery and execution.
+#[must_use]
+pub fn workspace_root(file: &Path, root_markers: &[String]) -> PathBuf {
+    let parent = file.parent().unwrap_or_else(|| Path::new("."));
+    if !root_markers.is_empty() {
+        for ancestor in parent.ancestors() {
+            if root_markers
+                .iter()
+                .any(|marker| ancestor.join(marker).exists())
+            {
+                return ancestor.to_path_buf();
+            }
+        }
+    }
+    parent.to_path_buf()
+}
+
+/// Resolves an executable, preferring conventional project-local tool directories.
+#[must_use]
+pub fn resolve_command(command: &str, workspace: &Path) -> Option<PathBuf> {
+    let command_path = Path::new(command);
+    if command_path.components().count() > 1 {
+        let candidate = if command_path.is_absolute() {
+            command_path.to_path_buf()
+        } else {
+            workspace.join(command_path)
+        };
+        return executable_candidate(&candidate);
+    }
+
+    for directory in [
+        workspace.join("node_modules/.bin"),
+        workspace.join(".venv/bin"),
+        workspace.join("venv/bin"),
+        workspace.join("vendor/bin"),
+    ] {
+        if let Some(candidate) = executable_candidate(&directory.join(command)) {
+            return Some(candidate);
+        }
+    }
+
+    env::var_os("PATH")
+        .into_iter()
+        .flat_map(|path| env::split_paths(&path).collect::<Vec<_>>())
+        .find_map(|directory| executable_candidate(&directory.join(command)))
+}
+
+fn executable_candidate(path: &Path) -> Option<PathBuf> {
+    if path.is_file() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            if path.metadata().ok()?.permissions().mode() & 0o111 == 0 {
+                return None;
+            }
+        }
+        return Some(path.to_path_buf());
+    }
+    #[cfg(windows)]
+    for extension in ["exe", "cmd", "bat"] {
+        let candidate = path.with_extension(extension);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+async fn read_bounded(
+    mut reader: impl AsyncRead + Unpin,
+    limit: usize,
+) -> std::io::Result<(Vec<u8>, bool)> {
+    let mut result = Vec::with_capacity(limit.min(8192));
+    let mut buffer = [0_u8; 8192];
+    let mut overflowed = false;
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            return Ok((result, overflowed));
+        }
+        let remaining = limit.saturating_sub(result.len());
+        result.extend_from_slice(&buffer[..read.min(remaining)]);
+        overflowed |= read > remaining;
+    }
+}
+
+#[must_use]
+pub fn is_available(config: &LanguageFormatterConfig, file: &Path) -> bool {
+    let workspace = workspace_root(file, &config.root_markers);
+    resolve_command(&config.command, &workspace).is_some()
+}
+
+/// Formats `contents`, returning `None` when the configured executable is unavailable.
+pub async fn format_document(
+    config: &LanguageFormatterConfig,
+    file: &Path,
+    contents: &str,
+) -> anyhow::Result<Option<FormattedDocument>> {
+    let workspace = workspace_root(file, &config.root_markers);
+    let Some(executable) = resolve_command(&config.command, &workspace) else {
+        return Ok(None);
+    };
+    let file = file.to_string_lossy();
+    let workspace_text = workspace.to_string_lossy();
+    let arguments = config.args.iter().map(|argument| {
+        argument
+            .replace("{file}", &file)
+            .replace("{workspace}", &workspace_text)
+    });
+    let environment = config.env.iter().map(|(key, value)| {
+        (
+            key,
+            value
+                .replace("{file}", &file)
+                .replace("{workspace}", &workspace_text),
+        )
+    });
+    let mut command = Command::new(&executable);
+    command
+        .args(arguments)
+        .current_dir(&workspace)
+        .envs(environment)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to launch formatter {}", config.name))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("formatter {} has no stdin", config.name))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("formatter {} has no stdout", config.name))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("formatter {} has no stderr", config.name))?;
+    let input = contents.as_bytes();
+    let run = async move {
+        let write_input = async move {
+            stdin.write_all(input).await?;
+            drop(stdin);
+            Ok::<_, std::io::Error>(())
+        };
+        tokio::join!(
+            write_input,
+            read_bounded(stdout, MAX_FORMATTED_BYTES),
+            read_bounded(stderr, MAX_ERROR_BYTES),
+            child.wait()
+        )
+    };
+    let (write_result, stdout_result, stderr_result, status_result) = timeout(FORMAT_TIMEOUT, run)
+        .await
+        .map_err(|_| anyhow!("formatter {} timed out after 30 seconds", config.name))?;
+    let status = status_result?;
+    let (stdout, stdout_overflowed) = stdout_result?;
+    let (stderr, _) = stderr_result?;
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr);
+        let detail = stderr.trim();
+        return Err(if detail.is_empty() {
+            anyhow!("formatter {} exited with {}", config.name, status)
+        } else {
+            anyhow!("formatter {} exited with {}: {detail}", config.name, status)
+        });
+    }
+    write_result
+        .with_context(|| format!("failed to write document to formatter {}", config.name))?;
+    anyhow::ensure!(
+        !stdout_overflowed,
+        "formatter {} returned more than 16 MiB",
+        config.name
+    );
+    let contents = String::from_utf8(stdout)
+        .with_context(|| format!("formatter {} returned non-UTF-8 output", config.name))?;
+    Ok(Some(FormattedDocument {
+        name: if config.name.trim().is_empty() {
+            config.command.clone()
+        } else {
+            config.name.clone()
+        },
+        contents,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_root_uses_nearest_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let nested = temp.path().join("src/deep");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(temp.path().join("project.toml"), "").unwrap();
+        assert_eq!(
+            workspace_root(
+                &nested.join("main.rs"),
+                &["project.toml".to_string(), ".git".to_string()]
+            ),
+            temp.path()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runs_local_formatter_with_placeholders() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("node_modules/.bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(temp.path().join("project.toml"), "").unwrap();
+        let script = bin.join("test-format");
+        std::fs::write(&script, "#!/bin/sh\ncat | tr 'a-z' 'A-Z'\n").unwrap();
+        let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).unwrap();
+        let file = temp.path().join("src/main.test");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        let config = LanguageFormatterConfig {
+            name: "Test Format".to_string(),
+            command: "test-format".to_string(),
+            args: vec!["{file}".to_string(), "{workspace}".to_string()],
+            root_markers: vec!["project.toml".to_string()],
+            env: Default::default(),
+        };
+
+        let formatted = format_document(&config, &file, "hello\n")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(formatted.name, "Test Format");
+        assert_eq!(formatted.contents, "HELLO\n");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod config;
 pub mod dispatcher;
 pub mod editing;
 pub mod editor;
+pub mod formatter;
 pub mod headless;
 pub mod highlighter;
 mod indent;

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.0",
+  "version": "0.10.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -33,9 +33,15 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.9.0";
-pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] =
-    &["0.4.0", "0.6.0", "0.7.0", "0.8.0", RED_HOST_API_VERSION];
+pub const RED_HOST_API_VERSION: &str = "0.10.0";
+pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
+    "0.4.0",
+    "0.6.0",
+    "0.7.0",
+    "0.8.0",
+    "0.9.0",
+    RED_HOST_API_VERSION,
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PluginModification {

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -37,6 +37,11 @@ pub enum EditOrigin {
         /// Managed language-server key.
         server: String,
     },
+    /// A whole-document change returned by an external formatter.
+    Formatter {
+        /// Human-readable formatter name from the active language pack.
+        name: String,
+    },
 }
 
 /// Zero-based line and Unicode-scalar position used by the canonical edit boundary.


### PR DESCRIPTION
Language packs can currently own grammar and language-server configuration, but formatting remains tied to LSP support. This adds a host capability so each pack can declare its canonical stdin-to-stdout formatter while Red preserves one edit, undo, and save boundary.

- add the optional `languages.*.formatter` contract and bump the host API to `0.10.0` while retaining prior supported minors
- resolve project-local formatter binaries before `PATH`, expand file/workspace placeholders, and run tools directly with bounded I/O and timeouts
- support manual and on-save formatting with `auto`, `external`, and `lsp` provider selection
- apply formatter output as attributed, undoable whole-document edits and surface formatter availability in the statusline
- keep formatter/save futures boxed outside the recursive action dispatcher so formatting schema growth does not regress block replay stack usage

## How to Test

1. Run `cargo test --all-targets --all-features --quiet` and confirm all library and integration targets pass.
2. Run `cargo clippy --all-targets --all-features -- -D warnings` and confirm there are no warnings.
3. Run `cargo test --all-features formatter` and confirm formatter discovery, placeholder expansion, manual formatting, save-time formatting, failure handling, and Save As routing tests pass.
4. Run `cargo test --all-features --test editing dot_repeats_linewise_paste_and_visual_block_insert` and confirm the recursive block-replay regression remains green.