### PR TITLE
feat(git): improve diff highlighting

### DIFF
--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -1516,6 +1516,7 @@ fn workspace_event(event: GitWorkspaceEvent) {
         event.action == "horizontal_start" ||
         event.action == "horizontal_end" ||
         event.action == "toggle_wrap" ||
+        event.action == "toggle_diff_highlights" ||
         event.action == "visual" ||
         event.action == "cancel_selection" ||
         event.action == "previous_hunk" ||
@@ -2519,6 +2520,7 @@ fn help_menu() {
         PickerItem { id: "scroll", label: "Ctrl-u/d half page · Ctrl-b/f full page", kind: "Action" },
         PickerItem { id: "hunks", label: "[h / ]h previous or next hunk", kind: "Action" },
         PickerItem { id: "wrap", label: "W toggle diff wrapping", kind: "Action" },
+        PickerItem { id: "highlights", label: "H toggle line / smart word highlights", kind: "Action" },
         PickerItem { id: "select", label: "v select diff lines", kind: "Action" },
         PickerItem { id: "partial", label: "s/u/x line or range · S/U/X hunk", kind: "Staged" },
         PickerItem { id: "c", label: "c commit", kind: "GitCommit" },

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -60,6 +60,6 @@ pub use window_bar::{
     WindowBarOverflow, WindowBarSegment, WindowBarSemanticStyle, WindowBarStyle,
 };
 pub use workspace::{
-    WorkspaceConfig, WorkspaceDocument, WorkspaceDocumentLine, WorkspaceManager, WorkspaceModel,
-    WorkspaceRow,
+    DiffHighlightMode, WorkspaceConfig, WorkspaceDocument, WorkspaceDocumentLine, WorkspaceManager,
+    WorkspaceModel, WorkspaceRow,
 };

--- a/src/plugin/process.rs
+++ b/src/plugin/process.rs
@@ -249,6 +249,12 @@ impl ProcessManager {
             let process_id = process_id.clone();
             thread::spawn(move || {
                 if let Err(error) = stdin.write_all(input.as_bytes()) {
+                    // A child can reject an operation before consuming its input
+                    // (for example, a failing Git pre-commit hook). Its stderr and
+                    // exit status explain that outcome; EPIPE must not replace them.
+                    if error.kind() == std::io::ErrorKind::BrokenPipe {
+                        return;
+                    }
                     let _ = event_sender.send(ProcessEvent::Error {
                         plugin_name,
                         process_id,
@@ -720,6 +726,37 @@ mod tests {
             code: Some(7),
         }));
         assert_eq!(manager.active_process_count("test"), 0);
+    }
+
+    #[test]
+    fn child_rejection_preserves_stderr_instead_of_reporting_broken_stdin() {
+        let mut options = stdout_stderr_exit_options();
+        // More than a pipe can hold: this child exits without reading stdin.
+        options.stdin = Some("x".repeat(512 * 1024));
+        let mut manager = manager_with_commands(&[options.command.as_str()]);
+        let process_id = manager.spawn("test", options).unwrap();
+
+        let mut events = collect_until_exit(&mut manager);
+        // The stdin writer currently runs independently of the exit supervisor.
+        // Include any late event so a post-exit write error cannot pass unnoticed.
+        thread::sleep(Duration::from_millis(50));
+        events.extend(manager.poll_events());
+        assert!(events.contains(&ProcessEvent::Stderr {
+            plugin_name: "test".to_string(),
+            process_id: process_id.clone(),
+            line: "problem".to_string(),
+        }));
+        assert!(events.contains(&ProcessEvent::Exit {
+            plugin_name: "test".to_string(),
+            process_id,
+            code: Some(7),
+        }));
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, ProcessEvent::Error { .. })),
+            "child rejection was replaced by a transport error: {events:?}"
+        );
     }
 
     #[test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -11914,6 +11914,12 @@ mod tests {
             .unwrap()
             .success());
 
+        // Force the stdin writer to observe the hook's early rejection instead
+        // of relying on whether a short message fits in the pipe before Git exits.
+        let rejected_message = format!(
+            "feat(git): describe staged files\n\n{}\n",
+            "commit feedback regression ".repeat(8192)
+        );
         runtime.execute_command("GitSubmitMessage").await.unwrap();
         let buffer_text_request = loop {
             if let PluginRequest::GetBufferText { request_id, .. } =
@@ -11925,12 +11931,12 @@ mod tests {
         runtime
             .resolve_request(
                 buffer_text_request,
-                serde_json::json!({ "text": "feat(git): describe staged files\n" }),
+                serde_json::json!({ "text": rejected_message }),
             )
             .await
             .unwrap();
 
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(30);
         let mut failure_reported = false;
         let mut failure_overlay = false;
         let mut commit_started = false;
@@ -11953,8 +11959,12 @@ mod tests {
                             .unwrap();
                     }
                     PluginRequest::Action(Action::Print(message))
-                        if message == "Git commit failed: blocked by commit feedback test" =>
+                        if message.starts_with("Git commit failed:") =>
                     {
+                        assert_eq!(
+                            message,
+                            "Git commit failed: blocked by commit feedback test"
+                        );
                         failure_reported = true;
                     }
                     PluginRequest::CreateOverlay { id, .. } if id == "git-operation-progress" => {
@@ -11991,7 +12001,10 @@ mod tests {
             {
                 break;
             }
-            assert!(Instant::now() < deadline, "commit failure was not reported");
+            assert!(
+                Instant::now() < deadline,
+                "commit failure was not reported: printed={failure_reported} overlay={failure_overlay} started={commit_started} busy={commit_busy} retry={retry_requested}"
+            );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
@@ -12012,7 +12025,7 @@ mod tests {
             }
             if let Some((request_id, text, submit)) = scratch {
                 assert_eq!(submit.as_deref(), Some("GitSubmitMessage"));
-                assert!(text.starts_with("feat(git): describe staged files\n"));
+                assert!(text.starts_with(rejected_message.trim_end()));
                 break request_id;
             }
             assert!(

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -24,6 +24,28 @@ use crate::{
 
 use super::PanelSegment;
 
+mod diff;
+
+use diff::word_changes;
+
+/// How changed lines are emphasized in a structured diff.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffHighlightMode {
+    #[default]
+    Lines,
+    SmartWords,
+}
+
+impl DiffHighlightMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Lines => "lines",
+            Self::SmartWords => "smart words",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct WorkspaceConfig {
@@ -39,6 +61,9 @@ pub struct WorkspaceConfig {
     /// Whether structured detail documents wrap long lines initially.
     #[serde(default = "default_detail_wrap")]
     pub detail_wrap: bool,
+    /// Initial diff emphasis; line-only colors are the quiet default.
+    #[serde(default)]
+    pub detail_diff_highlights: DiffHighlightMode,
     /// Whether navigation handled entirely by the detail pane is also sent to
     /// the owning plugin. Plugins only need this when they implement custom
     /// navigation behavior; line operations are always delivered.
@@ -74,6 +99,7 @@ impl Default for WorkspaceConfig {
             min_two_pane_width: default_min_two_pane_width(),
             min_stacked_height: default_min_stacked_height(),
             detail_wrap: default_detail_wrap(),
+            detail_diff_highlights: DiffHighlightMode::default(),
             notify_detail_navigation: default_notify_detail_navigation(),
         }
     }
@@ -352,6 +378,7 @@ pub struct WorkspaceEvent {
     pub detail_line: Option<WorkspaceDocumentLine>,
     pub detail_selection: Option<[usize; 2]>,
     pub detail_wrap: bool,
+    pub detail_diff_highlights: DiffHighlightMode,
     /// Core-only delivery policy used by the editor and omitted from the
     /// plugin payload.
     #[serde(skip)]
@@ -371,6 +398,7 @@ pub struct PluginWorkspace {
     detail_scroll: usize,
     detail_horizontal: usize,
     detail_wrap: bool,
+    detail_diff_highlights: DiffHighlightMode,
     detail_selection_anchor: Option<usize>,
     key_prefix: Option<String>,
     detail_highlights: Vec<Vec<crate::editor::StyleInfo>>,
@@ -390,6 +418,7 @@ pub struct PluginWorkspace {
 impl PluginWorkspace {
     fn new(id: String, config: WorkspaceConfig) -> Self {
         let detail_wrap = config.detail_wrap;
+        let detail_diff_highlights = config.detail_diff_highlights;
         Self {
             id,
             config,
@@ -402,6 +431,7 @@ impl PluginWorkspace {
             detail_scroll: 0,
             detail_horizontal: 0,
             detail_wrap,
+            detail_diff_highlights,
             detail_selection_anchor: None,
             key_prefix: None,
             detail_highlights: Vec::new(),
@@ -502,7 +532,12 @@ impl PluginWorkspace {
         if document_changed {
             self.detail_highlights =
                 highlight_document(model.detail_document.as_ref(), theme, registry);
-            self.detail_word_changes = word_changes(model.detail_document.as_ref());
+            self.detail_word_changes =
+                if self.detail_diff_highlights == DiffHighlightMode::SmartWords {
+                    word_changes(model.detail_document.as_ref())
+                } else {
+                    Vec::new()
+                };
         }
         self.model = model;
         self.rebuild_detail_visible();
@@ -648,6 +683,7 @@ impl PluginWorkspace {
             detail_line,
             detail_selection,
             detail_wrap: self.detail_wrap,
+            detail_diff_highlights: self.detail_diff_highlights,
             notify_plugin,
         }
     }
@@ -901,6 +937,7 @@ impl PluginWorkspace {
                 "0" if !self.detail_wrap => "horizontal_start",
                 "$" if !self.detail_wrap => "horizontal_end",
                 "W" => "toggle_wrap",
+                "H" => "toggle_diff_highlights",
                 "M" => "toggle_metadata",
                 "v" => "visual",
                 other => other,
@@ -1055,6 +1092,18 @@ impl PluginWorkspace {
                     self.detail_horizontal = 0;
                 }
             }
+            "toggle_diff_highlights" if self.focus == WorkspaceFocus::Detail => {
+                self.detail_diff_highlights = match self.detail_diff_highlights {
+                    DiffHighlightMode::Lines => DiffHighlightMode::SmartWords,
+                    DiffHighlightMode::SmartWords => DiffHighlightMode::Lines,
+                };
+                self.detail_word_changes =
+                    if self.detail_diff_highlights == DiffHighlightMode::SmartWords {
+                        word_changes(self.model.detail_document.as_ref())
+                    } else {
+                        Vec::new()
+                    };
+            }
             "left" if self.focus == WorkspaceFocus::Detail && !self.detail_wrap => {
                 self.detail_horizontal = self.detail_horizontal.saturating_sub(4);
             }
@@ -1180,6 +1229,16 @@ impl PluginWorkspace {
                         .with_priority(ActionPriority::Secondary),
                     UiAction::new("toggle_wrap", "W", "wrap")
                         .with_priority(ActionPriority::Secondary),
+                    UiAction::new(
+                        "toggle_diff_highlights",
+                        "H",
+                        if self.detail_diff_highlights == DiffHighlightMode::Lines {
+                            "smart word highlights"
+                        } else {
+                            "line highlights"
+                        },
+                    )
+                    .with_priority(ActionPriority::Secondary),
                     UiAction::new("toggle_metadata", "M", "patch metadata")
                         .with_priority(ActionPriority::Secondary),
                 ]);
@@ -1246,6 +1305,7 @@ fn is_core_detail_interaction(focus: WorkspaceFocus, action: &str) -> bool {
                 | "visual"
                 | "cancel_selection"
                 | "toggle_wrap"
+                | "toggle_diff_highlights"
                 | "toggle_metadata"
                 | "left"
                 | "right"
@@ -1569,60 +1629,6 @@ fn highlight_document(
         .collect()
 }
 
-/// Pair replacement lines within a bounded change block. Pure additions/removals
-/// retain their line tint; only actual replacements receive stronger word marks.
-fn word_changes(document: Option<&WorkspaceDocument>) -> Vec<Vec<Range<usize>>> {
-    let Some(document) = document else {
-        return Vec::new();
-    };
-    let mut result = vec![Vec::new(); document.lines.len()];
-    let mut index = 0;
-    while index < document.lines.len() {
-        if document.lines[index].kind != "removed" {
-            index += 1;
-            continue;
-        }
-        let old_start = index;
-        while index < document.lines.len() && document.lines[index].kind == "removed" {
-            index += 1;
-        }
-        let new_start = index;
-        while index < document.lines.len() && document.lines[index].kind == "added" {
-            index += 1;
-        }
-        let pairs = (new_start - old_start).min(index - new_start).min(128);
-        for offset in 0..pairs {
-            let old = &document.lines[old_start + offset].text;
-            let new = &document.lines[new_start + offset].text;
-            if old.len().saturating_add(new.len()) > 8192 {
-                continue;
-            }
-            let old_words = old.split_word_bounds().collect::<Vec<_>>();
-            let new_words = new.split_word_bounds().collect::<Vec<_>>();
-            let diff = similar::TextDiff::from_slices(&old_words, &new_words);
-            let (mut old_byte, mut new_byte) = (0, 0);
-            for change in diff.iter_all_changes() {
-                let length = change.value().len();
-                match change.tag() {
-                    similar::ChangeTag::Equal => {
-                        old_byte += length;
-                        new_byte += length;
-                    }
-                    similar::ChangeTag::Delete => {
-                        result[old_start + offset].push(old_byte..old_byte + length);
-                        old_byte += length;
-                    }
-                    similar::ChangeTag::Insert => {
-                        result[new_start + offset].push(new_byte..new_byte + length);
-                        new_byte += length;
-                    }
-                }
-            }
-        }
-    }
-    result
-}
-
 fn highlight_document_projection(
     document: &WorkspaceDocument,
     highlighter: &mut Highlighter,
@@ -1802,6 +1808,7 @@ fn render_detail_pane(
     } else {
         "nowrap"
     };
+    let highlight_label = workspace.detail_diff_highlights.label();
     let marker = if active { "›" } else { " " };
     let title = workspace.model.detail_document.as_ref().map_or_else(
         || {
@@ -1875,12 +1882,12 @@ fn render_detail_pane(
             .unwrap_or_else(|| "File details".to_string());
         let context = if document.truncated {
             format!(
-                "{context} · first {}/{} lines · L full patch",
+                "{context} · {highlight_label} · first {}/{} lines · L full patch",
                 document.lines.len(),
                 document.total_lines
             )
         } else {
-            format!("{context} · {wrap_label}")
+            format!("{context} · {wrap_label} · {highlight_label}")
         };
         buffer.set_text(
             x,
@@ -1993,7 +2000,10 @@ fn render_detail_pane(
                     .map_or(&[], Vec::as_slice),
                 &line_style,
             );
-            if !selected && !cursor {
+            if workspace.detail_diff_highlights == DiffHighlightMode::SmartWords
+                && !selected
+                && !cursor
+            {
                 let background = match line.kind.as_str() {
                     "added" => Some(palette.added_text),
                     "removed" => Some(palette.removed_text),
@@ -2251,6 +2261,123 @@ mod tests {
         assert_eq!(changed(0), "1");
         assert_eq!(changed(1), "4");
         assert!(ranges[2].is_empty() && ranges[3].is_empty());
+    }
+
+    #[test]
+    fn line_highlights_are_default_and_smart_words_toggle_locally() {
+        let config: WorkspaceConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config.detail_diff_highlights, DiffHighlightMode::Lines);
+        let theme = crate::theme::parse_vscode_theme("src/fixtures/mocha.json").unwrap();
+        let palette = DiffPalette::new(&theme);
+        let mut model = action_model();
+        model.actions[0].sections.clear();
+        model.actions[0].change_only = false;
+        model.detail_document.as_mut().unwrap().lines = [
+            ("removed", "    let count = 1;"),
+            ("added", "    let count = 4;"),
+            ("context", "next line"),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (kind, text))| WorkspaceDocumentLine {
+            id: index.to_string(),
+            kind: kind.to_string(),
+            text: text.to_string(),
+            ..Default::default()
+        })
+        .collect();
+        let mut manager = WorkspaceManager::default();
+        manager.open(
+            "git".to_string(),
+            WorkspaceConfig {
+                notify_detail_navigation: false,
+                ..config
+            },
+        );
+        manager.update("git", model.clone(), &theme);
+        manager.handle_action("focus_detail".to_string(), 12, 80);
+        manager.active.as_mut().unwrap().detail_cursor = 2;
+        assert!(manager
+            .active
+            .as_ref()
+            .unwrap()
+            .detail_word_changes
+            .is_empty());
+        assert!(manager
+            .active
+            .as_ref()
+            .unwrap()
+            .actions()
+            .iter()
+            .any(|action| action.label == "smart word highlights"));
+
+        let mut buffer = RenderBuffer::new(80, 12, &theme.style);
+        manager.render(&mut buffer, &theme, PickerIconsConfig::default());
+        for (text, background) in [
+            ("let count = 1;", palette.removed.bg),
+            ("let count = 4;", palette.added.bg),
+        ] {
+            let row = buffer
+                .cells
+                .chunks(buffer.width)
+                .find(|row| {
+                    row.iter()
+                        .map(|cell| cell.text.as_str())
+                        .collect::<String>()
+                        .contains(text)
+                })
+                .unwrap();
+            assert!(row.iter().all(|cell| cell.style.bg == background));
+        }
+
+        let event = manager.handle_action("H".to_string(), 12, 80).unwrap();
+        assert_eq!(event.action, "toggle_diff_highlights");
+        assert_eq!(event.detail_diff_highlights, DiffHighlightMode::SmartWords);
+        assert!(!event.notify_plugin);
+        manager.render(&mut buffer, &theme, PickerIconsConfig::default());
+        assert!(buffer_text(&buffer).contains("smart words"));
+        for (text, changed, background) in [
+            ("let count = 1;", "1", palette.removed_text),
+            ("let count = 4;", "4", palette.added_text),
+        ] {
+            let row = buffer
+                .cells
+                .chunks(buffer.width)
+                .find(|row| {
+                    row.iter()
+                        .map(|cell| cell.text.as_str())
+                        .collect::<String>()
+                        .contains(text)
+                })
+                .unwrap();
+            let emphasized = row
+                .iter()
+                .filter(|cell| cell.style.bg == Some(background))
+                .map(|cell| cell.text.as_str())
+                .collect::<String>();
+            assert_eq!(emphasized, changed);
+        }
+
+        model.detail_document.as_mut().unwrap().lines[1].text = "    let count = 9;".to_string();
+        manager.update("git", model, &theme);
+        let workspace = manager.active.as_ref().unwrap();
+        assert_eq!(
+            workspace.detail_diff_highlights,
+            DiffHighlightMode::SmartWords
+        );
+        let document = workspace.model.detail_document.as_ref().unwrap();
+        assert_eq!(
+            &document.lines[1].text[workspace.detail_word_changes[1][0].clone()],
+            "9"
+        );
+        let event = manager.handle_action("H".to_string(), 12, 80).unwrap();
+        assert_eq!(event.detail_diff_highlights, DiffHighlightMode::Lines);
+        assert!(manager
+            .active
+            .as_ref()
+            .unwrap()
+            .detail_word_changes
+            .is_empty());
     }
 
     #[test]

--- a/src/plugin/workspace/diff.rs
+++ b/src/plugin/workspace/diff.rs
@@ -1,0 +1,319 @@
+//! Conservative, display-only inline highlights. Patch text and line indices
+//! remain untouched so staging and discarding still use the original diff.
+
+use std::ops::Range;
+
+use similar::{ChangeTag, DiffTag, TextDiff};
+use unicode_segmentation::UnicodeSegmentation;
+
+use super::{WorkspaceDocument, WorkspaceDocumentLine};
+
+const MAX_BLOCK_LINES: usize = 128;
+const MAX_BLOCK_BYTES: usize = 32 * 1024;
+const MAX_PAIR_BYTES: usize = 8192;
+const MAX_TOKEN_COMPARISONS: usize = 256 * 1024;
+const MIN_SIMILARITY: usize = 65;
+
+pub(super) fn word_changes(document: Option<&WorkspaceDocument>) -> Vec<Vec<Range<usize>>> {
+    let Some(document) = document else {
+        return Vec::new();
+    };
+    let mut result = vec![Vec::new(); document.lines.len()];
+    let mut index = 0;
+    while index < document.lines.len() {
+        if document.lines[index].kind != "removed" {
+            index += 1;
+            continue;
+        }
+        let old_start = index;
+        while index < document.lines.len() && document.lines[index].kind == "removed" {
+            index += 1;
+        }
+        let new_start = index;
+        while index < document.lines.len() && document.lines[index].kind == "added" {
+            index += 1;
+        }
+        let old = &document.lines[old_start..new_start];
+        let new = &document.lines[new_start..index];
+        if old.is_empty()
+            || new.is_empty()
+            || old.len().max(new.len()) > MAX_BLOCK_LINES
+            || old
+                .iter()
+                .chain(new)
+                .map(|line| line.text.len())
+                .sum::<usize>()
+                > MAX_BLOCK_BYTES
+        {
+            continue;
+        }
+
+        // Anchor on matching code before considering replacements. Inserting a
+        // blank line or changing a block's indentation must not shift every pair.
+        let old_text = old.iter().map(|line| line.text.trim()).collect::<Vec<_>>();
+        let new_text = new.iter().map(|line| line.text.trim()).collect::<Vec<_>>();
+        let lines = TextDiff::from_slices(&old_text, &new_text);
+        for operation in lines.ops() {
+            if operation.tag() != DiffTag::Replace {
+                continue;
+            }
+            let old_range = operation.old_range();
+            let new_range = operation.new_range();
+            for (old_offset, new_offset) in
+                align_replacements(&old[old_range.clone()], &new[new_range.clone()])
+            {
+                let old_index = old_start + old_range.start + old_offset;
+                let new_index = new_start + new_range.start + new_offset;
+                let (removed, added) = changed_words(
+                    &document.lines[old_index].text,
+                    &document.lines[new_index].text,
+                );
+                result[old_index] = removed;
+                result[new_index] = added;
+            }
+        }
+    }
+    result
+}
+
+fn tokens(text: &str) -> Vec<&str> {
+    text.split_word_bounds()
+        .filter(|token| !token.chars().all(char::is_whitespace))
+        .collect()
+}
+
+fn similarity(old: &[&str], new: &[&str]) -> usize {
+    if old.is_empty() || new.is_empty() {
+        return 0;
+    }
+    let diff = TextDiff::from_slices(old, new);
+    let mut equal = 0;
+    let mut shares_word = false;
+    for change in diff.iter_all_changes() {
+        if change.tag() == ChangeTag::Equal {
+            equal += 1;
+            shares_word |= change.value().chars().any(char::is_alphanumeric);
+        }
+    }
+    let score = 200 * equal / (old.len() + new.len());
+    if shares_word && score >= MIN_SIMILARITY {
+        score
+    } else {
+        0
+    }
+}
+
+/// Find the highest-scoring order-preserving pairs, allowing either side to
+/// contain unmatched lines. Work is bounded because this runs on the UI thread.
+fn align_replacements(
+    old: &[WorkspaceDocumentLine],
+    new: &[WorkspaceDocumentLine],
+) -> Vec<(usize, usize)> {
+    let old_tokens = old
+        .iter()
+        .map(|line| tokens(&line.text))
+        .collect::<Vec<_>>();
+    let new_tokens = new
+        .iter()
+        .map(|line| tokens(&line.text))
+        .collect::<Vec<_>>();
+    let old_count = old_tokens.iter().map(Vec::len).sum::<usize>();
+    let new_count = new_tokens.iter().map(Vec::len).sum::<usize>();
+    if old_count.saturating_mul(new_count) > MAX_TOKEN_COMPARISONS {
+        return Vec::new();
+    }
+
+    let columns = new.len() + 1;
+    let mut scores = vec![0; old.len() * new.len()];
+    let mut best = vec![0; (old.len() + 1) * columns];
+    for i in (0..old.len()).rev() {
+        for j in (0..new.len()).rev() {
+            let score = if old[i].text.len().saturating_add(new[j].text.len()) <= MAX_PAIR_BYTES {
+                similarity(&old_tokens[i], &new_tokens[j])
+            } else {
+                0
+            };
+            scores[i * new.len() + j] = score;
+            best[i * columns + j] = best[(i + 1) * columns + j]
+                .max(best[i * columns + j + 1])
+                .max(score + best[(i + 1) * columns + j + 1]);
+        }
+    }
+
+    let mut pairs = Vec::new();
+    let (mut i, mut j) = (0, 0);
+    while i < old.len() && j < new.len() {
+        let score = scores[i * new.len() + j];
+        if score > 0 && best[i * columns + j] == score + best[(i + 1) * columns + j + 1] {
+            pairs.push((i, j));
+            i += 1;
+            j += 1;
+        } else if best[(i + 1) * columns + j] >= best[i * columns + j + 1] {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    pairs
+}
+
+fn changed_words(old: &str, new: &str) -> (Vec<Range<usize>>, Vec<Range<usize>>) {
+    let old_words = old.trim().split_word_bounds().collect::<Vec<_>>();
+    let new_words = new.trim().split_word_bounds().collect::<Vec<_>>();
+    let diff = TextDiff::from_slices(&old_words, &new_words);
+    let mut old_byte = old.len() - old.trim_start().len();
+    let mut new_byte = new.len() - new.trim_start().len();
+    let (mut removed, mut added) = (Vec::new(), Vec::new());
+    for change in diff.iter_all_changes() {
+        let length = change.value().len();
+        match change.tag() {
+            ChangeTag::Equal => {
+                old_byte += length;
+                new_byte += length;
+            }
+            ChangeTag::Delete => {
+                push_range(&mut removed, old, old_byte..old_byte + length);
+                old_byte += length;
+            }
+            ChangeTag::Insert => {
+                push_range(&mut added, new, new_byte..new_byte + length);
+                new_byte += length;
+            }
+        }
+    }
+    (removed, added)
+}
+
+/// Join adjacent edits and tiny whitespace gaps into one readable phrase.
+fn push_range(ranges: &mut Vec<Range<usize>>, text: &str, next: Range<usize>) {
+    if let Some(previous) = ranges.last_mut() {
+        let gap = &text[previous.end..next.start];
+        if gap.len() <= 3 && gap.bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
+            previous.end = next.end;
+            return;
+        }
+    }
+    ranges.push(next);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn highlights(old: &[&str], new: &[&str]) -> Vec<Vec<String>> {
+        let document = WorkspaceDocument {
+            lines: old
+                .iter()
+                .map(|text| ("removed", text))
+                .chain(new.iter().map(|text| ("added", text)))
+                .map(|(kind, text)| WorkspaceDocumentLine {
+                    kind: kind.to_string(),
+                    text: (*text).to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        word_changes(Some(&document))
+            .into_iter()
+            .zip(&document.lines)
+            .map(|(ranges, line)| {
+                ranges
+                    .into_iter()
+                    .map(|range| line.text[range].to_string())
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn blank_line_insertion_does_not_shift_replacement_pairs() {
+        let marks = highlights(
+            &["    let count = 1;", "    return count;"],
+            &["", "let count = 4;", "return count;"],
+        );
+        assert_eq!(marks[0], ["1"]);
+        assert_eq!(marks[3], ["4"]);
+        assert!([1, 2, 4].into_iter().all(|index| marks[index].is_empty()));
+    }
+
+    #[test]
+    fn reindented_guard_clause_leaves_the_moved_body_quiet() {
+        let marks = highlights(
+            &[
+                "    if (CheckCollision(a, b)) {",
+                "        b->active = false;",
+                "",
+                "        switch (a->size) {",
+                "            case ASTEROID_LARGE:",
+                "                SpawnAsteroidsFrom(g, a, ASTEROID_MEDIUM);",
+                "                break;",
+                "        }",
+            ],
+            &[
+                "    if (!CheckCollision(a, b)) continue;",
+                "",
+                "    b->active = false;",
+                "",
+                "    switch (a->size) {",
+                "        case ASTEROID_LARGE:",
+                "            SpawnAsteroidsFrom(g, a, ASTEROID_MEDIUM);",
+                "            break;",
+                "    }",
+            ],
+        );
+        assert!(!marks[0].is_empty());
+        assert!(marks[8].iter().any(|mark| mark.contains('!')));
+        assert!(marks
+            .iter()
+            .enumerate()
+            .all(|(index, ranges)| { index == 0 || index == 8 || ranges.is_empty() }));
+    }
+
+    #[test]
+    fn unrelated_lines_and_whitespace_only_changes_stay_line_only() {
+        for (old, new) in [
+            ("destroy_world(old);", "render_frame(next);"),
+            ("    do_work();", "\tdo_work();  "),
+            ("   ", ""),
+        ] {
+            assert!(highlights(&[old], &[new]).iter().all(Vec::is_empty));
+        }
+    }
+
+    #[test]
+    fn replacement_alignment_skips_unrelated_insertions() {
+        let marks = highlights(
+            &["let count = 1;", "return count;"],
+            &["log_start();", "let count = 4;", "return count + 1;"],
+        );
+        assert_eq!(marks[0], ["1"]);
+        assert!(marks[2].is_empty());
+        assert_eq!(marks[3], ["4"]);
+        assert!(marks[4].iter().any(|mark| mark.contains("+ 1")));
+    }
+
+    #[test]
+    fn changed_phrases_include_the_spaces_between_words() {
+        let (old, new) = changed_words("    call(old first, keep);", "  call(new second, keep);");
+        assert_eq!(&"    call(old first, keep);"[old[0].clone()], "old first");
+        assert_eq!(&"  call(new second, keep);"[new[0].clone()], "new second");
+        assert_eq!((old.len(), new.len()), (1, 1));
+    }
+
+    #[test]
+    fn unicode_ranges_are_original_utf8_offsets() {
+        let marks = highlights(&["    let café = \"旧\";"], &["  let café = \"新\";"]);
+        assert_eq!(marks, [vec!["旧"], vec!["新"]]);
+    }
+
+    #[test]
+    fn excessive_change_blocks_fall_back_to_line_colors() {
+        let old = vec!["let count = 1;"; MAX_BLOCK_LINES + 1];
+        let new = vec!["let count = 4;"; MAX_BLOCK_LINES + 1];
+        assert!(highlights(&old, &new).iter().all(Vec::is_empty));
+        let old = format!("{}old", "x ".repeat(MAX_PAIR_BYTES));
+        let new = format!("{}new", "x ".repeat(MAX_PAIR_BYTES));
+        assert!(highlights(&[&old], &[&new]).iter().all(Vec::is_empty));
+    }
+}

--- a/src/theme/surface.rs
+++ b/src/theme/surface.rs
@@ -157,7 +157,10 @@ impl DiffPalette {
                 .get(text_key)
                 .copied()
                 .unwrap_or_else(|| tint(accent, 72));
-            (theme.style.with_bg(Some(line)), blend_color(text, line))
+            // Keep inline emphasis subordinate to the code and its line tint,
+            // even when a theme supplies a very strong text background.
+            let text = blend_color(tint(blend_color(text, line), 160), line);
+            (theme.style.with_bg(Some(line)), text)
         };
         let (added_style, added_text) = resolve(
             "diffEditor.insertedLineBackground",


### PR DESCRIPTION
## Why

The Git diff viewer currently pairs removed and added lines by position, then adds strong word-level backgrounds. An inserted blank line or a reindented block can shift those pairs and produce misleading, fragmented highlights across otherwise unchanged code.

## What changed

- Default to full-width added/removed line colors while preserving syntax highlighting.
- Add `H` in the diff pane to switch between line-only and smart-word highlighting, with the current mode shown in the hunk header and the toggle listed in the action menu.
- Match unchanged or reindented lines first, then align similar replacements in order. Unrelated lines and oversized blocks retain only their line color.
- Join nearby changed words across small whitespace gaps and soften the inline highlight colors. Keep the original patch text and line indices unchanged.
- Add regression coverage for inserted blank lines, guard-clause refactors, reindentation, unrelated replacements, Unicode offsets, bounded work, and rendered mode switching.

## How to Test

1. In a repository with a tracked source file, change a small expression such as `let count = 1;` to `let count = 4;`. Open the Git dashboard and select that file. Expect continuous red/green row backgrounds with syntax colors and no stronger inline patches by default.
2. Press `Tab` to focus the diff, then `H`. Expect the header to show `smart words` and only the changed values to receive stronger backgrounds. Press `H` again to return to `lines`.
3. Refactor a nested conditional into a guard clause, insert a blank line, and unindent the retained body. In smart-word mode, expect the changed condition to be emphasized without highlighting the unchanged body. Pure indentation changes and unrelated replacements should retain only their line colors.
4. Run `cargo test -p red --lib plugin::workspace:: -- --test-threads=1`. This includes `reindented_guard_clause_leaves_the_moved_body_quiet` and `line_highlights_are_default_and_smart_words_toggle_locally`.

Validation: formatting, the debug build, and all 24 focused workspace tests passed. The full test suite and Clippy have not been run locally; they were deferred for early visual feedback.
