### PR TITLE
feat(keymap): add ctrl-w d side-by-side split alias

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -365,6 +365,7 @@ Esc = { EnterMode = "Normal" }
 "p" = "PreviousWindow"
 "s" = "SplitHorizontal"
 "v" = "SplitVertical"
+"d" = "SplitVertical"
 "|" = "SplitVertical"
 "c" = "CloseWindow"
 "q" = "CloseWindow"

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -175,7 +175,8 @@ The command palette includes descriptions, effective keymaps, and accepted
 
 ## Windows and buffers
 
-- `Ctrl-w s` and `Ctrl-w v` split horizontally and vertically.
+- `Ctrl-w s` splits horizontally (top/bottom); `Ctrl-w v` or `Ctrl-w d` splits
+  vertically (side by side).
 - `Ctrl-w h/j/k/l` move focus between editor windows and docked panes.
 - `Ctrl-w H/J/K/L` move the focused editor window or pane to the left, bottom,
   top, or right outer edge.

--- a/src/config.rs
+++ b/src/config.rs
@@ -3783,10 +3783,12 @@ groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
             ctrl_w.get("s"),
             Some(&KeyAction::Single(Action::SplitHorizontal))
         );
-        assert_eq!(
-            ctrl_w.get("v"),
-            Some(&KeyAction::Single(Action::SplitVertical))
-        );
+        for key in ["v", "d"] {
+            assert_eq!(
+                ctrl_w.get(key),
+                Some(&KeyAction::Single(Action::SplitVertical))
+            );
+        }
         assert_eq!(
             ctrl_w.get("r"),
             Some(&KeyAction::Single(Action::EnterPaneResizeMode))


### PR DESCRIPTION
Terminal users often use Cmd-d to open a pane beside the current one. Add `Ctrl-w d` as another default side-by-side split shortcut in Red, exactly matching `Ctrl-w v`.

The change reuses `SplitVertical`, documents the alias and split orientations in `docs/GETTING_STARTED.md`, and extends the default-keymap test to cover both vertical-split bindings. `Ctrl-w s` continues to create a top/bottom split.

## How to Test

1. Run Red with its default keybindings. In Normal mode, press `Ctrl-w`, then `d`. Expect the current editor window to split into left and right windows, just like `Ctrl-w v`.
2. Press `Ctrl-w v` and confirm the original side-by-side split shortcut still works. Press `Ctrl-w s` and confirm it still creates a top/bottom split.
3. Run `cargo test --all-features --lib config::test::default_config_enables_window_management_prefix -- --exact --test-threads=1`. Expect the default window-management keymap test to pass.

Validation completed on local commit `74628b5`: the focused keymap test, formatting check, and `cargo clippy --all-targets --all-features -- -D warnings` all passed. The corrected commit is awaiting the author's force-push.