### PR TITLE
perf(editor): coalesce scrolling and reuse unchanged surfaces

### DIFF
--- a/docs/performance-baseline-2026-08-15.md
+++ b/docs/performance-baseline-2026-08-15.md
@@ -1,0 +1,183 @@
+# Red scrolling and mouse performance — 2026-08-15
+
+Historical baseline. See [the implementation and matched follow-up](performance-scroll-improvements-2026-08-15.md)
+for the completed fixes and new measurements.
+
+## Outcome
+
+The current release build does unnecessary full-frame work for mouse motion,
+and editor splits multiply the frames produced by scrolling. The issue is
+measurable with a populated Agent pane, but these measurements do not establish
+which recent commit made it noticeable. Do not describe this as a confirmed
+regression in the latest tree-sitter change.
+
+Worktree: `red.codex-overall-performance`, branch `codex/overall-performance`.
+Baseline: `a8225610c3e024352019d3dca52a430855234a27` (fresh `origin/main`).
+Machine: Apple M4 Max, 128 GiB RAM, Darwin 25.6.0 arm64,
+Rust 1.94.1 (`e408947bf`), `cargo build --locked --release --bin red`.
+Baseline binary SHA-256:
+`f3c01278f6e6fb88fb769e421dbd648614106c9d9676d72c116b6a22ecbe1a17`.
+
+## Reproducible condition
+
+`scripts/workspace_scroll_bench.py` drives the real terminal editor through a
+continuously drained 200-column × 60-row PTY with truecolor enabled. It uses
+isolated configuration, bundled plugins, and disabled LSP. The main file is
+`src/editor.rs` (1,421,300 bytes; 37,475 lines at the baseline).
+
+The three layouts are:
+
+1. Highlighted Rust editor only.
+2. The same editor plus a populated Agent pane.
+3. Two highlighted Rust editor splits (`editor.rs` and `editor/rendering.rs`),
+   NeoTree, and the populated Agent pane.
+
+The Agent is Red's real UI and protocol bridge, backed by the script's local,
+deterministic app-server fixture. It renders twelve Markdown sections with Rust
+code blocks and lists. It does not contact a model or read user conversations.
+The measured Agent is populated and idle, not actively streaming.
+
+Each phase starts near line 100. The stress input is 200 events at 5 ms spacing:
+idle, mouse movement, held `j`, wheel-down, then wheel-down with three mouse
+moves per wheel. Thus the combined phase injects 800 events in approximately
+one second. CPU figures include queue drain and a short settling interval.
+Per-event times include Red's handler/render work, not physical-display latency.
+
+## Baseline results
+
+Each cell is the median of three runs. Times are milliseconds unless labeled.
+The three-repeat trace run uses `RED_PERF=trace`; the separate CPU control below
+disables the instrumentation.
+
+| Layout | Mouse event p95 | Wheel event p95 | Wheel CPU seconds | Combined CPU seconds | Full renders: wheel / combined |
+|---|---:|---:|---:|---:|---:|
+| Editor | 0.652 | 3.274 | 0.57 | 0.77 | 200 / 800 |
+| Editor + Agent | 0.940 | 3.505 | 0.58 | 0.86 | 200 / 800 |
+| Two editors + NeoTree + Agent | 0.923 | 3.068 | 0.59 | 0.88 | 597 / 1,173 |
+
+All 200 mouse-only events caused a full render in every accepted run. They
+produced 8,800 terminal bytes despite no changed text. All mouse and wheel
+events were accounted for. Three of the 1,800 injected `j` keys were discarded
+across the editor-only/Agent runs; Red intentionally drops stale repeated
+motion input. The harness now reports that separately.
+
+For the full workspace, combined-input drain observations were 25.5, 75.1,
+and 0.5 ms after injection stopped. These are polling-resolution observations,
+not precise input-to-pixel latency. The traced workload remained below the
+existing 16 ms p95 handler/frame budget, so this is evidence of avoidable work
+and occasional backlog, not proof of a persistent stall on this workstation.
+
+### Tracing-disabled control
+
+Three otherwise equivalent full-workspace runs, with `RED_PERF=off`:
+
+| Phase | Median CPU seconds | Median terminal bytes |
+|---|---:|---:|
+| Idle | 0.03 | 0 |
+| Mouse only | 0.17 | 8,800 |
+| Wheel only | 0.57 | 2,708,730 |
+| Wheel + mouse | 0.86 | 2,727,692 |
+
+Adding mouse motion costs approximately **51% more CPU** in this control.
+The old `drain_lag_ms` field in these archived no-trace JSON files includes the
+intentional 200 ms quiet-window detector and must not be treated as latency.
+The current harness distinguishes quiescence observations from exact-count
+drain observations.
+
+## Attribution
+
+An instrumentation-only build adds `render:prepare`, `render:panels`,
+`render:overlays+cursor`, per-pane `panel:paint`, and
+`panel:text_layout_miss`. No performance behavior was changed.
+
+In its combined-input run, full rendering totaled 717.8 ms over 1,153 frames:
+
+| Component | Total ms | Share of full-render time |
+|---|---:|---:|
+| Panel painting | 225.9 | 31.5% |
+| Editor-window painting | 225.0 | 31.3% |
+| Terminal diff/flush | 107.1 | 14.9% |
+| Global chrome | 88.6 | 12.3% |
+
+The Agent pane itself accounts for 113.0 ms and NeoTree 96.8 ms within panel
+painting. There were no text-panel layout-cache misses during the measured
+phases. Editor highlighting missed twenty times, totaling 11.4 ms (p95 0.794
+ms). These spans overlap their parent render spans; do not sum all labels.
+
+Turning syntax highlighting off in both editor splits reduced combined output
+from 2.71 MB to 1.64 MB, but CPU was 0.90 versus 0.89 seconds in this single
+instrumented comparison. This is a useful control, not a statistically robust
+claim about the exact cost of syntax highlighting. It argues against starting
+with a highlighter rewrite.
+
+## Source-grounded findings
+
+- `Editor::process_editor_event` calls `render` when no action/render advanced
+  `render_generation`, including ignored `MouseEventKind::Moved` events.
+  The fallback predates this investigation (June 2026).
+- `ScrollUp`/`ScrollDown` render directly. The action epilogue renders again
+  whenever more than one editor window exists; plugin effects may then request
+  another render. The multi-window fallback dates to 2025.
+- `read_ready_event` coalesces resize events, and the held-key path has a
+  bounded motion drain, but ordinary mouse movement and wheel events do not
+  get an equivalent frame budget. The outer input loop can postpone background
+  servicing while a continuous stream remains ready.
+- `render` repaints all editor windows and all visible panels. Text-panel
+  Markdown layout is already cached, but its cells and chrome are repainted on
+  each full frame. Even an empty terminal diff still updates cursor state and
+  flushes output.
+- Render generations also drive session-snapshot freshness. Review this
+  coupling when removing redundant renders, rather than accidentally weakening
+  recovery or causing needless snapshots.
+
+## Proposed implementation plan
+
+1. **Stop invalidation-free work.** Give event handling an explicit visible-state
+   change/render outcome. Ignore unhandled mouse moves without repainting;
+   preserve hover-enabled dialogs, divider drags, selection, focus restoration,
+   keymap hints, and panel interactions. Add deterministic render-count tests.
+   Acceptance: an idle mouse-move flood produces zero full renders and no
+   terminal output, unless visible hover state actually changes.
+2. **Render once per bounded input batch.** Remove unconditional multi-window
+   action redraws in favor of dirty windows/regions and a single flush point.
+   Coalesce adjacent wheel/motion events while preserving scroll distance,
+   direction changes, pointer target, modifier state, clicks, drags, and key
+   ordering. Service timers, LSP, and Agent events between bounded batches.
+   Acceptance: ordinary scroll does not produce two or three redundant full
+   frames per input; no stale scrolling continues after input stops.
+3. **Reuse unchanged surfaces.** Preserve rendered inactive editor windows and
+   idle panels; invalidate on content, viewport, selection, focus, size, theme,
+   diagnostics, or plugin-decoration changes. Keep the existing Markdown layout
+   cache. Use bulk rectangle fills where appropriate, and avoid cursor-only
+   terminal writes when cursor state is unchanged. Re-measure before introducing
+   more cache complexity.
+4. **Expand the regression matrix.** Add same-buffer/distant-viewport splits,
+   active Agent streaming, LSP/diagnostics enabled, relative line numbers,
+   wrapped/long lines, resize drags, and a real terminal with output backpressure.
+   Use deterministic work-count assertions in CI and retain workstation p95,
+   CPU, output-volume, and queue-drain comparisons. Bisect the July/August panel
+   changes only if a historical regression attribution is still needed.
+
+The order deliberately targets confirmed redundant work first. No speedup is
+claimed until the same retained baseline workload is rerun against a fix.
+
+## Reproduction and evidence
+
+```sh
+cargo build --locked --release --bin red
+python3 scripts/workspace_scroll_bench.py --layout editor --output target/perf/editor
+python3 scripts/workspace_scroll_bench.py --layout agent --output target/perf/agent
+python3 scripts/workspace_scroll_bench.py --layout workspace --output target/perf/workspace
+python3 scripts/workspace_scroll_bench.py --layout workspace --perf-mode off --output target/perf/untraced
+python3 scripts/workspace_scroll_bench.py --layout workspace --syntax-off --output target/perf/syntax-off
+```
+
+Output directories must not already exist. The retained bundle is
+`target/manual-smoke/perf-20260815-a822561/EVIDENCE.md`; it includes the original
+binary, accepted raw traces/JSON, exact instrumentation patch, colored terminal
+capture, and checksum manifest. Attach to `tmux attach -t red-perf-a822561` for
+the interactive layout. Failed setup pilots are excluded from the result table.
+
+Limitations: no historical binary A/B, no active model stream, no LSP load, no
+physical-terminal presentation timing, and no Windows measurement. The broad
+performance work is not implemented, committed, pushed, or published as a PR.

--- a/docs/performance-scroll-improvements-2026-08-15.md
+++ b/docs/performance-scroll-improvements-2026-08-15.md
@@ -1,0 +1,129 @@
+# Scroll performance implementation — 2026-08-15
+
+## Outcome
+
+Implemented the measured navigation/rendering fixes on
+`codex/scroll-performance` in the durable `red.codex-scroll-performance`
+worktree, created with `wt` from the exact measured base
+`a8225610c3e024352019d3dca52a430855234a27`.
+
+The full-workspace traced median fell from 0.90 to 0.38 CPU seconds for
+200 wheel events interleaved with 600 mouse moves. Unused mouse movement now
+produces no redraw and no terminal bytes. The optimized path preserves every
+wheel delta and continues servicing Agent/plugin events between bounded batches.
+
+## What changed
+
+- Ignore unhandled pointer movement without changing pending key sequences.
+  Dialogs can still request a hover redraw.
+- Gather only adjacent compatible wheel/move events, up to 64 events and an
+  8 ms collection budget. Direction, coordinates, modifiers, clicks, drags,
+  keys, and resize events remain ordering boundaries. Every wheel delta is
+  applied; this is not the existing stale-repeat-key dropping policy.
+- Accumulate the strongest required repaint and publish the final navigation
+  frame. Ordinary input also yields to background work after an 8 ms budget.
+  The collection budget is not a hard deadline for processing an entire batch.
+- Repaint the active editor, or all affected editor windows for shared
+  decorations, while retaining unchanged docked panes. Focus/layout/overlay
+  changes and streamed panel updates retain full-render fallbacks.
+- Preserve the existing syntax and Markdown layout caches. Add attribution
+  spans and reusable PTY comparison scripts instead of introducing another
+  broad surface-cache layer.
+
+## Matched measurements
+
+Apple M4 Max, 128 GiB, Darwin arm64, Rust 1.94.1; optimized release builds.
+Both versions open the exact same files in the original investigation
+worktree. The terminal is 200 × 60, syntax highlighting is enabled, bundled
+plugins are active, and the real Agent UI is populated by a deterministic local
+app-server fixture. No model call or personal conversation is involved.
+
+The main matrix is three serial, interleaved before/after repetitions. Each
+phase injects 200 events at 5 ms spacing; mixed input adds three mouse moves per
+wheel. Values below are medians. The baseline is the frozen instrumentation-only
+binary; both versions expose the same full-render attribution spans.
+
+| Layout | Wheel CPU seconds, before → after | Mixed CPU seconds, before → after | Full frames, wheel | Full frames, mixed |
+|---|---:|---:|---:|---:|
+| Highlighted editor | 0.57 → 0.51 | 0.76 → 0.50 | 200 → 0 | 800 → 0 |
+| Editor + Agent | 0.58 → 0.51 | 0.83 → 0.53 | 200 → 0 | 800 → 0 |
+| Two editors + NeoTree + Agent | 0.65 → 0.32 | 0.90 → 0.38 | 590 → 0 | 1,173 → 0 |
+
+Zero full frames does not mean no rendering: the optimized workspace emits
+200 scoped editor frames in the median wheel and mixed phases. Every traced
+mouse/wheel event was accounted for. Held-key dropping is reported separately
+because Red intentionally discards stale repeated motion keys.
+
+### Tracing-disabled control
+
+Three matched full-workspace repetitions use the original uninstrumented
+baseline and disable tracing in the optimized build.
+
+| Phase | CPU seconds, before → after | Terminal bytes, before → after |
+|---|---:|---:|
+| Idle | 0.05 → 0.05 | 44 → 44 |
+| Mouse movement | 0.30 → 0.03 | 8,800 → 0 |
+| Wheel | 0.59 → 0.33 | 2,708,666 → 2,607,820 |
+| Wheel + mouse | 0.84 → 0.37 | 2,730,701 → 2,625,287 |
+
+Mixed-input CPU is approximately **56% lower**. The remaining terminal bytes
+are principally actual scrolled text; this change removes redundant painting
+rather than suppressing the final visible scroll position. CPU accounting has
+10 ms resolution, so small differences should not be overinterpreted.
+
+### Extended controls
+
+These are single matched runs, not three-run medians.
+
+| Control | CPU seconds, before → after | Observed rendering |
+|---|---:|---|
+| Same-buffer splits, relative numbers, wrapping; mixed input | 1.39 → 0.44 | 1,004 full frames → 200 all-editor frames |
+| Agent actively streaming during mixed input | 0.91 → 0.44 | Both received 22 Agent updates; optimized build retained 29 necessary full frames |
+| Zero-delay 200-wheel burst | 0.46 → 0.03 | 404 full frames → 4 scoped frames |
+| Zero-delay mixed burst | 0.80 → 0.08 | 1,004 full frames → 13 scoped frames |
+
+All accepted controls have exact per-type input counts. Three initial unpadded
+stress runs decoded one SGR mouse report as ordinary keys; this happened on
+both old and new builds. Those runs are retained as rejected evidence, not used
+in the table. The corrected harness checks mouse, wheel, and key counts
+separately, handles short PTY writes, and uses fixed-width, zero-padded SGR
+coordinates for the stress controls. Crossterm 0.27's Unix parser can recognize
+a lone escape byte at a short-read boundary as an Escape key; this is a separate
+input-decoding follow-up, not a performance fix claimed by this branch.
+
+A final optimized-build smoke enabled the installed `rust-analyzer`, waited
+for initialization, and observed document-diagnostic and inlay-hint responses.
+Its 100 mouse moves, 100 wheel events, and 400 mixed events were all decoded
+exactly; ignored movement still emitted zero bytes. This is a functional
+LSP-on check, not a matched LSP performance comparison. The retained tmux
+layout also survived a 200×60 → 180×50 → 200×60 resize with both editors,
+NeoTree, and the populated Agent pane intact.
+
+## Validation
+
+- Eight new deterministic rendering tests pass. They check ignored movement,
+  exact wheel distance, shared/different-buffer splits, relative numbers,
+  wrapping, focus changes, batch ordering boundaries, shared decorations,
+  namespace replacement, live panel invalidation, and dialog hover.
+- Optimized screen cells are compared with a fresh full render.
+- The full all-targets/all-features test suite, release build, formatting, and
+  strict Clippy pass.
+
+## Reproduction
+
+Use `scripts/compare_workspace_scroll.py` with the frozen before/after binaries
+and `--fixture-root` pointing at the original investigation worktree. It runs
+the comparisons serially and writes raw logs, JSON, ANSI captures, and median
+summaries. Each output run directory must be new.
+
+The retained bundle is
+`target/manual-smoke/scroll-20260815-a822561/EVIDENCE.md`. It contains the
+optimized binary, exact source patch, raw measurements, walkthrough captures,
+verification script, and checksum manifest. The original baseline remains in
+the separate `red.codex-overall-performance` worktree.
+
+Per-event handler timing is no longer directly comparable: deferred handlers
+finish before the batch's final render. Use CPU, frame counts, output volume,
+and queue-drain observations. Neither PTY drain time nor the no-trace quiet
+detector measures physical-display latency. A real terminal under output
+backpressure and Windows remain follow-up measurement targets.

--- a/scripts/compare_workspace_scroll.py
+++ b/scripts/compare_workspace_scroll.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Run serial, matched before/after PTY measurements and summarize medians."""
+
+import argparse
+import json
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+
+HARNESS = Path(__file__).with_name("workspace_scroll_bench.py")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before", required=True)
+    parser.add_argument("--before-uninstrumented", required=True)
+    parser.add_argument("--after", required=True)
+    parser.add_argument("--fixture-root", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--controls-only", action="store_true")
+    parser.add_argument("--control", action="append",
+                        choices=("shared-wrap", "streaming", "burst"))
+    args = parser.parse_args()
+    if args.repetitions < 1:
+        parser.error("repetitions must be positive")
+    output = Path(args.output).resolve()
+    root = Path(args.fixture_root).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    runs = json.loads((output / "runs.json").read_text()) if args.controls_only else []
+
+    def run(name, version, layout, perf_mode="trace", extra=()):
+        binary = args.after if version == "after" else (
+            args.before_uninstrumented if perf_mode == "off" else args.before)
+        destination = output / name
+        command = [sys.executable, str(HARNESS), "--binary", binary,
+                   "--root", str(root), "--file", str(root / "src/editor.rs"),
+                   "--split-file", str(root / "src/editor/rendering.rs"),
+                   "--layout", layout, "--perf-mode", perf_mode,
+                   "--output", str(destination), *extra]
+        print(f"\n=== {name} ===", flush=True)
+        subprocess.run(command, check=True)
+        runs[:] = [entry for entry in runs if entry["name"] != name]
+        runs.append({"name": name, "version": version, "layout": layout,
+                     "perf_mode": perf_mode, "extra": list(extra)})
+        (output / "runs.json").write_text(json.dumps(runs, indent=2) + "\n")
+
+    for repetition in (() if args.controls_only else range(1, args.repetitions + 1)):
+        for layout in ("editor", "agent", "workspace"):
+            for version in ("before", "after"):
+                run(f"{version}-{layout}-{repetition}", version, layout)
+        for version in ("before", "after"):
+            run(f"{version}-untraced-{repetition}", version, "workspace", "off",
+                ("--phases", "idle", "mouse", "wheel", "mixed"))
+
+    controls = (
+        ("shared-wrap", ("--split-file", str(root / "src/editor.rs"),
+                         "--mouse-coordinate-width", "4",
+                         "--config-override", "relative_line_numbers=true",
+                         "--config-override", "wrap=true",
+                         "--phases", "mouse", "wheel", "mixed")),
+        ("streaming", ("--phases", "streaming")),
+        ("burst", ("--delay-ms", "0", "--mouse-coordinate-width", "4",
+                   "--phases", "wheel", "mixed")),
+    )
+    for control, extra in controls:
+        if args.control and control not in args.control:
+            continue
+        for version in ("before", "after"):
+            run(f"{version}-{control}", version, "workspace", extra=extra)
+
+    summary = {}
+    for layout in ("editor", "agent", "workspace", "untraced"):
+        summary[layout] = {}
+        for version in ("before", "after"):
+            samples = [json.loads((output / f"{version}-{layout}-{i}" / "results.json").read_text())
+                       for i in range(1, args.repetitions + 1)]
+            summary[layout][version] = {}
+            for phase in samples[0]:
+                values = [sample[phase] for sample in samples]
+                med = lambda field: statistics.median(value[field] for value in values)
+                frame_count = lambda label: statistics.median(
+                    value["timings"].get(label, {}).get("count", 0) for value in values)
+                summary[layout][version][phase] = {
+                    "cpu_seconds": round(med("process_cpu_seconds"), 3),
+                    "output_bytes": med("output_bytes"),
+                    "full_frames": frame_count("render:full"),
+                    "motion_frames": frame_count("render:motion_frame"),
+                    "editor_windows_frames": frame_count("render:editor_windows"),
+                    "minimum_delivered": min(value["delivered_events"] for value in values)
+                    if values[0]["delivered_events"] is not None else None,
+                }
+    (output / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    print(json.dumps(summary, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/workspace_scroll_bench.py
+++ b/scripts/workspace_scroll_bench.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Repeatable release-mode scroll/mouse workload with a real, populated Agent pane.
+
+The same executable acts as a deterministic local Codex app-server fixture. No
+model request or user conversation is used. Results and raw PERF spans are kept
+under --output; run with --layout editor, agent, or workspace for comparisons.
+"""
+
+import argparse
+from collections import defaultdict
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import pty
+import re
+import struct
+import subprocess
+import sys
+import termios
+import threading
+import time
+
+ROOT = Path(__file__).resolve().parent.parent
+TIMING = re.compile(r"\[PERF\] (\S+)(?: (.*?))?: (\d+)us")
+
+
+def response_text():
+    return "# Performance investigation\n\n" + "\n\n".join(
+        f"## Observation {n}\n\n"
+        "The editor should remain responsive while scrolling a highlighted file. "
+        "Measure input handling, syntax work, panel layout, and terminal output.\n\n"
+        "```rust\nfn render_frame(index: usize) -> usize {\n    index + 1\n}\n```\n\n"
+        "- Preserve cursor position\n- Reuse unchanged rows\n- Verify mouse behavior"
+        for n in range(1, 13)
+    )
+
+
+def mock_codex():
+    output_lock = threading.Lock()
+    turn_number = 0
+
+    def send(value):
+        with output_lock:
+            print(json.dumps(value), flush=True)
+
+    def finish_turn(turn_id, text, streaming):
+        chunks = [text[index:index + 80] for index in range(0, len(text), 80)] if streaming else [text]
+        for chunk in chunks:
+            send({"method": "item/agentMessage/delta", "params": {
+                "threadId": "red-perf-thread", "turnId": turn_id, "delta": chunk}})
+            if streaming:
+                time.sleep(0.05)
+        send({"method": "item/completed", "params": {
+            "threadId": "red-perf-thread", "turnId": turn_id,
+            "item": {"id": turn_id + "-message", "type": "agentMessage", "text": text}}})
+        send({"method": "turn/completed", "params": {
+            "threadId": "red-perf-thread", "turn": {"id": turn_id, "status": "completed"}}})
+
+    for line in sys.stdin:
+        message = json.loads(line)
+        method, ident = message.get("method"), message.get("id")
+        result = None
+        if method == "initialize":
+            result = {"userAgent": "red-performance-fixture"}
+        elif method == "account/read":
+            result = {"account": {"type": "chatgpt"}, "requiresOpenaiAuth": False}
+        elif method == "config/read":
+            result = {"config": {"mcp_servers": {}}, "origins": {}}
+        elif method == "configRequirements/read":
+            result = {"requirements": None}
+        elif method == "thread/start":
+            result = {"thread": {"id": "red-perf-thread"}}
+        elif method == "turn/start":
+            turn_number += 1
+            turn_id = f"red-perf-turn-{turn_number}"
+            send({"id": ident, "result": {"turn": {"id": turn_id}}})
+            text = response_text()
+            streaming = message["params"]["input"][0]["text"] == "stream benchmark"
+            threading.Thread(target=finish_turn, args=(turn_id, text, streaming), daemon=True).start()
+            continue
+        elif ident is not None:
+            result = {}
+        if ident is not None and result is not None:
+            send({"id": ident, "result": result})
+
+
+def stats(values):
+    values = sorted(values)
+    return {"count": len(values), "total_us": sum(values),
+            **{f"p{p}_us": values[(len(values) - 1) * p // 100] for p in (50, 95, 99)},
+            "max_us": values[-1]}
+
+
+def cpu_seconds(pid):
+    value = subprocess.check_output(["ps", "-o", "time=", "-p", str(pid)], text=True).strip()
+    total = 0.0
+    for component in value.replace("-", ":").split(":"):
+        total = total * 60 + float(component)
+    return total
+
+
+def mouse(code, x, y, release=False, width=0):
+    return f"\x1b[<{code};{x:0{width}d};{y:0{width}d}{'m' if release else 'M'}".encode()
+
+
+class Driver:
+    def __init__(self, args):
+        self.args = args
+        self.root = Path(args.root).resolve()
+        self.file = Path(args.file).resolve()
+        self.split_file = Path(args.split_file).resolve()
+        self.output = Path(args.output).resolve()
+        self.output.mkdir(parents=True, exist_ok=False)
+        self.config_home = self.output / "config"
+        config = self.config_home / "red"
+        config.mkdir(parents=True)
+        self.log = self.output / "red.log"
+        config.joinpath("config.toml").write_text(
+            f"log_file = {json.dumps(str(self.log))}\n"
+            "show_whats_new = false\nfetch_release_notes = false\n"
+            f"[lsp]\nenabled = {str(args.lsp).lower()}\n"
+            f"[agent]\ncommand = {json.dumps(str(Path(__file__).resolve()))}\n")
+        self.master, slave = pty.openpty()
+        fcntl.ioctl(slave, termios.TIOCSWINSZ,
+                    struct.pack("HHHH", args.rows, args.cols, 0, 0))
+        self.bytes = 0
+        self.capture = bytearray()
+        environment = dict(os.environ, RED_PERF=args.perf_mode, XDG_CONFIG_HOME=str(self.config_home),
+                           TERM="xterm-256color", COLORTERM="truecolor")
+        environment.pop("NO_COLOR", None)
+        self.process = subprocess.Popen(
+            [str(Path(args.binary).resolve()), "--root", str(self.root),
+             *[value for override in args.config_override for value in ("--config-override", override)],
+             str(self.file)],
+            cwd=self.root, stdin=slave, stdout=slave, stderr=slave,
+            env=environment,
+            close_fds=True)
+        os.close(slave)
+        threading.Thread(target=self.drain, daemon=True).start()
+        self.wait_for(lambda: ("[PERF] startup:interactive:" in self.read_log()
+                               if args.perf_mode == "trace" else len(self.capture) > 1000),
+                      90, "first paint")
+        time.sleep(0.3)
+
+    def drain(self):
+        while True:
+            try:
+                data = os.read(self.master, 1 << 20)
+            except OSError:
+                return
+            if not data:
+                return
+            self.bytes += len(data)
+            self.capture.extend(data)
+
+    def read_log(self):
+        return self.log.read_text(errors="replace") if self.log.exists() else ""
+
+    def wait_for(self, condition, timeout, description):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if condition():
+                return
+            if self.process.poll() is not None:
+                raise RuntimeError(f"Red exited during {description}: {self.process.returncode}")
+            time.sleep(0.02)
+        raise TimeoutError(description)
+
+    def send(self, data):
+        while data:
+            written = os.write(self.master, data)
+            if written == 0:
+                raise RuntimeError("PTY write made no progress")
+            data = data[written:]
+
+    def mouse(self, code, x, y, release=False):
+        return mouse(code, x, y, release, self.args.mouse_coordinate_width)
+
+    def command(self, command):
+        self.send(b":" + command.encode() + b"\r")
+        time.sleep(0.25)
+
+    def setup(self):
+        if self.args.lsp:
+            self.wait_for(lambda: "[lsp] server initialized" in self.read_log(),
+                          90, "LSP initialization")
+        if self.args.layout == "workspace":
+            self.command("sp " + str(self.split_file))
+            if self.args.syntax_off:
+                self.command("syntax off")
+            self.send(b"\x17k")
+            time.sleep(0.2)
+        if self.args.layout != "editor":
+            self.command("Agent")
+            self.send(b"Show the deterministic performance fixture")
+            time.sleep(0.1)
+            self.send(b"\x1b")
+            time.sleep(0.1)
+            self.send(b"\r")
+            preferences = self.config_home / "red/preferences.json"
+            self.wait_for(lambda: ("notify agent:completed" in self.read_log()
+                                   if self.args.perf_mode == "trace" else
+                                   preferences.exists() and "Observation 12" in preferences.read_text()),
+                          30, "agent completion")
+            time.sleep(0.4)
+            self.send(b"\x1b")
+            time.sleep(0.1)
+            self.send(self.mouse(0, 15, 8) + self.mouse(0, 15, 8, True))
+            time.sleep(0.2)
+        if self.args.layout == "workspace":
+            self.command("NeoTree")
+            time.sleep(0.4)
+        self.x = 65 if self.args.layout == "workspace" else 15
+        self.y = 8
+        self.send(self.mouse(0, self.x, self.y) + self.mouse(0, self.x, self.y, True))
+        time.sleep(0.2)
+        if self.args.syntax_off:
+            self.command("syntax off")
+        self.command("100")
+        time.sleep(0.4)
+        self.output.joinpath("setup.ansi").write_bytes(self.capture)
+        if self.args.perf_mode == "trace" and self.args.layout != "editor" and "drain UpdateTextPanel" not in self.read_log():
+            raise RuntimeError("agent fixture did not populate its panel")
+        if self.args.layout == "workspace" and "Handling command: NeoTree" not in self.read_log():
+            raise RuntimeError("file tree did not open")
+
+    def phase(self, name):
+        self.command("100")
+        time.sleep(0.15)
+        if name == "streaming":
+            self.command("Agent")
+            self.send(b"stream benchmark")
+            time.sleep(0.1)
+            self.send(b"\x1b")
+            time.sleep(0.1)
+            self.send(b"\r")
+            time.sleep(0.2)
+            self.send(self.mouse(0, self.x, self.y) + self.mouse(0, self.x, self.y, True))
+            time.sleep(0.1)
+        offset = self.log.stat().st_size
+        bytes_before, cpu_before = self.bytes, cpu_seconds(self.process.pid)
+        started = time.monotonic()
+        expected = 0
+        count = self.args.presses
+        for index in range(count):
+            if name == "idle":
+                payload = b""
+            elif name == "mouse":
+                payload = self.mouse(35, self.x + index % 7, self.y + index % 3)
+                expected += 1
+            elif name == "keys":
+                payload = b"j"
+                expected += 1
+            elif name == "wheel":
+                payload = self.mouse(65, self.x, self.y)
+                expected += 1
+            else:
+                payload = b"".join(self.mouse(35, self.x + (index + n) % 7, self.y + n % 3)
+                                    for n in range(self.args.moves_per_scroll))
+                payload += self.mouse(65, self.x, self.y)
+                expected += self.args.moves_per_scroll + 1
+            if payload:
+                self.send(payload)
+            deadline = started + (index + 1) * self.args.delay_ms / 1000
+            time.sleep(max(0, deadline - time.monotonic()))
+        enqueue_seconds = time.monotonic() - started
+
+        def phase_log():
+            with self.log.open("rb") as stream:
+                stream.seek(offset)
+                return stream.read().decode(errors="replace")
+
+        def delivered():
+            return len(re.findall(r"\[PERF\] event (?:Mouse|Key)\(", phase_log()))
+
+        if self.args.perf_mode != "trace":
+            last_bytes, last_change = self.bytes, time.monotonic()
+            deadline = last_change + 30
+            while time.monotonic() < deadline and time.monotonic() - last_change < 0.2:
+                time.sleep(0.01)
+                if self.bytes != last_bytes:
+                    last_bytes, last_change = self.bytes, time.monotonic()
+        elif name == "keys":
+            # Red intentionally discards stale repeated-motion keys. A quiet
+            # queue is completion even when not every injected key survives.
+            last_count, last_change = delivered(), time.monotonic()
+            while delivered() < expected and time.monotonic() - last_change < 0.2:
+                time.sleep(0.01)
+                current = delivered()
+                if current != last_count:
+                    last_count, last_change = current, time.monotonic()
+        elif expected:
+            self.wait_for(lambda: delivered() >= expected, 60, f"{name} event drain")
+        drained_seconds = time.monotonic() - started
+        time.sleep(0.15)
+        cpu = cpu_seconds(self.process.pid) - cpu_before
+        content = phase_log()
+        if name == "streaming" and self.args.perf_mode == "trace" and "notify agent:update" not in content:
+            raise RuntimeError("Agent did not stream during the measured phase")
+        self.output.joinpath(f"{name}.log").write_text(content)
+        samples = defaultdict(list)
+        for match in TIMING.finditer(content):
+            label, detail, micros = match.group(1), match.group(2) or "", int(match.group(3))
+            if label == "event":
+                label += " mouse" if "kind: Moved" in detail else (
+                    " wheel" if "kind: Scroll" in detail else " key")
+            elif label in ("notify", "drain", "husk:notify", "panel:paint"):
+                label += " " + detail.split()[0] if detail else ""
+            samples[label].append(micros)
+        observed = delivered() if self.args.perf_mode == "trace" else None
+        expected_types = {
+            "mouse": count if name == "mouse" else (
+                count * self.args.moves_per_scroll if name in ("mixed", "streaming") else 0),
+            "wheel": count if name in ("wheel", "mixed", "streaming") else 0,
+            "key": count if name == "keys" else 0,
+        }
+        observed_types = {kind: len(samples.get("event " + kind, []))
+                          for kind in expected_types} if observed is not None else None
+        dropped = max(0, expected - observed) if observed is not None else None
+        observation_ms = max(0, drained_seconds - enqueue_seconds) * 1000
+        exact_drain = observed_types == expected_types
+        result = {"input_events": expected, "delivered_events": observed,
+                  "expected_event_types": expected_types,
+                  "delivered_event_types": observed_types,
+                  "dropped_events": dropped,
+                  "enqueue_seconds": enqueue_seconds,
+                  "drained_seconds": drained_seconds,
+                  "drain_lag_ms": observation_ms if exact_drain else None,
+                  "quiescence_observation_ms": None if exact_drain else observation_ms,
+                  "process_cpu_seconds": cpu, "output_bytes": self.bytes-bytes_before,
+                  "timings": {key: stats(values) for key, values in samples.items()}}
+        self.output.joinpath(f"{name}.json").write_text(json.dumps(result, indent=2)+"\n")
+        important = {key: value for key, value in result.items() if key != "timings"}
+        important["p95_us"] = {key: value["p95_us"] for key, value in result["timings"].items()
+                               if key.startswith("event ") or key in ("render:full", "render:windows", "render:chrome", "highlight:miss")}
+        print(name, json.dumps(important), flush=True)
+        if observed_types is not None and name != "keys" and observed_types != expected_types:
+            raise RuntimeError(f"{name} decoded unexpected input: {observed_types} != {expected_types}")
+        return result
+
+    def close(self):
+        if self.process.poll() is None:
+            self.send(b"\x1b")
+            time.sleep(0.1)
+            self.send(b":qa!\r")
+            try:
+                self.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.process.terminate()
+                self.process.wait(timeout=5)
+        os.close(self.master)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", default=str(ROOT / "target/release/red"))
+    parser.add_argument("--root", default=str(ROOT))
+    parser.add_argument("--file", default=str(ROOT / "src/editor.rs"))
+    parser.add_argument("--split-file", default=str(ROOT / "src/editor/rendering.rs"))
+    parser.add_argument("--lsp", action="store_true")
+    parser.add_argument("--config-override", action="append", default=[])
+    parser.add_argument("--perf-mode", choices=("trace", "summary", "off"), default="trace")
+    parser.add_argument("--layout", choices=("editor", "agent", "workspace"), default="workspace")
+    parser.add_argument("--syntax-off", action="store_true")
+    parser.add_argument("--rows", type=int, default=60)
+    parser.add_argument("--cols", type=int, default=200)
+    parser.add_argument("--presses", type=int, default=200)
+    parser.add_argument("--delay-ms", type=float, default=5)
+    parser.add_argument("--moves-per-scroll", type=int, default=3)
+    parser.add_argument("--mouse-coordinate-width", type=int, default=0,
+                        help="optional zero padding for fixed-width SGR stress input")
+    parser.add_argument("--phases", nargs="+", default=["idle", "mouse", "keys", "wheel", "mixed"],
+                        choices=("idle", "mouse", "keys", "wheel", "mixed", "streaming"))
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    if args.rows < 20 or args.cols < 100 or args.presses < 1 or args.delay_ms < 0 or args.moves_per_scroll < 0:
+        parser.error("rows >= 20, cols >= 100, presses >= 1, delay-ms >= 0, and moves-per-scroll >= 0 are required")
+    if not 0 <= args.mouse_coordinate_width <= 8:
+        parser.error("mouse-coordinate-width must be between 0 and 8")
+    if args.layout == "workspace" and (args.rows < 40 or args.cols < 160):
+        parser.error("the fixed split/tree/agent workload requires at least 40 rows and 160 columns")
+    if "streaming" in args.phases and args.layout == "editor":
+        parser.error("streaming requires an Agent pane")
+    driver = Driver(args)
+    try:
+        driver.setup()
+        metadata = {"commit": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip(),
+                    "harness_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+                    "fixture_commit": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=driver.root, text=True).strip(),
+                    "file_sha256": hashlib.sha256(driver.file.read_bytes()).hexdigest(),
+                    "split_file_sha256": hashlib.sha256(driver.split_file.read_bytes()).hexdigest(),
+                    "args": vars(args), "binary_sha256": hashlib.sha256(Path(args.binary).read_bytes()).hexdigest(),
+                    "fixture_bytes": len(response_text().encode()), "pid": driver.process.pid}
+        driver.output.joinpath("metadata.json").write_text(json.dumps(metadata, indent=2)+"\n")
+        results = {phase: driver.phase(phase) for phase in args.phases}
+        driver.output.joinpath("results.json").write_text(json.dumps(results, indent=2)+"\n")
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    if "--version" in sys.argv:
+        print("codex-cli 0.144.5")
+    elif len(sys.argv) > 1 and sys.argv[1] == "app-server":
+        mock_codex()
+    else:
+        main()

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -20,6 +20,8 @@ mod buffer_manager;
 mod diagnostics_picker;
 mod display_layout;
 mod lsp_coordinator;
+#[cfg(test)]
+mod navigation_perf_tests;
 pub(crate) mod perf;
 pub mod render_buffer;
 pub mod rendering;
@@ -180,6 +182,8 @@ impl ActionDispatcher {
 pub const DEFAULT_REGISTER: char = '"';
 const JUMPLIST_SIZE: usize = 100;
 const REPEATED_MOTION_DRAIN_BUDGET_MS: u64 = 50;
+const INPUT_BATCH_BUDGET: Duration = Duration::from_millis(8);
+const SCROLL_EVENTS_PER_BATCH: usize = 64;
 const TERMINAL_SIZE_RECONCILE_INTERVAL: Duration = Duration::from_millis(100);
 const PLUGIN_REQUESTS_PER_TICK: usize = 64;
 const AGENT_EVENTS_PER_TICK: usize = 64;
@@ -966,7 +970,7 @@ struct SubstituteConfirmation {
     accepted: Vec<PlannedSubstitution>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct ProcessedEvent {
     quit: bool,
     drain_repeated_motion: bool,
@@ -977,6 +981,17 @@ struct ProcessedEvent {
 enum EventRenderMode {
     Immediate,
     DeferredMotion,
+}
+
+/// Strongest repaint requested while navigation is being coalesced.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+enum MotionRender {
+    #[default]
+    None,
+    Cursor,
+    Window,
+    EditorWindows,
+    Full,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2850,6 +2865,9 @@ pub struct Editor {
     #[cfg(test)]
     terminal_flush_generation: u64,
 
+    #[cfg(test)]
+    full_render_count: u64,
+
     /// Whether the terminal window currently has focus.
     is_focused: bool,
 
@@ -2859,6 +2877,9 @@ pub struct Editor {
 
     /// Incremented after full renders so event handling can avoid duplicate frames.
     render_generation: u64,
+
+    /// Active window represented by the last committed frame.
+    last_rendered_window: Option<WindowId>,
 
     /// True once the startup splash has been drawn at least once.
     splash_shown: bool,
@@ -2891,8 +2912,8 @@ pub struct Editor {
     /// Suppresses per-step repainting while queued repeated motions are drained.
     defer_motion_render: bool,
 
-    /// Tracks whether deferred motion changed the visible viewport.
-    deferred_motion_needs_full_render: bool,
+    /// Repaint scope accumulated by deferred navigation.
+    deferred_motion_render: MotionRender,
 
     /// Earliest state before a repeated-motion batch and the latest cause.
     /// The final snapshot is read when the batch flushes, so state events are
@@ -4167,9 +4188,12 @@ impl Editor {
             flushed_terminal_cursor: None,
             #[cfg(test)]
             terminal_flush_generation: 0,
+            #[cfg(test)]
+            full_render_count: 0,
             is_focused: true,
             suppress_reactivation_click: false,
             render_generation: 0,
+            last_rendered_window: None,
             splash_shown: false,
             splash_dismissed: false,
             previous_render_buffer: None,
@@ -4178,7 +4202,7 @@ impl Editor {
             last_rendered_bracket_rows: Vec::new(),
             last_rendered_cursor_surface: None,
             defer_motion_render: false,
-            deferred_motion_needs_full_render: false,
+            deferred_motion_render: MotionRender::None,
             deferred_plugin_event: None,
             block_replay_depth: 0,
             block_replay_change_deferred: false,
@@ -4426,14 +4450,16 @@ impl Editor {
         self.sync_to_window();
 
         if self.defer_motion_render {
-            if self.editor_view_state() != before {
-                self.deferred_motion_needs_full_render = true;
-            }
+            self.request_motion_render(if self.editor_view_state() != before {
+                MotionRender::Window
+            } else {
+                MotionRender::Cursor
+            });
             return Ok(());
         }
 
         if self.editor_view_state() != before {
-            self.render(buffer)
+            self.render_motion_frame(buffer)
         } else if self.can_render_cursor_motion_delta() {
             self.render_cursor_motion_delta(buffer)
         } else if self.relative_line_numbers_enabled()
@@ -7743,7 +7769,20 @@ impl Editor {
                 event::poll(Duration::from_millis(10))?;
             }
 
+            let input_started = Instant::now();
+            let mut serviced_background = false;
             while let Some(ev) = Self::read_ready_event(&mut pending_events)? {
+                if self.can_batch_scroll(&ev) {
+                    let events = Self::read_scroll_batch(ev, &mut pending_events)?;
+                    if self
+                        .process_scroll_batch(events, &mut buffer, &mut runtime)
+                        .await?
+                    {
+                        break 'editor_loop;
+                    }
+                    serviced_background = true;
+                    break;
+                }
                 let processed = self
                     .process_editor_event(ev, &mut buffer, &mut runtime, EventRenderMode::Immediate)
                     .await?;
@@ -7771,6 +7810,9 @@ impl Editor {
                     // before another held-key batch is drained.
                     break;
                 }
+                if input_started.elapsed() >= INPUT_BATCH_BUDGET {
+                    break;
+                }
             }
             self.suppress_reactivation_click = false;
 
@@ -7781,7 +7823,9 @@ impl Editor {
                     .await?;
             }
 
-            self.service_background(&mut buffer, &mut runtime).await?;
+            if !serviced_background {
+                self.service_background(&mut buffer, &mut runtime).await?;
+            }
             if self.persist_session_snapshot(/*force*/ false) {
                 self.render(&mut buffer)?;
             }
@@ -8350,6 +8394,7 @@ impl Editor {
         // single render at the end of the tick instead of one per item.
         let mut needs_render = false;
         let mut needs_motion_render = false;
+        let mut needs_editor_windows_render = false;
 
         // Always pump LSP responses. `recv_response` completes the
         // initialize handshake and flushes queued didOpen/change
@@ -8999,11 +9044,16 @@ impl Editor {
                     decorations,
                 } => {
                     let current_buffer_index = self.buffer_manager.active_index();
-                    let active_buffer_only = decorations.iter().all(|decoration| {
-                        decoration
-                            .buffer_index
-                            .is_none_or(|buffer_index| buffer_index == current_buffer_index)
-                    });
+                    let active_buffer_only = self
+                        .decoration_manager
+                        .buffers_for_namespace(&namespace)
+                        .iter()
+                        .all(|buffer_index| *buffer_index == current_buffer_index)
+                        && decorations.iter().all(|decoration| {
+                            decoration
+                                .buffer_index
+                                .is_none_or(|buffer_index| buffer_index == current_buffer_index)
+                        });
                     let decorations = decorations
                         .into_iter()
                         .map(|mut decoration| {
@@ -9012,10 +9062,10 @@ impl Editor {
                         })
                         .collect();
                     if self.decoration_manager.set(namespace, decorations) {
-                        if active_buffer_only && self.window_manager.windows().len() == 1 {
+                        if active_buffer_only && self.active_buffer_visible_once() {
                             needs_motion_render = true;
                         } else {
-                            needs_render = true;
+                            needs_editor_windows_render = true;
                         }
                     }
                 }
@@ -9024,7 +9074,7 @@ impl Editor {
                         if self.window_manager.windows().len() == 1 {
                             needs_motion_render = true;
                         } else {
-                            needs_render = true;
+                            needs_editor_windows_render = true;
                         }
                     }
                 }
@@ -9033,7 +9083,7 @@ impl Editor {
                         if self.window_manager.windows().len() == 1 {
                             needs_motion_render = true;
                         } else {
-                            needs_render = true;
+                            needs_editor_windows_render = true;
                         }
                     }
                 }
@@ -9042,7 +9092,7 @@ impl Editor {
                         if self.window_manager.windows().len() == 1 {
                             needs_motion_render = true;
                         } else {
-                            needs_render = true;
+                            needs_editor_windows_render = true;
                         }
                     }
                 }
@@ -9820,6 +9870,8 @@ impl Editor {
         }
         if needs_render {
             self.render(buffer)?;
+        } else if needs_editor_windows_render {
+            self.render_editor_windows_frame(buffer)?;
         } else if needs_motion_render {
             self.render_motion_frame(buffer)?;
         }
@@ -9859,6 +9911,16 @@ impl Editor {
             };
             perf::PerfSpan::with_detail("event", detail)
         });
+        let mouse_moved = matches!(
+            ev,
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Moved,
+                ..
+            })
+        );
+        if mouse_moved && self.current_dialog.is_none() {
+            return Ok(ProcessedEvent::default());
+        }
         let initial_bounds_span = perf::PerfSpan::start("event:initial_bounds");
         self.check_bounds();
         drop(initial_bounds_span);
@@ -9888,6 +9950,7 @@ impl Editor {
         }
 
         let render_generation = self.render_generation;
+        let window_before = self.window_manager.active_stable_window_id();
         let repeat_signature = Self::key_signature(&ev);
         let mut drain_repeated_motion = false;
 
@@ -9927,6 +9990,7 @@ impl Editor {
             );
         }
         drop(resolve_span);
+        let navigation_action = action.as_ref().is_some_and(Self::key_action_is_navigation);
         if let Some(action) = action {
             drain_repeated_motion =
                 !from_waiting_key_action && self.should_drain_repeated_motion(&ev, &action);
@@ -9948,7 +10012,10 @@ impl Editor {
         self.finish_semantic_change_event();
         drop(semantic_span);
 
-        if render_mode == EventRenderMode::Immediate && self.render_generation == render_generation
+        if render_mode == EventRenderMode::Immediate
+            && self.render_generation == render_generation
+            && (!mouse_moved && !navigation_action
+                || window_before != self.window_manager.active_stable_window_id())
         {
             self.render(buffer)?;
         }
@@ -9984,6 +10051,108 @@ impl Editor {
         )
         .await?;
         Ok(true)
+    }
+
+    fn request_motion_render(&mut self, request: MotionRender) {
+        self.deferred_motion_render = self.deferred_motion_render.max(request);
+    }
+
+    fn active_buffer_visible_once(&self) -> bool {
+        let active = self.buffer_manager.active_index();
+        self.window_manager
+            .windows()
+            .iter()
+            .filter(|window| window.buffer_index == active)
+            .count()
+            == 1
+    }
+
+    fn can_batch_scroll(&self, event: &Event) -> bool {
+        let Event::Mouse(mouse) = event else {
+            return false;
+        };
+        matches!(
+            mouse.kind,
+            MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
+        ) && self.is_normal()
+            && self.current_dialog.is_none()
+            && self.waiting_key_action.is_none()
+            && self.pending_operator.is_none()
+            && self.divider_drag.is_none()
+            && self.pane_resize_mode.is_none()
+            && !self.workspace_manager.is_active()
+            && !self.panel_manager.has_focused_panel()
+            && self
+                .window_manager
+                .window_at_position(usize::from(mouse.column), usize::from(mouse.row))
+                .is_some()
+    }
+
+    fn scroll_batch_accepts(first: &Event, next: &Event) -> bool {
+        matches!(
+            next,
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Moved,
+                ..
+            })
+        ) || first == next
+    }
+
+    fn read_scroll_batch(
+        first: Event,
+        pending: &mut VecDeque<Event>,
+    ) -> anyhow::Result<Vec<Event>> {
+        let mut events = vec![first];
+        let started = Instant::now();
+        while events.len() < SCROLL_EVENTS_PER_BATCH && started.elapsed() < INPUT_BATCH_BUDGET {
+            let Some(next) = Self::read_ready_event(pending)? else {
+                break;
+            };
+            if !Self::scroll_batch_accepts(&events[0], &next) {
+                pending.push_front(next);
+                break;
+            }
+            events.push(next);
+        }
+        Ok(events)
+    }
+
+    /// Preserve every wheel delta, but publish only the final navigation frame.
+    /// Nonmatching input stays queued so pointer targets and ordering are stable.
+    async fn process_scroll_batch(
+        &mut self,
+        events: Vec<Event>,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        perf::increment("scroll_batches", 1);
+        perf::increment("scroll_batch_events", events.len() as u64);
+        self.defer_motion_render = true;
+        let result: anyhow::Result<bool> = async {
+            for event in events {
+                if self
+                    .process_editor_event(event, buffer, runtime, EventRenderMode::DeferredMotion)
+                    .await?
+                    .quit
+                {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        .await;
+        self.defer_motion_render = false;
+        let quit = result?;
+        self.flush_deferred_plugin_event(runtime).await?;
+        let generation = self.render_generation;
+        self.service_background(buffer, runtime).await?;
+        if self.render_generation == generation {
+            self.flush_deferred_motion_render(buffer)?;
+        } else {
+            // Background effects already painted the final editor state.
+            self.deferred_motion_render = MotionRender::None;
+        }
+        Ok(quit)
     }
 
     async fn drain_repeated_motion_events(
@@ -10099,10 +10268,14 @@ impl Editor {
 
     fn flush_deferred_motion_render(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         self.defer_motion_render = false;
-        if self.deferred_motion_needs_full_render {
-            self.deferred_motion_needs_full_render = false;
-            self.render(buffer)
-        } else if self.can_render_cursor_motion_delta() {
+        match std::mem::take(&mut self.deferred_motion_render) {
+            MotionRender::None => return Ok(()),
+            MotionRender::Full => return self.render(buffer),
+            MotionRender::EditorWindows => return self.render_editor_windows_frame(buffer),
+            MotionRender::Window => return self.render_motion_frame(buffer),
+            MotionRender::Cursor => {}
+        }
+        if self.can_render_cursor_motion_delta() {
             self.render_cursor_motion_delta(buffer)
         } else if self.relative_line_numbers_enabled()
             || self.uses_synthetic_block_cursor()
@@ -10144,7 +10317,13 @@ impl Editor {
     ) -> anyhow::Result<bool> {
         // A count is one input command even though KeyAction expands it internally.
         // Keep that render boundary for both direct input and replayed events.
-        if self.should_defer_counted_relative_motion(action) {
+        if self.should_defer_counted_relative_motion(action)
+            || (self.is_normal()
+                && self.current_dialog.is_none()
+                && !self.panel_manager.has_focused_panel()
+                && !self.workspace_manager.is_active()
+                && Self::key_action_is_navigation(action))
+        {
             self.handle_key_action_with_deferred_motion(ev, action, buffer, runtime)
                 .await
         } else {
@@ -10287,6 +10466,22 @@ impl Editor {
             KeyAction::Repeating(_, action) => Self::key_action_is_pure_motion(action),
             KeyAction::None | KeyAction::Nested(_) => false,
         }
+    }
+
+    fn key_action_is_navigation(action: &KeyAction) -> bool {
+        match action {
+            KeyAction::Single(action) => Self::action_is_navigation(action),
+            KeyAction::Multiple(actions) => {
+                !actions.is_empty() && actions.iter().all(Self::action_is_navigation)
+            }
+            KeyAction::Repeating(_, action) => Self::key_action_is_navigation(action),
+            KeyAction::None | KeyAction::Nested(_) => false,
+        }
+    }
+
+    fn action_is_navigation(action: &Action) -> bool {
+        Self::action_is_pure_motion(action)
+            || matches!(action, Action::ScrollUp | Action::ScrollDown)
     }
 
     fn action_is_pure_motion(action: &Action) -> bool {
@@ -11815,6 +12010,23 @@ impl Editor {
         ev: &event::Event,
         runtime: Option<&Runtime>,
     ) -> anyhow::Result<Option<KeyAction>> {
+        // Pointer motion has no editor/pane action. Let dialogs opt into hover
+        // handling without clearing an in-progress key sequence or its hints.
+        if matches!(
+            ev,
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Moved,
+                ..
+            })
+        ) {
+            return Ok(if self.waiting_key_action.is_some() {
+                None
+            } else {
+                self.current_dialog
+                    .as_mut()
+                    .and_then(|dialog| dialog.handle_event(ev))
+            });
+        }
         if self.divider_drag.is_some()
             && matches!(
                 ev,
@@ -18158,7 +18370,7 @@ impl Editor {
                     let max_cy = viewport_height.saturating_sub(scrolloff).saturating_sub(1);
                     self.cy = self.cy.saturating_add(scrolled_lines).min(max_cy);
                     self.sync_to_window();
-                    self.render(buffer)?;
+                    self.render_motion_frame(buffer)?;
                 }
             }
             Action::ScrollDown => {
@@ -18182,7 +18394,7 @@ impl Editor {
                         .min(viewport_height.saturating_sub(1));
                     self.cy = self.cy.saturating_sub(scrolled_lines).max(scrolloff);
                     self.sync_to_window();
-                    self.render(buffer)?;
+                    self.render_motion_frame(buffer)?;
                 }
             }
             Action::ScrollViewLeft => {
@@ -19334,7 +19546,11 @@ impl Editor {
         drop(bounds_span);
 
         if bounds_changed {
-            self.render(buffer)?;
+            if Self::action_is_navigation(action) {
+                self.render_motion_frame(buffer)?;
+            } else {
+                self.render(buffer)?;
+            }
         }
 
         if self.is_visual() && Self::action_is_selection_motion(action) {
@@ -19356,8 +19572,9 @@ impl Editor {
         // This ensures window state is updated even for actions that don't trigger a full render
         self.sync_to_window();
 
-        // Always render after actions when in multi-window mode to ensure changes are visible
-        if self.window_manager.windows().len() > 1 {
+        // Navigation repaints its active window; other actions may affect shared
+        // buffers, layout, focus, or chrome in any editor window.
+        if self.window_manager.window_count() > 1 && !Self::action_is_navigation(action) {
             self.render(buffer)?;
         }
 
@@ -30620,13 +30837,13 @@ builtin = "rust"
     }
 
     #[tokio::test]
-    async fn counted_motion_keeps_the_existing_render_path_without_relative_numbers() {
+    async fn counted_motion_renders_only_the_final_frame_without_relative_numbers() {
         let (editor, _, generation_before_motion) = run_counted_down_motion(false).await;
 
         assert_eq!(editor.buffer_line(), 10);
         assert_eq!(
             editor.render_generation,
-            generation_before_motion.wrapping_add(10)
+            generation_before_motion.wrapping_add(1)
         );
     }
 

--- a/src/editor/navigation_perf_tests.rs
+++ b/src/editor/navigation_perf_tests.rs
@@ -1,0 +1,284 @@
+use super::*;
+
+fn mouse(kind: MouseEventKind, column: u16, row: u16) -> Event {
+    Event::Mouse(MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers: KeyModifiers::NONE,
+    })
+}
+
+fn workspace(shared_buffer: bool, relative: bool, wrap: bool) -> (Editor, RenderBuffer, Runtime) {
+    let mut config = Config {
+        relative_line_numbers: Some(relative),
+        wrap: Some(wrap),
+        ..Config::default()
+    };
+    config.lsp.enabled = false;
+    let source = (0..400)
+        .map(|n| {
+            format!("fn value_{n}() -> usize {{ {n} }} // a highlighted line with extra text\n")
+        })
+        .collect::<String>();
+    let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+    let mut editor = Editor::with_size(
+        lsp,
+        120,
+        30,
+        config,
+        Theme::default(),
+        vec![
+            Buffer::new(Some("fixture.rs".into()), source.clone()),
+            Buffer::new(Some("other.rs".into()), source),
+        ],
+    )
+    .unwrap();
+    editor.test_disable_terminal_output();
+    editor.panel_manager.create_text_panel(
+        "agent".into(),
+        plugin::PanelConfig {
+            side: plugin::PanelSide::Right,
+            width: 30,
+            title: Some("Agent".into()),
+            ..Default::default()
+        },
+    );
+    editor.panel_manager.update_text_panel(
+        "agent",
+        vec![plugin::TextPanelBlock {
+            id: "answer".into(),
+            kind: Default::default(),
+            format: Default::default(),
+            text: "An unchanged conversation".into(),
+        }],
+        30,
+        120,
+    );
+    editor.apply_panel_layout();
+    assert!(
+        editor.update_window_layout(|windows| windows.split_horizontal(if shared_buffer {
+            0
+        } else {
+            1
+        }))
+    );
+    editor.set_active_window(0);
+    let mut buffer = RenderBuffer::new(120, 30, &Style::default());
+    editor.render(&mut buffer).unwrap();
+    (editor, buffer, Runtime::new())
+}
+
+fn assert_matches_full_frame(editor: &mut Editor, buffer: &RenderBuffer) {
+    let mut full = buffer.clone();
+    editor.render(&mut full).unwrap();
+    assert_eq!(buffer.cells, full.cells);
+}
+
+#[tokio::test]
+async fn ignored_mouse_flood_does_not_render_or_mutate_editor_state() {
+    let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
+    let generation = editor.render_generation;
+    let flushes = editor.terminal_flush_generation;
+    let cells = buffer.cells.clone();
+    let view = editor.editor_view_state();
+    for index in 0..200 {
+        editor
+            .process_editor_event(
+                mouse(MouseEventKind::Moved, 10 + index % 30, 3),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(editor.render_generation, generation);
+    assert_eq!(editor.terminal_flush_generation, flushes);
+    assert_eq!(editor.editor_view_state(), view);
+    assert_eq!(buffer.cells, cells);
+}
+
+#[tokio::test]
+async fn wheel_batch_preserves_scroll_distance_and_reuses_unchanged_surfaces() {
+    for shared in [false, true] {
+        for (relative, wrap) in [(false, false), (true, false), (true, true)] {
+            let (mut editor, mut buffer, mut runtime) = workspace(shared, relative, wrap);
+            let generation = editor.render_generation;
+            let full_renders = editor.full_render_count;
+            let mut events = Vec::new();
+            for _ in 0..10 {
+                events.push(mouse(MouseEventKind::ScrollDown, 12, 3));
+                events.push(mouse(MouseEventKind::Moved, 16, 4));
+            }
+            assert!(!editor
+                .process_scroll_batch(events, &mut buffer, &mut runtime)
+                .await
+                .unwrap());
+            assert_eq!(editor.vtop, 30);
+            assert_eq!(editor.render_generation, generation + 1);
+            assert_eq!(editor.full_render_count, full_renders);
+            assert_matches_full_frame(&mut editor, &buffer);
+        }
+    }
+}
+
+#[tokio::test]
+async fn wheel_focus_change_repaints_the_previous_active_window() {
+    let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
+    let old_window = editor.window_manager.active_stable_window_id();
+    let full_renders = editor.full_render_count;
+    let lower = editor.window_manager.window_at_index(1).unwrap();
+    let event = mouse(
+        MouseEventKind::ScrollDown,
+        12,
+        (lower.position.y + 2) as u16,
+    );
+    editor
+        .process_scroll_batch(vec![event], &mut buffer, &mut runtime)
+        .await
+        .unwrap();
+    assert_ne!(editor.window_manager.active_stable_window_id(), old_window);
+    assert_eq!(editor.full_render_count, full_renders + 1);
+    assert_matches_full_frame(&mut editor, &buffer);
+}
+
+#[test]
+fn wheel_batch_stops_at_direction_target_modifier_and_ordering_boundaries() {
+    let first = mouse(MouseEventKind::ScrollDown, 12, 3);
+    assert!(Editor::scroll_batch_accepts(&first, &first));
+    assert!(Editor::scroll_batch_accepts(
+        &first,
+        &mouse(MouseEventKind::Moved, 80, 20)
+    ));
+    for next in [
+        mouse(MouseEventKind::ScrollUp, 12, 3),
+        mouse(MouseEventKind::ScrollDown, 13, 3),
+        mouse(MouseEventKind::Down(MouseButton::Left), 12, 3),
+        mouse(MouseEventKind::Drag(MouseButton::Left), 12, 3),
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 12,
+            row: 3,
+            modifiers: KeyModifiers::SHIFT,
+        }),
+        Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+        Event::Resize(100, 20),
+    ] {
+        assert!(!Editor::scroll_batch_accepts(&first, &next), "{next:?}");
+    }
+}
+
+#[tokio::test]
+async fn shared_buffer_decoration_updates_repaint_both_editor_windows() {
+    let (mut editor, mut buffer, mut runtime) = workspace(true, false, false);
+    let full_renders = editor.full_render_count;
+    ACTION_DISPATCHER.send_request(PluginRequest::SetGutterSigns {
+        namespace: "perf-test".into(),
+        signs: vec![plugin::GutterSign {
+            buffer_index: 0,
+            line: 0,
+            text: "!".into(),
+            style: Style::default(),
+            priority: 100,
+        }],
+    });
+    editor
+        .service_background(&mut buffer, &mut runtime)
+        .await
+        .unwrap();
+    assert_eq!(editor.full_render_count, full_renders);
+    assert_matches_full_frame(&mut editor, &buffer);
+}
+
+fn decoration(buffer_index: usize) -> plugin::Decoration {
+    plugin::Decoration {
+        buffer_index: Some(buffer_index),
+        anchor: plugin::DecorationAnchor::Column,
+        line: 0,
+        column: 3,
+        text: "!".into(),
+        style: Style::default(),
+        priority: 100,
+        repeat_linebreak: false,
+        only_whitespace: false,
+    }
+}
+
+#[tokio::test]
+async fn replacing_decorations_clears_the_previous_inactive_buffer() {
+    let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
+    editor
+        .decoration_manager
+        .set("moving".into(), vec![decoration(1)]);
+    editor.render(&mut buffer).unwrap();
+    let full_renders = editor.full_render_count;
+    ACTION_DISPATCHER.send_request(PluginRequest::SetDecorations {
+        namespace: "moving".into(),
+        decorations: vec![decoration(0)],
+    });
+    editor
+        .service_background(&mut buffer, &mut runtime)
+        .await
+        .unwrap();
+    assert_eq!(editor.full_render_count, full_renders);
+    assert_matches_full_frame(&mut editor, &buffer);
+}
+
+#[tokio::test]
+async fn streamed_panel_changes_still_invalidate_the_full_surface() {
+    let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
+    let full_renders = editor.full_render_count;
+    ACTION_DISPATCHER.send_request(PluginRequest::AppendTextPanel {
+        id: "agent".into(),
+        block_id: "answer".into(),
+        delta: "\nNew streamed content".into(),
+    });
+    editor
+        .service_background(&mut buffer, &mut runtime)
+        .await
+        .unwrap();
+    assert_eq!(editor.full_render_count, full_renders + 1);
+    assert!(render_text_rows(&buffer)
+        .join("\n")
+        .contains("New streamed content"));
+    assert_matches_full_frame(&mut editor, &buffer);
+}
+
+struct HoverDialog(bool);
+
+impl crate::ui::Component for HoverDialog {
+    fn draw(&self, _buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        (self.0
+            && matches!(
+                event,
+                Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::Moved,
+                    ..
+                })
+            ))
+        .then_some(KeyAction::Single(Action::Refresh))
+    }
+}
+
+#[tokio::test]
+async fn dialogs_may_request_hover_redraws_but_ignored_hover_is_free() {
+    let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
+    for redraw in [false, true] {
+        editor.current_dialog = Some(Box::new(HoverDialog(redraw)));
+        let generation = editor.render_generation;
+        editor
+            .process_editor_event(
+                mouse(MouseEventKind::Moved, 10, 3),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert_eq!(editor.render_generation != generation, redraw);
+    }
+}

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1090,17 +1090,23 @@ impl Editor {
     /// Renders the entire editor state to the terminal
     /// This is the main entry point for all rendering operations
     pub fn render(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
-        if self.relative_line_numbers_enabled() && self.defer_motion_render {
-            self.deferred_motion_needs_full_render = true;
+        if self.defer_motion_render {
+            self.request_motion_render(super::MotionRender::Full);
             return Ok(());
         }
 
         let _span = super::perf::PerfSpan::start("render:full");
+        #[cfg(test)]
+        {
+            self.full_render_count += 1;
+        }
+        let prepare_span = super::perf::PerfSpan::start("render:prepare");
         self.update_gutter_width();
         self.apply_panel_layout();
         self.fix_cursor_pos();
         self.check_bounds();
         self.sync_to_window();
+        drop(prepare_span);
         // Render all windows
         let windows_span = super::perf::PerfSpan::start("render:windows");
         let window_count = self.window_manager.window_count();
@@ -1133,12 +1139,14 @@ impl Editor {
                 }
             }
         }
+        let panels_span = super::perf::PerfSpan::start("render:panels");
         self.panel_manager.render_with_active_dividers(
             buffer,
             &self.theme,
             &active_panel_dividers,
             self.config.window_borders_ascii,
         );
+        drop(panels_span);
 
         // Render global UI elements
         let chrome_span = super::perf::PerfSpan::start("render:chrome");
@@ -1161,11 +1169,13 @@ impl Editor {
         drop(chrome_span);
 
         // Update overlay positions and render them
+        let overlays_span = super::perf::PerfSpan::start("render:overlays+cursor");
         self.update_and_render_overlays(buffer)?;
 
         self.update_terminal_cursor_surface(buffer);
         self.render_cursor_cell(buffer);
         self.last_rendered_cursor_position = self.render_cursor_position();
+        drop(overlays_span);
 
         // Flush changes to terminal
         let diff_span = super::perf::PerfSpan::start("render:diff+flush");
@@ -1173,6 +1183,7 @@ impl Editor {
         self.render_diff(&changes)?;
         self.commit_render_buffer_changes(&changes);
         drop(diff_span);
+        self.last_rendered_window = self.window_manager.active_stable_window_id();
         self.render_generation = self.render_generation.wrapping_add(1);
 
         Ok(())
@@ -1218,12 +1229,62 @@ impl Editor {
     }
 
     pub(crate) fn render_motion_frame(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        if self.defer_motion_render {
+            self.request_motion_render(super::MotionRender::Window);
+            return Ok(());
+        }
+        if !self.can_reuse_editor_surfaces() {
+            return self.render(buffer);
+        }
         let _span = super::perf::PerfSpan::start("render:motion_frame");
+        self.render_editor_frame(buffer, /*all_windows*/ false)
+    }
+
+    /// Repaint editor-owned decorations without rebuilding unchanged docked panes.
+    pub(crate) fn render_editor_windows_frame(
+        &mut self,
+        buffer: &mut RenderBuffer,
+    ) -> anyhow::Result<()> {
+        if self.defer_motion_render {
+            self.request_motion_render(super::MotionRender::EditorWindows);
+            return Ok(());
+        }
+        if !self.can_reuse_editor_surfaces() {
+            return self.render(buffer);
+        }
+        let _span = super::perf::PerfSpan::start("render:editor_windows");
+        self.render_editor_frame(buffer, /*all_windows*/ true)
+    }
+
+    fn can_reuse_editor_surfaces(&self) -> bool {
+        self.previous_render_buffer.is_some()
+            && !self.force_full_redraw
+            && self.last_rendered_window == self.window_manager.active_stable_window_id()
+            && self.current_dialog.is_none()
+            && !self.keymap_hints_visible
+            && !self.panel_manager.has_focused_panel()
+            && !self.workspace_manager.is_active()
+            && !self.overlay_manager.has_visible_content()
+            && self.render_commands.is_empty()
+            && !self.has_term()
+    }
+
+    fn render_editor_frame(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        all_windows: bool,
+    ) -> anyhow::Result<()> {
         self.update_gutter_width();
         self.fix_cursor_pos();
         self.sync_to_window();
-        let active_window_id = self.window_manager.active_window_id();
-        self.render_window(buffer, active_window_id)?;
+        if all_windows {
+            for window_id in 0..self.window_manager.window_count() {
+                self.render_window(buffer, window_id)?;
+            }
+            self.render_all_window_separators(buffer)?;
+        } else {
+            self.render_window(buffer, self.window_manager.active_window_id())?;
+        }
         self.render_ui_chrome(buffer)?;
         self.render_dialog(buffer)?;
         self.update_and_render_overlays(buffer)?;
@@ -1234,6 +1295,7 @@ impl Editor {
         let changes = self.render_buffer_changes(buffer);
         self.render_diff(&changes)?;
         self.commit_render_buffer_changes(&changes);
+        self.last_rendered_window = self.window_manager.active_stable_window_id();
         self.render_generation = self.render_generation.wrapping_add(1);
 
         Ok(())
@@ -1241,6 +1303,7 @@ impl Editor {
 
     pub(crate) fn can_render_cursor_motion_delta(&self) -> bool {
         self.terminal_output_enabled
+            && self.can_reuse_editor_surfaces()
             && !self.relative_line_numbers_enabled()
             && self.uses_synthetic_block_cursor()
             && self.current_dialog.is_none()

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -1155,6 +1155,7 @@ impl TextPanel {
             }
         }
 
+        let _span = crate::editor::perf::PerfSpan::start("panel:text_layout_miss");
         let content_width = TextPanelContentMetrics::new(width).width;
         let mut layout = TextPanelLayout::new(self.build_rendered_lines(content_width));
         if self.status.as_ref().is_some_and(|status| status.stream) {
@@ -3306,6 +3307,8 @@ impl PanelManager {
         use_ascii: bool,
     ) {
         for placement in self.panel_placements(buffer.width, buffer.height) {
+            let _span =
+                crate::editor::perf::PerfSpan::with_detail("panel:paint", placement.id.as_str());
             let Some(config) = self.panel_config(&placement.id) else {
                 continue;
             };


### PR DESCRIPTION
## Why

Mouse movement was triggering full redraws even when nothing visible changed. Scrolling with multiple editor splits also repainted the same workspace several times per event, including unchanged Agent and NeoTree panes.

## What changed

- Ignore unused pointer movement while preserving dialog hover behavior and pending key sequences.
- Process compatible wheel events in bounded, lossless batches, preserve input ordering, and service background work between batches.
- Repaint only the affected editor surfaces during navigation. Keep full-render fallbacks for focus, layout, overlays, and streamed panel changes.
- Add rendering regressions, a deterministic real-Agent PTY benchmark, and before/after reports in `docs/performance-baseline-2026-08-15.md` and `docs/performance-scroll-improvements-2026-08-15.md`.

Three matched release-build runs on an Apple M4 Max, with two highlighted Rust editors, NeoTree, and a populated Agent pane, reduced tracing-disabled mixed mouse/wheel CPU from **0.84 s to 0.37 s (56%)**. Mouse-only output fell from **8,800 bytes to zero**. The traced mixed workload went from **1,173 full renders to 200 scoped editor frames**. Accepted traces account for every wheel and mouse event. These are PTY/process measurements, not physical-display latency.

## How to Test

1. Build with `cargo build --locked --release --bin red`, then run:
   ```sh
   python3 scripts/workspace_scroll_bench.py --layout workspace --phases mouse wheel mixed --output target/perf/pr-scroll-workspace
   ```
   Expected: the fixture opens two highlighted files, NeoTree, and a populated Agent pane without contacting a model. Mouse movement emits zero bytes; the wheel and mixed phases report exactly 200 and 800 decoded events, respectively. Ordinary navigation uses scoped editor frames instead of repeated full renders.
2. Exercise changing pane content:
   ```sh
   python3 scripts/workspace_scroll_bench.py --layout workspace --phases streaming --output target/perf/pr-scroll-streaming
   ```
   Expected: Agent updates continue while scrolling, all 800 input events are accounted for, and real panel changes still trigger redraws.
3. Run `cargo test --locked --lib navigation_perf_tests -- --test-threads=1`. The eight regressions cover exact scroll distance, shared-buffer splits, wrapping and relative numbers, focus changes, direction/target/modifier ordering, decoration replacement, streamed panes, and hover-enabled dialogs. Optimized cells must match a fresh full render.

Validation completed: the full all-targets/all-features test suite, strict Clippy, 30 matched benchmark runs, real rust-analyzer diagnostics, and a live terminal resize/restore smoke. The reports also document the rejected input-decoding stress runs and remaining Windows/physical-terminal measurement limits.
