### PR TITLE
fix(editor): accept command keys as replacements

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -13784,6 +13784,10 @@ impl Editor {
     }
 
     fn handle_visual_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
+        if self.pending_replace {
+            return self.handle_replace_event(ev);
+        }
+
         if let Some(action) = self.handle_character_motion_event(ev) {
             return Some(action);
         }
@@ -13925,6 +13929,10 @@ impl Editor {
     }
 
     fn handle_normal_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
+        if self.pending_replace {
+            return self.handle_replace_event(ev);
+        }
+
         if let Some(action) = self.handle_operator_event(ev) {
             return Some(action);
         }

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -3430,19 +3430,42 @@ async fn test_change_line() {
 
 #[tokio::test]
 async fn test_replace_char() {
-    let mut harness = EditorHarness::with_content("Hello World");
+    let buffer = Buffer::new(None, "Hello World".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
 
-    // Replace character with 'r' - delete char and insert new one
-    harness
-        .execute_action(Action::DeleteCharAtCursorPos)
-        .await
-        .unwrap();
-    harness
-        .execute_action(Action::InsertCharAtCursorPos('J'))
-        .await
-        .unwrap();
+    type_normal_keys(&mut harness, "rJ").await;
+
     harness.assert_buffer_contents("Jello World");
-    harness.assert_mode(Mode::Normal); // Should stay in normal mode
+    harness.assert_mode(Mode::Normal);
+}
+
+#[tokio::test]
+async fn replace_char_accepts_operator_and_character_motion_prefixes() {
+    for replacement in ['d', 'c', 'y', 'f', 't', 'F', 'T'] {
+        let buffer = Buffer::new(None, "abc".to_string());
+        let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+        type_normal_keys(&mut harness, &format!("r{replacement}")).await;
+
+        harness.assert_buffer_contents(&format!("{replacement}bc"));
+        harness.assert_mode(Mode::Normal);
+
+        type_normal_keys(&mut harness, "x").await;
+        harness.assert_buffer_contents("bc");
+    }
+}
+
+#[tokio::test]
+async fn visual_replace_accepts_operator_and_character_motion_prefixes() {
+    for replacement in ['d', 'c', 'y', 'f', 't', 'F', 'T'] {
+        let buffer = Buffer::new(None, "abc".to_string());
+        let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+        type_normal_keys(&mut harness, &format!("vlr{replacement}")).await;
+
+        harness.assert_buffer_contents(&format!("{replacement}{replacement}c"));
+        harness.assert_mode(Mode::Normal);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

The character after Normal or Visual mode `r` should be treated as literal replacement text. Characters that also start operators or find/till motions (`d`, `c`, `y`, `f`, `t`, `F`, and `T`) were intercepted by those command handlers instead, so sequences such as `ry` left the buffer unchanged and started a yank command.

## What Changed

- Give an already-pending replacement priority over operator and character-motion dispatch in Normal and Visual modes.
- Exercise replacement through the real key-event path instead of direct delete/insert actions.
- Cover every replacement character that overlaps an operator or find/till prefix and verify that no pending command state remains afterward.

## How to Test

1. Open a buffer containing `abc` and press `ry` on the first character.
   Expected: the buffer becomes `ybc` and remains in Normal mode.
2. Undo, select the first two characters with `vl`, then press `rf`.
   Expected: the buffer becomes `ffc` and returns to Normal mode.
3. Press `r`, cancel with `Esc`, then press `x`.
   Expected: cancellation leaves the buffer unchanged, and `x` performs a normal character deletion.
4. Run `cargo test --test editing replace_char_accepts_operator_and_character_motion_prefixes -- --exact` and `cargo test --test editing visual_replace_accepts_operator_and_character_motion_prefixes -- --exact`.
   Expected: both focused regression tests pass.
