### PR TITLE
fix(editor): prevent stale commit buffer cache reuse

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2538,6 +2538,7 @@ pub struct HighlightSpan {
 /// of re-parsing per scrolled line.
 #[derive(Debug, Clone)]
 struct ViewportHighlightEntry {
+    buffer_id: BufferId,
     revision: u64,
     file: Option<String>,
     language_id: Option<String>,
@@ -2556,9 +2557,9 @@ struct ViewportHighlightEntry {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct LayoutCacheKey {
     buffer_index: usize,
+    buffer_id: BufferId,
     revision: u64,
-    /// Distinguishes different buffers reusing an index (`revision` restarts
-    /// at 0 for a fresh buffer), mirroring `HighlightCacheKey`.
+    /// Tracks filename-dependent layout settings when a buffer is renamed.
     file: Option<String>,
     vtop: usize,
     vleft: usize,
@@ -5280,6 +5281,7 @@ impl Editor {
         let break_indent = self.break_indent_options_for_buffer_index(window.buffer_index);
         let key = LayoutCacheKey {
             buffer_index: window.buffer_index,
+            buffer_id: buffer.id(),
             revision: buffer.revision(),
             file: buffer.file.clone(),
             vtop: window.vtop,
@@ -5676,6 +5678,7 @@ impl Editor {
         let Some(buffer) = self.buffer_manager.get(buffer_index) else {
             return Ok(Vec::new());
         };
+        let buffer_id = buffer.id();
         let revision = buffer.revision();
         let file = buffer.file.clone();
         let language_id = self.highlight_language_id_for_buffer_index(buffer_index);
@@ -5690,7 +5693,10 @@ impl Editor {
 
         let cached = self.highlight_cache.get(&buffer_index);
         let same_document = cached.is_some_and(|entry| {
-            entry.revision == revision && entry.file == file && entry.language_id == language_id
+            entry.buffer_id == buffer_id
+                && entry.revision == revision
+                && entry.file == file
+                && entry.language_id == language_id
         });
         let covered = same_document
             && cached.is_some_and(|entry| {
@@ -5741,6 +5747,7 @@ impl Editor {
             self.highlight_cache.insert(
                 buffer_index,
                 ViewportHighlightEntry {
+                    buffer_id,
                     revision,
                     file,
                     language_id,
@@ -29646,6 +29653,24 @@ builtin = "rust"
         editor.current_buffer_mut().insert_str(0, 10, "// ");
         let after = editor.viewport_highlight_spans(0, 10, 20).unwrap();
         assert_ne!(span_shape(&before), span_shape(&after));
+    }
+
+    #[test]
+    fn viewport_highlight_cache_distinguishes_reopened_buffers_with_the_same_name() {
+        let mut editor = rust_test_editor(1, 120, 22);
+        let original = editor.viewport_highlight_spans(0, 0, 1).unwrap();
+        let name = editor.current_buffer().file.clone();
+        let replacement = "// the replacement is entirely a comment\n".to_string();
+
+        editor.buffer_manager[0] = Buffer::new(name.clone(), replacement.clone());
+        let reopened = editor.viewport_highlight_spans(0, 0, 1).unwrap();
+
+        let mut fresh = rust_test_editor(1, 120, 22);
+        fresh.buffer_manager[0] = Buffer::new(name, replacement);
+        let expected = fresh.viewport_highlight_spans(0, 0, 1).unwrap();
+
+        assert_ne!(span_shape(&original), span_shape(&reopened));
+        assert_eq!(span_shape(&reopened), span_shape(&expected));
     }
 
     #[test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -3617,6 +3617,22 @@ mod tests {
     }
 
     #[test]
+    fn reopening_a_shorter_commit_buffer_does_not_reuse_stale_layout_bytes() {
+        let name = "[Git Commit].gitcommit";
+        let mut editor = rendering_test_editor(Buffer::new(Some(name.to_string()), "x".repeat(61)));
+        let mut buffer = RenderBuffer::new(60, 12, &Style::default());
+
+        editor.render(&mut buffer).unwrap();
+        editor.buffer_manager[0] = Buffer::new(Some(name.to_string()), "y".repeat(60));
+
+        editor.render(&mut buffer).unwrap();
+
+        assert!(rendered_rows(&buffer)
+            .iter()
+            .any(|row| row.contains("yyyy")));
+    }
+
+    #[test]
     fn edited_window_rows_preserve_completion_dialog() {
         let source = Buffer::new(None, "hello\nworld\n".to_string());
         let mut editor = rendering_test_editor(source);


### PR DESCRIPTION
## Why

Reopening a generated Git commit-message buffer can reuse the same buffer index, filename, and initial revision as its predecessor. The display layout then reuses byte ranges from the previous message, which panics when the replacement is shorter; the syntax-highlighting cache can likewise reuse spans from the wrong document.

## What Changed

- Include the stable in-memory `BufferId` in display-layout cache keys and viewport-highlighting cache identity.
- Add regressions for reopening a shorter `[Git Commit].gitcommit` buffer and replacing a same-named syntax-highlighted buffer.

## How to Test

1. Run `cargo test --lib editor::rendering::tests::reopening_a_shorter_commit_buffer_does_not_reuse_stale_layout_bytes -- --exact`; verify reopening a 60-byte commit buffer after a 61-byte buffer no longer panics.
2. Run `cargo test --lib editor::test::viewport_highlight_cache_distinguishes_reopened_buffers_with_the_same_name -- --exact`; verify the replacement receives freshly computed highlighting.
3. Generate a Git commit message, close its scratch buffer, then generate another shorter message; verify the editor opens the new message without crashing or displaying stale highlighting.

Validated with all 1,444 library tests passing and `cargo clippy --all-targets --all-features -- -D warnings` clean.
