### PR TITLE
perf(editor): coalesce keyboard navigation frames

### DIFF
--- a/docs/performance-keyboard-scroll-2026-08-15.md
+++ b/docs/performance-keyboard-scroll-2026-08-15.md
@@ -1,0 +1,321 @@
+# Keyboard viewport-edge scrolling — 2026-08-15
+
+## Outcome
+
+The original investigation found that keyboard scrolling still published
+redundant frames after #234. Each normal
+`j`/`k` first paints the moved editor, then applies the indent-guide plugin's
+queued decorations and paints it again. Crossing the viewport boundary changes
+many rows, so those frames generate much more terminal traffic. The output is
+not enclosed in synchronized-update markers. A constrained output sink makes
+this path exceed the 16 ms frame target by a wide margin.
+
+There are also two correctness concerns: a confirmed stale-row defect with
+`scrolloff = 0`, and repeated-key draining that can discard keys across a
+direction-change boundary. The implementation and matched remeasurement are
+recorded at the end of this report; the original baseline remains frozen.
+
+## Measured revision and setup
+
+- Branch/worktree: `codex/keyboard-scroll-investigation`,
+  `red.codex-keyboard-scroll-investigation`, created with `wt`.
+- HEAD: `8881e8fbbdbf32a17d14ff37f75de44cb2ef9c20`.
+- Tree: `ac69a424b053e47cb93cc333d8b0a93bba2ee72b`, identical to the previously
+  validated `4eab875` tree.
+- Frozen release binary SHA-256:
+  `e60d1b71867b54001bb2a8ee244b4b8d86c84e4b439ca5b692b475af692332c9`.
+- Apple M4 Max, 128 GiB RAM, macOS 26.6.1 / 25G76, arm64, Rust 1.94.1.
+- A 200×60 truecolor PTY, isolated configuration, bundled plugins, LSP off,
+  syntax-highlighted `src/editor.rs`, default wrapping and `scrolloff = 3`.
+- The full workspace has two editor splits, NeoTree, and the real Agent UI
+  populated by a deterministic local app-server fixture. No model request or
+  personal conversation is used.
+
+Each main phase sends 200 keys at 25 ms spacing. The inside-viewport control
+alternates `j/k` around the middle; down/up phases first move to the respective
+viewport edge. The main matrix runs serially, three times, with editor-only and
+full-workspace trace runs plus a tracing-disabled workspace control.
+
+Another Rust build and system indexing were observed using substantial CPU.
+Consequently, frame counts and output volume are stronger evidence here than
+small CPU differences or individual wall-time spikes. The PTY is not a physical
+display-latency measurement. The throttled sink is an explicit stress model,
+not a claim about the user's terminal's measured throughput.
+
+## Baseline
+
+Three-run medians; decimal MB. CPU is process CPU time for the entire phase,
+including settling. Event p95 covers the handler, not every later background
+decoration frame.
+
+| Layout / tracing | Motion | CPU seconds | Output | Nonempty terminal frames | Event p95 |
+|---|---|---:|---:|---:|---:|
+| Editor / trace | Inside | 0.86 | 0.816 MB | 400 | 9.50 ms |
+| Editor / trace | Down edge | 0.95 | 3.911 MB | 400 | 10.25 ms |
+| Editor / trace | Up edge | 1.20 | 5.307 MB | 389 | 10.62 ms |
+| Workspace / trace | Inside | 0.84 | 0.546 MB | 400 | 7.73 ms |
+| Workspace / trace | Down edge | 1.08 | 1.905 MB | 400 | 9.18 ms |
+| Workspace / trace | Up edge | 0.90 | 2.504 MB | 390 | 7.16 ms |
+| Workspace / off | Inside | 0.81 | 0.546 MB | 400 | — |
+| Workspace / off | Down edge | 0.71 | 1.905 MB | 399 | — |
+| Workspace / off | Up edge | 0.88 | 2.504 MB | 390 | — |
+
+All 3,600 keys in the six traced baseline runs were handled. The no-trace
+workspace sends 3.49× / 4.58× as many bytes when scrolling down/up as when
+moving inside the viewport. The larger editor-only viewport emits more text;
+the Agent is not the primary cause of this particular slowdown.
+
+### Attribution controls
+
+- Disable only `indent_guides`: exactly 200 nonempty frames in each 200-key
+  phase, versus approximately 400 normally. Down/up output is 1.715 / 2.356 MB.
+  This directly identifies the extra decoration frame.
+- Disable syntax: down/up output falls to 1.205 / 1.635 MB, but frame counts
+  remain approximately 400. Ordinary highlighted runs have only seven
+  highlight-cache misses per edge phase. Syntax coloring contributes escape
+  traffic; repeated parsing is not the leading explanation.
+- Disable wrapping: down/up output remains about 1.897 / 2.508 MB. Relative
+  numbers also retain the duplicate-frame pattern. Neither toggle removes the
+  main cause.
+- Limit PTY reads to 256 KiB/s: down/up motion-frame p95 rises to **45.6 / 68.5
+  ms**, with maximums of 96.7 / 91.5 ms. All 200 motions execute in each phase;
+  fewer intermediate frames are published. This reproduces an output-bound
+  stall.
+- File limits: 200 `k` keys at BOF emit zero bytes/frames; 200 `j` keys at EOF
+  emit 8,800 cursor-control bytes but no nonempty frames. The reported expensive
+  operation is scrolling the viewport, not reaching EOF/BOF.
+- Fast alternating input at 5 ms: 194 of 200 `j/k` events handled. The initial
+  pilot also handled 196 of 200 during a large scheduling stall. These runs are
+  retained separately and are not used as exact-input baseline results.
+
+In the second tracing-disabled workspace run, **93.0%** of downward output and
+**91.6%** of upward output are ANSI/OSC escape bytes. Downward scrolling emits
+134,992 SGR sequences and 33,748 absolute cursor moves; upward emits 174,292 and
+43,573. `render_diff` emits absolute positioning plus foreground, background,
+bold, and italic commands for every same-style run, including unchanged style
+components. This is a promising output-encoding optimization after removing
+duplicate frames.
+
+### Debug-build control and profile
+
+A running Red process was observed at `red/target/debug/red`. Its exact loaded
+source revision was not established, and its executable may have been rebuilt
+since launch. To avoid attributing a stale binary to this revision, the
+investigation built and froze a fresh debug executable from the pinned source.
+
+In one full-workspace run, inside/down/up cost **2.74 / 3.02 / 2.95 CPU seconds**.
+Down/up event p95 was **14.61 / 14.90 ms**; `cursor:moved` callback p95 was
+**9.96 / 10.05 ms**. All 600 keys were handled. Debug mode therefore leaves much
+less frame-budget headroom than the optimized build.
+
+A separate four-second macOS sampling profile during a 1,000-key / 5 ms stress
+run shows substantial main-thread work in `flush_deferred_plugin_event`,
+`Runtime::notify_isolated`, and Husk callback evaluation. Value copying,
+`heap_value_size`, and B-tree traversal appear among the busy leaf stacks.
+That profiled stress run handled 919/1,000 keys under the existing lossy repeat
+policy; it is attribution evidence, not a clean latency benchmark.
+
+## Source-level findings
+
+1. **Two publication boundaries for keyboard navigation.**
+   `src/editor.rs::handle_key_action_with_deferred_motion` flushes the plugin
+   notification and then the pending frame. `indent_guides.hk::refresh` queues
+   `SetDecorations`; `service_background` applies that request afterward and
+   requests another motion frame. The wheel path's `process_scroll_batch`
+   already services those effects before deciding whether another frame is
+   necessary. Reuse that ordering for keyboard navigation.
+2. **No atomic terminal presentation.**
+   `src/editor/rendering.rs::render_diff` hides the cursor, emits changed runs,
+   restores cursor state, and flushes. It never emits mode 2026 begin/end.
+   Every captured phase has zero synchronized-output markers. Buffering into
+   one application write does not guarantee atomic presentation by a terminal
+   or multiplexer. Crossterm 0.27 already exposes the relevant commands; see
+   the [synchronized-output protocol](https://github.com/contour-terminal/vt-extensions/blob/master/synchronized-output.md).
+3. **Confirmed incorrect viewport invalidation at zero scrolloff.**
+   `MoveUp` / `MoveDown` can mutate `vtop` before `finish_cursor_motion` takes
+   its `before` snapshot. If `check_bounds` makes no further change, the code
+   can choose a cursor-row delta for a moved viewport. The original ignored diagnostic
+   compares the resulting cells to a full render: down `100→101` leaves rows
+   0–11 stale; up `100→99` leaves rows 1–12 stale. Both are 12-row mismatches in
+   the split fixture. This is a distinct correctness bug, not proof that every
+   default-scrolloff visual artifact is stale data.
+4. **Repeat-discard can cross a key boundary.**
+   `drain_repeated_motion_events` processes a nonmatching key in its first loop,
+   breaks, and then still enters a second loop that discards the original key's
+   signature. Thus queued alternating directions can lose input. The 194/200
+   trace supports this path. The 50 ms repeated-motion budget also differs from
+   the newer 8 ms ordinary-input/wheel budget.
+
+## Proposed implementation order
+
+1. **Correctness first.** Compare motion against the last painted viewport (or
+   a pre-action view snapshot), not a snapshot taken after motion has already
+   changed it. Convert the ignored stale-row diagnostic into passing regression
+   tests. Cover both directions, scrolloff 0/3, wrapping, inline comments,
+   relative numbers, same/different-buffer splits, and cursor styles. Stop a
+   repeat-drain/discard run at every direction, modifier, mode, or non-motion
+   boundary; account explicitly for any intentionally discarded stale repeats.
+2. **One coherent navigation frame.** Apply a bounded keyboard batch, notify
+   plugins once for its final state, drain its relevant queued effects, then
+   render once using the strongest required damage scope. Preserve background
+   fairness, exact counted motions, macro/operator semantics, and full-render
+   fallbacks for layout, dialogs, focus, LSP, and streaming Agent changes.
+3. **Atomic presentation.** Enclose each completed terminal frame in
+   synchronized-update begin/end, with safe unsupported-terminal behavior and
+   restoration on error/exit. Test the actual terminal and tmux path. This
+   addresses presentation tearing; it does not replace correct damage tracking.
+4. **Reduce terminal bytes.** Track the emitted style/cursor state within a
+   frame, emit only changed SGR components, and evaluate cost-aware contiguous
+   runs. Consider terminal scrolling only for geometries that can safely retain
+   side panes and split contents; never scroll the entire terminal blindly.
+5. **Remeasure before wider runtime work.** Repeat this exact release/debug
+   matrix and slow-sink control. If the Husk callback remains material after
+   batching, cache viewport-invariant indent-guide work or optimize the measured
+   value-copy/accounting path. Do not start with a broad syntax-cache or VM
+   rewrite.
+
+### Acceptance criteria
+
+- Every optimized screen-cell result equals a fresh full frame, including both
+  viewport directions and comment/wrap boundaries.
+- Exact input accounting for alternating keys, counted motions, and ordering
+  boundaries; any held-repeat discard is explicit and confined to one run.
+- A stable 200-key workspace edge phase should need approximately 200 frames,
+  not 400, unless an independently changing background surface requires more.
+- Synchronized frame markers are balanced; resize, interruption, and exit never
+  leave synchronization enabled.
+- Preserve the existing release p95 target below 16 ms; report CPU, emitted
+  bytes, frame counts, and constrained-sink results together on a quieter host.
+- Run the full Rust suite, formatting, strict Clippy, and retained real-terminal
+  smoke before publishing an implementation.
+
+## Reproduction and evidence
+
+Run `scripts/compare_keyboard_scroll.py` with the frozen release binary,
+`--group main` and `--group controls`, using new output directories. The
+single-run `scripts/keyboard_scroll_bench.py` also supports a pinned debug
+binary and a separate macOS `--sample-phase` capture.
+
+The original retained entry point is
+`target/manual-smoke/keyboard-20260815-8881e8f/EVIDENCE.md`.
+It contains raw traces/ANSI output, machine-readable timings, exact binary
+hashes, the ignored diagnostic patch and failure log, the sampling profile,
+four tmux captures, and a checksum verifier. Attach to the preserved session
+with `tmux attach -t red-keyboard-8881e8f`.
+
+## Implementation
+
+The implementation starts from `0928ba8a2ecd40c07ae7be7af29d0c3b26dc79d4`,
+which includes #235's adjacent insertion-line-end viewport fix.
+
+- A committed viewport key includes `BufferId`, revision, scroll position,
+  wrapping, terminal size, and window geometry. Cursor-row damage is allowed
+  only while that key still matches the painted screen.
+- Normal navigation defers publication until its final plugin notification and
+  queued decoration effects have been applied. Native repeat batches preserve
+  every key, stop at input boundaries, and yield after 8 ms or 64 events.
+  Counts, operators, macro recording/replay, and semantic replay are not
+  consumed as ordinary repeat runs. Detached input uses the same publication
+  ordering.
+- Nonempty terminal frames use synchronized-update mode 2026, with best-effort
+  cleanup on write errors, panic, and exit. The encoder retains style and cursor
+  state only within one frame, emits only changed style components, and skips
+  redundant cursor moves without losing wide-grapheme padding.
+- `RED_PERF=trace` now exposes `navigation:publish`, which includes the deferred
+  plugin, background-effect, and final-render work. Key-handler timings alone
+  are no longer an honest measure of the whole publication path.
+
+The reusable paired runner is `scripts/compare_keyboard_scroll.py`; the
+verification entry point is `scripts/finalize_keyboard_comparison.py`.
+
+### Matched remeasurement
+
+The new comparison freezes both binaries at the updated base and extracts one
+immutable source fixture from that commit. It alternates before/after order,
+runs the three release configurations three times, repeats every original
+attribution control, and runs three debug pairs. The 200×60 PTY, 200 keys,
+25 ms spacing, highlighted file, populated Agent, splits, and NeoTree are
+unchanged. LSP is disabled for these timing runs.
+
+The verifier passed **38 runs / 19 fixture pairs**. Every one of the **9,400
+traced after-keys** was handled. Every nonempty after-frame has one balanced,
+properly ordered synchronized-update pair. The exact source files and binary
+hashes are checked independently of the current checkout.
+
+Three-run medians for the normal, tracing-disabled workspace:
+
+| Motion | Output before → after | Reduction | Frames before → after | CPU seconds before → after |
+|---|---:|---:|---:|---:|
+| Inside viewport | 0.546 → 0.211 MB | 61.4% | 400 → 200 | 0.73 → 0.54 |
+| Down edge | 1.905 → 0.878 MB | 53.9% | 400 → 200 | 0.75 → 0.59 |
+| Up edge | 2.504 → 1.102 MB | 56.0% | 390 → 200 | 0.45 → 0.65 |
+
+The CPU result is mixed, not a universal speedup. In the traced workspace,
+down/up CPU medians improve from 0.47/0.82 to 0.39/0.54 seconds. Desktop
+scheduling and terminal-reader stalls still affect timings; a process-name-only
+load snapshot is retained. One editor-only after-run had upward frame p95
+21.4 ms, and another caught up after a 322 ms event outlier without losing
+input. Do not interpret the medians as a hard latency guarantee.
+
+The new workspace `navigation:publish` p95 medians are **2.35 / 2.49 / 7.96 ms**
+inside/down/up. This includes deferred plugin callbacks and the final render;
+the shorter key-handler span is not compared directly with the old handler.
+Ordinary down/up motion-frame p95 medians are 0.94/2.39 ms. Editor-only edge
+output falls from 3.911/5.307 MB to 1.715/2.296 MB; its after frame-count
+medians are 193/200 because queued repeats can share a frame.
+
+The second tracing-disabled downward run emits 35,647 SGR sequences instead
+of 134,992, and 17,805 absolute cursor moves instead of 33,748. This confirms
+that reduced command encoding contributes independently of frame coalescing.
+
+### Stress and debug results
+
+- At **256 KiB/s**, down/up motion-frame p95 improves from **46.5/67.3 ms to
+  20.8/31.9 ms**. The after publication p95 is 24.6/36.0 ms. All keys execute;
+  the after path publishes 200/176 frames versus 168/123 before. This slow
+  sink still cannot meet a universal 16 ms budget, but it receives more
+  intermediate positions with substantially shorter stalls.
+- At 5 ms spacing, alternating `j/k` handles **195/200 before, 200/200 after**.
+  The after down/up phases also handle 200/200. BOF/EOF still emit no nonempty
+  screen frames.
+- The three debug edge pairs handle every key on both binaries. Down/up CPU
+  medians improve from **3.04/3.01 to 2.63/2.53 seconds** (about 13%/16%).
+  After publication p95 is **15.51/15.37 ms**. The debug inside control is not
+  an equal-input CPU comparison: baseline runs handle only 193, 193, and 175
+  of 200 keys, while every after-run handles 200.
+- The debug `cursor:moved` callback remains about 10 ms p95. That is the next
+  isolated CPU investigation if debug-build responsiveness remains a problem.
+  This change does not rewrite Husk allocation/accounting or introduce a new
+  cross-frame plugin cache. The release workspace callback is much cheaper,
+  and the confirmed output/correctness fixes can be evaluated independently.
+
+### Validation and retained evidence
+
+- `cargo fmt --all -- --check`: passed.
+- `cargo test --locked --all-features --all-targets -- --test-threads=1`:
+  **2,257 passed**, including a second run on the final instrumented source.
+- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
+- Screen-equivalence regressions cover both directions, scrolloff 0/3,
+  wrapping, inline comments, relative numbers, and shared/different-buffer
+  splits. Input tests cover bounded batches, counts, operators, macro state,
+  direction/modifier/release/resize boundaries. Encoder tests cover style
+  transitions, wide cells, and cleanup after a simulated write failure.
+- Retained tmux 3.6a smoke: highlighted split editors, Agent, NeoTree, down/up
+  navigation, and resize 200×60 → 180×50 → 200×60 all passed. This validates
+  final screen state and terminal protocol, not physical display latency or a
+  direct observation of the user's reported tearing.
+
+Implementation evidence:
+`target/manual-smoke/keyboard-after-20260815-0928ba8/EVIDENCE.md`.
+It includes the four frozen binaries, fixture archive, raw ANSI/log/JSON
+measurements, paired summaries, validation logs, tmux captures, source patch,
+and verified checksums. The retained session is
+`tmux attach -t red-keyboard-after-0928ba8`.
+
+To repeat the matrix, supply `--before-binary`, `--binary`, `--root` pointing
+to the extracted fixture, and a **new** `--output` directory to
+`scripts/compare_keyboard_scroll.py`. Run `--group main` and `--group controls`
+with the release pair, then `--group debug` with the debug pair. Run
+`scripts/finalize_keyboard_comparison.py --output <evidence-directory>
+--summarize` to check fixture identity, exact after-input counts, synchronization
+ordering, and medians. The original investigation bundle remains unchanged.

--- a/scripts/compare_keyboard_scroll.py
+++ b/scripts/compare_keyboard_scroll.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Run serial, optionally paired keyboard-scroll measurements."""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--before-binary")
+    parser.add_argument("--root", default=str(ROOT))
+    parser.add_argument("--file")
+    parser.add_argument("--split-file")
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--group", choices=("main", "controls", "debug"), default="main")
+    args = parser.parse_args()
+    if args.repetitions < 1:
+        parser.error("--repetitions must be positive")
+    output = Path(args.output).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    cases = []
+    if args.group == "main":
+        for repetition in range(1, args.repetitions + 1):
+            for layout, perf in (("editor", "trace"), ("workspace", "trace"), ("workspace", "off")):
+                cases.append((f"{layout}-{perf}-{repetition}", layout, perf, []))
+    elif args.group == "debug":
+        cases = [(f"workspace-trace-{repetition}", "workspace", "trace", [])
+                 for repetition in range(1, args.repetitions + 1)]
+    else:
+        cases = [
+            ("no-indent", "workspace", "trace", ["--config-override", 'disabled_plugins=["indent_guides"]']),
+            ("no-syntax", "workspace", "trace", ["--syntax-off"]),
+            ("no-wrap", "workspace", "trace", ["--config-override", "wrap=false"]),
+            ("relative", "workspace", "trace", ["--config-override", "relative_line_numbers=true"]),
+            ("fast-repeat", "workspace", "trace", ["--delay-ms", "5"]),
+            ("slow-output", "workspace", "trace", ["--read-kib-per-second", "256"]),
+            ("file-limits", "editor", "trace", ["--phases", "bof", "eof"]),
+        ]
+    index = []
+    root = Path(args.root).resolve()
+    fixture = ["--root", str(root), "--file", args.file or str(root / "src/editor.rs"),
+               "--split-file", args.split_file or str(root / "src/editor/rendering.rs")]
+    for case_index, (name, layout, perf, extra) in enumerate(cases):
+        variants = [("after", args.binary)]
+        if args.before_binary:
+            variants.insert(0, ("before", args.before_binary))
+            if case_index % 2:
+                variants.reverse()
+        for variant, binary in variants:
+            destination = output / variant / name if args.before_binary else output / name
+            command = [sys.executable, str(ROOT / "scripts/keyboard_scroll_bench.py"),
+                       "--binary", binary, "--layout", layout, "--perf-mode", perf,
+                       "--output", str(destination), *fixture, *extra]
+            print(f"=== {variant}/{name} ===", flush=True)
+            subprocess.run(command, check=True)
+            result = json.loads((destination / "results.json").read_text())
+            compact = {}
+            for phase, value in result.items():
+                compact[phase] = {key: value[key] for key in
+                    ("input_events", "handled_key_events", "process_cpu_seconds", "output_bytes",
+                     "nonempty_terminal_frames", "synchronized_output_begin", "synchronized_output_end")}
+                compact[phase]["spans"] = {key: value["timings"].get(key, {}) for key in
+                    ("event key", "navigation:publish", "render:motion_delta", "render:motion_frame", "render:editor_windows",
+                     "render:full", "highlight:miss", "notify cursor:moved", "notify viewport:changed")}
+            index.append({"name": name, "variant": variant, "layout": layout, "perf": perf,
+                          "extra": extra, "results": compact})
+            (output / (args.group + "-summary.json")).write_text(json.dumps(index, indent=2) + "\n")
+    print(json.dumps(index, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/finalize_keyboard_comparison.py
+++ b/scripts/finalize_keyboard_comparison.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Summarize, freeze, and verify a paired keyboard-scroll evidence bundle."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+
+ROOT = Path(__file__).resolve().parent.parent
+GROUPS = (("release", "main"), ("release", "controls"), ("debug", "debug"))
+ESCAPE = re.compile(rb"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]")
+SYNC = re.compile(rb"\x1b\[\?2026([hl])")
+
+
+def digest(path):
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def command(*args):
+    return subprocess.check_output(args, cwd=ROOT, text=True).strip()
+
+
+def read_runs(output):
+    return [(profile, group, run)
+            for profile, group in GROUPS
+            for run in json.loads((output / profile / (group + "-summary.json")).read_text())]
+
+
+def summarize(output):
+    runs = read_runs(output)
+    medians = {}
+    controls = {}
+    for profile, group, run in runs:
+        if group == "controls":
+            controls.setdefault(run["name"], {})[run["variant"]] = run["results"]
+            continue
+        key = "/".join((profile, run["variant"], run["layout"], run["perf"]))
+        for phase, value in run["results"].items():
+            bucket = medians.setdefault(key, {}).setdefault(phase, {})
+            for field in ("process_cpu_seconds", "output_bytes", "nonempty_terminal_frames"):
+                bucket.setdefault(field, []).append(value[field])
+            for span in ("event key", "navigation:publish", "render:motion_frame", "render:motion_delta", "notify cursor:moved"):
+                if value["spans"][span]:
+                    bucket.setdefault(span + " p95_us", []).append(value["spans"][span]["p95_us"])
+    medians = {key: {phase: {field: statistics.median(values)
+                            for field, values in fields.items()}
+                     for phase, fields in phases.items()}
+               for key, phases in medians.items()}
+    escapes = {}
+    for variant in ("before", "after"):
+        names = sorted(run["name"] for profile, group, run in runs
+                       if profile == "release" and group == "main"
+                       and run["variant"] == variant and run["layout"] == "workspace"
+                       and run["perf"] == "off")
+        representative = names[min(1, len(names) - 1)]
+        escapes[variant] = {}
+        for phase in ("inside", "down", "up"):
+            raw = (output / "release" / variant / representative / (phase + ".ansi")).read_bytes()
+            sequences = ESCAPE.findall(raw)
+            escapes[variant][phase] = {
+                "bytes": len(raw), "escape_bytes": sum(map(len, sequences)),
+                "sgr_sequences": sum(seq.startswith(b"\x1b[") and seq.endswith(b"m") for seq in sequences),
+                "cursor_moves": sum(seq.startswith(b"\x1b[") and seq.endswith(b"H") for seq in sequences),
+            }
+    return {"medians": medians, "controls": controls, "escape_analysis": escapes}
+
+
+def validate_runs(output):
+    after_keys = 0
+    pairs = {}
+    runs = read_runs(output)
+    for profile, group, run in runs:
+        directory = output / profile / run["variant"] / run["name"]
+        metadata = json.loads((directory / "metadata.json").read_text())
+        assert metadata["binary_sha256"] == digest(output / (run["variant"] + "-" + profile))
+        pairs.setdefault((profile, group, run["name"]), set()).add(
+            (metadata["file_sha256"], metadata["split_file_sha256"]))
+        for phase, value in run["results"].items():
+            if run["variant"] != "after":
+                continue
+            if run["perf"] == "trace":
+                assert value["handled_key_events"] == value["input_events"], (profile, run["name"], phase)
+                after_keys += value["handled_key_events"]
+            assert value["synchronized_output_begin"] == value["nonempty_terminal_frames"]
+            assert value["synchronized_output_end"] == value["synchronized_output_begin"]
+            active = False
+            for marker in SYNC.finditer((directory / (phase + ".ansi")).read_bytes()):
+                begins = marker.group(1) == b"h"
+                assert begins != active, (profile, run["name"], phase, "unbalanced frame")
+                active = begins
+            assert not active
+    assert all(len(hashes) == 1 for hashes in pairs.values()), "paired fixture mismatch"
+    assert len(runs) == len(pairs) * 2, "missing paired run"
+    return {"runs": len(runs), "after_traced_keys": after_keys, "paired_fixtures": len(pairs)}
+
+
+def verify(output):
+    count = 0
+    for line in (output / "SHA256SUMS").read_text().splitlines():
+        expected, name = line.split("  ", 1)
+        assert digest(output / name) == expected, name
+        count += 1
+    result = validate_runs(output)
+    metadata = json.loads((output / "metadata.json").read_text())
+    command("tmux", "has-session", "-t", metadata["tmux"])
+    print(json.dumps({"checksums": count, **result, "tmux": metadata["tmux"]}, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--base")
+    parser.add_argument("--session")
+    parser.add_argument("--summarize", action="store_true")
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args()
+    output = Path(args.output).resolve()
+    if args.verify:
+        verify(output)
+        return
+    comparison = summarize(output)
+    (output / "comparison.json").write_text(json.dumps(comparison, indent=2) + "\n")
+    validation = validate_runs(output)
+    if args.summarize:
+        print(json.dumps({"validation": validation, "medians": comparison["medians"]}, indent=2))
+        return
+    if not args.base or not args.session:
+        parser.error("--base and --session are required to freeze evidence")
+    assert not command("git", "diff", "HEAD", "--", "src"), "commit the tested source first"
+    metadata = {
+        "head": command("git", "rev-parse", "HEAD"),
+        "tree": command("git", "rev-parse", "HEAD^{tree}"),
+        "base": command("git", "rev-parse", args.base),
+        "branch": command("git", "branch", "--show-current"),
+        "worktree": str(ROOT), "os": platform.platform(),
+        "rustc": command("rustc", "--version"),
+        "tmux": args.session, "validation": validation,
+        "binaries": {name: digest(output / name) for name in
+                     ("before-release", "after-release", "before-debug", "after-debug")},
+    }
+    (output / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    shutil.copy2(ROOT / "docs/performance-keyboard-scroll-2026-08-15.md", output / "report.md")
+    harness = output / "harness"
+    harness.mkdir(exist_ok=True)
+    for name in ("workspace_scroll_bench.py", "keyboard_scroll_bench.py", "compare_keyboard_scroll.py",
+                 "keyboard_scroll_tmux.py", "finalize_keyboard_comparison.py"):
+        shutil.copy2(ROOT / "scripts" / name, harness / name)
+    (output / "implementation.patch").write_text(command("git", "diff", "--binary", args.base, "HEAD", "--", "src") + "\n")
+    paths = sorted(path for path in output.rglob("*") if path.is_file()
+                   and not {"live", "fixture"}.intersection(path.relative_to(output).parts)
+                   and path.name != "SHA256SUMS")
+    (output / "SHA256SUMS").write_text("".join(f"{digest(path)}  {path.relative_to(output)}\n" for path in paths))
+    verify(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/keyboard_scroll_bench.py
+++ b/scripts/keyboard_scroll_bench.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Measure keyboard motion in a populated Red workspace without changing Red."""
+
+import argparse
+from collections import defaultdict
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+
+sys.dont_write_bytecode = True
+import workspace_scroll_bench as base
+
+FRAME_START = b"\x1b[?25l\x1b[?7l"
+SYNC_START = b"\x1b[?2026h"
+SYNC_END = b"\x1b[?2026l"
+
+
+def summarize(content):
+    samples = defaultdict(list)
+    for match in base.TIMING.finditer(content):
+        label, detail, micros = match.group(1), match.group(2) or "", int(match.group(3))
+        if label == "event":
+            label += " " + ("key" if detail.startswith("Key(") else "other")
+        elif label in ("notify", "drain", "husk:notify", "panel:paint"):
+            label += " " + detail.split()[0] if detail else ""
+        samples[label].append(micros)
+    return {key: base.stats(values) for key, values in samples.items()}
+
+
+def byte_stats(values):
+    return {key.replace("_us", "_bytes"): value for key, value in base.stats(values).items()}
+
+
+class Driver(base.Driver):
+    def __init__(self, args):
+        self.chunks = []
+        super().__init__(args)
+
+    def drain(self):
+        while True:
+            try:
+                data = base.os.read(self.master, 65536)
+            except OSError:
+                return
+            if not data:
+                return
+            self.chunks.append((time.monotonic(), self.bytes, len(data)))
+            self.bytes += len(data)
+            self.capture.extend(data)
+            if self.args.read_kib_per_second:
+                time.sleep(len(data) / (1024 * self.args.read_kib_per_second))
+
+    def quiet(self, seconds=0.2, timeout=30):
+        previous, changed = self.bytes, time.monotonic()
+        deadline = changed + timeout
+        while time.monotonic() < deadline:
+            time.sleep(0.01)
+            if self.bytes != previous:
+                previous, changed = self.bytes, time.monotonic()
+            elif time.monotonic() - changed >= seconds:
+                return
+        raise TimeoutError("terminal output did not settle")
+
+    def position(self, phase):
+        # All phases begin in the same source region. M and a short alternating
+        # motion stay inside the viewport; repeated directional keys reach its
+        # boundary before the measured interval starts.
+        self.command(str(self.args.start_line))
+        if phase == "inside":
+            self.send(b"M")
+        elif phase in ("down", "up"):
+            self.send(str(self.args.rows * 2).encode() + (b"j" if phase == "down" else b"k"))
+        elif phase == "bof":
+            self.send(b"gg")
+        elif phase == "eof":
+            self.send(b"G")
+        self.quiet(seconds=0.6)
+
+    def keyboard_phase(self, name):
+        self.position(name)
+        offset = self.log.stat().st_size
+        byte_start = self.bytes
+        cpu_start = base.cpu_seconds(self.process.pid)
+        started = time.monotonic()
+        sampler = None
+        if self.args.sample_phase == name:
+            sampler = subprocess.Popen(["sample", str(self.process.pid), "4", "1", "-file",
+                                        str(self.output / (name + "-sample.txt"))],
+                                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        sends = []
+        for index in range(self.args.presses):
+            key = (b"j" if index % 2 == 0 else b"k") if name == "inside" else (
+                b"k" if name in ("up", "bof") else b"j")
+            sends.append(time.monotonic() - started)
+            self.send(key)
+            deadline = started + (index + 1) * self.args.delay_ms / 1000
+            time.sleep(max(0, deadline - time.monotonic()))
+        enqueue_seconds = time.monotonic() - started
+        self.quiet()
+        finished = time.monotonic()
+        cpu = base.cpu_seconds(self.process.pid) - cpu_start
+        if sampler is not None:
+            sampler.wait(timeout=15)
+        with self.log.open("rb") as stream:
+            stream.seek(offset)
+            content = stream.read().decode(errors="replace")
+        raw = bytes(self.capture[byte_start:self.bytes])
+        timings = summarize(content)
+        starts = [match.start() for match in re.finditer(re.escape(FRAME_START), raw)]
+        frame_sizes = [end - start for start, end in zip(starts, starts[1:] + [len(raw)])]
+        chunks = [(round(t - started, 6), pos - byte_start, size)
+                  for t, pos, size in self.chunks if pos >= byte_start]
+        result = {
+            "input_events": self.args.presses,
+            "handled_key_events": timings.get("event key", {}).get("count")
+                if self.args.perf_mode == "trace" else None,
+            "enqueue_seconds": enqueue_seconds,
+            "quiet_observation_seconds": finished - started,
+            "process_cpu_seconds": round(cpu, 4),
+            "output_bytes": len(raw),
+            "nonempty_terminal_frames": len(starts),
+            "frame_bytes": byte_stats(frame_sizes) if frame_sizes else None,
+            "synchronized_output_begin": raw.count(SYNC_START),
+            "synchronized_output_end": raw.count(SYNC_END),
+            "timings": timings,
+        }
+        self.output.joinpath(name + ".ansi").write_bytes(raw)
+        self.output.joinpath(name + ".log").write_text(content)
+        self.output.joinpath(name + "-io.json").write_text(json.dumps({"sends": sends, "chunks": chunks}) + "\n")
+        self.output.joinpath(name + ".json").write_text(json.dumps(result, indent=2) + "\n")
+        compact = {key: value for key, value in result.items() if key != "timings"}
+        compact["spans"] = {key: value for key, value in timings.items()
+                            if key in ("event key", "navigation:publish", "render:motion_delta", "render:motion_frame", "render:editor_windows", "render:full", "highlight:miss", "notify cursor:moved", "notify viewport:changed")}
+        print(name, json.dumps(compact), flush=True)
+        return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--root", default=str(base.ROOT))
+    parser.add_argument("--file", default=str(base.ROOT / "src/editor.rs"))
+    parser.add_argument("--split-file", default=str(base.ROOT / "src/editor/rendering.rs"))
+    parser.add_argument("--layout", choices=("editor", "agent", "workspace"), default="workspace")
+    parser.add_argument("--perf-mode", choices=("trace", "off"), default="trace")
+    parser.add_argument("--config-override", action="append", default=[])
+    parser.add_argument("--syntax-off", action="store_true")
+    parser.add_argument("--lsp", action="store_true")
+    parser.add_argument("--rows", type=int, default=60)
+    parser.add_argument("--cols", type=int, default=200)
+    parser.add_argument("--start-line", type=int, default=1500)
+    parser.add_argument("--presses", type=int, default=200)
+    parser.add_argument("--delay-ms", type=float, default=25)
+    parser.add_argument("--read-kib-per-second", type=float, default=0)
+    parser.add_argument("--sample-phase", choices=("inside", "down", "up", "bof", "eof"))
+    parser.add_argument("--phases", nargs="+", default=["inside", "down", "up"],
+                        choices=("inside", "down", "up", "bof", "eof"))
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    args.mouse_coordinate_width = 4
+    driver = Driver(args)
+    try:
+        driver.setup()
+        metadata = {"args": vars(args),
+                    "commit": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=base.ROOT, text=True).strip(),
+                    "tree": subprocess.check_output(["git", "rev-parse", "HEAD^{tree}"], cwd=base.ROOT, text=True).strip(),
+                    "binary_sha256": hashlib.sha256(Path(args.binary).read_bytes()).hexdigest(),
+                    "harness_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+                    "file_sha256": hashlib.sha256(driver.file.read_bytes()).hexdigest(),
+                    "split_file_sha256": hashlib.sha256(driver.split_file.read_bytes()).hexdigest(),
+                    "pid": driver.process.pid}
+        driver.output.joinpath("metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+        results = {phase: driver.keyboard_phase(phase) for phase in args.phases}
+        driver.output.joinpath("results.json").write_text(json.dumps(results, indent=2) + "\n")
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/keyboard_scroll_tmux.py
+++ b/scripts/keyboard_scroll_tmux.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Retain a populated interactive workspace for the keyboard-scroll walkthrough."""
+import argparse
+import json
+from pathlib import Path
+import shlex
+import subprocess
+import time
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def tmux(*args, capture=False):
+    return subprocess.run(["tmux", *args], check=True, text=True,
+                          stdout=subprocess.PIPE if capture else None).stdout
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--session", required=True)
+    parser.add_argument("--root", default=str(ROOT))
+    args = parser.parse_args()
+    root = Path(args.root).resolve()
+    session = args.session
+    output = Path(args.output).resolve()
+    live = output / "live"
+    config = live / "config/red"
+    config.mkdir(parents=True, exist_ok=True)
+    log = live / "red.log"
+    (config / "config.toml").write_text(
+        f"log_file = {json.dumps(str(log))}\nshow_whats_new=false\nfetch_release_notes=false\n"
+        f"[lsp]\nenabled=false\n[agent]\ncommand={json.dumps(str(ROOT / 'scripts/workspace_scroll_bench.py'))}\n")
+    command = shlex.join(["env", "RED_PERF=trace", "XDG_CONFIG_HOME=" + str(live / "config"),
+                          str(Path(args.binary).resolve()), "--root", str(root), str(root / "src/editor.rs")])
+    tmux("new-session", "-d", "-s", session, "-n", "workspace", "-x", "200", "-y", "60", "-c", str(root), command)
+    target = session + ":workspace"
+
+    def wait_for(text):
+        deadline = time.monotonic() + 90
+        while time.monotonic() < deadline:
+            if log.exists() and text in log.read_text(errors="replace"):
+                return
+            time.sleep(0.1)
+        raise TimeoutError(text)
+
+    def send(text, pause=0.3):
+        tmux("send-keys", "-t", target, "-l", text)
+        time.sleep(pause)
+
+    def cmd(text):
+        send(":" + text)
+        tmux("send-keys", "-t", target, "Enter")
+        time.sleep(0.4)
+
+    def capture(name):
+        (output / name).write_text(tmux("capture-pane", "-p", "-e", "-t", target, capture=True))
+
+    wait_for("[PERF] startup:interactive:")
+    cmd("sp " + str(root / "src/editor/rendering.rs"))
+    tmux("send-keys", "-t", target, "C-w", "k")
+    cmd("Agent")
+    send("Show the deterministic performance fixture")
+    tmux("send-keys", "-t", target, "Escape")
+    time.sleep(0.1)
+    tmux("send-keys", "-t", target, "Enter")
+    wait_for("notify agent:completed")
+    time.sleep(0.3)
+    tmux("send-keys", "-t", target, "Escape")
+    send("\x1b[<0;0015;0008M\x1b[<0;0015;0008m")
+    cmd("NeoTree")
+    send("\x1b[<0;0065;0008M\x1b[<0;0065;0008m")
+    cmd("1500")
+    send("120j", 0.7)
+    capture("tmux-before.txt")
+    for _ in range(40):
+        send("j", 0.025)
+    capture("tmux-down.txt")
+    send("120k", 0.7)
+    for _ in range(40):
+        send("k", 0.025)
+    capture("tmux-up.txt")
+    tmux("resize-window", "-t", target, "-x", "180", "-y", "50")
+    time.sleep(0.5)
+    tmux("resize-window", "-t", target, "-x", "200", "-y", "60")
+    time.sleep(0.5)
+    capture("tmux-restored.txt")
+    tmux("has-session", "-t", session)
+    print(json.dumps({"session": session, "target": target, "captures": 4}), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -185,9 +185,9 @@ impl ActionDispatcher {
 
 pub const DEFAULT_REGISTER: char = '"';
 const JUMPLIST_SIZE: usize = 100;
-const REPEATED_MOTION_DRAIN_BUDGET_MS: u64 = 50;
 const INPUT_BATCH_BUDGET: Duration = Duration::from_millis(8);
 const SCROLL_EVENTS_PER_BATCH: usize = 64;
+const KEY_EVENTS_PER_BATCH: usize = 64;
 const TERMINAL_SIZE_RECONCILE_INTERVAL: Duration = Duration::from_millis(100);
 const PLUGIN_REQUESTS_PER_TICK: usize = 64;
 const AGENT_EVENTS_PER_TICK: usize = 64;
@@ -860,6 +860,7 @@ fn parse_substitute_segment(input: &str, delimiter: char) -> anyhow::Result<(Str
     anyhow::bail!("substitute is missing a closing {delimiter}")
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EditorViewState {
     vtop: usize,
@@ -867,6 +868,22 @@ struct EditorViewState {
     skipcol: usize,
     cy: usize,
     wrap: bool,
+}
+
+/// Geometry and document identity represented by the last committed editor frame.
+/// Cursor movement alone does not change this key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RenderedViewport {
+    buffer_id: BufferId,
+    revision: u64,
+    vtop: usize,
+    vleft: usize,
+    skipcol: usize,
+    wrap: bool,
+    terminal_size: (u16, u16),
+    bounds: (usize, usize, usize, usize),
+    content_top: usize,
+    gutter_width: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -979,12 +996,14 @@ struct ProcessedEvent {
     quit: bool,
     drain_repeated_motion: bool,
     repeat_signature: Option<KeySignature>,
+    navigation_deferred: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EventRenderMode {
     Immediate,
     DeferredMotion,
+    CoalescedNavigation,
 }
 
 /// Strongest repaint requested while navigation is being coalesced.
@@ -2909,6 +2928,9 @@ pub struct Editor {
     /// Active window represented by the last committed frame.
     last_rendered_window: Option<WindowId>,
 
+    /// Viewport represented by the committed cells, not the latest logical motion.
+    last_rendered_viewport: Option<RenderedViewport>,
+
     /// True once the startup splash has been drawn at least once.
     splash_shown: bool,
 
@@ -3270,13 +3292,19 @@ impl DetachedEditorCore {
                 event,
                 &mut self.render_buffer,
                 &mut self.runtime,
-                EventRenderMode::Immediate,
+                EventRenderMode::CoalescedNavigation,
             )
             .await?;
         self.stopped = processed.quit;
-        self.editor
-            .service_background(&mut self.render_buffer, &mut self.runtime)
-            .await?;
+        if processed.navigation_deferred {
+            self.editor
+                .finish_navigation_batch(&mut self.render_buffer, &mut self.runtime)
+                .await?;
+        } else {
+            self.editor
+                .service_background(&mut self.render_buffer, &mut self.runtime)
+                .await?;
+        }
         if self.editor.persist_session_snapshot(/*force*/ false) {
             self.editor.render(&mut self.render_buffer)?;
         }
@@ -4226,6 +4254,7 @@ impl Editor {
             suppress_reactivation_click: false,
             render_generation: 0,
             last_rendered_window: None,
+            last_rendered_viewport: None,
             splash_shown: false,
             splash_dismissed: false,
             previous_render_buffer: None,
@@ -4441,6 +4470,7 @@ impl Editor {
         }
     }
 
+    #[cfg(test)]
     fn editor_view_state(&self) -> EditorViewState {
         EditorViewState {
             vtop: self.vtop,
@@ -4449,6 +4479,27 @@ impl Editor {
             cy: self.cy,
             wrap: self.wrap,
         }
+    }
+
+    fn rendered_viewport(&self) -> Option<RenderedViewport> {
+        let window = self.window_manager.active_window()?;
+        Some(RenderedViewport {
+            buffer_id: self.current_buffer().id(),
+            revision: self.current_buffer().revision(),
+            vtop: self.vtop,
+            vleft: self.vleft,
+            skipcol: self.skipcol,
+            wrap: self.wrap,
+            terminal_size: self.size,
+            bounds: (
+                window.position.x,
+                window.position.y,
+                window.inner_width(),
+                window.inner_height(),
+            ),
+            content_top: self.window_content_top(window),
+            gutter_width: self.gutter_width_for_window(window),
+        })
     }
 
     fn active_window_with_editor_view(&self) -> Option<crate::window::Window> {
@@ -4470,7 +4521,6 @@ impl Editor {
         buffer: &mut RenderBuffer,
         preserve_cursor_goal: bool,
     ) -> anyhow::Result<()> {
-        let before = self.editor_view_state();
         if !preserve_cursor_goal {
             self.refresh_cursor_goal();
         }
@@ -4480,9 +4530,10 @@ impl Editor {
         // invalidates.
         self.check_bounds();
         self.sync_to_window();
+        let viewport_changed = self.last_rendered_viewport != self.rendered_viewport();
 
         if self.defer_motion_render {
-            self.request_motion_render(if self.editor_view_state() != before {
+            self.request_motion_render(if viewport_changed {
                 MotionRender::Window
             } else {
                 MotionRender::Cursor
@@ -4490,7 +4541,7 @@ impl Editor {
             return Ok(());
         }
 
-        if self.editor_view_state() != before {
+        if viewport_changed {
             self.render_motion_frame(buffer)
         } else if self.can_render_cursor_motion_delta() {
             self.render_cursor_motion_delta(buffer)
@@ -7904,30 +7955,39 @@ impl Editor {
                     break;
                 }
                 let processed = self
-                    .process_editor_event(ev, &mut buffer, &mut runtime, EventRenderMode::Immediate)
+                    .process_editor_event(
+                        ev,
+                        &mut buffer,
+                        &mut runtime,
+                        EventRenderMode::CoalescedNavigation,
+                    )
                     .await?;
                 if processed.quit {
                     break 'editor_loop;
                 }
-                if let Some(signature) = processed
-                    .drain_repeated_motion
-                    .then_some(processed.repeat_signature)
-                    .flatten()
-                {
-                    perf::increment("repeated_motion_batches", 1);
-                    if self
-                        .drain_repeated_motion_events(
-                            signature,
-                            &mut pending_events,
-                            &mut buffer,
-                            &mut runtime,
-                        )
-                        .await?
+                if processed.navigation_deferred {
+                    if let Some(signature) = processed
+                        .drain_repeated_motion
+                        .then_some(processed.repeat_signature)
+                        .flatten()
                     {
-                        break 'editor_loop;
+                        perf::increment("repeated_motion_batches", 1);
+                        if self
+                            .drain_repeated_motion_events(
+                                signature,
+                                &mut pending_events,
+                                &mut buffer,
+                                &mut runtime,
+                            )
+                            .await?
+                        {
+                            break 'editor_loop;
+                        }
+                    } else {
+                        self.finish_navigation_batch(&mut buffer, &mut runtime)
+                            .await?;
                     }
-                    // Give plugin effects, timers, and LSP responses one turn
-                    // before another held-key batch is drained.
+                    serviced_background = true;
                     break;
                 }
                 if input_started.elapsed() >= INPUT_BATCH_BUDGET {
@@ -10011,12 +10071,20 @@ impl Editor {
                 }
             }
         }
-        if needs_render {
-            self.render(buffer)?;
+        let background_render = if needs_render {
+            MotionRender::Full
         } else if needs_editor_windows_render {
-            self.render_editor_windows_frame(buffer)?;
+            MotionRender::EditorWindows
         } else if needs_motion_render {
-            self.render_motion_frame(buffer)?;
+            MotionRender::Window
+        } else {
+            MotionRender::None
+        };
+        if background_render != MotionRender::None {
+            self.request_motion_render(background_render);
+            if !self.defer_motion_render {
+                self.flush_deferred_motion_render(buffer)?;
+            }
         }
         Ok(())
     }
@@ -10039,6 +10107,7 @@ impl Editor {
                 quit: false,
                 drain_repeated_motion: false,
                 repeat_signature: None,
+                navigation_deferred: false,
             });
         }
 
@@ -10081,6 +10150,7 @@ impl Editor {
                 quit: false,
                 drain_repeated_motion: false,
                 repeat_signature: None,
+                navigation_deferred: false,
             });
         }
 
@@ -10089,6 +10159,7 @@ impl Editor {
                 quit: false,
                 drain_repeated_motion: false,
                 repeat_signature: None,
+                navigation_deferred: false,
             });
         }
 
@@ -10096,8 +10167,10 @@ impl Editor {
         let window_before = self.window_manager.active_stable_window_id();
         let repeat_signature = Self::key_signature(&ev);
         let mut drain_repeated_motion = false;
+        let mut navigation_deferred = false;
 
         let from_waiting_key_action = self.waiting_key_action.is_some();
+        let had_repeater = self.repeater.is_some();
         let started_with_panel_focus = self.panel_manager.focused_panel_id().is_some();
         let started_in_normal = self.is_normal();
         let semantic_can_start = started_in_normal || self.is_visual();
@@ -10135,12 +10208,23 @@ impl Editor {
         drop(resolve_span);
         let navigation_action = action.as_ref().is_some_and(Self::key_action_is_navigation);
         if let Some(action) = action {
-            drain_repeated_motion =
-                !from_waiting_key_action && self.should_drain_repeated_motion(&ev, &action);
+            drain_repeated_motion = !from_waiting_key_action
+                && !had_repeater
+                && self.should_drain_repeated_motion(&ev, &action);
+            navigation_deferred = render_mode == EventRenderMode::CoalescedNavigation
+                && self.is_normal()
+                && self.current_dialog.is_none()
+                && !self.panel_manager.has_focused_panel()
+                && !self.workspace_manager.is_active()
+                && navigation_action;
             let action_span = perf::PerfSpan::start("event:handle_action");
-            let should_quit = self
+            let was_deferring = self.defer_motion_render;
+            self.defer_motion_render |= navigation_deferred;
+            let result = self
                 .handle_resolved_key_action(&ev, &action, buffer, runtime)
-                .await?;
+                .await;
+            self.defer_motion_render = was_deferring;
+            let should_quit = result?;
             drop(action_span);
             if should_quit {
                 self.finish_semantic_change_event();
@@ -10148,6 +10232,7 @@ impl Editor {
                     quit: true,
                     drain_repeated_motion: false,
                     repeat_signature: None,
+                    navigation_deferred: false,
                 });
             }
         }
@@ -10155,7 +10240,8 @@ impl Editor {
         self.finish_semantic_change_event();
         drop(semantic_span);
 
-        if render_mode == EventRenderMode::Immediate
+        if render_mode != EventRenderMode::DeferredMotion
+            && !navigation_deferred
             && self.render_generation == render_generation
             && (!mouse_moved && !navigation_action
                 || window_before != self.window_manager.active_stable_window_id())
@@ -10167,6 +10253,7 @@ impl Editor {
             quit: false,
             drain_repeated_motion,
             repeat_signature,
+            navigation_deferred,
         })
     }
 
@@ -10286,16 +10373,26 @@ impl Editor {
         .await;
         self.defer_motion_render = false;
         let quit = result?;
+        self.finish_navigation_batch(buffer, runtime).await?;
+        Ok(quit)
+    }
+
+    /// Apply queued plugin effects before publishing the final navigation frame.
+    async fn finish_navigation_batch(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let _span = perf::PerfSpan::start("navigation:publish");
         self.flush_deferred_plugin_event(runtime).await?;
         let generation = self.render_generation;
         self.service_background(buffer, runtime).await?;
         if self.render_generation == generation {
             self.flush_deferred_motion_render(buffer)?;
         } else {
-            // Background effects already painted the final editor state.
             self.deferred_motion_render = MotionRender::None;
         }
-        Ok(quit)
+        Ok(())
     }
 
     async fn drain_repeated_motion_events(
@@ -10305,25 +10402,36 @@ impl Editor {
         buffer: &mut RenderBuffer,
         runtime: &mut Runtime,
     ) -> anyhow::Result<bool> {
+        self.drain_repeated_motion_with_reader(
+            signature,
+            pending_events,
+            buffer,
+            runtime,
+            INPUT_BATCH_BUDGET,
+            Self::read_ready_event,
+        )
+        .await
+    }
+
+    async fn drain_repeated_motion_with_reader(
+        &mut self,
+        signature: KeySignature,
+        pending_events: &mut VecDeque<Event>,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+        budget: Duration,
+        mut read: impl FnMut(&mut VecDeque<Event>) -> anyhow::Result<Option<Event>>,
+    ) -> anyhow::Result<bool> {
         let started = Instant::now();
-        let mut deferred_motion = false;
-        while started.elapsed() < Duration::from_millis(REPEATED_MOTION_DRAIN_BUDGET_MS) {
-            let Some(ev) = Self::read_ready_event(pending_events)? else {
+        let mut count = 1;
+        let mut quit = false;
+        while count < KEY_EVENTS_PER_BATCH && started.elapsed() < budget {
+            let Some(ev) = read(pending_events)? else {
                 break;
             };
             let same_key = Self::key_signature(&ev).is_some_and(|next| next == signature);
             if !same_key {
-                if deferred_motion {
-                    self.flush_deferred_plugin_event(runtime).await?;
-                    self.flush_deferred_motion_render(buffer)?;
-                    deferred_motion = false;
-                }
-                let processed = self
-                    .process_editor_event(ev, buffer, runtime, EventRenderMode::Immediate)
-                    .await?;
-                if processed.quit {
-                    return Ok(true);
-                }
+                pending_events.push_front(ev);
                 break;
             }
 
@@ -10333,43 +10441,22 @@ impl Editor {
                 .await;
             self.defer_motion_render = false;
             let processed = processed_result?;
-            deferred_motion = true;
+            count += 1;
             if processed.quit {
-                return Ok(true);
+                quit = true;
+                break;
             }
             if !processed.drain_repeated_motion {
                 break;
             }
         }
 
-        // Repeated motion events are lossy once they exceed the frame budget.
-        // This keeps a released key from continuing to walk through stale input.
-        while let Some(ev) = Self::read_ready_event(pending_events)? {
-            if Self::key_signature(&ev).is_some_and(|next| next == signature) {
-                continue;
-            }
-
-            if deferred_motion {
-                self.flush_deferred_plugin_event(runtime).await?;
-                self.flush_deferred_motion_render(buffer)?;
-                deferred_motion = false;
-            }
-
-            let processed = self
-                .process_editor_event(ev, buffer, runtime, EventRenderMode::Immediate)
-                .await?;
-            if processed.quit {
-                return Ok(true);
-            }
-            break;
-        }
-
-        if deferred_motion {
-            self.flush_deferred_plugin_event(runtime).await?;
-            self.flush_deferred_motion_render(buffer)?;
-        }
-
-        Ok(false)
+        // Never discard Press events: traditional terminals cannot distinguish
+        // physical key repeats from deliberate adjacent presses. Bound work,
+        // retain the rest in order, and let background work run between batches.
+        perf::increment("repeated_motion_events", count as u64);
+        self.finish_navigation_batch(buffer, runtime).await?;
+        Ok(quit)
     }
 
     /// Reads the next ready terminal event while collapsing only adjacent
@@ -10476,7 +10563,10 @@ impl Editor {
 
     fn key_signature(ev: &event::Event) -> Option<KeySignature> {
         let event::Event::Key(KeyEvent {
-            code, modifiers, ..
+            code,
+            modifiers,
+            kind: KeyEventKind::Press | KeyEventKind::Repeat,
+            ..
         }) = ev
         else {
             return None;
@@ -10594,6 +10684,10 @@ impl Editor {
             && self.repeater.is_none()
             && self.pending_operator.is_none()
             && self.waiting_key_action.is_none()
+            && self.macro_recording.is_none()
+            && self.macro_replay_depth == 0
+            && !self.replaying_semantic_change
+            && !matches!(action, KeyAction::Repeating(_, _))
             && Self::key_action_is_pure_motion(action)
     }
 
@@ -15771,6 +15865,7 @@ impl Editor {
             &Style::default(),
         );
         self.last_rendered_cursor_position = None;
+        self.last_rendered_viewport = None;
         self.last_rendered_bracket_rows.clear();
         self.last_rendered_cursor_surface = None;
         self.force_full_redraw = true;
@@ -15784,6 +15879,9 @@ impl Editor {
     }
 
     fn restore_terminal_output(output: &mut impl std::io::Write) -> anyhow::Result<()> {
+        output
+            .execute(terminal::EndSynchronizedUpdate)?
+            .execute(terminal::EnableLineWrap)?;
         write!(output, "\x1b]112\x1b\\")?;
         #[cfg(unix)]
         output.execute(event::PopKeyboardEnhancementFlags)?;
@@ -20285,6 +20383,7 @@ impl Editor {
         let primary_cursor = self.cursor_snapshot();
         let committed_terminal_frame = self.previous_render_buffer.clone();
         let committed_render_generation = self.render_generation;
+        let committed_viewport = self.last_rendered_viewport;
         let committed_cursor_position = self.last_rendered_cursor_position;
         let committed_bracket_rows = self.last_rendered_bracket_rows.clone();
         let committed_cursor_surface = self.last_rendered_cursor_surface.clone();
@@ -20319,6 +20418,7 @@ impl Editor {
         // then return to the primary edit so Escape finishes at the block's first row.
         self.previous_render_buffer = committed_terminal_frame;
         self.render_generation = committed_render_generation;
+        self.last_rendered_viewport = committed_viewport;
         self.last_rendered_cursor_position = committed_cursor_position;
         self.last_rendered_bracket_rows = committed_bracket_rows;
         self.last_rendered_cursor_surface = committed_cursor_surface;

--- a/src/editor/navigation_perf_tests.rs
+++ b/src/editor/navigation_perf_tests.rs
@@ -76,6 +76,311 @@ fn assert_matches_full_frame(editor: &mut Editor, buffer: &RenderBuffer) {
 }
 
 #[tokio::test]
+async fn keyboard_edge_frame_matches_full_frame() {
+    let mut failures = Vec::new();
+    for down in [true, false] {
+        let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
+        editor.terminal_output_enabled = true;
+        editor.config.scrolloff = Some(0);
+        editor
+            .config
+            .keys
+            .normal
+            .insert("j".into(), KeyAction::Single(Action::MoveDown));
+        editor
+            .config
+            .keys
+            .normal
+            .insert("k".into(), KeyAction::Single(Action::MoveUp));
+        editor.vtop = 100;
+        editor.cy = if down { editor.vheight() - 1 } else { 0 };
+        editor.cx = 0;
+        editor.sync_to_window();
+        editor.render(&mut buffer).unwrap();
+        assert!(editor.can_render_cursor_motion_delta());
+        let old_vtop = editor.vtop;
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(
+                    KeyCode::Char(if down { 'j' } else { 'k' }),
+                    KeyModifiers::NONE,
+                )),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert_ne!(old_vtop, editor.vtop);
+        let mut full = buffer.clone();
+        editor.render(&mut full).unwrap();
+        let different_rows = buffer
+            .cells
+            .chunks(buffer.width)
+            .zip(full.cells.chunks(full.width))
+            .enumerate()
+            .filter_map(|(row, (actual, expected))| (actual != expected).then_some(row))
+            .collect::<Vec<_>>();
+        eprintln!(
+            "direction={} viewport={}→{} stale_rows={different_rows:?}",
+            if down { "down" } else { "up" },
+            old_vtop,
+            editor.vtop
+        );
+        if !different_rows.is_empty() {
+            failures.push((down, different_rows));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "keyboard edge frames differ from a full redraw: {failures:?}"
+    );
+}
+
+fn key(character: char) -> Event {
+    Event::Key(KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE))
+}
+
+fn bind_keyboard_motions(editor: &mut Editor) {
+    for (name, action) in [("j", Action::MoveDown), ("k", Action::MoveUp)] {
+        editor
+            .config
+            .keys
+            .normal
+            .insert(name.into(), KeyAction::Single(action));
+    }
+}
+
+async fn keyboard_batch(
+    editor: &mut Editor,
+    buffer: &mut RenderBuffer,
+    runtime: &mut Runtime,
+    pending: &mut VecDeque<Event>,
+) -> usize {
+    let before = pending.len();
+    let event = pending.pop_front().unwrap();
+    let processed = editor
+        .process_editor_event(event, buffer, runtime, EventRenderMode::CoalescedNavigation)
+        .await
+        .unwrap();
+    if processed.navigation_deferred {
+        if processed.drain_repeated_motion {
+            editor
+                .drain_repeated_motion_with_reader(
+                    processed.repeat_signature.unwrap(),
+                    pending,
+                    buffer,
+                    runtime,
+                    Duration::MAX,
+                    |pending| Ok(pending.pop_front()),
+                )
+                .await
+                .unwrap();
+        } else {
+            editor
+                .finish_navigation_batch(buffer, runtime)
+                .await
+                .unwrap();
+        }
+    }
+    before - pending.len()
+}
+
+#[tokio::test]
+async fn keyboard_batches_preserve_every_key_and_stop_at_direction_boundaries() {
+    let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
+    bind_keyboard_motions(&mut editor);
+    editor.vtop = 100;
+    editor.cy = 3;
+    editor.sync_to_window();
+    editor.render(&mut buffer).unwrap();
+    let start = editor.buffer_line();
+    let mut pending = VecDeque::from([key('j'), key('j'), key('k'), key('j'), key('k')]);
+    assert_eq!(
+        keyboard_batch(&mut editor, &mut buffer, &mut runtime, &mut pending).await,
+        2
+    );
+    assert_eq!(editor.buffer_line(), start + 2);
+    assert_eq!(pending.front(), Some(&key('k')));
+    while !pending.is_empty() {
+        keyboard_batch(&mut editor, &mut buffer, &mut runtime, &mut pending).await;
+    }
+    assert_eq!(editor.buffer_line(), start + 1);
+    assert_matches_full_frame(&mut editor, &buffer);
+
+    let start = editor.buffer_line();
+    let mut pending = VecDeque::from(vec![key('j'); KEY_EVENTS_PER_BATCH * 2 + 7]);
+    let mut handled = 0;
+    while !pending.is_empty() {
+        let count = keyboard_batch(&mut editor, &mut buffer, &mut runtime, &mut pending).await;
+        assert!((1..=KEY_EVENTS_PER_BATCH).contains(&count));
+        handled += count;
+    }
+    assert_eq!(handled, KEY_EVENTS_PER_BATCH * 2 + 7);
+    assert_eq!(editor.buffer_line(), start + handled);
+    assert_matches_full_frame(&mut editor, &buffer);
+}
+
+#[tokio::test]
+async fn keyboard_batch_leaves_nonmatching_input_queued() {
+    for boundary in [
+        key('k'),
+        Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL)),
+        Event::Key(KeyEvent::new_with_kind(
+            KeyCode::Char('j'),
+            KeyModifiers::NONE,
+            KeyEventKind::Release,
+        )),
+        Event::Resize(100, 25),
+        key('i'),
+    ] {
+        let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
+        bind_keyboard_motions(&mut editor);
+        let mut pending = VecDeque::from([key('j'), boundary.clone(), key('j')]);
+        assert_eq!(
+            keyboard_batch(&mut editor, &mut buffer, &mut runtime, &mut pending).await,
+            1
+        );
+        assert_eq!(pending, VecDeque::from([boundary, key('j')]));
+    }
+}
+
+#[test]
+fn keyboard_repeat_drain_excludes_counts_operators_and_macro_state() {
+    let (mut editor, _, _) = workspace(false, false, false);
+    let motion = KeyAction::Single(Action::MoveDown);
+    assert!(editor.should_drain_repeated_motion(&key('j'), &motion));
+    assert!(!editor.should_drain_repeated_motion(
+        &key('j'),
+        &KeyAction::Repeating(2, Box::new(motion.clone()))
+    ));
+    editor.pending_operator = Some(PendingOperator::new(EditOperator::Delete, 1));
+    assert!(!editor.should_drain_repeated_motion(&key('j'), &motion));
+    editor.pending_operator = None;
+    editor.macro_recording = Some(MacroRecording {
+        register: 'q',
+        events: Vec::new(),
+    });
+    assert!(!editor.should_drain_repeated_motion(&key('j'), &motion));
+    editor.macro_recording = None;
+    editor.macro_replay_depth = 1;
+    assert!(!editor.should_drain_repeated_motion(&key('j'), &motion));
+    editor.macro_replay_depth = 0;
+    editor.replaying_semantic_change = true;
+    assert!(!editor.should_drain_repeated_motion(&key('j'), &motion));
+}
+
+#[tokio::test]
+async fn counted_keyboard_motion_is_one_publication_and_not_a_repeat_run() {
+    let (mut editor, mut buffer, mut runtime) = workspace(false, true, false);
+    bind_keyboard_motions(&mut editor);
+    editor
+        .process_editor_event(
+            key('2'),
+            &mut buffer,
+            &mut runtime,
+            EventRenderMode::Immediate,
+        )
+        .await
+        .unwrap();
+    let generation = editor.render_generation;
+    let processed = editor
+        .process_editor_event(
+            key('j'),
+            &mut buffer,
+            &mut runtime,
+            EventRenderMode::CoalescedNavigation,
+        )
+        .await
+        .unwrap();
+    assert!(processed.navigation_deferred);
+    assert!(!processed.drain_repeated_motion);
+    assert_eq!(editor.render_generation, generation);
+    editor
+        .finish_navigation_batch(&mut buffer, &mut runtime)
+        .await
+        .unwrap();
+    assert_eq!(editor.buffer_line(), 2);
+    assert_eq!(editor.render_generation, generation + 1);
+    assert_matches_full_frame(&mut editor, &buffer);
+}
+
+#[tokio::test]
+async fn keyboard_batch_merges_pending_decoration_damage_before_painting() {
+    for shared in [false, true] {
+        let (mut editor, mut buffer, mut runtime) = workspace(shared, false, false);
+        bind_keyboard_motions(&mut editor);
+        let generation = editor.render_generation;
+        let processed = editor
+            .process_editor_event(
+                key('j'),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::CoalescedNavigation,
+            )
+            .await
+            .unwrap();
+        assert!(processed.navigation_deferred);
+        assert_eq!(editor.render_generation, generation);
+        ACTION_DISPATCHER.send_request(PluginRequest::SetDecorations {
+            namespace: "keyboard-test".into(),
+            decorations: vec![decoration(0)],
+        });
+        editor
+            .finish_navigation_batch(&mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.render_generation, generation + 1);
+        assert_matches_full_frame(&mut editor, &buffer);
+    }
+}
+
+#[tokio::test]
+async fn keyboard_scrolling_matches_full_frames_with_wrapping_and_comments() {
+    for shared in [false, true] {
+        for (relative, wrap, comments, scrolloff) in [
+            (false, false, false, 0),
+            (false, false, false, 3),
+            (false, true, false, 3),
+            (true, true, true, 0),
+            (false, true, true, 3),
+            (true, false, true, 3),
+        ] {
+            let (mut editor, mut buffer, mut runtime) = workspace(shared, relative, wrap);
+            bind_keyboard_motions(&mut editor);
+            editor.terminal_output_enabled = true;
+            editor.config.scrolloff = Some(scrolloff);
+            if comments {
+                for (start, end) in [(95, 98), (104, 106), (114, 118)] {
+                    let comment = editor.make_inline_comment(
+                        start,
+                        end,
+                        "A long annotation spanning source lines and wrapping in the editor."
+                            .into(),
+                        inline_comments::InlineCommentOrigin::Sample,
+                    );
+                    editor.inline_comments.push(comment);
+                }
+                editor.layout_cache.borrow_mut().clear();
+            }
+            editor.vtop = 100;
+            editor.cy = 0;
+            editor.sync_to_window();
+            editor.render(&mut buffer).unwrap();
+            let source = editor.current_buffer().contents();
+            for direction in ['j', 'k'] {
+                for _ in 0..24 {
+                    let mut pending = VecDeque::from([key(direction)]);
+                    keyboard_batch(&mut editor, &mut buffer, &mut runtime, &mut pending).await;
+                    assert_matches_full_frame(&mut editor, &buffer);
+                }
+            }
+            assert_eq!(editor.current_buffer().contents(), source);
+        }
+    }
+}
+
+#[tokio::test]
 async fn ignored_mouse_flood_does_not_render_or_mutate_editor_state() {
     let (mut editor, mut buffer, mut runtime) = workspace(false, false, false);
     let generation = editor.render_generation;

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -986,19 +986,99 @@ fn decoration_local_x(
 
 use super::display_layout::leading_whitespace_display_width;
 
-fn queue_cell_attributes(output: &mut impl io::Write, cell_style: &Style) -> anyhow::Result<()> {
-    if cell_style.bold {
-        output.queue(style::SetAttribute(style::Attribute::Bold))?;
-    } else {
-        output.queue(style::SetAttribute(style::Attribute::NormalIntensity))?;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TerminalCellStyle {
+    fg: Color,
+    bg: Color,
+    bold: bool,
+    italic: bool,
+}
+
+impl TerminalCellStyle {
+    fn resolve(style: &Style, theme: &Style) -> Self {
+        let (fg, bg) = resolve_cell_colors(style, theme);
+        Self {
+            fg,
+            bg,
+            bold: style.bold,
+            italic: style.italic,
+        }
     }
 
-    if cell_style.italic {
-        output.queue(style::SetAttribute(style::Attribute::Italic))?;
-    } else {
-        output.queue(style::SetAttribute(style::Attribute::NoItalic))?;
+    fn queue_delta(
+        self,
+        output: &mut impl io::Write,
+        previous: Option<Self>,
+    ) -> anyhow::Result<()> {
+        if previous.is_none_or(|old| old.bg != self.bg) {
+            output.queue(style::SetBackgroundColor(self.bg.into()))?;
+        }
+        if previous.is_none_or(|old| old.fg != self.fg) {
+            output.queue(style::SetForegroundColor(self.fg.into()))?;
+        }
+        if previous.is_none_or(|old| old.bold != self.bold) {
+            output.queue(style::SetAttribute(if self.bold {
+                style::Attribute::Bold
+            } else {
+                style::Attribute::NormalIntensity
+            }))?;
+        }
+        if previous.is_none_or(|old| old.italic != self.italic) {
+            output.queue(style::SetAttribute(if self.italic {
+                style::Attribute::Italic
+            } else {
+                style::Attribute::NoItalic
+            }))?;
+        }
+        Ok(())
     }
+}
 
+/// Encode changed cells while retaining only frame-local terminal state.
+/// Every frame establishes its first style, so external terminal users cannot
+/// invalidate a cross-frame style cache.
+fn queue_diff_cells(
+    output: &mut impl io::Write,
+    change_set: &[Change<'_>],
+    theme: &Style,
+) -> anyhow::Result<()> {
+    let mut previous_style = None;
+    let mut cursor_position = None;
+    let mut text = String::new();
+    let mut i = 0;
+    while i < change_set.len() {
+        let change = &change_set[i];
+        let (x, y) = (change.x, change.y);
+        let cell_style = &change.cell.style;
+        let terminal_style = TerminalCellStyle::resolve(cell_style, theme);
+        if cursor_position != Some((x, y)) {
+            output.queue(MoveTo(x as u16, y as u16))?;
+        }
+        terminal_style.queue_delta(output, previous_style)?;
+        previous_style = Some(terminal_style);
+
+        let mut next_x = x;
+        text.clear();
+        while i < change_set.len() {
+            let change = &change_set[i];
+            if change.y != y || change.x != next_x || change.cell.style != *cell_style {
+                break;
+            }
+            let cell_width = display_width(change.cell.text.as_str()).max(1);
+            text.push_str(&change.cell.text);
+            next_x += cell_width;
+            i += 1;
+            while cell_width > 1 && i < change_set.len() {
+                let padding = &change_set[i];
+                if padding.y != y || padding.x >= next_x || padding.cell.text != " " {
+                    break;
+                }
+                i += 1;
+            }
+        }
+        output.queue(style::Print(text.as_str()))?;
+        cursor_position = Some((next_x, y));
+    }
     Ok(())
 }
 
@@ -1088,6 +1168,7 @@ impl Editor {
             .expect("render buffer diff requires a previous frame")
             .apply_changes(changes);
         self.force_full_redraw = false;
+        self.last_rendered_viewport = self.rendered_viewport();
     }
 
     /// Renders the entire editor state to the terminal
@@ -1307,6 +1388,8 @@ impl Editor {
     pub(crate) fn can_render_cursor_motion_delta(&self) -> bool {
         self.terminal_output_enabled
             && self.can_reuse_editor_surfaces()
+            && self.last_rendered_viewport.is_some()
+            && self.last_rendered_viewport == self.rendered_viewport()
             && !self.relative_line_numbers_enabled()
             && self.uses_synthetic_block_cursor()
             && self.current_dialog.is_none()
@@ -1338,6 +1421,10 @@ impl Editor {
         self.update_gutter_width();
         self.fix_cursor_pos();
         self.sync_to_window();
+
+        if self.last_rendered_viewport != self.rendered_viewport() {
+            return self.render_motion_frame(buffer);
+        }
 
         let new_cursor_position = self.render_cursor_position();
         let active_window_id = self.window_manager.active_window_id();
@@ -2834,60 +2921,31 @@ impl Editor {
             return Ok(());
         }
 
-        self.stdout.queue(cursor::Hide)?;
-        self.stdout.queue(terminal::DisableLineWrap)?;
-
-        let mut i = 0;
-        let mut text = String::new();
-        while i < change_set.len() {
-            let change = &change_set[i];
-            let x = change.x;
-            let y = change.y;
-            let style = change.cell.style.clone();
-
-            self.stdout.queue(MoveTo(x as u16, y as u16))?;
-            self.queue_cell_style(&style)?;
-
-            let mut next_x = x;
-            text.clear();
-
-            while i < change_set.len() {
-                let change = &change_set[i];
-                if change.y != y || change.x != next_x || change.cell.style != style {
-                    break;
-                }
-
-                let cell_width = display_width(change.cell.text.as_str()).max(1);
-                text.push_str(change.cell.text.as_str());
-                next_x += cell_width;
-                i += 1;
-
-                while cell_width > 1 && i < change_set.len() {
-                    let padding = &change_set[i];
-                    if padding.y != y || padding.x >= next_x || padding.cell.text != " " {
-                        break;
-                    }
-                    i += 1;
-                }
-            }
-
-            self.stdout.queue(style::Print(text.as_str()))?;
+        // Unsupported terminals ignore this private mode. Keep the end marker
+        // outside the fallible body so an interrupted frame cannot leave a
+        // supporting terminal displaying a frozen screen.
+        let result = (|| -> anyhow::Result<()> {
+            self.stdout.queue(terminal::BeginSynchronizedUpdate)?;
+            self.stdout.queue(cursor::Hide)?;
+            self.stdout.queue(terminal::DisableLineWrap)?;
+            queue_diff_cells(&mut self.stdout, change_set, &self.theme.style)?;
+            self.set_cursor_style()?;
+            self.draw_cursor_preserving_cursor_goal()?;
+            Ok(())
+        })();
+        let restore_wrap = self.stdout.queue(terminal::EnableLineWrap).map(|_| ());
+        let end_frame = self
+            .stdout
+            .queue(terminal::EndSynchronizedUpdate)
+            .map(|_| ());
+        let flush = self.flush_terminal_output();
+        if result.is_err() || restore_wrap.is_err() || end_frame.is_err() || flush.is_err() {
+            self.force_full_redraw = true;
         }
-
-        self.stdout.queue(terminal::EnableLineWrap)?;
-        self.set_cursor_style()?;
-        self.draw_cursor_preserving_cursor_goal()?;
-        self.flush_terminal_output()?;
-
-        Ok(())
-    }
-
-    fn queue_cell_style(&mut self, cell_style: &Style) -> anyhow::Result<()> {
-        let (fg, bg) = resolve_cell_colors(cell_style, &self.theme.style);
-        self.stdout.queue(style::SetBackgroundColor(bg.into()))?;
-        self.stdout.queue(style::SetForegroundColor(fg.into()))?;
-        queue_cell_attributes(&mut self.stdout, cell_style)?;
-
+        result?;
+        restore_wrap?;
+        end_frame?;
+        flush?;
         Ok(())
     }
 
@@ -4538,14 +4596,15 @@ mod tests {
     fn queue_cell_attributes_sets_and_clears_tracked_attributes() {
         let mut output = Vec::new();
 
-        queue_cell_attributes(
-            &mut output,
+        TerminalCellStyle::resolve(
             &Style {
                 bold: true,
                 italic: true,
                 ..Style::default()
             },
+            &Style::default(),
         )
+        .queue_delta(&mut output, None)
         .unwrap();
 
         let output = String::from_utf8(output).unwrap();
@@ -4559,7 +4618,9 @@ mod tests {
         );
 
         let mut output = Vec::new();
-        queue_cell_attributes(&mut output, &Style::default()).unwrap();
+        TerminalCellStyle::resolve(&Style::default(), &Style::default())
+            .queue_delta(&mut output, None)
+            .unwrap();
 
         let output = String::from_utf8(output).unwrap();
         assert!(
@@ -4570,5 +4631,166 @@ mod tests {
             output.contains("\x1b[23m"),
             "plain style should clear italic attribute"
         );
+    }
+
+    #[test]
+    fn terminal_diff_reuses_style_and_position_without_losing_wide_cells() {
+        let first = Style {
+            fg: Some(Color::Rgb { r: 1, g: 2, b: 3 }),
+            bg: Some(Color::Rgb { r: 4, g: 5, b: 6 }),
+            ..Style::default()
+        };
+        let second = Style {
+            fg: Some(Color::Rgb { r: 7, g: 8, b: 9 }),
+            ..first.clone()
+        };
+        let emphasized = Style {
+            bold: true,
+            italic: true,
+            ..second.clone()
+        };
+        let mut buffer = RenderBuffer::new(8, 2, &Style::default());
+        for (x, style) in [
+            (0, &first),
+            (1, &second),
+            (2, &emphasized),
+            (3, &first),
+            (6, &first),
+        ] {
+            buffer.set_text(x, 0, "x", style);
+        }
+        buffer.set_text(0, 1, "界z", &first);
+        let changes = [0, 1, 2, 3, 6, 8, 9, 10]
+            .into_iter()
+            .map(|index| Change {
+                x: index % 8,
+                y: index / 8,
+                cell: &buffer.cells[index],
+            })
+            .collect::<Vec<_>>();
+        let mut output = Vec::new();
+        queue_diff_cells(&mut output, &changes, &Style::default()).unwrap();
+        let mut expected = Vec::new();
+        expected.queue(MoveTo(0, 0)).unwrap();
+        TerminalCellStyle::resolve(&first, &Style::default())
+            .queue_delta(&mut expected, None)
+            .unwrap();
+        expected.queue(style::Print("x")).unwrap();
+        expected
+            .queue(style::SetForegroundColor(second.fg.unwrap().into()))
+            .unwrap()
+            .queue(style::Print("x"))
+            .unwrap()
+            .queue(style::SetAttribute(style::Attribute::Bold))
+            .unwrap()
+            .queue(style::SetAttribute(style::Attribute::Italic))
+            .unwrap()
+            .queue(style::Print("x"))
+            .unwrap()
+            .queue(style::SetForegroundColor(first.fg.unwrap().into()))
+            .unwrap()
+            .queue(style::SetAttribute(style::Attribute::NormalIntensity))
+            .unwrap()
+            .queue(style::SetAttribute(style::Attribute::NoItalic))
+            .unwrap()
+            .queue(style::Print("x"))
+            .unwrap()
+            .queue(MoveTo(6, 0))
+            .unwrap()
+            .queue(style::Print("x"))
+            .unwrap()
+            .queue(MoveTo(0, 1))
+            .unwrap()
+            .queue(style::Print("界z"))
+            .unwrap();
+        assert_eq!(output, expected);
+        let output = String::from_utf8(output).unwrap();
+        assert_eq!(output.matches("\x1b[22m").count(), 2);
+        assert_eq!(output.matches("\x1b[23m").count(), 2);
+        assert_eq!(output.matches("\x1b[1m").count(), 1);
+        assert_eq!(output.matches("\x1b[3m").count(), 1);
+        assert!(output.contains("\x1b[1;1H"));
+        assert!(output.contains("\x1b[1;7H"));
+        assert!(output.contains("\x1b[2;1H界z"));
+        assert_eq!(output.matches('H').count(), 3);
+    }
+
+    #[test]
+    fn terminal_style_delta_compares_resolved_theme_colors() {
+        let theme = Style {
+            fg: Some(Color::Rgb { r: 1, g: 2, b: 3 }),
+            ..Style::default()
+        };
+        let implicit = TerminalCellStyle::resolve(&Style::default(), &theme);
+        let explicit = TerminalCellStyle::resolve(&theme, &theme);
+        assert_eq!(implicit, explicit);
+        let mut output = Vec::new();
+        explicit.queue_delta(&mut output, Some(implicit)).unwrap();
+        assert!(output.is_empty());
+    }
+
+    struct CapturedOutput {
+        bytes: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+        fail_at: Option<usize>,
+    }
+
+    impl io::Write for CapturedOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            let mut output = self.bytes.lock().unwrap();
+            if let Some(limit) = self.fail_at {
+                if output.len() >= limit {
+                    self.fail_at = None;
+                    return Err(io::Error::other("injected frame write failure"));
+                }
+                let count = bytes.len().min(limit - output.len());
+                output.extend_from_slice(&bytes[..count]);
+                return Ok(count);
+            }
+            output.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn synchronized_terminal_frames_end_on_success_and_write_failure() {
+        for fail_at in [None, Some(40)] {
+            let mut editor = rendering_test_editor(Buffer::new(None, "text".into()));
+            editor.terminal_output_enabled = true;
+            let bytes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            editor.stdout = std::io::BufWriter::with_capacity(
+                1,
+                Box::new(CapturedOutput {
+                    bytes: bytes.clone(),
+                    fail_at,
+                }) as super::super::TerminalOutput,
+            );
+            let source =
+                RenderBuffer::new_with_contents(4, 1, Style::default(), vec!["test".into()]);
+            let changes = source
+                .cells
+                .iter()
+                .enumerate()
+                .map(|(x, cell)| Change { x, y: 0, cell })
+                .collect::<Vec<_>>();
+            let result = editor.render_diff(&changes);
+            let output = String::from_utf8(bytes.lock().unwrap().clone()).unwrap();
+            assert!(output.starts_with("\x1b[?2026h"));
+            assert!(output.ends_with("\x1b[?7h\x1b[?2026l"));
+            assert_eq!(output.matches("\x1b[?2026h").count(), 1);
+            assert_eq!(output.matches("\x1b[?2026l").count(), 1);
+            if fail_at.is_some() {
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("injected frame write failure"));
+                assert!(editor.force_full_redraw);
+            } else {
+                result.unwrap();
+            }
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,8 @@ async fn run() -> anyhow::Result<()> {
 
     panic::set_hook(Box::new(|info| {
         let mut stdout = stdout();
+        _ = stdout.execute(terminal::EndSynchronizedUpdate);
+        _ = stdout.execute(terminal::EnableLineWrap);
         _ = write!(stdout, "\x1b]112\x1b\\");
         _ = stdout.execute(event::DisableBracketedPaste);
         _ = stdout.execute(event::DisableFocusChange);
@@ -666,6 +668,7 @@ struct DetachedTerminalGuard;
 impl Drop for DetachedTerminalGuard {
     fn drop(&mut self) {
         let mut output = stdout();
+        _ = output.execute(terminal::EndSynchronizedUpdate);
         _ = output.execute(event::DisableBracketedPaste);
         _ = output.execute(event::DisableFocusChange);
         _ = output.execute(event::DisableMouseCapture);


### PR DESCRIPTION
## Why

After #234, normal `j`/`k` navigation still painted the editor before applying the indent-guide plugin's queued decorations, then painted it again. Scrolling at a viewport edge amplified that terminal traffic and exposed partially drawn frames. The investigation also found stale rows with `scrolloff = 0` and a repeat-draining path that could discard keys across a direction change.

This follows #234 and includes #235's adjacent insertion-line-end fix in its base.

## Changes

- Compare cursor-only damage against the last committed viewport, including buffer identity, revision, scrolling, wrapping, and window geometry.
- Preserve every navigation key in bounded 8 ms / 64-event batches, stop at input boundaries, and apply plugin decorations before publishing the final frame. Keep counts, operators, macros, and detached input correct.
- Enclose nonempty terminal frames in synchronized updates, restore terminal state on errors and exit, and emit only changed style components and necessary cursor moves.
- Add screen-equivalence, input-ordering, wide-cell, and write-failure regressions, plus reusable PTY/tmux benchmarks and a `navigation:publish` timing span.

## Measurements

Three-run medians for a 200×60 workspace with highlighted Rust, two editor splits, NeoTree, and a populated deterministic Agent fixture; 200 keys at 25 ms spacing, tracing disabled:

| Motion | Output before → after | Frames before → after | CPU seconds before → after |
|---|---:|---:|---:|
| Inside viewport | 0.546 → 0.211 MB | 400 → 200 | 0.73 → 0.54 |
| Down edge | 1.905 → 0.878 MB | 400 → 200 | 0.75 → 0.59 |
| Up edge | 2.504 → 1.102 MB | 390 → 200 | 0.45 → 0.65 |

At a constrained 256 KiB/s sink, down/up motion-frame p95 improved from 46.5/67.3 ms to 20.8/31.9 ms. Fast alternating `j/k` handled 195/200 keys before and 200/200 after. All 9,400 traced after-keys across 38 paired runs were handled, with balanced synchronized frames.

CPU results are mixed, desktop timing remains noisy, and debug-mode plugin callbacks still cost about 10 ms p95. This does not claim a universal 16 ms ceiling or measured physical-display latency. The complete methodology, results, and remaining runtime work are in `docs/performance-keyboard-scroll-2026-08-15.md`.

## How to Test

1. Build the optimized binary with `cargo build --locked --release --all-features --bin red`.
2. Run `python3 scripts/keyboard_scroll_tmux.py --binary target/release/red --session red-keyboard-pr-smoke --output target/manual-smoke/keyboard-pr-smoke` using a fresh session/output name. Attach to the session and inspect the retained down/up/restored captures. Both highlighted editor splits, Agent, and NeoTree should remain intact through scrolling and the resize round trip.
3. Run `python3 scripts/keyboard_scroll_bench.py --binary target/release/red --layout workspace --perf-mode trace --delay-ms 5 --output target/manual-smoke/keyboard-pr-fast`. Each phase should handle all 200 keys; synchronized-update begin/end counts should match the nonempty frame count. The Agent fixture is local and makes no model request.
4. Run `cargo test --locked --all-features --lib navigation_perf_tests -- --test-threads=1`. In particular, `keyboard_edge_frame_matches_full_frame` must report no stale rows, and the batching/count/operator/macro tests must preserve exact input order.
5. Run `cargo test --locked --all-features --lib synchronized_terminal_frames_end_on_success_and_write_failure`. Both successful output and the injected write-failure path should terminate the synchronized frame safely.

Already validated at `ecc2ede`: formatting, strict Clippy, 2,257 Rust tests, the 38-run release/debug comparison, and the retained tmux smoke. Local evidence is indexed at `target/manual-smoke/keyboard-after-20260815-0928ba8/EVIDENCE.md`; its 785 checksums and the original investigation's 391 checksums verify.
