### PR TITLE
feat(window): add reversible pane zoom

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -376,6 +376,7 @@ Esc = { EnterMode = "Normal" }
 ">" = { ResizeWindowRight = 1 }
 "=" = "BalanceWindows"
 "_" = "MaximizeWindow"
+"z" = "TogglePaneZoom"
 "o" = "OnlyWindow"
 
 [keys.normal." "]

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -189,6 +189,9 @@ The command palette includes descriptions, effective keymaps, and accepted
 - `Ctrl-w c` closes a window.
 - `Ctrl-w =` balances editor splits or restores a focused pane's original size.
 - `Ctrl-w _` and `Ctrl-w o` maximize or keep only the current window.
+- `Ctrl-w z` maximizes the focused window or docked pane; press it again to
+  restore the layout. Moving focus or changing the layout restores it first.
+  The same chord zooms the focused file-list or diff pane in Git workspaces.
 - `Space Space`, `Space n`, and `Space p` move through buffers.
 
 ## Command mode

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -905,6 +905,15 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Action::MaximizeWindow,
         ),
         builtin(
+            "window.toggle_zoom",
+            "Maximize/restore pane",
+            "Window",
+            "Toggle a fullscreen view of the focused window or pane",
+            None,
+            &["zoom", "restore"],
+            Action::TogglePaneZoom,
+        ),
+        builtin(
             "lsp.diagnostics",
             "Diagnostics",
             "LSP",
@@ -1239,6 +1248,7 @@ fn action_label(action: &Action) -> String {
         Action::BalanceWindows => "Balance windows".to_string(),
         Action::ResetPanelLayout(_) => "Reset panel layout".to_string(),
         Action::MaximizeWindow => "Maximize window".to_string(),
+        Action::TogglePaneZoom => "Maximize/restore pane".to_string(),
         Action::NextWindow => "Next window".to_string(),
         Action::PreviousWindow => "Previous window".to_string(),
         Action::MoveWindowLeft => "Focus window left".to_string(),
@@ -1416,6 +1426,12 @@ mod tests {
             .shortcuts
             .iter()
             .any(|shortcut| shortcut == "Ctrl-w r"));
+        let zoom = entries
+            .iter()
+            .find(|entry| entry.id == "window.toggle_zoom")
+            .unwrap();
+        assert_eq!(zoom.action, Action::TogglePaneZoom);
+        assert!(zoom.shortcuts.iter().any(|shortcut| shortcut == "Ctrl-w z"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3820,6 +3820,10 @@ groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
             Some(&KeyAction::Single(Action::MaximizeWindow))
         );
         assert_eq!(
+            ctrl_w.get("z"),
+            Some(&KeyAction::Single(Action::TogglePaneZoom))
+        );
+        assert_eq!(
             ctrl_w.get("o"),
             Some(&KeyAction::Single(Action::OnlyWindow))
         );

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -129,7 +129,10 @@ use crate::{
     undo::{AppliedTextEdit, CursorSnapshot, EditOrigin, RevertEdit, TextPosition, TextRange},
     utils::{expand_user_path, get_workspace_path, normalized_file_path, same_file_path},
     whats_new::ReleaseNotes,
-    window::{JumpEntry, JumpList, WindowDivider, WindowId, WindowManager, WindowManagerSnapshot},
+    window::{
+        JumpEntry, JumpList, WindowDivider, WindowId, WindowManager, WindowManagerSnapshot,
+        WindowPresentation,
+    },
 };
 
 use self::display_layout::{
@@ -2517,6 +2520,7 @@ pub enum Action {
     BalanceWindows,
     ResetPanelLayout(Option<String>),
     MaximizeWindow,
+    TogglePaneZoom,
     OnlyWindow,
 }
 
@@ -3015,6 +3019,9 @@ pub struct Editor {
 
     /// Captured dividers moved by directional keys while pane resize mode is active.
     pane_resize_mode: Option<PaneResizeMode>,
+
+    /// Temporary presentation of one live window or docked pane.
+    zoomed_pane: Option<FocusTarget>,
 
     /// Cursor position where the current insert session began.
     insert_entry_cursor: Option<CursorSnapshot>,
@@ -4292,6 +4299,7 @@ impl Editor {
             vx,
             mode: Mode::Normal,
             pane_resize_mode: None,
+            zoomed_pane: None,
             insert_entry_cursor: None,
             generated_indent: None,
             waiting_command: None,
@@ -4589,6 +4597,7 @@ impl Editor {
             return false;
         }
 
+        self.clear_pane_zoom();
         self.sync_to_window();
         self.window_manager.set_active(window_id);
         self.sync_with_window();
@@ -4658,6 +4667,13 @@ impl Editor {
     }
 
     fn focus_target(&mut self, target: &FocusTarget) -> bool {
+        if self
+            .zoomed_pane
+            .as_ref()
+            .is_some_and(|zoomed| zoomed != target)
+        {
+            self.clear_pane_zoom();
+        }
         match target {
             FocusTarget::Panel(id) => {
                 if self.panel_manager.focused_panel_id() == Some(id.as_str()) {
@@ -5150,6 +5166,7 @@ impl Editor {
         &mut self,
         update: impl FnOnce(&mut WindowManager) -> Option<()>,
     ) -> bool {
+        self.clear_pane_zoom();
         self.sync_to_window();
         if update(&mut self.window_manager).is_some() {
             self.sync_with_window();
@@ -5159,8 +5176,78 @@ impl Editor {
         }
     }
 
+    fn clear_pane_zoom(&mut self) -> bool {
+        if self.zoomed_pane.take().is_none() {
+            return false;
+        }
+        self.divider_drag = None;
+        self.pane_resize_mode = None;
+        self.apply_panel_layout();
+        self.force_full_redraw = true;
+        true
+    }
+
+    fn toggle_pane_zoom(&mut self) {
+        if self.clear_pane_zoom() {
+            return;
+        }
+        let Some(target) = self.current_focus_target() else {
+            return;
+        };
+        if matches!(target, FocusTarget::Window(_)) && self.focus_ring().len() <= 1 {
+            return;
+        }
+        self.zoomed_pane = Some(target);
+        self.divider_drag = None;
+        self.pane_resize_mode = None;
+        self.apply_panel_layout();
+        self.force_full_redraw = true;
+    }
+
+    fn clear_replaced_panel_zoom(&mut self, id: &str) {
+        if matches!(&self.zoomed_pane, Some(FocusTarget::Panel(target)) if target == id) {
+            self.clear_pane_zoom();
+        }
+    }
+
+    fn configure_pane_presentation(&mut self, terminal_size: (usize, usize)) {
+        let valid = self.zoomed_pane.as_ref().is_none_or(|target| {
+            self.current_focus_target().as_ref() == Some(target)
+                && match target {
+                    FocusTarget::Window(id) => self.window_manager.window(*id).is_some(),
+                    FocusTarget::Panel(id) => self.panel_manager.is_visible(id),
+                }
+        });
+        if !valid {
+            self.zoomed_pane = None;
+            self.divider_drag = None;
+            self.pane_resize_mode = None;
+            self.force_full_redraw = true;
+        }
+        let (windows, panels) = match &self.zoomed_pane {
+            Some(FocusTarget::Window(id)) => (
+                WindowPresentation::Zoomed(*id),
+                plugin::panel::PanelPresentation::Hidden,
+            ),
+            Some(FocusTarget::Panel(id)) => (
+                WindowPresentation::Hidden,
+                plugin::panel::PanelPresentation::Zoomed {
+                    id: id.clone(),
+                    size: (terminal_size.0, terminal_size.1.saturating_sub(2)),
+                },
+            ),
+            None => (
+                WindowPresentation::All,
+                plugin::panel::PanelPresentation::Docked,
+            ),
+        };
+        self.window_manager.set_presentation(windows);
+        self.panel_manager.set_presentation(panels);
+    }
+
     fn resize_window_layout(&mut self, terminal_size: (usize, usize)) {
         self.sync_to_window();
+        self.configure_pane_presentation(terminal_size);
         let (reserved_left, reserved_right) = self.reserved_panel_widths(terminal_size.0);
         let (reserved_top, reserved_bottom) = self.reserved_panel_heights(terminal_size.1);
         self.window_manager.resize_with_origin(
@@ -5209,23 +5296,13 @@ impl Editor {
     }
 
     fn apply_panel_layout(&mut self) {
-        self.sync_to_window();
-        let (reserved_left, reserved_right) = self.reserved_panel_widths(self.size.0 as usize);
-        let (reserved_top, reserved_bottom) = self.reserved_panel_heights(self.size.1 as usize);
-        self.window_manager.resize_with_origin(
-            Point::new(reserved_left, reserved_top),
-            (
-                (self.size.0 as usize)
-                    .saturating_sub(reserved_left)
-                    .saturating_sub(reserved_right),
-                (self.size.1 as usize)
-                    .saturating_sub(reserved_top)
-                    .saturating_sub(reserved_bottom),
-            ),
-        );
+        self.resize_window_layout((usize::from(self.size.0), usize::from(self.size.1)));
     }
 
     fn reserved_panel_widths(&self, terminal_width: usize) -> (usize, usize) {
+        if matches!(self.zoomed_pane, Some(FocusTarget::Window(_))) {
+            return (0, 0);
+        }
         let max_reserved = terminal_width.saturating_sub(MIN_EDITOR_WINDOW_WIDTH);
         let reserved_left = self.panel_manager.reserved_left_width().min(max_reserved);
         let reserved_right = self
@@ -5236,6 +5313,9 @@ impl Editor {
     }
 
     fn reserved_panel_heights(&self, terminal_height: usize) -> (usize, usize) {
+        if matches!(self.zoomed_pane, Some(FocusTarget::Window(_))) {
+            return (0, 0);
+        }
         let max_reserved = terminal_height.saturating_sub(MIN_EDITOR_WINDOW_HEIGHT);
         let reserved_top = self.panel_manager.reserved_top_height().min(max_reserved);
         let reserved_bottom = self
@@ -9766,6 +9846,7 @@ impl Editor {
                     }
                 }
                 PluginRequest::CreatePanel { id, config } => {
+                    self.clear_replaced_panel_zoom(&id);
                     self.panel_manager.create_panel(id.clone(), config);
                     self.restore_panel_layout(&id);
                     self.panel_manager.apply_pending_shell_restore(&id);
@@ -9782,6 +9863,7 @@ impl Editor {
                     needs_render = true;
                 }
                 PluginRequest::CreateTextPanel { id, config } => {
+                    self.clear_replaced_panel_zoom(&id);
                     self.panel_manager.create_text_panel(id.clone(), config);
                     self.restore_panel_layout(&id);
                     self.panel_manager.apply_pending_shell_restore(&id);
@@ -9876,6 +9958,7 @@ impl Editor {
                     needs_render = true;
                 }
                 PluginRequest::OpenWorkspace { id, config } => {
+                    self.clear_pane_zoom();
                     self.workspace_manager.open(id, config);
                     needs_render = true;
                 }
@@ -13088,6 +13171,7 @@ impl Editor {
             | Action::BalanceWindows
             | Action::ResetPanelLayout(_)
             | Action::MaximizeWindow
+            | Action::TogglePaneZoom
             | Action::OnlyWindow => true,
             Action::PluginCommand(command) => runtime.is_some_and(|runtime| {
                 runtime.command_scope(command).map_or_else(
@@ -16209,6 +16293,37 @@ impl Editor {
         }
 
         let mut add_to_history = tracking;
+        if matches!(
+            action,
+            Action::SplitHorizontal
+                | Action::SplitVertical
+                | Action::SplitHorizontalWithFile(_)
+                | Action::SplitVerticalWithFile(_)
+                | Action::CloseWindow
+                | Action::NextWindow
+                | Action::PreviousWindow
+                | Action::MoveWindowUp
+                | Action::MoveWindowDown
+                | Action::MoveWindowLeft
+                | Action::MoveWindowRight
+                | Action::MoveWindowToLeft
+                | Action::MoveWindowToBottom
+                | Action::MoveWindowToTop
+                | Action::MoveWindowToRight
+                | Action::EnterPaneResizeMode
+                | Action::ResizeWindowUp(_)
+                | Action::ResizeWindowDown(_)
+                | Action::ResizeWindowLeft(_)
+                | Action::ResizeWindowRight(_)
+                | Action::BalanceWindows
+                | Action::ResetPanelLayout(_)
+                | Action::MaximizeWindow
+                | Action::OnlyWindow
+        ) && self.clear_pane_zoom()
+        {
+            self.invalidate_terminal_render_state(buffer);
+            self.render(buffer)?;
+        }
         let action_buffer_id = self.current_buffer().id();
         let action_buffer_revision = self.current_buffer().revision();
         self.lsp_coordinator
@@ -19951,6 +20066,16 @@ impl Editor {
                     self.render(buffer)?;
                 }
             }
+            Action::TogglePaneZoom => {
+                add_to_history = false;
+                if self.workspace_manager.is_active() {
+                    self.workspace_manager.toggle_zoom();
+                } else {
+                    self.toggle_pane_zoom();
+                }
+                self.invalidate_terminal_render_state(buffer);
+                self.render(buffer)?;
+            }
             Action::OnlyWindow => {
                 let panel_ids = self.panel_manager.hide_all_panels();
                 for panel_id in &panel_ids {
@@ -23064,6 +23189,7 @@ impl Editor {
             self.buffer_manager.len() == snapshot.buffers.len(),
             "session buffer count does not match the reconstructed editor"
         );
+        self.clear_pane_zoom();
         let duplicate_file_count = snapshot_duplicate_file_count(snapshot);
         let divergences = detect_disk_divergence(snapshot);
         let buffer_map = snapshot
@@ -23730,6 +23856,7 @@ impl Editor {
             });
         }
 
+        self.clear_pane_zoom();
         let has_panel_restore = !snapshot.panels.panels.is_empty();
         self.panel_manager.stage_restore(snapshot.panels.clone());
         self.panel_manager.apply_pending_to_existing(
@@ -26855,6 +26982,7 @@ impl Editor {
 
     #[doc(hidden)]
     pub fn test_create_panel(&mut self, id: &str, config: plugin::PanelConfig) {
+        self.clear_replaced_panel_zoom(id);
         self.panel_manager.create_panel(id.to_string(), config);
         self.restore_panel_layout(id);
         self.apply_panel_layout();
@@ -26863,6 +26991,7 @@ impl Editor {
 
     #[doc(hidden)]
     pub fn test_create_text_panel(&mut self, id: &str, config: plugin::PanelConfig) {
+        self.clear_replaced_panel_zoom(id);
         self.panel_manager.create_text_panel(id.to_string(), config);
         self.restore_panel_layout(id);
         self.apply_panel_layout();

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1187,6 +1187,13 @@ impl Editor {
         let prepare_span = super::perf::PerfSpan::start("render:prepare");
         self.update_gutter_width();
         self.apply_panel_layout();
+        if self.force_full_redraw {
+            *buffer = RenderBuffer::new(
+                usize::from(self.size.0),
+                usize::from(self.size.1),
+                &self.theme.style,
+            );
+        }
         self.fix_cursor_pos();
         self.check_bounds();
         self.sync_to_window();
@@ -1499,6 +1506,9 @@ impl Editor {
         let Some(window) = window_data else {
             return Ok(());
         };
+        if !self.window_manager.is_presented(window.id) {
+            return Ok(());
+        }
 
         let local_rows = terminal_rows
             .iter()
@@ -1822,6 +1832,9 @@ impl Editor {
     /// recomputed per render; once its conditions fail after it has been
     /// shown, the splash is latched off for the rest of the session.
     fn splash_should_render(&mut self) -> bool {
+        if self.zoomed_pane.is_some() {
+            return false;
+        }
         if self.splash_dismissed {
             return false;
         }
@@ -1880,6 +1893,9 @@ impl Editor {
     fn render_window(&mut self, buffer: &mut RenderBuffer, window_id: usize) -> anyhow::Result<()> {
         // Clone the window data to avoid borrowing issues
         if let Some(window) = self.window_manager.window_at_index(window_id).cloned() {
+            if !self.window_manager.is_presented(window.id) {
+                return Ok(());
+            }
             self.render_window_bar(buffer, &window);
 
             // Render the gutter for this window
@@ -1925,6 +1941,9 @@ impl Editor {
 
     /// Render all window separators based on the split tree
     fn render_all_window_separators(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        if !self.window_manager.presents_dividers() {
+            return Ok(());
+        }
         let separator_style = Style {
             fg: Some(Color::Rgb {
                 r: 100,
@@ -3181,6 +3200,15 @@ impl Editor {
         let right_start =
             draw_statusline_right(buffer, y, term_width, right, &base_style, right_separator);
         draw_statusline_left(buffer, y, right_start, &left, &base_style, left_separator);
+        if self.zoomed_pane.is_some() {
+            let hint = truncate_display_width(" ZOOM · Ctrl-w z ", term_width);
+            buffer.set_text(
+                term_width.saturating_sub(display_width(&hint)),
+                y,
+                &hint,
+                &base_style,
+            );
+        }
     }
 
     fn refresh_statusline_git(&mut self, file: Option<&str>, load_changes: bool) {
@@ -3478,6 +3506,9 @@ impl Editor {
         range: TextRange,
     ) -> Option<(usize, usize)> {
         let window = self.window_manager.window(window_id)?;
+        if !self.window_manager.is_presented(window_id) {
+            return None;
+        }
         let layout = self.layout_for_window(window);
         let last_line = range.end.line.saturating_sub(usize::from(
             range.end.character == 0 && range.end.line > range.start.line,
@@ -4396,6 +4427,38 @@ mod tests {
             .unwrap();
 
         assert!(editor.search_match_cache.is_none());
+    }
+
+    #[test]
+    fn window_zoom_partial_frames_do_not_repaint_hidden_windows() {
+        let config = Config::default();
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let source = Buffer::new(None, "visible-marker\n".to_string());
+        let hidden = Buffer::new(None, "hidden-marker\n".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 80, 24, config, Theme::default(), vec![source, hidden]).unwrap();
+        editor.test_disable_terminal_output();
+        editor.window_manager.split_vertical(1).unwrap();
+        editor.window_manager.set_active(0);
+        editor.sync_with_window();
+        editor.toggle_pane_zoom();
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+        editor.render(&mut buffer).unwrap();
+        editor.render_editor_windows_frame(&mut buffer).unwrap();
+        let content = buffer.cells[..80 * 22]
+            .iter()
+            .map(|cell| cell.text.as_str())
+            .collect::<String>();
+        assert!(content.contains("visible-marker"));
+        assert!(!content.contains("hidden-marker"));
+        assert!(!content.contains('│'));
+        editor.clear_pane_zoom();
+        editor.render(&mut buffer).unwrap();
+        let content = buffer.cells[..80 * 22]
+            .iter()
+            .map(|cell| cell.text.as_str())
+            .collect::<String>();
+        assert!(content.contains("hidden-marker"));
     }
 
     #[test]

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -1659,8 +1659,44 @@ impl PanelSizes {
     }
 }
 
+/// Transient presentation; logical visibility and saved docking remain unchanged.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) enum PanelPresentation {
+    #[default]
+    Docked,
+    Hidden,
+    Zoomed {
+        id: String,
+        size: (usize, usize),
+    },
+}
+
+impl PanelPresentation {
+    fn zoom_size(&self) -> Option<(usize, usize)> {
+        match self {
+            Self::Zoomed { size, .. } => Some(*size),
+            _ => None,
+        }
+    }
+
+    fn width(&self, id: &str, config: &PanelConfig, terminal_width: usize) -> usize {
+        match self {
+            Self::Zoomed { id: target, size } if target == id => size.0,
+            _ => effective_panel_width(config, terminal_width),
+        }
+    }
+
+    fn height(&self, id: &str, config: &PanelConfig, available_height: usize) -> usize {
+        match self {
+            Self::Zoomed { id: target, size } if target == id => size.1,
+            _ => effective_panel_height(config, available_height),
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct PanelManager {
+    presentation: PanelPresentation,
     panels: HashMap<String, PluginPanel>,
     text_panels: HashMap<String, TextPanel>,
     default_layouts: HashMap<String, (PanelSide, usize)>,
@@ -1673,6 +1709,51 @@ pub struct PanelManager {
 }
 
 impl PanelManager {
+    pub(crate) fn set_presentation(&mut self, presentation: PanelPresentation) {
+        if self.presentation == presentation {
+            return;
+        }
+        if let Some((terminal_width, content_height)) = presentation
+            .zoom_size()
+            .or_else(|| self.presentation.zoom_size())
+        {
+            for panel in self.text_panels.values_mut() {
+                let old_width = self
+                    .presentation
+                    .width(&panel.id, &panel.config, terminal_width);
+                let width = presentation.width(&panel.id, &panel.config, terminal_width);
+                let old_height = self
+                    .presentation
+                    .height(&panel.id, &panel.config, content_height);
+                let height = presentation.height(&panel.id, &panel.config, content_height);
+                if (old_width, old_height) == (width, height) {
+                    continue;
+                }
+                if panel.follow_tail {
+                    panel.scroll_to_bottom(height, width);
+                    continue;
+                }
+                // Reflow by source offset, not by a row number from the old width.
+                let old_layout = panel.layout(old_width);
+                let anchor = (panel.scroll..old_layout.lines.len())
+                    .find_map(|row| old_layout.offset_at(row, 0));
+                let layout = panel.layout(width);
+                panel.scroll = anchor
+                    .and_then(|offset| layout.position(offset))
+                    .map_or(0, |(row, _, _)| row);
+                panel.clamp_scroll(height, width);
+                if panel.scrollback.focused {
+                    panel.reveal_scrollback_cursor(&layout, height);
+                }
+            }
+        }
+        self.presentation = presentation;
+    }
+
+    pub(crate) fn is_visible(&self, id: &str) -> bool {
+        self.z_order.iter().any(|candidate| candidate == id) && self.panel_config(id).is_some()
+    }
+
     /// Captures durable, plugin-independent pane state by stable resource ID.
     pub fn snapshot(&self, terminal_width: usize) -> PanelManagerSnapshot {
         let panels = self
@@ -1707,7 +1788,9 @@ impl PanelManager {
                 }
 
                 let panel = self.text_panels.get(&id)?;
-                let width = effective_panel_width(&panel.config, terminal_width);
+                let width = self
+                    .presentation
+                    .width(&panel.id, &panel.config, terminal_width);
                 let layout = panel.layout(width);
                 let scroll_anchor = (!panel.follow_tail).then(|| {
                     (panel.scroll..layout.lines.len())
@@ -1870,8 +1953,12 @@ impl PanelManager {
                 let Some(panel) = self.text_panels.get_mut(id) else {
                     return false;
                 };
-                let width = effective_panel_width(&panel.config, terminal_width);
-                let panel_height = effective_panel_height(&panel.config, panel_height);
+                let width = self
+                    .presentation
+                    .width(&panel.id, &panel.config, terminal_width);
+                let panel_height = self
+                    .presentation
+                    .height(&panel.id, &panel.config, panel_height);
                 if let (Some(composer), Some(saved_composer)) =
                     (panel.composer.as_mut(), saved.composer)
                 {
@@ -1953,8 +2040,12 @@ impl PanelManager {
         terminal_width: usize,
     ) {
         if let Some(panel) = self.text_panels.get_mut(id) {
-            let width = effective_panel_width(&panel.config, terminal_width);
-            let panel_height = effective_panel_height(&panel.config, panel_height);
+            let width = self
+                .presentation
+                .width(&panel.id, &panel.config, terminal_width);
+            let panel_height = self
+                .presentation
+                .height(&panel.id, &panel.config, panel_height);
             panel.update_blocks(blocks, panel_height, width);
         }
     }
@@ -1968,8 +2059,12 @@ impl PanelManager {
         terminal_width: usize,
     ) {
         if let Some(panel) = self.text_panels.get_mut(id) {
-            let width = effective_panel_width(&panel.config, terminal_width);
-            let panel_height = effective_panel_height(&panel.config, panel_height);
+            let width = self
+                .presentation
+                .width(&panel.id, &panel.config, terminal_width);
+            let panel_height = self
+                .presentation
+                .height(&panel.id, &panel.config, panel_height);
             panel.append_delta(block_id, delta, panel_height, width);
         }
     }
@@ -2130,7 +2225,9 @@ impl PanelManager {
         {
             self.focused = Some(id.to_string());
             if let Some(panel) = self.text_panels.get_mut(id) {
-                let width = effective_panel_width(&panel.config, usize::MAX);
+                let width = self
+                    .presentation
+                    .width(&panel.id, &panel.config, usize::MAX);
                 panel.focus_scrollback(width);
             }
             true
@@ -2148,7 +2245,9 @@ impl PanelManager {
 
         self.focused = Some(id.to_string());
         if let Some(panel) = self.text_panels.get_mut(id) {
-            let width = effective_panel_width(&panel.config, usize::MAX);
+            let width = self
+                .presentation
+                .width(&panel.id, &panel.config, usize::MAX);
             panel.restore_focused_region(width);
         }
         true
@@ -2286,8 +2385,12 @@ impl PanelManager {
     ) -> Option<PanelEvent> {
         let focused = self.focused.clone()?;
         if let Some(panel) = self.text_panels.get_mut(&focused) {
-            let width = effective_panel_width(&panel.config, terminal_width);
-            let panel_height = effective_panel_height(&panel.config, panel_height);
+            let width = self
+                .presentation
+                .width(&panel.id, &panel.config, terminal_width);
+            let panel_height = self
+                .presentation
+                .height(&panel.id, &panel.config, panel_height);
             match action {
                 "up" => panel.move_scroll(-1, panel_height, width),
                 "down" => panel.move_scroll(1, panel_height, width),
@@ -2318,6 +2421,9 @@ impl PanelManager {
             });
         }
         let panel = self.panels.get_mut(&focused)?;
+        let panel_height = self
+            .presentation
+            .height(&panel.id, &panel.config, panel_height);
 
         match action {
             "up" => panel.move_selection(-1, panel_height),
@@ -2353,8 +2459,12 @@ impl PanelManager {
         let Event::Key(key) = event else {
             return None;
         };
-        let width = effective_panel_width(&panel.config, terminal_width);
-        let panel_height = effective_panel_height(&panel.config, panel_height);
+        let width = self
+            .presentation
+            .width(&panel.id, &panel.config, terminal_width);
+        let panel_height = self
+            .presentation
+            .height(&panel.id, &panel.config, panel_height);
 
         if let Some(pending) = panel.scrollback.pending_find.take() {
             if key.code == KeyCode::Esc {
@@ -2511,8 +2621,12 @@ impl PanelManager {
     ) -> Option<PanelEvent> {
         let action = if delta < 0 { "up" } else { "down" };
         if let Some(panel) = self.text_panels.get_mut(id) {
-            let width = effective_panel_width(&panel.config, terminal_width);
-            let panel_height = effective_panel_height(&panel.config, panel_height);
+            let width = self
+                .presentation
+                .width(&panel.id, &panel.config, terminal_width);
+            let panel_height = self
+                .presentation
+                .height(&panel.id, &panel.config, panel_height);
             panel.move_scroll(delta, panel_height, width);
             if panel.scrollback.focused {
                 let layout = panel.layout(width);
@@ -2562,8 +2676,12 @@ impl PanelManager {
         let Some(panel) = self.text_panels.get_mut(&focused) else {
             return false;
         };
-        let width = effective_panel_width(&panel.config, terminal_width);
-        let panel_height = effective_panel_height(&panel.config, panel_height);
+        let width = self
+            .presentation
+            .width(&panel.id, &panel.config, terminal_width);
+        let panel_height = self
+            .presentation
+            .height(&panel.id, &panel.config, panel_height);
         if let Some(composer) = panel.composer.as_mut() {
             composer.focused = false;
         }
@@ -2577,7 +2695,9 @@ impl PanelManager {
         let Some(panel) = self.text_panels.get_mut(&focused) else {
             return false;
         };
-        let width = effective_panel_width(&panel.config, terminal_width);
+        let width = self
+            .presentation
+            .width(&panel.id, &panel.config, terminal_width);
         panel.focus_scrollback(width);
         true
     }
@@ -2587,7 +2707,9 @@ impl PanelManager {
         terminal_width: usize,
     ) -> Option<TextPanelLinkTarget> {
         let panel = self.text_panels.get(self.focused.as_deref()?)?;
-        let width = effective_panel_width(&panel.config, terminal_width);
+        let width = self
+            .presentation
+            .width(&panel.id, &panel.config, terminal_width);
         if panel.scrollback.focused {
             panel.layout(width).link_at(panel.scrollback.cursor)
         } else {
@@ -2750,7 +2872,9 @@ impl PanelManager {
     ) -> Option<PanelEvent> {
         let focused = self.focused.clone()?;
         let panel = self.text_panels.get_mut(&focused)?;
-        let panel_width = effective_panel_width(&panel.config, terminal_width);
+        let panel_width = self
+            .presentation
+            .width(&panel.id, &panel.config, terminal_width);
         let composer = panel.composer.as_mut()?;
         if !composer.focused || !composer.enabled {
             return None;
@@ -3119,6 +3243,9 @@ impl PanelManager {
         terminal_width: usize,
         terminal_height: usize,
     ) -> Option<PanelDivider> {
+        if self.presentation != PanelPresentation::Docked {
+            return None;
+        }
         if x >= terminal_width || y >= terminal_height.saturating_sub(2) {
             return None;
         }
@@ -3162,6 +3289,23 @@ impl PanelManager {
         terminal_width: usize,
         terminal_height: usize,
     ) -> Vec<PanelPlacement> {
+        match &self.presentation {
+            PanelPresentation::Hidden => return Vec::new(),
+            PanelPresentation::Zoomed { id, .. } => {
+                return self
+                    .is_visible(id)
+                    .then(|| PanelPlacement {
+                        id: id.clone(),
+                        x: 0,
+                        y: 0,
+                        width: terminal_width,
+                        height: terminal_height.saturating_sub(2),
+                    })
+                    .into_iter()
+                    .collect();
+            }
+            PanelPresentation::Docked => {}
+        }
         let mut placements = Vec::new();
         let mut left_x: usize = 0;
         let mut right_x = terminal_width;
@@ -3274,15 +3418,17 @@ impl PanelManager {
             } else {
                 " "
             };
-            render_panel_separator(
-                buffer,
-                position,
-                placement.width,
-                placement.height,
-                config.side,
-                &border_style,
-                separator,
-            );
+            if self.presentation == PanelPresentation::Docked {
+                render_panel_separator(
+                    buffer,
+                    position,
+                    placement.width,
+                    placement.height,
+                    config.side,
+                    &border_style,
+                    separator,
+                );
+            }
 
             if let Some(panel) = self.panels.get(&placement.id) {
                 render_panel_at(
@@ -4372,6 +4518,114 @@ mod tests {
         let position = text_position(buffer, needle)
             .unwrap_or_else(|| panic!("missing rendered text {needle:?}"));
         &buffer.cells[position.y * buffer.width + position.x].style
+    }
+
+    #[test]
+    fn pane_zoom_reflows_scrollback_without_losing_its_source_cursor() {
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "text".to_string(),
+            PanelConfig {
+                width: 18,
+                ..PanelConfig::default()
+            },
+        );
+        manager.update_text_panel(
+            "text",
+            vec![TextPanelBlock {
+                id: "answer".to_string(),
+                kind: TextPanelBlockKind::Text,
+                format: TextPanelBlockFormat::Plain,
+                text: "word ".repeat(180),
+            }],
+            22,
+            100,
+        );
+        assert!(manager.focus_panel("text"));
+        let panel = manager.text_panels.get_mut("text").unwrap();
+        let cursor = panel.layout(18).offset_at(15, 0).unwrap();
+        panel.scrollback.cursor = cursor;
+        panel.scrollback.selection_anchor = Some(cursor.saturating_sub(2));
+        panel.scrollback.mode = TextPanelScrollbackMode::Visual;
+        panel.scroll = 12;
+        panel.follow_tail = false;
+        panel.viewport.restore(12, false);
+
+        manager.set_presentation(PanelPresentation::Zoomed {
+            id: "text".to_string(),
+            size: (100, 22),
+        });
+        assert!(manager
+            .focused_text_panel_cursor_position(100, 24)
+            .is_some());
+        manager.append_text_panel("text", "answer", "more words", 22, 100);
+        manager.set_presentation(PanelPresentation::Docked);
+        let panel = &manager.text_panels["text"];
+        assert_eq!(panel.scrollback.cursor, cursor);
+        assert_eq!(
+            panel.scrollback.selection_anchor,
+            Some(cursor.saturating_sub(2))
+        );
+        assert!(!panel.follow_tail);
+        assert!(manager
+            .focused_text_panel_cursor_position(100, 24)
+            .is_some());
+    }
+
+    #[test]
+    fn pane_zoom_preserves_docking_and_uses_one_fullscreen_placement() {
+        for side in [
+            PanelSide::Left,
+            PanelSide::Right,
+            PanelSide::Top,
+            PanelSide::Bottom,
+        ] {
+            for text in [false, true] {
+                let mut manager = PanelManager::default();
+                manager.create_panel("other".to_string(), PanelConfig::default());
+                let config = PanelConfig {
+                    side,
+                    width: 12,
+                    ..PanelConfig::default()
+                };
+                if text {
+                    manager.create_text_panel("target".to_string(), config);
+                } else {
+                    manager.create_panel("target".to_string(), config);
+                }
+                assert!(manager.focus_panel("target"));
+                let before = manager.snapshot(80);
+                let placements = manager.panel_placements(80, 24);
+                manager.set_presentation(PanelPresentation::Zoomed {
+                    id: "target".to_string(),
+                    size: (80, 22),
+                });
+                assert_eq!(
+                    manager.panel_placements(80, 24),
+                    vec![PanelPlacement {
+                        id: "target".to_string(),
+                        x: 0,
+                        y: 0,
+                        width: 80,
+                        height: 22,
+                    }]
+                );
+                assert_eq!(
+                    manager.panel_at_position(79, 21, 80, 24).unwrap().id,
+                    "target"
+                );
+                assert!(manager.panel_divider_at_position(12, 4, 80, 24).is_none());
+                let config = manager.panel_config("target").unwrap();
+                assert_eq!(manager.presentation.width("target", config, 80), 80);
+                assert_eq!(manager.presentation.height("target", config, 22), 22);
+                assert_eq!(manager.snapshot(80), before);
+                manager.set_presentation(PanelPresentation::Hidden);
+                assert!(manager.panel_at_position(0, 0, 80, 24).is_none());
+                manager.set_presentation(PanelPresentation::Docked);
+                assert_eq!(manager.panel_placements(80, 24), placements);
+                assert_eq!(manager.snapshot(80), before);
+            }
+        }
     }
 
     #[test]

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -194,6 +194,14 @@ impl WorkspaceLayout {
             width,
             height: height.saturating_sub(3),
         };
+        if let Some(focus) = workspace.zoomed {
+            return Self {
+                mode: WorkspaceLayoutMode::Focused,
+                rows: (focus == WorkspaceFocus::Rows).then_some(body),
+                detail: (focus == WorkspaceFocus::Detail).then_some(body),
+                separator: None,
+            };
+        }
         if workspace.rows_hidden && workspace.model.detail_document.is_some() {
             return Self {
                 mode: WorkspaceLayoutMode::Focused,
@@ -358,6 +366,7 @@ pub struct PluginWorkspace {
     selected: usize,
     scroll: usize,
     focus: WorkspaceFocus,
+    zoomed: Option<WorkspaceFocus>,
     detail_cursor: usize,
     detail_scroll: usize,
     detail_horizontal: usize,
@@ -388,6 +397,7 @@ impl PluginWorkspace {
             selected: 0,
             scroll: 0,
             focus: WorkspaceFocus::Rows,
+            zoomed: None,
             detail_cursor: 0,
             detail_scroll: 0,
             detail_horizontal: 0,
@@ -422,6 +432,9 @@ impl PluginWorkspace {
     ) {
         if model.detail_document.is_none() {
             self.focus = WorkspaceFocus::Rows;
+            if self.zoomed == Some(WorkspaceFocus::Detail) {
+                self.zoomed = None;
+            }
             self.detail_selection_anchor = None;
         }
         let selected_id = self
@@ -857,9 +870,6 @@ impl PluginWorkspace {
             self.action_menu.open();
             return self.event("noop".to_string());
         }
-        let layout = WorkspaceLayout::calculate(self, height, width);
-        let visible_rows = layout.visible_rows(self.focus);
-
         if let Some(prefix) = self.key_prefix.take() {
             action = match (prefix.as_str(), action.as_str()) {
                 ("ctrl_w", "w" | "ctrl_w") => "focus_next",
@@ -867,6 +877,7 @@ impl PluginWorkspace {
                 ("ctrl_w", "h") => "focus_rows",
                 ("ctrl_w", "l") => "focus_detail",
                 ("ctrl_w", "o") => "toggle_rows",
+                ("ctrl_w", "z") => "toggle_zoom",
                 ("ctrl_w", "<") => "narrow_rows",
                 ("ctrl_w", ">") => "widen_rows",
                 ("ctrl_w", "c" | "q") => "escape",
@@ -916,8 +927,26 @@ impl PluginWorkspace {
             .to_string();
         }
 
+        if matches!(
+            action.as_str(),
+            "toggle"
+                | "back_toggle"
+                | "focus_next"
+                | "focus_previous"
+                | "focus_rows"
+                | "focus_detail"
+                | "toggle_rows"
+                | "narrow_rows"
+                | "widen_rows"
+        ) {
+            self.zoomed = None;
+        }
+        let layout = WorkspaceLayout::calculate(self, height, width);
+        let visible_rows = layout.visible_rows(self.focus);
+
         match action.as_str() {
             "filter" => self.filtering = true,
+            "toggle_zoom" => self.toggle_zoom(),
             "collapse_section" => {
                 self.toggle_section();
                 action = "filter_changed".to_string();
@@ -1059,6 +1088,15 @@ impl PluginWorkspace {
         self.event(action)
     }
 
+    fn toggle_zoom(&mut self) {
+        self.zoomed = if self.zoomed.is_some() {
+            None
+        } else {
+            Some(self.focus)
+        };
+        self.dragging_separator = false;
+    }
+
     fn actions(&self) -> Vec<UiAction> {
         if self.filtering {
             return vec![
@@ -1190,6 +1228,7 @@ fn is_core_detail_interaction(focus: WorkspaceFocus, action: &str) -> bool {
             | "focus_detail"
             | "filter"
             | "toggle_rows"
+            | "toggle_zoom"
             | "narrow_rows"
             | "widen_rows"
     ) || (focus == WorkspaceFocus::Detail
@@ -1288,6 +1327,12 @@ impl WorkspaceManager {
 
     pub fn is_active(&self) -> bool {
         self.active.is_some()
+    }
+
+    pub(crate) fn toggle_zoom(&mut self) {
+        if let Some(workspace) = self.active.as_mut() {
+            workspace.toggle_zoom();
+        }
     }
 
     pub fn is_filtering(&self) -> bool {
@@ -1400,7 +1445,12 @@ impl WorkspaceManager {
             return;
         }
 
-        let title = format!(" {} ", workspace.config.title);
+        let zoom_hint = if workspace.zoomed.is_some() {
+            " · ZOOM · Ctrl-w z"
+        } else {
+            ""
+        };
+        let title = format!(" {}{} ", workspace.config.title, zoom_hint);
         buffer.set_text(
             1,
             0,
@@ -2473,6 +2523,53 @@ mod tests {
         assert!(detail.contains("src/main.rs"));
         assert!(detail.contains("wrap"));
         assert!(detail.contains("let first = true"));
+    }
+
+    #[test]
+    fn workspace_zoom_restores_responsive_layout_and_preferences() {
+        let theme = Theme::default();
+        let mut workspace = PluginWorkspace::new(
+            "git".to_string(),
+            WorkspaceConfig {
+                notify_detail_navigation: false,
+                ..WorkspaceConfig::default()
+            },
+        );
+        workspace.update(model_with_document(), &theme);
+        workspace.rows_width = Some(31);
+        for (width, height) in [(120, 28), (80, 24), (60, 12)] {
+            for focus in [WorkspaceFocus::Rows, WorkspaceFocus::Detail] {
+                workspace.focus = focus;
+                let normal = WorkspaceLayout::calculate(&workspace, height, width);
+                workspace.handle_action("ctrl_w".to_string(), height, width);
+                let event = workspace.handle_action("z".to_string(), height, width);
+                assert_eq!(event.action, "toggle_zoom");
+                assert!(!event.notify_plugin);
+                let zoomed = WorkspaceLayout::calculate(&workspace, height, width);
+                assert_eq!(zoomed.pane(focus).unwrap().width, width);
+                assert_eq!(zoomed.pane(focus).unwrap().height, height - 3);
+                assert!(zoomed.separator.is_none());
+                assert_eq!(workspace.rows_width, Some(31));
+                workspace.handle_action("toggle_zoom".to_string(), height, width);
+                assert_eq!(
+                    WorkspaceLayout::calculate(&workspace, height, width),
+                    normal
+                );
+            }
+        }
+        workspace.rows_hidden = true;
+        workspace.focus = WorkspaceFocus::Detail;
+        workspace.toggle_zoom();
+        workspace.toggle_zoom();
+        assert!(workspace.rows_hidden);
+        workspace.toggle_zoom();
+        workspace.handle_action("focus_rows".to_string(), 24, 120);
+        assert_eq!(workspace.zoomed, None);
+        assert_eq!(workspace.focus, WorkspaceFocus::Rows);
+        workspace.focus = WorkspaceFocus::Detail;
+        workspace.toggle_zoom();
+        workspace.update(WorkspaceModel::default(), &theme);
+        assert_eq!(workspace.zoomed, None);
     }
 
     #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -548,6 +548,45 @@ mod tests {
     }
 
     #[test]
+    fn window_zoom_preserves_nested_layout_and_stable_ids() {
+        let mut manager = nested_window_manager();
+        manager.resize_window(Direction::Right, 3);
+        let before = manager.snapshot();
+        let ids = manager
+            .windows()
+            .iter()
+            .map(|window| window.id)
+            .collect::<Vec<_>>();
+        let target = manager.active_stable_window_id().unwrap();
+
+        manager.set_presentation(WindowPresentation::Zoomed(target));
+        manager.resize_with_origin(Point::new(0, 0), (120, 32));
+        assert_eq!(manager.active_window().unwrap().size, (120, 30));
+        assert_eq!(manager.window_at_position(0, 0).unwrap().1.id, target);
+        assert!(manager.divider_at_position(39, 4).is_none());
+        assert_eq!(manager.snapshot(), before);
+
+        manager.resize((100, 26));
+        assert_eq!(manager.active_window().unwrap().size, (100, 24));
+        manager.set_presentation(WindowPresentation::All);
+        manager.resize((100, 26));
+        assert!(manager.active_window().unwrap().size.0 < 100);
+        assert_eq!(manager.snapshot(), before);
+        assert_eq!(
+            manager
+                .windows()
+                .iter()
+                .map(|window| window.id)
+                .collect::<Vec<_>>(),
+            ids
+        );
+
+        manager.set_presentation(WindowPresentation::Hidden);
+        assert!(manager.window_at_position(0, 0).is_none());
+        assert!(!manager.is_presented(target));
+    }
+
+    #[test]
     fn maximize_window_expands_active_window() {
         let mut manager = WindowManager::new(0, (80, 26));
         manager.split_vertical(0).unwrap();
@@ -1105,6 +1144,15 @@ impl Split {
     }
 }
 
+/// Which live windows participate in the current terminal presentation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum WindowPresentation {
+    #[default]
+    All,
+    Zoomed(WindowId),
+    Hidden,
+}
+
 /// Manages windows and their layout
 pub struct WindowManager {
     /// The root of the split tree
@@ -1112,6 +1160,7 @@ pub struct WindowManager {
 
     /// Currently active window ID (index in the windows list)
     active_window_id: usize,
+    presentation: WindowPresentation,
 }
 
 impl WindowManager {
@@ -1132,6 +1181,7 @@ impl WindowManager {
         Self {
             root,
             active_window_id: 0,
+            presentation: WindowPresentation::All,
         }
     }
 
@@ -1161,6 +1211,7 @@ impl WindowManager {
         let mut manager = Self {
             root,
             active_window_id: 0,
+            presentation: WindowPresentation::All,
         };
         let window_count = manager.root.windows().len();
         if window_count == 0 {
@@ -1295,6 +1346,22 @@ impl WindowManager {
         self.root.windows_mut()
     }
 
+    pub(crate) fn set_presentation(&mut self, presentation: WindowPresentation) {
+        self.presentation = presentation;
+    }
+
+    pub(crate) fn is_presented(&self, id: WindowId) -> bool {
+        match self.presentation {
+            WindowPresentation::All => true,
+            WindowPresentation::Zoomed(target) => target == id,
+            WindowPresentation::Hidden => false,
+        }
+    }
+
+    pub(crate) fn presents_dividers(&self) -> bool {
+        self.presentation == WindowPresentation::All
+    }
+
     /// Updates the layout when terminal is resized
     pub fn resize(&mut self, terminal_size: (usize, usize)) {
         self.resize_with_origin(Point::new(0, 0), terminal_size);
@@ -1302,10 +1369,17 @@ impl WindowManager {
 
     /// Recomputes layout under an explicit terminal origin.
     pub fn resize_with_origin(&mut self, position: Point, terminal_size: (usize, usize)) {
-        self.root.layout(
-            position,
-            (terminal_size.0, terminal_size.1.saturating_sub(2)),
-        );
+        let size = (terminal_size.0, terminal_size.1.saturating_sub(2));
+        self.root.layout(position, size);
+        if let WindowPresentation::Zoomed(id) = self.presentation {
+            if let Some(index) = self.window_index(id) {
+                if let Some(window) = Self::get_window_mut_recursive(&mut self.root, &mut 0, index)
+                {
+                    window.position = position;
+                    window.size = size;
+                }
+            }
+        }
     }
 
     /// Sets the active window by ID
@@ -1328,12 +1402,15 @@ impl WindowManager {
             .windows()
             .iter()
             .enumerate()
-            .find(|(_, w)| w.contains_position(x, y))
+            .find(|(_, w)| self.is_presented(w.id) && w.contains_position(x, y))
             .map(|(id, w)| (id, *w))
     }
 
     /// Finds the split divider actually painted at a terminal-cell position.
     pub(crate) fn divider_at_position(&self, x: usize, y: usize) -> Option<WindowDivider> {
+        if !self.presents_dividers() {
+            return None;
+        }
         let (origin, size) = self.layout_geometry()?;
         let mut path = Vec::new();
         Self::find_divider(&self.root, origin, size, x, y, &mut path)
@@ -1341,6 +1418,9 @@ impl WindowManager {
 
     /// Resolves a captured divider against the current split-tree geometry.
     pub(crate) fn divider_span(&self, divider: &WindowDivider) -> Option<DividerSpan> {
+        if !self.presents_dividers() {
+            return None;
+        }
         let (origin, size) = self.layout_geometry()?;
         Self::find_divider_span(&self.root, origin, size, &divider.path, divider.axis)
     }

--- a/tests/window_zoom.rs
+++ b/tests/window_zoom.rs
@@ -1,0 +1,274 @@
+mod common;
+
+use common::EditorHarness;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use red::{
+    buffer::Buffer,
+    config::Config,
+    editor::{Action, Mode, Point},
+    plugin::{
+        PanelConfig, PanelSide, TextPanelBlock, TextPanelBlockFormat, TextPanelBlockKind,
+        TextPanelComposerConfig,
+    },
+};
+
+fn harness() -> EditorHarness {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    EditorHarness::with_config(
+        Buffer::new(None, "editor-only-marker\n".to_string()),
+        config,
+    )
+}
+
+async fn key(harness: &mut EditorHarness, code: KeyCode, modifiers: KeyModifiers) {
+    harness
+        .execute_event(Event::Key(KeyEvent::new(code, modifiers)))
+        .await
+        .unwrap();
+}
+
+async fn chord(harness: &mut EditorHarness, key_name: char) {
+    key(harness, KeyCode::Char('w'), KeyModifiers::CONTROL).await;
+    key(harness, KeyCode::Char(key_name), KeyModifiers::NONE).await;
+}
+
+fn content(harness: &mut EditorHarness, height: usize) -> String {
+    (0..height)
+        .map(|y| harness.render_row(y).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn block(text: &str) -> TextPanelBlock {
+    TextPanelBlock {
+        id: "answer".to_string(),
+        kind: TextPanelBlockKind::Agent,
+        format: TextPanelBlockFormat::Plain,
+        text: text.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn window_zoom_restores_nested_splits_and_docked_panes() {
+    let mut editor = harness();
+    editor.execute_action(Action::SplitVertical).await.unwrap();
+    editor
+        .execute_action(Action::SplitHorizontal)
+        .await
+        .unwrap();
+    editor
+        .execute_action(Action::ResizeWindowUp(2))
+        .await
+        .unwrap();
+    editor.editor.test_create_panel(
+        "tree",
+        PanelConfig {
+            title: Some("tree-only-marker".to_string()),
+            width: 20,
+            ..PanelConfig::default()
+        },
+    );
+    let bounds = editor.editor.test_active_window_bounds();
+    let before = editor.editor.test_session_snapshot();
+
+    chord(&mut editor, 'z').await;
+    assert_eq!(
+        editor.editor.test_active_window_bounds(),
+        Some((Point::new(0, 0), (80, 22)))
+    );
+    assert!(editor.statusline_row().contains("ZOOM"));
+    assert_eq!(editor.editor.test_window_count(), 3);
+    assert!(!content(&mut editor, 22).contains("tree-only-marker"));
+    let during = editor.editor.test_session_snapshot();
+    assert_eq!(during.window_layout, before.window_layout);
+    assert_eq!(during.panels, before.panels);
+
+    chord(&mut editor, 'z').await;
+    assert_eq!(editor.editor.test_active_window_bounds(), bounds);
+    assert!(!editor.statusline_row().contains("ZOOM"));
+    assert!(content(&mut editor, 22).contains("tree-only-marker"));
+    assert_eq!(
+        editor.editor.test_session_snapshot().window_layout,
+        before.window_layout
+    );
+}
+
+#[tokio::test]
+async fn window_zoom_survives_resize_and_restores_before_layout_changes() {
+    let mut editor = harness();
+    editor.execute_action(Action::SplitVertical).await.unwrap();
+    let before = editor.editor.test_session_snapshot().window_layout;
+    chord(&mut editor, 'z').await;
+    editor.execute_event(Event::Resize(100, 30)).await.unwrap();
+    assert_eq!(
+        editor.editor.test_active_window_bounds(),
+        Some((Point::new(0, 0), (100, 28)))
+    );
+    chord(&mut editor, 'z').await;
+    assert_eq!(editor.editor.test_session_snapshot().window_layout, before);
+    assert!(editor.editor.test_active_window_bounds().unwrap().1 .0 < 100);
+
+    for action in [
+        Action::NextWindow,
+        Action::BalanceWindows,
+        Action::ResizeWindowLeft(1),
+        Action::SplitHorizontal,
+    ] {
+        chord(&mut editor, 'z').await;
+        assert!(editor.statusline_row().contains("ZOOM"));
+        editor.execute_action(action).await.unwrap();
+        assert!(!editor.statusline_row().contains("ZOOM"));
+    }
+    chord(&mut editor, 'z').await;
+    editor.execute_action(Action::CloseWindow).await.unwrap();
+    assert!(!editor.statusline_row().contains("ZOOM"));
+}
+
+#[tokio::test]
+async fn pane_zoom_covers_all_dock_edges_and_preserves_saved_layout() {
+    for side in [
+        PanelSide::Left,
+        PanelSide::Right,
+        PanelSide::Top,
+        PanelSide::Bottom,
+    ] {
+        for text in [false, true] {
+            let mut editor = harness();
+            let config = PanelConfig {
+                side,
+                width: 12,
+                title: Some("pane-only-marker".to_string()),
+                ..PanelConfig::default()
+            };
+            if text {
+                editor.editor.test_create_text_panel("target", config);
+                editor
+                    .editor
+                    .test_update_text_panel("target", vec![block("stream contents")]);
+            } else {
+                editor.editor.test_create_panel("target", config);
+            }
+            assert!(editor.editor.test_focus_panel("target"));
+            editor.execute_action(Action::Refresh).await.unwrap();
+            let before = editor.editor.test_session_snapshot();
+            chord(&mut editor, 'z').await;
+            assert!(editor.statusline_row().contains("ZOOM"));
+            let screen = content(&mut editor, 22);
+            assert!(screen.contains("pane-only-marker"));
+            assert!(!screen.contains("editor-only-marker"));
+            assert_eq!(editor.editor.test_panel_layout("target"), Some((side, 12)));
+            chord(&mut editor, 'z').await;
+            let after = editor.editor.test_session_snapshot();
+            assert_eq!(after.window_layout, before.window_layout);
+            assert_eq!(after.panels.panels[0].side, before.panels.panels[0].side);
+            assert_eq!(
+                after.panels.panels[0].vertical_size,
+                before.panels.panels[0].vertical_size
+            );
+            assert_eq!(
+                after.panels.panels[0].horizontal_size,
+                before.panels.panels[0].horizontal_size
+            );
+            assert_eq!(editor.editor.test_focused_panel_id(), Some("target"));
+        }
+    }
+}
+
+#[tokio::test]
+async fn agent_pane_zoom_preserves_draft_stream_and_composer_focus() {
+    let mut editor = harness();
+    editor.editor.test_create_text_panel(
+        "agent",
+        PanelConfig {
+            side: PanelSide::Right,
+            width: 25,
+            title: Some("Agent".to_string()),
+            composer: Some(TextPanelComposerConfig {
+                placeholder: "Ask".to_string(),
+                rows: 3,
+            }),
+            ..PanelConfig::default()
+        },
+    );
+    assert!(editor.editor.test_focus_text_panel_composer("agent"));
+    editor
+        .execute_event(Event::Paste("draft survives zoom".to_string()))
+        .await
+        .unwrap();
+    chord(&mut editor, 'z').await;
+    editor
+        .editor
+        .test_update_text_panel("agent", vec![block("stream arrived while zoomed")]);
+    let cursor = editor.editor.test_render_cursor_position().unwrap();
+    assert!(cursor.0 < 80 && cursor.1 < 22);
+    assert!(content(&mut editor, 22).contains("stream arrived while zoomed"));
+    chord(&mut editor, 'z').await;
+    let saved = editor.editor.test_session_snapshot().panels;
+    let agent = saved
+        .panels
+        .iter()
+        .find(|panel| panel.id == "agent")
+        .unwrap();
+    assert_eq!(
+        agent.text.as_ref().unwrap().composer.as_ref().unwrap().text,
+        "draft survives zoom"
+    );
+    assert_eq!(editor.editor.test_focused_panel_id(), Some("agent"));
+    assert!(editor.editor.test_render_cursor_position().is_some());
+
+    chord(&mut editor, 'z').await;
+    editor.editor.test_close_panel("agent");
+    editor.execute_action(Action::Refresh).await.unwrap();
+    assert!(!editor.statusline_row().contains("ZOOM"));
+    assert!(content(&mut editor, 22).contains("editor-only-marker"));
+}
+
+#[tokio::test]
+async fn window_zoom_keeps_edits_and_leaves_legacy_commands_intact() {
+    let mut editor = harness();
+    chord(&mut editor, 'z').await;
+    assert!(!editor.statusline_row().contains("ZOOM"));
+    editor.execute_action(Action::SplitVertical).await.unwrap();
+    chord(&mut editor, 'z').await;
+    editor
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    editor
+        .execute_action(Action::InsertString("new ".to_string()))
+        .await
+        .unwrap();
+    editor
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    chord(&mut editor, 'z').await;
+    assert!(editor.buffer_contents().contains("new "));
+    let ordinary_width = editor.editor.test_active_window_bounds().unwrap().1 .0;
+    chord(&mut editor, '_').await;
+    assert!(editor.editor.test_active_window_bounds().unwrap().1 .0 > ordinary_width);
+    assert!(!editor.statusline_row().contains("ZOOM"));
+    chord(&mut editor, 'o').await;
+    assert_eq!(editor.editor.test_window_count(), 1);
+}
+
+#[tokio::test]
+async fn window_zoom_is_cleared_by_session_restore_and_panel_replacement() {
+    let mut editor = harness();
+    editor.execute_action(Action::SplitVertical).await.unwrap();
+    let snapshot = editor.editor.test_session_snapshot();
+    chord(&mut editor, 'z').await;
+    editor.editor.restore_session_snapshot(&snapshot).unwrap();
+    editor.execute_action(Action::Refresh).await.unwrap();
+    assert!(!editor.statusline_row().contains("ZOOM"));
+    assert_eq!(editor.editor.test_window_count(), 2);
+    editor
+        .editor
+        .test_create_panel("target", PanelConfig::default());
+    assert!(editor.editor.test_focus_panel("target"));
+    chord(&mut editor, 'z').await;
+    editor
+        .editor
+        .test_create_panel("target", PanelConfig::default());
+    assert!(!editor.statusline_row().contains("ZOOM"));
+}


### PR DESCRIPTION
The existing `Ctrl-w _` changes split ratios, while `Ctrl-w o` keeps only the current window. Neither provides a temporary full-size view that can restore the layout afterward. This makes it awkward to inspect a long file, agent conversation, or Git diff without rearranging the workspace.

This adds `Ctrl-w z` to maximize and restore the focused editor window, docked pane, or modal workspace pane. Zoom changes presentation only: the live split tree, stable IDs, buffers, pane preferences, and agent drafts remain intact. It also extends the Git workspace controls introduced in #239.

## Changes

- Add the `TogglePaneZoom` action, default keybinding, command-palette entry, and visible `ZOOM` restore hint.
- Keep rendering, cursor placement, wrapping, scrolling, and mouse hit testing aligned with the presented surface. Hidden windows and dividers cannot repaint or intercept input.
- Preserve zoom across terminal resizing; restore before focus or layout changes. Clear invalid targets and leave session persistence and the existing `_`/`o` commands unchanged.
- Support both Git workspace panes and preserve agent transcript selection, composer drafts, and streaming state. Add focused layout/rendering tests and `tests/window_zoom.rs` keyboard integration coverage.

## How to Test

1. Run `cargo run -- path/to/a/file`. Create nested splits with `Ctrl-w v` and `Ctrl-w s`, then press `Ctrl-w z`. Confirm that only the focused window fills the content area and the status line shows `ZOOM`. Press it again and confirm the original split arrangement returns.
2. Zoom again, resize the terminal, then press `Ctrl-w w` or create another split. Confirm the normal layout is restored at the new terminal size before the requested operation. Check that `Ctrl-w _` still enlarges a split and `Ctrl-w o` still keeps only the current window.
3. Open the file tree with `Ctrl-e` and toggle `Ctrl-w z` twice. In a Git checkout with a local change, open `Space G`; zoom the file list, use `Tab` to restore and focus the diff, then zoom and restore the diff.
4. Open the agent pane with `Ctrl-w a`, press `a` to edit, and enter a draft. Zoom and restore the pane; confirm the draft and composer cursor survive. With an agent backend configured, submit a harmless prompt and toggle zoom while its response streams.

Targeted automated tests:

```sh
cargo test --all-features --lib zoom -- --test-threads=1
cargo test --all-features --test window_zoom -- --test-threads=1
```

Local validation passed: 2,329 tests across the full serialized suite, strict all-targets/all-features Clippy, and seven retained TUI smoke scenarios with 15 verified capture assertions. The interactive agent smoke used the real bundled agent UI with a deterministic local app-server fixture; it did not send a prompt to a live account.
