### PR TITLE
fix(editor): match neovim jumplist semantics

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -278,6 +278,7 @@ Esc = { EnterMode = "Normal" }
 "Ctrl-u" = { HalfPageUp = 0 }
 "Ctrl-d" = { HalfPageDown = 0 }
 "Ctrl-o" = "JumpBack"
+"Ctrl-i" = "JumpForward"
 "Tab" = "JumpForward"
 "x" = "DeleteCharAtCursorPos"
 "X" = { DeletePreviousChars = 1 }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -50,7 +50,7 @@ and intentional differences precisely.
 - `zz` centers the current line.
 - `%` jumps to a matching bracket. `g%`, `[%`, and `]%` provide related
   matching-bracket motions.
-- `Ctrl-o` and `Tab` move backward and forward through the jump list.
+- `Ctrl-o` and `Ctrl-i` (or `Tab`) move backward and forward through the current window's jump list.
 - `gj` and `gk` move by screen line when wrapping is enabled.
 
 ## Editing

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -61,7 +61,7 @@ the corresponding integration tests.
 | Substitute syntax | **intentional difference** | Patterns and capture expansion use Rust `regex`; delimiters may be escaped. Vim magic modes, expression replacement, and omitted trailing delimiters are not supported. |
 | Undo/redo | **supported** | Linear, per-buffer transactions with dirty-state checkpoints. |
 | Undo tree | **supported** | Undo followed by a new edit creates a sibling branch. `g-`/`g+` select a sibling deterministically and redo traverses it; `:undotree` opens the small visual navigator. |
-| Jumplist | **supported** | Search and long/file motions record jumps; `Ctrl-o` and `Tab` traverse backward/forward. |
+| Jumplist | **supported** | Search and long/file motions record window-local jumps; splits copy their source window's list, positions follow edits, same-line entries are cleaned up, and `Ctrl-o` / `Ctrl-i` (`Tab`) traverse backward/forward without discarding the forward branch. |
 | Local marks | **supported** | `ma`–`mz`, exact backtick jump, and first-nonblank apostrophe jump. They remain tied to the in-memory buffer and report an error after it is deleted. |
 | Global marks | **supported** | `mA`–`mZ`; an existing marked file is reopened after its buffer closes. A deleted file produces an error and is never recreated by a jump. |
 | Special marks | **supported** | Previous jump (`''`/````), last change (`'.`/``.` ``), and last visual bounds (`'<`, `'>`, `` `< ``, `` `> ``). |

--- a/docs/VIM_DOGFOOD.md
+++ b/docs/VIM_DOGFOOD.md
@@ -15,7 +15,7 @@ At minimum, the week must exercise:
 - named macros, `@@`, counted playback, and dot-repeat across distinct locations;
 - insert, visual, visual-line, and visual-block changes;
 - search, substitution with confirmation, command cancellation, undo, and redo;
-- local/global/special marks and backward/forward jumplist traversal;
+- local/global/special marks and Neovim-style window-local jumplist traversal;
 - Unicode text, an empty buffer, both final-line forms, wrapped lines, and two windows.
 
 ## Issue classification

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -110,7 +110,7 @@ use crate::{
         capture_session_disk_fingerprint, detect_disk_divergence, read_session_disk_contents,
         RecoveryDivergence, SessionAnchorAffinity, SessionBufferSnapshot, SessionDiskFingerprint,
         SessionJump, SessionMark, SessionSnapshot, SessionStore, SessionVisualMode,
-        SessionVisualSelection, SESSION_SCHEMA_VERSION,
+        SessionVisualSelection, SessionWindowJumps, SESSION_SCHEMA_VERSION,
     },
     theme::{parse_vscode_theme, parse_vscode_theme_contents, Style, Theme},
     ui::{
@@ -122,7 +122,7 @@ use crate::{
     undo::{AppliedTextEdit, CursorSnapshot, EditOrigin, RevertEdit, TextPosition, TextRange},
     utils::{expand_user_path, get_workspace_path, normalized_file_path, same_file_path},
     whats_new::ReleaseNotes,
-    window::{WindowDivider, WindowId, WindowManager, WindowManagerSnapshot},
+    window::{JumpEntry, JumpList, WindowDivider, WindowId, WindowManager, WindowManagerSnapshot},
 };
 
 use self::display_layout::{
@@ -3058,13 +3058,6 @@ pub struct Editor {
     /// Indentation rules per file type
     indentation: HashMap<String, Indentation>,
 
-    /// Cursor locations remembered for CTRL-O/CTRL-I style jumps.
-    jump_list: Vec<HistoryEntry>,
-
-    /// Current position in `jump_list`; `jump_list.len()` means the live cursor
-    /// is past the newest recorded jump.
-    jump_index: usize,
-
     /// Pending render commands from plugins
     render_commands: VecDeque<RenderCommand>,
 
@@ -3494,6 +3487,7 @@ struct PathCompletionCandidate {
 #[derive(Debug, Clone)]
 struct SearchSession {
     origin: HistoryEntry,
+    jump_origin: JumpEntry,
     origin_vtop: usize,
     direction: SearchDirection,
     draft: String,
@@ -3630,14 +3624,6 @@ struct ExternalFormatOnSave {
 impl HistoryEntry {
     fn new(file: Option<String>, x: usize, y: usize) -> Self {
         Self { file, x, y }
-    }
-
-    fn same_location(&self, other: &Self) -> bool {
-        self.file == other.file && self.x == other.x && self.y == other.y
-    }
-
-    fn moved_from(&self, other: &Self) -> bool {
-        !self.same_location(other)
     }
 }
 
@@ -4230,8 +4216,6 @@ impl Editor {
             clipboard,
             diagnostics: HashMap::new(),
             indentation,
-            jump_list: Vec::new(),
-            jump_index: 0,
             render_commands: VecDeque::new(),
             overlay_manager: plugin::OverlayManager::new(),
             decoration_manager: plugin::DecorationManager::default(),
@@ -13298,6 +13282,7 @@ impl Editor {
     fn begin_search(&mut self, direction: SearchDirection) {
         self.active_search = Some(SearchSession {
             origin: self.current_history_entry(),
+            jump_origin: self.current_jump_entry(),
             origin_vtop: self.vtop,
             direction,
             draft: String::new(),
@@ -15449,7 +15434,7 @@ impl Editor {
             .ensure_notified_revision(action_buffer_id, action_buffer_revision);
         let event_snapshot_before_action = self.event_snapshot();
         let action_cause = Self::action_cause(action);
-        let history_entry_before_action = self.current_history_entry();
+        let jump_entry_before_action = self.current_jump_entry();
         let picker_handle_before_action = self
             .current_dialog
             .as_ref()
@@ -16560,11 +16545,7 @@ impl Editor {
                 if *mark == '\'' {
                     add_to_history = false;
                     if let Some(entry) = self.jump_back_entry() {
-                        let action = self.action_for_history_entry(&entry);
-                        self.execute_with_tracking(
-                            &action, buffer, runtime, /*tracking*/ false,
-                        )
-                        .await?;
+                        self.jump_to_entry(&entry, buffer, runtime).await?;
                     } else {
                         self.last_error = Some("previous jump is not set".to_string());
                     }
@@ -16944,19 +16925,30 @@ impl Editor {
             }
             Action::DumpHistory => {
                 add_to_history = false;
+                self.clean_jump_list();
+                let (entries, index) = {
+                    let list = self.active_jump_list();
+                    (list.entries.clone(), list.index)
+                };
                 log!("");
                 log!("--------------- JUMP LIST ------------------");
-                for (idx, item) in self.jump_list.iter().enumerate() {
-                    let marker = if idx == self.jump_index { ">" } else { " " };
+                for (idx, item) in entries.iter().enumerate() {
+                    let marker = if idx == index { ">" } else { " " };
+                    let name = self
+                        .buffer_manager
+                        .iter()
+                        .find(|candidate| candidate.id() == item.buffer_id)
+                        .map(|candidate| candidate.name().to_string())
+                        .unwrap_or_else(|| "<unloaded>".to_string());
                     log!(
                         "{} {:<25} | {:>2} {:>2}",
                         marker,
-                        item.file.as_deref().unwrap_or("<unnamed>"),
-                        item.x,
-                        item.y
+                        name,
+                        item.fallback.character,
+                        item.fallback.line
                     );
                 }
-                if self.jump_index == self.jump_list.len() {
+                if index == entries.len() {
                     log!("> <current>");
                 }
                 log!("--------------------------------------------");
@@ -18173,7 +18165,7 @@ impl Editor {
                     self.active_search = None;
                     self.mode = Mode::Normal;
                     self.move_to_search_match(match_);
-                    self.save_to_history(session.origin);
+                    self.save_to_history(session.jump_origin);
                     self.render(buffer)?;
                     self.notify_search_highlighted(runtime, "CommitSearch")
                         .await?;
@@ -18777,9 +18769,7 @@ impl Editor {
                 add_to_history = false;
                 if let Some(entry) = self.jump_back_entry() {
                     log!("jumping back to {entry:?}");
-                    let action = self.action_for_history_entry(&entry);
-                    self.execute_with_tracking(&action, buffer, runtime, false)
-                        .await?;
+                    self.jump_to_entry(&entry, buffer, runtime).await?;
                 } else {
                     self.last_error = Some("at start of jump list".to_string());
                     self.draw_commandline(buffer);
@@ -18789,9 +18779,7 @@ impl Editor {
                 add_to_history = false;
                 if let Some(entry) = self.jump_forward_entry() {
                     log!("jumping forward to {entry:?}");
-                    let action = self.action_for_history_entry(&entry);
-                    self.execute_with_tracking(&action, buffer, runtime, false)
-                        .await?;
+                    self.jump_to_entry(&entry, buffer, runtime).await?;
                 } else {
                     self.last_error = Some("at end of jump list".to_string());
                     self.draw_commandline(buffer);
@@ -19075,7 +19063,7 @@ impl Editor {
         }
 
         if add_to_history && Self::records_jump(action) {
-            self.save_to_history(history_entry_before_action);
+            self.save_to_history(jump_entry_before_action);
         }
 
         if self.current_buffer().id() == action_buffer_id
@@ -19166,10 +19154,11 @@ impl Editor {
                 | Action::RepeatSearch
                 | Action::RepeatSearchOpposite
                 | Action::SearchWordUnderCursor
-                | Action::PageDown
-                | Action::PageUp
                 | Action::MoveToBottom
                 | Action::MoveToTop
+                | Action::MoveToViewportTop(_)
+                | Action::MoveToViewportMiddle
+                | Action::MoveToViewportBottom(_)
                 | Action::MoveToFilePercent(_)
                 | Action::MatchitForward
                 | Action::MatchitBackward
@@ -19182,88 +19171,182 @@ impl Editor {
                 | Action::JumpToMark { .. }
                 | Action::OpenLocation(_, _)
                 | Action::OpenFile(_)
+                | Action::SplitHorizontalWithFile(_)
+                | Action::SplitVerticalWithFile(_)
                 | Action::NextBuffer
                 | Action::PreviousBuffer
         )
     }
 
-    fn action_for_history_entry(&self, entry: &HistoryEntry) -> Action {
-        match &entry.file {
-            Some(file) if self.current_buffer().file.as_ref() != Some(file) => {
-                Action::MoveToFilePos(file.clone(), entry.x, entry.y + 1)
-            }
-            _ => Action::MoveTo(entry.x, entry.y + 1),
+    fn active_jump_list(&self) -> &JumpList {
+        &self
+            .window_manager
+            .active_window()
+            .expect("editor must always retain an active window")
+            .jump_list
+    }
+
+    fn active_jump_list_mut(&mut self) -> &mut JumpList {
+        &mut self
+            .window_manager
+            .active_window_mut()
+            .expect("editor must always retain an active window")
+            .jump_list
+    }
+
+    fn current_jump_entry(&self) -> JumpEntry {
+        let fallback = self.cursor_text_position();
+        JumpEntry {
+            buffer_id: self.current_buffer().id(),
+            char_index: self.current_buffer().position_to_char_idx(fallback),
+            fallback,
         }
     }
 
-    fn save_to_history(&mut self, entry: HistoryEntry) {
-        let current = self.current_history_entry();
-        if entry.same_location(&current) {
+    fn clean_jump_list(&mut self) {
+        let valid_buffers = self
+            .buffer_manager
+            .iter()
+            .map(Buffer::id)
+            .collect::<HashSet<_>>();
+        let current_buffer_id = self.current_buffer().id();
+        let current_line = self.buffer_line();
+        let list = self.active_jump_list_mut();
+        let old_index = list.index.min(list.entries.len());
+        let mut keep = vec![false; list.entries.len()];
+
+        for (from, entry) in list.entries.iter().enumerate() {
+            if !valid_buffers.contains(&entry.buffer_id) {
+                continue;
+            }
+            let duplicate_ahead = list.entries[from + 1..].iter().any(|later| {
+                later.buffer_id == entry.buffer_id && later.fallback.line == entry.fallback.line
+            });
+            keep[from] = !duplicate_ahead;
+        }
+
+        let new_index = keep
+            .iter()
+            .take(old_index)
+            .filter(|keep_entry| **keep_entry)
+            .count();
+        let mut position = 0;
+        list.entries.retain(|_| {
+            let retain = keep[position];
+            position += 1;
+            retain
+        });
+        list.index = new_index.min(list.entries.len());
+
+        if list.index == list.entries.len()
+            && list.entries.last().is_some_and(|last| {
+                last.buffer_id == current_buffer_id && last.fallback.line == current_line
+            })
+        {
+            list.entries.pop();
+            list.index = list.entries.len();
+        }
+    }
+
+    fn forget_jumps_for_buffer(&mut self, buffer_id: BufferId) {
+        for window in self.window_manager.windows_mut() {
+            let old_index = window.jump_list.index.min(window.jump_list.entries.len());
+            let retained_before_index = window.jump_list.entries[..old_index]
+                .iter()
+                .filter(|entry| entry.buffer_id != buffer_id)
+                .count();
+            window
+                .jump_list
+                .entries
+                .retain(|entry| entry.buffer_id != buffer_id);
+            window.jump_list.index = retained_before_index.min(window.jump_list.entries.len());
+        }
+    }
+
+    fn save_to_history(&mut self, entry: JumpEntry) {
+        let current = self.current_jump_entry();
+        if entry.buffer_id == current.buffer_id && entry.char_index == current.char_index {
             return;
         }
-
-        if self.jump_index < self.jump_list.len() {
-            self.jump_list.truncate(self.jump_index + 1);
-        }
-
-        if let Some(prev) = self.jump_list.last() {
-            if !entry.moved_from(prev) {
-                self.jump_index = self.jump_list.len();
-                return;
-            }
-        }
-
         self.push_history_entry(entry);
     }
 
     fn push_current_history_entry(&mut self) {
-        let entry = self.current_history_entry();
-        if self
-            .jump_list
-            .last()
-            .is_some_and(|prev| prev.same_location(&entry))
-        {
-            self.jump_index = self.jump_list.len();
-            return;
-        }
-        self.push_history_entry(entry);
+        self.push_history_entry(self.current_jump_entry());
     }
 
-    fn push_history_entry(&mut self, entry: HistoryEntry) {
-        self.jump_list.push(entry);
-        if self.jump_list.len() > JUMPLIST_SIZE {
-            self.jump_list.remove(0);
+    fn push_history_entry(&mut self, entry: JumpEntry) {
+        let list = self.active_jump_list_mut();
+        list.entries.push(entry);
+        if list.entries.len() > JUMPLIST_SIZE {
+            list.entries.remove(0);
         }
-        self.jump_index = self.jump_list.len();
+        list.index = list.entries.len();
     }
 
-    fn jump_back_entry(&mut self) -> Option<HistoryEntry> {
-        if self.jump_index == self.jump_list.len() {
-            if self.jump_list.is_empty() {
+    fn jump_back_entry(&mut self) -> Option<JumpEntry> {
+        self.clean_jump_list();
+        if self.active_jump_list().index == self.active_jump_list().entries.len() {
+            if self.active_jump_list().entries.is_empty() {
                 return None;
             }
             self.push_current_history_entry();
-            if self.jump_list.len() < 2 {
+            let list = self.active_jump_list_mut();
+            if list.entries.len() < 2 {
                 return None;
             }
-            self.jump_index = self.jump_list.len() - 2;
+            list.index = list.entries.len() - 2;
         } else {
-            if self.jump_index == 0 {
+            let list = self.active_jump_list_mut();
+            if list.index == 0 {
                 return None;
             }
-            self.jump_index -= 1;
+            list.index -= 1;
         }
 
-        self.jump_list.get(self.jump_index).cloned()
+        let list = self.active_jump_list();
+        list.entries.get(list.index).cloned()
     }
 
-    fn jump_forward_entry(&mut self) -> Option<HistoryEntry> {
-        if self.jump_list.is_empty() || self.jump_index >= self.jump_list.len().saturating_sub(1) {
+    fn jump_forward_entry(&mut self) -> Option<JumpEntry> {
+        self.clean_jump_list();
+        let list = self.active_jump_list_mut();
+        if list.entries.is_empty() || list.index >= list.entries.len().saturating_sub(1) {
             return None;
         }
 
-        self.jump_index += 1;
-        self.jump_list.get(self.jump_index).cloned()
+        list.index += 1;
+        list.entries.get(list.index).cloned()
+    }
+
+    async fn jump_to_entry(
+        &mut self,
+        entry: &JumpEntry,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let Some(buffer_index) = self
+            .buffer_manager
+            .iter()
+            .position(|candidate| candidate.id() == entry.buffer_id)
+        else {
+            return Ok(());
+        };
+
+        if self.buffer_manager.active_index() != buffer_index {
+            self.set_current_buffer(buffer, buffer_index).await?;
+        }
+        let position = self.current_buffer().char_idx_to_position(entry.char_index);
+        let line = self.current_buffer().get(position.line).unwrap_or_default();
+        let x = char_to_grapheme(trim_line_ending(&line), position.character);
+        self.execute_with_tracking(
+            &Action::MoveTo(x, position.line + 1),
+            buffer,
+            runtime,
+            false,
+        )
+        .await?;
+        Ok(())
     }
 
     /// Move to the top line of the selection
@@ -20073,6 +20156,7 @@ impl Editor {
 
         self.sync_to_window();
         let removed_id = self.current_buffer().id();
+        self.forget_jumps_for_buffer(removed_id);
         self.scratch_buffers.remove(&removed_id);
         let removed_uri = self.current_buffer().uri()?;
         if let Some(uri) = removed_uri.as_deref() {
@@ -21210,6 +21294,26 @@ impl Editor {
                 );
             }
         }
+        for window in self.window_manager.windows_mut() {
+            for entry in &mut window.jump_list.entries {
+                if entry.buffer_id == buffer_id {
+                    let mut anchor = EditAnchor {
+                        buffer_id: entry.buffer_id,
+                        file: None,
+                        char_index: entry.char_index,
+                        fallback: entry.fallback,
+                        affinity: AnchorAffinity::Right,
+                    };
+                    Self::transform_anchor_for_edit(
+                        &mut anchor,
+                        edit.start_char,
+                        edit.end_char,
+                        edit.new_char_len,
+                    );
+                    entry.char_index = anchor.char_index;
+                }
+            }
+        }
 
         let buffer = self.current_buffer();
         let fallback_positions = self
@@ -21228,12 +21332,16 @@ impl Editor {
                     .filter(|((anchor_buffer_id, _), _)| *anchor_buffer_id == buffer_id)
                     .map(|(_, anchor)| anchor),
             )
-            .map(|anchor| {
-                (
-                    anchor.char_index,
-                    buffer.char_idx_to_position(anchor.char_index),
-                )
-            })
+            .map(|anchor| anchor.char_index)
+            .chain(
+                self.window_manager
+                    .windows()
+                    .into_iter()
+                    .flat_map(|window| window.jump_list.entries.iter())
+                    .filter(|entry| entry.buffer_id == buffer_id)
+                    .map(|entry| entry.char_index),
+            )
+            .map(|char_index| (char_index, buffer.char_idx_to_position(char_index)))
             .collect::<HashMap<_, _>>();
         let update_fallback = |anchor: &mut EditAnchor| {
             if let Some(position) = fallback_positions.get(&anchor.char_index) {
@@ -21252,6 +21360,18 @@ impl Editor {
             .filter(|((anchor_buffer_id, _), _)| *anchor_buffer_id == buffer_id)
             .map(|(_, anchor)| anchor)
             .for_each(update_fallback);
+        for window in self.window_manager.windows_mut() {
+            window
+                .jump_list
+                .entries
+                .iter_mut()
+                .filter(|entry| entry.buffer_id == buffer_id)
+                .for_each(|entry| {
+                    if let Some(position) = fallback_positions.get(&entry.char_index) {
+                        entry.fallback = *position;
+                    }
+                });
+        }
     }
 
     fn replace_range(&mut self, range: TextRange, new_text: &str) {
@@ -21956,16 +22076,38 @@ impl Editor {
         });
         self.panel_manager.stage_restore(snapshot.panels.clone());
         self.registers = snapshot.registers.clone();
-        self.jump_list = snapshot
-            .jumps
+        let saved_window_jumps = if snapshot.window_jumps.is_empty() {
+            vec![SessionWindowJumps {
+                window_index: self.window_manager.active_window_id(),
+                jumps: snapshot.jumps.clone(),
+                jump_index: snapshot.jump_index,
+            }]
+        } else {
+            snapshot.window_jumps.clone()
+        };
+        let restored_window_jumps = saved_window_jumps
             .iter()
-            .map(|jump| HistoryEntry {
-                file: jump.file.clone(),
-                x: jump.x,
-                y: jump.y,
+            .map(|saved| {
+                let entries = saved
+                    .jumps
+                    .iter()
+                    .filter_map(|jump| self.restore_session_jump(jump, &buffer_map))
+                    .collect::<Vec<_>>();
+                (
+                    saved.window_index,
+                    JumpList {
+                        index: saved.jump_index.min(entries.len()),
+                        entries,
+                    },
+                )
             })
-            .collect();
-        self.jump_index = snapshot.jump_index.min(self.jump_list.len());
+            .collect::<Vec<_>>();
+        let mut windows = self.window_manager.windows_mut();
+        for (window_index, jump_list) in restored_window_jumps {
+            if let Some(window) = windows.get_mut(window_index) {
+                *window.jump_list = jump_list;
+            }
+        }
         self.local_marks.clear();
         self.global_marks.clear();
         self.special_marks.clear();
@@ -22146,6 +22288,36 @@ impl Editor {
         })
     }
 
+    fn restore_session_jump(
+        &self,
+        jump: &SessionJump,
+        buffer_map: &HashMap<usize, usize>,
+    ) -> Option<JumpEntry> {
+        let buffer_index = jump
+            .buffer_index
+            .and_then(|saved| buffer_map.get(&saved).copied())
+            .or_else(|| {
+                jump.file.as_ref().and_then(|file| {
+                    self.buffer_manager
+                        .iter()
+                        .position(|buffer| buffer.file.as_ref() == Some(file))
+                })
+            })
+            .unwrap_or_else(|| self.buffer_manager.active_index());
+        let buffer = self.buffer_manager.get(buffer_index)?;
+        let char_index = jump.char_index.unwrap_or_else(|| {
+            let line = buffer.get(jump.y).unwrap_or_default();
+            let character = grapheme_to_char(trim_line_ending(&line), jump.x);
+            buffer.position_to_char_idx(TextPosition::new(jump.y, character))
+        });
+        let fallback = buffer.char_idx_to_position(char_index);
+        Some(JumpEntry {
+            buffer_id: buffer.id(),
+            char_index: buffer.position_to_char_idx(fallback),
+            fallback,
+        })
+    }
+
     fn durable_session_snapshot(
         &mut self,
         include_disk_contents: bool,
@@ -22223,6 +22395,34 @@ impl Editor {
             .enumerate()
             .map(|(index, buffer)| (buffer.id(), index))
             .collect::<HashMap<_, _>>();
+        let window_jumps = self
+            .window_manager
+            .windows()
+            .into_iter()
+            .enumerate()
+            .map(|(window_index, window)| {
+                let jumps = window
+                    .jump_list
+                    .entries
+                    .iter()
+                    .filter_map(|jump| self.snapshot_jump(jump, &buffer_indices))
+                    .collect::<Vec<_>>();
+                SessionWindowJumps {
+                    window_index,
+                    jump_index: window.jump_list.index.min(jumps.len()),
+                    jumps,
+                }
+            })
+            .collect::<Vec<_>>();
+        let active_window_jumps = window_jumps
+            .iter()
+            .find(|saved| saved.window_index == self.window_manager.active_window_id());
+        let jumps = active_window_jumps
+            .map(|saved| saved.jumps.clone())
+            .unwrap_or_default();
+        let jump_index = active_window_jumps
+            .map(|saved| saved.jump_index)
+            .unwrap_or_default();
         let local_marks = self
             .local_marks
             .values()
@@ -22276,16 +22476,9 @@ impl Editor {
                 window_layout: self.window_manager.snapshot(),
                 panels: self.panel_manager.snapshot(usize::from(self.size.0)),
                 registers: self.registers.clone(),
-                jumps: self
-                    .jump_list
-                    .iter()
-                    .map(|jump| SessionJump {
-                        file: jump.file.clone(),
-                        x: jump.x,
-                        y: jump.y,
-                    })
-                    .collect(),
-                jump_index: self.jump_index,
+                jumps,
+                jump_index,
+                window_jumps,
                 local_marks,
                 global_marks,
                 special_marks,
@@ -22317,6 +22510,24 @@ impl Editor {
                 AnchorAffinity::Left => SessionAnchorAffinity::Left,
                 AnchorAffinity::Right => SessionAnchorAffinity::Right,
             },
+        })
+    }
+
+    fn snapshot_jump(
+        &self,
+        jump: &JumpEntry,
+        buffer_indices: &HashMap<BufferId, usize>,
+    ) -> Option<SessionJump> {
+        let buffer_index = *buffer_indices.get(&jump.buffer_id)?;
+        let buffer = self.buffer_manager.get(buffer_index)?;
+        let fallback = buffer.char_idx_to_position(jump.char_index);
+        let line = buffer.get(fallback.line).unwrap_or_default();
+        Some(SessionJump {
+            file: buffer.file.clone(),
+            x: char_to_grapheme(trim_line_ending(&line), fallback.character),
+            y: fallback.line,
+            buffer_index: Some(buffer_index),
+            char_index: Some(jump.char_index),
         })
     }
 
@@ -35218,7 +35429,7 @@ while True:
         assert_eq!(editor.buffer_line(), 1);
         assert_eq!(editor.cx, 2);
         assert_eq!(editor.buffer_manager.len(), 2);
-        assert!(!editor.jump_list.is_empty());
+        assert!(!editor.active_jump_list().entries.is_empty());
 
         editor
             .execute(

--- a/src/session.rs
+++ b/src/session.rs
@@ -98,6 +98,9 @@ pub struct SessionSnapshot {
     /// Current position in [`Self::jumps`].
     #[serde(default)]
     pub jump_index: usize,
+    /// Per-window jumplists in split-tree order.
+    #[serde(default)]
+    pub window_jumps: Vec<SessionWindowJumps>,
     /// Buffer-local marks.
     #[serde(default)]
     pub local_marks: Vec<SessionMark>,
@@ -173,6 +176,23 @@ pub struct SessionJump {
     pub x: usize,
     /// Zero-based line.
     pub y: usize,
+    /// Saved buffer index, which distinguishes unnamed buffers.
+    #[serde(default)]
+    pub buffer_index: Option<usize>,
+    /// Absolute Unicode scalar position used by edit-tracked jump entries.
+    #[serde(default)]
+    pub char_index: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// One window's durable jumplist state.
+pub struct SessionWindowJumps {
+    /// Window position in split-tree traversal order.
+    pub window_index: usize,
+    /// Jump destinations in traversal order.
+    pub jumps: Vec<SessionJump>,
+    /// Current position in [`Self::jumps`].
+    pub jump_index: usize,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -2289,6 +2309,7 @@ mod tests {
             registers: HashMap::new(),
             jumps: Vec::new(),
             jump_index: 0,
+            window_jumps: Vec::new(),
             local_marks: Vec::new(),
             global_marks: Vec::new(),
             special_marks: Vec::new(),

--- a/src/window.rs
+++ b/src/window.rs
@@ -9,7 +9,11 @@
 //! columns. Buffer mutation and cursor validity remain editor responsibilities; this
 //! module only owns per-window presentation and split topology.
 
-use crate::editor::{CursorGoal, Point};
+use crate::{
+    buffer::BufferId,
+    editor::{CursorGoal, Point},
+    undo::TextPosition,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -158,6 +162,24 @@ pub struct Window {
 
     /// X offset of the viewport (for horizontal positioning)
     pub vx: usize,
+
+    /// Cursor locations remembered for CTRL-O/CTRL-I navigation in this window.
+    pub(crate) jump_list: Box<JumpList>,
+}
+
+/// One edit-tracked destination in a window's jumplist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JumpEntry {
+    pub(crate) buffer_id: BufferId,
+    pub(crate) char_index: usize,
+    pub(crate) fallback: TextPosition,
+}
+
+/// Window-local jumplist and its current traversal position.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct JumpList {
+    pub(crate) entries: Vec<JumpEntry>,
+    pub(crate) index: usize,
 }
 
 impl Window {
@@ -186,6 +208,7 @@ impl Window {
             cursor_goal: CursorGoal::default(),
             active: false,
             vx: 0,
+            jump_list: Box::default(),
         }
     }
 
@@ -962,13 +985,13 @@ impl Split {
     }
 
     /// Removes a leaf without recreating windows or changing surviving split ratios.
-    fn detach_window(self, target_id: WindowId) -> Result<(Option<Self>, Window), Self> {
+    fn detach_window(self, target_id: WindowId) -> Result<(Option<Self>, Window), Box<Self>> {
         match self {
             Self::Window(window) => {
                 if window.id == target_id {
                     Ok((None, window))
                 } else {
-                    Err(Self::Window(window))
+                    Err(Box::new(Self::Window(window)))
                 }
             }
             Self::Horizontal { top, bottom, ratio } => match (*top).detach_window(target_id) {
@@ -984,18 +1007,14 @@ impl Split {
                 Err(top) => match (*bottom).detach_window(target_id) {
                     Ok((Some(bottom), window)) => Ok((
                         Some(Self::Horizontal {
-                            top: Box::new(top),
+                            top,
                             bottom: Box::new(bottom),
                             ratio,
                         }),
                         window,
                     )),
-                    Ok((None, window)) => Ok((Some(top), window)),
-                    Err(bottom) => Err(Self::Horizontal {
-                        top: Box::new(top),
-                        bottom: Box::new(bottom),
-                        ratio,
-                    }),
+                    Ok((None, window)) => Ok((Some(*top), window)),
+                    Err(bottom) => Err(Box::new(Self::Horizontal { top, bottom, ratio })),
                 },
             },
             Self::Vertical { left, right, ratio } => match (*left).detach_window(target_id) {
@@ -1011,18 +1030,14 @@ impl Split {
                 Err(left) => match (*right).detach_window(target_id) {
                     Ok((Some(right), window)) => Ok((
                         Some(Self::Vertical {
-                            left: Box::new(left),
+                            left,
                             right: Box::new(right),
                             ratio,
                         }),
                         window,
                     )),
-                    Ok((None, window)) => Ok((Some(left), window)),
-                    Err(right) => Err(Self::Vertical {
-                        left: Box::new(left),
-                        right: Box::new(right),
-                        ratio,
-                    }),
+                    Ok((None, window)) => Ok((Some(*left), window)),
+                    Err(right) => Err(Box::new(Self::Vertical { left, right, ratio })),
                 },
             },
         }
@@ -1755,7 +1770,7 @@ impl WindowManager {
                 return None;
             }
             Err(root) => {
-                self.root = root;
+                self.root = *root;
                 return None;
             }
         };
@@ -2446,6 +2461,7 @@ impl WindowManager {
                     );
                     new_window.active = false;
                     new_window.wrap = window.wrap;
+                    new_window.jump_list = window.jump_list.clone();
 
                     let mut old_window = window.clone();
                     old_window.active = false;

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1162,6 +1162,39 @@ async fn global_mark_reopens_a_closed_file_buffer() {
 }
 
 #[tokio::test]
+async fn jumplist_switches_buffers_but_forgets_a_deleted_buffer() {
+    let first_path = temp_file_path("jumplist-first");
+    let second_path = temp_file_path("jumplist-second");
+    fs::write(&first_path, "one\ntwo\nthree").unwrap();
+    fs::write(&second_path, "alpha\nbeta").unwrap();
+    let buffer = Buffer::new(Some(first_path.clone()), "one\ntwo\nthree".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness
+        .execute_action(Action::OpenFile(second_path.clone()))
+        .await
+        .unwrap();
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_buffer_contents("one\ntwo\nthree");
+    harness.assert_cursor_at(0, 1);
+    harness.execute_action(Action::JumpForward).await.unwrap();
+    harness.assert_buffer_contents("alpha\nbeta");
+
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness
+        .execute_action(Action::DeleteBuffer(/*force*/ true))
+        .await
+        .unwrap();
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_buffer_contents("alpha\nbeta");
+    assert!(harness.commandline_row().contains("at start of jump list"));
+
+    fs::remove_file(first_path).unwrap();
+    fs::remove_file(second_path).unwrap();
+}
+
+#[tokio::test]
 async fn mark_tracks_a_visual_block_multi_edit_transaction() {
     let mut harness = EditorHarness::with_content("a\nb\nc");
     harness.execute_action(Action::MoveDown).await.unwrap();

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -6,7 +6,7 @@ use red::{
     buffer::Buffer,
     color::Color,
     config::{Config, KeyAction},
-    editor::{Action, Mode, SearchDirection},
+    editor::{Action, Editor, Mode, SearchDirection},
     theme::Style,
 };
 use std::collections::HashMap;
@@ -1125,7 +1125,7 @@ async fn repeated_jump_back_and_forward_do_not_skip_entries() {
 }
 
 #[tokio::test]
-async fn new_jump_from_middle_discards_forward_entries() {
+async fn new_jump_from_middle_preserves_forward_entries_like_neovim_default() {
     let mut harness = EditorHarness::with_content("one\ntwo\nthree\nfour\nfive");
 
     harness.execute_action(Action::MoveTo(0, 2)).await.unwrap();
@@ -1143,11 +1143,18 @@ async fn new_jump_from_middle_discards_forward_entries() {
 
     harness.execute_action(Action::JumpBack).await.unwrap();
     harness.assert_cursor_at(0, 1);
+
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(0, 3);
 }
 
 #[tokio::test]
-async fn default_normal_keys_map_ctrl_o_and_tab_to_jumplist_navigation() {
+async fn default_normal_keys_map_ctrl_o_ctrl_i_and_tab_to_jumplist_navigation() {
     let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    assert_eq!(
+        config.keys.normal.get("Ctrl-i"),
+        Some(&KeyAction::Single(Action::JumpForward))
+    );
     assert_eq!(
         config.keys.normal.get("Tab"),
         Some(&KeyAction::Single(Action::JumpForward))
@@ -1167,9 +1174,139 @@ async fn default_normal_keys_map_ctrl_o_and_tab_to_jumplist_navigation() {
         .unwrap();
     harness.assert_cursor_at(0, 0);
 
-    let tab_event = Event::Key(KeyEvent::from(KeyCode::Tab));
-    harness.execute_event(tab_event).await.unwrap();
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('i'),
+            KeyModifiers::CONTROL,
+        )))
+        .await
+        .unwrap();
     harness.assert_cursor_at(0, 2);
+
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(0, 0);
+
+    harness
+        .execute_event(Event::Key(KeyEvent::from(KeyCode::Tab)))
+        .await
+        .unwrap();
+    harness.assert_cursor_at(0, 2);
+}
+
+#[tokio::test]
+async fn jumplist_keeps_only_the_newest_column_for_each_buffer_line() {
+    let mut harness = EditorHarness::with_content("abcdef\nsecond\nthird");
+
+    harness.execute_action(Action::MoveTo(3, 1)).await.unwrap();
+    harness.execute_action(Action::MoveTo(0, 3)).await.unwrap();
+
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(3, 0);
+
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(3, 0);
+    assert!(harness.commandline_row().contains("at start of jump list"));
+}
+
+#[tokio::test]
+async fn jumplist_positions_follow_lines_inserted_before_them() {
+    let mut harness = EditorHarness::with_content("one\ntwo\nthree\nfour\nfive");
+
+    harness.execute_action(Action::MoveTo(0, 3)).await.unwrap();
+    harness.execute_action(Action::MoveTo(0, 5)).await.unwrap();
+    harness.execute_action(Action::MoveTo(0, 1)).await.unwrap();
+    harness
+        .execute_action(Action::InsertLineAtCursor)
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(0, 5);
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(0, 3);
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(0, 1);
+}
+
+#[tokio::test]
+async fn split_windows_copy_then_independently_traverse_their_jumplists() {
+    let mut harness = EditorHarness::with_content("one\ntwo\nthree\nfour\nfive");
+
+    harness.execute_action(Action::MoveTo(0, 2)).await.unwrap();
+    harness.execute_action(Action::MoveTo(0, 4)).await.unwrap();
+    harness.execute_action(Action::SplitVertical).await.unwrap();
+    harness.execute_action(Action::MoveTo(0, 5)).await.unwrap();
+
+    harness.execute_action(Action::NextWindow).await.unwrap();
+    harness.assert_cursor_at(0, 3);
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(0, 1);
+
+    harness.execute_action(Action::NextWindow).await.unwrap();
+    harness.assert_cursor_at(0, 4);
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(0, 0);
+}
+
+#[tokio::test]
+async fn per_window_jumplists_round_trip_through_session_recovery() {
+    let contents = "one\ntwo\nthree\nfour\nfive";
+    let mut source = EditorHarness::with_content(contents);
+
+    source.execute_action(Action::MoveTo(0, 2)).await.unwrap();
+    source.execute_action(Action::MoveTo(0, 4)).await.unwrap();
+    source.execute_action(Action::SplitVertical).await.unwrap();
+    source.execute_action(Action::MoveTo(0, 5)).await.unwrap();
+    let snapshot = source.editor.test_session_snapshot();
+
+    assert_eq!(snapshot.window_jumps.len(), 2);
+    let mut buffers = Editor::buffers_from_session_snapshot(&snapshot);
+    let mut restored = EditorHarness::with_buffer(buffers.remove(0));
+    restored.editor.restore_session_snapshot(&snapshot).unwrap();
+
+    restored.execute_action(Action::JumpBack).await.unwrap();
+    restored.assert_cursor_at(0, 0);
+    restored.execute_action(Action::NextWindow).await.unwrap();
+    restored.assert_cursor_at(0, 3);
+    restored.execute_action(Action::JumpBack).await.unwrap();
+    restored.assert_cursor_at(0, 1);
+}
+
+#[tokio::test]
+async fn viewport_motions_record_jumps_but_page_scrolling_does_not() {
+    let contents = (1..=60)
+        .map(|line| format!("line {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut viewport_harness = EditorHarness::with_content(&contents);
+    for _ in 0..30 {
+        viewport_harness
+            .execute_action(Action::MoveDown)
+            .await
+            .unwrap();
+    }
+    viewport_harness
+        .execute_action(Action::MoveToViewportTop(1))
+        .await
+        .unwrap();
+    viewport_harness
+        .execute_action(Action::JumpBack)
+        .await
+        .unwrap();
+    viewport_harness.assert_cursor_at(0, 30);
+
+    let mut page_harness = EditorHarness::with_content(&contents);
+    page_harness.execute_action(Action::PageDown).await.unwrap();
+    let cursor_after_page = page_harness.cursor_position();
+    page_harness.execute_action(Action::JumpBack).await.unwrap();
+    assert_eq!(page_harness.cursor_position(), cursor_after_page);
+    assert!(page_harness
+        .commandline_row()
+        .contains("at start of jump list"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Red enables disambiguated terminal key reporting, where Ctrl-i arrives as its own control-key event instead of legacy Tab. The default keymap only handled Tab, and the underlying jumplist also diverged from current Neovim behavior: it was editor-global, discarded the forward branch after a new jump, stored static file coordinates, and treated page scrolling as a jump.

This change makes jumplists window-local and copies them when splitting, matching Neovim window behavior. Entries use stable buffer identity plus edit-tracked scalar offsets, clean older same-line duplicates and deleted buffers, preserve the forward branch under the default clean semantics, and survive session recovery with backward-compatible legacy snapshot fallback. It also binds Ctrl-i directly, retains Tab as an alias, records H/M/L viewport jumps, and stops recording Ctrl-f/Ctrl-b page scrolling.

## How to Test

Main workflow:

1. Run `cargo test --test movement jump`.
2. Open a multi-line file with `cargo run -- path/to/file`.
3. Press `G`, then `Ctrl-o`, then `Ctrl-i`.
4. Verify the cursor moves to the last line, back to the original line, and forward to the last line again.
5. Repeat step 3 with `Tab` instead of `Ctrl-i` and verify the alias still works.

Regression coverage:

1. Run `cargo test --test editing jumplist_switches_buffers_but_forgets_a_deleted_buffer`.
2. Run `cargo test --all-targets --all-features`.
3. Run `cargo clippy --all-targets --all-features -- -D warnings`.
4. Verify split windows traverse independent copied lists, jump positions follow inserted lines, same-line duplicates collapse to the newest column, session recovery restores each window list, page scrolling does not create jumps, and traversal past the oldest entry reports a no-op.