### PR TITLE
ci: streamline pull request validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
-  security-events: write
-  actions: read
-  issues: write # Sometimes needed
-  pull-requests: write # Sometimes needed
 
 env:
   CARGO_TERM_COLOR: always
@@ -68,7 +68,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
 
       - name: Install ripgrep (Linux)
         if: runner.os == 'Linux'
@@ -125,16 +124,13 @@ jobs:
       - name: Run tests
         run: cargo test --all-targets --all-features --verbose
 
-      - name: Run tests (no default features)
-        run: cargo test --all-targets --no-default-features --verbose
-
   clippy:
     name: Clippy (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -149,22 +145,6 @@ jobs:
 
       - name: Deny every Clippy warning
         run: cargo clippy --all-targets --all-features -- -D warnings
-
-  perf:
-    name: Deterministic performance gate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Check bundled Husk callback budget
-        run: cargo run --locked --release --example husk_cursor_bench -- --assert
 
   fmt:
     name: Rustfmt
@@ -288,6 +268,7 @@ jobs:
 
   build:
     name: Build
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -366,18 +347,3 @@ jobs:
         run: |
           python3 scripts/check_markdown_links.py --self-test
           python3 scripts/check_markdown_links.py
-
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Run security audit
-        uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -18,6 +18,10 @@ on:
       - ".github/workflows/release.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,3 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-targets --all-features --verbose
-
-      - name: Run tests (no default features)
-        run: cargo test --all-targets --no-default-features --verbose

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,50 @@
+name: Performance
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/performance.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/husk*/**'
+      - 'examples/husk_cursor_bench.rs'
+      - 'plugins/indent_guides.hk'
+      - 'src/plugin/**'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/performance.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/husk*/**'
+      - 'examples/husk_cursor_bench.rs'
+      - 'plugins/indent_guides.hk'
+      - 'src/plugin/**'
+  schedule:
+    - cron: '47 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  perf:
+    name: Deterministic performance gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check bundled Husk callback budget
+        run: cargo run --locked --release --example husk_cursor_bench -- --assert

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -2,6 +2,7 @@ name: Husk Plugin Check
 
 on:
   push:
+    branches: [main, develop]
     paths:
       - '.github/workflows/plugin-check.yml'
       - 'Cargo.lock'
@@ -27,6 +28,10 @@ on:
       - 'src/config.rs'
       - 'src/plugin/**'
       - 'src/self_check.rs'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   bundled-plugins:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,43 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/security-audit.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - '**/Cargo.toml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/security-audit.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - '**/Cargo.toml'
+  schedule:
+    - cron: '17 7 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run security audit
+        uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR validation currently repeats an equivalent feature configuration, performs release-only work on every change, and can duplicate plugin checks for the same feature-branch update. This keeps the high-signal cross-platform test coverage while moving slower specialized checks off the critical path.

## Summary

- remove the redundant no-default-features test pass from stable and nightly runs
- keep tests cross-platform on PRs, but run only Linux Clippy and defer release builds plus cross-platform Clippy to main/develop pushes
- run the deterministic performance gate and security audit only for relevant paths, weekly schedules, or manual dispatches
- prevent duplicate feature-branch plugin runs and cancel superseded PR workflow runs
- remove unused test-job components and permissions

## How to Test

1. Run actionlint 1.7.12 across .github/workflows and expect no diagnostics.
2. Run python3 scripts/readme_release.py --check and python3 -m unittest tests.test_discord_release; expect both to pass.
3. On this PR, confirm CI still schedules Linux, macOS, and Windows test jobs, schedules only the Ubuntu Clippy job, and skips the release build matrix.
4. Confirm Performance and Security Audit run for this PR because their workflow files changed. On a later source-only PR outside their path filters, confirm they are not scheduled.
5. Push a replacement commit to an open PR and confirm older runs from the same workflow are cancelled.