### PR TITLE
feat(git): polish workspace and standardize action strips

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -236,6 +236,18 @@ when there is not enough height for both. In the diff, `j`/`k`,
 `[h`/`]h` provide line, page, and hunk navigation. `W` toggles wrapping; when
 wrapping is off, `h`/`l`, the arrow keys, and `0`/`$` scroll horizontally.
 
+The bottom action strip follows the focused pane and selection. Press `?` or
+`F1` for the complete, actionable list. In the file pane, `/` filters paths;
+`Enter` applies the filter and `Esc` clears it. `C` or `Enter` on a section
+heading collapses that section. Drag the vertical divider, or use `Ctrl-w <`
+and `Ctrl-w >`, to resize the file pane; `Ctrl-w o` hides or restores it.
+The chosen width is retained while the editor remains open.
+
+The diff header keeps the file, staged state, change counts, and current hunk
+visible. `M` toggles raw patch metadata, and `L` opens the complete patch in a
+scratch buffer when the bounded preview is not enough. Line colors and exact
+changed-word highlights use the active theme without replacing syntax colors.
+
 Use `v` to select changed lines. Lowercase `s`, `u`, and `x` stage, unstage,
 or discard the current changed line or selection; uppercase `S`, `U`, and `X`
 apply the same operation to the current hunk. Destructive actions remain

--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -172,6 +172,17 @@ struct AgentHistoryEvent {
     row: AgentHistoryRow,
 }
 
+struct AgentWorkspaceActionHint {
+    id: String,
+    key: String,
+    label: String,
+    priority: String,
+}
+
+struct AgentWorkspaceAction {
+    hint: AgentWorkspaceActionHint,
+}
+
 struct AgentPermissionOption {
     option_id: String,
     name: String,
@@ -1641,7 +1652,9 @@ fn render_history(result: AgentHistoryResult) {
     red::execute("UpdateWorkspace", "agent-history", WorkspaceModel {
         rows: rows,
         detail: state().history_detail,
-        footer: [PanelSegment { text: "r safe revert  Esc/q close", style: muted_style() }],
+        actions: [AgentWorkspaceAction {
+            hint: AgentWorkspaceActionHint { id: "r", key: "r", label: "safe revert", priority: "essential" },
+        }],
     });
 }
 

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -17,6 +17,13 @@ struct GitEntry {
     kind: String,
 }
 
+struct GitDisplayEntry {
+    entry: GitEntry,
+    filename: String,
+    parent: String,
+    label: String,
+}
+
 struct GitState {
     head: String,
     oid: String,
@@ -190,6 +197,10 @@ struct GitWorkspaceDocumentLine {
 struct GitWorkspaceDocument {
     path: String,
     lines: [GitWorkspaceDocumentLine],
+    added: i32,
+    removed: i32,
+    total_lines: i32,
+    truncated: bool,
 }
 
 struct GitWorkspaceRowData {
@@ -223,6 +234,25 @@ struct GitWorkspaceModel {
     detail: [[PanelSegment]],
     detail_document: Option<GitWorkspaceDocument>,
     footer: [PanelSegment],
+    actions: [GitWorkspaceAction],
+    status: String,
+    detail_title: String,
+}
+
+struct GitUiAction {
+    id: String,
+    key: String,
+    label: String,
+    priority: String,
+}
+
+struct GitWorkspaceAction {
+    hint: GitUiAction,
+    focus: String,
+    sections: [String],
+    selection: String,
+    change_only: bool,
+    hunk_only: bool,
 }
 
 struct GitRebaseCommit {
@@ -284,6 +314,13 @@ struct GitPluginState {
     detail_process: String,
     detail_output: String,
     detail_pending_output: String,
+    detail_error: String,
+    detail_status: String,
+    detail_suppressed: bool,
+    stats: Json,
+    stats_process: String,
+    stats_section: String,
+    stats_output: String,
     detail_path: String,
     detail_section: String,
     detail_rendered_path: String,
@@ -405,6 +442,13 @@ fn initial_state() -> GitPluginState {
         detail_process: "",
         detail_output: "",
         detail_pending_output: "",
+        detail_error: "",
+        detail_status: "",
+        detail_suppressed: false,
+        stats: Json {},
+        stats_process: "",
+        stats_section: "",
+        stats_output: "",
         detail_path: "",
         detail_section: "",
         detail_rendered_path: "",
@@ -497,6 +541,7 @@ fn dashboard() {
         return;
     }
     red::state_patch(GitPluginState { dashboard_open: true });
+    red::state_patch(GitPluginState { detail_suppressed: false });
     red::execute("OpenWorkspace", "git-dashboard", WorkspaceConfig {
         title: "Git",
         detail_ratio: 58,
@@ -509,6 +554,10 @@ fn dashboard() {
 
 fn close_dashboard() {
     cancel_detail_timer();
+    if plugin_state().stats_process != "" {
+        red::execute("KillProcess", plugin_state().stats_process);
+        red::state_patch(GitPluginState { stats_process: "" });
+    }
     let detail_process = red::string(plugin_state().detail_process, "");
     if detail_process != "" {
         red::execute("KillProcess", detail_process);
@@ -688,6 +737,16 @@ fn git_info_loaded(info: GitEditorInfo) {
     render_dashboard();
 }
 
+#[red::on("theme:changed")]
+fn git_theme_changed(event: Json) {
+    red::request("GetEditorInfo", git_theme_info_loaded);
+}
+
+fn git_theme_info_loaded(info: GitEditorInfo) {
+    git_info_loaded(info);
+    red::request("GetWindows", sign_windows_loaded);
+}
+
 fn watch_git_directory(git_dir: String) {
     let path = git_dir;
     if !red::starts_with(path, "/") {
@@ -759,6 +818,7 @@ fn update_status(output: String) {
     let safe_sync_pending = plugin_state().safe_sync_pending;
     if changed || forced {
         render_dashboard();
+        if plugin_state().dashboard_open { refresh_stats(); }
     }
     if changed || forced {
         red::request("GetWindows", sign_windows_loaded);
@@ -773,7 +833,7 @@ fn update_status(output: String) {
 }
 
 fn refresh_selected_detail(render_loading: bool) {
-    if !plugin_state().dashboard_open {
+    if !plugin_state().dashboard_open || plugin_state().detail_suppressed {
         return;
     }
     let path = red::string(plugin_state().detail_path, "");
@@ -793,6 +853,7 @@ fn refresh_selected_detail(render_loading: bool) {
                 return;
             }
         }
+        clear_detail("Working tree clean.", true);
         return;
     }
     let preferred_section = red::string(plugin_state().detail_section, "");
@@ -827,8 +888,7 @@ fn refresh_selected_detail(render_loading: bool) {
             }
         }
     }
-    red::state_patch(GitPluginState { detail_document: None });
-    red::state_patch(GitPluginState { detail: [[PanelSegment { text: "The selected file has no remaining changes.", style: success_style() }]] });
+    clear_detail("The selected file has no remaining changes.", false);
     if render_loading { render_dashboard(); }
 }
 
@@ -1163,10 +1223,13 @@ fn sign_style(kind: String, staged: bool) -> Style {
         return style;
     }
     let color = colors["gitDecoration.modifiedResourceForeground"];
+    if color == red::null() { color = colors["editorGutter.modifiedBackground"]; }
     if kind == "add" {
         color = colors["gitDecoration.addedResourceForeground"];
+        if color == red::null() { color = colors["editorGutter.addedBackground"]; }
     } else if kind == "delete" || kind == "topdelete" || kind == "changedelete" {
         color = colors["gitDecoration.deletedResourceForeground"];
+        if color == red::null() { color = colors["editorGutter.deletedBackground"]; }
     }
     if color != red::null() {
         style.fg = color;
@@ -1192,6 +1255,7 @@ fn render_dashboard() {
         return;
     }
     let state = plugin_state().state;
+    let stats = plugin_state().stats;
     let rows: [GitWorkspaceRow] = [];
     if red::string(plugin_state().operation, "") != "" {
         rows = red::push(rows, GitWorkspaceRow {
@@ -1203,10 +1267,10 @@ fn render_dashboard() {
             }],
         });
     }
-    rows = append_section(rows, "Conflicts", "conflicted", state.conflicted);
-    rows = append_section(rows, "Staged", "staged", state.staged);
-    rows = append_section(rows, "Unstaged", "unstaged", state.unstaged);
-    rows = append_section(rows, "Untracked", "untracked", state.untracked);
+    rows = append_section(rows, "Conflicts", "conflicted", state.conflicted, stats);
+    rows = append_section(rows, "Staged", "staged", state.staged, stats);
+    rows = append_section(rows, "Unstaged", "unstaged", state.unstaged, stats);
+    rows = append_section(rows, "Untracked", "untracked", state.untracked, stats);
     if red::bool(state.truncated, false) {
         rows = red::push(rows, GitWorkspaceRow {
             id: "status-truncated",
@@ -1229,14 +1293,55 @@ fn render_dashboard() {
         rows: rows,
         detail: plugin_state().detail,
         detail_document: plugin_state().detail_document,
-        footer: [PanelSegment {
-            text: "Tab/Ctrl-w w focus  j/k scroll  [h/]h hunks  W wrap  v select  s/u/x line  S/U/X hunk  Enter open  ? help  q close",
-            style: muted_style(),
-        }],
+        actions: dashboard_actions(),
+        status: plugin_state().detail_status,
+        detail_title: plugin_state().detail_path,
     });
 }
 
-fn append_section(rows: [GitWorkspaceRow], title: String, section: String, entries: [GitEntry]) -> [GitWorkspaceRow] {
+fn dashboard_action(id: String, key: String, label: String, focus: String, sections: [String], priority: String) -> GitWorkspaceAction {
+    let selection = "";
+    if id == "activate" || id == "L" { selection = "item"; }
+    return GitWorkspaceAction {
+        hint: GitUiAction { id: id, key: key, label: label, priority: priority },
+        focus: focus,
+        sections: sections,
+        selection: selection,
+        change_only: id == "s" || id == "u" || id == "x",
+        hunk_only: id == "S" || id == "U" || id == "X",
+    };
+}
+
+fn dashboard_actions() -> [GitWorkspaceAction] {
+    return [
+        dashboard_action("s", "s", "stage {scope}", "", ["unstaged", "untracked"], "essential"),
+        dashboard_action("u", "u", "unstage {scope}", "", ["staged"], "essential"),
+        dashboard_action("S", "S", "stage hunk", "detail", ["unstaged", "untracked"], "primary"),
+        dashboard_action("U", "U", "unstage hunk", "detail", ["staged"], "primary"),
+        dashboard_action("activate", "Enter", "open", "", [], "primary"),
+        dashboard_action("L", "L", "full patch", "detail", [], "secondary"),
+        dashboard_action("x", "x", "discard {scope}…", "", ["unstaged"], "secondary"),
+        dashboard_action("X", "X", "discard hunk…", "detail", ["unstaged"], "secondary"),
+        dashboard_action("c", "c", "commit", "", [], "secondary"),
+        dashboard_action("r", "r", "refresh", "", [], "secondary"),
+        dashboard_action("f", "f", "fetch", "", [], "secondary"),
+        dashboard_action("p", "p", "push…", "", [], "secondary"),
+        dashboard_action("P", "P", "pull", "", [], "secondary"),
+        dashboard_action("y", "y", "safe sync", "", [], "secondary"),
+        dashboard_action("b", "b", "branches…", "", [], "secondary"),
+        dashboard_action("t", "t", "tags…", "", [], "secondary"),
+        dashboard_action("z", "z", "stashes…", "", [], "secondary"),
+        dashboard_action("w", "w", "worktrees…", "", [], "secondary"),
+        dashboard_action("e", "e", "remotes…", "", [], "secondary"),
+        dashboard_action("l", "l", "log", "rows", [], "secondary"),
+        dashboard_action("R", "R", "reset…", "", [], "secondary"),
+        dashboard_action("i", "i", "rebase…", "rows", [], "secondary"),
+        dashboard_action("o", "o", "operation…", "", [], "secondary"),
+        dashboard_action("$", "$", "command log", "rows", [], "secondary"),
+    ];
+}
+
+fn append_section(rows: [GitWorkspaceRow], title: String, section: String, entries: [GitEntry], stats: Json) -> [GitWorkspaceRow] {
     if red::len(entries) == 0 {
         return rows;
     }
@@ -1247,17 +1352,16 @@ fn append_section(rows: [GitWorkspaceRow], title: String, section: String, entri
     });
     let status_style = section_style(section);
     let secondary_style = muted_style();
-    for entry in entries {
+    let display_entries: [GitDisplayEntry] = red::git_core("display_entries", entries);
+    for display in display_entries {
+        let entry = display.entry;
         rows = red::push(rows, GitWorkspaceRow {
             id: section + ":" + entry.path,
             selectable: true,
             depth: 1,
             path: Some(entry.path),
-            segments: entry_path_segments(entry, secondary_style),
-            right_segments: [PanelSegment {
-                text: status_label(entry),
-                style: status_style,
-            }],
+            segments: entry_path_segments(display, secondary_style),
+            right_segments: entry_stat_segments(display, section, status_style, stats),
             data: Some(GitWorkspaceRowData {
                 section: section,
                 path: entry.path,
@@ -1268,25 +1372,82 @@ fn append_section(rows: [GitWorkspaceRow], title: String, section: String, entri
     return rows;
 }
 
-fn entry_path_segments(entry: GitEntry, secondary_style: Style) -> [PanelSegment] {
-    let parts = red::split(entry.path, "/");
-    let filename = entry.path;
-    let parent = "";
-    let part_count = red::len(parts);
-    if part_count > 0 {
-        filename = parts[part_count - 1];
-        let index = 0;
-        while index + 1 < part_count {
-            if parent != "" { parent = parent + "/"; }
-            parent = parent + parts[index];
-            index = index + 1;
+fn entry_stat_segments(display: GitDisplayEntry, section: String, status_style: Style, stats: Json) -> [PanelSegment] {
+    let entry = display.entry;
+    let stat = stats[section + ":" + entry.path];
+    if stat != red::null() {
+        let added = red::string(stat.added, "0");
+        let removed = red::string(stat.removed, "0");
+        if added == "-" {
+            return [PanelSegment { text: "binary  " + display.label, style: status_style }];
         }
+        return [PanelSegment { text: "+" + added + " −" + removed + "  " + display.label, style: status_style }];
     }
+    return [PanelSegment { text: display.label, style: status_style }];
+}
+
+fn refresh_stats() {
+    if plugin_state().stats_process != "" { red::execute("KillProcess", plugin_state().stats_process); }
+    red::state_patch(GitPluginState { stats: Json {} });
+    start_stats("staged");
+}
+
+fn start_stats(section: String) {
+    let args = ["diff", "--numstat", "-z", "--no-ext-diff"];
+    if section == "staged" { args = red::push(args, "--cached"); }
+    let process_id = red::execute("SpawnProcess", Process {
+        command: "git", args: args, raw_output: true, cwd: plugin_state().root,
+    });
+    red::state_patch(GitPluginState { stats_process: process_id, stats_section: section, stats_output: "" });
+    red::on("process:" + process_id, stats_event);
+}
+
+fn stats_event(event: ProcessEvent) {
+    match event {
+        ProcessEvent::Stdout { process_id, line, plugin_name } => {
+            if process_id == plugin_state().stats_process {
+                red::state_patch(GitPluginState { stats_output: plugin_state().stats_output + line });
+            }
+        }
+        ProcessEvent::Exit { process_id, code, plugin_name } => {
+            if process_id != plugin_state().stats_process { return; }
+            let section = plugin_state().stats_section;
+            let records = red::split(plugin_state().stats_output, "\0");
+            let stats = plugin_state().stats;
+            let index = 0;
+            while index < red::len(records) {
+                let fields = red::split(records[index], "\t");
+                if red::len(fields) >= 3 {
+                    let path = fields[2];
+                    if path == "" && index + 2 < red::len(records) {
+                        path = records[index + 2];
+                        index = index + 2;
+                    } else {
+                        let part = 3;
+                        while part < red::len(fields) { path = path + "\t" + fields[part]; part = part + 1; }
+                    }
+                    stats[section + ":" + path] = Json { added: fields[0], removed: fields[1] };
+                }
+                index = index + 1;
+            }
+            red::state_patch(GitPluginState { stats: stats, stats_process: "" });
+            if section == "staged" && plugin_state().dashboard_open { start_stats("unstaged"); }
+            else { render_dashboard(); }
+        }
+        ProcessEvent::Error { process_id, message, plugin_name } => {
+            if process_id == plugin_state().stats_process { red::state_patch(GitPluginState { stats_process: "" }); }
+        }
+        ProcessEvent::Stderr { process_id, line, plugin_name } => {}
+    }
+}
+
+fn entry_path_segments(display: GitDisplayEntry, secondary_style: Style) -> [PanelSegment] {
+    let entry = display.entry;
     let segments = [
-        PanelSegment { text: filename },
+        PanelSegment { text: display.filename },
     ];
-    if parent != "" {
-        segments = red::push(segments, PanelSegment { text: "  " + parent, style: secondary_style });
+    if display.parent != "" {
+        segments = red::push(segments, PanelSegment { text: "  " + display.parent, style: secondary_style });
     }
     if entry.kind == "renamed" {
         if let Some(original_path) = entry.original_path {
@@ -1324,15 +1485,6 @@ fn operation_header() -> String {
     return "  " + operation;
 }
 
-fn status_label(entry: GitEntry) -> String {
-    if entry.kind == "untracked" { return "?"; }
-    if entry.kind == "conflicted" { return "!"; }
-    if entry.x == "R" || entry.y == "R" { return "R"; }
-    if entry.x == "A" || entry.y == "A" { return "+"; }
-    if entry.x == "D" || entry.y == "D" { return "−"; }
-    return "~";
-}
-
 #[red::on("workspace:event:git-dashboard")]
 fn workspace_event(event: GitWorkspaceEvent) {
     let row = event.row;
@@ -1347,6 +1499,7 @@ fn workspace_event(event: GitWorkspaceEvent) {
         event.action == "last" ||
         event.action == "mouse_up" ||
         event.action == "mouse_down" ||
+        event.action == "filter_changed" ||
         event.action == "mouse_click"
     ) {
         schedule_detail(row);
@@ -1386,6 +1539,10 @@ fn workspace_event(event: GitWorkspaceEvent) {
     }
     if event.action == "$" {
         command_log();
+        return;
+    }
+    if event.action == "L" {
+        red::request("OpenScratchBuffer", full_patch_opened, "[Git Diff].diff", plugin_state().detail_output);
         return;
     }
     if event.action == "activate" && event.focus == "detail" {
@@ -1463,6 +1620,10 @@ fn workspace_event(event: GitWorkspaceEvent) {
     }
 }
 
+fn full_patch_opened(event: GitScratchOpenedEvent) {
+    close_dashboard();
+}
+
 fn cancel_detail_timer() {
     let timer = red::string(plugin_state().detail_timer, "");
     if timer != "" {
@@ -1482,6 +1643,7 @@ fn schedule_detail(row: Option<GitWorkspaceRow>) {
         show_detail(None, true);
         return;
     };
+    red::state_patch(GitPluginState { detail_suppressed: false });
     if data.path == plugin_state().detail_path &&
         data.section == plugin_state().detail_section {
         return;
@@ -1490,16 +1652,29 @@ fn schedule_detail(row: Option<GitWorkspaceRow>) {
     red::state_patch(GitPluginState { detail_timer: red::execute("SetTimeout", 60) });
 }
 
+fn clear_detail(message: String, clear_path: bool) {
+    cancel_detail_timer();
+    let process_id = plugin_state().detail_process;
+    if process_id != "" { red::execute("KillProcess", process_id); }
+    red::state_patch(GitPluginState {
+        detail_process: "", detail_output: "", detail_pending_output: "",
+        detail_status: "", detail_error: "", detail_document: None,
+        detail_rendered_path: "", detail_rendered_section: "",
+        detail: [[PanelSegment { text: message, style: muted_style() }]],
+    });
+    if clear_path { red::state_patch(GitPluginState { detail_path: "", detail_section: "" }); }
+}
+
 fn show_detail(row: Option<GitWorkspaceRow>, render_loading: bool) {
     let Some(selected_row) = row else {
-        red::state_patch(GitPluginState { detail: [[PanelSegment { text: "Select a change to inspect its diff.", style: muted_style() }]] });
-        red::state_patch(GitPluginState { detail_document: None });
+        clear_detail("Select a change to inspect its diff.", true);
+        red::state_patch(GitPluginState { detail_suppressed: true });
         if render_loading { render_dashboard(); }
         return;
     };
     let Some(data) = selected_row.data else {
-        red::state_patch(GitPluginState { detail: [[PanelSegment { text: "Select a change to inspect its diff.", style: muted_style() }]] });
-        red::state_patch(GitPluginState { detail_document: None });
+        clear_detail("Select a change to inspect its diff.", true);
+        red::state_patch(GitPluginState { detail_suppressed: true });
         if render_loading { render_dashboard(); }
         return;
     };
@@ -1507,12 +1682,14 @@ fn show_detail(row: Option<GitWorkspaceRow>, render_loading: bool) {
     if previous != "" {
         red::execute("KillProcess", previous);
     }
-    if render_loading {
+    let changed_file = data.path != plugin_state().detail_rendered_path || data.section != plugin_state().detail_rendered_section;
+    if render_loading || changed_file {
         red::state_patch(GitPluginState { detail: [[PanelSegment { text: "Loading diff…", style: muted_style() }]] });
         red::state_patch(GitPluginState { detail_document: None });
         red::state_patch(GitPluginState { detail_output: "" });
     }
     red::state_patch(GitPluginState { detail_pending_output: "" });
+    red::state_patch(GitPluginState { detail_error: "", detail_status: "Loading " + data.path + "…" });
     red::state_patch(GitPluginState { detail_path: data.path });
     red::state_patch(GitPluginState { detail_section: data.section });
     let process_id = red::execute("SpawnProcess", Process {
@@ -1523,7 +1700,7 @@ fn show_detail(row: Option<GitWorkspaceRow>, render_loading: bool) {
     });
     red::state_patch(GitPluginState { detail_process: process_id });
     red::on("process:" + process_id, detail_event);
-    if render_loading { render_dashboard(); }
+    if render_loading || changed_file { render_dashboard(); }
 }
 
 fn detail_event(event: ProcessEvent) {
@@ -1537,22 +1714,45 @@ fn detail_event(event: ProcessEvent) {
         }
         ProcessEvent::Exit { process_id, code, plugin_name } => {
             if process_id == plugin_state().detail_process {
-                finish_detail();
+                let exit_code = 1;
+                if let Some(value) = code { exit_code = value; }
+                if exit_code == 0 || (exit_code == 1 && plugin_state().detail_section == "untracked") {
+                    finish_detail();
+                } else {
+                    fail_detail("git diff exited with code " + exit_code);
+                }
             }
         }
-        ProcessEvent::Stderr { process_id, line, plugin_name } => {}
-        ProcessEvent::Error { process_id, message, plugin_name } => {}
+        ProcessEvent::Stderr { process_id, line, plugin_name } => {
+            if process_id == plugin_state().detail_process {
+                red::state_patch(GitPluginState { detail_error: plugin_state().detail_error + line });
+            }
+        }
+        ProcessEvent::Error { process_id, message, plugin_name } => {
+            if process_id == plugin_state().detail_process { fail_detail(message); }
+        }
     }
 }
 
+fn fail_detail(fallback: String) {
+    let message = red::trim(plugin_state().detail_error);
+    if message == "" { message = fallback; }
+    red::state_patch(GitPluginState {
+        detail_process: "", detail_status: "Diff failed · r retry", detail_document: None,
+        detail: [[PanelSegment { text: "Could not load diff: " + bounded_git_error(message), style: warning_style() }]],
+    });
+    render_dashboard();
+}
+
 fn finish_detail() {
-    red::state_patch(GitPluginState { detail_process: "" });
+    red::state_patch(GitPluginState { detail_process: "", detail_status: "" });
     let output = red::string(plugin_state().detail_pending_output, "");
     let path = red::string(plugin_state().detail_path, "");
     let section = red::string(plugin_state().detail_section, "");
     if output == red::string(plugin_state().detail_output, "") &&
         path == red::string(plugin_state().detail_rendered_path, "") &&
         section == red::string(plugin_state().detail_rendered_section, "") {
+        render_dashboard();
         return;
     }
     red::state_patch(GitPluginState { detail_output: output });
@@ -1677,6 +1877,10 @@ fn row_action_finished(event: ProcessEvent) {
 }
 
 fn run_detail_action(event: GitWorkspaceEvent) {
+    if plugin_state().detail_process != "" || plugin_state().detail_timer != "" {
+        red::execute("Print", "Wait for the current diff to finish loading");
+        return;
+    }
     let Some(line) = event.detail_line else {
         return;
     };
@@ -2974,12 +3178,15 @@ fn rebase_item_selected(value: String) {
 
 fn render_error(message: String) {
     if plugin_state().dashboard_open {
+        clear_detail("Repository status unavailable.", true);
         red::execute("UpdateWorkspace", "git-dashboard", GitWorkspaceModel {
             rows: [GitWorkspaceRow {
                 id: "git-error",
                 selectable: false,
                 segments: [PanelSegment { text: message, style: warning_style() }],
             }],
+            actions: [dashboard_action("r", "r", "retry", "", [], "essential")],
+            status: "Git status failed",
         });
     }
 }
@@ -3000,6 +3207,7 @@ fn muted_style() -> Style {
     if ui == red::null() { return normal_style(); }
     let style = ui.muted;
     if style == red::null() { return normal_style(); }
+    style.bg = red::null();
     return style;
 }
 fn heading_style() -> Style {
@@ -3017,6 +3225,7 @@ fn heading_style() -> Style {
     let style = ui.popup_title;
     if style == red::null() { style = normal_style(); }
     style.bold = true;
+    style.bg = red::null();
     return style;
 }
 fn branch_style() -> Style { return heading_style(); }
@@ -3026,6 +3235,8 @@ fn success_style() -> Style {
     let colors = info.theme.colors;
     if colors == red::null() { return style; }
     let color = colors["gitDecoration.addedResourceForeground"];
+    if color == red::null() { color = colors["editorGutter.addedBackground"]; }
+    if color == red::null() { color = colors["terminal.ansiGreen"]; }
     if color != red::null() { style.fg = color; }
     return style;
 }
@@ -3035,6 +3246,8 @@ fn warning_style() -> Style {
     let colors = info.theme.colors;
     if colors == red::null() { return style; }
     let color = colors["gitDecoration.deletedResourceForeground"];
+    if color == red::null() { color = colors["editorGutter.deletedBackground"]; }
+    if color == red::null() { color = colors["terminal.ansiRed"]; }
     if color != red::null() { style.fg = color; }
     return style;
 }

--- a/plugins/git_core/src/patch.hk
+++ b/plugins/git_core/src/patch.hk
@@ -72,6 +72,10 @@ pub struct WorkspaceDocumentLine {
 pub struct WorkspaceDocument {
     path: String,
     lines: [WorkspaceDocumentLine],
+    added: i32,
+    removed: i32,
+    total_lines: i32,
+    truncated: bool,
 }
 
 fn parse_patch(text: String) -> Patch {
@@ -336,7 +340,21 @@ pub fn detail_document(text: String, path: String, section: String) -> Workspace
             }
         }
     }
-    WorkspaceDocument { path: path, lines: lines }
+    let mut added = 0;
+    let mut removed = 0;
+    let mut in_hunk = false;
+    let raw_lines = text.split("\n");
+    for raw in raw_lines {
+        if raw.starts_with("diff --git ") { in_hunk = false; }
+        else if raw.starts_with("@@ ") { in_hunk = true; }
+        else if in_hunk {
+            if raw.starts_with("+") { added += 1; }
+            if raw.starts_with("-") { removed += 1; }
+        }
+    }
+    let mut total = raw_lines.len();
+    if text.ends_with("\n") || text == "" { total -= 1; }
+    WorkspaceDocument { path: path, lines: lines, added: added, removed: removed, total_lines: total, truncated: total > lines.len() }
 }
 
 fn document_meta(raw: String, path: String, section: String, index: i32) -> WorkspaceDocumentLine {

--- a/plugins/git_core/src/status.hk
+++ b/plugins/git_core/src/status.hk
@@ -71,6 +71,30 @@ pub struct GitState {
     truncated: bool,
 }
 
+pub struct DisplayEntry {
+    entry: GitEntry,
+    filename: String,
+    parent: String,
+    label: String,
+}
+
+// Prepare the bounded file list in the native core. The compatibility plugin
+// can then attach theme styles without repeating path parsing for every paint.
+pub fn display_entries(entries: [GitEntry]) -> [DisplayEntry] {
+    let mut result = [];
+    for entry in entries {
+        let parts = entry.path.rsplit_once("/").unwrap_or(("", entry.path));
+        let mut label = "~";
+        if entry.kind == "untracked" { label = "?"; }
+        else if entry.kind == "conflicted" { label = "!"; }
+        else if entry.x == "R" || entry.y == "R" { label = "R"; }
+        else if entry.x == "A" || entry.y == "A" { label = "+"; }
+        else if entry.x == "D" || entry.y == "D" { label = "−"; }
+        result.push(DisplayEntry { entry: entry, filename: parts.1, parent: parts.0, label: label });
+    }
+    result
+}
+
 pub fn parse_status(output: String) -> GitState {
     status_view(parse_porcelain(output, 500))
 }

--- a/scripts/git_workspace_bench.py
+++ b/scripts/git_workspace_bench.py
@@ -111,7 +111,9 @@ def run(args):
         config_dir = config_home / "red"
         config_dir.mkdir(parents=True)
         log = temp / "red.log"
-        (config_dir / "config.toml").write_text(f'log_file = "{log}"\n', encoding="utf-8")
+        (config_dir / "config.toml").write_text(
+            f'log_file = "{log}"\nshow_whats_new = false\n', encoding="utf-8"
+        )
 
         master, slave = pty.openpty()
         fcntl.ioctl(
@@ -163,6 +165,16 @@ def run(args):
                 raise RuntimeError("editor did not reach first paint")
 
             os.write(master, b":GitDashboard\r")
+            deadline = time.monotonic() + 12
+            while time.monotonic() < deadline:
+                contents = log.read_text(encoding="utf-8", errors="replace")
+                if "[PERF] drain UpdateWorkspace:" in contents:
+                    break
+                if process.poll() is not None:
+                    raise RuntimeError("editor exited before opening Git workspace")
+                time.sleep(0.02)
+            else:
+                raise RuntimeError("Git workspace did not receive its initial model")
             time.sleep(1.2)
             with log.open("a", encoding="utf-8") as stream:
                 stream.write("[GIT BENCH] rows begin\n")
@@ -176,6 +188,8 @@ def run(args):
                 log, "[GIT BENCH] rows begin", "[GIT BENCH] rows end"
             )
             row_processes = process_count(row_samples)
+            if not row_samples.get("notify workspace:event:git-dashboard"):
+                raise RuntimeError("file-list input never reached the Git workspace")
 
             os.write(master, b"\t")
             time.sleep(0.1)

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3125,6 +3125,7 @@ pub struct Editor {
 
     /// Active dialog/popup component
     current_dialog: Option<Box<dyn Component>>,
+    dialog_action_menu: crate::ui::ActionMenu,
 
     /// Number prefix for repeating commands
     repeater: Option<u16>,
@@ -4334,6 +4335,7 @@ impl Editor {
             search_highlights_suppressed: false,
             last_error: None,
             current_dialog: None,
+            dialog_action_menu: crate::ui::ActionMenu::default(),
             repeater: None,
             selection_start: None,
             selection: None,
@@ -12329,6 +12331,24 @@ impl Editor {
         }
 
         if let Some(current_dialog) = &mut self.current_dialog {
+            let surface_actions = current_dialog.surface_actions();
+            if self.dialog_action_menu.is_open() {
+                let selected = self.dialog_action_menu.handle_event(ev, &surface_actions);
+                return Ok(selected
+                    .and_then(|id| current_dialog.activate_surface_action(&id))
+                    .or(Some(KeyAction::Single(Action::Refresh))));
+            }
+            if matches!(
+                ev,
+                Event::Key(KeyEvent {
+                    code: KeyCode::F(1),
+                    ..
+                })
+            ) && !surface_actions.is_empty()
+            {
+                self.dialog_action_menu.open();
+                return Ok(Some(KeyAction::Single(Action::Refresh)));
+            }
             let action = current_dialog.handle_event(ev);
             let allows_passthrough = current_dialog.allows_event_passthrough();
             if action.is_some() || !allows_passthrough {
@@ -12346,6 +12366,10 @@ impl Editor {
                 };
                 return Ok(action);
             }
+        }
+
+        if !self.panel_manager.has_focused_panel() {
+            self.dialog_action_menu.close();
         }
 
         if self.workspace_manager.is_active() {
@@ -12367,6 +12391,30 @@ impl Editor {
         }
 
         if self.panel_manager.focused_panel_id().is_some() {
+            let surface_actions = self.panel_manager.surface_actions();
+            if self.dialog_action_menu.is_open() {
+                let selected = self.dialog_action_menu.handle_event(ev, &surface_actions);
+                let event = selected.and_then(|id| {
+                    surface_actions
+                        .iter()
+                        .find(|action| action.id == id)
+                        .and_then(crate::ui::UiAction::event)
+                });
+                return Ok(event
+                    .and_then(|event| self.handle_panel_event(&event, runtime))
+                    .or(Some(KeyAction::Single(Action::Refresh))));
+            }
+            if matches!(
+                ev,
+                Event::Key(KeyEvent {
+                    code: KeyCode::F(1),
+                    ..
+                })
+            ) && !surface_actions.is_empty()
+            {
+                self.dialog_action_menu.open();
+                return Ok(Some(KeyAction::Single(Action::Refresh)));
+            }
             if !self.panel_manager.focused_text_input_active() && self.handle_repeater(ev) {
                 return Ok(None);
             }
@@ -12421,6 +12469,8 @@ impl Editor {
                 MouseEventKind::ScrollUp => "mouse_up",
                 MouseEventKind::ScrollDown => "mouse_down",
                 MouseEventKind::Down(MouseButton::Left) => "mouse_click",
+                MouseEventKind::Drag(MouseButton::Left) => "mouse_drag",
+                MouseEventKind::Up(MouseButton::Left) => "mouse_release",
                 _ => return None,
             };
             self.workspace_manager.handle_mouse(
@@ -12430,28 +12480,48 @@ impl Editor {
                 self.size.1 as usize,
                 self.size.0 as usize,
             )?
+        } else if let Event::Paste(text) = ev {
+            if !self.workspace_manager.is_filtering() {
+                return None;
+            }
+            self.workspace_manager.handle_action(
+                format!("filter_text:{}", text.lines().next().unwrap_or_default()),
+                self.size.1 as usize,
+                self.size.0 as usize,
+            )?
         } else if let Event::Key(event) = ev {
             let control = event.modifiers.contains(KeyModifiers::CONTROL);
-            let action = match event.code {
-                KeyCode::Char('w') if control => "ctrl_w".to_string(),
-                KeyCode::Char('u') if control => "half_page_up".to_string(),
-                KeyCode::Char('d') if control => "half_page_down".to_string(),
-                KeyCode::Char('b') if control => "page_up".to_string(),
-                KeyCode::Char('f') if control => "page_down".to_string(),
-                KeyCode::Up | KeyCode::Char('k') => "up".to_string(),
-                KeyCode::Down | KeyCode::Char('j') => "down".to_string(),
-                KeyCode::Left => "left".to_string(),
-                KeyCode::Right => "right".to_string(),
-                KeyCode::Home => "first".to_string(),
-                KeyCode::End => "last".to_string(),
-                KeyCode::PageUp => "page_up".to_string(),
-                KeyCode::PageDown => "page_down".to_string(),
-                KeyCode::Enter => "activate".to_string(),
-                KeyCode::Esc => "escape".to_string(),
-                KeyCode::Tab => "toggle".to_string(),
-                KeyCode::BackTab => "back_toggle".to_string(),
-                KeyCode::Char(c) => c.to_string(),
-                _ => return None,
+            let action = if self.workspace_manager.is_filtering() {
+                match event.code {
+                    KeyCode::Enter => "filter_accept".to_string(),
+                    KeyCode::Esc => "filter_cancel".to_string(),
+                    KeyCode::Backspace => "filter_backspace".to_string(),
+                    KeyCode::Char(character) if !control => format!("filter_text:{character}"),
+                    _ => "noop".to_string(),
+                }
+            } else {
+                match event.code {
+                    KeyCode::Char('w') if control => "ctrl_w".to_string(),
+                    KeyCode::Char('u') if control => "half_page_up".to_string(),
+                    KeyCode::Char('d') if control => "half_page_down".to_string(),
+                    KeyCode::Char('b') if control => "page_up".to_string(),
+                    KeyCode::Char('f') if control => "page_down".to_string(),
+                    KeyCode::Up | KeyCode::Char('k') => "up".to_string(),
+                    KeyCode::Down | KeyCode::Char('j') => "down".to_string(),
+                    KeyCode::Left => "left".to_string(),
+                    KeyCode::Right => "right".to_string(),
+                    KeyCode::Home => "first".to_string(),
+                    KeyCode::End => "last".to_string(),
+                    KeyCode::PageUp => "page_up".to_string(),
+                    KeyCode::PageDown => "page_down".to_string(),
+                    KeyCode::Enter => "activate".to_string(),
+                    KeyCode::Esc => "escape".to_string(),
+                    KeyCode::Tab => "toggle".to_string(),
+                    KeyCode::BackTab => "back_toggle".to_string(),
+                    KeyCode::F(1) => "F1".to_string(),
+                    KeyCode::Char(c) => c.to_string(),
+                    _ => return None,
+                }
             };
             self.workspace_manager.handle_action(
                 action,

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -2890,6 +2890,14 @@ impl Editor {
     fn render_dialog(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         if let Some(current_dialog) = &self.current_dialog {
             current_dialog.draw(buffer)?;
+            self.dialog_action_menu
+                .render(buffer, &self.theme, &current_dialog.surface_actions());
+        } else {
+            self.dialog_action_menu.render(
+                buffer,
+                &self.theme,
+                &self.panel_manager.surface_actions(),
+            );
         }
 
         if self.keymap_hints_visible {

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -21,16 +21,12 @@ use super::markdown::{
 };
 use super::text_link::{TextPanelLink, TextPanelLinkTarget};
 use crate::{
-    color::{blend_color, ensure_minimum_contrast, Color},
     editor::{render_buffer::RenderBuffer, Point},
     text_layout::{LayoutOptions, TextLayout},
-    theme::{
-        SelectionForegroundPriority, Style, Theme, ThemeStyleSpec,
-        MINIMUM_SELECTION_STATE_CONTRAST, MINIMUM_SELECTION_TEXT_CONTRAST,
-    },
+    theme::{SelectionForegroundPriority, Style, SurfacePalette, Theme, ThemeStyleSpec},
     ui::{
-        normalize_prompt_newlines, FollowTailViewport, PromptBuffer, PromptInput, PromptKeyPolicy,
-        PROMPT_MAX_BYTES,
+        normalize_prompt_newlines, ActionBar, ActionPriority, FollowTailViewport, PromptBuffer,
+        PromptInput, PromptKeyPolicy, UiAction, PROMPT_MAX_BYTES,
     },
     unicode_utils::{display_width, fit_display_width, truncate_display_width},
 };
@@ -288,92 +284,10 @@ pub struct TextPanelStatus {
 }
 
 /// Foreground-first visual roles for a source-backed text panel.
-///
-/// Popup, input, and dialog styles may carry different backgrounds. Text panels are
-/// persistent surfaces, so every role is normalized onto the configured panel surface;
-/// selection and explicitly themed syntax spans are the only background exceptions.
-#[derive(Debug, Clone)]
-struct TextPanelPalette {
-    surface: Style,
-    primary: Style,
-    secondary: Style,
-    muted: Style,
-    accent: Style,
-    error: Style,
-    divider: Style,
-}
+type TextPanelPalette = SurfacePalette;
 
-impl TextPanelPalette {
-    fn new(theme: &Theme, config: &PanelConfig) -> Self {
-        let surface = panel_style(theme, config.surface.as_ref());
-        let surface_background = surface.bg.or(theme.style.bg);
-        let contrast_background = blend_color(
-            surface_background.unwrap_or(Color::Rgb { r: 0, g: 0, b: 0 }),
-            Color::Rgb { r: 0, g: 0, b: 0 },
-        );
-        let primary_foreground = surface.fg.or(theme.style.fg).unwrap_or(Color::Rgb {
-            r: 255,
-            g: 255,
-            b: 255,
-        });
-        let secondary_foreground = theme_color(
-            theme,
-            &["descriptionForeground", "editorLineNumber.foreground"],
-        )
-        .or(theme.ui_style.muted.fg)
-        .unwrap_or(primary_foreground);
-        let muted_foreground = theme_color(
-            theme,
-            &["editorLineNumber.foreground", "descriptionForeground"],
-        )
-        .or(theme.ui_style.muted.fg)
-        .unwrap_or(secondary_foreground);
-        let accent_foreground = theme_color(
-            theme,
-            &[
-                "textLink.foreground",
-                "editorInfo.foreground",
-                "focusBorder",
-            ],
-        )
-        .or(theme.ui_style.dialog_border.fg)
-        .or(theme.ui_style.popup_border.fg)
-        .unwrap_or(primary_foreground);
-        let error_foreground =
-            theme_color(theme, &["editorError.foreground", "list.errorForeground"])
-                .or(theme.error_style.as_ref().and_then(|style| style.fg))
-                .or(theme.ui_style.deprecated.fg)
-                .unwrap_or(primary_foreground);
-        let role = |foreground, minimum_contrast, bold| Style {
-            fg: Some(ensure_minimum_contrast(
-                foreground,
-                contrast_background,
-                minimum_contrast,
-            )),
-            bg: surface_background,
-            bold,
-            italic: false,
-        };
-
-        Self {
-            surface: Style {
-                bg: surface_background,
-                ..surface
-            },
-            primary: role(primary_foreground, MINIMUM_SELECTION_TEXT_CONTRAST, false),
-            secondary: role(secondary_foreground, MINIMUM_SELECTION_TEXT_CONTRAST, false),
-            muted: role(muted_foreground, MINIMUM_SELECTION_STATE_CONTRAST, false),
-            accent: role(accent_foreground, MINIMUM_SELECTION_TEXT_CONTRAST, true),
-            error: role(error_foreground, MINIMUM_SELECTION_TEXT_CONTRAST, false),
-            divider: role(muted_foreground, MINIMUM_SELECTION_STATE_CONTRAST, false),
-        }
-    }
-}
-
-fn theme_color(theme: &Theme, candidates: &[&str]) -> Option<Color> {
-    candidates
-        .iter()
-        .find_map(|candidate| theme.colors.get(*candidate).copied())
+fn text_panel_palette(theme: &Theme, config: &PanelConfig) -> TextPanelPalette {
+    SurfacePalette::new(theme, &panel_style(theme, config.surface.as_ref()))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2278,6 +2192,23 @@ impl PanelManager {
             .is_some_and(|panel| panel.composer.is_some())
     }
 
+    pub(crate) fn surface_actions(&self) -> Vec<UiAction> {
+        let Some(panel) = self
+            .focused
+            .as_ref()
+            .and_then(|id| self.text_panels.get(id))
+        else {
+            return Vec::new();
+        };
+        panel
+            .composer
+            .as_ref()
+            .map(|composer| {
+                text_panel_actions(composer, &panel.scrollback, TextPanelOverflow::None).1
+            })
+            .unwrap_or_default()
+    }
+
     pub fn focused_row_panel(&self) -> bool {
         self.focused
             .as_deref()
@@ -3504,7 +3435,7 @@ fn render_text_panel(
     if width == 0 || height == 0 {
         return;
     }
-    let palette = TextPanelPalette::new(theme, &panel.config);
+    let palette = text_panel_palette(theme, &panel.config);
     let metrics = TextPanelContentMetrics::new(width);
     let content_position = Point::new(metrics.x(position.x), position.y);
 
@@ -3634,6 +3565,7 @@ fn render_text_panel(
             content_height + status_height,
             overflow,
             &palette,
+            theme,
         );
     }
 }
@@ -3827,6 +3759,50 @@ fn text_panel_composer_hints(
     }
 }
 
+fn text_panel_actions(
+    composer: &TextPanelComposer,
+    scrollback: &TextPanelScrollback,
+    overflow: TextPanelOverflow,
+) -> (&'static str, Vec<UiAction>) {
+    let (mode, hints) = text_panel_composer_hints(composer, scrollback);
+    let mut actions = hints
+        .iter()
+        .enumerate()
+        .map(|(index, hint)| {
+            let action = UiAction::new(hint.keys, hint.keys, hint.action).with_priority(
+                if index == 0 || hint.keys == "Esc" {
+                    ActionPriority::Essential
+                } else {
+                    ActionPriority::Secondary
+                },
+            );
+            match hint.keys {
+                "Enter" => action.with_compact_key("↵"),
+                "Ctrl+Enter" => action.with_compact_key("^↵"),
+                "hjkl/arrows" => action.with_trigger("h"),
+                "motions" => action.with_trigger("l"),
+                "g/G" => action.with_trigger("G"),
+                _ => action,
+            }
+        })
+        .collect::<Vec<_>>();
+    if !scrollback.focused {
+        let hint = match overflow {
+            TextPanelOverflow::Both => Some(("↑↓", "more")),
+            TextPanelOverflow::Below => Some(("↓", "more")),
+            TextPanelOverflow::Above => Some(("↑", "history")),
+            TextPanelOverflow::None => None,
+        };
+        if let Some((key, label)) = hint {
+            actions.push(
+                UiAction::new("history-overflow", key, label)
+                    .with_priority(ActionPriority::Secondary),
+            );
+        }
+    }
+    (mode, actions)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_text_panel_composer_footer(
     buffer: &mut RenderBuffer,
@@ -3837,101 +3813,13 @@ fn render_text_panel_composer_footer(
     width: usize,
     overflow: TextPanelOverflow,
     palette: &TextPanelPalette,
+    theme: &Theme,
 ) {
-    let mut used = 0usize;
-    if let Some(validation) = composer.validation {
-        append_text_panel_piece(
-            buffer,
-            position,
-            y,
-            width,
-            &mut used,
-            validation,
-            &palette.error,
-        );
-    } else if let Some(status) = composer.status.as_deref() {
-        append_text_panel_piece(
-            buffer,
-            position,
-            y,
-            width,
-            &mut used,
-            status,
-            &palette.secondary,
-        );
-    }
-
-    let (mode, hints) = text_panel_composer_hints(composer, scrollback);
-    if used > 0 {
-        if used.saturating_add(3 + display_width(mode)) > width {
-            return;
-        }
-        append_text_panel_piece(
-            buffer,
-            position,
-            y,
-            width,
-            &mut used,
-            " · ",
-            &palette.divider,
-        );
-    }
-    append_text_panel_piece(buffer, position, y, width, &mut used, mode, &palette.accent);
-
-    for hint in hints {
-        render_text_panel_shortcut_hint(buffer, position, y, width, &mut used, *hint, palette);
-    }
-
-    if !scrollback.focused {
-        let overflow_hint = match overflow {
-            TextPanelOverflow::Both => Some(TextPanelShortcutHint {
-                keys: "↑↓",
-                action: "more",
-            }),
-            TextPanelOverflow::Below => Some(TextPanelShortcutHint {
-                keys: "↓",
-                action: "more",
-            }),
-            TextPanelOverflow::Above => Some(TextPanelShortcutHint {
-                keys: "↑",
-                action: "history",
-            }),
-            TextPanelOverflow::None => None,
-        };
-        if let Some(hint) = overflow_hint {
-            render_text_panel_shortcut_hint(buffer, position, y, width, &mut used, hint, palette);
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn render_text_panel_shortcut_hint(
-    buffer: &mut RenderBuffer,
-    position: Point,
-    y: usize,
-    width: usize,
-    used: &mut usize,
-    hint: TextPanelShortcutHint,
-    palette: &TextPanelPalette,
-) {
-    let group_width = 3 + display_width(hint.keys) + 1 + display_width(hint.action);
-    if used.saturating_add(group_width) > width {
-        return;
-    }
-    append_text_panel_piece(buffer, position, y, width, used, " · ", &palette.divider);
-    let mut keys = palette.secondary.clone();
-    keys.bold = true;
-    append_text_panel_piece(buffer, position, y, width, used, hint.keys, &keys);
-    append_text_panel_piece(buffer, position, y, width, used, " ", &palette.surface);
-    append_text_panel_piece(
-        buffer,
-        position,
-        y,
-        width,
-        used,
-        hint.action,
-        &palette.muted,
-    );
+    let (mode, actions) = text_panel_actions(composer, scrollback, overflow);
+    ActionBar::new(&actions)
+        .with_context(mode)
+        .with_status(composer.validation.or(composer.status.as_deref()))
+        .render(buffer, position.x, y, width, theme, &palette.surface);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3944,6 +3832,7 @@ fn render_text_panel_composer(
     top: usize,
     overflow: TextPanelOverflow,
     palette: &TextPanelPalette,
+    theme: &Theme,
 ) {
     if width == 0 {
         return;
@@ -3999,6 +3888,7 @@ fn render_text_panel_composer(
         width,
         overflow,
         palette,
+        theme,
     );
 }
 
@@ -5273,7 +5163,7 @@ mod tests {
             selection: TextPanelLineSelection::Semantic,
         };
         let mut buffer = RenderBuffer::new(2, 1, &theme.style);
-        let palette = TextPanelPalette::new(&theme, &PanelConfig::default());
+        let palette = text_panel_palette(&theme, &PanelConfig::default());
 
         render_text_spans(&mut buffer, 0, 0, 2, &line, 0, None, None, &theme, &palette);
 
@@ -5322,7 +5212,7 @@ mod tests {
         };
         let mut normal = RenderBuffer::new(3, 1, &theme.style);
         let mut selected = RenderBuffer::new(3, 1, &theme.style);
-        let palette = TextPanelPalette::new(&theme, &PanelConfig::default());
+        let palette = text_panel_palette(&theme, &PanelConfig::default());
 
         render_text_spans(&mut normal, 0, 0, 3, &line, 0, None, None, &theme, &palette);
         render_text_spans(
@@ -6401,7 +6291,7 @@ mod tests {
             }),
             border: None,
         };
-        let palette = TextPanelPalette::new(&theme, &config);
+        let palette = text_panel_palette(&theme, &config);
         let mut panel = TextPanel::new("agent".to_string(), config);
         panel.blocks = vec![
             TextPanelBlock {
@@ -6556,7 +6446,7 @@ mod tests {
                 }),
                 ..PanelConfig::default()
             };
-            let palette = TextPanelPalette::new(&theme, &config);
+            let palette = text_panel_palette(&theme, &config);
             let mut panel = TextPanel::new("agent".to_string(), config);
             panel.blocks = vec![TextPanelBlock {
                 id: "activity".to_string(),
@@ -6608,7 +6498,9 @@ mod tests {
         render_text_panel(&mut buffer, &panel, Point::new(0, 0), 26, 6, &theme);
 
         let footer = row_text(&buffer, 5).trim_end().to_string();
-        assert_eq!(footer, " INSERT · Enter send");
+        assert!(footer.contains("↵ send"), "{footer:?}");
+        assert!(footer.contains("Esc normal"), "{footer:?}");
+        assert!(!footer.contains("Ctrl+Ent"));
         assert!(!footer.ends_with('·'));
     }
 

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -4154,11 +4154,12 @@ fn _keep_config_used(_: &Config) {}
 mod tests {
     use std::{
         path::{Path, PathBuf},
+        process::Command,
         time::{Duration, Instant},
     };
 
     #[cfg(not(windows))]
-    use std::{fs, process::Command};
+    use std::fs;
 
     use super::*;
     use crate::{color::Color, editor::PluginRequest, ui::PickerPresentation};
@@ -4612,7 +4613,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(windows))]
     async fn load_git_runtime(root: &Path) -> Runtime {
         let mut runtime = Runtime::new_with_permissions(HashMap::from([(
             "git".to_string(),
@@ -11157,16 +11157,33 @@ mod tests {
     async fn git_menus_and_prompts_use_scoped_picker_callbacks() {
         drain_requests();
 
-        let mut runtime = Runtime::new_with_permissions(HashMap::from([(
-            "git".to_string(),
-            PluginPermissions {
-                process: vec!["git".to_string()],
-            },
-        )]));
-        runtime
-            .load_plugin("git", include_str!("../../plugins/git.hk"))
-            .await
-            .unwrap();
+        // Submitting the branch prompt runs real Git. Resolve the plugin's cwd
+        // before invoking it so the test cannot switch the checkout under test.
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        for args in [
+            vec!["init", "-q", "-b", "main"],
+            vec![
+                "-c",
+                "user.name=Red Tests",
+                "-c",
+                "user.email=red@example.com",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--allow-empty",
+                "-qm",
+                "test: initial",
+            ],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success());
+        }
+        let mut runtime = load_git_runtime(root).await;
         drain_requests();
 
         runtime
@@ -11270,6 +11287,35 @@ mod tests {
             }
             _ => panic!("expected callback-backed command log"),
         }
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            drain_requests();
+            if runtime
+                .inner
+                .lock()
+                .unwrap()
+                .host
+                .process_manager
+                .active_process_count("git")
+                == 0
+            {
+                break;
+            }
+            assert!(Instant::now() < deadline, "branch creation did not finish");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let branch = Command::new("git")
+            .args(["symbolic-ref", "--short", "HEAD"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(branch.status.success());
+        assert_eq!(
+            String::from_utf8(branch.stdout).unwrap().trim(),
+            "feature/readable-pickers"
+        );
     }
 
     #[cfg(not(windows))]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -2588,8 +2588,17 @@ impl RedHost {
     }
 
     fn call_git_core(&mut self, operation: &str, args: &[Value]) -> anyhow::Result<Value> {
+        // The full patch remains in plugin state for staging and the scratch view.
+        // Only the bounded preview enters the instruction-metered document parser.
+        let preview = if operation == "detail_document" {
+            Some(git_detail_preview(args)?)
+        } else {
+            None
+        };
+        let args = preview.as_ref().map_or(args, |(args, _)| args.as_slice());
         let function = match operation {
             "parse_status" => "status::parse_status",
+            "display_entries" => "status::display_entries",
             "sign_hunks" => "patch::sign_hunks",
             "detail_document" => "patch::detail_document",
             "dashboard_hunk" => "patch::dashboard_hunk",
@@ -2620,8 +2629,24 @@ impl RedHost {
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("Git core VM did not initialize"))?;
         let mut host = NativeCoreHost;
-        let result = vm.call_export("red-git-core", function, args.to_vec(), &mut host)?;
-        Ok(normalize_native_core_value(result))
+        // A structured preview emits several typed records per line. Give only
+        // this trusted, 1,000-line-bounded core call enough instructions to do so.
+        if preview.is_some() {
+            vm.set_instruction_budget(PLUGIN_INSTRUCTION_BUDGET * 4);
+        }
+        let result = vm.call_export("red-git-core", function, args.to_vec(), &mut host);
+        vm.set_instruction_budget(PLUGIN_INSTRUCTION_BUDGET);
+        let result = result?;
+        let result = normalize_native_core_value(result);
+        if let Some((_, summary)) = preview {
+            let mut document = result.to_json();
+            document["added"] = summary.added.into();
+            document["removed"] = summary.removed.into();
+            document["total_lines"] = summary.total_lines.into();
+            document["truncated"] = (summary.total_lines > summary.preview_lines).into();
+            return Ok(Value::Json(document));
+        }
+        Ok(result)
     }
 
     fn call_neotree_core(&mut self, operation: &str, args: &[Value]) -> anyhow::Result<Value> {
@@ -2658,6 +2683,43 @@ impl RedHost {
         let result = vm.call_export("red-neotree-core", function, args.to_vec(), &mut host)?;
         Ok(normalize_native_core_value(result))
     }
+}
+
+#[derive(Default)]
+struct GitDiffSummary {
+    added: usize,
+    removed: usize,
+    total_lines: usize,
+    preview_lines: usize,
+}
+
+fn git_detail_preview(args: &[Value]) -> anyhow::Result<(Vec<Value>, GitDiffSummary)> {
+    const PREVIEW_LINES: usize = 1000;
+    let text = red_required_string(args, 0, "Git detail document")?;
+    let mut summary = GitDiffSummary::default();
+    let mut preview = String::new();
+    let mut in_hunk = false;
+    for line in text.lines() {
+        if summary.preview_lines < PREVIEW_LINES {
+            if summary.preview_lines > 0 {
+                preview.push('\n');
+            }
+            preview.push_str(line);
+            summary.preview_lines += 1;
+        }
+        summary.total_lines += 1;
+        if line.starts_with("diff --git ") {
+            in_hunk = false;
+        } else if line.starts_with("@@ ") {
+            in_hunk = true;
+        } else if in_hunk {
+            summary.added += usize::from(line.starts_with('+'));
+            summary.removed += usize::from(line.starts_with('-'));
+        }
+    }
+    let mut args = args.to_vec();
+    args[0] = Value::String(preview);
+    Ok((args, summary))
 }
 
 struct NativeCoreHost;
@@ -4656,6 +4718,28 @@ mod tests {
             error.to_string().contains("unknown Git core operation"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn git_core_detail_bounds_large_previews_and_reports_full_counts() {
+        let patch = format!("diff --git a/large.txt b/large.txt\n--- a/large.txt\n+++ b/large.txt\n@@ -1 +1,15001 @@\n-old\n{}", "+new\n".repeat(15001));
+        let mut host = RedHost::new(HashMap::new());
+        let document = host
+            .call_git_core(
+                "detail_document",
+                &[
+                    Value::String(patch),
+                    Value::String("large.txt".to_string()),
+                    Value::String("unstaged".to_string()),
+                ],
+            )
+            .unwrap()
+            .to_json();
+        assert_eq!(document["lines"].as_array().unwrap().len(), 1000);
+        assert_eq!(document["added"], 15001);
+        assert_eq!(document["removed"], 1);
+        assert_eq!(document["total_lines"], 15006);
+        assert_eq!(document["truncated"], true);
     }
 
     #[test]
@@ -11003,6 +11087,67 @@ mod tests {
             assert!(
                 Instant::now() < deadline,
                 "git dashboard did not render the bounded status"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_dashboard_renders_numstat_for_a_large_tracked_file_list() {
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        let git = |args: &[&str]| {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .output()
+                .unwrap()
+                .status
+                .success());
+        };
+        git(&["init", "-q"]);
+        for index in 0..500 {
+            fs::write(root.join(format!("tracked_{index}.txt")), "before\n").unwrap();
+        }
+        git(&["add", "."]);
+        git(&[
+            "-c",
+            "user.name=Red Test",
+            "-c",
+            "user.email=red@example.test",
+            "commit",
+            "-qm",
+            "baseline",
+        ]);
+        for index in 0..500 {
+            fs::write(root.join(format!("tracked_{index}.txt")), "after\n").unwrap();
+        }
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::UpdateWorkspace { model, .. } = request {
+                    let counted = model
+                        .rows
+                        .iter()
+                        .filter(|row| {
+                            row.right_segments
+                                .iter()
+                                .any(|segment| segment.text.contains("+1 −1"))
+                        })
+                        .count();
+                    if counted == 500 {
+                        return;
+                    }
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "large file list did not receive numstat counts"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -7,15 +7,18 @@
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Range,
+};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
-    color::Color,
     config::PickerIconsConfig,
     editor::render_buffer::RenderBuffer,
     highlighter::{Highlighter, LanguageRegistry},
-    theme::{SelectionForegroundPriority, Style, Theme},
-    ui::{IconCatalog, ScreenRect},
+    theme::{DiffPalette, SelectionForegroundPriority, Style, SurfacePalette, Theme},
+    ui::{ActionBar, ActionMenu, ActionPriority, IconCatalog, ScreenRect, UiAction},
     unicode_utils::{display_width, fit_display_width, truncate_display_width},
 };
 
@@ -91,6 +94,30 @@ pub struct WorkspaceModel {
     pub detail_document: Option<WorkspaceDocument>,
     #[serde(default)]
     pub footer: Vec<PanelSegment>,
+    /// Structured actions supersede the legacy footer when present.
+    #[serde(default)]
+    pub actions: Vec<WorkspaceAction>,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub detail_title: String,
+}
+
+/// Plugin actions are filtered locally, so cursor movement never requires a plugin round trip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct WorkspaceAction {
+    pub hint: UiAction,
+    #[serde(default)]
+    pub focus: String,
+    #[serde(default)]
+    pub sections: Vec<String>,
+    #[serde(default)]
+    pub selection: String,
+    #[serde(default)]
+    pub change_only: bool,
+    #[serde(default)]
+    pub hunk_only: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -100,6 +127,14 @@ pub struct WorkspaceDocument {
     pub path: String,
     #[serde(default)]
     pub lines: Vec<WorkspaceDocumentLine>,
+    #[serde(default)]
+    pub added: usize,
+    #[serde(default)]
+    pub removed: usize,
+    #[serde(default)]
+    pub total_lines: usize,
+    #[serde(default)]
+    pub truncated: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -159,12 +194,24 @@ impl WorkspaceLayout {
             width,
             height: height.saturating_sub(3),
         };
+        if workspace.rows_hidden && workspace.model.detail_document.is_some() {
+            return Self {
+                mode: WorkspaceLayoutMode::Focused,
+                rows: None,
+                detail: Some(body),
+                separator: None,
+            };
+        }
         if width >= workspace.config.min_two_pane_width {
             let maximum_rows_width = width.saturating_sub(21).max(20);
             let rows_width = width
                 .saturating_mul(100usize.saturating_sub(workspace.config.detail_ratio as usize))
                 / 100;
-            let rows_width = rows_width.clamp(20, maximum_rows_width).min(width);
+            let rows_width = workspace
+                .rows_width
+                .unwrap_or(rows_width.min(48))
+                .clamp(20, maximum_rows_width)
+                .min(width);
             let separator = WorkspaceRect {
                 x: rows_width,
                 y: body.y,
@@ -233,13 +280,16 @@ impl WorkspaceLayout {
 
     fn visible_rows(self, focus: WorkspaceFocus) -> usize {
         self.pane(focus)
-            .map_or(1, WorkspaceRect::content_height)
+            .map_or(1, |rect| {
+                rect.content_height()
+                    .saturating_sub(usize::from(focus == WorkspaceFocus::Detail))
+            })
             .max(1)
     }
 
-    fn detail_code_width(self) -> usize {
+    fn detail_code_width(self, gutter_width: usize) -> usize {
         self.detail
-            .map_or(1, |rect| rect.width.saturating_sub(14).max(1))
+            .map_or(1, |rect| rect.width.saturating_sub(gutter_width + 1).max(1))
     }
 
     fn focus_at(self, column: usize, row: usize) -> Option<WorkspaceFocus> {
@@ -315,6 +365,17 @@ pub struct PluginWorkspace {
     detail_selection_anchor: Option<usize>,
     key_prefix: Option<String>,
     detail_highlights: Vec<Vec<crate::editor::StyleInfo>>,
+    detail_word_changes: Vec<Vec<Range<usize>>>,
+    detail_visible: Vec<usize>,
+    show_metadata: bool,
+    action_menu: ActionMenu,
+    rows_visible: Vec<usize>,
+    collapsed_sections: HashSet<String>,
+    filter: String,
+    filtering: bool,
+    rows_hidden: bool,
+    rows_width: Option<usize>,
+    dragging_separator: bool,
 }
 
 impl PluginWorkspace {
@@ -334,6 +395,17 @@ impl PluginWorkspace {
             detail_selection_anchor: None,
             key_prefix: None,
             detail_highlights: Vec::new(),
+            detail_word_changes: Vec::new(),
+            detail_visible: Vec::new(),
+            show_metadata: false,
+            action_menu: ActionMenu::default(),
+            rows_visible: Vec::new(),
+            collapsed_sections: HashSet::new(),
+            filter: String::new(),
+            filtering: false,
+            rows_hidden: false,
+            rows_width: None,
+            dragging_separator: false,
         }
     }
 
@@ -357,24 +429,49 @@ impl PluginWorkspace {
             .rows
             .get(self.selected)
             .map(|row| row.id.as_str());
+        let selected_path = self
+            .model
+            .rows
+            .get(self.selected)
+            .and_then(|row| row.path.as_deref());
         let selected = selected_id
             .and_then(|id| model.rows.iter().position(|row| row.id == id))
+            .or_else(|| {
+                selected_path.and_then(|path| {
+                    model
+                        .rows
+                        .iter()
+                        .position(|row| row.path.as_deref() == Some(path))
+                })
+            })
             .or_else(|| model.rows.iter().position(|row| row.selectable))
             .unwrap_or(0);
-        let detail_id = self
-            .model
-            .detail_document
-            .as_ref()
-            .and_then(|document| document.lines.get(self.detail_cursor))
-            .map(|line| line.id.as_str());
-        let restored_detail = detail_id.and_then(|id| {
-            model
-                .detail_document
-                .as_ref()?
-                .lines
-                .iter()
-                .position(|line| line.id == id)
-        });
+        let previous_document = self.model.detail_document.as_ref();
+        let previous_line =
+            previous_document.and_then(|document| document.lines.get(self.detail_cursor));
+        let same_path = previous_document
+            .zip(model.detail_document.as_ref())
+            .is_some_and(|(previous, next)| previous.path == next.path);
+        let restored_detail = same_path
+            .then(|| {
+                let previous = previous_line?;
+                model
+                    .detail_document
+                    .as_ref()?
+                    .lines
+                    .iter()
+                    .position(|line| {
+                        line.kind == previous.kind
+                            && line.text == previous.text
+                            && (line.old_line == previous.old_line
+                                || line.new_line == previous.new_line)
+                    })
+            })
+            .flatten();
+        let document_changed = self.model.detail_document != model.detail_document;
+        if document_changed {
+            self.detail_selection_anchor = None;
+        }
         let first_change = model.detail_document.as_ref().and_then(|document| {
             document
                 .lines
@@ -389,38 +486,123 @@ impl PluginWorkspace {
                     .map_or(0, |document| document.lines.len().saturating_sub(1)),
             )
         });
-        if self.model.detail_document != model.detail_document {
+        if document_changed {
             self.detail_highlights =
                 highlight_document(model.detail_document.as_ref(), theme, registry);
+            self.detail_word_changes = word_changes(model.detail_document.as_ref());
         }
         self.model = model;
+        self.rebuild_detail_visible();
         self.selected = selected;
+        self.rebuild_rows();
         self.scroll = self.scroll.min(self.selected);
         self.detail_scroll = self.detail_scroll.min(self.detail_cursor);
     }
 
     fn move_selection(&mut self, delta: isize, visible_rows: usize) {
-        if self.model.rows.is_empty() {
+        if self.rows_visible.is_empty() {
             return;
         }
-        let mut next = self.selected;
+        let mut next = self
+            .rows_visible
+            .iter()
+            .position(|index| *index == self.selected)
+            .unwrap_or(0);
         loop {
             let candidate = next
                 .saturating_add_signed(delta)
-                .min(self.model.rows.len() - 1);
+                .min(self.rows_visible.len() - 1);
             if candidate == next {
                 break;
             }
             next = candidate;
-            if self.model.rows[next].selectable {
-                self.selected = next;
+            if self.row_selectable(self.rows_visible[next]) {
+                self.selected = self.rows_visible[next];
                 break;
             }
         }
-        if self.selected < self.scroll {
-            self.scroll = self.selected;
-        } else if self.selected >= self.scroll + visible_rows.max(1) {
-            self.scroll = self.selected.saturating_sub(visible_rows.saturating_sub(1));
+        if next < self.scroll {
+            self.scroll = next;
+        } else if next >= self.scroll + visible_rows.max(1) {
+            self.scroll = next.saturating_sub(visible_rows.saturating_sub(1));
+        }
+    }
+
+    fn row_selectable(&self, index: usize) -> bool {
+        self.model.rows.get(index).is_some_and(|row| {
+            row.selectable || (!self.model.actions.is_empty() && row.id.starts_with("section:"))
+        })
+    }
+
+    fn rebuild_rows(&mut self) {
+        let query = self.filter.to_lowercase();
+        let mut section = None;
+        let mut pending_heading = None;
+        self.rows_visible.clear();
+        for (index, row) in self.model.rows.iter().enumerate() {
+            if row.id.starts_with("section:") {
+                section = Some(row.id.as_str());
+                if query.is_empty() {
+                    self.rows_visible.push(index);
+                } else {
+                    pending_heading = Some(index);
+                }
+                continue;
+            }
+            if query.is_empty()
+                && section.is_some_and(|section| self.collapsed_sections.contains(section))
+            {
+                continue;
+            }
+            let matches = query.is_empty()
+                || row
+                    .path
+                    .as_deref()
+                    .is_some_and(|path| path.to_lowercase().contains(&query))
+                || (!row.selectable
+                    && row
+                        .segments
+                        .iter()
+                        .any(|segment| segment.text.to_lowercase().contains(&query)));
+            if matches {
+                if let Some(heading) = pending_heading.take() {
+                    self.rows_visible.push(heading);
+                }
+                self.rows_visible.push(index);
+            }
+        }
+        if !self.rows_visible.contains(&self.selected) {
+            self.selected = self
+                .rows_visible
+                .iter()
+                .copied()
+                .find(|index| self.model.rows[*index].selectable)
+                .or_else(|| self.rows_visible.first().copied())
+                .unwrap_or(0);
+        }
+        self.scroll = self.scroll.min(self.rows_visible.len().saturating_sub(1));
+    }
+
+    fn toggle_section(&mut self) {
+        if let Some(section) = self
+            .model
+            .rows
+            .iter()
+            .take(self.selected + 1)
+            .rev()
+            .find(|row| row.id.starts_with("section:"))
+            .map(|row| row.id.clone())
+        {
+            if !self.collapsed_sections.remove(&section) {
+                self.collapsed_sections.insert(section.clone());
+            }
+            self.selected = self
+                .model
+                .rows
+                .iter()
+                .position(|row| row.id == section)
+                .unwrap_or(self.selected);
+            self.rebuild_rows();
         }
     }
 
@@ -443,7 +625,11 @@ impl PluginWorkspace {
             workspace_id: self.id.clone(),
             action,
             selected_index: self.selected,
-            row: self.model.rows.get(self.selected).cloned(),
+            row: self
+                .rows_visible
+                .contains(&self.selected)
+                .then(|| self.model.rows.get(self.selected).cloned())
+                .flatten(),
             focus: self.focus,
             detail_index: self.detail_cursor,
             detail_line,
@@ -460,12 +646,63 @@ impl PluginWorkspace {
             .map_or(0, |document| document.lines.len())
     }
 
+    fn rebuild_detail_visible(&mut self) {
+        self.detail_visible = self
+            .model
+            .detail_document
+            .as_ref()
+            .map(|document| {
+                let has_hunks = document.lines.iter().any(|line| line.kind == "hunk");
+                document
+                    .lines
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, line)| {
+                        self.show_metadata
+                            || !has_hunks
+                            || line.kind != "meta"
+                            || line.text.starts_with('\\')
+                    })
+                    .map(|(index, _)| index)
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !self.detail_visible.contains(&self.detail_cursor) {
+            self.detail_cursor = self
+                .detail_visible
+                .iter()
+                .copied()
+                .find(|index| *index >= self.detail_cursor)
+                .or_else(|| self.detail_visible.last().copied())
+                .unwrap_or(0);
+        }
+    }
+
+    fn gutter_width(&self) -> usize {
+        let maximum = self
+            .model
+            .detail_document
+            .as_ref()
+            .into_iter()
+            .flat_map(|document| &document.lines)
+            .flat_map(|line| [line.old_line, line.new_line])
+            .flatten()
+            .max()
+            .unwrap_or(1);
+        maximum.to_string().len().max(2) * 2 + 4
+    }
+
     fn detail_line_at_visual_offset(&self, offset: usize, code_width: usize) -> usize {
         let Some(document) = self.model.detail_document.as_ref() else {
             return 0;
         };
         let mut remaining = offset;
-        for (index, line) in document.lines.iter().enumerate().skip(self.detail_scroll) {
+        for &index in self
+            .detail_visible
+            .iter()
+            .filter(|index| **index >= self.detail_scroll)
+        {
+            let line = &document.lines[index];
             let visual_rows = if self.detail_wrap {
                 display_width(&line.text).max(1).div_ceil(code_width.max(1))
             } else {
@@ -480,14 +717,18 @@ impl PluginWorkspace {
     }
 
     fn move_detail(&mut self, delta: isize, visible_rows: usize) {
-        let len = self.detail_len();
+        let len = self.detail_visible.len();
         if len == 0 {
             return;
         }
-        self.detail_cursor = self
-            .detail_cursor
+        let position = self
+            .detail_visible
+            .iter()
+            .position(|index| *index == self.detail_cursor)
+            .unwrap_or(0);
+        self.detail_cursor = self.detail_visible[position
             .saturating_add_signed(delta)
-            .min(len.saturating_sub(1));
+            .min(len.saturating_sub(1))];
         if self.detail_cursor < self.detail_scroll {
             self.detail_scroll = self.detail_cursor;
         } else if self.detail_cursor >= self.detail_scroll + visible_rows.max(1) {
@@ -503,16 +744,17 @@ impl PluginWorkspace {
             self.detail_scroll = self.detail_cursor;
             return;
         }
-        let code_width = layout.detail_code_width();
+        let code_width = layout.detail_code_width(self.gutter_width());
         let Some(document) = self.model.detail_document.as_ref() else {
             return;
         };
-        let occupied = document
-            .lines
+        let occupied = self
+            .detail_visible
             .iter()
-            .skip(self.detail_scroll)
-            .take(self.detail_cursor.saturating_sub(self.detail_scroll) + 1)
-            .map(|line| {
+            .copied()
+            .filter(|index| *index >= self.detail_scroll && *index <= self.detail_cursor)
+            .map(|index| {
+                let line = &document.lines[index];
                 if self.detail_wrap {
                     display_width(&line.text).max(1).div_ceil(code_width)
                 } else {
@@ -560,11 +802,61 @@ impl PluginWorkspace {
                 .map(|(index, _)| index)
         };
         if let Some(target) = target {
-            self.move_detail(target as isize - self.detail_cursor as isize, visible_rows);
+            let current = self
+                .detail_visible
+                .iter()
+                .position(|index| *index == self.detail_cursor)
+                .unwrap_or(0);
+            let target = self
+                .detail_visible
+                .iter()
+                .position(|index| *index == target)
+                .unwrap_or(current);
+            self.move_detail(target as isize - current as isize, visible_rows);
         }
     }
 
     fn handle_action(&mut self, mut action: String, height: usize, width: usize) -> WorkspaceEvent {
+        if self.filtering {
+            match action.as_str() {
+                "filter_accept" => self.filtering = false,
+                "filter_cancel" => {
+                    self.filtering = false;
+                    self.filter.clear();
+                }
+                "filter_backspace" => {
+                    self.filter.pop();
+                }
+                _ => {
+                    if let Some(text) = action.strip_prefix("filter_text:") {
+                        self.filter.push_str(text);
+                    }
+                }
+            }
+            self.rebuild_rows();
+            return self.event(
+                if self.filtering {
+                    "noop"
+                } else {
+                    "filter_changed"
+                }
+                .to_string(),
+            );
+        }
+        if self.action_menu.is_open() {
+            let actions = self.actions();
+            let Some(selected) = self.action_menu.handle(&action, &actions) else {
+                return self.event("noop".to_string());
+            };
+            action = selected;
+        } else if matches!(action.as_str(), "?" | "F1") && !self.model.actions.is_empty() {
+            self.action_menu.open();
+            return self.event("noop".to_string());
+        }
+        if action == "?" {
+            self.action_menu.open();
+            return self.event("noop".to_string());
+        }
         let layout = WorkspaceLayout::calculate(self, height, width);
         let visible_rows = layout.visible_rows(self.focus);
 
@@ -574,6 +866,9 @@ impl PluginWorkspace {
                 ("ctrl_w", "W" | "p") => "focus_previous",
                 ("ctrl_w", "h") => "focus_rows",
                 ("ctrl_w", "l") => "focus_detail",
+                ("ctrl_w", "o") => "toggle_rows",
+                ("ctrl_w", "<") => "narrow_rows",
+                ("ctrl_w", ">") => "widen_rows",
                 ("ctrl_w", "c" | "q") => "escape",
                 ("g", "g") => "first",
                 ("[", "h") => "previous_hunk",
@@ -595,22 +890,67 @@ impl PluginWorkspace {
                 "0" if !self.detail_wrap => "horizontal_start",
                 "$" if !self.detail_wrap => "horizontal_end",
                 "W" => "toggle_wrap",
+                "M" => "toggle_metadata",
                 "v" => "visual",
                 other => other,
             }
             .to_string();
         }
 
+        if self.focus == WorkspaceFocus::Rows
+            && action == "activate"
+            && self
+                .model
+                .rows
+                .get(self.selected)
+                .is_some_and(|row| row.id.starts_with("section:"))
+        {
+            action = "collapse_section".to_string();
+        }
+        if self.focus == WorkspaceFocus::Rows {
+            action = match action.as_str() {
+                "/" => "filter",
+                "C" => "collapse_section",
+                other => other,
+            }
+            .to_string();
+        }
+
         match action.as_str() {
+            "filter" => self.filtering = true,
+            "collapse_section" => {
+                self.toggle_section();
+                action = "filter_changed".to_string();
+            }
+            "toggle_rows" => {
+                self.rows_hidden = !self.rows_hidden;
+                if self.rows_hidden && self.model.detail_document.is_some() {
+                    self.focus = WorkspaceFocus::Detail;
+                }
+            }
+            "narrow_rows" | "widen_rows" => {
+                let current = layout.rows.map_or(36, |rect| rect.width);
+                self.rows_width = Some(
+                    current
+                        .saturating_add_signed(if action == "narrow_rows" { -4 } else { 4 })
+                        .clamp(20, width.saturating_sub(21).max(20)),
+                );
+            }
             "toggle" | "back_toggle" | "focus_next" | "focus_previous" => {
                 if self.model.detail_document.is_some() {
                     self.focus = match self.focus {
                         WorkspaceFocus::Rows => WorkspaceFocus::Detail,
                         WorkspaceFocus::Detail => WorkspaceFocus::Rows,
                     };
+                    if self.focus == WorkspaceFocus::Rows {
+                        self.rows_hidden = false;
+                    }
                 }
             }
-            "focus_rows" => self.focus = WorkspaceFocus::Rows,
+            "focus_rows" => {
+                self.rows_hidden = false;
+                self.focus = WorkspaceFocus::Rows;
+            }
             "focus_detail" if self.model.detail_document.is_some() => {
                 self.focus = WorkspaceFocus::Detail;
             }
@@ -675,6 +1015,11 @@ impl PluginWorkspace {
                 };
             }
             "cancel_selection" => self.detail_selection_anchor = None,
+            "toggle_metadata" if self.focus == WorkspaceFocus::Detail => {
+                self.show_metadata = !self.show_metadata;
+                self.rebuild_detail_visible();
+                self.detail_scroll = self.detail_scroll.min(self.detail_cursor);
+            }
             "toggle_wrap" if self.focus == WorkspaceFocus::Detail => {
                 self.detail_wrap = !self.detail_wrap;
                 if self.detail_wrap {
@@ -703,7 +1048,8 @@ impl PluginWorkspace {
                             .max()
                     })
                     .unwrap_or_default();
-                self.detail_horizontal = max_width.saturating_sub(layout.detail_code_width());
+                self.detail_horizontal =
+                    max_width.saturating_sub(layout.detail_code_width(self.gutter_width()));
             }
             _ => {}
         }
@@ -711,6 +1057,123 @@ impl PluginWorkspace {
             self.ensure_detail_cursor_visible(WorkspaceLayout::calculate(self, height, width));
         }
         self.event(action)
+    }
+
+    fn actions(&self) -> Vec<UiAction> {
+        if self.filtering {
+            return vec![
+                UiAction::new("filter_accept", "Enter", "apply filter")
+                    .with_priority(ActionPriority::Essential),
+                UiAction::new("filter_cancel", "Esc", "clear filter")
+                    .with_priority(ActionPriority::Essential),
+            ];
+        }
+        let detail = self.focus == WorkspaceFocus::Detail;
+        let line = self
+            .model
+            .detail_document
+            .as_ref()
+            .and_then(|document| document.lines.get(self.detail_cursor));
+        let row = self
+            .rows_visible
+            .contains(&self.selected)
+            .then(|| self.model.rows.get(self.selected))
+            .flatten();
+        let section = if detail {
+            line.map(|line| &line.data)
+        } else {
+            row.map(|row| &row.data)
+        }
+        .and_then(|data| data.get("section"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+        let selected = self.detail_selection_anchor.is_some();
+        let scope = if detail {
+            self.detail_selection_anchor
+                .map(|anchor| format!("{} lines", anchor.abs_diff(self.detail_cursor) + 1))
+                .unwrap_or_else(|| "line".to_string())
+        } else {
+            "file".to_string()
+        };
+        let mut actions = self
+            .model
+            .actions
+            .iter()
+            .filter(|action| {
+                (action.focus.is_empty() || action.focus == if detail { "detail" } else { "rows" })
+                    && (action.sections.is_empty()
+                        || action.sections.iter().any(|candidate| candidate == section))
+                    && match action.selection.as_str() {
+                        "" => true,
+                        "range" => selected,
+                        "item" => {
+                            if detail {
+                                line.is_some()
+                            } else {
+                                row.is_some_and(|row| row.selectable)
+                            }
+                        }
+                        "none" => !selected,
+                        _ => false,
+                    }
+                    && (!action.change_only
+                        || !detail
+                        || selected
+                        || line
+                            .is_some_and(|line| matches!(line.kind.as_str(), "added" | "removed")))
+                    && (!action.hunk_only || line.is_some_and(|line| line.hunk_id.is_some()))
+            })
+            .map(|action| {
+                let mut hint = action.hint.clone();
+                hint.label = hint.label.replace("{scope}", &scope);
+                hint
+            })
+            .collect::<Vec<_>>();
+        if !actions.is_empty() {
+            if detail {
+                actions.extend([
+                    UiAction::new("visual", "v", "select").with_enabled(!selected),
+                    UiAction::new("cancel_selection", "Esc", "clear selection")
+                        .with_enabled(selected)
+                        .with_priority(ActionPriority::Essential),
+                    UiAction::new("previous_hunk", "[h", "previous hunk")
+                        .with_priority(ActionPriority::Secondary),
+                    UiAction::new("next_hunk", "]h", "next hunk")
+                        .with_priority(ActionPriority::Secondary),
+                    UiAction::new("toggle_wrap", "W", "wrap")
+                        .with_priority(ActionPriority::Secondary),
+                    UiAction::new("toggle_metadata", "M", "patch metadata")
+                        .with_priority(ActionPriority::Secondary),
+                ]);
+            }
+            if !detail {
+                actions.push(UiAction::new("filter", "/", "filter files"));
+                actions.push(
+                    UiAction::new("collapse_section", "C", "collapse section")
+                        .with_priority(ActionPriority::Secondary),
+                );
+            }
+            actions.push(
+                UiAction::new("toggle_rows", "Ctrl+w o", "toggle files")
+                    .with_priority(ActionPriority::Secondary),
+            );
+            actions.push(
+                UiAction::new("narrow_rows", "Ctrl+w <", "narrow files")
+                    .with_priority(ActionPriority::Secondary),
+            );
+            actions.push(
+                UiAction::new("widen_rows", "Ctrl+w >", "widen files")
+                    .with_priority(ActionPriority::Secondary),
+            );
+            actions.push(
+                UiAction::new("focus_next", "Tab", if detail { "files" } else { "diff" })
+                    .with_enabled(self.model.detail_document.is_some()),
+            );
+            actions
+                .push(UiAction::new("?", "?", "actions").with_priority(ActionPriority::Essential));
+            actions.push(UiAction::new("q", "q", "close").with_priority(ActionPriority::Essential));
+        }
+        actions
     }
 }
 
@@ -725,6 +1188,10 @@ fn is_core_detail_interaction(focus: WorkspaceFocus, action: &str) -> bool {
             | "focus_previous"
             | "focus_rows"
             | "focus_detail"
+            | "filter"
+            | "toggle_rows"
+            | "narrow_rows"
+            | "widen_rows"
     ) || (focus == WorkspaceFocus::Detail
         && matches!(
             action,
@@ -740,6 +1207,7 @@ fn is_core_detail_interaction(focus: WorkspaceFocus, action: &str) -> bool {
                 | "visual"
                 | "cancel_selection"
                 | "toggle_wrap"
+                | "toggle_metadata"
                 | "left"
                 | "right"
                 | "horizontal_start"
@@ -755,11 +1223,17 @@ fn is_core_detail_interaction(focus: WorkspaceFocus, action: &str) -> bool {
 #[derive(Debug, Default)]
 pub struct WorkspaceManager {
     active: Option<PluginWorkspace>,
+    widths: HashMap<String, Option<usize>>,
 }
 
 impl WorkspaceManager {
     pub fn open(&mut self, id: String, config: WorkspaceConfig) {
-        self.active = Some(PluginWorkspace::new(id, config));
+        if let Some(active) = &self.active {
+            self.widths.insert(active.id.clone(), active.rows_width);
+        }
+        let mut workspace = PluginWorkspace::new(id.clone(), config);
+        workspace.rows_width = self.widths.get(&id).copied().flatten();
+        self.active = Some(workspace);
     }
 
     pub fn update(&mut self, id: &str, model: WorkspaceModel, theme: &Theme) -> bool {
@@ -787,6 +1261,12 @@ impl WorkspaceManager {
             .as_ref()
             .is_some_and(|workspace| workspace.id == id)
         {
+            self.widths.insert(
+                id.to_string(),
+                self.active
+                    .as_ref()
+                    .and_then(|workspace| workspace.rows_width),
+            );
             self.active = None;
             true
         } else {
@@ -810,6 +1290,12 @@ impl WorkspaceManager {
         self.active.is_some()
     }
 
+    pub fn is_filtering(&self) -> bool {
+        self.active
+            .as_ref()
+            .is_some_and(|workspace| workspace.filtering)
+    }
+
     pub fn handle_action(
         &mut self,
         action: String,
@@ -830,6 +1316,20 @@ impl WorkspaceManager {
     ) -> Option<WorkspaceEvent> {
         let workspace = self.active.as_mut()?;
         let layout = WorkspaceLayout::calculate(workspace, height, width);
+        if action == "mouse_release" {
+            workspace.dragging_separator = false;
+            return Some(workspace.event("noop".to_string()));
+        }
+        if action == "mouse_click"
+            && matches!(layout.separator, Some(WorkspaceSeparator::Columns(rect)) if rect.contains(column, row))
+        {
+            workspace.dragging_separator = true;
+            return Some(workspace.event("noop".to_string()));
+        }
+        if action == "mouse_drag" && workspace.dragging_separator {
+            workspace.rows_width = Some(column.clamp(20, width.saturating_sub(21).max(20)));
+            return Some(workspace.event("noop".to_string()));
+        }
         if let Some(focus) = layout.focus_at(column, row) {
             if focus == WorkspaceFocus::Rows || workspace.model.detail_document.is_some() {
                 workspace.focus = focus;
@@ -856,21 +1356,26 @@ impl WorkspaceManager {
             "mouse_click" => match workspace.focus {
                 WorkspaceFocus::Rows => {
                     if let Some(offset) = layout.rows.and_then(|rect| rect.content_offset(row)) {
-                        let candidate = workspace.scroll.saturating_add(offset);
-                        if workspace
-                            .model
-                            .rows
-                            .get(candidate)
-                            .is_some_and(|row| row.selectable)
+                        if let Some(candidate) = workspace
+                            .rows_visible
+                            .get(workspace.scroll.saturating_add(offset))
+                            .copied()
+                            .filter(|candidate| workspace.row_selectable(*candidate))
                         {
                             workspace.selected = candidate;
                         }
                     }
                 }
                 WorkspaceFocus::Detail => {
-                    if let Some(offset) = layout.detail.and_then(|rect| rect.content_offset(row)) {
-                        workspace.detail_cursor = workspace
-                            .detail_line_at_visual_offset(offset, layout.detail_code_width());
+                    if let Some(offset) = layout
+                        .detail
+                        .and_then(|rect| rect.content_offset(row))
+                        .and_then(|offset| offset.checked_sub(1))
+                    {
+                        workspace.detail_cursor = workspace.detail_line_at_visual_offset(
+                            offset,
+                            layout.detail_code_width(workspace.gutter_width()),
+                        );
                     }
                 }
             },
@@ -945,14 +1450,41 @@ impl WorkspaceManager {
             );
         }
 
-        render_segments(
-            buffer,
-            (1, buffer.height - 1, buffer.width - 2),
-            &workspace.model.footer,
-            editor_style,
-            theme,
-            false,
-        );
+        if workspace.model.actions.is_empty() {
+            render_segments(
+                buffer,
+                (1, buffer.height - 1, buffer.width - 2),
+                &workspace.model.footer,
+                editor_style,
+                theme,
+                false,
+            );
+        } else {
+            let actions = workspace.actions();
+            let context = if workspace.filtering {
+                "FILTER"
+            } else if workspace.detail_selection_anchor.is_some() {
+                "VISUAL"
+            } else if workspace.focus == WorkspaceFocus::Detail {
+                "DIFF"
+            } else {
+                "FILES"
+            };
+            ActionBar::new(&actions)
+                .with_context(context)
+                .with_status(
+                    (!workspace.model.status.is_empty()).then_some(workspace.model.status.as_str()),
+                )
+                .render(
+                    buffer,
+                    1,
+                    buffer.height - 1,
+                    buffer.width - 2,
+                    theme,
+                    editor_style,
+                );
+            workspace.action_menu.render(buffer, theme, &actions);
+        }
     }
 }
 
@@ -985,6 +1517,60 @@ fn highlight_document(
             _ => Vec::new(),
         })
         .collect()
+}
+
+/// Pair replacement lines within a bounded change block. Pure additions/removals
+/// retain their line tint; only actual replacements receive stronger word marks.
+fn word_changes(document: Option<&WorkspaceDocument>) -> Vec<Vec<Range<usize>>> {
+    let Some(document) = document else {
+        return Vec::new();
+    };
+    let mut result = vec![Vec::new(); document.lines.len()];
+    let mut index = 0;
+    while index < document.lines.len() {
+        if document.lines[index].kind != "removed" {
+            index += 1;
+            continue;
+        }
+        let old_start = index;
+        while index < document.lines.len() && document.lines[index].kind == "removed" {
+            index += 1;
+        }
+        let new_start = index;
+        while index < document.lines.len() && document.lines[index].kind == "added" {
+            index += 1;
+        }
+        let pairs = (new_start - old_start).min(index - new_start).min(128);
+        for offset in 0..pairs {
+            let old = &document.lines[old_start + offset].text;
+            let new = &document.lines[new_start + offset].text;
+            if old.len().saturating_add(new.len()) > 8192 {
+                continue;
+            }
+            let old_words = old.split_word_bounds().collect::<Vec<_>>();
+            let new_words = new.split_word_bounds().collect::<Vec<_>>();
+            let diff = similar::TextDiff::from_slices(&old_words, &new_words);
+            let (mut old_byte, mut new_byte) = (0, 0);
+            for change in diff.iter_all_changes() {
+                let length = change.value().len();
+                match change.tag() {
+                    similar::ChangeTag::Equal => {
+                        old_byte += length;
+                        new_byte += length;
+                    }
+                    similar::ChangeTag::Delete => {
+                        result[old_start + offset].push(old_byte..old_byte + length);
+                        old_byte += length;
+                    }
+                    similar::ChangeTag::Insert => {
+                        result[new_start + offset].push(new_byte..new_byte + length);
+                        new_byte += length;
+                    }
+                }
+            }
+        }
+    }
+    result
 }
 
 fn highlight_document_projection(
@@ -1037,26 +1623,44 @@ fn render_row_pane(
         return;
     }
     let active = workspace.focus == WorkspaceFocus::Rows;
-    let mut title_style = theme.ui_style.popup_title.clone();
+    let mut title_style = SurfacePalette::new(theme, &theme.style).primary;
     title_style.bold = active;
+    let title = if workspace.filtering || !workspace.filter.is_empty() {
+        format!(
+            "{} Changes /{}",
+            if active { "›" } else { " " },
+            workspace.filter
+        )
+    } else {
+        format!("{} Changes", if active { "›" } else { " " })
+    };
     buffer.set_text(
         x + 1,
         top,
-        if active { "› Changes" } else { "  Changes" },
+        &truncate_display_width(&title, width.saturating_sub(1)),
         &title_style,
     );
     let content_top = top + 1;
     let content_height = height.saturating_sub(1);
-    for (screen_row, row) in workspace
-        .model
-        .rows
+    if workspace.rows_visible.is_empty() && !workspace.filter.is_empty() && content_height > 0 {
+        let muted = SurfacePalette::new(theme, &theme.style).muted;
+        buffer.set_text(
+            x + 1,
+            content_top,
+            &truncate_display_width("No matching files", width.saturating_sub(2)),
+            &muted,
+        );
+    }
+    for (screen_row, &row_index) in workspace
+        .rows_visible
         .iter()
         .skip(workspace.scroll)
         .take(content_height)
         .enumerate()
     {
+        let row = &workspace.model.rows[row_index];
         let y = content_top + screen_row;
-        let selected = workspace.scroll + screen_row == workspace.selected && row.selectable;
+        let selected = row_index == workspace.selected && workspace.row_selectable(row_index);
         let row_style = if selected && active {
             theme.selected_style(
                 &theme.style,
@@ -1068,6 +1672,19 @@ fn render_row_pane(
         };
         buffer.set_text(x, y, &fit_display_width("", width), &row_style);
         let mut content_x = x + 1 + row.depth.saturating_mul(2);
+        if row.id.starts_with("section:") && !workspace.model.actions.is_empty() {
+            buffer.set_text(
+                content_x,
+                y,
+                if workspace.collapsed_sections.contains(&row.id) {
+                    "▸ "
+                } else {
+                    "▾ "
+                },
+                &row_style,
+            );
+            content_x += 2;
+        }
         if let Some(path) = row.path.as_deref() {
             let icon = IconCatalog::file(path, icons.style);
             if !icon.glyph.is_empty() {
@@ -1082,23 +1699,23 @@ fn render_row_pane(
                 content_x += 3;
             }
         }
+        let right_width = row
+            .right_segments
+            .iter()
+            .map(|segment| display_width(&segment.text))
+            .sum::<usize>();
         render_segments(
             buffer,
             (
                 content_x,
                 y,
-                width.saturating_sub(content_x.saturating_sub(x) + 1),
+                width.saturating_sub(content_x.saturating_sub(x) + right_width + 2),
             ),
             &row.segments,
             &row_style,
             theme,
             selected,
         );
-        let right_width = row
-            .right_segments
-            .iter()
-            .map(|segment| display_width(&segment.text))
-            .sum::<usize>();
         if right_width > 0 && right_width + 1 < width {
             render_segments(
                 buffer,
@@ -1128,21 +1745,40 @@ fn render_detail_pane(
         return;
     }
     let active = workspace.focus == WorkspaceFocus::Detail;
-    let mut title_style = theme.ui_style.popup_title.clone();
+    let mut title_style = SurfacePalette::new(theme, &theme.style).primary;
     title_style.bold = active;
     let wrap_label = if workspace.detail_wrap {
         "wrap"
     } else {
         "nowrap"
     };
-    let title = if active {
-        format!(" › Diff  {wrap_label}")
-    } else {
-        format!("   Diff  {wrap_label}")
-    };
+    let marker = if active { "›" } else { " " };
+    let title = workspace.model.detail_document.as_ref().map_or_else(
+        || {
+            format!(
+                " {marker} {} · {wrap_label}",
+                if workspace.model.detail_title.is_empty() {
+                    "Diff"
+                } else {
+                    &workspace.model.detail_title
+                }
+            )
+        },
+        |document| {
+            let section = document
+                .lines
+                .iter()
+                .find_map(|line| line.data.get("section").and_then(serde_json::Value::as_str))
+                .unwrap_or("diff");
+            format!(
+                " {marker} {} · {section} · +{} −{}",
+                document.path, document.added, document.removed
+            )
+        },
+    );
     buffer.set_text(x, top, &truncate_display_width(&title, width), &title_style);
-    let content_top = top + 1;
-    let content_height = height.saturating_sub(1);
+    let content_top = top + 2;
+    let content_height = height.saturating_sub(2);
     let Some(document) = workspace.model.detail_document.as_ref() else {
         for (index, line) in workspace
             .model
@@ -1163,7 +1799,49 @@ fn render_detail_pane(
         return;
     };
 
-    let gutter_width = 13.min(width.saturating_sub(1));
+    if height > 1 {
+        let palette = SurfacePalette::new(theme, &theme.style);
+        let hunks = document
+            .lines
+            .iter()
+            .enumerate()
+            .filter(|(_, line)| line.kind == "hunk")
+            .collect::<Vec<_>>();
+        let current = hunks
+            .iter()
+            .rposition(|(index, _)| *index <= workspace.detail_cursor);
+        let context = current
+            .map(|position| {
+                let header = &hunks[position].1.text;
+                let symbol = header.split("@@").nth(2).unwrap_or_default().trim();
+                format!(
+                    "Hunk {} of {}{}{}",
+                    position + 1,
+                    hunks.len(),
+                    if symbol.is_empty() { "" } else { " · " },
+                    symbol
+                )
+            })
+            .unwrap_or_else(|| "File details".to_string());
+        let context = if document.truncated {
+            format!(
+                "{context} · first {}/{} lines · L full patch",
+                document.lines.len(),
+                document.total_lines
+            )
+        } else {
+            format!("{context} · {wrap_label}")
+        };
+        buffer.set_text(
+            x,
+            top + 1,
+            &fit_display_width(&format!(" {context}"), width),
+            &palette.muted,
+        );
+    }
+
+    let gutter_width = workspace.gutter_width().min(width.saturating_sub(1));
+    let number_width = workspace.gutter_width().saturating_sub(4) / 2;
     let code_width = width.saturating_sub(gutter_width + 1).max(1);
     let selection = workspace.detail_selection_anchor.map(|anchor| {
         (
@@ -1172,12 +1850,13 @@ fn render_detail_pane(
         )
     });
     let mut screen_row = 0;
-    for (line_index, line) in document
-        .lines
+    let palette = DiffPalette::new(theme);
+    for &line_index in workspace
+        .detail_visible
         .iter()
-        .enumerate()
-        .skip(workspace.detail_scroll)
+        .filter(|index| **index >= workspace.detail_scroll)
     {
+        let line = &document.lines[line_index];
         if screen_row >= content_height {
             break;
         }
@@ -1198,7 +1877,7 @@ fn render_detail_pane(
             let selected =
                 selection.is_some_and(|(start, end)| line_index >= start && line_index <= end);
             let cursor = active && line_index == workspace.detail_cursor;
-            let mut line_style = diff_line_style(&line.kind, theme);
+            let mut line_style = diff_line_style(&line.kind, theme, &palette);
             if selected {
                 line_style = theme.selected_style(
                     &line_style,
@@ -1229,12 +1908,16 @@ fn render_detail_pane(
                     _ => " ",
                 };
                 let gutter = format!(
-                    "{:>4} {:>4} {marker} ",
+                    "{:>number_width$} {:>number_width$} {marker} ",
                     line.old_line.map_or(String::new(), |line| line.to_string()),
                     line.new_line.map_or(String::new(), |line| line.to_string()),
                 );
                 let mut gutter_style = line_style.clone();
-                gutter_style.fg = diff_foreground(&line.kind, theme).or(gutter_style.fg);
+                gutter_style.fg = match line.kind.as_str() {
+                    "added" => Some(palette.added_marker),
+                    "removed" => Some(palette.removed_marker),
+                    _ => gutter_style.fg,
+                };
                 buffer.set_text(
                     x,
                     y,
@@ -1260,6 +1943,31 @@ fn render_detail_pane(
                     .map_or(&[], Vec::as_slice),
                 &line_style,
             );
+            if !selected && !cursor {
+                let background = match line.kind.as_str() {
+                    "added" => Some(palette.added_text),
+                    "removed" => Some(palette.removed_text),
+                    _ => None,
+                };
+                if let Some(background) = background {
+                    for range in workspace
+                        .detail_word_changes
+                        .get(line_index)
+                        .into_iter()
+                        .flatten()
+                    {
+                        let start = range.start.max(segment.byte_start).min(segment.byte_end);
+                        let end = range.end.min(segment.byte_end).max(start);
+                        if start < end {
+                            let first = display_width(&line.text[segment.byte_start..start]);
+                            let last = display_width(&line.text[segment.byte_start..end]);
+                            for column in first..last.min(code_width) {
+                                buffer.set_bg(code_x + column, y, &background, theme);
+                            }
+                        }
+                    }
+                }
+            }
             screen_row += 1;
         }
     }
@@ -1346,61 +2054,18 @@ fn render_syntax_overlays(
             continue;
         }
         let highlighted = truncate_display_width(&text[start..end], width - offset);
-        let style = span.style.fallback_bg(line_style);
+        let style = span.style.with_bg(line_style.bg);
         buffer.set_text(x + offset, y, &highlighted, &style);
     }
 }
 
-fn diff_line_style(kind: &str, theme: &Theme) -> Style {
-    let mut style = theme.style.clone();
-    style.bg = match kind {
-        "added" => diff_background(
-            theme,
-            "diffEditor.insertedLineBackground",
-            "gitDecoration.addedResourceForeground",
-        ),
-        "removed" => diff_background(
-            theme,
-            "diffEditor.removedLineBackground",
-            "gitDecoration.deletedResourceForeground",
-        ),
-        "hunk" => theme
-            .colors
-            .get("diffEditor.diagonalFill")
-            .copied()
-            .or_else(|| {
-                theme
-                    .line_highlight_style
-                    .as_ref()
-                    .and_then(|style| style.bg)
-            }),
-        _ => style.bg,
-    };
-    style
-}
-
-fn diff_background(theme: &Theme, preferred: &str, fallback: &str) -> Option<Color> {
-    theme.colors.get(preferred).copied().or_else(|| {
-        theme
-            .colors
-            .get(fallback)
-            .copied()
-            .map(|color| match color {
-                Color::Rgb { r, g, b } | Color::Rgba { r, g, b, .. } => {
-                    Color::Rgba { r, g, b, a: 38 }
-                }
-            })
-    })
-}
-
-fn diff_foreground(kind: &str, theme: &Theme) -> Option<Color> {
-    let key = match kind {
-        "added" => "gitDecoration.addedResourceForeground",
-        "removed" => "gitDecoration.deletedResourceForeground",
-        "hunk" => "gitDecoration.modifiedResourceForeground",
-        _ => return None,
-    };
-    theme.colors.get(key).copied()
+fn diff_line_style(kind: &str, theme: &Theme, palette: &DiffPalette) -> Style {
+    match kind {
+        "added" => palette.added.clone(),
+        "removed" => palette.removed.clone(),
+        "hunk" => palette.hunk.clone(),
+        _ => theme.style.clone(),
+    }
 }
 
 fn render_segments(
@@ -1419,10 +2084,12 @@ fn render_segments(
         }
         let text = truncate_display_width(&segment.text, end - x);
         let mut style = segment
-            .style
-            .clone()
+            .semantic
+            .as_ref()
+            .map(|spec| theme.resolve_style(spec))
+            .or_else(|| segment.style.clone())
             .unwrap_or_else(|| editor_style.clone())
-            .fallback_bg(editor_style);
+            .with_bg(editor_style.bg);
         if selected {
             // Segment styles commonly carry the editor background so they can
             // render correctly on an unselected row. The selected row fill
@@ -1479,6 +2146,7 @@ mod tests {
                     ..WorkspaceDocumentLine::default()
                 },
             ],
+            ..WorkspaceDocument::default()
         }
     }
 
@@ -1488,6 +2156,180 @@ mod tests {
             detail_document: Some(document()),
             ..WorkspaceModel::default()
         }
+    }
+
+    fn action_model() -> WorkspaceModel {
+        let mut model = model_with_document();
+        model.actions = vec![WorkspaceAction {
+            hint: UiAction::new("s", "s", "stage {scope}"),
+            focus: String::new(),
+            sections: vec!["unstaged".to_string()],
+            selection: String::new(),
+            change_only: true,
+            hunk_only: false,
+        }];
+        model.rows[0].path = Some("src/main.rs".to_string());
+        model.rows[0].data = serde_json::json!({"section":"unstaged"});
+        for line in &mut model.detail_document.as_mut().unwrap().lines {
+            line.data = serde_json::json!({"section":"unstaged"});
+        }
+        model
+    }
+
+    #[test]
+    fn word_highlights_cover_only_replaced_words() {
+        let mut document = WorkspaceDocument::default();
+        for (kind, text) in [
+            ("removed", "let count = 1;"),
+            ("added", "let count = 4;"),
+            ("context", "unchanged"),
+            ("added", "brand new line"),
+        ] {
+            document.lines.push(WorkspaceDocumentLine {
+                kind: kind.to_string(),
+                text: text.to_string(),
+                ..Default::default()
+            });
+        }
+        let ranges = word_changes(Some(&document));
+        let changed = |index: usize| {
+            ranges[index]
+                .iter()
+                .map(|range| &document.lines[index].text[range.clone()])
+                .collect::<String>()
+        };
+        assert_eq!(changed(0), "1");
+        assert_eq!(changed(1), "4");
+        assert!(ranges[2].is_empty() && ranges[3].is_empty());
+    }
+
+    #[test]
+    fn metadata_folding_preserves_patch_indices_and_local_action_scope() {
+        let mut model = action_model();
+        model.detail_document.as_mut().unwrap().lines.insert(
+            0,
+            WorkspaceDocumentLine {
+                id: "meta".to_string(),
+                kind: "meta".to_string(),
+                text: "diff --git a/b b/b".to_string(),
+                ..Default::default()
+            },
+        );
+        let mut workspace = PluginWorkspace::new(
+            "git".to_string(),
+            WorkspaceConfig {
+                notify_detail_navigation: false,
+                ..Default::default()
+            },
+        );
+        workspace.update(model, &Theme::default());
+        assert!(!workspace.detail_visible.contains(&0));
+        assert!(workspace
+            .actions()
+            .iter()
+            .any(|action| action.label == "stage file"));
+        workspace.handle_action("toggle".to_string(), 24, 120);
+        assert_eq!(workspace.detail_cursor, 2);
+        assert!(workspace
+            .actions()
+            .iter()
+            .any(|action| action.label == "stage line"));
+        workspace.handle_action("visual".to_string(), 24, 120);
+        workspace.handle_action("down".to_string(), 24, 120);
+        assert!(workspace
+            .actions()
+            .iter()
+            .any(|action| action.label == "stage 2 lines"));
+        let event = workspace.handle_action("M".to_string(), 24, 120);
+        assert!(!event.notify_plugin);
+        assert!(workspace.detail_visible.contains(&0));
+        assert_eq!(event.detail_selection, Some([2, 3]));
+    }
+
+    #[test]
+    fn filter_collapse_and_width_survive_model_updates() {
+        let mut model = action_model();
+        let mut heading = row("section:unstaged", false);
+        heading.segments.push(PanelSegment {
+            text: "Unstaged".to_string(),
+            style: None,
+            semantic: None,
+        });
+        model.rows.insert(0, heading);
+        let mut other = row("other", true);
+        other.path = Some("docs/readme.md".to_string());
+        model.rows.push(other);
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update("git", model.clone(), &Theme::default());
+        manager.handle_action("/".to_string(), 24, 120);
+        manager.handle_action("filter_text:readme".to_string(), 24, 120);
+        let event = manager
+            .handle_action("filter_accept".to_string(), 24, 120)
+            .unwrap();
+        assert_eq!(event.row.unwrap().id, "other");
+        assert_eq!(manager.active.as_ref().unwrap().rows_visible, vec![0, 2]);
+        manager.handle_action("/".to_string(), 24, 120);
+        manager.handle_action("filter_cancel".to_string(), 24, 120);
+        manager.handle_action("C".to_string(), 24, 120);
+        assert_eq!(manager.active.as_ref().unwrap().rows_visible, vec![0]);
+        manager.update("git", model, &Theme::default());
+        assert_eq!(manager.active.as_ref().unwrap().rows_visible, vec![0]);
+        manager.handle_action("widen_rows".to_string(), 24, 120);
+        let width = manager.active.as_ref().unwrap().rows_width;
+        manager.close("git");
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        assert_eq!(manager.active.as_ref().unwrap().rows_width, width);
+    }
+
+    #[test]
+    fn reused_patch_index_does_not_restore_an_unrelated_line() {
+        let mut workspace = PluginWorkspace::new("git".to_string(), WorkspaceConfig::default());
+        let mut model = action_model();
+        workspace.update(model.clone(), &Theme::default());
+        workspace.detail_cursor = 3;
+        workspace.detail_selection_anchor = Some(1);
+        model.detail_document.as_mut().unwrap().lines[3].text = "different change".to_string();
+        workspace.update(model, &Theme::default());
+        assert_eq!(workspace.detail_cursor, 1);
+        assert!(workspace.detail_selection_anchor.is_none());
+    }
+
+    #[test]
+    fn one_dark_plain_text_and_syntax_keep_the_owning_background() {
+        let theme = crate::theme::parse_vscode_theme("themes/one-dark-pro.json").unwrap();
+        let mut model = model_with_document();
+        model.header = vec![PanelSegment {
+            text: "branch".to_string(),
+            style: Some(theme.ui_style.popup_title.clone()),
+            semantic: None,
+        }];
+        let mut manager = WorkspaceManager::default();
+        manager.open("git".to_string(), WorkspaceConfig::default());
+        manager.update("git", model, &theme);
+        let mut buffer = RenderBuffer::new(120, 24, &theme.style);
+        manager.render(&mut buffer, &theme, PickerIconsConfig::default());
+        assert!(buffer.cells[120..240]
+            .iter()
+            .all(|cell| cell.style.bg == theme.style.bg));
+        let added = buffer
+            .cells
+            .chunks(120)
+            .find(|row| {
+                row.iter()
+                    .map(|cell| cell.text.as_str())
+                    .collect::<String>()
+                    .contains("let first = true")
+            })
+            .unwrap();
+        let palette = DiffPalette::new(&theme);
+        let detail_start = WorkspaceLayout::calculate(manager.active.as_ref().unwrap(), 24, 120)
+            .detail
+            .unwrap()
+            .x;
+        assert!(added[detail_start..]
+            .iter()
+            .all(|cell| cell.style.bg == palette.added.bg));
     }
 
     fn buffer_text(buffer: &RenderBuffer) -> String {
@@ -1628,7 +2470,8 @@ mod tests {
         manager.handle_action("toggle".to_string(), 12, 80);
         manager.render(&mut buffer, &theme, PickerIconsConfig::default());
         let detail = buffer_text(&buffer);
-        assert!(detail.contains("Diff  wrap"));
+        assert!(detail.contains("src/main.rs"));
+        assert!(detail.contains("wrap"));
         assert!(detail.contains("let first = true"));
     }
 
@@ -1683,7 +2526,8 @@ mod tests {
 
         let rendered = buffer_text(&buffer);
         assert!(rendered.contains("Changes"));
-        assert!(rendered.contains("Diff  wrap"));
+        assert!(rendered.contains("src/main.rs"));
+        assert!(rendered.contains("wrap"));
         assert!(rendered.contains("let first = true"));
         let layout = WorkspaceLayout::calculate(manager.active.as_ref().unwrap(), 24, 80);
         let rows = layout.rows.unwrap();
@@ -1701,7 +2545,7 @@ mod tests {
         assert_eq!(event.row.unwrap().id, "second");
 
         let event = manager
-            .handle_mouse("mouse_click", 20, detail.y + 4, 24, 80)
+            .handle_mouse("mouse_click", 20, detail.y + 5, 24, 80)
             .unwrap();
         assert_eq!(event.focus, WorkspaceFocus::Detail);
         assert_eq!(event.detail_index, 3);
@@ -1852,11 +2696,17 @@ mod tests {
 
         manager.render(&mut buffer, &theme, PickerIconsConfig::default());
 
-        let added_row = &buffer.cells[4 * buffer.width..5 * buffer.width];
-        let expected_background = theme
-            .colors
-            .get("diffEditor.insertedLineBackground")
-            .copied();
+        let added_row = buffer
+            .cells
+            .chunks(buffer.width)
+            .find(|row| {
+                row.iter()
+                    .map(|cell| cell.text.as_str())
+                    .collect::<String>()
+                    .contains("let first = true")
+            })
+            .unwrap();
+        let expected_background = DiffPalette::new(&theme).added.bg;
         assert!(added_row
             .iter()
             .any(|cell| cell.style.bg == expected_background));

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -6,7 +6,9 @@
 //! comments through the VS Code adapter but produces the same internal model as bundled
 //! native themes.
 
+mod surface;
 mod vscode;
+pub(crate) use surface::{DiffPalette, SurfacePalette};
 
 use std::collections::BTreeMap;
 

--- a/src/theme/surface.rs
+++ b/src/theme/surface.rs
@@ -1,0 +1,218 @@
+//! Foreground-first styles for persistent UI surfaces and structured diffs.
+
+use crate::color::{blend_color, ensure_minimum_contrast, Color};
+
+use super::{Style, Theme, ThemeMode, MINIMUM_SELECTION_TEXT_CONTRAST};
+
+/// Text roles whose backgrounds always belong to the surrounding surface.
+#[derive(Debug, Clone)]
+pub(crate) struct SurfacePalette {
+    pub surface: Style,
+    pub primary: Style,
+    pub secondary: Style,
+    pub muted: Style,
+    pub accent: Style,
+    pub error: Style,
+    pub divider: Style,
+}
+
+impl SurfacePalette {
+    pub fn new(theme: &Theme, surface: &Style) -> Self {
+        let background = blend_color(
+            surface.bg.or(theme.style.bg).unwrap_or_default(),
+            Color::default(),
+        );
+        let primary = surface.fg.or(theme.style.fg).unwrap_or(Color::Rgb {
+            r: 255,
+            g: 255,
+            b: 255,
+        });
+        let color = |keys: &[&str], fallback: Color| {
+            keys.iter()
+                .find_map(|key| theme.colors.get(*key).copied())
+                .unwrap_or(fallback)
+        };
+        let secondary = color(&["descriptionForeground"], primary);
+        let muted = color(
+            &["editorLineNumber.foreground", "descriptionForeground"],
+            theme.ui_style.muted.fg.unwrap_or(secondary),
+        );
+        let accent = color(
+            &[
+                "textLink.foreground",
+                "editorInfo.foreground",
+                "focusBorder",
+            ],
+            theme.ui_style.popup_title.fg.unwrap_or(primary),
+        );
+        let error = color(&["editorError.foreground", "list.errorForeground"], primary);
+        let role = |foreground, minimum, bold| Style {
+            fg: Some(ensure_minimum_contrast(foreground, background, minimum)),
+            bg: Some(background),
+            bold,
+            italic: false,
+        };
+        Self {
+            surface: surface.with_bg(Some(background)),
+            primary: role(primary, MINIMUM_SELECTION_TEXT_CONTRAST, false),
+            secondary: role(secondary, MINIMUM_SELECTION_TEXT_CONTRAST, false),
+            muted: role(muted, 3.0, false),
+            accent: role(accent, MINIMUM_SELECTION_TEXT_CONTRAST, true),
+            error: role(error, MINIMUM_SELECTION_TEXT_CONTRAST, false),
+            divider: role(muted, 3.0, false),
+        }
+    }
+}
+
+/// Resolved, opaque diff colors. Text colors never carry another surface's background.
+pub(crate) struct DiffPalette {
+    pub added: Style,
+    pub removed: Style,
+    pub added_text: Color,
+    pub removed_text: Color,
+    pub added_marker: Color,
+    pub removed_marker: Color,
+    pub hunk: Style,
+}
+
+impl DiffPalette {
+    pub fn new(theme: &Theme) -> Self {
+        let surface = SurfacePalette::new(theme, &theme.style);
+        let background = surface.surface.bg.unwrap_or_default();
+        let accent = |added: bool| {
+            let (keys, scope, fallback) = if added {
+                (
+                    [
+                        "gitDecoration.addedResourceForeground",
+                        "editorGutter.addedBackground",
+                        "terminal.ansiGreen",
+                    ],
+                    "markup.inserted.diff",
+                    Color::Rgb {
+                        r: 80,
+                        g: 160,
+                        b: 100,
+                    },
+                )
+            } else {
+                (
+                    [
+                        "gitDecoration.deletedResourceForeground",
+                        "editorGutter.deletedBackground",
+                        "terminal.ansiRed",
+                    ],
+                    "markup.deleted.diff",
+                    Color::Rgb {
+                        r: 210,
+                        g: 85,
+                        b: 95,
+                    },
+                )
+            };
+            keys[..2]
+                .iter()
+                .find_map(|key| theme.colors.get(*key).copied())
+                .or_else(|| theme.get_style(scope).and_then(|style| style.fg))
+                .or_else(|| theme.colors.get(keys[2]).copied())
+                .unwrap_or(fallback)
+        };
+        let added = accent(true);
+        let removed = accent(false);
+        let resolve = |line_key: &str, text_key: &str, accent: Color| {
+            let line = theme
+                .colors
+                .get(line_key)
+                .copied()
+                .or_else(|| theme.colors.get(text_key).copied())
+                .unwrap_or_else(|| tint(accent, 32));
+            let line = blend_color(line, background);
+            let text = theme
+                .colors
+                .get(text_key)
+                .copied()
+                .unwrap_or_else(|| tint(accent, 72));
+            (theme.style.with_bg(Some(line)), blend_color(text, line))
+        };
+        let (added_style, added_text) = resolve(
+            "diffEditor.insertedLineBackground",
+            "diffEditor.insertedTextBackground",
+            added,
+        );
+        let (removed_style, removed_text) = resolve(
+            "diffEditor.removedLineBackground",
+            "diffEditor.removedTextBackground",
+            removed,
+        );
+        let hunk_background = theme
+            .colors
+            .get("multiDiffEditor.headerBackground")
+            .copied()
+            .or_else(|| {
+                theme
+                    .line_highlight_style
+                    .as_ref()
+                    .and_then(|style| style.bg)
+            })
+            .unwrap_or_else(|| {
+                tint(
+                    surface.accent.fg.unwrap_or(added),
+                    if theme.mode() == ThemeMode::Light {
+                        20
+                    } else {
+                        28
+                    },
+                )
+            });
+        Self {
+            added: added_style,
+            removed: removed_style,
+            added_text,
+            removed_text,
+            added_marker: ensure_minimum_contrast(added, background, 3.0),
+            removed_marker: ensure_minimum_contrast(removed, background, 3.0),
+            hunk: surface
+                .secondary
+                .with_bg(Some(blend_color(hunk_background, background))),
+        }
+    }
+}
+
+fn tint(color: Color, alpha: u8) -> Color {
+    let (Color::Rgb { r, g, b } | Color::Rgba { r, g, b, .. }) = color;
+    Color::Rgba { r, g, b, a: alpha }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_dark_has_distinct_opaque_diff_surfaces() {
+        let theme = crate::theme::parse_vscode_theme("themes/one-dark-pro.json").unwrap();
+        let palette = DiffPalette::new(&theme);
+        assert_ne!(palette.added.bg, theme.style.bg);
+        assert_ne!(palette.removed.bg, theme.style.bg);
+        assert_ne!(palette.added.bg, palette.removed.bg);
+        assert!(matches!(palette.added.bg, Some(Color::Rgb { .. })));
+        assert!(matches!(palette.removed.bg, Some(Color::Rgb { .. })));
+    }
+
+    #[test]
+    fn all_bundled_themes_have_resolved_diff_backgrounds() {
+        for entry in std::fs::read_dir("themes").unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().is_none_or(|extension| extension != "json") {
+                continue;
+            }
+            let theme = crate::theme::parse_vscode_theme(path.to_str().unwrap()).unwrap();
+            let palette = DiffPalette::new(&theme);
+            for color in [palette.added.bg, palette.removed.bg, palette.hunk.bg] {
+                assert!(
+                    matches!(color, Some(Color::Rgb { .. })),
+                    "{}",
+                    path.display()
+                );
+            }
+        }
+    }
+}

--- a/src/ui/action_bar.rs
+++ b/src/ui/action_bar.rs
@@ -4,11 +4,12 @@
 //! picker, or plugin workspace without cutting a key binding or hiding the
 //! number of actions that did not fit.
 
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     editor::RenderBuffer,
-    theme::{Style, Theme},
+    theme::{SelectionForegroundPriority, Style, SurfacePalette, Theme},
     unicode_utils::{display_width, truncate_display_width},
 };
 
@@ -82,6 +83,9 @@ pub struct UiAction {
     /// Optional shorter representation of the same key binding.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compact_key: Option<String>,
+    /// Canonical single key used when a grouped display label is chosen from help.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<String>,
     /// Responsive display priority.
     #[serde(default)]
     pub priority: ActionPriority,
@@ -103,6 +107,7 @@ impl UiAction {
             label: label.into(),
             compact_label: None,
             compact_key: None,
+            trigger: None,
             priority: ActionPriority::Primary,
             modes: Vec::new(),
             enabled: true,
@@ -130,6 +135,12 @@ impl UiAction {
         self
     }
 
+    #[must_use]
+    pub fn with_trigger(mut self, key: impl Into<String>) -> Self {
+        self.trigger = Some(key.into());
+        self
+    }
+
     /// Restricts this action to the supplied interaction modes.
     #[must_use]
     pub fn with_modes(mut self, modes: impl IntoIterator<Item = ActionMode>) -> Self {
@@ -147,6 +158,68 @@ impl UiAction {
     fn is_available(&self, mode: Option<ActionMode>) -> bool {
         self.enabled
             && (self.modes.is_empty() || mode.is_some_and(|mode| self.modes.contains(&mode)))
+    }
+
+    /// Resolves the first advertised alternative for modal action-menu dispatch.
+    pub(crate) fn event(&self) -> Option<Event> {
+        let binding = self.trigger.as_deref().unwrap_or(&self.key).trim();
+        let binding = if binding == "/" || binding.ends_with("+/") {
+            binding
+        } else {
+            binding.split('/').next()?
+        };
+        let normalized = binding
+            .replace("Ctrl-", "Ctrl+")
+            .replace("Alt-", "Alt+")
+            .replace("Shift-", "Shift+")
+            .replace("C-", "Ctrl+")
+            .replace("A-", "Alt+");
+        let mut key = normalized.as_str();
+        let mut modifiers = KeyModifiers::NONE;
+        for (prefix, modifier) in [
+            ("Ctrl+", KeyModifiers::CONTROL),
+            ("Alt+", KeyModifiers::ALT),
+            ("Shift+", KeyModifiers::SHIFT),
+            ("^", KeyModifiers::CONTROL),
+        ] {
+            if let Some(rest) = key.strip_prefix(prefix) {
+                modifiers |= modifier;
+                key = rest;
+            }
+        }
+        let code = match key {
+            "Enter" | "↵" => KeyCode::Enter,
+            "Esc" => KeyCode::Esc,
+            "Tab" => KeyCode::Tab,
+            "Space" => KeyCode::Char(' '),
+            "Backspace" => KeyCode::Backspace,
+            "Delete" => KeyCode::Delete,
+            "Home" => KeyCode::Home,
+            "End" => KeyCode::End,
+            "PageUp" => KeyCode::PageUp,
+            "PageDown" => KeyCode::PageDown,
+            "↑" | "↑↓" => KeyCode::Up,
+            "↓" => KeyCode::Down,
+            "←" => KeyCode::Left,
+            "→" => KeyCode::Right,
+            value if value.starts_with('F') && value.len() > 1 => {
+                KeyCode::F(value[1..].parse().ok()?)
+            }
+            value if value.chars().count() == 1 => {
+                let character = value.chars().next()?;
+                KeyCode::Char(
+                    if modifiers.contains(KeyModifiers::CONTROL)
+                        && !modifiers.contains(KeyModifiers::SHIFT)
+                    {
+                        character.to_ascii_lowercase()
+                    } else {
+                        character
+                    },
+                )
+            }
+            _ => return None,
+        };
+        Some(Event::Key(KeyEvent::new(code, modifiers)))
     }
 }
 
@@ -205,6 +278,7 @@ pub struct ActionBar<'a> {
     actions: &'a [UiAction],
     mode: Option<ActionMode>,
     status: Option<&'a str>,
+    context: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -221,6 +295,7 @@ impl<'a> ActionBar<'a> {
             actions,
             mode: None,
             status: None,
+            context: None,
         }
     }
 
@@ -228,6 +303,13 @@ impl<'a> ActionBar<'a> {
     #[must_use]
     pub const fn with_mode(mut self, mode: ActionMode) -> Self {
         self.mode = Some(mode);
+        self
+    }
+
+    /// Identifies the focused surface without pretending it is a Vim mode.
+    #[must_use]
+    pub const fn with_context(mut self, context: &'a str) -> Self {
+        self.context = Some(context);
         self
     }
 
@@ -303,7 +385,7 @@ impl<'a> ActionBar<'a> {
 
         for (_, action, compact) in &packed.visible {
             if used > 0 {
-                push_span(&mut spans, &mut used, "  ", ActionBarRole::Separator);
+                push_span(&mut spans, &mut used, " · ", ActionBarRole::Separator);
             }
             let key = if *compact {
                 action.compact_key.as_deref().unwrap_or(&action.key)
@@ -341,7 +423,10 @@ impl<'a> ActionBar<'a> {
             let separator_width = usize::from(used > 0);
             let marker = overflow_marker(
                 hidden_actions.len(),
-                width.saturating_sub(used).saturating_sub(separator_width),
+                width
+                    .saturating_sub(used)
+                    .saturating_sub(separator_width)
+                    .saturating_sub(status_reserved),
             );
             if !marker.is_empty() {
                 if used > 0 {
@@ -441,7 +526,8 @@ impl<'a> ActionBar<'a> {
             return ActionBarLayout::default();
         }
 
-        buffer.set_text(x, y, &" ".repeat(width), surface);
+        let palette = SurfacePalette::new(theme, surface);
+        buffer.set_text(x, y, &" ".repeat(width), &palette.surface);
         let layout = self.layout(width);
         let mut column = match alignment {
             ActionBarAlignment::Left => x,
@@ -451,14 +537,13 @@ impl<'a> ActionBar<'a> {
         };
         for span in &layout.spans {
             let style = match span.role {
-                ActionBarRole::Mode => theme.ui_style.popup_title.with_bg(surface.bg),
-                ActionBarRole::Key | ActionBarRole::Overflow => {
-                    theme.ui_style.picker_prompt.with_bg(surface.bg)
-                }
-                ActionBarRole::Separator | ActionBarRole::Status => {
-                    theme.ui_style.muted.with_bg(surface.bg)
-                }
-                ActionBarRole::Label => surface.clone(),
+                ActionBarRole::Mode => palette.accent.clone(),
+                ActionBarRole::Key | ActionBarRole::Overflow => Style {
+                    bold: true,
+                    ..palette.secondary.clone()
+                },
+                ActionBarRole::Separator => palette.divider.clone(),
+                ActionBarRole::Status | ActionBarRole::Label => palette.muted.clone(),
             };
             buffer.set_text(column, y, &span.text, &style);
             column = column.saturating_add(display_width(&span.text));
@@ -489,40 +574,43 @@ impl<'a> ActionBar<'a> {
         } else {
             essential_width(actions, false)
         };
-        let mode = self.mode.and_then(|mode| {
-            let full = mode.label();
-            if display_width(full)
-                .saturating_add(usize::from(action_preferred > 0) * 2)
-                .saturating_add(action_preferred)
-                .saturating_add(reserved)
-                <= width
-            {
-                Some(full)
-            } else if display_width(mode.compact_label())
-                .saturating_add(usize::from(action_preferred > 0) * 2)
-                .saturating_add(action_preferred)
-                .saturating_add(reserved)
-                <= width
-            {
-                Some(mode.compact_label())
-            } else if display_width(full)
-                .saturating_add(usize::from(action_minimum > 0) * 2)
-                .saturating_add(action_minimum)
-                .saturating_add(reserved)
-                <= width
-            {
-                Some(full)
-            } else if display_width(mode.compact_label())
-                .saturating_add(usize::from(action_minimum > 0) * 2)
-                .saturating_add(action_minimum)
-                .saturating_add(reserved)
-                <= width
-            {
-                Some(mode.compact_label())
-            } else {
-                None
-            }
-        });
+        let mode = self
+            .context
+            .or(self.mode.map(ActionMode::label))
+            .and_then(|full| {
+                let compact = self.mode.map(ActionMode::compact_label).unwrap_or(full);
+                if display_width(full)
+                    .saturating_add(usize::from(action_preferred > 0) * 3)
+                    .saturating_add(action_preferred)
+                    .saturating_add(reserved)
+                    <= width
+                {
+                    Some(full)
+                } else if display_width(compact)
+                    .saturating_add(usize::from(action_preferred > 0) * 3)
+                    .saturating_add(action_preferred)
+                    .saturating_add(reserved)
+                    <= width
+                {
+                    Some(compact)
+                } else if display_width(full)
+                    .saturating_add(usize::from(action_minimum > 0) * 3)
+                    .saturating_add(action_minimum)
+                    .saturating_add(reserved)
+                    <= width
+                {
+                    Some(full)
+                } else if display_width(compact)
+                    .saturating_add(usize::from(action_minimum > 0) * 3)
+                    .saturating_add(action_minimum)
+                    .saturating_add(reserved)
+                    <= width
+                {
+                    Some(compact)
+                } else {
+                    None
+                }
+            });
 
         let mut used = mode.map_or(0, display_width);
         let mut visible = Vec::new();
@@ -533,7 +621,7 @@ impl<'a> ActionBar<'a> {
                 continue;
             }
 
-            let separator_width = usize::from(used > 0) * 2;
+            let separator_width = usize::from(used > 0) * 3;
             let remaining = width
                 .saturating_sub(used)
                 .saturating_sub(separator_width)
@@ -541,7 +629,7 @@ impl<'a> ActionBar<'a> {
             let full_width = action_width(action, false);
             let compact_width = action_width(action, true);
             let remaining_essentials = minimum_essential_width(&actions[position + 1..]);
-            let following_separator = usize::from(remaining_essentials > 0) * 2;
+            let following_separator = usize::from(remaining_essentials > 0) * 3;
             let preserve_essentials = remaining_essentials.saturating_add(following_separator);
             let compact = if full_width.saturating_add(preserve_essentials) <= remaining {
                 false
@@ -562,6 +650,7 @@ impl<'a> ActionBar<'a> {
             visible.push((*index, *action, compact));
         }
 
+        visible.sort_by_key(|(index, _, _)| *index);
         PackedActions {
             mode,
             visible,
@@ -571,7 +660,7 @@ impl<'a> ActionBar<'a> {
 }
 
 struct PackedActions<'a> {
-    mode: Option<&'static str>,
+    mode: Option<&'a str>,
     visible: Vec<(usize, &'a UiAction, bool)>,
     used: usize,
 }
@@ -588,7 +677,7 @@ fn essential_width(actions: &[(usize, &UiAction)], compact: bool) -> usize {
             continue;
         }
         if count > 0 {
-            width = width.saturating_add(2);
+            width = width.saturating_add(3);
         }
         width = width.saturating_add(action_width(action, compact));
         count = count.saturating_add(1);
@@ -616,7 +705,7 @@ fn overflow_marker(hidden: usize, width: usize) -> String {
     if hidden == 0 || width == 0 {
         return String::new();
     }
-    let marker = format!("… +{hidden}");
+    let marker = format!("… F1 +{hidden}");
     if display_width(&marker) <= width {
         marker
     } else if display_width("…") <= width {
@@ -637,6 +726,174 @@ fn push_span(spans: &mut Vec<ActionBarSpan>, used: &mut usize, text: &str, role:
     });
 }
 
+/// A small, surface-owned menu for the same actions shown in an action strip.
+/// It does not replace the owning dialog or lose its selection/input state.
+#[derive(Debug, Default)]
+pub(crate) struct ActionMenu {
+    selected: Option<usize>,
+}
+
+impl ActionMenu {
+    pub fn is_open(&self) -> bool {
+        self.selected.is_some()
+    }
+
+    pub fn open(&mut self) {
+        self.selected = Some(0);
+    }
+
+    pub fn close(&mut self) {
+        self.selected = None;
+    }
+
+    pub fn handle_event(&mut self, event: &Event, actions: &[UiAction]) -> Option<String> {
+        let Event::Key(key) = event else {
+            return None;
+        };
+        let action = match key.code {
+            KeyCode::Up | KeyCode::Char('k') => "up",
+            KeyCode::Down | KeyCode::Char('j') => "down",
+            KeyCode::Enter => "activate",
+            KeyCode::Esc | KeyCode::Char('q') | KeyCode::F(1) => "escape",
+            _ => "noop",
+        };
+        self.handle(action, actions)
+    }
+
+    /// Returns the selected action ID. Navigation and cancellation are consumed.
+    pub fn handle(&mut self, action: &str, actions: &[UiAction]) -> Option<String> {
+        let selected = self.selected.as_mut()?;
+        let available = actions
+            .iter()
+            .filter(|action| action.enabled)
+            .collect::<Vec<_>>();
+        match action {
+            "up" | "k" => *selected = selected.saturating_sub(1),
+            "down" | "j" => {
+                *selected = selected
+                    .saturating_add(1)
+                    .min(available.len().saturating_sub(1))
+            }
+            "escape" | "q" | "?" | "F1" => self.selected = None,
+            "activate" => {
+                let id = available.get(*selected).map(|action| action.id.clone());
+                self.selected = None;
+                return id;
+            }
+            _ => {}
+        }
+        None
+    }
+
+    pub fn render(&self, buffer: &mut RenderBuffer, theme: &Theme, actions: &[UiAction]) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        let actions = actions
+            .iter()
+            .filter(|action| action.enabled)
+            .collect::<Vec<_>>();
+        if buffer.width < 8 || buffer.height < 5 {
+            return;
+        }
+        let key_width = actions
+            .iter()
+            .map(|action| display_width(&action.key))
+            .max()
+            .unwrap_or(0);
+        let width = actions
+            .iter()
+            .map(|action| key_width + display_width(&action.label) + 6)
+            .max()
+            .unwrap_or(20)
+            .clamp(32, 76)
+            .min(buffer.width.saturating_sub(4));
+        let height = (actions.len() + 3).min(buffer.height.saturating_sub(2));
+        let x = (buffer.width - width) / 2;
+        let y = (buffer.height - height) / 2;
+        let palette = SurfacePalette::new(theme, &theme.ui_style.popup);
+        for row in y..y + height {
+            buffer.set_text(x, row, &" ".repeat(width), &palette.surface);
+            buffer.set_text(x, row, "│", &palette.divider);
+            buffer.set_text(x + width - 1, row, "│", &palette.divider);
+        }
+        buffer.set_text(
+            x,
+            y,
+            &format!("┌{}┐", "─".repeat(width - 2)),
+            &palette.divider,
+        );
+        buffer.set_text(
+            x,
+            y + height - 1,
+            &format!("└{}┘", "─".repeat(width - 2)),
+            &palette.divider,
+        );
+        let title = format!(
+            " Actions {}/{} ",
+            selected.saturating_add(1).min(actions.len()),
+            actions.len()
+        );
+        if display_width(&title) <= width.saturating_sub(4) {
+            buffer.set_text(x + 2, y, &title, &palette.accent);
+        }
+        let content_width = width.saturating_sub(4);
+        let key_width = key_width.min(content_width);
+        let visible = height.saturating_sub(3);
+        let first = selected.saturating_sub(visible.saturating_sub(1));
+        for (offset, action) in actions.iter().skip(first).take(visible).enumerate() {
+            let row = y + 1 + offset;
+            let style = if first + offset == selected {
+                theme.selected_style(
+                    &palette.surface,
+                    &theme.list_selection_style(),
+                    SelectionForegroundPriority::Selection,
+                )
+            } else {
+                palette.surface.clone()
+            };
+            buffer.set_text(x + 1, row, &" ".repeat(width - 2), &style);
+            let key = if display_width(&action.key) <= key_width {
+                action.key.as_str()
+            } else {
+                action
+                    .compact_key
+                    .as_deref()
+                    .filter(|key| display_width(key) <= key_width)
+                    .unwrap_or("")
+            };
+            let key_style = Style {
+                bold: true,
+                ..style.clone()
+            };
+            buffer.set_text(x + 2, row, key, &key_style);
+            let label_width = content_width.saturating_sub(key_width + 2);
+            if label_width > 0 {
+                buffer.set_text(
+                    x + 2 + key_width + 2,
+                    row,
+                    &truncate_display_width(&action.label, label_width),
+                    &style,
+                );
+            }
+        }
+        let navigation = [
+            UiAction::new("select", "Enter", "select")
+                .with_compact_key("↵")
+                .with_priority(ActionPriority::Essential),
+            UiAction::new("return", "Esc", "back").with_priority(ActionPriority::Essential),
+        ];
+        ActionBar::new(&navigation).render(
+            buffer,
+            x + 1,
+            y + height - 2,
+            width - 2,
+            theme,
+            &palette.surface,
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -654,13 +911,67 @@ mod tests {
     }
 
     #[test]
+    fn overflow_preserves_reserved_validation_status() {
+        let actions = vec![
+            UiAction::new("send", "Ctrl+Enter", "send")
+                .with_compact_key("^↵")
+                .with_priority(ActionPriority::Secondary),
+            UiAction::new("cancel", "Esc", "normal").with_priority(ActionPriority::Essential),
+        ];
+        let layout = ActionBar::new(&actions)
+            .with_status(Some("Prompt exceeds 128 KiB"))
+            .layout(40);
+        assert!(layout.text().contains("Esc normal"));
+        assert!(
+            layout.text().contains("Prompt exceeds 128 KiB"),
+            "{}",
+            layout.text()
+        );
+        assert!(display_width(&layout.text()) <= 40);
+    }
+
+    #[test]
+    fn grouped_hint_dispatches_its_canonical_key() {
+        let action = UiAction::new("move", "hjkl/arrows", "move").with_trigger("h");
+        assert_eq!(
+            action.event(),
+            Some(Event::Key(KeyEvent::new(
+                KeyCode::Char('h'),
+                KeyModifiers::NONE
+            )))
+        );
+        assert_eq!(
+            UiAction::new("scroll", "^J/^K", "scroll").event(),
+            Some(Event::Key(KeyEvent::new(
+                KeyCode::Char('j'),
+                KeyModifiers::CONTROL
+            )))
+        );
+    }
+
+    #[test]
+    fn menu_returns_only_enabled_actions_and_can_cancel() {
+        let actions = vec![
+            UiAction::new("disabled", "x", "disabled").with_enabled(false),
+            UiAction::new("send", "Enter", "send"),
+        ];
+        let mut menu = ActionMenu::default();
+        menu.open();
+        assert_eq!(menu.handle("activate", &actions).as_deref(), Some("send"));
+        assert!(!menu.is_open());
+        menu.open();
+        assert_eq!(menu.handle("escape", &actions), None);
+        assert!(!menu.is_open());
+    }
+
+    #[test]
     fn wide_layout_shows_all_complete_actions_without_overflow() {
         let actions = actions();
         let layout = ActionBar::new(&actions)
             .with_mode(ActionMode::Insert)
             .layout(100);
 
-        assert!(layout.text().starts_with("INSERT  Ctrl+Enter Send"));
+        assert!(layout.text().starts_with("INSERT · Ctrl+Enter Send"));
         assert!(layout.text().contains("Esc Close"));
         assert!(layout.text().contains("Enter New line"));
         assert!(layout.text().contains("Ctrl+P/N History"));

--- a/src/ui/agent_composer.rs
+++ b/src/ui/agent_composer.rs
@@ -205,6 +205,32 @@ impl AgentComposer {
 }
 
 impl Component for AgentComposer {
+    fn surface_actions(&self) -> Vec<UiAction> {
+        let normal = self.prompt.mode() == Mode::Normal;
+        let mut actions = vec![
+            UiAction::new("send", "Enter", "send")
+                .with_compact_key("↵")
+                .with_priority(if self.validation_status.is_some() {
+                    ActionPriority::Secondary
+                } else {
+                    ActionPriority::Essential
+                }),
+            UiAction::new("cancel", "Esc", if normal { "cancel" } else { "normal" })
+                .with_priority(ActionPriority::Essential),
+        ];
+        if self.validation_status.is_none() {
+            if !normal {
+                actions.push(UiAction::new("newline", "Ctrl+J", "new line"));
+            }
+            actions.push(
+                UiAction::new("history", "Ctrl+P/N", "history")
+                    .with_compact_key("^P/N")
+                    .with_priority(ActionPriority::Secondary),
+            );
+        }
+        actions
+    }
+
     fn composer_handle(&self) -> Option<ComposerHandle> {
         match &self.target {
             ComposerTarget::Legacy { .. } => None,
@@ -245,28 +271,8 @@ impl Component for AgentComposer {
         if self.dialog.height > body_height {
             let status_y = content_y + body_height;
             let prompt_mode = self.prompt.mode();
-            let normal_mode = prompt_mode == Mode::Normal;
-            let escape_label = if normal_mode { "Cancel" } else { "Normal" };
-            let actions = [
-                UiAction::new("send", "Enter", "Send")
-                    .with_modes([ActionMode::Insert, ActionMode::Normal])
-                    .with_compact_key("↵")
-                    .with_compact_label("")
-                    .with_priority(ActionPriority::Essential),
-                UiAction::new("cancel", "Esc", escape_label)
-                    .with_compact_label("")
-                    .with_priority(ActionPriority::Essential),
-                UiAction::new("newline", "Ctrl+J", "New line").with_modes([ActionMode::Insert]),
-                UiAction::new("history", "Ctrl+P/N", "History")
-                    .with_compact_key("^P/N")
-                    .with_priority(ActionPriority::Secondary),
-            ];
-            let visible_actions = if self.validation_status.is_some() {
-                &actions[..2]
-            } else {
-                &actions[..]
-            };
-            ActionBar::new(visible_actions)
+            let actions = self.surface_actions();
+            ActionBar::new(&actions)
                 .with_mode(match prompt_mode {
                     Mode::Normal => ActionMode::Normal,
                     Mode::Visual | Mode::VisualLine | Mode::VisualBlock => ActionMode::Visual,
@@ -793,12 +799,12 @@ mod tests {
         composer.draw(&mut buffer).unwrap();
         let insert_status = rendered_row(&buffer, status_y);
         assert!(insert_status.contains("INSERT"), "{insert_status:?}");
-        assert!(insert_status.contains("Enter Send"), "{insert_status:?}");
+        assert!(insert_status.contains("Enter send"), "{insert_status:?}");
         assert!(
-            insert_status.contains("Ctrl+J New line"),
+            insert_status.contains("Ctrl+J new line"),
             "{insert_status:?}"
         );
-        assert!(insert_status.contains("Esc Normal"), "{insert_status:?}");
+        assert!(insert_status.contains("Esc normal"), "{insert_status:?}");
 
         assert_eq!(
             composer.handle_event(&key(KeyCode::Esc, KeyModifiers::NONE)),
@@ -807,10 +813,10 @@ mod tests {
         composer.draw(&mut buffer).unwrap();
         let normal_status = rendered_row(&buffer, status_y);
         assert!(normal_status.contains("NORMAL"), "{normal_status:?}");
-        assert!(normal_status.contains("Enter Send"), "{normal_status:?}");
-        assert!(normal_status.contains("Esc Cancel"), "{normal_status:?}");
+        assert!(normal_status.contains("Enter send"), "{normal_status:?}");
+        assert!(normal_status.contains("Esc cancel"), "{normal_status:?}");
         assert!(!normal_status.contains("Ctrl+Enter"), "{normal_status:?}");
-        assert!(!normal_status.contains("New line"), "{normal_status:?}");
+        assert!(!normal_status.contains("new line"), "{normal_status:?}");
 
         assert_eq!(
             composer.handle_event(&key(KeyCode::Enter, KeyModifiers::NONE)),
@@ -938,7 +944,7 @@ mod tests {
         let status_y = composer.dialog.y + 1 + composer.body_height();
 
         let status = rendered_row(&buffer, status_y);
-        assert!(status.contains("Send"), "{status:?}");
+        assert!(status.contains("send"), "{status:?}");
         assert!(status.contains("Esc"), "{status:?}");
     }
 
@@ -962,9 +968,9 @@ mod tests {
         let status_y = composer.dialog.y + 1 + composer.body_height();
         let status = rendered_row(&buffer, status_y);
 
-        assert!(status.contains("Send"), "{status:?}");
+        assert!(status.contains("send"), "{status:?}");
         assert!(status.contains("Esc"), "{status:?}");
-        assert!(!status.contains("New line"), "{status:?}");
+        assert!(!status.contains("new line"), "{status:?}");
         assert!(!status.contains("^↵"), "{status:?}");
     }
 

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -165,6 +165,10 @@ impl Dialog {
         self.actions = actions;
     }
 
+    pub(crate) fn actions(&self) -> Vec<UiAction> {
+        self.actions.clone()
+    }
+
     /// Keeps responsive footer actions a consistent distance from both borders.
     pub(crate) fn set_action_inset(&mut self, inset: usize) {
         self.action_inset = inset;

--- a/src/ui/hover_info.rs
+++ b/src/ui/hover_info.rs
@@ -158,15 +158,15 @@ impl HoverInfo {
         };
         self.dialog.set_title(Some(title));
         let mut actions =
-            vec![UiAction::new("close", "Esc", "Close").with_priority(ActionPriority::Essential)];
+            vec![UiAction::new("close", "Esc", "close").with_priority(ActionPriority::Essential)];
         if !self.actions.is_empty() {
             actions.push(
-                UiAction::new("open", "Enter", "Open").with_priority(ActionPriority::Essential),
+                UiAction::new("open", "Enter", "open").with_priority(ActionPriority::Essential),
             );
-            actions.push(UiAction::new("actions", "Tab", "Actions"));
+            actions.push(UiAction::new("actions", "Tab", "actions"));
         }
         if self.max_scroll() > 0 {
-            actions.push(UiAction::new("scroll", "↑↓", "Scroll"));
+            actions.push(UiAction::new("scroll", "↑↓", "scroll"));
         }
         self.dialog.set_actions(actions);
     }
@@ -246,6 +246,9 @@ impl HoverInfo {
 }
 
 impl Component for HoverInfo {
+    fn surface_actions(&self) -> Vec<UiAction> {
+        self.dialog.actions()
+    }
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         self.dialog.draw(buffer)?;
 
@@ -710,7 +713,7 @@ mod tests {
 
         assert!(first.contains("The first documentation line"), "{first:?}");
         assert!(last.contains("The final documentation line"), "{last:?}");
-        assert!(footer.contains("Esc Close"), "{footer:?}");
+        assert!(footer.contains("Esc close"), "{footer:?}");
         assert_eq!(buffer.cells[(footer_y + 1) * buffer.width + info.x].c, '└');
         assert_eq!(
             buffer.cells[(footer_y + 1) * buffer.width + info.x + info.width + 1].c,

--- a/src/ui/inline_assist.rs
+++ b/src/ui/inline_assist.rs
@@ -13,8 +13,8 @@ use super::{
     dialog::{BorderStyle, Dialog, SurfaceRole},
     first_prompt_line,
     geometry::{anchored_popup_geometry, anchored_popup_geometry_avoiding_rows},
-    spinner_frame, wrap_text, Component, OverlayLayout, PromptBuffer, ScreenRect,
-    SPINNER_FRAME_INTERVAL_MS,
+    spinner_frame, wrap_text, ActionBar, ActionPriority, Component, OverlayLayout, PromptBuffer,
+    ScreenRect, UiAction, SPINNER_FRAME_INTERVAL_MS,
 };
 
 const MAX_WIDTH: usize = 72;
@@ -40,6 +40,16 @@ pub struct InlineAssistPopup {
 }
 
 impl InlineAssistPopup {
+    fn draw_actions(&self, buffer: &mut RenderBuffer, x: usize, y: usize, width: usize) {
+        ActionBar::new(&self.surface_actions()).render(
+            buffer,
+            x,
+            y,
+            width,
+            &self.theme,
+            &self.style,
+        );
+    }
     pub fn new(editor: &Editor, scope: impl Into<String>, state: InlineAssistPopupState) -> Self {
         let local_anchor = editor.cursor_position();
         let anchor = editor.render_cursor_position().unwrap_or(local_anchor);
@@ -246,6 +256,27 @@ impl InlineAssistPopup {
 }
 
 impl Component for InlineAssistPopup {
+    fn surface_actions(&self) -> Vec<UiAction> {
+        let essential =
+            |id, key, label| UiAction::new(id, key, label).with_priority(ActionPriority::Essential);
+        match &self.state {
+            InlineAssistPopupState::Prompt { .. } => vec![
+                essential("apply", "Enter", "apply"),
+                essential("cancel", "Esc", "cancel"),
+            ],
+            InlineAssistPopupState::Working => vec![essential("cancel", "Esc", "cancel")],
+            InlineAssistPopupState::Applied { edited, .. } => vec![
+                essential("keep", "Enter", "keep"),
+                UiAction::new("undo", "u", if *edited { "undo" } else { "dismiss" }),
+                UiAction::new("refine", "r", "refine"),
+                UiAction::new("agent", "A", "agent"),
+            ],
+            InlineAssistPopupState::Failed(_) => vec![
+                essential("retry", "r", "retry/refine"),
+                essential("close", "Esc", "close"),
+            ],
+        }
+    }
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         self.dialog.draw(buffer)?;
         let x = self.dialog.x.saturating_add(1);
@@ -284,11 +315,11 @@ impl Component for InlineAssistPopup {
                     }
                 }
                 if show_help {
-                    buffer.set_text(
+                    self.draw_actions(
+                        buffer,
                         x,
                         y.saturating_add(self.dialog.height.saturating_sub(1)),
-                        &truncate_display_width("Enter apply · Esc cancel", width),
-                        &self.theme.ui_style.muted,
+                        width,
                     );
                 }
             }
@@ -301,12 +332,7 @@ impl Component for InlineAssistPopup {
                     buffer.set_text(x, y, &truncate_display_width(&message, width), &self.style);
                 }
                 if self.dialog.height > 1 {
-                    buffer.set_text(
-                        x,
-                        y.saturating_add(1),
-                        &truncate_display_width("Esc cancel", width),
-                        &self.theme.ui_style.muted,
-                    );
+                    self.draw_actions(buffer, x, y.saturating_add(1), width);
                 }
             }
             InlineAssistPopupState::Applied { edited, comments } => {
@@ -320,19 +346,7 @@ impl Component for InlineAssistPopup {
                     buffer.set_text(x, y, &truncate_display_width(&message, width), &self.style);
                 }
                 if self.dialog.height > 1 {
-                    buffer.set_text(
-                        x,
-                        y.saturating_add(1),
-                        &truncate_display_width(
-                            if *edited {
-                                "Enter keep · u undo · r refine · A agent"
-                            } else {
-                                "Enter keep · u dismiss · r refine · A agent"
-                            },
-                            width,
-                        ),
-                        &self.theme.ui_style.muted,
-                    );
+                    self.draw_actions(buffer, x, y.saturating_add(1), width);
                 }
             }
             InlineAssistPopupState::Failed(message) => {
@@ -354,11 +368,11 @@ impl Component for InlineAssistPopup {
                     buffer.set_text(x, y.saturating_add(1 + offset), row, &self.style);
                 }
                 if self.dialog.height > 1 {
-                    buffer.set_text(
+                    self.draw_actions(
+                        buffer,
                         x,
                         y.saturating_add(self.dialog.height.saturating_sub(1)),
-                        &truncate_display_width("r retry/refine · Esc close", width),
-                        &self.theme.ui_style.muted,
+                        width,
                     );
                 }
             }

--- a/src/ui/inline_history.rs
+++ b/src/ui/inline_history.rs
@@ -2,7 +2,7 @@
 
 use super::{
     dialog::{BorderStyle, Dialog, SurfaceRole},
-    wrap_text, Component,
+    wrap_text, ActionBar, ActionPriority, Component, UiAction,
 };
 use crate::{
     config::KeyAction,
@@ -60,6 +60,35 @@ impl InlineHistoryPanel {
 }
 
 impl Component for InlineHistoryPanel {
+    fn surface_actions(&self) -> Vec<UiAction> {
+        let essential =
+            |id, key, label| UiAction::new(id, key, label).with_priority(ActionPriority::Essential);
+        if self.confirm_forget {
+            return vec![
+                essential("confirm", "y", "forget conversation"),
+                essential("cancel", "Esc", "cancel"),
+            ];
+        }
+        if self.searching {
+            return vec![
+                essential("done", "Enter", "done"),
+                essential("clear", "Esc", "clear"),
+            ];
+        }
+        vec![
+            UiAction::new("browse", "j/k", "browse"),
+            UiAction::new("turns", "l/h", "turns"),
+            UiAction::new("search", "/", "search"),
+            UiAction::new("workspace", "w", "workspace"),
+            UiAction::new("view", "v", "view"),
+            UiAction::new("continue", "r", "continue"),
+            UiAction::new("recheck", "R", "recheck").with_priority(ActionPriority::Secondary),
+            UiAction::new("resolve", "d", "resolve").with_priority(ActionPriority::Secondary),
+            UiAction::new("forget", "D", "forget…").with_priority(ActionPriority::Secondary),
+            essential("jump", "Enter", "jump"),
+            essential("return", "Esc", "return"),
+        ]
+    }
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         let width = self.width.saturating_sub(2);
         let height = (self.height / 2)
@@ -155,20 +184,23 @@ impl Component for InlineHistoryPanel {
                 &self.theme.ui_style.dialog,
             );
         }
-        let help = if self.confirm_forget {
-            "Forget this entire conversation? y confirm · Esc cancel"
-        } else if self.searching {
-            "Type to search · Enter done · Esc clear"
-        } else {
-            "j/k browse · l/h turns · / search · w workspace · v view · r continue · R recheck · d resolve · D forget · Enter jump · Esc return"
-        };
         if height > 0 {
-            buffer.set_text(
-                1,
-                y + height,
-                &truncate_display_width(help, width),
-                &self.theme.ui_style.muted,
-            );
+            ActionBar::new(&self.surface_actions())
+                .with_context(if self.confirm_forget {
+                    "CONFIRM"
+                } else if self.searching {
+                    "SEARCH"
+                } else {
+                    "HISTORY"
+                })
+                .render(
+                    buffer,
+                    1,
+                    y + height,
+                    width,
+                    &self.theme,
+                    &self.theme.ui_style.dialog,
+                );
         }
         Ok(())
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -30,6 +30,7 @@ mod spinner;
 mod statusline_layout;
 mod whats_new;
 
+pub(crate) use action_bar::ActionMenu;
 pub use action_bar::{
     ActionBar, ActionBarLayout, ActionBarRole, ActionBarSpan, ActionMode, ActionPriority, UiAction,
 };
@@ -76,6 +77,20 @@ use crate::{
 
 pub trait Component: Send {
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()>;
+
+    /// Actions for the surface-local F1 menu. The default keeps passive popups unchanged.
+    fn surface_actions(&self) -> Vec<UiAction> {
+        Vec::new()
+    }
+
+    fn activate_surface_action(&mut self, id: &str) -> Option<KeyAction> {
+        let event = self
+            .surface_actions()
+            .iter()
+            .find(|action| action.id == id && action.enabled)?
+            .event()?;
+        self.handle_event(&event)
+    }
 
     fn tick(&mut self) -> anyhow::Result<bool> {
         Ok(false)

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -39,8 +39,8 @@ use crate::{
 };
 
 use super::{
-    dialog::BorderStyle, first_prompt_line, spinner_frame, Component, Dialog, IconCatalog, List,
-    ScreenRect, SPINNER_FRAME_INTERVAL_MS,
+    dialog::BorderStyle, first_prompt_line, spinner_frame, ActionBar, ActionPriority, Component,
+    Dialog, IconCatalog, List, ScreenRect, UiAction, SPINNER_FRAME_INTERVAL_MS,
 };
 
 type SelectAction = Box<dyn Fn(String) -> Action + Send>;
@@ -366,6 +366,7 @@ struct PickerLayout {
     preview: Option<PickerPreviewLayout>,
     separator_y: usize,
     query_y: usize,
+    action_y: Option<usize>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -1341,6 +1342,8 @@ impl Picker {
     }
 
     fn layout(&self) -> PickerLayout {
+        let action_rows = usize::from(!self.key_actions.is_empty() && self.height >= 6);
+        let action_y = (action_rows > 0).then_some(self.y + self.height.saturating_sub(1));
         let content_y = match self.input_position {
             PickerInputPosition::Top => self.y + 3,
             PickerInputPosition::Bottom => self.y + 1,
@@ -1349,15 +1352,15 @@ impl Picker {
             x: self.x + 1,
             y: content_y,
             width: self.width,
-            height: self.height.saturating_sub(3),
+            height: self.height.saturating_sub(3 + action_rows),
         };
         let separator_y = match self.input_position {
             PickerInputPosition::Top => self.y + 2,
-            PickerInputPosition::Bottom => self.y + self.height.saturating_sub(2),
+            PickerInputPosition::Bottom => self.y + self.height.saturating_sub(2 + action_rows),
         };
         let query_y = match self.input_position {
             PickerInputPosition::Top => self.y + 1,
-            PickerInputPosition::Bottom => self.y + self.height.saturating_sub(1),
+            PickerInputPosition::Bottom => self.y + self.height.saturating_sub(1 + action_rows),
         };
 
         let Some(preview) = self.preview_layout(content) else {
@@ -1366,6 +1369,7 @@ impl Picker {
                 preview: None,
                 separator_y,
                 query_y,
+                action_y,
             };
         };
 
@@ -1401,6 +1405,7 @@ impl Picker {
             preview: Some(preview),
             separator_y,
             query_y,
+            action_y,
         }
     }
 
@@ -3094,6 +3099,23 @@ fn merge_preview_style(base: &Style, syntax: &Style) -> Style {
 }
 
 impl Component for Picker {
+    fn surface_actions(&self) -> Vec<UiAction> {
+        let mut actions = vec![
+            UiAction::new("select", "Enter", "select").with_priority(ActionPriority::Essential)
+        ];
+        actions.extend(self.key_actions.iter().map(|action| {
+            UiAction::new(
+                format!("custom:{}", action.action),
+                action.key.replace("Ctrl-", "Ctrl+").replace("Alt-", "Alt+"),
+                action.label.as_deref().unwrap_or(&action.action),
+            )
+            .with_priority(ActionPriority::Secondary)
+        }));
+        actions.push(
+            UiAction::new("cancel", "Esc", "cancel").with_priority(ActionPriority::Essential),
+        );
+        actions
+    }
     fn tick(&mut self) -> anyhow::Result<bool> {
         let Some(since) = self.busy_since else {
             return Ok(false);
@@ -3312,6 +3334,16 @@ impl Component for Picker {
 
         if let (Some(preview), Some(preview_layout)) = (self.current_preview(), layout.preview) {
             self.draw_preview(buffer, preview.as_ref(), preview_layout)?;
+        }
+        if let Some(y) = layout.action_y {
+            ActionBar::new(&self.surface_actions()).render(
+                buffer,
+                self.x + 1,
+                y,
+                self.width,
+                &self.theme,
+                &self.theme.ui_style.popup,
+            );
         }
 
         Ok(())

--- a/src/ui/statusline_layout.rs
+++ b/src/ui/statusline_layout.rs
@@ -14,12 +14,25 @@ use crate::{
 
 use super::{
     dialog::{BorderStyle, Dialog, SurfaceRole},
-    Component, IconCatalog,
+    ActionPriority, Component, IconCatalog, UiAction,
 };
 
 const WIDE_LAYOUT_MIN_WIDTH: usize = 72;
 const DESIRED_WIDTH: usize = 96;
 const BODY_ROWS: usize = 7;
+
+fn statusline_actions() -> Vec<UiAction> {
+    vec![
+        UiAction::new("focus", "h/l", "focus"),
+        UiAction::new("select", "j/k", "select"),
+        UiAction::new("left", "H", "move left"),
+        UiAction::new("right", "L", "move right"),
+        UiAction::new("reorder", "K/J", "reorder"),
+        UiAction::new("remove", "x", "remove"),
+        UiAction::new("save", "s", "save").with_priority(ActionPriority::Essential),
+        UiAction::new("cancel", "Esc", "cancel").with_priority(ActionPriority::Essential),
+    ]
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Bucket {
@@ -76,10 +89,7 @@ impl StatuslineLayoutPanel {
             &editor.theme,
         )
         .with_surface_theme(&editor.theme, SurfaceRole::Dialog);
-        dialog.set_footer(Some(
-            "h/l focus · j/k select · H left · L right · K/J reorder · x remove · s save · esc cancel"
-                .to_string(),
-        ));
+        dialog.set_actions(statusline_actions());
 
         let original = editor.statusline_config().clone();
         let has_available = StatuslineSection::ALL
@@ -380,6 +390,9 @@ impl StatuslineLayoutPanel {
 }
 
 impl Component for StatuslineLayoutPanel {
+    fn surface_actions(&self) -> Vec<UiAction> {
+        self.dialog.actions()
+    }
     fn set_theme(&mut self, theme: &Theme) {
         self.theme = theme.clone();
         self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);

--- a/src/ui/whats_new.rs
+++ b/src/ui/whats_new.rs
@@ -234,22 +234,22 @@ impl WhatsNewPanel {
             ReleaseView::Changelog => "Highlights",
         };
         let mut actions = vec![
-            UiAction::new("close", "Esc", "Close").with_priority(ActionPriority::Essential),
+            UiAction::new("close", "Esc", "close").with_priority(ActionPriority::Essential),
             UiAction::new("view", "Tab", destination).with_priority(ActionPriority::Essential),
             UiAction::new("github", "o", "GitHub"),
         ];
         if self.max_scroll() > 0 {
             actions.push(
-                UiAction::new("scroll", "j/k", "Scroll").with_priority(ActionPriority::Secondary),
+                UiAction::new("scroll", "j/k", "scroll").with_priority(ActionPriority::Secondary),
             );
         }
         if !self.links.is_empty() {
             if self.links.len() > 1 {
                 actions.push(
-                    UiAction::new("links", "[ ]", "Links").with_priority(ActionPriority::Secondary),
+                    UiAction::new("links", "[/]", "links").with_priority(ActionPriority::Secondary),
                 );
             }
-            actions.push(UiAction::new("link", "Enter", "Open link"));
+            actions.push(UiAction::new("link", "Enter", "open link"));
         }
         self.dialog.set_actions(actions);
         self.dialog
@@ -481,6 +481,9 @@ impl WhatsNewPanel {
 }
 
 impl Component for WhatsNewPanel {
+    fn surface_actions(&self) -> Vec<UiAction> {
+        self.dialog.actions()
+    }
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
         self.dialog.draw(buffer)?;
         self.draw_hero(buffer);
@@ -845,7 +848,7 @@ mod tests {
         let mut buffer = RenderBuffer::new(120, 35, &Style::default());
         panel.draw(&mut buffer).unwrap();
 
-        assert!(rendered_text(&buffer).contains("[ ] Links"));
+        assert!(rendered_text(&buffer).contains("[/] links"));
         assert_eq!(panel.selected_link, Some(0));
 
         panel.handle_event(&Event::Key(crossterm::event::KeyEvent::new(


### PR DESCRIPTION
## Why

One Dark Pro and other themes can omit the diff colors the Git workspace previously expected. That could leave syntax tokens with black backgrounds, while popup-derived styles painted unrelated text-width rectangles. The Git footer also exposed a long, unstructured list of shortcuts that did not reflect the focused pane or current selection.

## Changes

- Add foreground-first surface roles and resolved diff-color fallbacks. Preserve syntax foregrounds, tint complete changed lines, and highlight only replaced words.
- Share the agent-style action strip across Git, text/composer panels, pickers, hover/release notes, inline-assist/history, and the statusline editor. Keep complete shortcuts at narrow widths and expose omitted actions through a surface-local menu.
- Add file filtering, collapsible sections, resizable/hidden file panes, per-file counts, dynamic line-number gutters, and persistent file/hunk context. `M` toggles patch metadata; `L` opens the complete patch.
- Preserve raw patch indices and partial-staging behavior. Cancel stale detail work, expose loading/error/empty states, and bound structured previews to 1,000 lines while retaining full counts and raw patch text.
- Keep large file lists within the plugin budget and make the Git benchmark verify that it actually opened and exercised the workspace.

## How to Test

1. Build with `cargo build --locked --release`. Open a disposable Git repository containing staged and unstaged edits using One Dark Pro, then run `:GitDashboard`. Expect a consistent window background, distinct added/removed rows, syntax colors, aligned file counts, and a persistent file/hunk header.
2. Press `Tab` to focus the diff. Select a replacement with `v` and movement keys, open `?` or `F1`, and choose the scoped stage action. Check `git diff --cached`: only the selected change should be staged. Destructive actions should still require confirmation.
3. In the file pane, use `/` to filter, `Enter` to apply, and `Esc` while editing the filter to clear it. Collapse a section with `C`, resize with `Ctrl-w <` / `Ctrl-w >`, and toggle the file pane with `Ctrl-w o`. Resize to roughly 70 columns; shortcuts should remain complete and overflow should remain usable.
4. Filter to a nonexistent path. Expect “No matching files,” no stale diff, and no unavailable open/stage action. Inspect a patch longer than 1,000 lines: the preview should report its limit, and `L` should open the complete patch. Repeat the clean-state/diff check with GitHub Light.
5. Run the focused regressions and performance check:

```sh
cargo test -p red one_dark_plain_text_and_syntax_keep_the_owning_background
cargo test -p red metadata_folding_preserves_patch_indices_and_local_action_scope
cargo test -p red git_core_detail_bounds_large_previews_and_reports_full_counts
cargo test -p red git_dashboard_renders_numstat_for_a_large_tracked_file_list
python3 scripts/git_workspace_bench.py --files 80 --presses 120
```

## Validation

Validated commit `5068e2c` with the complete workspace/all-targets/all-features test matrix, strict Clippy, and a release build. All 1,520 Red library tests passed. Retained terminal smoke covered One Dark Pro, GitHub Light, partial staging, empty states, narrow layouts, and the full-patch path. The corrected benchmark recorded one Git invocation for 120 rapid file-list keys and zero during diff navigation.