### PR TITLE
feat(editor): support visual command ranges

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -403,6 +403,7 @@ Esc = { EnterMode = "Normal" }
 
 [keys.visual]
 Esc = { EnterMode = "Normal" }
+":" = { EnterMode = "Command" }
 "y" = [ "Yank", { EnterMode = "Normal" } ]
 "x" = [ "Delete", { EnterMode = "Normal" } ]
 "c" = "ChangeSelection"

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Red Vim compatibility matrix
 
-**Matrix version:** 1.4
+**Matrix version:** 1.5
 **Validated against:** Red 0.5.0, August 2026
 **Status vocabulary:** **supported**, **intentional difference**, **not yet supported**
 
@@ -20,8 +20,8 @@ the corresponding integration tests.
 | `r{char}` | **supported** | Replaces one or a counted run of graphemes and is one undoable change. A count longer than the remaining line is rejected without editing. |
 | Editing aliases | **supported** | `D`, `C`, and Neovim-style `Y` operate to line end; `S`, `s`, and `X` provide line/character substitute and backward-delete shortcuts. Counts, default-register kind, undo, and Insert transitions are preserved. `U` is an additional redo alias. |
 | Case changes | **supported** | `~`, `gu{motion}`, `gU{motion}`, `g~{motion}`, and the `guu`/`gUU`/`g~~` line forms transform Unicode text as one transaction. |
-| Join | **supported** | `J` joins at least two lines, removes following indentation, and inserts a space unless trailing whitespace or `)` makes it unnecessary; `gJ` preserves whitespace. Normal counts, Visual joins, `:j[oin][!] [count]`, undo, dot-repeat, and macros are covered. |
-| Ex commands and default-key differences | **intentional difference** | Red implements a documented Ex subset, uses `gW` to toggle wrapping, and uses `Ctrl-e` for NeoTree; these Red-specific defaults can be remapped. `:` enters the command line, while `;` and `W` retain their Vim meanings. Red does not implement Vimscript. |
+| Join | **supported** | `J` joins at least two lines, removes following indentation, and inserts a space unless trailing whitespace or `)` makes it unnecessary; `gJ` preserves whitespace. Normal counts, Visual joins, `:j[oin][!] [count]`, and `%`, numeric, or last-Visual Ex ranges without a separate count are covered alongside undo, dot-repeat, and macros. |
+| Ex commands and default-key differences | **intentional difference** | Red implements a documented Ex subset, uses `gW` to toggle wrapping, and uses `Ctrl-e` for NeoTree; these Red-specific defaults can be remapped. `:` enters the command line and prefills `'<,'>` from Visual mode, while `;` and `W` retain their Vim meanings. Red does not implement Vimscript. |
 
 ## Registers, repeat, and macros
 
@@ -47,6 +47,7 @@ the corresponding integration tests.
 | Restore Visual selection | **supported** | `gv` restores the previous buffer-local Visual area with its character, line, or block shape and original direction. In Visual mode it exchanges the current and previous areas. Selection metadata survives session recovery, while `<` and `>` continue to track edits. |
 | Visual indent | **supported** | `[count]>` and `[count]<` shift every covered line right or left by `count × shiftwidth` in one undoable transaction for character, line, and block selections. Empty lines remain empty, indentation saturates at column zero, and `gv` restores the shifted range. |
 | Visual `r` replace and case changes | **supported** | Visual `r{char}`, `u`, `U`, and `~` replace/change the selection in one transaction, including shifted terminal key events and Visual-line/block selections. |
+| Visual command line | **supported** | `:` captures the selection as `'<` and `'>`, opens Command mode with `'<,'>` prefilled, and supports normal command-line editing and cancellation. Character, line, and block selections produce line-oriented Ex ranges. |
 | Wrapped-line motions | **supported** | `gj`, `gk`, `g0`, `g^`, and `g$`; scroll and cursor state are window-local. |
 
 ## Search, substitution, history, and marks
@@ -55,7 +56,7 @@ the corresponding integration tests.
 |---|---|---|
 | Search | **supported** | `/`, `?`, incremental preview, `n`, `N`, `*`, wrapscan, smartcase/ignorecase, cancellation, and highlight clearing. |
 | Search syntax | **intentional difference** | Patterns use Rust `regex` syntax rather than Vim's regex dialect. |
-| Substitute ranges | **supported** | Current line, `%`, one-based numeric line/range, and `'<,'>` last-visual range. |
+| Substitute ranges | **supported** | Current line, `%`, one-based numeric line/range, and `'<,'>` last-Visual range. Visual `:` prefills that range, so substitution applies to every line touched by character, line, or block selections. |
 | Substitute flags | **supported** | `g`, `i`, and explicit `c` confirmation with `y/n/a/q/l`. All accepted replacements from one command form one transaction. |
 | Substitute syntax | **intentional difference** | Patterns and capture expansion use Rust `regex`; delimiters may be escaped. Vim magic modes, expression replacement, and omitted trailing delimiters are not supported. |
 | Undo/redo | **supported** | Linear, per-buffer transactions with dirty-state checkpoints. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -3602,6 +3602,10 @@ input_position = "left"
         assert_eq!(normal_g.get("v"), restore);
         assert_eq!(visual_g.get("v"), restore);
         assert_eq!(
+            config.keys.visual.get(":"),
+            Some(&KeyAction::Single(Action::EnterMode(Mode::Command)))
+        );
+        assert_eq!(
             config.keys.visual.get(">"),
             Some(&KeyAction::Single(Action::IndentSelection(1)))
         );

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -930,6 +930,12 @@ pub struct SubstituteCommand {
     confirm: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExLineRange {
+    start_line: usize,
+    end_line: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 /// User response while confirming individual substitute matches.
 pub enum SubstituteDecision {
@@ -2197,6 +2203,11 @@ pub enum Action {
     ChangeCharsAtCursor(u16),
     JoinLines(u16),
     JoinLinesKeepSpaces(u16),
+    JoinLinesInRange {
+        start_line: usize,
+        end_line: usize,
+        keep_spaces: bool,
+    },
     ToggleCharCase(u16),
     StartCommentOperator(u16),
     ToggleCommentLines(u16),
@@ -12589,22 +12600,85 @@ impl Editor {
         false
     }
 
-    fn parse_substitute_command(&self, command: &str) -> anyhow::Result<Option<SubstituteCommand>> {
-        let Some(substitute_index) = command.find('s') else {
-            return Ok(None);
-        };
-        let range = &command[..substitute_index];
-        let valid_range = range.is_empty()
-            || range == "%"
-            || range == "'<,'>"
-            || range
-                .split(',')
-                .all(|value| !value.is_empty() && value.chars().all(|c| c.is_ascii_digit()));
-        if !valid_range {
-            return Ok(None);
+    fn split_ex_line_range(command: &str) -> (&str, &str) {
+        if let Some(command) = command.strip_prefix('%') {
+            return ("%", command);
+        }
+        if let Some(command) = command.strip_prefix("'<,'>") {
+            return ("'<,'>", command);
         }
 
-        let body = &command[substitute_index + 1..];
+        let bytes = command.as_bytes();
+        let mut end = bytes
+            .iter()
+            .take_while(|byte| byte.is_ascii_digit())
+            .count();
+        if end == 0 {
+            return ("", command);
+        }
+        if bytes.get(end) == Some(&b',') {
+            let second_start = end + 1;
+            end = second_start
+                + bytes[second_start..]
+                    .iter()
+                    .take_while(|byte| byte.is_ascii_digit())
+                    .count();
+            if end == second_start {
+                return ("", command);
+            }
+        }
+
+        command.split_at(end)
+    }
+
+    fn resolve_ex_line_range(&self, range: &str, operation: &str) -> anyhow::Result<ExLineRange> {
+        let (start_line, end_line) = if range == "%" {
+            (0, self.last_navigable_line())
+        } else if range == "'<,'>" {
+            let buffer_id = self.current_buffer().id();
+            let start = self
+                .special_marks
+                .get(&(buffer_id, '<'))
+                .ok_or_else(|| anyhow::anyhow!("last visual range is not set"))?;
+            let end = self
+                .special_marks
+                .get(&(buffer_id, '>'))
+                .ok_or_else(|| anyhow::anyhow!("last visual range is not set"))?;
+            (
+                start.fallback.line.min(end.fallback.line),
+                start.fallback.line.max(end.fallback.line),
+            )
+        } else {
+            let lines = range
+                .split(',')
+                .map(str::parse::<usize>)
+                .collect::<Result<Vec<_>, _>>()?;
+            let start = lines[0];
+            let end = *lines.get(1).unwrap_or(&start);
+            anyhow::ensure!(
+                start > 0 && end > 0,
+                "{operation} line numbers are one-based"
+            );
+            anyhow::ensure!(start <= end, "{operation} range start exceeds its end");
+            (start - 1, end - 1)
+        };
+
+        anyhow::ensure!(
+            start_line <= self.last_navigable_line(),
+            "{operation} range starts past the end of the buffer"
+        );
+        Ok(ExLineRange {
+            start_line,
+            end_line: end_line.min(self.last_navigable_line()),
+        })
+    }
+
+    fn parse_substitute_command(&self, command: &str) -> anyhow::Result<Option<SubstituteCommand>> {
+        let (range, command) = Self::split_ex_line_range(command);
+        let command = command.trim_start();
+        let Some(body) = command.strip_prefix('s') else {
+            return Ok(None);
+        };
         let Some(delimiter) = body.chars().next() else {
             anyhow::bail!("substitute is missing a delimiter");
         };
@@ -12620,40 +12694,19 @@ impl Editor {
             "unsupported substitute flags: {flags}"
         );
 
-        let (start_line, end_line) = if range.is_empty() {
+        let range = if range.is_empty() {
             let line = self.buffer_line();
-            (line, line)
-        } else if range == "%" {
-            (0, self.last_navigable_line())
-        } else if range == "'<,'>" {
-            let buffer_id = self.current_buffer().id();
-            let start = self
-                .special_marks
-                .get(&(buffer_id, '<'))
-                .ok_or_else(|| anyhow::anyhow!("last visual range is not set"))?;
-            let end = self
-                .special_marks
-                .get(&(buffer_id, '>'))
-                .ok_or_else(|| anyhow::anyhow!("last visual range is not set"))?;
-            (start.fallback.line, end.fallback.line)
+            ExLineRange {
+                start_line: line,
+                end_line: line,
+            }
         } else {
-            let lines = range
-                .split(',')
-                .map(str::parse::<usize>)
-                .collect::<Result<Vec<_>, _>>()?;
-            let start = lines[0];
-            let end = *lines.get(1).unwrap_or(&start);
-            anyhow::ensure!(
-                start > 0 && end > 0,
-                "substitute line numbers are one-based"
-            );
-            anyhow::ensure!(start <= end, "substitute range start exceeds its end");
-            (start - 1, end - 1)
+            self.resolve_ex_line_range(range, "substitute")?
         };
 
         Ok(Some(SubstituteCommand {
-            start_line,
-            end_line,
+            start_line: range.start_line,
+            end_line: range.end_line,
             pattern,
             replacement,
             replace_all: flags.contains('g'),
@@ -12691,6 +12744,55 @@ impl Editor {
                 self.last_error = Some(error.to_string());
                 return Vec::new();
             }
+        }
+
+        let (range, ranged_command) = Self::split_ex_line_range(cmd);
+        let ranged_command = ranged_command.trim_start();
+        let (name, arguments) = ranged_command
+            .split_once(' ')
+            .unwrap_or((ranged_command, ""));
+        let keep_spaces = name.ends_with('!');
+        let name = name.strip_suffix('!').unwrap_or(name);
+        if matches!(name, "j" | "join") {
+            if range.is_empty() {
+                let count = if arguments.trim().is_empty() {
+                    2
+                } else if let Ok(count) = arguments.trim().parse::<u16>() {
+                    count.max(2)
+                } else {
+                    self.last_error = Some("join count must be a positive integer".to_string());
+                    return Vec::new();
+                };
+                return vec![if keep_spaces {
+                    Action::JoinLinesKeepSpaces(count)
+                } else {
+                    Action::JoinLines(count)
+                }];
+            }
+            if !arguments.trim().is_empty() {
+                self.last_error = Some("join count cannot be combined with a range".to_string());
+                return Vec::new();
+            }
+            let range = match self.resolve_ex_line_range(range, "join") {
+                Ok(range) => range,
+                Err(error) => {
+                    self.last_error = Some(error.to_string());
+                    return Vec::new();
+                }
+            };
+            return vec![Action::JoinLinesInRange {
+                start_line: range.start_line,
+                end_line: range.end_line,
+                keep_spaces,
+            }];
+        }
+        if !range.is_empty() {
+            self.last_error = Some(if ranged_command.is_empty() {
+                "line range requires a command".to_string()
+            } else {
+                format!("command {name:?} does not support a line range")
+            });
+            return Vec::new();
         }
 
         if matches!(cmd, "commands" | "command-palette") {
@@ -12759,23 +12861,7 @@ impl Editor {
         }
 
         let (name, arguments) = cmd.split_once(' ').unwrap_or((cmd, ""));
-        let keep_spaces = name.ends_with('!');
         let name = name.strip_suffix('!').unwrap_or(name);
-        if matches!(name, "j" | "join") {
-            let count = if arguments.trim().is_empty() {
-                2
-            } else if let Ok(count) = arguments.trim().parse::<u16>() {
-                count.max(2)
-            } else {
-                self.last_error = Some("join count must be a positive integer".to_string());
-                return Vec::new();
-            };
-            return vec![if keep_spaces {
-                Action::JoinLinesKeepSpaces(count)
-            } else {
-                Action::JoinLines(count)
-            }];
-        }
 
         if matches!(name, "syntax" | "syn" | "ft") {
             let mut arguments = arguments.split_whitespace();
@@ -15838,6 +15924,12 @@ impl Editor {
                 if matches!(new_mode, Mode::Command) {
                     self.reset_command_history_navigation();
                     self.reset_command_completion();
+                    if matches!(
+                        old_mode,
+                        Mode::Visual | Mode::VisualLine | Mode::VisualBlock
+                    ) {
+                        self.command = "'<,'>".to_string();
+                    }
                 }
 
                 self.mode = *new_mode;
@@ -16097,6 +16189,20 @@ impl Editor {
             Action::JoinLines(count) | Action::JoinLinesKeepSpaces(count) => {
                 let keep_spaces = matches!(action, Action::JoinLinesKeepSpaces(_));
                 if self.join_lines(*count, keep_spaces) {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::JoinLinesInRange {
+                start_line,
+                end_line,
+                keep_spaces,
+            } => {
+                if self.join_line_range(
+                    *start_line,
+                    (*end_line).max(start_line.saturating_add(1)),
+                    *keep_spaces,
+                ) {
                     self.notify_change(runtime).await?;
                 }
                 self.render(buffer)?;
@@ -21430,6 +21536,15 @@ impl Editor {
                 start.saturating_add(usize::from(count.max(2).saturating_sub(1))),
             )
         };
+        self.join_line_range(start_line, requested_last_line, keep_spaces)
+    }
+
+    fn join_line_range(
+        &mut self,
+        start_line: usize,
+        requested_last_line: usize,
+        keep_spaces: bool,
+    ) -> bool {
         let last_line = requested_last_line.min(self.last_navigable_line());
         if last_line <= start_line {
             return false;

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1233,6 +1233,56 @@ async fn substitute_supports_current_whole_numeric_and_visual_ranges() {
 }
 
 #[tokio::test]
+async fn visual_colon_prefills_last_visual_range_and_can_be_cancelled() {
+    for mode in [Mode::Visual, Mode::VisualLine, Mode::VisualBlock] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, "one\ntwo\nthree".to_string()),
+            default_key_config(),
+        );
+        harness
+            .execute_action(Action::EnterMode(mode))
+            .await
+            .unwrap();
+        harness.execute_action(Action::MoveDown).await.unwrap();
+
+        command_key(&mut harness, KeyCode::Char(':')).await;
+
+        harness.assert_mode(Mode::Command);
+        assert_eq!(harness.commandline_text(), "'<,'>");
+
+        command_key(&mut harness, KeyCode::Backspace).await;
+        assert_eq!(harness.commandline_text(), "'<,'");
+        command_key(&mut harness, KeyCode::Esc).await;
+        harness.assert_mode(Mode::Normal);
+        assert_eq!(harness.commandline_text(), "");
+    }
+}
+
+#[tokio::test]
+async fn visual_colon_substitute_is_line_scoped_for_every_visual_mode() {
+    for mode in [Mode::Visual, Mode::VisualLine, Mode::VisualBlock] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, "foo foo\nFoo foo\nfoo foo".to_string()),
+            default_key_config(),
+        );
+        harness
+            .execute_action(Action::EnterMode(mode))
+            .await
+            .unwrap();
+        harness.execute_action(Action::MoveDown).await.unwrap();
+
+        command_key(&mut harness, KeyCode::Char(':')).await;
+        type_normal_keys(&mut harness, "s/foo/bar/gi").await;
+        command_key(&mut harness, KeyCode::Enter).await;
+
+        harness.assert_mode(Mode::Normal);
+        harness.assert_buffer_contents("bar bar\nbar bar\nfoo foo");
+        harness.execute_action(Action::Undo).await.unwrap();
+        harness.assert_buffer_contents("foo foo\nFoo foo\nfoo foo");
+    }
+}
+
+#[tokio::test]
 async fn confirmed_substitute_tracks_each_match_and_is_one_undo_transaction() {
     let mut harness = EditorHarness::with_content("foo foo\nalpha beta\nfoo gamma");
     harness
@@ -3850,6 +3900,55 @@ async fn join_ex_command_supports_count_and_bang() {
 
         harness.assert_buffer_contents(expected);
     }
+}
+
+#[tokio::test]
+async fn join_ex_command_supports_numeric_and_visual_ranges() {
+    for (contents, command, expected) in [
+        ("one\ntwo\nthree\nfour", "2join", "one\ntwo three\nfour"),
+        (
+            "one\ntwo\n  three\nfour",
+            "2,3join!",
+            "one\ntwo  three\nfour",
+        ),
+        ("one\n  two\nthree", "%join", "one two three"),
+    ] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, contents.to_string()),
+            default_key_config(),
+        );
+
+        harness
+            .execute_action(Action::Command(command.to_string()))
+            .await
+            .unwrap();
+
+        harness.assert_buffer_contents(expected);
+    }
+
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "one\n  two\nthree".to_string()),
+        default_key_config(),
+    );
+    type_normal_keys(&mut harness, "Vj:join").await;
+    command_key(&mut harness, KeyCode::Enter).await;
+    harness.assert_buffer_contents("one two\nthree");
+}
+
+#[tokio::test]
+async fn unsupported_ranged_command_reports_a_specific_error() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "one\ntwo".to_string()),
+        default_key_config(),
+    );
+    type_normal_keys(&mut harness, "Vj:w").await;
+    command_key(&mut harness, KeyCode::Enter).await;
+
+    assert_eq!(
+        harness.last_error(),
+        Some("command \"w\" does not support a line range")
+    );
+    harness.assert_buffer_contents("one\ntwo");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Visual mode currently has no `:` binding, so selecting text and trying to run an Ex command does nothing. Although substitution already understands the last-Visual marks, users have to leave Visual mode and type the range manually.

This change makes Visual `:` capture the selection and open Command mode with `'<,'>` prefilled. Substitution is line-scoped across character, line, and block selections, and the shared range parser also gives the existing `:join[!]` command `%`, numeric, and last-Visual ranges. Commands that do not support a range now report a specific error instead of falling through as unknown commands.

The Vim compatibility matrix documents the new command-entry and range behavior.

## How to Test

1. Open a buffer containing `foo` on at least three lines, select the first two with `Vj`, and press `:`. The command line should display `:'<,'>`.
2. Enter `s/foo/bar/gi`. Only the selected lines should change, and one `u` should restore all replacements as a single transaction.
3. Select lines with `Vj`, press `:`, and enter `join`. The selected lines should join.
4. Select lines with `Vj`, press `:`, and enter `w`. Red should report `command "w" does not support a line range` without changing the buffer.

Targeted automated coverage: `cargo test --test editing visual_colon` and `cargo test --test editing join_ex_command_supports_numeric_and_visual_ranges`.
