### PR TITLE
perf(ci): speed up test and validation workflows

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,14 @@
+[profile.default]
+final-status-level = "slow"
+slow-timeout = { period = "30s" }
+
+[profile.ci]
+fail-fast = false
+failure-output = "immediate-final"
+flaky-result = "fail"
+retries = 1
+slow-timeout = { period = "30s", terminate-after = 4 }
+status-level = "slow"
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/actions/install-ripgrep/action.yml
+++ b/.github/actions/install-ripgrep/action.yml
@@ -1,0 +1,61 @@
+name: Install ripgrep
+description: Install checksum-verified ripgrep releases without refreshing package indexes.
+
+runs:
+  using: composite
+  steps:
+    - name: Install ripgrep on Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        version=15.2.0
+        archive="$RUNNER_TEMP/ripgrep-$version-x86_64-unknown-linux-musl.tar.gz"
+        install_dir="$RUNNER_TEMP/ripgrep"
+        expected_sha256=33e15bcf1624b25cdd2a55813a47a2f95dbe126268203e76aa6a585d1e7b149c
+
+        curl --fail --show-error --silent --location --retry 3 \
+          "https://github.com/BurntSushi/ripgrep/releases/download/$version/ripgrep-$version-x86_64-unknown-linux-musl.tar.gz" \
+          --output "$archive"
+        printf '%s  %s\n' "$expected_sha256" "$archive" | sha256sum --check
+        mkdir -p "$install_dir"
+        tar -xzf "$archive" -C "$install_dir" --strip-components=1
+        printf '%s\n' "$install_dir" >> "$GITHUB_PATH"
+        "$install_dir/rg" --version
+
+    - name: Install ripgrep on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v rg >/dev/null 2>&1; then
+          brew install ripgrep
+        fi
+        rg --version
+
+    - name: Install ripgrep on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $version = "15.2.0"
+        $archive = Join-Path $env:RUNNER_TEMP "ripgrep.zip"
+        $extractRoot = Join-Path $env:RUNNER_TEMP "ripgrep"
+        $url = "https://github.com/BurntSushi/ripgrep/releases/download/$version/ripgrep-$version-x86_64-pc-windows-msvc.zip"
+        $expectedSha256 = "71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5"
+
+        Invoke-WebRequest -Uri $url -OutFile $archive
+        $actualSha256 = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualSha256 -ne $expectedSha256) {
+          throw "ripgrep archive checksum mismatch: expected $expectedSha256, got $actualSha256"
+        }
+
+        Expand-Archive -Path $archive -DestinationPath $extractRoot -Force
+        $installDir = Join-Path $extractRoot "ripgrep-$version-x86_64-pc-windows-msvc"
+        $executable = Join-Path $installDir "rg.exe"
+        if (-not (Test-Path $executable)) {
+          throw "ripgrep executable was not found at $executable"
+        }
+
+        $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        & $executable --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
   RUST_BACKTRACE: 1
 
 jobs:
@@ -36,6 +38,9 @@ jobs:
 
       - name: Test Discord release announcements
         run: python3 -m unittest tests.test_discord_release
+
+      - name: Test validation helpers
+        run: python3 -m unittest tests.test_doctest_packages tests.test_test_performance
 
   test:
     name: Test Suite (${{ matrix.platform.standard }}, ${{ matrix.rust }})
@@ -67,57 +72,13 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - name: Install ripgrep (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install --yes ripgrep
+      - name: Install ripgrep
+        uses: ./.github/actions/install-ripgrep
 
-      - name: Install ripgrep (macOS)
-        if: runner.os == 'macOS'
-        run: brew install ripgrep
-
-      - name: Install ripgrep (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $version = "15.2.0"
-          $archive = Join-Path $env:RUNNER_TEMP "ripgrep.zip"
-          $extractRoot = Join-Path $env:RUNNER_TEMP "ripgrep"
-          $url = "https://github.com/BurntSushi/ripgrep/releases/download/$version/ripgrep-$version-x86_64-pc-windows-msvc.zip"
-          $expectedSha256 = "71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5"
-
-          Invoke-WebRequest -Uri $url -OutFile $archive
-          $actualSha256 = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($actualSha256 -ne $expectedSha256) {
-            throw "ripgrep archive checksum mismatch: expected $expectedSha256, got $actualSha256"
-          }
-
-          Expand-Archive -Path $archive -DestinationPath $extractRoot -Force
-          $installDir = Join-Path $extractRoot "ripgrep-$version-x86_64-pc-windows-msvc"
-          $executable = Join-Path $installDir "rg.exe"
-          if (-not (Test-Path $executable)) {
-            throw "ripgrep executable was not found at $executable"
-          }
-
-          $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          & $executable --version
-
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: validation-${{ runner.os }}
 
       - name: Run tests
         run: cargo test --all-targets --all-features --verbose
@@ -140,6 +101,8 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: validation-${{ runner.os }}
 
       - name: Deny every Clippy warning
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -169,23 +132,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-self-check-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: validation-${{ runner.os }}
 
       - name: Initialize bundled runtime
         run: cargo run --locked -- --self-check
@@ -288,23 +238,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - name: Cache Rust release build artifacts
+        uses: Swatinem/rust-cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-release-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: release-${{ matrix.target }}
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
@@ -327,11 +264,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: validation-${{ runner.os }}
 
       - name: Build documentation and deny rustdoc warnings
         env:
@@ -339,7 +275,7 @@ jobs:
         run: cargo doc --workspace --no-deps --all-features --document-private-items
 
       - name: Run documentation tests
-        run: cargo test --workspace --doc
+        run: python3 scripts/doctest_packages.py --no-default-features
 
       - name: Check documentation links
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
   RUST_BACKTRACE: 1
 
 jobs:
@@ -25,25 +27,12 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install --yes ripgrep
+        uses: ./.github/actions/install-ripgrep
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-nightly-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: validation-${{ runner.os }}
 
       - name: Run tests
         run: cargo test --all-targets --all-features --verbose

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -32,6 +32,12 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  RUST_BACKTRACE: 1
+
 jobs:
   perf:
     name: Deterministic performance gate
@@ -45,6 +51,8 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-x86_64-unknown-linux-gnu
 
       - name: Check bundled Husk callback budget
         run: cargo run --locked --release --example husk_cursor_bench -- --assert

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -33,6 +33,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  RUST_BACKTRACE: 1
+
 jobs:
   bundled-plugins:
     name: Parse and initialize bundled Husk plugins
@@ -46,16 +55,19 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: validation-${{ runner.os }}
 
       - name: Test the Husk runtime and plugin bridge
         run: |
-          cargo test --all-features -p red husk
-          cargo test --all-features -p red plugin::runtime::tests::lsp_symbols_
-          cargo test --all-features -p red plugin::runtime::tests::git_
-          cargo test --all-features -p red plugin::runtime::tests::embedded_git_core_
-          cargo test --all-features -p red plugin::runtime::tests::neotree_
-          cargo test --all-features -p red plugin::runtime::tests::embedded_neotree_core_
-          cargo test --all-features -p husk -p husk-ast -p husk-diagnostics -p husk-lexer -p husk-package -p husk-parser -p husk-semantic -p husk-stdlib -p husk-types
+          cargo test --all-features -p red --lib --bin red -- \
+            husk \
+            plugin::runtime::tests::lsp_symbols_ \
+            plugin::runtime::tests::git_ \
+            plugin::runtime::tests::embedded_git_core_ \
+            plugin::runtime::tests::neotree_ \
+            plugin::runtime::tests::embedded_neotree_core_
+          cargo test --workspace --exclude red --all-features --tests
           cargo run --all-features -p husk-cli -- test --locked plugins/git_core
           cargo run --all-features -p husk-cli -- test --locked plugins/neotree_core
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache Rust release build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-${{ matrix.target }}
+        env:
+          RUSTFLAGS: --remap-path-prefix=${{ github.workspace }}=/red
+
       - name: Build release binary
         env:
           RUSTFLAGS: --remap-path-prefix=${{ github.workspace }}=/red

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -1,0 +1,160 @@
+name: Rust Test Performance
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Runner platform to benchmark
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+      runner:
+        description: Test runners to compare
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - cargo
+          - nextest
+      scope:
+        description: Run the root package or every workspace package
+        required: true
+        default: root
+        type: choice
+        options:
+          - root
+          - workspace
+      package:
+        description: Optional package for a quick focused benchmark with root scope
+        required: false
+        default: ''
+        type: string
+      runs:
+        description: Number of measured runs per runner
+        required: true
+        default: '3'
+        type: choice
+        options:
+          - '1'
+          - '3'
+          - '5'
+      warm_build:
+        description: Prebuild tests and collect Cargo compilation timings
+        required: true
+        default: true
+        type: boolean
+      use_sccache:
+        description: Enable the GitHub Actions sccache backend
+        required: true
+        default: false
+        type: boolean
+      use_mold:
+        description: Use the mold linker on Linux
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  RUST_BACKTRACE: 1
+
+jobs:
+  benchmark:
+    name: Compare ${{ inputs.runner }} on ${{ inputs.platform }}
+    runs-on: ${{ inputs.platform }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install ripgrep
+        uses: ./.github/actions/install-ripgrep
+
+      - name: Install cargo-nextest
+        if: inputs.runner != 'cargo'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.143
+          checksum: true
+          fallback: none
+
+      - name: Set up sccache
+        if: inputs.use_sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Enable sccache
+        if: inputs.use_sccache
+        shell: bash
+        run: |
+          echo 'SCCACHE_GHA_ENABLED=true' >> "$GITHUB_ENV"
+          echo 'RUSTC_WRAPPER=sccache' >> "$GITHUB_ENV"
+
+      - name: Reject mold outside Linux
+        if: inputs.use_mold && runner.os != 'Linux'
+        shell: bash
+        run: |
+          echo 'The mold linker benchmark is only supported on Linux.' >&2
+          exit 1
+
+      - name: Install mold
+        if: inputs.use_mold && runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes mold
+          echo 'RUSTFLAGS=-C link-arg=-fuse-ld=mold' >> "$GITHUB_ENV"
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ (inputs.use_mold || inputs.use_sccache) && format('benchmark-{0}-mold-{1}-sccache-{2}', runner.os, inputs.use_mold, inputs.use_sccache) || format('validation-{0}', runner.os) }}
+
+      - name: Benchmark test runners
+        shell: bash
+        env:
+          BENCHMARK_RUNNER: ${{ inputs.runner }}
+          BENCHMARK_SCOPE: ${{ inputs.scope }}
+          BENCHMARK_PACKAGE: ${{ inputs.package }}
+          BENCHMARK_RUNS: ${{ inputs.runs }}
+          BENCHMARK_WARM_BUILD: ${{ inputs.warm_build }}
+        run: |
+          args=(--runner "$BENCHMARK_RUNNER" --scope "$BENCHMARK_SCOPE" --runs "$BENCHMARK_RUNS")
+          if [[ "$BENCHMARK_WARM_BUILD" == true ]]; then
+            args+=(--timings)
+          else
+            args+=(--no-prebuild)
+          fi
+          if [[ -n "$BENCHMARK_PACKAGE" ]]; then
+            args+=(--package "$BENCHMARK_PACKAGE")
+          fi
+          python3 scripts/test_performance.py "${args[@]}"
+
+      - name: Report sccache statistics
+        if: always() && inputs.use_sccache
+        shell: bash
+        run: sccache --show-stats
+
+      - name: Upload benchmark and test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-performance-${{ inputs.platform }}-${{ github.run_id }}
+          path: |
+            target/test-performance/results.json
+            target/cargo-timings
+            target/nextest/ci/junit.xml
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -281,6 +281,23 @@ cargo test --all-targets --all-features
 cargo clippy --all-targets --all-features -- -D warnings
 ```
 
+Use narrower commands while iterating on a specific crate or test:
+
+```shell
+cargo test -p red --lib editor::tests::
+cargo test --workspace --exclude red --all-features --tests
+python3 scripts/doctest_packages.py --no-default-features
+```
+
+`cargo test` is the default runner because Red's many short tests complete
+faster in shared test-binary processes. Install `cargo-nextest` when per-test
+isolation, timing, retries, or JUnit reports are useful, then compare both
+runners with `python3 scripts/test_performance.py --runner both --timings`.
+Add `--package husk-lexer` for a short, focused comparison.
+The manual **Rust Test Performance** GitHub Actions workflow provides the same
+comparison on Linux, macOS, or Windows and can optionally enable `sccache` or
+the Linux `mold` linker.
+
 Use `RED_RUNTIME=.` while iterating on bundled plugins or themes without
 rebuilding the executable:
 

--- a/almanac/guides/development/build-test-and-validate.md
+++ b/almanac/guides/development/build-test-and-validate.md
@@ -15,6 +15,9 @@ sources:
   - id: plugin-check
     type: file
     path: .github/workflows/plugin-check.yml
+  - id: test-performance
+    type: file
+    path: .github/workflows/test-performance.yml
   - id: editor
     type: file
     path: src/editor.rs
@@ -33,7 +36,26 @@ For ordinary Rust changes, run the normal test suite first:
 cargo test --all-targets --all-features
 ```
 
-CI runs that command with `--verbose` on Ubuntu, macOS, and Windows [@ci]. Add narrower or feature-specific local checks when the change touches feature-gated code, dependency declarations, CLI utility behavior, or anything that may compile differently under a non-default feature set.
+CI runs that command with `--verbose` on Ubuntu, macOS, and Windows [@ci]. It
+uses line-table debug information and a shared, toolchain-aware Rust cache in
+CI without changing local incremental compilation. Run an additional
+`cargo test --all-targets --no-default-features` pass locally when a change
+touches feature-gated code, dependency declarations, CLI utility behavior, or
+anything that may compile differently without default features.
+
+Keep normal local runs narrow when possible:
+
+```shell
+cargo test -p red --lib editor::tests::
+cargo test -p husk-runtime
+cargo test --workspace --exclude red --all-features --tests
+python3 scripts/doctest_packages.py --no-default-features
+```
+
+The doctest helper discovers Rust examples in workspace libraries and tests
+only the packages that contain them. Husk's current example does not need its
+default WebAssembly feature, so `--no-default-features` avoids compiling the
+Wasmtime and Cranelift dependency graph.
 
 For Rust changes that may be pushed, the repository policy is stricter than a test-only pass:
 
@@ -41,7 +63,10 @@ For Rust changes that may be pushed, the repository policy is stricter than a te
 cargo clippy --all-targets --all-features -- -D warnings
 ```
 
-`AGENTS.md` requires this command before pushing Rust changes and requires every warning or error to be fixed [@agents]. The CI clippy job runs the same command across Ubuntu, macOS, and Windows [@ci].
+`AGENTS.md` requires this command before pushing Rust changes and requires every
+warning or error to be fixed [@agents]. The CI clippy job runs the same command
+on Ubuntu for pull requests and on Ubuntu, macOS, and Windows for other events
+[@ci].
 
 ## Match The Main CI Gates
 
@@ -55,11 +80,47 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo fmt --all -- --check
 cargo run --locked -- --self-check
 cargo run --locked --release --example husk_cursor_bench -- --assert
+python3 scripts/doctest_packages.py --no-default-features
 python3 scripts/readme_release.py --check
-python3 -m unittest tests.test_discord_release
+python3 -m unittest tests.test_discord_release tests.test_doctest_packages tests.test_test_performance
 ```
 
-The workflow lint job validates GitHub Actions, checks the README release version, and runs Discord announcement tests [@ci]. The CI `fmt`, `self-check`, and `perf` jobs respectively run rustfmt, `cargo run --locked -- --self-check`, and the release-mode Husk cursor benchmark with `--assert` [@ci]. For the details of the CI surface, see [CI And Validation](../../reference/validation/ci-and-validation); for benchmark thresholds and workstation baselines, see [Performance Checks](../performance/performance-checks); for the runtime diagnostic itself, see [Self Check](../../reference/runtime/self-check).
+The workflow lint job validates GitHub Actions, checks the README release
+version, and runs Discord announcement and validation-helper tests [@ci]. The
+CI `fmt` and `self-check` jobs run rustfmt and
+`cargo run --locked -- --self-check`; the separate path-filtered Performance
+workflow runs the release-mode Husk cursor benchmark with `--assert`. For the
+details of the CI surface, see
+[CI And Validation](../../reference/validation/ci-and-validation); for benchmark
+thresholds and workstation baselines, see
+[Performance Checks](../performance/performance-checks); for the runtime
+diagnostic itself, see [Self Check](../../reference/runtime/self-check).
+
+## Compare Test Runners And Build Settings
+
+Keep `cargo test` as the normal runner: Red has many short tests, and its shared
+test-binary processes are faster than starting a separate process for every
+test. Install the optional runner with `cargo install cargo-nextest --locked`,
+then collect equivalent warmed runs and Cargo build timings:
+
+```shell
+python3 scripts/test_performance.py --runner both --runs 3 --timings
+python3 scripts/test_performance.py --runner both --package husk-lexer
+python3 scripts/test_performance.py --runner nextest --scope workspace
+cargo nextest run --all-targets --all-features --profile ci
+```
+
+The `ci` nextest profile reports slow tests, retries failures without treating
+flaky successes as passing, and writes JUnit XML to
+`target/nextest/ci/junit.xml`. The manually dispatched Rust Test Performance
+workflow compares runners on any supported operating system and can enable
+`sccache` or Linux `mold` for controlled compilation experiments
+[@test-performance]. These compiler and linker settings remain opt-in because
+`sccache` can interfere with the fast incremental local development path, and
+linker gains depend on the platform and workload.
+
+Focused package and workspace comparisons use `--tests` so Criterion benchmark
+binaries are not mistaken for unit tests or counted by only one runner.
 
 ## Handle Terminal Output Tests
 
@@ -79,13 +140,14 @@ If the change touches `crates/husk*`, `plugins/`, `src/plugin/`, `src/assets.rs`
 The workflow runs these families of commands:
 
 ```shell
-cargo test --all-features -p red husk
-cargo test --all-features -p red plugin::runtime::tests::lsp_symbols_
-cargo test --all-features -p red plugin::runtime::tests::git_
-cargo test --all-features -p red plugin::runtime::tests::embedded_git_core_
-cargo test --all-features -p red plugin::runtime::tests::neotree_
-cargo test --all-features -p red plugin::runtime::tests::embedded_neotree_core_
-cargo test --all-features -p husk -p husk-ast -p husk-diagnostics -p husk-lexer -p husk-package -p husk-parser -p husk-semantic -p husk-stdlib -p husk-types
+cargo test --all-features -p red --lib --bin red -- \
+  husk \
+  plugin::runtime::tests::lsp_symbols_ \
+  plugin::runtime::tests::git_ \
+  plugin::runtime::tests::embedded_git_core_ \
+  plugin::runtime::tests::neotree_ \
+  plugin::runtime::tests::embedded_neotree_core_
+cargo test --workspace --exclude red --all-features --tests
 cargo run --all-features -p husk-cli -- test --locked plugins/git_core
 cargo run --all-features -p husk-cli -- test --locked plugins/neotree_core
 python3 -m json.tool examples/example-plugin/package.json > /dev/null

--- a/almanac/reference/validation/ci-and-validation.md
+++ b/almanac/reference/validation/ci-and-validation.md
@@ -12,6 +12,12 @@ sources:
   - id: nightly
     type: file
     path: .github/workflows/nightly.yml
+  - id: performance
+    type: file
+    path: .github/workflows/performance.yml
+  - id: test-performance
+    type: file
+    path: .github/workflows/test-performance.yml
   - id: release
     type: file
     path: .github/workflows/release.yml
@@ -20,43 +26,86 @@ sources:
     path: AGENTS.md
 ---
 
-Red's validation contract spans local commands and GitHub Actions workflows. CI runs workflow lint, cross-platform tests, clippy with warnings denied, formatting, a deterministic performance gate, the bundled runtime self-check, and changelog checks [@ci]. Separate workflows validate bundled Husk plugins, run the suite on nightly Rust, build and smoke-test release archives, publish draft GitHub releases, and update the Homebrew tap after a release is published [@plugin-check] [@nightly] [@release]. For runtime context, the bundled self-check is also part of the [runtime assets](../../architecture/runtime/runtime-assets) area.
+Red's validation contract spans local commands and GitHub Actions workflows. CI
+runs workflow lint, cross-platform tests, clippy with warnings denied,
+formatting, the bundled runtime self-check, documentation checks, and
+changelog checks [@ci]. Separate workflows validate bundled Husk plugins, run
+a deterministic performance gate, test nightly Rust, benchmark test runners on
+demand, build and smoke-test release archives, publish draft GitHub releases,
+and update the Homebrew tap after a release is published [@plugin-check]
+[@performance] [@nightly] [@test-performance] [@release]. For runtime context,
+the bundled self-check is also part of the
+[runtime assets](../../architecture/runtime/runtime-assets) area.
 
 ## Local Policy
 
 `AGENTS.md` requires `cargo clippy --all-targets --all-features -- -D warnings` before pushing Rust changes and requires every warning or error to be fixed [@agents]. It also says PR work must follow `.agents/skills/good-pr/SKILL.md`, including repository-specific PR publishing defaults [@agents].
 
-The local clippy command matches the CI clippy job. The workflow installs the stable Rust toolchain with clippy on Ubuntu, macOS, and Windows, then runs `cargo clippy --all-targets --all-features -- -D warnings` [@ci].
+The local clippy command matches the CI clippy job. Pull requests run it on
+Ubuntu; other CI events run it on Ubuntu, macOS, and Windows [@ci].
 
 ## Main CI Workflow
 
-The main CI workflow runs on pushes and pull requests targeting `main` or `develop`, and it can also be started manually with `workflow_dispatch` [@ci]. Its global environment enables colored Cargo output and `RUST_BACKTRACE=1` [@ci].
+The main CI workflow runs on pushes and pull requests targeting `main` or
+`develop`, and it can also be started manually with `workflow_dispatch` [@ci].
+Its global environment enables colored Cargo output, `RUST_BACKTRACE=1`, and
+line-table-only development and test debug information. Validation jobs share
+toolchain-aware Rust caches by operating system; release builds use separate
+target-specific caches [@ci].
 
 | Job | Main checks |
 | --- | --- |
-| `workflow-lint` | Checks out the repository, validates GitHub Actions workflows with actionlint, verifies the README release version, and runs Discord release announcement tests [@ci]. |
-| `test` | Runs on Ubuntu, macOS, and Windows for stable Rust; installs ripgrep per OS, caches Cargo data, and runs all-target all-feature tests with verbose Cargo output [@ci]. |
-| `clippy` | Runs clippy on Ubuntu, macOS, and Windows with all targets and all features, denying every warning [@ci]. |
-| `perf` | Runs the release-mode `husk_cursor_bench` example with `--assert` as a deterministic performance gate [@ci]. |
+| `workflow-lint` | Validates GitHub Actions workflows, checks the README release version, and runs Discord release announcement and test-tooling unit tests [@ci]. |
+| `test` | Runs `cargo test --all-targets --all-features --verbose` with stable Rust and checksum-verified ripgrep on Ubuntu, macOS, and Windows [@ci]. |
+| `clippy` | Denies every all-target, all-feature clippy warning; pull requests use Ubuntu, while push and manual runs cover Ubuntu, macOS, and Windows [@ci]. |
 | `fmt` | Runs `cargo fmt --all -- --check` [@ci]. |
 | `self-check` | Runs `cargo run --locked -- --self-check` to initialize and validate bundled runtime state [@ci]. |
 | `changelog` | Validates `cliff.toml`, and on `release/v*` PRs regenerates and diffs release changelog content against `CHANGELOG.md` [@ci]. |
+| `build` | Builds target-specific release binaries on non-pull-request events [@ci]. |
+| `docs` | Builds workspace API documentation, discovers packages with runnable Rust examples before doctesting them without default features, and validates Markdown links [@ci]. |
 
-The Windows ripgrep install path in the `test` job downloads the official `ripgrep-15.2.0-x86_64-pc-windows-msvc.zip` release archive, verifies SHA-256 `71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5`, extracts it under `RUNNER_TEMP`, adds the extracted directory to `GITHUB_PATH`, and runs `rg.exe --version` [@ci]. This avoids depending on Chocolatey availability for Windows tests that exercise project search and other `rg`-backed paths [@ci].
+The shared ripgrep action downloads pinned Linux and Windows ripgrep 15.2.0
+release archives, verifies their published SHA-256 digests, and installs them
+without refreshing Linux package indexes. macOS reuses an existing ripgrep or
+installs it with Homebrew [@ci].
 
 ## Plugin Check Workflow
 
 The Husk Plugin Check workflow is path-filtered to plugin, Husk, asset, configuration, self-check, and example changes [@plugin-check]. It runs on push and pull request events when those paths change [@plugin-check].
 
-The `bundled-plugins` job runs targeted Rust tests for Husk and plugin runtime areas, runs all-feature tests across Husk crates, executes locked Husk CLI tests for bundled `git_core` and `neotree_core` plugins, validates example plugin metadata with `python3 -m json.tool`, and initializes the bundled runtime with `cargo run --all-features -- --self-check` [@plugin-check].
+The `bundled-plugins` job runs Husk and plugin runtime test filters in one
+root-package invocation, then runs
+`cargo test --workspace --exclude red --all-features --tests` to cover every
+Husk workspace crate. It executes locked Husk CLI tests for bundled `git_core`
+and `neotree_core` plugins, validates example plugin metadata with
+`python3 -m json.tool`, and initializes the bundled runtime with
+`cargo run --all-features -- --self-check` [@plugin-check].
+
+## Performance And Runner Benchmarks
+
+The path-filtered Performance workflow runs the release-mode
+`husk_cursor_bench` example with `--assert` as a deterministic performance
+gate [@performance]. The separate manually dispatched Rust Test Performance
+workflow compares `cargo test` and `cargo-nextest` on Linux, macOS, or Windows,
+records Cargo build timings and JSON results, uploads optional nextest JUnit
+reports, and supports explicit `sccache` and Linux `mold` experiments
+[@test-performance]. Normal validation keeps `cargo test` as its default
+because separate nextest processes are slower for Red's many short tests.
 
 ## Nightly Rust Workflow
 
-The Nightly Rust workflow runs on a scheduled Monday cron and can be started manually [@nightly]. It installs the nightly toolchain on Ubuntu, installs ripgrep, caches Cargo data, and runs the all-target all-feature test command with verbose Cargo output [@nightly].
+The Nightly Rust workflow runs on a scheduled Monday cron and can be started
+manually [@nightly]. It installs the nightly toolchain and checksum-verified
+ripgrep on Ubuntu, restores a toolchain-aware Rust cache, and runs the same
+all-target, all-feature test command used by the main CI test job [@nightly].
 
 ## Release Workflow
 
-The Release workflow runs for `v*` tag pushes, manual dispatch with an existing tag name, and published release events [@release]. For tag and manual runs, it builds release binaries for Linux x86_64, macOS Intel, macOS Apple Silicon, and Windows x86_64, with `RUSTFLAGS` remapping the workspace path to `/red` [@release].
+The Release workflow runs for `v*` tag pushes, manual dispatch with an existing
+tag name, and published release events [@release]. For tag and manual runs, it
+restores target-specific Rust caches and builds release binaries for Linux
+x86_64, macOS Intel, macOS Apple Silicon, and Windows x86_64, with `RUSTFLAGS`
+remapping the workspace path to `/red` [@release].
 
 The smoke job downloads each archive, extracts it, runs `--self-check`, requires the final line to be `red self-check ok`, fails if plugin health output reports pending, disabled, quarantined, reload-rejected, or error states, and checks that the binary does not contain the GitHub workspace path [@release]. The publish job downloads archives, adds installer scripts, verifies the package version and committed changelog, regenerates the changelog with git-cliff, generates SHA-256 sums, writes release notes, and creates or updates a draft release before uploading artifacts [@release].
 

--- a/scripts/doctest_packages.py
+++ b/scripts/doctest_packages.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Run doctests only for workspace libraries that contain Rust examples."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+DOC_FENCE = re.compile(r"^\s*//(?:/|!)\s*(`{3,}|~{3,})(.*)$")
+RUSTDOC_ATTRIBUTES = {
+    "compile_fail",
+    "no_run",
+    "rust",
+    "should_panic",
+    "standalone_crate",
+    "test_harness",
+}
+
+
+def contains_rust_doctest(source: str) -> bool:
+    """Identify runnable fenced Rust examples in ordinary Rust doc comments."""
+
+    open_fence: str | None = None
+    for line in source.splitlines():
+        match = DOC_FENCE.match(line)
+        if match is None:
+            continue
+
+        fence, info = match.groups()
+        if open_fence is not None:
+            if fence.startswith(open_fence) and not info.strip():
+                open_fence = None
+            continue
+
+        open_fence = fence
+        tags = [tag for tag in re.split(r"[,\s]+", info.strip()) if tag]
+        if any(tag == "ignore" or tag.startswith("ignore-") for tag in tags):
+            continue
+        if not tags or tags[0] in RUSTDOC_ATTRIBUTES or tags[0].startswith("edition"):
+            return True
+
+    return False
+
+
+def doctest_packages(metadata: dict[str, object]) -> list[str]:
+    """Find workspace library packages with runnable Rust documentation fences."""
+
+    members = set(metadata["workspace_members"])
+    packages: list[str] = []
+    for package in metadata["packages"]:
+        if package["id"] not in members:
+            continue
+
+        for target in package["targets"]:
+            if not {"lib", "proc-macro"}.intersection(target["kind"]):
+                continue
+
+            source_root = Path(target["src_path"]).parent
+            if any(
+                contains_rust_doctest(source.read_text(encoding="utf-8"))
+                for source in source_root.rglob("*.rs")
+            ):
+                packages.append(package["name"])
+                break
+
+    return sorted(packages)
+
+
+def cargo_command(packages: list[str], *, no_default_features: bool) -> list[str]:
+    command = ["cargo", "test", "--locked", "--doc"]
+    if no_default_features:
+        command.append("--no-default-features")
+    for package in packages:
+        command.extend(["-p", package])
+    return command
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="list packages without running tests")
+    parser.add_argument(
+        "--no-default-features",
+        action="store_true",
+        help="avoid feature-only dependencies while running documentation examples",
+    )
+    args = parser.parse_args()
+
+    metadata = json.loads(
+        subprocess.check_output(
+            ["cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"],
+            text=True,
+        )
+    )
+    packages = doctest_packages(metadata)
+    print("Rust doctest packages:", ", ".join(packages) if packages else "none", flush=True)
+    if args.list or not packages:
+        return 0
+
+    command = cargo_command(packages, no_default_features=args.no_default_features)
+    print("Running:", " ".join(command), flush=True)
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_performance.py
+++ b/scripts/test_performance.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Measure equivalent Cargo and nextest suites without changing the default runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Measurement:
+    runner: str
+    command: list[str]
+    elapsed_seconds: float
+    exit_code: int
+
+
+def test_arguments(scope: str, package: str | None = None) -> list[str]:
+    targets = "--tests" if scope == "workspace" or package is not None else "--all-targets"
+    arguments = ["--locked", targets, "--all-features"]
+    if scope == "workspace":
+        arguments.insert(0, "--workspace")
+    if package is not None:
+        arguments.extend(["-p", package])
+    return arguments
+
+
+def command_for(
+    runner: str,
+    scope: str,
+    *,
+    nextest_profile: str,
+    package: str | None = None,
+) -> list[str]:
+    if runner == "cargo":
+        return ["cargo", "test", *test_arguments(scope, package)]
+    return [
+        "cargo",
+        "nextest",
+        "run",
+        *test_arguments(scope, package),
+        "--profile",
+        nextest_profile,
+    ]
+
+
+def measure(runner: str, command: list[str]) -> Measurement:
+    print("\nRunning:", " ".join(command), flush=True)
+    started = time.perf_counter()
+    completed = subprocess.run(command, check=False)
+    elapsed = time.perf_counter() - started
+    print(f"{runner} finished in {elapsed:.3f}s (exit {completed.returncode})", flush=True)
+    return Measurement(runner, command, round(elapsed, 6), completed.returncode)
+
+
+def report(
+    *,
+    scope: str,
+    package: str | None = None,
+    prebuild: Measurement | None,
+    measurements: list[Measurement],
+) -> dict[str, object]:
+    medians = {
+        runner: round(
+            statistics.median(
+                measurement.elapsed_seconds
+                for measurement in measurements
+                if measurement.runner == runner and measurement.exit_code == 0
+            ),
+            6,
+        )
+        for runner in dict.fromkeys(measurement.runner for measurement in measurements)
+        if any(
+            measurement.runner == runner and measurement.exit_code == 0
+            for measurement in measurements
+        )
+    }
+    return {
+        "scope": scope,
+        "package": package,
+        "prebuild": asdict(prebuild) if prebuild is not None else None,
+        "measurements": [asdict(measurement) for measurement in measurements],
+        "median_seconds": medians,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runner", choices=("cargo", "nextest", "both"), default="both")
+    parser.add_argument("--scope", choices=("root", "workspace"), default="root")
+    parser.add_argument("--package", help="benchmark one workspace package instead of the root")
+    parser.add_argument("--runs", type=int, default=1)
+    parser.add_argument("--nextest-profile", default="ci")
+    parser.add_argument("--no-prebuild", action="store_true")
+    parser.add_argument("--timings", action="store_true")
+    parser.add_argument("--output", type=Path, default=Path("target/test-performance/results.json"))
+    args = parser.parse_args()
+    if args.runs < 1:
+        parser.error("--runs must be at least 1")
+    if args.scope == "workspace" and args.package:
+        parser.error("--package cannot be combined with --scope workspace")
+
+    selected = ["cargo", "nextest"] if args.runner == "both" else [args.runner]
+    measurements: list[Measurement] = []
+    prebuild = None
+    if not args.no_prebuild:
+        command = ["cargo", "test", *test_arguments(args.scope, args.package), "--no-run"]
+        if args.timings:
+            command.append("--timings")
+        prebuild = measure("prebuild", command)
+
+    if prebuild is None or prebuild.exit_code == 0:
+        for _ in range(args.runs):
+            for runner in selected:
+                result = measure(
+                    runner,
+                    command_for(
+                        runner,
+                        args.scope,
+                        nextest_profile=args.nextest_profile,
+                        package=args.package,
+                    ),
+                )
+                measurements.append(result)
+                if result.exit_code != 0:
+                    break
+            else:
+                continue
+            break
+
+    result = report(
+        scope=args.scope,
+        package=args.package,
+        prebuild=prebuild,
+        measurements=measurements,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print("\nMedian successful runtimes:", result["median_seconds"], flush=True)
+    print("Report:", args.output, flush=True)
+
+    failed = [measurement.exit_code for measurement in measurements if measurement.exit_code]
+    if prebuild is not None and prebuild.exit_code:
+        return prebuild.exit_code
+    return failed[0] if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_doctest_packages.py
+++ b/tests/test_doctest_packages.py
@@ -1,0 +1,63 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.doctest_packages import cargo_command, contains_rust_doctest, doctest_packages
+
+
+class DoctestPackagesTest(unittest.TestCase):
+    def test_detects_unannotated_rust_examples(self) -> None:
+        self.assertTrue(contains_rust_doctest("//! ```\n//! assert!(true);\n//! ```"))
+
+    def test_detects_annotated_rust_examples(self) -> None:
+        self.assertTrue(contains_rust_doctest("/// ```rust,no_run\n/// work();\n/// ```"))
+
+    def test_ignores_ignored_and_non_rust_examples(self) -> None:
+        source = "\n".join(
+            [
+                "/// ```rust,ignore",
+                "/// ignored();",
+                "/// ```",
+                "/// ```bash",
+                "/// cargo test",
+                "/// ```",
+            ]
+        )
+        self.assertFalse(contains_rust_doctest(source))
+
+    def test_discovers_only_documented_workspace_libraries(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            documented = root / "documented" / "src"
+            documented.mkdir(parents=True)
+            (documented / "lib.rs").write_text("//! ```\n//! assert!(true);\n//! ```\n")
+            empty = root / "empty" / "src"
+            empty.mkdir(parents=True)
+            (empty / "lib.rs").write_text("pub fn work() {}\n")
+            metadata = {
+                "workspace_members": ["documented-id", "empty-id"],
+                "packages": [
+                    {
+                        "id": "documented-id",
+                        "name": "documented",
+                        "targets": [{"kind": ["lib"], "src_path": str(documented / "lib.rs")}],
+                    },
+                    {
+                        "id": "empty-id",
+                        "name": "empty",
+                        "targets": [{"kind": ["lib"], "src_path": str(empty / "lib.rs")}],
+                    },
+                ],
+            }
+
+            self.assertEqual(doctest_packages(metadata), ["documented"])
+
+    def test_builds_scoped_no_default_features_command(self) -> None:
+        self.assertEqual(
+            cargo_command(["husk"], no_default_features=True),
+            ["cargo", "test", "--locked", "--doc", "--no-default-features", "-p", "husk"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_test_performance.py
+++ b/tests/test_test_performance.py
@@ -1,0 +1,56 @@
+import unittest
+
+from scripts.test_performance import Measurement, command_for, report, test_arguments
+
+
+class TestPerformanceTest(unittest.TestCase):
+    def test_root_arguments_match_the_normal_ci_suite(self) -> None:
+        self.assertEqual(test_arguments("root"), ["--locked", "--all-targets", "--all-features"])
+
+    def test_workspace_arguments_include_every_package(self) -> None:
+        self.assertEqual(
+            test_arguments("workspace"),
+            ["--workspace", "--locked", "--tests", "--all-features"],
+        )
+
+    def test_package_arguments_select_one_workspace_member(self) -> None:
+        self.assertEqual(
+            test_arguments("root", "husk-lexer"),
+            ["--locked", "--tests", "--all-features", "-p", "husk-lexer"],
+        )
+
+    def test_builds_nextest_command_with_the_requested_profile(self) -> None:
+        self.assertEqual(
+            command_for("nextest", "root", nextest_profile="ci"),
+            [
+                "cargo",
+                "nextest",
+                "run",
+                "--locked",
+                "--all-targets",
+                "--all-features",
+                "--profile",
+                "ci",
+            ],
+        )
+
+    def test_report_uses_only_successful_runs_for_medians(self) -> None:
+        measurements = [
+            Measurement("cargo", ["cargo", "test"], 2.0, 0),
+            Measurement("cargo", ["cargo", "test"], 4.0, 0),
+            Measurement("nextest", ["cargo", "nextest", "run"], 8.0, 1),
+        ]
+
+        result = report(scope="root", prebuild=None, measurements=measurements)
+
+        self.assertEqual(result["median_seconds"], {"cargo": 3.0})
+        self.assertEqual(len(result["measurements"]), 3)
+
+    def test_report_preserves_the_selected_package(self) -> None:
+        result = report(scope="root", package="husk-lexer", prebuild=None, measurements=[])
+
+        self.assertEqual(result["package"], "husk-lexer")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

CI currently spends unnecessary time restoring large raw `target` caches, refreshing package indexes for ripgrep, compiling the Wasmtime/Cranelift graph for a single doctest, and launching the same plugin test binaries six times. The plugin workflow also misses 97 tests across eight Husk crates.

`cargo-nextest` improves isolation and reporting, but its process-per-test model is slower for Red's many short tests: the full local suite took 23.57 seconds with `cargo test` versus 69.77 seconds with nextest. This change therefore speeds up the existing default path and makes nextest an explicit measurement tool instead of replacing `cargo test`.

## What Changed

- Replace raw Cargo caches with shared, toolchain-aware Rust caches across test, Clippy, docs, self-check, nightly, performance, and release jobs; use line-table-only CI debug information.
- Install pinned, checksum-verified ripgrep releases through a reusable composite action, avoiding Linux package-index refreshes.
- Discover workspace crates that actually contain runnable Rust doctests and run the current Husk doctest without its optional WebAssembly dependency graph.
- Consolidate plugin bridge filters into one root-package invocation and test every non-Red workspace crate, restoring coverage for the 97 previously omitted tests.
- Add an opt-in, cross-platform test-performance workflow and local benchmark helper with pinned nextest installation, focused package comparisons, Cargo timing reports, JUnit output, optional sccache, and isolated mold/sccache caches.
- Document the faster local commands, nextest tradeoffs, and updated CI behavior.

## How to Test

1. Run `python3 -m unittest tests.test_doctest_packages tests.test_test_performance` and confirm all helper tests pass.
2. Run `python3 scripts/doctest_packages.py --no-default-features` and confirm it selects only `husk` and passes the existing doctest.
3. Run `cargo test --workspace --exclude red --all-features --tests` and confirm all 383 Husk workspace tests pass, including the previously omitted crates.
4. Run `cargo test --all-features -p red --lib --bin red -- husk plugin::runtime::tests::lsp_symbols_ plugin::runtime::tests::git_ plugin::runtime::tests::embedded_git_core_ plugin::runtime::tests::neotree_ plugin::runtime::tests::embedded_neotree_core_` and confirm all 44 plugin checks pass, including both 4,097-item LSP boundary cases.
5. Run `python3 scripts/test_performance.py --runner both --package husk-lexer --runs 2 --timings` and confirm both runners pass while JSON, Cargo timing, and nextest JUnit reports are generated.
6. Run `cargo clippy --all-targets --all-features -- -D warnings` and confirm the repository's required Rust gate passes.

The full root suite also passed all 2,169 tests, and the workspace documentation build, bundled plugin tests, runtime self-check, Markdown checks, formatting, and actionlint all passed locally.
