### PR TITLE
feat(search): add persistent search history

### DIFF
--- a/almanac/architecture/preferences/preferences-store.md
+++ b/almanac/architecture/preferences/preferences-store.md
@@ -1,6 +1,6 @@
 ---
 title: "Preferences Store"
-summary: "Red's preferences store persists convenience state such as command history, picker history, and plugin-owned JSON without becoming recovery state."
+summary: "Red's preferences store persists convenience state such as command and search history, picker history, and plugin-owned JSON without becoming recovery state."
 topics: [architecture, persistence, preferences, plugins, history]
 sources:
   - id: preferences
@@ -16,17 +16,19 @@ sources:
 
 # Preferences Store
 
-The preferences store is Red's best-effort persistence layer for convenience state. It keeps command-line history, picker query history, and plugin-owned JSON values in `preferences.json`, while session recovery and crash-safe editor state remain owned by a separate snapshot system [@preferences] [@startup]. This boundary lets editor features remember recent user choices without treating a corrupt or unavailable preferences file as a startup failure.
+The preferences store is Red's best-effort persistence layer for convenience state. It keeps command-line history, search history, picker query history, and plugin-owned JSON values in `preferences.json`, while session recovery and crash-safe editor state remain owned by a separate snapshot system [@preferences] [@startup]. This boundary lets editor features remember recent user choices without treating a corrupt or unavailable preferences file as a startup failure.
 
 ## Ownership Boundary
 
 `PreferencesStore` owns a serialized `Preferences` value plus an optional filesystem path [@preferences]. Interactive startup loads it from `Config::path("preferences.json")` after configuration, logging, and theme setup, then passes the store into `Editor::new_with_preferences` [@startup]. Tests and embedded callers can use `PreferencesStore::in_memory`, which gives the same mutation semantics without filesystem writes [@preferences].
 
-The stored fields are deliberately narrow. `command_history` is a list of colon commands, `picker_history` is a map from picker namespace to recent queries, and `plugin_storage` is a JSON map keyed by plugin and logical key [@preferences]. The editor reads these values for command history navigation, picker history, agent transcript restoration, and plugin host storage requests [@editor].
+The stored fields are deliberately narrow. `command_history` is a list of colon commands, `search_history` holds patterns shared by `/` and `?`, `picker_history` is a map from picker namespace to recent queries, and `plugin_storage` is a JSON map keyed by plugin and logical key [@preferences]. The editor reads these values for prompt history navigation, picker history, agent transcript restoration, and plugin host storage requests [@editor].
 
 ## Histories
 
 Command history is stored from oldest to newest. `record_command` ignores blank commands, skips only a duplicate of the newest entry, caps the list at 100 entries, and saves immediately for filesystem-backed stores [@preferences]. The editor records executed command-line commands through this API and uses prefix-filtered history navigation when the user moves through command history [@editor].
+
+Search history uses the same ordering, limit, consecutive-duplicate handling, and immediate persistence. `record_search` ignores empty patterns but preserves meaningful whitespace. The editor records non-empty patterns on Enter, including invalid patterns and searches with no matches; cancellation does not add an entry. Both `/` and `?` use prefix-filtered Up/Down or Ctrl-p/Ctrl-n navigation and restore the original draft when moving past the newest match [@preferences] [@editor].
 
 Picker history is also namespace-scoped and bounded to 100 entries per key [@preferences]. `record_picker_query` ignores blank keys or blank queries, skips consecutive duplicates within the same namespace, and persists immediately [@preferences]. The editor derives picker keys from picker title and optional ID, exposes stored history to picker UI, records accepted picker queries, and removes the legacy agent composer history namespace `picker:802` when the modern agent composer opens [@editor].
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -84,6 +84,9 @@ pair.
 ## Searching
 
 - `/` and `?` search forward and backward with live preview.
+- In either search prompt, Up/Down or Ctrl-p/Ctrl-n recall submitted searches,
+  filtered by what you have typed. Down past the newest match restores your
+  draft. Both directions share a history that persists across restarts.
 - `n` and `N` repeat in the same or opposite direction.
 - `*` searches for the word under the cursor.
 - `:noh` clears highlights.

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -57,7 +57,7 @@ the corresponding integration tests.
 
 | Area | Status | Red behavior |
 |---|---|---|
-| Search | **supported** | `/`, `?`, incremental preview, `n`, `N`, `*`, wrapscan, smartcase/ignorecase, cancellation, and highlight clearing. |
+| Search | **supported** | `/`, `?`, persistent shared search history with prefix-filtered Up/Down and Ctrl-p/Ctrl-n recall, incremental preview, `n`, `N`, `*`, wrapscan, smartcase/ignorecase, cancellation, and highlight clearing. |
 | Search syntax | **intentional difference** | Patterns use Rust `regex` syntax rather than Vim's regex dialect. |
 | Substitute ranges | **supported** | Current line, `%`, one-based numeric line/range, and `'<,'>` last-Visual range. Visual `:` prefills that range, so substitution applies to every line touched by character, line, or block selections. |
 | Substitute flags | **supported** | `g`, `i`, and explicit `c` confirmation with `y/n/a/q/l`. All accepted replacements from one command form one transaction. |

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3118,7 +3118,7 @@ pub struct Editor {
     whats_new_needs_persistence: bool,
 
     /// Active command-history navigation state.
-    command_history_navigation: Option<CommandHistoryNavigation>,
+    command_history_navigation: Option<PromptHistoryNavigation>,
 
     /// Active command-line completion state.
     command_completion: Option<CommandCompletionState>,
@@ -3565,16 +3565,57 @@ struct HistoryEntry {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CommandHistoryDirection {
+enum PromptHistoryDirection {
     Previous,
     Next,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct CommandHistoryNavigation {
+struct PromptHistoryNavigation {
     prefix: String,
     original: String,
     position: usize,
+}
+
+impl PromptHistoryNavigation {
+    fn navigate(
+        history: &[String],
+        navigation: &mut Option<Self>,
+        text: &mut String,
+        direction: PromptHistoryDirection,
+    ) -> bool {
+        let mut state = navigation.take().unwrap_or_else(|| Self {
+            prefix: text.clone(),
+            original: text.clone(),
+            position: history.len(),
+        });
+        let matches: Vec<_> = history
+            .iter()
+            .filter(|entry| entry.starts_with(&state.prefix))
+            .collect();
+        if matches.is_empty() {
+            return false;
+        }
+        state.position = state.position.min(matches.len());
+
+        let recalled = match direction {
+            PromptHistoryDirection::Previous => {
+                state.position = state.position.saturating_sub(1);
+                matches[state.position]
+            }
+            PromptHistoryDirection::Next => {
+                state.position = (state.position + 1).min(matches.len());
+                matches
+                    .get(state.position)
+                    .copied()
+                    .unwrap_or(&state.original)
+            }
+        };
+        let changed = text.as_str() != recalled.as_str();
+        text.clone_from(recalled);
+        *navigation = Some(state);
+        changed
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3613,6 +3654,7 @@ struct SearchSession {
     origin_vtop: usize,
     direction: SearchDirection,
     draft: String,
+    history_navigation: Option<PromptHistoryNavigation>,
     preview: Option<SearchMatch>,
 }
 
@@ -13968,6 +14010,7 @@ impl Editor {
             origin_vtop: self.vtop,
             direction,
             draft: String::new(),
+            history_navigation: None,
             preview: None,
         });
         self.mode = Mode::Search;
@@ -14112,51 +14155,30 @@ impl Editor {
         self.command_completion = None;
     }
 
-    fn command_history_matches(&self, prefix: &str) -> Vec<usize> {
-        self.preferences
-            .command_history()
-            .iter()
-            .enumerate()
-            .filter_map(|(index, command)| command.starts_with(prefix).then_some(index))
-            .collect()
+    fn navigate_command_history(&mut self, direction: PromptHistoryDirection) {
+        PromptHistoryNavigation::navigate(
+            self.preferences.command_history(),
+            &mut self.command_history_navigation,
+            &mut self.command,
+            direction,
+        );
     }
 
-    fn navigate_command_history(&mut self, direction: CommandHistoryDirection) {
-        let mut navigation = self.command_history_navigation.take().unwrap_or_else(|| {
-            let prefix = self.command.clone();
-            let position = self.command_history_matches(&prefix).len();
-            CommandHistoryNavigation {
-                prefix,
-                original: self.command.clone(),
-                position,
-            }
-        });
-
-        let matches = self.command_history_matches(&navigation.prefix);
-        if matches.is_empty() {
-            self.command_history_navigation = None;
+    fn navigate_search_history(&mut self, direction: PromptHistoryDirection) {
+        let Some(session) = &mut self.active_search else {
+            return;
+        };
+        if !PromptHistoryNavigation::navigate(
+            self.preferences.search_history(),
+            &mut session.history_navigation,
+            &mut session.draft,
+            direction,
+        ) {
             return;
         }
-
-        match direction {
-            CommandHistoryDirection::Previous => {
-                navigation.position = navigation.position.saturating_sub(1);
-                self.command =
-                    self.preferences.command_history()[matches[navigation.position]].clone();
-            }
-            CommandHistoryDirection::Next => {
-                if navigation.position + 1 < matches.len() {
-                    navigation.position += 1;
-                    self.command =
-                        self.preferences.command_history()[matches[navigation.position]].clone();
-                } else {
-                    navigation.position = matches.len();
-                    self.command = navigation.original.clone();
-                }
-            }
-        }
-
-        self.command_history_navigation = Some(navigation);
+        session.preview = None;
+        self.last_error = None;
+        self.update_search_preview();
     }
 
     fn command_accepts_file_completion(command: &str) -> bool {
@@ -14405,6 +14427,12 @@ impl Editor {
         }
     }
 
+    fn record_search_history(&mut self, pattern: &str) {
+        if let Err(error) = self.preferences.record_search(pattern) {
+            log!("failed to save search history: {error}");
+        }
+    }
+
     pub(crate) fn picker_history(&self, key: &str) -> &[String] {
         self.preferences.picker_history(key)
     }
@@ -14477,11 +14505,11 @@ impl Editor {
                 }
                 KeyCode::Up => {
                     self.reset_command_completion();
-                    self.navigate_command_history(CommandHistoryDirection::Previous);
+                    self.navigate_command_history(PromptHistoryDirection::Previous);
                 }
                 KeyCode::Down => {
                     self.reset_command_completion();
-                    self.navigate_command_history(CommandHistoryDirection::Next);
+                    self.navigate_command_history(PromptHistoryDirection::Next);
                 }
                 KeyCode::Tab => {
                     self.reset_command_history_navigation();
@@ -14526,6 +14554,7 @@ impl Editor {
             Event::Paste(text) => {
                 if let Some(active_search) = &mut self.active_search {
                     active_search.draft.push_str(&pasted_input_line(text));
+                    active_search.history_navigation = None;
                     active_search.preview = None;
                 }
                 self.update_search_preview();
@@ -14541,12 +14570,19 @@ impl Editor {
                     (KeyCode::Backspace, _) => {
                         if let Some(active_search) = &mut self.active_search {
                             Self::delete_last_char(&mut active_search.draft);
+                            active_search.history_navigation = None;
                             active_search.preview = None;
                         }
                         self.update_search_preview();
                     }
                     (KeyCode::Enter, _) => {
                         return Some(KeyAction::Single(Action::CommitSearch));
+                    }
+                    (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
+                        self.navigate_search_history(PromptHistoryDirection::Previous);
+                    }
+                    (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
+                        self.navigate_search_history(PromptHistoryDirection::Next);
                     }
                     (KeyCode::Char('g'), KeyModifiers::CONTROL) => {
                         return Some(KeyAction::Single(Action::FindNext));
@@ -14557,6 +14593,7 @@ impl Editor {
                     (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
                         if let Some(active_search) = &mut self.active_search {
                             active_search.draft.push(c);
+                            active_search.history_navigation = None;
                         }
                         self.update_search_preview();
                     }
@@ -19207,6 +19244,7 @@ impl Editor {
                     self.mode = Mode::Normal;
                     self.render(buffer)?;
                 } else {
+                    self.record_search_history(&session.draft);
                     let matches = match self.search_matches(&session.draft) {
                         Ok(matches) => matches,
                         Err(err) => {

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use crate::{plugin::PanelSide, LOGGER};
 
 const COMMAND_HISTORY_LIMIT: usize = 100;
+const SEARCH_HISTORY_LIMIT: usize = 100;
 const PICKER_HISTORY_LIMIT: usize = 100;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -24,6 +25,8 @@ const PICKER_HISTORY_LIMIT: usize = 100;
 pub struct Preferences {
     #[serde(default)]
     command_history: Vec<String>,
+    #[serde(default)]
+    search_history: Vec<String>,
     #[serde(default)]
     picker_history: HashMap<String, Vec<String>>,
     #[serde(default)]
@@ -106,6 +109,11 @@ impl PreferencesStore {
         &self.preferences.command_history
     }
 
+    /// Returns shared forward/backward search history from oldest to newest.
+    pub fn search_history(&self) -> &[String] {
+        &self.preferences.search_history
+    }
+
     /// Returns history for a picker namespace from oldest to newest.
     pub fn picker_history(&self, key: &str) -> &[String] {
         self.preferences
@@ -155,6 +163,25 @@ impl PreferencesStore {
             .saturating_sub(COMMAND_HISTORY_LIMIT);
         if overflow > 0 {
             self.preferences.command_history.drain(0..overflow);
+        }
+
+        self.save()
+    }
+
+    /// Appends a non-empty search pattern unless it duplicates the newest entry.
+    ///
+    /// Whitespace is meaningful in search patterns. History is bounded and a
+    /// filesystem-backed store saves immediately.
+    pub fn record_search(&mut self, pattern: &str) -> anyhow::Result<()> {
+        let history = &mut self.preferences.search_history;
+        if pattern.is_empty() || history.last().is_some_and(|last| last == pattern) {
+            return Ok(());
+        }
+
+        history.push(pattern.to_string());
+        let overflow = history.len().saturating_sub(SEARCH_HISTORY_LIMIT);
+        if overflow > 0 {
+            history.drain(0..overflow);
         }
 
         self.save()
@@ -487,6 +514,7 @@ mod tests {
         let store = PreferencesStore::load(path);
 
         assert!(store.command_history().is_empty());
+        assert!(store.search_history().is_empty());
         assert_eq!(store.last_seen_version(), None);
     }
 
@@ -513,6 +541,7 @@ mod tests {
         let store = PreferencesStore::load(&path);
 
         assert_eq!(store.command_history(), ["write"]);
+        assert!(store.search_history().is_empty());
         assert_eq!(store.last_seen_version(), None);
         fs::remove_dir_all(dir).ok();
     }
@@ -642,6 +671,45 @@ mod tests {
         store.record_command("quit").unwrap();
 
         assert_eq!(store.command_history(), ["write", "quit"]);
+    }
+
+    #[test]
+    fn search_history_preserves_whitespace_and_skips_empty_or_consecutive_duplicates() {
+        let mut store = PreferencesStore::in_memory();
+
+        for pattern in ["", "alpha", "alpha", "   ", "   ", "alpha"] {
+            store.record_search(pattern).unwrap();
+        }
+
+        assert_eq!(store.search_history(), ["alpha", "   ", "alpha"]);
+        assert!(store.command_history().is_empty());
+    }
+
+    #[test]
+    fn search_history_reloads_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("preferences.json");
+        let mut store = PreferencesStore::load(&path);
+        store.record_command("write").unwrap();
+        store.record_search("alpha").unwrap();
+        store.record_search(" beta ").unwrap();
+
+        let reloaded = PreferencesStore::load(&path);
+
+        assert_eq!(reloaded.search_history(), ["alpha", " beta "]);
+        assert_eq!(reloaded.command_history(), ["write"]);
+    }
+
+    #[test]
+    fn search_history_is_capped_at_limit() {
+        let mut store = PreferencesStore::in_memory();
+        for index in 0..(SEARCH_HISTORY_LIMIT + 5) {
+            store.record_search(&format!("pattern-{index}")).unwrap();
+        }
+
+        assert_eq!(store.search_history().len(), SEARCH_HISTORY_LIMIT);
+        assert_eq!(store.search_history().first().unwrap(), "pattern-5");
+        assert_eq!(store.search_history().last().unwrap(), "pattern-104");
     }
 
     #[test]

--- a/tests/search_history.rs
+++ b/tests/search_history.rs
@@ -1,0 +1,252 @@
+mod common;
+
+use common::{EditorHarness, MockLsp};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use red::{
+    buffer::Buffer,
+    clipboard::DisabledClipboardProvider,
+    config::Config,
+    editor::{Action, Editor, Mode},
+    preferences::PreferencesStore,
+    theme::Theme,
+};
+
+fn default_config() -> Config {
+    toml::from_str(include_str!("../default_config.toml")).unwrap()
+}
+
+fn with_preferences(
+    contents: &str,
+    config: Config,
+    preferences: PreferencesStore,
+) -> EditorHarness {
+    let mut editor = Editor::with_size_and_preferences(
+        Box::new(MockLsp),
+        /*width*/ 80,
+        /*height*/ 24,
+        config,
+        Theme::default(),
+        vec![Buffer::new(None, contents.to_string())],
+        preferences,
+    )
+    .unwrap();
+    editor.test_disable_terminal_output();
+    editor.test_set_clipboard(Box::new(DisabledClipboardProvider));
+    EditorHarness { editor }
+}
+
+fn with_history(contents: &str, patterns: &[&str]) -> EditorHarness {
+    let mut preferences = PreferencesStore::in_memory();
+    for pattern in patterns {
+        preferences.record_search(pattern).unwrap();
+    }
+    with_preferences(contents, default_config(), preferences)
+}
+
+async fn key(harness: &mut EditorHarness, code: KeyCode) {
+    harness
+        .execute_event(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+}
+
+async fn control(harness: &mut EditorHarness, character: char) {
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char(character),
+            KeyModifiers::CONTROL,
+        )))
+        .await
+        .unwrap();
+}
+
+async fn paste(harness: &mut EditorHarness, text: &str) {
+    harness
+        .execute_event(Event::Paste(text.to_string()))
+        .await
+        .unwrap();
+}
+
+async fn start(harness: &mut EditorHarness, prompt: char) {
+    key(harness, KeyCode::Char(prompt)).await;
+    harness.assert_mode(Mode::Search);
+}
+
+async fn submit(harness: &mut EditorHarness, prompt: char, pattern: &str) {
+    start(harness, prompt).await;
+    paste(harness, pattern).await;
+    key(harness, KeyCode::Enter).await;
+    harness.assert_mode(Mode::Normal);
+}
+
+#[tokio::test]
+async fn search_history_is_shared_by_both_prompts_and_separate_from_commands() {
+    let mut harness = with_history("alpha-one\nbeta-two\nalpha-three", &[]);
+    submit(&mut harness, '/', "alpha-one").await;
+    submit(&mut harness, '?', "beta-two").await;
+    submit(&mut harness, '/', "alpha-three").await;
+    harness
+        .execute_action(Action::Command("write-history-only".to_string()))
+        .await
+        .unwrap();
+
+    for prompt in ['/', '?'] {
+        start(&mut harness, prompt).await;
+        key(&mut harness, KeyCode::Down).await;
+        assert_eq!(harness.commandline_text(), "");
+        for expected in ["alpha-three", "beta-two", "alpha-one", "alpha-one"] {
+            key(&mut harness, KeyCode::Up).await;
+            assert_eq!(harness.commandline_text(), expected);
+        }
+        for expected in ["beta-two", "alpha-three", "", ""] {
+            key(&mut harness, KeyCode::Down).await;
+            assert_eq!(harness.commandline_text(), expected);
+        }
+        key(&mut harness, KeyCode::Esc).await;
+    }
+
+    key(&mut harness, KeyCode::Char(':')).await;
+    key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "write-history-only");
+}
+
+#[tokio::test]
+async fn search_history_filters_by_prefix_and_restores_the_original_draft() {
+    let mut harness = with_history("", &["alpha-one", "beta-two", "alpha-three"]);
+    start(&mut harness, '?').await;
+    paste(&mut harness, "alp").await;
+
+    control(&mut harness, 'p').await;
+    assert_eq!(harness.commandline_text(), "alpha-three");
+    key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "alpha-one");
+    control(&mut harness, 'n').await;
+    assert_eq!(harness.commandline_text(), "alpha-three");
+    key(&mut harness, KeyCode::Down).await;
+    assert_eq!(harness.commandline_text(), "alp");
+    key(&mut harness, KeyCode::Esc).await;
+
+    start(&mut harness, '/').await;
+    paste(&mut harness, "no-match").await;
+    key(&mut harness, KeyCode::Up).await;
+    key(&mut harness, KeyCode::Down).await;
+    assert_eq!(harness.commandline_text(), "no-match");
+}
+
+#[tokio::test]
+async fn search_history_edits_start_a_new_prefix_session() {
+    let mut harness = with_history("", &["alpha-one", "alpha-two"]);
+
+    for edit in [
+        Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
+        Event::Key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+        Event::Paste("x\nignored".to_string()),
+    ] {
+        start(&mut harness, '/').await;
+        paste(&mut harness, "alp").await;
+        key(&mut harness, KeyCode::Up).await;
+        assert_eq!(harness.commandline_text(), "alpha-two");
+        harness.execute_event(edit).await.unwrap();
+        let edited = harness.commandline_text().to_string();
+
+        key(&mut harness, KeyCode::Up).await;
+        key(&mut harness, KeyCode::Down).await;
+        assert_eq!(harness.commandline_text(), edited);
+        key(&mut harness, KeyCode::Esc).await;
+    }
+}
+
+#[tokio::test]
+async fn recalled_search_previews_and_commits_in_the_current_direction() {
+    let mut harness = with_history("alpha\nalpha\nmiddle\nalpha\nalpha", &[]);
+    submit(&mut harness, '/', "alpha").await;
+    harness
+        .execute_action(Action::SetCursor(0, 2))
+        .await
+        .unwrap();
+
+    start(&mut harness, '?').await;
+    key(&mut harness, KeyCode::Up).await;
+    harness.assert_cursor_at(0, 1);
+    assert!(harness.commandline_row().starts_with("?alpha"));
+    key(&mut harness, KeyCode::Enter).await;
+    key(&mut harness, KeyCode::Char('n')).await;
+    harness.assert_cursor_at(0, 0);
+    key(&mut harness, KeyCode::Char('N')).await;
+    harness.assert_cursor_at(0, 1);
+
+    start(&mut harness, '/').await;
+    key(&mut harness, KeyCode::Up).await;
+    harness.assert_cursor_at(0, 3);
+    key(&mut harness, KeyCode::Down).await;
+    harness.assert_cursor_at(0, 1);
+    key(&mut harness, KeyCode::Up).await;
+    key(&mut harness, KeyCode::Esc).await;
+    harness.assert_cursor_at(0, 1);
+    key(&mut harness, KeyCode::Char('n')).await;
+    harness.assert_cursor_at(0, 0);
+}
+
+#[tokio::test]
+async fn unchanged_history_recall_preserves_manual_preview_navigation() {
+    let mut harness = with_history("start\nalpha\nalpha\nalpha", &["alpha"]);
+    start(&mut harness, '/').await;
+    key(&mut harness, KeyCode::Up).await;
+    harness.assert_cursor_at(0, 1);
+    control(&mut harness, 'g').await;
+    harness.assert_cursor_at(0, 2);
+    key(&mut harness, KeyCode::Up).await;
+    harness.assert_cursor_at(0, 2);
+    control(&mut harness, 't').await;
+    harness.assert_cursor_at(0, 1);
+}
+
+#[tokio::test]
+async fn search_history_respects_disabled_incremental_search() {
+    let mut preferences = PreferencesStore::in_memory();
+    preferences.record_search("alpha").unwrap();
+    let mut config = default_config();
+    config.search.incsearch = false;
+    let mut harness = with_preferences("start\nalpha\nalpha", config, preferences);
+
+    start(&mut harness, '/').await;
+    key(&mut harness, KeyCode::Up).await;
+    assert_eq!(harness.commandline_text(), "alpha");
+    harness.assert_cursor_at(0, 0);
+    key(&mut harness, KeyCode::Enter).await;
+    harness.assert_cursor_at(0, 1);
+}
+
+#[tokio::test]
+async fn submitted_searches_persist_but_cancelled_and_empty_drafts_do_not() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("preferences.json");
+    let mut harness = with_preferences(
+        "alpha beta",
+        default_config(),
+        PreferencesStore::load(&path),
+    );
+
+    submit(&mut harness, '/', "alpha").await;
+    submit(&mut harness, '?', "alpha").await;
+    submit(&mut harness, '/', "missing").await;
+    assert!(harness.last_error().unwrap().contains("Pattern not found"));
+    submit(&mut harness, '?', "[").await;
+    assert!(harness.last_error().is_some());
+    start(&mut harness, '/').await;
+    paste(&mut harness, "cancelled").await;
+    key(&mut harness, KeyCode::Esc).await;
+    submit(&mut harness, '?', "").await;
+    submit(&mut harness, '/', "   ").await;
+
+    let reloaded = PreferencesStore::load(&path);
+    assert_eq!(reloaded.search_history(), ["alpha", "missing", "[", "   "]);
+    assert!(reloaded.command_history().is_empty());
+
+    let mut reopened = with_preferences("alpha beta", default_config(), reloaded);
+    start(&mut reopened, '?').await;
+    for expected in ["   ", "[", "missing", "alpha"] {
+        key(&mut reopened, KeyCode::Up).await;
+        assert_eq!(reopened.commandline_text(), expected);
+    }
+}


### PR DESCRIPTION
## Summary

The document-search prompts remembered only the last pattern for `n`/`N`, so returning to an older search required typing it again. This gives `/` and `?` a shared, persistent history without mixing searches into `:` command history.

- Recall submitted patterns with Up/Down or Ctrl-p/Ctrl-n, filtered by the current draft. Moving past the newest match restores that draft; editing a recalled pattern starts a new navigation session.
- Keep the newest 100 entries in `preferences.json`, skip consecutive duplicates, and preserve meaningful whitespace. Enter records non-empty patterns, including unsuccessful or invalid searches; Escape does not.
- Reuse command-history navigation while preserving search direction, incremental preview, cancellation, and Ctrl-g/Ctrl-t match navigation. Add integration and persistence coverage and document the bindings.

## How to Test

1. Open a document containing `alpha-one`, `beta-two`, and `alpha-three`. Submit `/alpha-one`, `?beta-two`, and `/alpha-three`. Open `?alp` and press Up twice: it should recall `alpha-three`, then `alpha-one`. Press Down twice: it should restore `alp`. Ctrl-p/Ctrl-n should behave the same way.
2. Recall a pattern in `?`, press Enter, then use `n`/`N`. The search should retain the backward direction. Restart Red and confirm both prompts can still recall the submitted patterns.
3. Recall a pattern, move to another match with Ctrl-g, and press Up when already at the oldest matching history entry. The cursor should stay on that match. Press Escape: the original cursor position should be restored, and the cancelled draft should not enter history.
4. Run `cargo test --all-features --test search_history -- --test-threads=1`. The targeted tests also cover editing recalled text, disabled incremental search, invalid patterns, persistence, and separation from command history.

Validation at `ea8f67b`: the full serialized all-features suite passed all 2,367 tests; strict all-targets/all-features Clippy, formatting, and whitespace checks passed.
