### PR TITLE
feat(composer): wrap words with source-backed text layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,7 @@ dependencies = [
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
  "tree-sitter-yaml",
+ "unicode-linebreak",
  "unicode-segmentation",
  "unicode-width 0.2.1",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ tree-sitter-rust = "0.24.2"
 tree-sitter-toml-ng = "0.7.0"
 tree-sitter-typescript = "0.23.2"
 tree-sitter-yaml = "0.7.2"
+unicode-linebreak = "0.1"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2"
 uuid = { version = "1.12.0", features = ["v4", "v5"] }

--- a/src/editing/textarea.rs
+++ b/src/editing/textarea.rs
@@ -12,15 +12,13 @@ use super::{
 use crate::{
     buffer::Buffer,
     editor::Mode,
+    text_layout::{LayoutOptions, TextLayout},
     undo::{CursorSnapshot, TextPosition, TextRange},
-    unicode_utils::{
-        char_to_grapheme, display_width, grapheme_len, grapheme_to_byte, trim_line_ending,
-    },
+    unicode_utils::{char_to_grapheme, grapheme_len, grapheme_to_byte, trim_line_ending},
 };
 
 const DEFAULT_MAX_BYTES: usize = 128 * 1024;
 const MAX_MACRO_EVENTS: usize = 1_000;
-const TAB_WIDTH: usize = 4;
 
 /// Result of handling one input event in a host-owned editing surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -369,6 +367,16 @@ impl TextArea {
 
     /// Applies one editing event, leaving submission and focus decisions to the host.
     pub fn handle_event(&mut self, event: &Event, wrap_width: usize) -> TextAreaOutcome {
+        self.handle_event_with_layout_options(event, LayoutOptions::grapheme(wrap_width.max(1)))
+    }
+
+    /// Applies an event using the host's display policy for visual-row motions.
+    /// Logical-line operators and the document itself are independent of this policy.
+    pub fn handle_event_with_layout_options(
+        &mut self,
+        event: &Event,
+        layout: LayoutOptions,
+    ) -> TextAreaOutcome {
         match event {
             Event::Paste(text) => {
                 self.state.pending = None;
@@ -379,12 +387,12 @@ impl TextArea {
                     TextAreaOutcome::Unhandled
                 }
             }
-            Event::Key(key) => self.handle_key(*key, wrap_width),
+            Event::Key(key) => self.handle_key(*key, layout),
             _ => TextAreaOutcome::Unhandled,
         }
     }
 
-    fn handle_key(&mut self, key: KeyEvent, wrap_width: usize) -> TextAreaOutcome {
+    fn handle_key(&mut self, key: KeyEvent, layout: LayoutOptions) -> TextAreaOutcome {
         if self.state.mode == Mode::Search {
             return self.handle_search_key(key);
         }
@@ -434,11 +442,11 @@ impl TextArea {
                 return TextAreaOutcome::Changed;
             }
             KeyCode::Up => {
-                self.move_vertical(-1, wrap_width);
+                self.move_vertical(-1, layout);
                 return TextAreaOutcome::Changed;
             }
             KeyCode::Down => {
-                self.move_vertical(1, wrap_width);
+                self.move_vertical(1, layout);
                 return TextAreaOutcome::Changed;
             }
             KeyCode::Home => {
@@ -478,7 +486,7 @@ impl TextArea {
                         TextAreaOutcome::Unhandled
                     };
                 }
-                return self.handle_normal_character(character, wrap_width);
+                return self.handle_normal_character(character, layout);
             }
             _ => {}
         }
@@ -486,7 +494,11 @@ impl TextArea {
         TextAreaOutcome::Unhandled
     }
 
-    fn handle_normal_character(&mut self, character: char, wrap_width: usize) -> TextAreaOutcome {
+    fn handle_normal_character(
+        &mut self,
+        character: char,
+        layout: LayoutOptions,
+    ) -> TextAreaOutcome {
         if let Some((_, recorded)) = self.state.recording.as_mut() {
             if character != 'q' {
                 recorded.push(character);
@@ -494,7 +506,7 @@ impl TextArea {
         }
 
         if let Some(pending) = self.state.pending.take() {
-            return self.handle_pending(pending, character, wrap_width);
+            return self.handle_pending(pending, character, layout);
         }
 
         if character.is_ascii_digit() && (character != '0' || self.state.count.is_some()) {
@@ -546,8 +558,8 @@ impl TextArea {
             'o' | 'O' => self.open_line(character == 'o', character),
             'h' => self.repeat_motion(count, |area| area.move_horizontal(-1)),
             'l' => self.repeat_motion(count, |area| area.move_horizontal(1)),
-            'j' => self.repeat_motion(count, |area| area.move_vertical(1, wrap_width)),
-            'k' => self.repeat_motion(count, |area| area.move_vertical(-1, wrap_width)),
+            'j' => self.repeat_motion(count, |area| area.move_vertical(1, layout)),
+            'k' => self.repeat_motion(count, |area| area.move_vertical(-1, layout)),
             '0' => self.set_cursor(self.current_line_start()),
             '^' => self.move_to_first_non_blank(),
             '$' => self.move_to_line_end(count),
@@ -633,7 +645,7 @@ impl TextArea {
             }
             '~' => self.toggle_case(count, vec!['~']),
             'J' => self.join_lines(count.max(2), false, vec!['J']),
-            '.' => self.repeat_last_change(count, wrap_width),
+            '.' => self.repeat_last_change(count, layout),
             '/' | '?' => {
                 self.state.search = Some(SearchState {
                     pattern: String::new(),
@@ -663,7 +675,7 @@ impl TextArea {
         &mut self,
         pending: PendingInput,
         character: char,
-        wrap_width: usize,
+        layout: LayoutOptions,
     ) -> TextAreaOutcome {
         match pending {
             PendingInput::Operator {
@@ -797,10 +809,10 @@ impl TextArea {
                     }
                     'J' if operator.is_none() => self.join_lines(count.max(2), true, keys),
                     'j' if operator.is_none() => {
-                        self.repeat_motion(count, |area| area.move_vertical(1, wrap_width));
+                        self.repeat_motion(count, |area| area.move_vertical(1, layout));
                     }
                     'k' if operator.is_none() => {
-                        self.repeat_motion(count, |area| area.move_vertical(-1, wrap_width));
+                        self.repeat_motion(count, |area| area.move_vertical(-1, layout));
                     }
                     '0' if operator.is_none() => self.set_cursor(self.current_line_start()),
                     '$' if operator.is_none() => self.set_cursor(self.current_line_last_grapheme()),
@@ -830,7 +842,7 @@ impl TextArea {
                 };
                 if let Some(register) = register {
                     self.state.last_macro = Some(register);
-                    self.play_macro(register, count, wrap_width);
+                    self.play_macro(register, count, layout);
                 }
             }
         }
@@ -1504,39 +1516,39 @@ impl TextArea {
         }
     }
 
-    fn repeat_last_change(&mut self, count: u16, width: usize) {
+    fn repeat_last_change(&mut self, count: u16, layout: LayoutOptions) {
         let Some(recipe) = self.state.last_change.clone() else {
             return;
         };
         let previous_replaying = self.replaying;
         self.replaying = true;
         for _ in 0..count {
-            self.replay_keys(&recipe, width);
+            self.replay_keys(&recipe, layout);
         }
         self.replaying = previous_replaying;
         self.state.last_change = Some(recipe);
     }
 
-    fn play_macro(&mut self, register: char, count: u16, width: usize) {
+    fn play_macro(&mut self, register: char, count: u16, layout: LayoutOptions) {
         let Some(recipe) = self.macro_registers.get(&register).cloned() else {
             return;
         };
         let previous_replaying = self.replaying;
         self.replaying = true;
         for _ in 0..count {
-            self.replay_keys(&recipe, width);
+            self.replay_keys(&recipe, layout);
         }
         self.replaying = previous_replaying;
     }
 
-    fn replay_keys(&mut self, recipe: &[char], width: usize) {
+    fn replay_keys(&mut self, recipe: &[char], layout: LayoutOptions) {
         for character in recipe.iter().take(MAX_MACRO_EVENTS) {
             let code = if *character == '\u{1b}' {
                 KeyCode::Esc
             } else {
                 KeyCode::Char(*character)
             };
-            self.handle_key(KeyEvent::new(code, KeyModifiers::NONE), width);
+            self.handle_key(KeyEvent::new(code, KeyModifiers::NONE), layout);
         }
     }
 
@@ -1556,22 +1568,19 @@ impl TextArea {
         self.set_cursor(cursor);
     }
 
-    fn move_vertical(&mut self, direction: isize, width: usize) {
-        let positions = wrapped_positions(&self.text(), width.max(1));
-        let Some(&(row, column)) = positions.get(self.state.cursor) else {
+    fn move_vertical(&mut self, direction: isize, options: LayoutOptions) {
+        let layout = TextLayout::new(&self.text(), options);
+        let Some(position) = layout.position(self.state.cursor) else {
             return;
         };
+        let row = position.row;
+        let column = position.column;
         let target = row.saturating_add_signed(direction);
         if target == row {
             return;
         }
         let preferred = *self.state.preferred_column.get_or_insert(column);
-        if let Some((index, _)) = positions
-            .iter()
-            .enumerate()
-            .filter(|(_, position)| position.0 == target)
-            .min_by_key(|(_, position)| position.1.abs_diff(preferred))
-        {
+        if let Some(index) = layout.nearest_offset_on_row(target, preferred) {
             self.state.cursor = index;
             if self.state.mode != Mode::Insert {
                 self.clamp_normal_cursor();
@@ -1796,52 +1805,6 @@ fn operator_for_character(character: char) -> Operator {
         'y' => Operator::Yank,
         _ => unreachable!("operator is validated by the input parser"),
     }
-}
-
-fn wrapped_positions(text: &str, width: usize) -> Vec<(usize, usize)> {
-    let width = width.max(1);
-    let mut positions = Vec::with_capacity(grapheme_len(text) + 1);
-    let mut row = 0;
-    let mut column = 0;
-    positions.push((row, column));
-
-    for grapheme in text.graphemes(true) {
-        if grapheme == "\n" {
-            row += 1;
-            column = 0;
-            positions.push((row, column));
-            continue;
-        }
-        if column == width {
-            row += 1;
-            column = 0;
-        }
-        let mut grapheme_width = if grapheme == "\t" {
-            TAB_WIDTH - (column % TAB_WIDTH)
-        } else {
-            display_width(grapheme)
-        };
-        if grapheme_width > width.saturating_sub(column) && column > 0 {
-            row += 1;
-            column = 0;
-            grapheme_width = if grapheme == "\t" {
-                TAB_WIDTH
-            } else {
-                display_width(grapheme)
-            };
-        }
-        column += if grapheme_width > width {
-            1
-        } else {
-            grapheme_width
-        };
-        if column == width {
-            positions.push((row + 1, 0));
-        } else {
-            positions.push((row, column));
-        }
-    }
-    positions
 }
 
 fn normalize_newlines(text: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ mod self_check;
 pub mod session;
 pub mod splash;
 pub mod sync;
+pub mod text_layout;
 mod textobjects;
 pub mod theme;
 pub mod ui;

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -23,13 +23,14 @@ use super::text_link::{TextPanelLink, TextPanelLinkTarget};
 use crate::{
     color::{blend_color, ensure_minimum_contrast, Color},
     editor::{render_buffer::RenderBuffer, Point},
+    text_layout::{LayoutOptions, TextLayout},
     theme::{
         SelectionForegroundPriority, Style, Theme, ThemeStyleSpec,
         MINIMUM_SELECTION_STATE_CONTRAST, MINIMUM_SELECTION_TEXT_CONTRAST,
     },
     ui::{
-        normalize_prompt_newlines, wrap_text, FollowTailViewport, PromptBuffer, PromptInput,
-        PromptKeyPolicy, PROMPT_MAX_BYTES,
+        normalize_prompt_newlines, FollowTailViewport, PromptBuffer, PromptInput, PromptKeyPolicy,
+        PROMPT_MAX_BYTES,
     },
     unicode_utils::{display_width, fit_display_width, truncate_display_width},
 };
@@ -568,6 +569,20 @@ struct TextPanelComposer {
 }
 
 impl TextPanelComposer {
+    /// `content_width` excludes the panel inset, but includes the prompt marker.
+    fn layout_options(content_width: usize) -> LayoutOptions {
+        LayoutOptions::word(content_width.saturating_sub(2).max(1))
+    }
+
+    fn layout(&self, content_width: usize) -> TextLayout {
+        self.prompt.layout(Self::layout_options(content_width))
+    }
+
+    fn handle_event(&mut self, event: &Event, content_width: usize) -> PromptInput {
+        self.prompt
+            .handle_event_with_layout_options(event, Self::layout_options(content_width))
+    }
+
     fn new(config: TextPanelComposerConfig) -> Self {
         Self {
             config,
@@ -2456,9 +2471,7 @@ impl PanelManager {
                 if let Some(composer) = panel.composer.as_mut() {
                     composer.focused = true;
                     composer.prompt.set_mode(crate::editor::Mode::Normal);
-                    let _ = composer
-                        .prompt
-                        .handle_event(event, width.saturating_sub(2).max(1));
+                    let _ = composer.handle_event(event, TextPanelContentMetrics::new(width).width);
                 }
                 return Some(TextPanelScrollbackInput::Handled);
             }
@@ -2852,38 +2865,36 @@ impl PanelManager {
             },
             _ => 0,
         };
-        let (action, text) = match composer
-            .prompt
-            .handle_event(event, panel_width.saturating_sub(2).max(1))
-        {
-            PromptInput::Changed => {
-                composer.validation = None;
-                ("composer_input", None)
-            }
-            PromptInput::Submit => match composer.take_submission() {
-                Some(text) => {
-                    panel.resume_tail_following();
-                    ("submit", Some(text))
+        let (action, text) =
+            match composer.handle_event(event, TextPanelContentMetrics::new(panel_width).width) {
+                PromptInput::Changed => {
+                    composer.validation = None;
+                    ("composer_input", None)
                 }
-                None => ("composer_input", None),
-            },
-            PromptInput::Cancel => {
-                composer.focused = false;
-                panel.scrollback.focused = true;
-                panel.scrollback.mode = TextPanelScrollbackMode::Normal;
-                panel.scrollback.selection_anchor = None;
-                let layout = panel.layout(panel_width);
-                panel.scrollback.cursor = layout.clamp(panel.scrollback.cursor);
-                ("composer_blur", None)
-            }
-            PromptInput::Unhandled
-                if inserted_bytes > MAX_COMPOSER_BYTES.saturating_sub(previous_bytes) =>
-            {
-                composer.validation = Some("Prompt exceeds 128 KiB");
-                ("composer_input", None)
-            }
-            PromptInput::Unhandled => return None,
-        };
+                PromptInput::Submit => match composer.take_submission() {
+                    Some(text) => {
+                        panel.resume_tail_following();
+                        ("submit", Some(text))
+                    }
+                    None => ("composer_input", None),
+                },
+                PromptInput::Cancel => {
+                    composer.focused = false;
+                    panel.scrollback.focused = true;
+                    panel.scrollback.mode = TextPanelScrollbackMode::Normal;
+                    panel.scrollback.selection_anchor = None;
+                    let layout = panel.layout(panel_width);
+                    panel.scrollback.cursor = layout.clamp(panel.scrollback.cursor);
+                    ("composer_blur", None)
+                }
+                PromptInput::Unhandled
+                    if inserted_bytes > MAX_COMPOSER_BYTES.saturating_sub(previous_bytes) =>
+                {
+                    composer.validation = Some("Prompt exceeds 128 KiB");
+                    ("composer_input", None)
+                }
+                PromptInput::Unhandled => return None,
+            };
 
         Some(PanelEvent {
             panel_id: panel.id.clone(),
@@ -2945,13 +2956,12 @@ impl PanelManager {
             return None;
         }
         let metrics = TextPanelContentMetrics::new(placement.width);
-        let content_width = metrics.width.saturating_sub(2).max(1);
-        let wrapped = wrap_text(&composer.prompt.text(), content_width);
-        let (row, column) = wrapped
-            .positions
-            .get(composer.prompt.cursor())
-            .copied()
+        let wrapped = composer.layout(metrics.width);
+        let position = wrapped
+            .position(composer.prompt.cursor())
             .unwrap_or_default();
+        let row = position.row;
+        let column = position.column;
         let rows = composer.config.rows.max(1);
         let first = row.saturating_sub(rows.saturating_sub(1));
         let top = placement.height.saturating_sub(panel.composer_height());
@@ -3006,23 +3016,15 @@ impl PanelManager {
             {
                 if let Some(composer) = panel.composer.as_mut() {
                     composer.focused = true;
-                    let content_width = metrics.width.saturating_sub(2).max(1);
-                    let wrapped = wrap_text(&composer.prompt.text(), content_width);
+                    let wrapped = composer.layout(metrics.width);
                     let cursor_row = wrapped
-                        .positions
-                        .get(composer.prompt.cursor())
-                        .map_or(0, |position| position.0);
+                        .position(composer.prompt.cursor())
+                        .map_or(0, |position| position.row);
                     let rows = composer.config.rows.max(1);
                     let first = cursor_row.saturating_sub(rows.saturating_sub(1));
                     let row = first.saturating_add(y.saturating_sub(composer_top + 1));
                     let column = x.saturating_sub(metrics.x(placement.x).saturating_add(2));
-                    if let Some((index, _)) = wrapped
-                        .positions
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, position)| position.0 == row)
-                        .min_by_key(|(_, position)| position.1.abs_diff(column))
-                    {
+                    if let Some(index) = wrapped.nearest_offset_on_row(row, column) {
                         composer.prompt.set_cursor(index);
                     }
                 }
@@ -3949,17 +3951,16 @@ fn render_text_panel_composer(
     let top = position.y.saturating_add(top);
 
     let rows = composer.config.rows.max(1);
-    let content_width = width.saturating_sub(2).max(1);
-    let wrapped = wrap_text(&composer.prompt.text(), content_width);
+    let content_width = TextPanelComposer::layout_options(width).width;
+    let wrapped = composer.layout(width);
     let cursor_row = wrapped
-        .positions
-        .get(composer.prompt.cursor())
-        .map_or(0, |position| position.0);
+        .position(composer.prompt.cursor())
+        .map_or(0, |position| position.row);
     let first = cursor_row.saturating_sub(rows.saturating_sub(1));
     let active_row = cursor_row.saturating_sub(first).min(rows.saturating_sub(1));
     for row in 0..rows {
         let y = top + 1 + row;
-        let line = wrapped.rows.get(first + row).map(String::as_str);
+        let line = wrapped.rows().get(first + row).map(|row| row.text.as_str());
         let placeholder =
             line.is_some_and(str::is_empty) && composer.prompt.text().is_empty() && row == 0;
         let text = if placeholder {
@@ -5996,6 +5997,90 @@ mod tests {
 
         let composer = manager.text_panels["agent"].composer.as_ref().unwrap();
         assert_eq!(composer.prompt.text(), "first line\nsecXond line");
+    }
+
+    #[test]
+    fn word_wrapped_composer_render_navigation_and_click_use_the_same_width() {
+        use crossterm::event::KeyEvent;
+
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "agent".to_string(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 11,
+                title: None,
+                composer: Some(TextPanelComposerConfig {
+                    placeholder: "Ask".to_string(),
+                    rows: 3,
+                }),
+                ..PanelConfig::default()
+            },
+        );
+        assert!(manager.focus_text_panel_composer("agent"));
+        manager.handle_focused_text_input(&Event::Paste("one two three".to_string()), 40);
+        manager
+            .text_panels
+            .get_mut("agent")
+            .unwrap()
+            .composer
+            .as_mut()
+            .unwrap()
+            .prompt
+            .set_cursor(0);
+
+        let placement = manager
+            .panel_placements(40, 20)
+            .into_iter()
+            .find(|placement| placement.id == "agent")
+            .unwrap();
+        let x = TextPanelContentMetrics::new(placement.width).x(placement.x) + 2;
+        let y = placement.y + placement.height - manager.text_panels["agent"].composer_height() + 1;
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(40, 20, &theme.style);
+        manager.render(&mut buffer, &theme);
+        assert_eq!(text_position(&buffer, "one two"), Some(Point::new(x, y)));
+        assert_eq!(text_position(&buffer, "three"), Some(Point::new(x, y + 1)));
+
+        let down = Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        manager.handle_focused_text_input(&down, 40);
+        assert_eq!(
+            manager.text_panels["agent"]
+                .composer
+                .as_ref()
+                .unwrap()
+                .prompt
+                .cursor(),
+            8
+        );
+        assert_eq!(
+            manager.focused_text_panel_cursor_position(40, 20),
+            Some((x, y + 1))
+        );
+        manager
+            .focus_panel_at_position(x + 2, y + 1, 40, 20)
+            .unwrap();
+        manager.handle_focused_text_input(&Event::Paste("X".to_string()), 40);
+        assert_eq!(
+            manager.text_panels["agent"]
+                .composer
+                .as_ref()
+                .unwrap()
+                .prompt
+                .text(),
+            "one two thXree"
+        );
+
+        let (cursor_x, cursor_y) = manager.focused_text_panel_cursor_position(18, 20).unwrap();
+        assert!(cursor_x < 18 && cursor_y < 20);
+        let submitted = manager
+            .handle_focused_text_input(
+                &Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL)),
+                40,
+            )
+            .unwrap();
+        assert_eq!(submitted.action, "submit");
+        assert_eq!(submitted.text.as_deref(), Some("one two thXree"));
     }
 
     #[test]

--- a/src/text_layout.rs
+++ b/src/text_layout.rs
@@ -1,0 +1,580 @@
+//! Source-backed soft wrapping for editable terminal text.
+//!
+//! The source remains authoritative. Row ranges and cursor offsets count extended
+//! graphemes, while display positions count terminal cells. Tabs and omitted soft-
+//! wrap separators affect only the projection, never the document or undo history.
+
+use std::{cmp::Reverse, ops::Range};
+
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::unicode_utils::{display_width, grapheme_len};
+
+/// How a view chooses its soft line breaks.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WrapMode {
+    /// Preserve the existing embedded-textarea character-wrap behavior.
+    #[default]
+    Grapheme,
+    /// Prefer Unicode line-break opportunities, splitting long words as needed.
+    Word,
+}
+
+/// View-local layout policy, independent of the underlying document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LayoutOptions {
+    pub width: usize,
+    pub tab_width: usize,
+    pub wrap_mode: WrapMode,
+}
+
+impl LayoutOptions {
+    #[must_use]
+    pub const fn grapheme(width: usize) -> Self {
+        Self {
+            width,
+            tab_width: 4,
+            wrap_mode: WrapMode::Grapheme,
+        }
+    }
+
+    #[must_use]
+    pub const fn word(width: usize) -> Self {
+        Self {
+            wrap_mode: WrapMode::Word,
+            ..Self::grapheme(width)
+        }
+    }
+}
+
+/// A zero-based visual row and terminal-cell column.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DisplayPosition {
+    pub row: usize,
+    pub column: usize,
+}
+
+/// Why the next display row starts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum LineBreak {
+    Soft,
+    Hard,
+    #[default]
+    End,
+}
+
+/// One display row and the exact source graphemes it accounts for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LayoutRow {
+    pub text: String,
+    /// Absolute grapheme range, including an omitted separator or hard newline.
+    pub source: Range<usize>,
+    pub break_after: LineBreak,
+}
+
+impl LayoutRow {
+    fn empty(start: usize) -> Self {
+        Self {
+            text: String::new(),
+            source: start..start,
+            break_after: LineBreak::End,
+        }
+    }
+}
+
+/// An immutable projection with one position for every source cursor boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextLayout {
+    rows: Vec<LayoutRow>,
+    positions: Vec<DisplayPosition>,
+    wrap_mode: WrapMode,
+}
+
+impl TextLayout {
+    #[must_use]
+    pub fn new(text: &str, options: LayoutOptions) -> Self {
+        if options.width == 0 {
+            return Self {
+                rows: Vec::new(),
+                positions: vec![DisplayPosition::default(); grapheme_len(text) + 1],
+                wrap_mode: options.wrap_mode,
+            };
+        }
+        match options.wrap_mode {
+            WrapMode::Grapheme => grapheme_layout(text, options),
+            WrapMode::Word => word_layout(text, options),
+        }
+    }
+
+    #[must_use]
+    pub fn rows(&self) -> &[LayoutRow] {
+        &self.rows
+    }
+
+    #[must_use]
+    pub fn positions(&self) -> &[DisplayPosition] {
+        &self.positions
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<LayoutRow>, Vec<DisplayPosition>) {
+        (self.rows, self.positions)
+    }
+
+    #[must_use]
+    pub fn position(&self, grapheme_offset: usize) -> Option<DisplayPosition> {
+        self.positions.get(grapheme_offset).copied()
+    }
+
+    /// Finds a representable cursor boundary on a visual row.
+    ///
+    /// A soft-wrap separator can share a cell with the following word. In that
+    /// case prefer the word's start, so clicking its first cell does not select
+    /// invisible whitespace. Equidistant *different* columns prefer the left.
+    #[must_use]
+    pub fn nearest_offset_on_row(&self, row: usize, column: usize) -> Option<usize> {
+        if row >= self.rows.len() {
+            return None;
+        }
+        if self.wrap_mode == WrapMode::Grapheme {
+            return self
+                .positions
+                .iter()
+                .enumerate()
+                .filter(|(_, position)| position.row == row)
+                .min_by_key(|(_, position)| position.column.abs_diff(column))
+                .map(|(offset, _)| offset);
+        }
+        self.positions
+            .iter()
+            .enumerate()
+            .filter(|(_, position)| position.row == row)
+            .min_by_key(|(offset, position)| {
+                (
+                    position.column.abs_diff(column),
+                    position.column,
+                    Reverse(*offset),
+                )
+            })
+            .map(|(offset, _)| offset)
+    }
+}
+
+fn grapheme_width(grapheme: &str, column: usize, tab_width: usize) -> usize {
+    if grapheme == "\t" {
+        let tab_width = tab_width.max(1);
+        tab_width - column % tab_width
+    } else {
+        display_width(grapheme)
+    }
+}
+
+fn append_grapheme(row: &mut String, grapheme: &str, width: usize, viewport: usize) -> usize {
+    if width > viewport {
+        row.push('?');
+        1
+    } else if grapheme == "\t" {
+        row.extend(std::iter::repeat_n(' ', width));
+        width
+    } else {
+        row.push_str(grapheme);
+        width
+    }
+}
+
+fn caret_after(row: usize, column: usize, width: usize) -> DisplayPosition {
+    if column == width {
+        DisplayPosition {
+            row: row + 1,
+            column: 0,
+        }
+    } else {
+        DisplayPosition { row, column }
+    }
+}
+
+// Keep this path byte-for-byte compatible with the old UI wrap_text projection.
+// Existing consumers opt into Word explicitly instead of changing their defaults.
+fn grapheme_layout(text: &str, options: LayoutOptions) -> TextLayout {
+    let mut rows = vec![LayoutRow::empty(0)];
+    let mut positions = Vec::with_capacity(grapheme_len(text) + 1);
+    let mut row = 0;
+    let mut column = 0;
+    positions.push(DisplayPosition::default());
+
+    for (index, grapheme) in text.graphemes(true).enumerate() {
+        if grapheme == "\n" {
+            rows[row].source.end = index + 1;
+            rows[row].break_after = LineBreak::Hard;
+            row += 1;
+            column = 0;
+            rows.push(LayoutRow::empty(index + 1));
+            positions.push(DisplayPosition { row, column });
+            continue;
+        }
+        if column == options.width {
+            rows[row].break_after = LineBreak::Soft;
+            row += 1;
+            column = 0;
+            rows.push(LayoutRow::empty(index));
+        }
+        let mut width = grapheme_width(grapheme, column, options.tab_width);
+        if width > options.width.saturating_sub(column) && column > 0 {
+            rows[row].break_after = LineBreak::Soft;
+            row += 1;
+            column = 0;
+            rows.push(LayoutRow::empty(index));
+            width = grapheme_width(grapheme, column, options.tab_width);
+        }
+        column += append_grapheme(&mut rows[row].text, grapheme, width, options.width);
+        rows[row].source.end = index + 1;
+        positions.push(caret_after(row, column, options.width));
+    }
+    if positions
+        .last()
+        .is_some_and(|position| position.row >= rows.len())
+    {
+        rows[row].break_after = LineBreak::Soft;
+        rows.push(LayoutRow::empty(positions.len() - 1));
+    }
+    TextLayout {
+        rows,
+        positions,
+        wrap_mode: options.wrap_mode,
+    }
+}
+
+struct Grapheme<'a> {
+    text: &'a str,
+    break_after: bool,
+}
+
+impl Grapheme<'_> {
+    fn separator(&self) -> bool {
+        // Only ordinary word separators are elided. In particular NBSP and
+        // narrow NBSP must not silently become breakable spaces.
+        matches!(self.text, " " | "\t")
+    }
+
+    fn newline(&self) -> bool {
+        matches!(self.text, "\n" | "\r\n" | "\r")
+    }
+}
+
+struct RowPlan {
+    source: Range<usize>,
+    visible_end: usize,
+    break_after: LineBreak,
+}
+
+fn word_layout(text: &str, options: LayoutOptions) -> TextLayout {
+    let mut breaks = unicode_linebreak::linebreaks(text).peekable();
+    let graphemes = text
+        .grapheme_indices(true)
+        .map(|(byte, grapheme)| {
+            let end = byte + grapheme.len();
+            while breaks.peek().is_some_and(|(offset, _)| *offset < end) {
+                breaks.next();
+            }
+            Grapheme {
+                text: grapheme,
+                break_after: breaks.peek().is_some_and(|(offset, _)| *offset == end),
+            }
+        })
+        .collect::<Vec<_>>();
+    let mut plans = Vec::new();
+    let mut line_start = 0;
+    for (index, grapheme) in graphemes.iter().enumerate() {
+        if grapheme.newline() {
+            plan_logical_line(&graphemes, line_start..index, options, &mut plans);
+            let last = plans.last_mut().expect("a logical line has a display row");
+            last.source.end = index + 1;
+            last.break_after = LineBreak::Hard;
+            line_start = index + 1;
+        }
+    }
+    plan_logical_line(&graphemes, line_start..graphemes.len(), options, &mut plans);
+
+    let mut rows = Vec::with_capacity(plans.len());
+    let mut positions = vec![DisplayPosition::default(); graphemes.len() + 1];
+    for (row, plan) in plans.into_iter().enumerate() {
+        let mut text = String::new();
+        let mut column = 0;
+        for index in plan.source.start..plan.visible_end {
+            positions[index] = caret_after(row, column, options.width);
+            let grapheme = graphemes[index].text;
+            let width = grapheme_width(grapheme, column, options.tab_width);
+            column += append_grapheme(&mut text, grapheme, width, options.width);
+        }
+        let end = caret_after(row, column, options.width);
+        positions[plan.visible_end..=plan.source.end].fill(end);
+        rows.push(LayoutRow {
+            text,
+            source: plan.source,
+            break_after: plan.break_after,
+        });
+    }
+    if positions
+        .last()
+        .is_some_and(|position| position.row >= rows.len())
+    {
+        rows.last_mut().expect("text has a display row").break_after = LineBreak::Soft;
+        rows.push(LayoutRow::empty(graphemes.len()));
+    }
+    TextLayout {
+        rows,
+        positions,
+        wrap_mode: options.wrap_mode,
+    }
+}
+
+fn plan_logical_line(
+    graphemes: &[Grapheme<'_>],
+    line: Range<usize>,
+    options: LayoutOptions,
+    rows: &mut Vec<RowPlan>,
+) {
+    let mut start = line.start;
+    loop {
+        let (end, visible_end) = word_row_end(graphemes, start..line.end, options);
+        rows.push(RowPlan {
+            source: start..end,
+            visible_end,
+            break_after: if end < line.end {
+                LineBreak::Soft
+            } else {
+                LineBreak::End
+            },
+        });
+        if end == line.end {
+            break;
+        }
+        start = end;
+    }
+}
+
+fn word_row_end(
+    graphemes: &[Grapheme<'_>],
+    source: Range<usize>,
+    options: LayoutOptions,
+) -> (usize, usize) {
+    let mut index = source.start;
+    let mut column = 0;
+    let mut separator_start = None;
+    let mut candidate = None;
+    while index < source.end {
+        let grapheme = &graphemes[index];
+        let width = grapheme_width(grapheme.text, column, options.tab_width);
+        let width = if column == 0 && width > options.width {
+            1
+        } else {
+            width
+        };
+        if width > options.width.saturating_sub(column) {
+            break;
+        }
+        column += width;
+        if grapheme.separator() {
+            separator_start.get_or_insert(index);
+        } else {
+            separator_start = None;
+        }
+        index += 1;
+        if grapheme.break_after && index < source.end {
+            let visible_end = separator_start.unwrap_or(index);
+            // Leading indentation is real content, not a disposable separator.
+            if visible_end > source.start {
+                candidate = Some((index, visible_end));
+            }
+        }
+    }
+    if index == source.end {
+        return (index, index);
+    }
+
+    // A word that exactly fills the row must not leave its separating space on
+    // a row by itself. Consume the whole separator run only if another word
+    // follows; real trailing whitespace remains visible/editable.
+    let run_start = separator_start.unwrap_or(index);
+    if graphemes[index].separator() && run_start > source.start {
+        let mut end = index;
+        while end < source.end && graphemes[end].separator() {
+            end += 1;
+        }
+        if end < source.end && graphemes[end - 1].break_after {
+            return (end, run_start);
+        }
+    }
+    candidate.unwrap_or_else(|| {
+        let end = index.max(source.start + 1);
+        (end, end)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows(layout: &TextLayout) -> Vec<&str> {
+        layout.rows().iter().map(|row| row.text.as_str()).collect()
+    }
+
+    fn position(row: usize, column: usize) -> DisplayPosition {
+        DisplayPosition { row, column }
+    }
+
+    #[test]
+    fn word_wrap_prefers_breaks_and_reflows_the_complete_remaining_word() {
+        for (text, width, expected) in [
+            ("one two three", 8, vec!["one two", "three"]),
+            ("abad abcde", 4, vec!["abad", "abcd", "e"]),
+            ("hello world", 5, vec!["hello", "world", ""]),
+            ("one   two", 7, vec!["one", "two"]),
+            ("abc   ", 4, vec!["abc ", "  "]),
+            ("ab\u{a0}cd ef", 6, vec!["ab\u{a0}cd", "ef"]),
+            ("你好 世界", 5, vec!["你好", "世界"]),
+            ("abcdefghijkl", 5, vec!["abcde", "fghij", "kl"]),
+        ] {
+            assert_eq!(
+                rows(&TextLayout::new(text, LayoutOptions::word(width))),
+                expected,
+                "{text:?} at {width}"
+            );
+        }
+    }
+
+    #[test]
+    fn source_ranges_preserve_separators_hard_breaks_and_indentation() {
+        let layout = TextLayout::new("one   two\n\n  x\t \n", LayoutOptions::word(7));
+        assert_eq!(rows(&layout), ["one", "two", "", "  x  ", ""]);
+        assert_eq!(layout.rows()[0].source, 0..6);
+        assert_eq!(layout.rows()[0].break_after, LineBreak::Soft);
+        assert_eq!(layout.rows()[1].source, 6..10);
+        assert_eq!(layout.rows()[1].break_after, LineBreak::Hard);
+        assert_eq!(layout.rows()[2].source, 10..11);
+        assert_eq!(layout.rows()[2].break_after, LineBreak::Hard);
+        assert_eq!(layout.position(3), Some(position(0, 3)));
+        assert_eq!(layout.position(5), Some(position(0, 3)));
+        assert_eq!(layout.position(6), Some(position(1, 0)));
+        assert_eq!(layout.nearest_offset_on_row(1, 0), Some(6));
+    }
+
+    #[test]
+    fn full_rows_have_a_bounded_caret_and_forward_soft_break_affinity() {
+        let layout = TextLayout::new("hello world", LayoutOptions::word(5));
+        assert_eq!(layout.position(5), Some(position(1, 0)));
+        assert_eq!(layout.position(6), Some(position(1, 0)));
+        assert_eq!(layout.nearest_offset_on_row(1, 0), Some(6));
+        assert_eq!(layout.position(11), Some(position(2, 0)));
+        assert_eq!(layout.rows()[2].source, 11..11);
+
+        let hard = TextLayout::new("hello\nworld", LayoutOptions::word(5));
+        assert_eq!(rows(&hard), ["hello", "world", ""]);
+        assert_eq!(hard.rows()[0].break_after, LineBreak::Hard);
+        assert_eq!(hard.position(6), Some(position(1, 0)));
+    }
+
+    #[test]
+    fn wide_graphemes_tabs_and_zero_width_views_are_bounded() {
+        let text = "e\u{301} 👨‍👩‍👧‍👦\t漢";
+        let zero = TextLayout::new(text, LayoutOptions::word(0));
+        assert!(zero.rows().is_empty());
+        assert_eq!(zero.positions().len(), grapheme_len(text) + 1);
+        assert_eq!(zero.nearest_offset_on_row(0, 0), None);
+        assert_eq!(
+            rows(&TextLayout::new("漢", LayoutOptions::word(1))),
+            ["?", ""]
+        );
+        assert_eq!(
+            rows(&TextLayout::new(
+                "a\tb",
+                LayoutOptions {
+                    width: 9,
+                    tab_width: 8,
+                    wrap_mode: WrapMode::Word
+                }
+            )),
+            ["a       b", ""]
+        );
+        let wide = TextLayout::new("漢x", LayoutOptions::word(4));
+        assert_eq!(wide.nearest_offset_on_row(0, 1), Some(0));
+    }
+
+    #[test]
+    fn word_layout_partitions_source_and_maps_every_cursor_at_many_widths() {
+        let samples = [
+            "",
+            "\n",
+            "\n\n",
+            "abcd\n",
+            "one two three",
+            "abad abcde",
+            "  leading   and trailing  ",
+            "\t\tword\t next\t",
+            "漢字かな カナ",
+            "e\u{301} 👨‍👩‍👧‍👦 🇧🇷 x",
+            "abcd\u{200b}\u{200d}x\u{301}",
+            "\u{301}a\u{200b}\n",
+            "non\u{a0}breaking narrow\u{202f}space",
+            "https://example.test/a-very-long-path?q=one_two",
+            "\r\nlast\r",
+        ];
+        for text in samples {
+            let graphemes = text.graphemes(true).collect::<Vec<_>>();
+            for width in 1..=16 {
+                let layout = TextLayout::new(text, LayoutOptions::word(width));
+                assert_eq!(layout.positions().len(), graphemes.len() + 1);
+                let mut end = 0;
+                let mut reconstructed = String::new();
+                for row in layout.rows() {
+                    assert_eq!(row.source.start, end, "{text:?} at {width}");
+                    assert!(
+                        display_width(&row.text) <= width,
+                        "{text:?} at {width}: {row:?}"
+                    );
+                    reconstructed.extend(graphemes[row.source.clone()].iter().copied());
+                    end = row.source.end;
+                }
+                assert_eq!(end, graphemes.len());
+                assert_eq!(reconstructed, text);
+                for position in layout.positions() {
+                    assert!(
+                        position.row < layout.rows().len(),
+                        "{text:?} at {width}: {position:?}"
+                    );
+                    assert!(position.column < width, "{text:?} at {width}: {position:?}");
+                }
+                assert!(
+                    layout.positions().windows(2).all(|pair| {
+                        (pair[0].row, pair[0].column) <= (pair[1].row, pair[1].column)
+                    }),
+                    "{text:?} at {width}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_layout_keeps_existing_rows_positions_and_tie_breaks() {
+        let layout = TextLayout::new("ab 漢\n\tZ", LayoutOptions::grapheme(4));
+        assert_eq!(rows(&layout), ["ab ", "漢", "    ", "Z"]);
+        assert_eq!(
+            layout.positions(),
+            [
+                position(0, 0),
+                position(0, 1),
+                position(0, 2),
+                position(0, 3),
+                position(1, 2),
+                position(2, 0),
+                position(3, 0),
+                position(3, 1)
+            ]
+        );
+        let exact = TextLayout::new("abcd\nx", LayoutOptions::grapheme(4));
+        assert_eq!(rows(&exact), ["abcd", "x"]);
+        assert_eq!(exact.nearest_offset_on_row(1, 0), Some(4));
+        let zero = TextLayout::new("漢x", LayoutOptions::grapheme(0));
+        assert!(zero.rows().is_empty());
+        assert_eq!(zero.positions(), [position(0, 0); 3]);
+    }
+}

--- a/src/ui/agent_composer.rs
+++ b/src/ui/agent_composer.rs
@@ -2,14 +2,14 @@
 
 use crossterm::event::Event;
 use serde_json::json;
-use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
     config::KeyAction,
     editor::{Action, ComposerCallback, Editor, Mode, RenderBuffer},
     plugin::ComposerHandle,
+    text_layout::{LayoutOptions, TextLayout},
     theme::{Style, Theme},
-    unicode_utils::{display_width, grapheme_len, truncate_display_width},
+    unicode_utils::truncate_display_width,
 };
 
 use super::{
@@ -18,7 +18,6 @@ use super::{
     PromptInput, PromptKeyPolicy, UiAction, PROMPT_MAX_BYTES,
 };
 
-const TAB_WIDTH: usize = 4;
 const MAX_PROMPT_BYTES: usize = PROMPT_MAX_BYTES;
 const EMPTY_STATUS: &str = "Prompt is empty";
 const OVERSIZED_STATUS: &str = "Prompt exceeds 128 KiB";
@@ -196,8 +195,8 @@ impl AgentComposer {
         }
     }
 
-    fn wrapped_text(&self) -> WrappedText {
-        wrap_text(&self.prompt.buffer().contents(), self.dialog.width)
+    fn wrapped_text(&self) -> TextLayout {
+        self.prompt.layout(LayoutOptions::word(self.dialog.width))
     }
 
     fn redraw() -> Option<KeyAction> {
@@ -229,18 +228,17 @@ impl Component for AgentComposer {
         } else {
             let wrapped = self.wrapped_text();
             let cursor_row = wrapped
-                .positions
-                .get(self.prompt.cursor())
-                .map_or(0, |position| position.0);
+                .position(self.prompt.cursor())
+                .map_or(0, |position| position.row);
             let scroll = cursor_row.saturating_sub(body_height - 1);
             for (offset, row) in wrapped
-                .rows
+                .rows()
                 .iter()
                 .skip(scroll)
                 .take(body_height)
                 .enumerate()
             {
-                buffer.set_text(content_x, content_y + offset, row, &self.style);
+                buffer.set_text(content_x, content_y + offset, &row.text, &self.style);
             }
         }
 
@@ -306,7 +304,10 @@ impl Component for AgentComposer {
             _ => 0,
         };
 
-        match self.prompt.handle_event(event, self.dialog.width) {
+        match self
+            .prompt
+            .handle_event_with_layout_options(event, LayoutOptions::word(self.dialog.width))
+        {
             PromptInput::Changed => {
                 self.validation_status = None;
                 Self::redraw()
@@ -356,11 +357,9 @@ impl Component for AgentComposer {
 
     fn cursor_position(&self) -> Option<(usize, usize)> {
         let wrapped = self.wrapped_text();
-        let (row, column) = wrapped
-            .positions
-            .get(self.prompt.cursor())
-            .copied()
-            .unwrap_or_default();
+        let position = wrapped.position(self.prompt.cursor()).unwrap_or_default();
+        let row = position.row;
+        let column = position.column;
         let body_height = self.body_height();
         let scroll = row.saturating_sub(body_height.saturating_sub(1));
         let x = self
@@ -384,81 +383,14 @@ impl Component for AgentComposer {
 }
 
 pub(crate) fn wrap_text(text: &str, width: usize) -> WrappedText {
-    let grapheme_count = grapheme_len(text);
-    if width == 0 {
-        return WrappedText {
-            rows: Vec::new(),
-            positions: vec![(0, 0); grapheme_count + 1],
-        };
+    let (rows, positions) = TextLayout::new(text, LayoutOptions::grapheme(width)).into_parts();
+    WrappedText {
+        rows: rows.into_iter().map(|row| row.text).collect(),
+        positions: positions
+            .into_iter()
+            .map(|position| (position.row, position.column))
+            .collect(),
     }
-
-    let mut rows = vec![String::new()];
-    let mut positions = Vec::with_capacity(grapheme_count + 1);
-    let mut row = 0;
-    let mut column = 0;
-    positions.push((row, column));
-
-    for grapheme in text.graphemes(true) {
-        if grapheme == "\n" {
-            row += 1;
-            column = 0;
-            if rows.len() <= row {
-                rows.push(String::new());
-            }
-            positions.push((row, column));
-            continue;
-        }
-
-        if column == width {
-            row += 1;
-            column = 0;
-            if rows.len() <= row {
-                rows.push(String::new());
-            }
-        }
-
-        let mut grapheme_width = if grapheme == "\t" {
-            TAB_WIDTH - (column % TAB_WIDTH)
-        } else {
-            display_width(grapheme)
-        };
-        if grapheme_width > width.saturating_sub(column) && column > 0 {
-            row += 1;
-            column = 0;
-            rows.push(String::new());
-            grapheme_width = if grapheme == "\t" {
-                TAB_WIDTH
-            } else {
-                display_width(grapheme)
-            };
-        }
-
-        if grapheme_width > width {
-            rows[row].push('?');
-            column += 1;
-        } else if grapheme == "\t" {
-            rows[row].push_str(&" ".repeat(grapheme_width));
-            column += grapheme_width;
-        } else {
-            rows[row].push_str(grapheme);
-            column += grapheme_width;
-        }
-
-        if column == width {
-            positions.push((row + 1, 0));
-        } else {
-            positions.push((row, column));
-        }
-    }
-
-    if positions
-        .last()
-        .is_some_and(|position| position.0 >= rows.len())
-    {
-        rows.push(String::new());
-    }
-
-    WrappedText { rows, positions }
 }
 
 #[cfg(test)]
@@ -534,6 +466,45 @@ mod tests {
     }
 
     #[test]
+    fn word_wrapping_moves_and_renders_the_cursor_without_rewriting_the_draft() {
+        let editor = editor(40, 18);
+        let original = "one two three";
+        let mut composer = new_composer(&editor, None, 17, original.to_string(), vec![]);
+        composer.dialog.width = 7;
+        composer.prompt.set_cursor(0);
+        let revision = composer.prompt.buffer().revision();
+        let mut buffer = RenderBuffer::new(40, editor.vheight(), &Style::default());
+        composer.draw(&mut buffer).unwrap();
+        assert!(rendered_row(&buffer, composer.dialog.y + 1).contains("one two"));
+        assert!(rendered_row(&buffer, composer.dialog.y + 2).contains("three"));
+
+        composer.handle_event(&key(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(composer.prompt.cursor(), 8);
+        assert_eq!(
+            composer.cursor_position(),
+            Some((composer.dialog.x + 1, composer.dialog.y + 2))
+        );
+        composer.resize(30, 12);
+        assert_eq!(composer.prompt.cursor(), 8);
+        assert_eq!(composer.prompt.text(), original);
+        assert_eq!(composer.prompt.buffer().revision(), revision);
+        assert_eq!(
+            submit(&mut composer),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::NotifyPlugin(
+                    "agent".to_string(),
+                    "composer:submitted:17".to_string(),
+                    json!(original)
+                ),
+            ]))
+        );
+
+        // Confirmations and inline assist still use the legacy projection.
+        assert_eq!(wrap_text(original, 7).rows, ["one two", " three"]);
+    }
+
+    #[test]
     fn paste_preserves_all_lines_normalizes_crlf_and_renders_tabs_as_spaces() {
         let editor = editor(60, 18);
         let mut composer = new_composer(
@@ -549,9 +520,9 @@ mod tests {
 
         assert_eq!(composer.prompt.text(), "first\tline\n  second\nthird\n");
         let wrapped = composer.wrapped_text();
-        assert_eq!(wrapped.rows[0], "first   line");
-        assert_eq!(wrapped.rows[1], "  second");
-        assert_eq!(wrapped.rows[2], "third");
+        assert_eq!(wrapped.rows()[0].text, "first   line");
+        assert_eq!(wrapped.rows()[1].text, "  second");
+        assert_eq!(wrapped.rows()[2].text, "third");
         assert_eq!(
             submit(&mut composer),
             Some(KeyAction::Multiple(vec![
@@ -1084,7 +1055,8 @@ mod tests {
         assert_eq!(composer.prompt.history(), ["safe history".to_string()]);
         assert_eq!(composer.validation_status, Some(OVERSIZED_STATUS));
         let wrapped = composer.wrapped_text();
-        assert_eq!(wrapped.rows, vec![String::new()]);
+        assert_eq!(wrapped.rows().len(), 1);
+        assert!(wrapped.rows()[0].text.is_empty());
         composer.handle_event(&key(KeyCode::Char('p'), KeyModifiers::CONTROL));
         assert_eq!(composer.prompt.text(), "safe history");
         assert_eq!(composer.validation_status, None);

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -10,6 +10,7 @@ use crate::{
     buffer::Buffer,
     editing::{TextArea, TextAreaOutcome},
     editor::Mode,
+    text_layout::{LayoutOptions, TextLayout},
     unicode_utils::grapheme_len,
 };
 
@@ -84,6 +85,11 @@ impl PromptBuffer {
     #[must_use]
     pub(crate) fn text(&self) -> String {
         self.area.text()
+    }
+
+    /// Projects the current draft without modifying its logical representation.
+    pub(crate) fn layout(&self, options: LayoutOptions) -> TextLayout {
+        TextLayout::new(&self.text(), options)
     }
 
     /// Returns the cursor as an absolute extended-grapheme index.
@@ -210,16 +216,26 @@ impl PromptBuffer {
         Some(text)
     }
 
-    /// Applies local prompt policy before delegating modal editing to the shared engine.
+    /// Exercises the legacy grapheme-wrap policy in prompt compatibility tests.
+    #[cfg(test)]
     pub(crate) fn handle_event(&mut self, event: &Event, wrap_width: usize) -> PromptInput {
+        self.handle_event_with_layout_options(event, LayoutOptions::grapheme(wrap_width.max(1)))
+    }
+
+    /// Applies local prompt policy before delegating modal editing to the shared engine.
+    pub(crate) fn handle_event_with_layout_options(
+        &mut self,
+        event: &Event,
+        layout: LayoutOptions,
+    ) -> PromptInput {
         let Event::Key(key) = event else {
-            return self.apply_area_event(event, wrap_width);
+            return self.apply_area_event(event, layout);
         };
         if key.kind == KeyEventKind::Release {
             return PromptInput::Changed;
         }
         if self.key_policy == PromptKeyPolicy::EnterSends {
-            if let Some(outcome) = self.handle_composer_key(*key, wrap_width) {
+            if let Some(outcome) = self.handle_composer_key(*key, layout) {
                 return outcome;
             }
         }
@@ -271,11 +287,11 @@ impl PromptBuffer {
                 self.set_cursor(grapheme_len(&self.text()));
                 PromptInput::Changed
             }
-            _ => self.apply_area_event(event, wrap_width),
+            _ => self.apply_area_event(event, layout),
         }
     }
 
-    fn handle_composer_key(&mut self, key: KeyEvent, wrap_width: usize) -> Option<PromptInput> {
+    fn handle_composer_key(&mut self, key: KeyEvent, layout: LayoutOptions) -> Option<PromptInput> {
         let enter = matches!(key.code, KeyCode::Enter | KeyCode::Char('\r'));
         let newline = matches!(key.code, KeyCode::Char('\n'))
             || (matches!(key.code, KeyCode::Char('j' | 'J'))
@@ -297,7 +313,7 @@ impl PromptBuffer {
 
         // A search owns Enter, and unfinished Vim commands must not send a draft.
         if self.mode() == Mode::Search || self.area.state().has_pending_input() {
-            let outcome = self.apply_area_event(&Event::Key(key), wrap_width);
+            let outcome = self.apply_area_event(&Event::Key(key), layout);
             return Some(match outcome {
                 PromptInput::Unhandled => PromptInput::Changed,
                 outcome => outcome,
@@ -308,7 +324,7 @@ impl PromptBuffer {
                 // Preserve insert-session undo grouping and dot-repeat recording.
                 self.apply_area_event(
                     &Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
-                    wrap_width,
+                    layout,
                 );
             } else {
                 self.insert("\n");
@@ -325,9 +341,9 @@ impl PromptBuffer {
         })
     }
 
-    fn apply_area_event(&mut self, event: &Event, wrap_width: usize) -> PromptInput {
+    fn apply_area_event(&mut self, event: &Event, layout: LayoutOptions) -> PromptInput {
         let previous_revision = self.buffer().revision();
-        let result = self.area.handle_event(event, wrap_width);
+        let result = self.area.handle_event_with_layout_options(event, layout);
         self.detach_history_after_edit(self.buffer().revision() != previous_revision);
         match result {
             TextAreaOutcome::Changed => PromptInput::Changed,
@@ -367,6 +383,7 @@ mod tests {
         first_prompt_line, normalize_prompt_newlines, Mode, PromptBuffer, PromptInput,
         PromptKeyPolicy, PROMPT_MAX_BYTES,
     };
+    use crate::text_layout::LayoutOptions;
 
     #[test]
     fn single_line_paste_shares_crlf_normalization_without_accepting_a_newline() {
@@ -447,6 +464,36 @@ mod tests {
             PromptInput::Changed
         );
         assert_eq!(ordinary.text(), "hello\n");
+    }
+
+    #[test]
+    fn word_wrapped_composer_keeps_enter_and_newline_at_the_visual_cursor() {
+        let layout = LayoutOptions::word(7);
+        let mut prompt = composer("one two three");
+        prompt.set_cursor(0);
+        assert_eq!(
+            prompt
+                .handle_event_with_layout_options(&key(KeyCode::Down, KeyModifiers::NONE), layout),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.cursor(), 8);
+        assert_eq!(
+            prompt.handle_event_with_layout_options(
+                &key(KeyCode::Enter, KeyModifiers::SHIFT),
+                layout
+            ),
+            PromptInput::Changed
+        );
+        assert_eq!(prompt.text(), "one two \nthree");
+        assert!(prompt.undo());
+        assert_eq!(prompt.text(), "one two three");
+        assert!(prompt.redo());
+        assert_eq!(
+            prompt
+                .handle_event_with_layout_options(&key(KeyCode::Enter, KeyModifiers::NONE), layout),
+            PromptInput::Submit
+        );
+        assert_eq!(prompt.text(), "one two \nthree");
     }
 
     #[test]

--- a/tests/modal_textarea.rs
+++ b/tests/modal_textarea.rs
@@ -7,6 +7,7 @@ use red::{
     config::Config,
     editing::{TextArea, TextAreaOutcome},
     editor::Mode,
+    text_layout::{LayoutOptions, TextLayout},
 };
 
 fn event(character: char) -> Event {
@@ -16,6 +17,41 @@ fn event(character: char) -> Event {
         KeyCode::Char(character)
     };
     Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+}
+
+#[test]
+fn word_wrapped_vertical_motion_uses_the_display_projection() {
+    let text = "one two three";
+    let options = LayoutOptions::word(7);
+    let layout = TextLayout::new(text, options);
+    let mut area = TextArea::new(text);
+    area.set_cursor(0);
+    let down = Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+    let up = Event::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+    area.handle_event_with_layout_options(&down, options);
+    assert_eq!(area.cursor(), 8);
+    assert_eq!(layout.position(area.cursor()).unwrap().row, 1);
+    area.handle_event_with_layout_options(&up, options);
+    assert_eq!(area.cursor(), 0);
+    assert_eq!(area.text(), text);
+
+    // The old API remains character-wrapped for every caller that has not opted in.
+    area.handle_event(&down, 7);
+    assert_eq!(area.cursor(), 7);
+}
+
+#[test]
+fn word_wrap_does_not_turn_visual_rows_into_logical_lines() {
+    let mut area = TextArea::new("one two three\nlast");
+    let options = LayoutOptions::word(7);
+    area.set_mode(Mode::Normal);
+    area.set_cursor(0);
+    for character in ['d', 'd'] {
+        area.handle_event_with_layout_options(&event(character), options);
+    }
+    assert_eq!(area.text(), "last");
+    area.handle_event_with_layout_options(&event('u'), options);
+    assert_eq!(area.text(), "one two three\nlast");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Long composer prompts currently split words at the terminal edge, and rendering and vertical movement calculate their wrapped positions separately. Changing only the displayed rows would leave keyboard movement and mouse placement out of sync.

This adds a reusable, source-backed layout in `src/text_layout.rs` and opts the agent dialog and text-panel composer into Unicode-aware word wrapping. Display rows retain their source ranges, so soft breaks never modify the draft, submitted text, or undo history. Both composers use the same layout rules for rendering and cursor movement; the text-panel composer also uses them for mouse placement and consistently accounts for its inset and prompt marker. Other views keep the existing grapheme-wrap behavior.

## How to Test

1. Run `cargo test --lib text_layout::tests`. Expect the word-boundary, whitespace, Unicode, source-reconstruction, narrow-view, and legacy-compatibility cases to pass.
2. Run `cargo test --lib word_wrap` and `cargo test --test modal_textarea`. The composer regressions check rendering, arrow movement, mouse insertion, resize, exact submission, and logical-line Vim operations.
3. In the agent dialog and side-panel composer, enter a paragraph with a long URL, explicit blank lines, tabs, and CJK or emoji text. Narrow and widen the view, move vertically in Insert mode, and click within a wrapped word before inserting text. Words should wrap where possible, the cursor should stay on the displayed text, and submission should preserve the original logical text.

Validation completed: all 2,257 tests passed in the serial all-features suite; `cargo clippy --all-targets --all-features -- -D warnings`, formatting, and diff checks passed.
