### PR TITLE
fix(editor): preserve viewport at insertion line ends

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -6148,7 +6148,7 @@ impl Editor {
         self.layout_for_window(&window)
             .rows
             .iter()
-            .any(|segment| segment.line == line_index && segment.contains_display_col(display_col))
+            .any(|segment| segment.line == line_index && segment.contains_cursor_col(display_col))
     }
 
     fn scroll_wrapped_viewport_down_one_screen_line(&mut self) -> bool {
@@ -6247,7 +6247,7 @@ impl Editor {
         let segments = self.wrapped_line_segments_for_width(line_index, width);
         let current_index = segments
             .iter()
-            .position(|segment| segment.contains_display_col(display_col))
+            .position(|segment| segment.contains_cursor_col(display_col))
             .or_else(|| segments.len().checked_sub(1))?;
         let current = segments[current_index];
         // Preserve the screen column across rows: with break-indent the same
@@ -6398,7 +6398,7 @@ impl Editor {
 
         let layout = self.layout_for_window(&window);
         let Some(current_index) = layout.rows.iter().position(|segment| {
-            segment.line == line_index && segment.contains_display_col(display_col)
+            segment.line == line_index && segment.contains_cursor_col(display_col)
         }) else {
             return;
         };

--- a/src/editor/display_layout.rs
+++ b/src/editor/display_layout.rs
@@ -174,6 +174,8 @@ pub struct LineSegment {
     pub start_grapheme_col: usize,
     pub source_offset: usize,
     pub first_segment: bool,
+    /// Whether this segment reaches the source line's end, not just the viewport edge.
+    pub last_segment: bool,
     /// Blank screen columns drawn before the segment's text. Zero on first
     /// segments; on wrapped continuations it aligns the text with the
     /// line's indentation (vim's 'breakindent').
@@ -187,6 +189,12 @@ impl LineSegment {
         }
 
         col >= self.start_col && col < self.end_col
+    }
+
+    /// Includes the insertion caret after the final character, but keeps
+    /// boundaries between wrapped segments exclusive on the preceding row.
+    pub fn contains_cursor_col(&self, col: usize) -> bool {
+        self.contains_display_col(col) || (self.last_segment && col == self.end_col)
     }
 
     pub fn screen_col_for_display_col(&self, col: usize, width: usize) -> usize {
@@ -308,7 +316,7 @@ impl DisplayLayout {
     pub fn segment_for_cursor(&self, line: usize, display_col: usize) -> Option<&LineSegment> {
         self.rows
             .iter()
-            .find(|segment| segment.line == line && segment.contains_display_col(display_col))
+            .find(|segment| segment.line == line && segment.contains_cursor_col(display_col))
             .or_else(|| self.rows.iter().rev().find(|segment| segment.line == line))
     }
 }
@@ -450,6 +458,7 @@ fn wrap_line_segments_with_limit(
                     start_grapheme_col: start_col,
                     source_offset: 0,
                     first_segment,
+                    last_segment: false,
                     visual_offset: if first_segment { 0 } else { indent },
                 });
                 if segments.len() == max_segments {
@@ -481,6 +490,7 @@ fn wrap_line_segments_with_limit(
             start_grapheme_col: start_col,
             source_offset: 0,
             first_segment,
+            last_segment: true,
             visual_offset: if first_segment { 0 } else { indent },
         });
     }
@@ -526,6 +536,7 @@ fn wrap_line_segments_with_limit(
             start_grapheme_col,
             source_offset: 0,
             first_segment,
+            last_segment: start_col == line_width,
             visual_offset: if first_segment { 0 } else { indent },
         });
     }
@@ -586,6 +597,7 @@ fn nowrap_line_segment(
         start_grapheme_col,
         source_offset: 0,
         first_segment: true,
+        last_segment: end_byte == line.len(),
         visual_offset: 0,
     }]
 }
@@ -602,6 +614,34 @@ mod tests {
         assert_eq!((segments[0].start_col, segments[0].end_col), (0, 3));
         assert_eq!((segments[1].start_col, segments[1].end_col), (3, 6));
         assert!(!segments[1].first_segment);
+    }
+
+    #[test]
+    fn cursor_columns_include_only_the_actual_line_end() {
+        let segments = wrap_line_segments("abcdef", 0, 3, 0, BreakIndentOptions::disabled());
+        assert!(!segments[0].last_segment);
+        assert!(!segments[0].contains_cursor_col(3));
+        assert!(segments[1].last_segment);
+        assert!(segments[1].contains_cursor_col(3));
+        assert!(!segments[1].contains_display_col(6));
+        assert!(segments[1].contains_cursor_col(6));
+        assert!(!segments[1].contains_cursor_col(7));
+
+        let clipped =
+            wrap_line_segments_with_limit("abcdef", 0, 3, 0, BreakIndentOptions::disabled(), 1);
+        assert_eq!(clipped.len(), 1);
+        assert!(!clipped[0].contains_cursor_col(3));
+
+        let nowrap = nowrap_line_segment("abcdef", 0, 3, 0, 4);
+        assert!(!nowrap[0].contains_cursor_col(3));
+        let nowrap_end = nowrap_line_segment("abcdef", 0, 3, 3, 4);
+        assert!(nowrap_end[0].contains_cursor_col(6));
+
+        let unicode = wrap_line_segments("a\t界", 0, 4, 0, BreakIndentOptions::disabled());
+        assert!(!unicode[0].contains_cursor_col(4));
+        assert!(unicode[1].contains_cursor_col(6));
+        let empty = wrap_line_segments("", 0, 3, 0, BreakIndentOptions::disabled());
+        assert!(empty[0].contains_cursor_col(0));
     }
 
     #[test]

--- a/src/editor/inline_comments.rs
+++ b/src/editor/inline_comments.rs
@@ -614,7 +614,7 @@ impl Editor {
             if let Some(segment) = self
                 .wrapped_line_segments_for_width(line, self.active_content_width())
                 .into_iter()
-                .find(|segment| segment.contains_display_col(display_col))
+                .find(|segment| segment.contains_cursor_col(display_col))
             {
                 self.vtop = line;
                 self.cy = 0;

--- a/src/editor/inline_comments/tests.rs
+++ b/src/editor/inline_comments/tests.rs
@@ -460,6 +460,101 @@ fn inline_comments_keep_bottom_cursor_visible_in_both_wrap_modes() {
     }
 }
 
+#[tokio::test]
+async fn inline_comments_preserve_viewport_at_insert_line_end() {
+    let text = (0..80)
+        .map(|line| format!("    line_{line};\n"))
+        .collect::<String>();
+    let cases: &[(&str, &[KeyCode], usize)] = &[
+        ("o", &[KeyCode::Char('o')], 33),
+        ("O", &[KeyCode::Char('O')], 32),
+        ("A", &[KeyCode::Char('A')], 32),
+        ("Enter", &[KeyCode::Char('A'), KeyCode::Enter], 33),
+    ];
+
+    for wrap in [false, true] {
+        for comment_line in [None, Some(32), Some(34)] {
+            for &(name, keys, target_line) in cases {
+                let mut editor = editor(&text, 80, 24, wrap);
+                if let Some(line) = comment_line {
+                    editor.test_set_viewport_cursor(20, 4, line - 20);
+                    editor.set_inline_comment("Review this line");
+                }
+                editor.test_set_viewport_cursor(20, 4, 12);
+
+                for &key in keys {
+                    editor
+                        .test_execute_event(Event::Key(KeyEvent::new(key, KeyModifiers::NONE)))
+                        .await
+                        .unwrap();
+                    assert_eq!(
+                        editor.vtop, 20,
+                        "{name}: wrap={wrap}, comment_line={comment_line:?}, key={key:?}"
+                    );
+                }
+
+                assert_eq!(editor.mode, Mode::Insert);
+                assert_eq!(editor.buffer_line(), target_line);
+                let expected = if name == "A" {
+                    "    line_32;\n"
+                } else {
+                    "    \n"
+                };
+                assert_eq!(editor.current_line_contents().as_deref(), Some(expected));
+                assert_eq!(editor.cx, expected.trim_end_matches('\n').len());
+                assert!(editor.visible_cursor_segment(target_line, editor.cx));
+
+                editor
+                    .test_execute_event(Event::Key(KeyEvent::new(
+                        KeyCode::Char('x'),
+                        KeyModifiers::NONE,
+                    )))
+                    .await
+                    .unwrap();
+                assert_eq!(editor.vtop, 20, "typing after {name}");
+                assert_eq!(editor.buffer_line(), target_line);
+                assert!(editor.visible_cursor_segment(target_line, editor.cx));
+            }
+        }
+    }
+}
+
+#[test]
+fn inline_comments_reveal_the_actual_wrapped_cursor_segment() {
+    let text = (0..40)
+        .map(|line| {
+            if line == 26 {
+                format!("{}\n", "x".repeat(300))
+            } else {
+                format!("line {line}\n")
+            }
+        })
+        .collect::<String>();
+    let mut editor = editor(&text, 40, 8, true);
+    editor.test_set_viewport_cursor(20, 0, 15);
+    editor.set_inline_comment("Review a later line");
+    editor.mode = Mode::Insert;
+    let width = editor.active_content_width();
+    let bottom_row = editor.vheight() - 1;
+    let initial_top = 26 - bottom_row;
+    editor.test_set_viewport_cursor(initial_top, width, bottom_row);
+
+    assert!(!editor.visible_cursor_segment(26, width));
+    editor.ensure_inline_comment_cursor_visible();
+    assert_eq!(editor.vtop, initial_top + 1);
+    assert_eq!(editor.buffer_line(), 26);
+    assert!(editor.visible_cursor_segment(26, width));
+
+    // An end-of-line caret beyond a full screen must use the final segment,
+    // even when the fallback has to scroll within the logical line.
+    editor.test_set_viewport_cursor(initial_top, 300, bottom_row);
+    assert!(!editor.visible_cursor_segment(26, 300));
+    editor.ensure_inline_comment_cursor_visible();
+    assert_eq!(editor.buffer_line(), 26);
+    assert!(editor.skipcol > 0);
+    assert!(editor.visible_cursor_segment(26, 300));
+}
+
 #[test]
 fn clearing_inline_comments_preserves_cursor_near_eof() {
     let mut editor = editor("alpha\nbeta\ngamma\ndelta\nepsilon\n", 40, 6, false);

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -3753,6 +3753,7 @@ mod tests {
             start_grapheme_col: start_col,
             source_offset: 0,
             first_segment,
+            last_segment: true,
             visual_offset: 0,
         }
     }


### PR DESCRIPTION
With wrapping enabled and an inline comment present, entering Insert mode at the end of an indented line could scroll that line to the top of the viewport. The caret was valid, but the visibility check treated the position immediately after the last character as outside the line. This fixes the regression exposed by #233.

Track whether each display segment reaches the actual source-line end, and use an insertion-aware column check for cursor placement, movement, and inline-comment scrolling. Internal wrap boundaries remain exclusive, so a clipped continuation row is not incorrectly treated as visible.

Regression coverage includes `o`, `O`, `A`, Enter, and subsequent typing with wrapping on/off and comments on or below the edited line, plus clipped long lines, tabs, Unicode, and empty lines.

## How to Test

1. Open a file with several screens of indented code and enable wrapping. Add an inline comment on or near the current line (`Space C` with the default bindings), then place the cursor on an indented line in the middle of the viewport. Try `o`, `O`, `A`, Enter, and typing. The edit and caret should be correct without snapping the line to the top.
2. Narrow the viewport and move through a long wrapped line. A caret at an internal wrap boundary must appear on the following segment; a caret at the actual line end must remain visible, scrolling only when necessary.
3. Run `cargo test -p red --lib inline_comments_` and `cargo test -p red --lib cursor_columns_include_only_the_actual_line_end`.

Local validation: all 1,508 unit tests and 531 editing/insertion/movement/Unicode integration tests passed. `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` passed.