### PR TITLE
feat(notifications): add bottom-line summary and message history

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ is fine: the embedded defaults, plugins, and themes are enough to start editing.
 | Key | Action |
 | --- | --- |
 | `Space ?` | Discover commands and their effective keymaps |
+| `Space m` | Browse notifications and recent messages |
 | `Ctrl-p` | Find a file with fuzzy search and live preview |
 | `Space G` | Open the Git status workspace |
 | `Space A` | Ask the agent with editor context |

--- a/default_config.toml
+++ b/default_config.toml
@@ -380,6 +380,7 @@ Esc = { EnterMode = "Normal" }
 "o" = "OnlyWindow"
 
 [keys.normal." "]
+"m" = "OpenMessages"
 "H" = "OpenInlineHistory"
 "C" = "AddSampleInlineComment"
 "X" = "ClearInlineComments"

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -216,6 +216,14 @@ Enter Command mode with `:` or `;`.
 | `:languages reload` | Reload custom language definitions, trusted grammars, and changed language servers |
 | `:join [count]` / `:join! [count]` | Join with normalized or preserved spacing |
 | `:commands` | Open the command palette |
+| `:messages` | Browse active notifications and recent messages |
+
+The bottom line shows the current notification and how many are active. Open
+the history with `Space m`, `:messages`, or a click on the message line. Use
+`j`/`k` to browse, `/` to search full message text, `f` to switch filters,
+`Enter` to acknowledge, `y` to copy, and `Esc` to return. `Ctrl-d`/`Ctrl-u`
+scroll long details; `D` clears inactive history. Messages are retained for
+the current Red session, subject to the history limit.
 
 ## Git workspace
 

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -44,6 +44,7 @@ pub(crate) const BUILTIN_COLON_COMMANDS: &[&str] = &[
     "plugins",
     "statusline",
     "config-diagnostics",
+    "messages",
 ];
 
 const SPECIAL_BUILTIN_COLON_COMMANDS: &[&str] = &[
@@ -382,6 +383,15 @@ pub(crate) fn keymap_hints(
 
 fn builtin_commands() -> Vec<BuiltinCommand> {
     vec![
+        builtin(
+            "editor.messages",
+            "Messages",
+            "Editor",
+            "Browse active notifications and recent message history",
+            Some(":messages"),
+            &["notifications", "message history", "errors"],
+            Action::OpenMessages,
+        ),
         builtin(
             "editor.inline_history",
             "Inline assist history",
@@ -1201,6 +1211,7 @@ fn key_action_label(action: &KeyAction) -> Option<String> {
 fn action_label(action: &Action) -> String {
     match action {
         Action::CommandPalette => "All commands".to_string(),
+        Action::OpenMessages => "Messages".to_string(),
         Action::OpenInlineHistory => "Inline assist history".to_string(),
         Action::ConfigDiagnostics => "Configuration diagnostics".to_string(),
         Action::OpenWhatsNew => "What’s new in Red".to_string(),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3148,7 +3148,7 @@ pub struct Editor {
     /// Session-local notification records, independent of the legacy display slot.
     notifications: NotificationCenter,
     message_browser: Option<notifications::MessageBrowser>,
-    notification_presentation: Option<notifications::NotificationPresentation>,
+    notification_presentation: notifications::NotificationPresentation,
     notification_animation_start: Instant,
     notification_fallback: Option<String>,
     config_notification: Option<NotificationId>,
@@ -4429,7 +4429,7 @@ impl Editor {
             search_highlights_suppressed: false,
             notifications: NotificationCenter::default(),
             message_browser: None,
-            notification_presentation: None,
+            notification_presentation: notifications::NotificationPresentation::default(),
             notification_animation_start: Instant::now(),
             notification_fallback: None,
             config_notification: None,
@@ -37200,14 +37200,15 @@ while True:
 
     #[tokio::test]
     async fn command_feedback_renders_after_prompt_closes() {
-        for (command, dirty, expected) in [
+        for (command, dirty, expected, marker) in [
             (
                 "q",
                 true,
                 "The following buffers have unwritten changes: [No Name]",
+                "",
             ),
-            ("w", true, "No file name"),
-            ("xyz", false, "unknown command \"xyz\""),
+            ("w", true, "No file name", "× "),
+            ("xyz", false, "unknown command \"xyz\"", "× "),
         ] {
             let mut editor = test_editor(80, 5);
             editor.current_buffer_mut().dirty = dirty;
@@ -37228,7 +37229,12 @@ while True:
 
             assert!(!processed.quit, "command {command:?} unexpectedly quit");
             assert_eq!(editor.last_error.as_deref(), Some(expected));
-            assert_eq!(render_row(&render_buffer, 4).trim_end(), expected);
+            let row = render_row(&render_buffer, 4);
+            let message = row
+                .trim_end()
+                .strip_suffix("[1 active · :messages]")
+                .expect("command feedback should include the active-message badge");
+            assert_eq!(message.trim_end(), format!("{marker}{expected}"));
         }
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -24,6 +24,7 @@ mod inline_history;
 mod lsp_coordinator;
 #[cfg(test)]
 mod navigation_perf_tests;
+mod notifications;
 pub(crate) mod perf;
 pub mod render_buffer;
 pub mod rendering;
@@ -111,8 +112,8 @@ use crate::{
     },
     matchit::{self, MatchDirection, MatchMotion},
     notification::{
-        Notice, NotificationCenter, NotificationError, NotificationId, NotificationSource,
-        NotificationTime, Severity,
+        MessageAction, Notice, NotificationCenter, NotificationError, NotificationId,
+        NotificationSource, NotificationTime, Severity,
     },
     plugin::{self, ComposerHandle, PickerHandle, PluginRegistry, RequestId, Runtime},
     preferences::{PanelLayoutPreference, PreferencesStore},
@@ -2420,6 +2421,8 @@ pub enum Action {
         failure_reason: Option<String>,
     },
     Print(String),
+    OpenMessages,
+    MessageHistory(MessageAction),
 
     OpenTextPanelTurnActions,
     CopyTextPanelTurn {
@@ -3144,6 +3147,13 @@ pub struct Editor {
 
     /// Session-local notification records, independent of the legacy display slot.
     notifications: NotificationCenter,
+    message_browser: Option<notifications::MessageBrowser>,
+    notification_presentation: Option<notifications::NotificationPresentation>,
+    notification_animation_start: Instant,
+    notification_fallback: Option<String>,
+    config_notification: Option<NotificationId>,
+    session_notification: Option<NotificationId>,
+    persistent_notification_messages: [Option<String>; 2],
 
     /// Compatibility display slot while existing producers are migrated.
     last_error: Option<String>,
@@ -3983,8 +3993,7 @@ impl Editor {
         &self.notifications
     }
 
-    /// Records a typed notice without changing the legacy command-line display slot.
-    /// The bottom-line renderer will consume this store after its layout migration.
+    /// Records a typed notice for the bottom line and message history.
     pub fn publish_notification(
         &mut self,
         notice: Notice,
@@ -3999,6 +4008,7 @@ impl Editor {
     ) {
         self.config_diagnostics = diagnostics;
         self.config_diagnostics_acknowledged = self.config_diagnostics.is_empty();
+        self.sync_persistent_notifications();
         if recovery == ConfigRecovery::WholeFileFallback && !self.config_diagnostics.is_empty() {
             self.open_config_diagnostics();
         }
@@ -4106,6 +4116,7 @@ impl Editor {
         self.config.commenting = loaded.config.commenting;
         self.config_diagnostics = loaded.diagnostics;
         self.config_diagnostics_acknowledged = self.config_diagnostics.is_empty();
+        self.sync_persistent_notifications();
         self.highlighter = highlighter;
         self.syntax_textobjects.reset(Arc::clone(&registry));
         self.indentation = indentation;
@@ -4133,6 +4144,7 @@ impl Editor {
 
     fn open_config_diagnostics(&mut self) {
         self.config_diagnostics_acknowledged = true;
+        self.sync_persistent_notifications();
         let diagnostics = self.config_diagnostics.clone();
         let actions = diagnostics
             .iter()
@@ -4416,6 +4428,13 @@ impl Editor {
             search_match_cache: None,
             search_highlights_suppressed: false,
             notifications: NotificationCenter::default(),
+            message_browser: None,
+            notification_presentation: None,
+            notification_animation_start: Instant::now(),
+            notification_fallback: None,
+            config_notification: None,
+            session_notification: None,
+            persistent_notification_messages: [None, None],
             last_error: None,
             current_dialog: None,
             dialog_action_menu: crate::ui::ActionMenu::default(),
@@ -4840,7 +4859,7 @@ impl Editor {
             crate::window::Direction::Left => "no window to the left",
             crate::window::Direction::Right => "no window to the right",
         };
-        self.last_error = Some(message.to_string());
+        self.set_legacy_message(Some(message.to_string()));
         self.draw_commandline(buffer);
         Ok(())
     }
@@ -5007,7 +5026,9 @@ impl Editor {
             Ok(changed) => changed,
             Err(error) => {
                 log!("failed to reset panel layout preferences: {error}");
-                self.last_error = Some(format!("unable to save panel layout reset: {error}"));
+                self.set_legacy_message(Some(format!(
+                    "unable to save panel layout reset: {error}"
+                )));
                 false
             }
         };
@@ -5025,7 +5046,7 @@ impl Editor {
             }
         }
         if let Some(panel_id) = panel_id.filter(|_| !live_found && !preference_changed) {
-            self.last_error = Some(format!("unknown panel {panel_id:?}"));
+            self.set_legacy_message(Some(format!("unknown panel {panel_id:?}")));
         }
         if live_changed {
             self.apply_panel_layout();
@@ -7456,9 +7477,9 @@ impl Editor {
         } else {
             Ok(())
         } {
-            self.last_error = Some(format!(
+            self.set_legacy_message(Some(format!(
                 "inline edit applied, but change notification failed: {error}"
-            ));
+            )));
         }
         let scope = self
             .inline_assist
@@ -7988,7 +8009,9 @@ impl Editor {
             return Ok(false);
         }
         if self.agent_manager.is_session_active(&session_id) {
-            self.last_error = Some("a Codex prompt is already active for this session".to_string());
+            self.set_legacy_message(Some(
+                "a Codex prompt is already active for this session".to_string(),
+            ));
             return Ok(true);
         }
         let turn_id = uuid::Uuid::new_v4().to_string();
@@ -8687,7 +8710,9 @@ impl Editor {
                         plugin_json(serde_json::to_value(conversation)?),
                     )
                     .await?;
-                self.last_error = Some(format!("{message}; restoring the persisted agent session"));
+                self.set_legacy_message(Some(format!(
+                    "{message}; restoring the persisted agent session"
+                )));
             } else {
                 self.plugin_registry
                     .notify(runtime, "agent:session_lost", json!({ "message": message }))
@@ -8796,7 +8821,7 @@ impl Editor {
             Ok(None) => {}
             Err(err) => {
                 log!("ERROR: Lsp error: {err}");
-                self.last_error = Some(err.to_string());
+                self.set_legacy_message(Some(err.to_string()));
                 needs_render = true;
             }
         }
@@ -9099,9 +9124,9 @@ impl Editor {
                 } => {
                     if runtime.composer_plugin(handle).as_deref() != Some(owner.as_str()) {
                         runtime.release_composer(handle);
-                        self.last_error = Some(
+                        self.set_legacy_message(Some(
                             "ignored a composer whose callback owner no longer exists".to_string(),
-                        );
+                        ));
                         needs_render = true;
                         continue;
                     }
@@ -9122,9 +9147,9 @@ impl Editor {
                 } => {
                     if runtime.composer_plugin(handle).as_deref() != Some(owner.as_str()) {
                         runtime.release_composer(handle);
-                        self.last_error = Some(
+                        self.set_legacy_message(Some(
                             "ignored an input whose callback owner no longer exists".to_string(),
-                        );
+                        ));
                         needs_render = true;
                         continue;
                     }
@@ -9159,9 +9184,9 @@ impl Editor {
                 } => {
                     if runtime.picker_plugin(handle).as_deref() != Some(owner.as_str()) {
                         runtime.release_picker(handle);
-                        self.last_error = Some(
+                        self.set_legacy_message(Some(
                             "ignored a picker whose callback owner no longer exists".to_string(),
-                        );
+                        ));
                         needs_render = true;
                         continue;
                     }
@@ -9184,10 +9209,10 @@ impl Editor {
                 } => {
                     if runtime.picker_plugin(handle).as_deref() != Some(owner.as_str()) {
                         runtime.release_picker(handle);
-                        self.last_error = Some(
+                        self.set_legacy_message(Some(
                             "ignored a confirmation whose callback owner no longer exists"
                                 .to_string(),
-                        );
+                        ));
                         needs_render = true;
                         continue;
                     }
@@ -10246,6 +10271,8 @@ impl Editor {
                 }
             }
         }
+        self.sync_persistent_notifications();
+        needs_render |= self.notification_presentation_changed();
         let background_render = if needs_render {
             MotionRender::Full
         } else if needs_editor_windows_render {
@@ -11121,7 +11148,7 @@ impl Editor {
         runtime: &mut Runtime,
     ) -> anyhow::Result<()> {
         let Some(change) = self.last_semantic_change.clone() else {
-            self.last_error = Some("no change to repeat".to_string());
+            self.set_legacy_message(Some("no change to repeat".to_string()));
             return Ok(());
         };
 
@@ -11152,24 +11179,24 @@ impl Editor {
         runtime: &mut Runtime,
     ) -> anyhow::Result<()> {
         let Some(register) = normalize_macro_register(register) else {
-            self.last_error = Some("macro register must be a letter or digit".to_string());
+            self.set_legacy_message(Some("macro register must be a letter or digit".to_string()));
             return Ok(());
         };
         let depth = self.macro_replay_depth.saturating_add(1);
         if depth > MACRO_MAX_REPLAY_DEPTH {
-            self.last_error = Some(format!(
+            self.set_legacy_message(Some(format!(
                 "macro recursion limit ({MACRO_MAX_REPLAY_DEPTH}) reached"
-            ));
+            )));
             return Ok(());
         }
         let Some(content) = self.registers.get(&register) else {
-            self.last_error = Some(format!("macro register @{register} is empty"));
+            self.set_legacy_message(Some(format!("macro register @{register} is empty")));
             return Ok(());
         };
         let events = match Self::macro_events_from_notation(&content.text) {
             Ok(events) => events,
             Err(error) => {
-                self.last_error = Some(error.to_string());
+                self.set_legacy_message(Some(error.to_string()));
                 return Ok(());
             }
         };
@@ -11192,9 +11219,9 @@ impl Editor {
         let result = async {
             while let Some(replay) = self.macro_replay_queue.pop_front() {
                 if self.macro_instructions_remaining == 0 {
-                    self.last_error = Some(format!(
+                    self.set_legacy_message(Some(format!(
                         "macro instruction limit ({MACRO_MAX_REPLAY_EVENTS}) reached"
-                    ));
+                    )));
                     self.macro_replay_queue.clear();
                     break;
                 }
@@ -11556,7 +11583,7 @@ impl Editor {
             } else {
                 "format response is stale; buffer changed".to_string()
             };
-            self.last_error = Some(warning.clone());
+            self.set_legacy_message(Some(warning.clone()));
             return save.filter(|save| save.save_as.is_some()).map(|save| {
                 Action::RestoreLspFormatSave {
                     buffer_id: pending.buffer_id,
@@ -11583,7 +11610,7 @@ impl Editor {
                 } else {
                     format!("invalid LSP formatting response: {error}")
                 };
-                self.last_error = Some(warning.clone());
+                self.set_legacy_message(Some(warning.clone()));
                 return save.filter(|save| save.save_as.is_some()).map(|save| {
                     Action::RestoreLspFormatSave {
                         buffer_id: pending.buffer_id,
@@ -11613,7 +11640,7 @@ impl Editor {
             crate::lsp::apply_text_edits(&contents, &edits).err()
         }) {
             let warning = format!("invalid LSP formatting edits; Save As cancelled: {error}");
-            self.last_error = Some(warning.clone());
+            self.set_legacy_message(Some(warning.clone()));
             let save = save?;
             return Some(Action::RestoreLspFormatSave {
                 buffer_id: pending.buffer_id,
@@ -11646,14 +11673,16 @@ impl Editor {
         let pending = self.pending_lsp_edit_requests.remove(&response.id)?;
         let revision_snapshot = self.pending_lsp_revision_snapshots.remove(&response.id);
         if !self.pending_lsp_edit_is_current(&pending) {
-            self.last_error = Some("code-action response is stale; buffer changed".to_string());
+            self.set_legacy_message(Some(
+                "code-action response is stale; buffer changed".to_string(),
+            ));
             return None;
         }
         let values = match &response.result {
             Value::Null => return None,
             Value::Array(values) => values,
             _ => {
-                self.last_error = Some("invalid LSP code-action response".to_string());
+                self.set_legacy_message(Some("invalid LSP code-action response".to_string()));
                 return None;
             }
         };
@@ -11671,7 +11700,9 @@ impl Editor {
                 Some(edit) => match workspace_edit_operations(edit) {
                     Ok(operations) => operations,
                     Err(error) => {
-                        self.last_error = Some(format!("invalid LSP code-action edit: {error}"));
+                        self.set_legacy_message(Some(format!(
+                            "invalid LSP code-action edit: {error}"
+                        )));
                         continue;
                     }
                 },
@@ -11686,7 +11717,9 @@ impl Editor {
                 Some(command) => match serde_json::from_value::<LspCommand>(command) {
                     Ok(command) => Some(command),
                     Err(error) => {
-                        self.last_error = Some(format!("invalid LSP code-action command: {error}"));
+                        self.set_legacy_message(Some(format!(
+                            "invalid LSP code-action command: {error}"
+                        )));
                         continue;
                     }
                 },
@@ -11703,12 +11736,12 @@ impl Editor {
             ) {
                 Ok(revisions) => revisions,
                 Err(error) => {
-                    self.last_error = Some(error);
+                    self.set_legacy_message(Some(error));
                     continue;
                 }
             };
             if let Err(error) = self.validate_workspace_edit_origin(&operations, &pending.uri) {
-                self.last_error = Some(error);
+                self.set_legacy_message(Some(error));
                 continue;
             }
 
@@ -11747,7 +11780,7 @@ impl Editor {
 
         if items.is_empty() {
             if self.last_error.is_none() {
-                self.last_error = Some("no applicable LSP code actions".to_string());
+                self.set_legacy_message(Some("no applicable LSP code actions".to_string()));
             }
             return None;
         }
@@ -11972,17 +12005,17 @@ impl Editor {
         let pending = self.pending_lsp_edit_requests.remove(&response.id)?;
         let revision_snapshot = self.pending_lsp_revision_snapshots.remove(&response.id);
         if !self.pending_lsp_edit_is_current(&pending) {
-            self.last_error = Some("rename response is stale; buffer changed".to_string());
+            self.set_legacy_message(Some("rename response is stale; buffer changed".to_string()));
             return None;
         }
         if response.result.is_null() {
-            self.last_error = Some("language server returned no rename edit".to_string());
+            self.set_legacy_message(Some("language server returned no rename edit".to_string()));
             return None;
         }
         let operations = match workspace_edit_operations(&response.result) {
             Ok(operations) => operations,
             Err(error) => {
-                self.last_error = Some(format!("invalid LSP rename response: {error}"));
+                self.set_legacy_message(Some(format!("invalid LSP rename response: {error}")));
                 return None;
             }
         };
@@ -11993,12 +12026,12 @@ impl Editor {
         ) {
             Ok(revisions) => revisions,
             Err(error) => {
-                self.last_error = Some(error);
+                self.set_legacy_message(Some(error));
                 return None;
             }
         };
         if let Err(error) = self.validate_workspace_edit_origin(&operations, &pending.uri) {
-            self.last_error = Some(error);
+            self.set_legacy_message(Some(error));
             return None;
         }
         Some(self.workspace_edit_action(
@@ -12167,16 +12200,16 @@ impl Editor {
                         if msg.request.is_some()
                             && self.completion_filter_for_response(msg).is_none()
                         {
-                            self.last_error = Some(
+                            self.set_legacy_message(Some(
                                 "completion response is stale; cursor moved before the request position"
                                     .to_string(),
-                            );
+                            ));
                             return None;
                         }
                         let Some(snapshot) = self.snapshot_for_completion_response(&pending) else {
-                            self.last_error = Some(
+                            self.set_legacy_message(Some(
                                 "completion response is stale; active buffer changed".to_string(),
-                            );
+                            ));
                             return None;
                         };
                         if msg.result.is_null() {
@@ -12281,7 +12314,7 @@ impl Editor {
                 {
                     return Some(Action::ShowDialog);
                 }
-                self.last_error = Some(error_msg.message.clone());
+                self.set_legacy_message(Some(error_msg.message.clone()));
                 let save_as = save.as_ref().is_some_and(|save| save.save_as.is_some());
                 if (error_msg.code == -32601 || save_as)
                     && method.as_deref() == Some("textDocument/formatting")
@@ -12315,7 +12348,7 @@ impl Editor {
                                 "format response is stale; Save As cancelled: {}",
                                 error_msg.message
                             );
-                            self.last_error = Some(warning.clone());
+                            self.set_legacy_message(Some(warning.clone()));
                             return Some(Action::RestoreLspFormatSave {
                                 buffer_id: pending.buffer_id,
                                 uri: pending.uri,
@@ -12347,7 +12380,7 @@ impl Editor {
                     {
                         return Some(Action::ShowDialog);
                     }
-                    self.last_error = Some(error.to_string());
+                    self.set_legacy_message(Some(error.to_string()));
                     let save_as = save.as_ref().is_some_and(|save| save.save_as.is_some());
                     if (matches!(
                         error,
@@ -12382,7 +12415,7 @@ impl Editor {
                             if save.save_as.is_some() {
                                 let warning =
                                     format!("format response is stale; Save As cancelled: {error}");
-                                self.last_error = Some(warning.clone());
+                                self.set_legacy_message(Some(warning.clone()));
                                 return Some(Action::RestoreLspFormatSave {
                                     buffer_id: pending.buffer_id,
                                     uri: pending.uri,
@@ -12458,6 +12491,18 @@ impl Editor {
 
         if self.substitute_confirmation.is_some() {
             return Ok(self.handle_substitute_confirmation_event(ev));
+        }
+
+        if !self.has_term()
+            && (self.notifications.records().len() > 0 || self.notification_fallback.is_some())
+            && matches!(ev, Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left), row, ..
+            }) if *row == self.size.1.saturating_sub(1))
+        {
+            self.waiting_key_action = None;
+            self.waiting_command = None;
+            self.clear_keymap_hints();
+            return Ok(Some(KeyAction::Single(Action::OpenMessages)));
         }
 
         if matches!(ev, Event::Paste(_)) {
@@ -12828,11 +12873,11 @@ impl Editor {
                         Content::charwise(yank.text)
                     };
                     self.set_default_register(content);
-                    self.last_error = Some(if yank.linewise {
+                    self.set_legacy_message(Some(if yank.linewise {
                         format!("{} lines yanked", lines.max(1))
                     } else {
                         format!("{length} characters yanked")
-                    });
+                    }));
                     KeyAction::Single(Action::Refresh)
                 }
             });
@@ -12846,15 +12891,17 @@ impl Editor {
                         .focused_text_for_copy(copy_all, usize::from(self.size.0))
                     {
                         self.set_default_register(Content::charwise(text));
-                        self.last_error = Some(if copy_all {
+                        self.set_legacy_message(Some(if copy_all {
                             "conversation copied".to_string()
                         } else {
                             "answer copied".to_string()
-                        });
+                        }));
                         return Some(KeyAction::Single(Action::Refresh));
                     }
                     if !self.panel_manager.focused_row_panel() {
-                        self.last_error = Some("selected turn has no answer to copy".to_string());
+                        self.set_legacy_message(Some(
+                            "selected turn has no answer to copy".to_string(),
+                        ));
                         return Some(KeyAction::Single(Action::Refresh));
                     }
                 }
@@ -13084,7 +13131,7 @@ impl Editor {
         match target {
             plugin::TextPanelLinkTarget::File { path, location } => {
                 if let Err(error) = validate_text_panel_file(&path) {
-                    self.last_error = Some(format!("Unable to open link: {error}"));
+                    self.set_legacy_message(Some(format!("Unable to open link: {error}")));
                     return KeyAction::Single(Action::Refresh);
                 }
                 self.panel_manager.focus_editor();
@@ -13221,6 +13268,7 @@ impl Editor {
             | Action::ConfigDiagnostics
             | Action::Suspend
             | Action::ViewLogs
+            | Action::OpenMessages
             | Action::ListPlugins
             | Action::SplitHorizontal
             | Action::SplitVertical
@@ -13475,7 +13523,7 @@ impl Editor {
         self.command = String::new();
         self.waiting_command = None;
         self.repeater = None;
-        self.last_error = None;
+        self.set_legacy_message(None);
 
         if let Some(commands) = self.scratch_buffers.get(&self.current_buffer().id()) {
             let routed = match cmd.trim() {
@@ -13496,7 +13544,7 @@ impl Editor {
             Ok(Some(command)) => return vec![Action::Substitute(command)],
             Ok(None) => {}
             Err(error) => {
-                self.last_error = Some(error.to_string());
+                self.set_legacy_message(Some(error.to_string()));
                 return Vec::new();
             }
         }
@@ -13515,7 +13563,9 @@ impl Editor {
                 } else if let Ok(count) = arguments.trim().parse::<u16>() {
                     count.max(2)
                 } else {
-                    self.last_error = Some("join count must be a positive integer".to_string());
+                    self.set_legacy_message(Some(
+                        "join count must be a positive integer".to_string(),
+                    ));
                     return Vec::new();
                 };
                 return vec![if keep_spaces {
@@ -13525,13 +13575,15 @@ impl Editor {
                 }];
             }
             if !arguments.trim().is_empty() {
-                self.last_error = Some("join count cannot be combined with a range".to_string());
+                self.set_legacy_message(Some(
+                    "join count cannot be combined with a range".to_string(),
+                ));
                 return Vec::new();
             }
             let range = match self.resolve_ex_line_range(range, "join") {
                 Ok(range) => range,
                 Err(error) => {
-                    self.last_error = Some(error.to_string());
+                    self.set_legacy_message(Some(error.to_string()));
                     return Vec::new();
                 }
             };
@@ -13542,11 +13594,11 @@ impl Editor {
             }];
         }
         if !range.is_empty() {
-            self.last_error = Some(if ranged_command.is_empty() {
+            self.set_legacy_message(Some(if ranged_command.is_empty() {
                 "line range requires a command".to_string()
             } else {
                 format!("command {name:?} does not support a line range")
-            });
+            }));
             return Vec::new();
         }
 
@@ -13558,6 +13610,9 @@ impl Editor {
         }
         if cmd == "config-diagnostics" {
             return vec![Action::ConfigDiagnostics];
+        }
+        if cmd == "messages" {
+            return vec![Action::OpenMessages];
         }
         if matches!(cmd, "InlineHistory" | "inline-history") {
             return vec![Action::OpenInlineHistory];
@@ -13605,16 +13660,20 @@ impl Editor {
         }
         if let Some(assignment) = cmd.strip_prefix("register ") {
             let Some((register, keys)) = assignment.split_once(' ') else {
-                self.last_error = Some("usage: register <name> <key-notation>".to_string());
+                self.set_legacy_message(Some("usage: register <name> <key-notation>".to_string()));
                 return Vec::new();
             };
             let mut register_chars = register.chars();
             let Some(register) = register_chars.next() else {
-                self.last_error = Some("macro register must be a letter or digit".to_string());
+                self.set_legacy_message(Some(
+                    "macro register must be a letter or digit".to_string(),
+                ));
                 return Vec::new();
             };
             if register_chars.next().is_some() || normalize_macro_register(register).is_none() {
-                self.last_error = Some("macro register must be a letter or digit".to_string());
+                self.set_legacy_message(Some(
+                    "macro register must be a letter or digit".to_string(),
+                ));
                 return Vec::new();
             }
             return vec![Action::SetMacroRegister {
@@ -13632,7 +13691,7 @@ impl Editor {
                 return vec![Action::OpenSyntaxPicker];
             };
             if arguments.next().is_some() {
-                self.last_error = Some("usage: syntax [language|auto|off]".to_string());
+                self.set_legacy_message(Some("usage: syntax [language|auto|off]".to_string()));
                 return Vec::new();
             }
             return vec![Action::SetSyntax(syntax.to_string())];
@@ -13642,7 +13701,7 @@ impl Editor {
             return if arguments.trim() == "reload" {
                 vec![Action::ReloadLanguages]
             } else {
-                self.last_error = Some("usage: languages reload".to_string());
+                self.set_legacy_message(Some("usage: languages reload".to_string()));
                 Vec::new()
             };
         }
@@ -13651,7 +13710,7 @@ impl Editor {
             return if arguments.trim().is_empty() {
                 vec![Action::ListPlugins]
             } else {
-                self.last_error = Some("usage: plugins".to_string());
+                self.set_legacy_message(Some("usage: plugins".to_string()));
                 Vec::new()
             };
         }
@@ -13659,18 +13718,22 @@ impl Editor {
         if name == "set" {
             let mut options = arguments.split_whitespace();
             let Some(option) = options.next() else {
-                self.last_error = Some("usage: set {relativenumber|norelativenumber}".to_string());
+                self.set_legacy_message(Some(
+                    "usage: set {relativenumber|norelativenumber}".to_string(),
+                ));
                 return Vec::new();
             };
             if options.next().is_some() {
-                self.last_error = Some("usage: set {relativenumber|norelativenumber}".to_string());
+                self.set_legacy_message(Some(
+                    "usage: set {relativenumber|norelativenumber}".to_string(),
+                ));
                 return Vec::new();
             }
             return match option {
                 "relativenumber" | "rnu" => vec![Action::SetRelativeLineNumbers(true)],
                 "norelativenumber" | "nornu" => vec![Action::SetRelativeLineNumbers(false)],
                 _ => {
-                    self.last_error = Some(format!("unknown option {option:?}"));
+                    self.set_legacy_message(Some(format!("unknown option {option:?}")));
                     Vec::new()
                 }
             };
@@ -13682,7 +13745,10 @@ impl Editor {
             if runtime.command_plugin(cmd).is_some() {
                 return vec![Action::PluginCommand(cmd.to_string())];
             }
-            self.last_error = Some(format!("unknown command {cmd:?}"));
+            self.set_notification_message(
+                Severity::Error,
+                Some(format!("unknown command {cmd:?}")),
+            );
             return vec![];
         };
 
@@ -13760,7 +13826,9 @@ impl Editor {
 
             if cmd == "panel-layout-reset" {
                 if parsed.args.len() > 1 {
-                    self.last_error = Some("usage: panel-layout-reset [panel-id]".to_string());
+                    self.set_legacy_message(Some(
+                        "usage: panel-layout-reset [panel-id]".to_string(),
+                    ));
                     return Vec::new();
                 }
                 actions.push(Action::ResetPanelLayout(parsed.args.first().cloned()));
@@ -13849,10 +13917,10 @@ impl Editor {
             .char_idx_to_position(substitution.start_char);
         self.move_to_text_position(position);
         self.refresh_cursor_goal();
-        self.last_error = Some(format!(
+        self.set_legacy_message(Some(format!(
             "replace with {:?}? (y/n/a/q/l)",
             substitution.replacement
-        ));
+        )));
         self.render(buffer)
     }
 
@@ -13863,7 +13931,7 @@ impl Editor {
         runtime: &mut Runtime,
     ) -> anyhow::Result<()> {
         if substitutions.is_empty() {
-            self.last_error = Some("pattern not found".to_string());
+            self.set_legacy_message(Some("pattern not found".to_string()));
             self.render(buffer)?;
             return Ok(());
         }
@@ -14038,7 +14106,7 @@ impl Editor {
         self.mode = Mode::Search;
         self.waiting_command = None;
         self.repeater = None;
-        self.last_error = None;
+        self.set_legacy_message(None);
     }
 
     fn update_search_preview(&mut self) {
@@ -14062,13 +14130,13 @@ impl Editor {
         ) {
             Ok(preview) => preview,
             Err(err) => {
-                self.last_error = Some(err.to_string());
+                self.set_legacy_message(Some(err.to_string()));
                 None
             }
         };
 
         if let Some(match_) = preview {
-            self.last_error = None;
+            self.set_legacy_message(None);
             self.move_to_search_match(match_);
         } else {
             self.restore_search_origin(&session.origin, session.origin_vtop);
@@ -14084,7 +14152,7 @@ impl Editor {
             self.restore_search_origin(&session.origin, session.origin_vtop);
         }
         self.mode = Mode::Normal;
-        self.last_error = None;
+        self.set_legacy_message(None);
     }
 
     fn finish_search_with_error(&mut self, session: SearchSession, error: String) {
@@ -14094,7 +14162,7 @@ impl Editor {
         self.search_highlights_suppressed = false;
         self.active_search = None;
         self.mode = Mode::Normal;
-        self.last_error = Some(error);
+        self.set_legacy_message(Some(error));
     }
 
     fn pattern_not_found_message(pattern: &str) -> String {
@@ -14132,7 +14200,7 @@ impl Editor {
             .to_string();
         if pattern.is_empty() {
             if self.active_search.is_none() {
-                self.last_error = Some("no previous search".to_string());
+                self.set_legacy_message(Some("no previous search".to_string()));
                 self.draw_commandline(buffer);
             }
             return Ok(false);
@@ -14147,13 +14215,13 @@ impl Editor {
         ) {
             Ok(matched) => matched,
             Err(err) => {
-                self.last_error = Some(err.to_string());
+                self.set_legacy_message(Some(err.to_string()));
                 self.render(buffer)?;
                 return Ok(false);
             }
         };
         if let Some(match_) = matched {
-            self.last_error = None;
+            self.set_legacy_message(None);
             self.search_highlights_suppressed = false;
             self.move_to_search_match(match_);
             if let Some(active_search) = &mut self.active_search {
@@ -14162,7 +14230,7 @@ impl Editor {
             self.render(buffer)?;
             return Ok(true);
         } else {
-            self.last_error = Some(Self::pattern_not_found_message(&pattern));
+            self.set_legacy_message(Some(Self::pattern_not_found_message(&pattern)));
             self.render(buffer)?;
         }
 
@@ -14199,7 +14267,7 @@ impl Editor {
             return;
         }
         session.preview = None;
-        self.last_error = None;
+        self.set_legacy_message(None);
         self.update_search_preview();
     }
 
@@ -14677,7 +14745,7 @@ impl Editor {
             if let Some(kind) = SyntaxObjectKind::for_text_object_key(*c) {
                 let Some(object) = self.syntax_text_object(scope, kind) else {
                     if self.last_error.is_none() {
-                        self.last_error = Some("text object not found".to_string());
+                        self.set_legacy_message(Some("text object not found".to_string()));
                     }
                     return Some(KeyAction::None);
                 };
@@ -14689,26 +14757,26 @@ impl Editor {
                 if selected {
                     return Some(KeyAction::Single(Action::Refresh));
                 }
-                self.last_error = Some("text object not found".to_string());
+                self.set_legacy_message(Some("text object not found".to_string()));
                 return Some(KeyAction::None);
             }
             let Some(kind) = text_object_kind_for_key(*c) else {
                 if *c == '%' {
                     let Some(range) = self.matchit_select_around_range() else {
-                        self.last_error = Some("text object not found".to_string());
+                        self.set_legacy_message(Some("text object not found".to_string()));
                         return Some(KeyAction::None);
                     };
                     if self.select_text_range(range) {
                         return Some(KeyAction::Single(Action::Refresh));
                     }
-                    self.last_error = Some("text object not found".to_string());
+                    self.set_legacy_message(Some("text object not found".to_string()));
                     return Some(KeyAction::None);
                 }
                 return self.pending_visual_text_object_invalid();
             };
 
             let Some(range) = self.text_object_range(scope, kind) else {
-                self.last_error = Some("text object not found".to_string());
+                self.set_legacy_message(Some("text object not found".to_string()));
                 return Some(KeyAction::None);
             };
 
@@ -14718,7 +14786,7 @@ impl Editor {
             if self.select_text_range(range) {
                 return Some(KeyAction::Single(Action::Refresh));
             }
-            self.last_error = Some("text object not found".to_string());
+            self.set_legacy_message(Some("text object not found".to_string()));
             return Some(KeyAction::None);
         }
 
@@ -14740,7 +14808,7 @@ impl Editor {
     fn pending_visual_text_object_invalid(&mut self) -> Option<KeyAction> {
         self.pending_visual_text_object_scope = None;
         self.waiting_command = None;
-        self.last_error = Some("invalid text object".to_string());
+        self.set_legacy_message(Some("invalid text object".to_string()));
         Some(KeyAction::None)
     }
 
@@ -14842,12 +14910,12 @@ impl Editor {
                 return Some(KeyAction::None);
             }
             if !matches!(*modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT) {
-                self.last_error = Some("replacement must be a character".to_string());
+                self.set_legacy_message(Some("replacement must be a character".to_string()));
                 self.repeater = None;
                 return Some(KeyAction::None);
             }
             let KeyCode::Char(character) = code else {
-                self.last_error = Some("replacement must be a character".to_string());
+                self.set_legacy_message(Some("replacement must be a character".to_string()));
                 self.repeater = None;
                 return Some(KeyAction::None);
             };
@@ -14934,7 +15002,9 @@ impl Editor {
     fn invalid_mark(&mut self) -> Option<KeyAction> {
         self.pending_mark_action = None;
         self.waiting_command = None;
-        self.last_error = Some("mark must be a letter or a supported special mark".to_string());
+        self.set_legacy_message(Some(
+            "mark must be a letter or a supported special mark".to_string(),
+        ));
         Some(KeyAction::None)
     }
 
@@ -14974,7 +15044,7 @@ impl Editor {
                 PendingMacroAction::Play => {
                     let register = if *register == '@' {
                         let Some(register) = self.last_played_macro else {
-                            self.last_error = Some("no previously played macro".to_string());
+                            self.set_legacy_message(Some("no previously played macro".to_string()));
                             self.repeater = None;
                             return Some(KeyAction::None);
                         };
@@ -15046,7 +15116,7 @@ impl Editor {
         self.pending_macro_action = None;
         self.waiting_command = None;
         self.repeater = None;
-        self.last_error = Some("macro register must be a letter or digit".to_string());
+        self.set_legacy_message(Some("macro register must be a letter or digit".to_string()));
         Some(KeyAction::None)
     }
 
@@ -15122,7 +15192,7 @@ impl Editor {
         self.pending_character_motion = None;
         self.waiting_command = None;
         self.repeater = None;
-        self.last_error = Some("invalid character motion".to_string());
+        self.set_legacy_message(Some("invalid character motion".to_string()));
         Some(KeyAction::None)
     }
 
@@ -15494,7 +15564,7 @@ impl Editor {
         self.pending_operator = None;
         self.waiting_command = None;
         self.repeater = None;
-        self.last_error = Some("invalid operator motion".to_string());
+        self.set_legacy_message(Some("invalid operator motion".to_string()));
         Some(KeyAction::None)
     }
 
@@ -15507,7 +15577,7 @@ impl Editor {
         self.pending_operator = None;
         self.waiting_command = None;
         let Some(range) = range else {
-            self.last_error = Some(error.to_string());
+            self.set_legacy_message(Some(error.to_string()));
             return Some(KeyAction::None);
         };
 
@@ -15542,7 +15612,7 @@ impl Editor {
         self.pending_operator = None;
         self.waiting_command = None;
         let Some(range) = range else {
-            self.last_error = Some(error.to_string());
+            self.set_legacy_message(Some(error.to_string()));
             return Some(KeyAction::None);
         };
 
@@ -15921,7 +15991,7 @@ impl Editor {
         {
             Ok(object) => object,
             Err(error) => {
-                self.last_error = Some(error.to_string());
+                self.set_legacy_message(Some(error.to_string()));
                 None
             }
         }
@@ -15947,7 +16017,7 @@ impl Editor {
         ) {
             Ok(target) => target,
             Err(error) => {
-                self.last_error = Some(error.to_string());
+                self.set_legacy_message(Some(error.to_string()));
                 None
             }
         }
@@ -15998,7 +16068,7 @@ impl Editor {
                 Ok(Some(ranges)) => ranges,
                 Ok(None) => return false,
                 Err(error) => {
-                    self.last_error = Some(error.to_string());
+                    self.set_legacy_message(Some(error.to_string()));
                     return false;
                 }
             };
@@ -16347,7 +16417,7 @@ impl Editor {
         tracking: bool,
     ) -> anyhow::Result<bool> {
         // log!("Action: {action:?}");
-        self.last_error = None;
+        self.set_legacy_message(None);
         let sensitive_action = matches!(action, Action::NotifyPlugin(_, _, _))
             || matches!(action, Action::SubmitInlineAssist(_))
             || matches!(action, Action::NotifyPlugins(method, _) if method.starts_with("composer:"));
@@ -16429,10 +16499,10 @@ impl Editor {
                     if modified_buffers.is_empty() {
                         return Ok(true);
                     }
-                    self.last_error = Some(format!(
+                    self.set_legacy_message(Some(format!(
                         "The following buffers have unwritten changes: {}",
                         modified_buffers.join(", ")
-                    ));
+                    )));
                     return Ok(false);
                 }
             }
@@ -16510,14 +16580,14 @@ impl Editor {
             }
             Action::RepeatCharSearch(count) => {
                 let Some((kind, target)) = self.last_character_motion else {
-                    self.last_error = Some("no previous character search".to_string());
+                    self.set_legacy_message(Some("no previous character search".to_string()));
                     return Ok(false);
                 };
                 self.move_to_forward_character(target, *count, kind, buffer)?;
             }
             Action::RepeatCharSearchOpposite(count) => {
                 let Some((kind, target)) = self.last_character_motion else {
-                    self.last_error = Some("no previous character search".to_string());
+                    self.set_legacy_message(Some("no previous character search".to_string()));
                     return Ok(false);
                 };
                 let kind = match kind {
@@ -16676,7 +16746,7 @@ impl Editor {
                 if self.restore_last_visual_selection() {
                     self.render(buffer)?;
                 } else {
-                    self.last_error = Some("last visual selection is not set".to_string());
+                    self.set_legacy_message(Some("last visual selection is not set".to_string()));
                     self.draw_commandline(buffer);
                 }
             }
@@ -16697,9 +16767,9 @@ impl Editor {
                     } else {
                         format!("lines {}–{}", start_line + 1, end_line + 1)
                     };
-                    self.last_error = Some(format!(
+                    self.set_legacy_message(Some(format!(
                         "sample comment · {scope} · Space C replace · Space X clear"
-                    ));
+                    )));
                     self.render(buffer)?;
                 }
             }
@@ -16728,8 +16798,9 @@ impl Editor {
                 match self.inline_assist_target() {
                     Ok((range, scope)) => {
                         let Some(window_id) = self.window_manager.active_stable_window_id() else {
-                            self.last_error =
-                                Some("inline assist requires an active editor window".to_string());
+                            self.set_legacy_message(Some(
+                                "inline assist requires an active editor window".to_string(),
+                            ));
                             self.draw_commandline(buffer);
                             return Ok(false);
                         };
@@ -16759,7 +16830,7 @@ impl Editor {
                         self.render(buffer)?;
                     }
                     Err(error) => {
-                        self.last_error = Some(error.to_string());
+                        self.set_legacy_message(Some(error.to_string()));
                         self.draw_commandline(buffer);
                     }
                 }
@@ -16775,13 +16846,13 @@ impl Editor {
                         )
                     })
                 else {
-                    self.last_error = Some("inline assist is no longer active".to_string());
+                    self.set_legacy_message(Some("inline assist is no longer active".to_string()));
                     return Ok(false);
                 };
                 let mut context = match self.inline_assist_context(range) {
                     Ok(context) => context,
                     Err(error) => {
-                        self.last_error = Some(error.to_string());
+                        self.set_legacy_message(Some(error.to_string()));
                         return Ok(false);
                     }
                 };
@@ -16793,7 +16864,7 @@ impl Editor {
                 }
                 let request_id = uuid::Uuid::new_v4().to_string();
                 if let Err(error) = self.begin_inline_history_turn(&request_id, prompt, range) {
-                    self.last_error = Some(error.to_string());
+                    self.set_legacy_message(Some(error.to_string()));
                     self.render(buffer)?;
                     return Ok(false);
                 }
@@ -16881,7 +16952,7 @@ impl Editor {
                 add_to_history = false;
                 let result = self.inline_assist_result_state();
                 self.close_inline_assist_session();
-                self.last_error = Some(match result {
+                self.set_legacy_message(Some(match result {
                     InlineAssistPopupState::Applied {
                         edited: true,
                         comments,
@@ -16890,7 +16961,7 @@ impl Editor {
                         "kept {comments} inline comment(s) · Space v view · Space x dismiss"
                     ),
                     _ => "inline assist closed".to_string(),
-                });
+                }));
                 self.render(buffer)?;
             }
             Action::UndoInlineAssist => {
@@ -16942,13 +17013,13 @@ impl Editor {
                 if is_latest {
                     self.undo_transaction(buffer, runtime).await?;
                 } else if transaction_id.is_some() {
-                    self.last_error = Some(
+                    self.set_legacy_message(Some(
                         "inline edit is no longer the latest change; use transaction history to revert it"
                             .to_string(),
-                    );
+                    ));
                     self.render(buffer)?;
                 } else {
-                    self.last_error = Some("dismissed inline comments".to_string());
+                    self.set_legacy_message(Some("dismissed inline comments".to_string()));
                     self.render(buffer)?;
                 }
             }
@@ -17350,7 +17421,7 @@ impl Editor {
                     self.notify_change(runtime).await?;
                     self.finish_cursor_motion(buffer, false)?;
                 } else if self.last_error.is_none() {
-                    self.last_error = Some("adjacent text object not found".to_string());
+                    self.set_legacy_message(Some("adjacent text object not found".to_string()));
                 }
             }
             Action::StartCommentOperator(count)
@@ -17459,7 +17530,7 @@ impl Editor {
                 let available = line_length.saturating_sub(self.cx);
                 let count = usize::from(*count);
                 if count == 0 || count > available {
-                    self.last_error = Some("not enough characters to replace".to_string());
+                    self.set_legacy_message(Some("not enough characters to replace".to_string()));
                 } else {
                     let start = self.grapheme_to_char_on_line(self.cx, line);
                     let end = self.grapheme_to_char_on_line(self.cx + count, line);
@@ -17580,7 +17651,7 @@ impl Editor {
             }
             Action::SelectPreviousUndoBranch => {
                 add_to_history = false;
-                self.last_error = self
+                let message = self
                     .current_buffer_mut()
                     .undo_history
                     .select_previous_branch()
@@ -17588,11 +17659,12 @@ impl Editor {
                         format!("undo branch {selected}/{total} selected; redo to traverse")
                     })
                     .or_else(|| Some("no alternate undo branch".to_string()));
+                self.set_legacy_message(message);
                 self.draw_commandline(buffer);
             }
             Action::SelectNextUndoBranch => {
                 add_to_history = false;
-                self.last_error = self
+                let message = self
                     .current_buffer_mut()
                     .undo_history
                     .select_next_branch()
@@ -17600,6 +17672,7 @@ impl Editor {
                         format!("undo branch {selected}/{total} selected; redo to traverse")
                     })
                     .or_else(|| Some("no alternate undo branch".to_string()));
+                self.set_legacy_message(message);
                 self.draw_commandline(buffer);
             }
             Action::RevertTransaction(transaction_id) => {
@@ -17610,7 +17683,7 @@ impl Editor {
                 {
                     Ok(edits) => edits,
                     Err(error) => {
-                        self.last_error = Some(format!("revert conflict: {error}"));
+                        self.set_legacy_message(Some(format!("revert conflict: {error}")));
                         self.draw_commandline(buffer);
                         return Ok(false);
                     }
@@ -17651,7 +17724,7 @@ impl Editor {
                     if let Some(entry) = self.jump_back_entry() {
                         self.jump_to_entry(&entry, buffer, runtime).await?;
                     } else {
-                        self.last_error = Some("previous jump is not set".to_string());
+                        self.set_legacy_message(Some("previous jump is not set".to_string()));
                     }
                 } else {
                     let current_buffer_id = self.current_buffer().id();
@@ -17666,7 +17739,7 @@ impl Editor {
                         self.special_marks.get(&(current_buffer_id, *mark)).cloned()
                     };
                     let Some(mut anchor) = anchor else {
-                        self.last_error = Some(format!("mark {mark} is not set"));
+                        self.set_legacy_message(Some(format!("mark {mark} is not set")));
                         return Ok(false);
                     };
 
@@ -17683,11 +17756,15 @@ impl Editor {
                             .char_idx_to_position(anchor.char_index);
                     } else if mark.is_ascii_uppercase() {
                         let Some(file) = anchor.file.clone() else {
-                            self.last_error = Some(format!("marked buffer for {mark} disappeared"));
+                            self.set_legacy_message(Some(format!(
+                                "marked buffer for {mark} disappeared"
+                            )));
                             return Ok(false);
                         };
                         if !Path::new(&file).exists() {
-                            self.last_error = Some(format!("marked file for {mark} disappeared"));
+                            self.set_legacy_message(Some(format!(
+                                "marked file for {mark} disappeared"
+                            )));
                             return Ok(false);
                         }
                         self.execute_with_tracking(
@@ -17702,7 +17779,9 @@ impl Editor {
                             self.current_buffer().position_to_char_idx(anchor.fallback);
                         self.global_marks.insert(*mark, anchor.clone());
                     } else {
-                        self.last_error = Some(format!("marked buffer for {mark} disappeared"));
+                        self.set_legacy_message(Some(format!(
+                            "marked buffer for {mark} disappeared"
+                        )));
                         return Ok(false);
                     }
 
@@ -17721,7 +17800,7 @@ impl Editor {
                 let substitutions = match self.plan_substitutions(command) {
                     Ok(substitutions) => substitutions,
                     Err(error) => {
-                        self.last_error = Some(error.to_string());
+                        self.set_legacy_message(Some(error.to_string()));
                         self.render(buffer)?;
                         return Ok(false);
                     }
@@ -17742,7 +17821,9 @@ impl Editor {
             Action::ConfirmSubstitute(decision) => {
                 add_to_history = false;
                 let Some(mut confirmation) = self.substitute_confirmation.take() else {
-                    self.last_error = Some("no substitute confirmation is active".to_string());
+                    self.set_legacy_message(Some(
+                        "no substitute confirmation is active".to_string(),
+                    ));
                     return Ok(false);
                 };
                 match decision {
@@ -17773,7 +17854,7 @@ impl Editor {
                 ) || confirmation.current >= confirmation.substitutions.len();
                 if finished {
                     if confirmation.accepted.is_empty() {
-                        self.last_error = Some("0 substitutions".to_string());
+                        self.set_legacy_message(Some("0 substitutions".to_string()));
                         self.render(buffer)?;
                     } else {
                         self.apply_substitutions(confirmation.accepted, buffer, runtime)
@@ -17787,11 +17868,13 @@ impl Editor {
             Action::SetMacroRegister { register, keys } => {
                 add_to_history = false;
                 let Some(register) = normalize_macro_register(*register) else {
-                    self.last_error = Some("macro register must be a letter or digit".to_string());
+                    self.set_legacy_message(Some(
+                        "macro register must be a letter or digit".to_string(),
+                    ));
                     return Ok(false);
                 };
                 if let Err(error) = Self::macro_events_from_notation(keys) {
-                    self.last_error = Some(error.to_string());
+                    self.set_legacy_message(Some(error.to_string()));
                     return Ok(false);
                 }
                 self.set_register(register, Content::charwise(keys.clone()));
@@ -17805,7 +17888,7 @@ impl Editor {
                     .map(|(register, content)| (*register, content.text.clone()))
                     .collect::<Vec<_>>();
                 registers.sort_by_key(|(register, _)| *register);
-                self.last_error = Some(if registers.is_empty() {
+                self.set_legacy_message(Some(if registers.is_empty() {
                     "no registers".to_string()
                 } else {
                     registers
@@ -17813,7 +17896,7 @@ impl Editor {
                         .map(|(register, text)| format!("{register}: {text}"))
                         .collect::<Vec<_>>()
                         .join("  ")
-                });
+                }));
                 self.draw_commandline(buffer);
             }
             Action::InsertLineAt(y, contents) => {
@@ -18087,7 +18170,10 @@ impl Editor {
                     let path = match normalized_file_path(&log_file) {
                         Ok(path) => path,
                         Err(e) => {
-                            self.last_error = Some(format!("Failed to open log file: {}", e));
+                            self.set_legacy_message(Some(format!(
+                                "Failed to open log file: {}",
+                                e
+                            )));
                             return Ok(false);
                         }
                     };
@@ -18096,16 +18182,19 @@ impl Editor {
                         let (index, _, _) = match self.load_or_reuse_file_buffer(&log_file).await {
                             Ok(opened) => opened,
                             Err(e) => {
-                                self.last_error = Some(format!("Failed to open log file: {}", e));
+                                self.set_legacy_message(Some(format!(
+                                    "Failed to open log file: {}",
+                                    e
+                                )));
                                 return Ok(false);
                             }
                         };
                         self.set_current_buffer(buffer, index).await?;
                     } else {
-                        self.last_error = Some(format!("Log file not found: {}", log_file));
+                        self.set_legacy_message(Some(format!("Log file not found: {}", log_file)));
                     }
                 } else {
-                    self.last_error = Some("No log file configured".to_string());
+                    self.set_legacy_message(Some("No log file configured".to_string()));
                 }
             }
             Action::ListPlugins => {
@@ -18114,7 +18203,7 @@ impl Editor {
                 let installed = match manager.list() {
                     Ok(installed) => installed,
                     Err(error) => {
-                        self.last_error = Some(error.to_string());
+                        self.set_legacy_message(Some(error.to_string()));
                         Vec::new()
                     }
                 };
@@ -18217,7 +18306,9 @@ impl Editor {
             Action::PluginManagerSelect(selection) => {
                 add_to_history = false;
                 if selection == "retry-catalog" {
-                    self.last_error = Some("Retrying official language-pack catalog…".to_string());
+                    self.set_legacy_message(Some(
+                        "Retrying official language-pack catalog…".to_string(),
+                    ));
                     runtime.send_request(PluginRequest::Action(Action::ListPlugins));
                 } else if selection == "custom-source" {
                     self.current_dialog = Some(Box::new(InputPrompt::new(
@@ -18237,7 +18328,7 @@ impl Editor {
                                 "Language pack `{id}` changed availability; select it again to continue."
                             )
                         });
-                    self.last_error = Some(message.clone());
+                    self.set_legacy_message(Some(message.clone()));
                     let manager = plugin::package::PluginPackageManager::new(Config::config_dir());
                     let installed = manager.list().unwrap_or_default();
                     let items = plugin_manager_items(
@@ -18452,7 +18543,7 @@ impl Editor {
                 add_to_history = false;
                 let package = package.clone();
                 let digests = digests.clone();
-                self.last_error = Some("Approving native grammar bytes…".to_string());
+                self.set_legacy_message(Some("Approving native grammar bytes…".to_string()));
                 let runtime = runtime.clone();
                 tokio::spawn(async move {
                     let manager = plugin::package::PluginPackageManager::new(Config::config_dir());
@@ -18499,7 +18590,7 @@ impl Editor {
                 let trust_native_grammars = *trust_native_grammars;
                 let catalog_url = catalog_url.clone();
                 let package = (**package).clone();
-                self.last_error = Some(format!("Installing {}…", package.name));
+                self.set_legacy_message(Some(format!("Installing {}…", package.name)));
                 let runtime = runtime.clone();
                 tokio::spawn(async move {
                     let manager = plugin::package::PluginPackageManager::new(Config::config_dir());
@@ -18535,9 +18626,9 @@ impl Editor {
                 add_to_history = false;
                 let source = source.trim().to_string();
                 if source.is_empty() {
-                    self.last_error = Some("plugin source cannot be empty".to_string());
+                    self.set_legacy_message(Some("plugin source cannot be empty".to_string()));
                 } else {
-                    self.last_error = Some(format!("Installing plugin from {source}…"));
+                    self.set_legacy_message(Some(format!("Installing plugin from {source}…")));
                     let runtime = runtime.clone();
                     tokio::spawn(async move {
                         let manager =
@@ -18580,7 +18671,7 @@ impl Editor {
             Action::PluginManagerAction(operation) => {
                 add_to_history = false;
                 let operation = operation.clone();
-                self.last_error = Some("Updating plugin installation…".to_string());
+                self.set_legacy_message(Some("Updating plugin installation…".to_string()));
                 let runtime = runtime.clone();
                 tokio::spawn(async move {
                     let manager = plugin::package::PluginPackageManager::new(Config::config_dir());
@@ -18618,7 +18709,7 @@ impl Editor {
                 if *restart_plugins {
                     message.push_str(" Restart Red to refresh plugin code.");
                 }
-                self.last_error = Some(message.clone());
+                self.set_legacy_message(Some(message.clone()));
                 let manager = plugin::package::PluginPackageManager::new(Config::config_dir());
                 let installed = manager.list().unwrap_or_default();
                 let items = plugin_manager_items(
@@ -18635,7 +18726,7 @@ impl Editor {
                 self.record_command_history(cmd);
 
                 for action in self.handle_command(cmd, runtime) {
-                    self.last_error = None;
+                    self.set_legacy_message(None);
                     if self.execute(&action, buffer, runtime).await? {
                         return Ok(true);
                     }
@@ -18732,8 +18823,9 @@ impl Editor {
                         self.pending_lsp_revision_snapshots
                             .insert(request_id, revisions);
                     } else {
-                        self.last_error =
-                            Some("no language server is available for this file".to_string());
+                        self.set_legacy_message(Some(
+                            "no language server is available for this file".to_string(),
+                        ));
                     }
                 }
             }
@@ -18780,8 +18872,9 @@ impl Editor {
                         self.pending_lsp_revision_snapshots
                             .insert(request_id, revisions);
                     } else {
-                        self.last_error =
-                            Some("no language server is available for this file".to_string());
+                        self.set_legacy_message(Some(
+                            "no language server is available for this file".to_string(),
+                        ));
                     }
                 }
             }
@@ -18859,7 +18952,7 @@ impl Editor {
             } => {
                 self.restore_lsp_format_save_identity(*buffer_id, uri, previous_file.clone())
                     .await;
-                self.last_error = Some(warning.clone());
+                self.set_legacy_message(Some(warning.clone()));
             }
             Action::RespondLspWorkspaceEdit {
                 request,
@@ -18894,7 +18987,9 @@ impl Editor {
             Action::OpenExternalUrl(url) => {
                 let lowercase = url.to_ascii_lowercase();
                 if !lowercase.starts_with("https://") && !lowercase.starts_with("http://") {
-                    self.last_error = Some("Only HTTP and HTTPS links can be opened".to_string());
+                    self.set_legacy_message(Some(
+                        "Only HTTP and HTTPS links can be opened".to_string(),
+                    ));
                     return Ok(false);
                 }
                 match open_external_url(url) {
@@ -18904,7 +18999,7 @@ impl Editor {
                         });
                     }
                     Err(error) => {
-                        self.last_error = Some(format!("Unable to open link: {error}"));
+                        self.set_legacy_message(Some(format!("Unable to open link: {error}")));
                         return Ok(false);
                     }
                 }
@@ -18914,7 +19009,7 @@ impl Editor {
                     match self.load_or_reuse_file_buffer(&location.path).await {
                         Ok(opened) => opened,
                         Err(error) => {
-                            self.last_error = Some(error.to_string());
+                            self.set_legacy_message(Some(error.to_string()));
                             return Ok(false);
                         }
                     };
@@ -18934,8 +19029,9 @@ impl Editor {
                     if added_buffer {
                         self.buffer_manager.pop_buffer();
                     }
-                    self.last_error =
-                        Some("Unable to open location in requested target".to_string());
+                    self.set_legacy_message(Some(
+                        "Unable to open location in requested target".to_string(),
+                    ));
                     return Ok(false);
                 }
 
@@ -19161,7 +19257,7 @@ impl Editor {
                     self.move_to_text_position(position);
                     self.finish_cursor_motion(buffer, false)?;
                 } else if self.last_error.is_none() {
-                    self.last_error = Some("text object not found".to_string());
+                    self.set_legacy_message(Some("text object not found".to_string()));
                 }
             }
             Action::MoveToFilePercent(percent) => {
@@ -19191,7 +19287,7 @@ impl Editor {
                         self.render(buffer)?;
                     }
                 } else {
-                    self.last_error = Some("text object not found".to_string());
+                    self.set_legacy_message(Some("text object not found".to_string()));
                 }
             }
             Action::MoveLineToViewportBottom => {
@@ -19395,7 +19491,7 @@ impl Editor {
                 let (index, added_buffer, path) = match self.load_or_reuse_file_buffer(path).await {
                     Ok(opened) => opened,
                     Err(e) => {
-                        self.last_error = Some(e.to_string());
+                        self.set_legacy_message(Some(e.to_string()));
                         return Ok(false);
                     }
                 };
@@ -19414,8 +19510,9 @@ impl Editor {
             }
             Action::ReloadFile(force) => {
                 if self.current_buffer().is_dirty() && !force {
-                    self.last_error =
-                        Some("E37: No write since last change (add ! to override)".to_string());
+                    self.set_legacy_message(Some(
+                        "E37: No write since last change (add ! to override)".to_string(),
+                    ));
                     self.render(buffer)?;
                     return Ok(false);
                 }
@@ -19431,15 +19528,15 @@ impl Editor {
                         self.sync_to_window();
                         self.commit_transaction(self.cursor_snapshot());
                         self.current_buffer_mut().mark_saved();
-                        self.last_error = Some(format!(
+                        self.set_legacy_message(Some(format!(
                             "{file:?} {}L, {}B read",
                             self.current_buffer().len(),
                             byte_count
-                        ));
+                        )));
                         self.render(buffer)?;
                     }
                     Err(e) => {
-                        self.last_error = Some(e.to_string());
+                        self.set_legacy_message(Some(e.to_string()));
                         self.render(buffer)?;
                         return Ok(false);
                     }
@@ -19499,8 +19596,9 @@ impl Editor {
                     _ => {
                         let Some(language_id) = self.highlighter.language_id_for_name(syntax)
                         else {
-                            self.last_error =
-                                Some(format!("unknown syntax {syntax:?} (try :syntax)"));
+                            self.set_legacy_message(Some(format!(
+                                "unknown syntax {syntax:?} (try :syntax)"
+                            )));
                             self.render(buffer)?;
                             return Ok(false);
                         };
@@ -19517,7 +19615,7 @@ impl Editor {
                     .invalidate(self.current_buffer().id());
                 self.bracket_match_cache = None;
                 self.force_full_redraw = true;
-                self.last_error = Some(format!("syntax: {label}"));
+                self.set_legacy_message(Some(format!("syntax: {label}")));
                 self.render(buffer)?;
             }
             Action::OpenWhatsNew => {
@@ -19526,7 +19624,9 @@ impl Editor {
                     self.render(buffer)?;
                     self.mark_whats_new_presented();
                 } else {
-                    self.last_error = Some("terminal is too small for release notes".to_string());
+                    self.set_legacy_message(Some(
+                        "terminal is too small for release notes".to_string(),
+                    ));
                     self.render(buffer)?;
                 }
             }
@@ -19557,11 +19657,12 @@ impl Editor {
                     Ok(()) => {
                         self.config.statusline = statusline.clone();
                         self.current_dialog = None;
-                        self.last_error = Some("saved status-line layout".to_string());
+                        self.set_legacy_message(Some("saved status-line layout".to_string()));
                     }
                     Err(error) => {
-                        self.last_error =
-                            Some(format!("could not save status-line layout: {error}"));
+                        self.set_legacy_message(Some(format!(
+                            "could not save status-line layout: {error}"
+                        )));
                     }
                 }
                 self.force_full_redraw = true;
@@ -19571,7 +19672,7 @@ impl Editor {
                 add_to_history = false;
                 self.config.statusline = statusline.clone();
                 self.current_dialog = None;
-                self.last_error = None;
+                self.set_legacy_message(None);
                 self.force_full_redraw = true;
                 self.render(buffer)?;
             }
@@ -19583,13 +19684,13 @@ impl Editor {
             Action::ReloadLanguages => {
                 match self.reload_languages().await {
                     Ok(count) => {
-                        self.last_error = Some(format!(
+                        self.set_legacy_message(Some(format!(
                             "reloaded {count} configured language{}",
                             if count == 1 { "" } else { "s" }
-                        ));
+                        )));
                     }
                     Err(error) => {
-                        self.last_error = Some(format!("language reload failed: {error:#}"));
+                        self.set_legacy_message(Some(format!("language reload failed: {error:#}")));
                     }
                 }
                 self.render(buffer)?;
@@ -19598,6 +19699,20 @@ impl Editor {
                 self.render(buffer)?;
             }
             Action::CloseDialog => {
+                if self.message_browser.is_some() {
+                    if self
+                        .current_dialog
+                        .as_ref()
+                        .is_some_and(|dialog| dialog.is_message_history())
+                    {
+                        self.close_messages();
+                    } else {
+                        self.release_current_dialog_callbacks(runtime);
+                        self.refresh_message_browser();
+                    }
+                    self.render(buffer)?;
+                    return Ok(false);
+                }
                 if self.inline_history_browser.is_some() {
                     self.handle_inline_history_action(
                         &crate::inline_history::HistoryAction::Close,
@@ -19631,17 +19746,18 @@ impl Editor {
                 self.render(buffer)?;
             }
             Action::Print(msg) => {
-                // Print has no severity or source metadata. Preserve its visible behavior
-                // while recording each message for the upcoming notification UI.
-                if !msg.is_empty() {
-                    let notice = Notice::new(NotificationSource::Editor, Severity::Info, msg)
-                        .with_details(msg);
-                    if let Err(error) = self.publish_notification(notice) {
-                        log!("could not retain legacy notification: {error}");
-                    }
-                }
-                self.last_error = Some(msg.clone());
+                self.set_legacy_message(Some(msg.clone()));
                 self.draw_commandline(buffer);
+            }
+            Action::OpenMessages => {
+                add_to_history = false;
+                self.open_messages();
+                self.render(buffer)?;
+            }
+            Action::MessageHistory(action) => {
+                add_to_history = false;
+                self.handle_message_action(action);
+                self.render(buffer)?;
             }
             Action::OpenTextPanelTurnActions => {
                 add_to_history = false;
@@ -19714,7 +19830,7 @@ impl Editor {
                     self.release_current_dialog_callbacks(runtime);
                     self.current_dialog = Some(Box::new(picker));
                 } else {
-                    self.last_error = Some("no user prompt selected".to_string());
+                    self.set_legacy_message(Some("no user prompt selected".to_string()));
                 }
                 self.render(buffer)?;
             }
@@ -19729,15 +19845,17 @@ impl Editor {
                     .text_turn_for_copy(panel_id, prompt_id, *part)
                 {
                     self.set_default_register(Content::charwise(text));
-                    self.last_error = Some(
+                    self.set_legacy_message(Some(
                         match part {
                             plugin::panel::TextPanelTurnPart::Prompt => "prompt copied",
                             plugin::panel::TextPanelTurnPart::Answer => "answer copied",
                         }
                         .to_string(),
-                    );
+                    ));
                 } else {
-                    self.last_error = Some("selected turn text is no longer available".to_string());
+                    self.set_legacy_message(Some(
+                        "selected turn text is no longer available".to_string(),
+                    ));
                 }
                 self.render(buffer)?;
             }
@@ -19753,8 +19871,9 @@ impl Editor {
                     *expected_draft,
                 ) {
                     Ok(plugin::panel::TextPanelReuseOutcome::Loaded) => {
-                        self.last_error =
-                            Some("prompt loaded for editing; nothing sent".to_string());
+                        self.set_legacy_message(Some(
+                            "prompt loaded for editing; nothing sent".to_string(),
+                        ));
                     }
                     Ok(plugin::panel::TextPanelReuseOutcome::Confirm(revision)) => {
                         self.release_current_dialog_callbacks(runtime);
@@ -19772,7 +19891,7 @@ impl Editor {
                             Action::Print("current draft kept".to_string()),
                         )));
                     }
-                    Err(message) => self.last_error = Some(message.to_string()),
+                    Err(message) => self.set_legacy_message(Some(message.to_string())),
                 }
                 self.render(buffer)?;
             }
@@ -19831,7 +19950,7 @@ impl Editor {
                             )
                             .await?;
                     }
-                    Err(err) => self.last_error = Some(err.to_string()),
+                    Err(err) => self.set_legacy_message(Some(err.to_string())),
                 }
                 self.render(buffer)?;
             }
@@ -19847,7 +19966,7 @@ impl Editor {
                             )
                             .await?;
                     }
-                    Err(err) => self.last_error = Some(err.to_string()),
+                    Err(err) => self.set_legacy_message(Some(err.to_string())),
                 }
                 self.render(buffer)?;
             }
@@ -20006,7 +20125,7 @@ impl Editor {
             Action::ShowProgress(progress) => {
                 add_to_history = false;
                 match progress.token {
-                    ProgressToken::String(ref s) => self.last_error = Some(s.to_string()),
+                    ProgressToken::String(ref s) => self.set_legacy_message(Some(s.to_string())),
                     ProgressToken::Number(_) => {}
                 }
             }
@@ -20064,7 +20183,7 @@ impl Editor {
                     log!("jumping back to {entry:?}");
                     self.jump_to_entry(&entry, buffer, runtime).await?;
                 } else {
-                    self.last_error = Some("at start of jump list".to_string());
+                    self.set_legacy_message(Some("at start of jump list".to_string()));
                     self.draw_commandline(buffer);
                 }
             }
@@ -20074,7 +20193,7 @@ impl Editor {
                     log!("jumping forward to {entry:?}");
                     self.jump_to_entry(&entry, buffer, runtime).await?;
                 } else {
-                    self.last_error = Some("at end of jump list".to_string());
+                    self.set_legacy_message(Some("at end of jump list".to_string()));
                     self.draw_commandline(buffer);
                 }
             }
@@ -20139,7 +20258,7 @@ impl Editor {
                     match self.load_or_reuse_file_buffer(file).await {
                         Ok(opened) => opened,
                         Err(e) => {
-                            self.last_error = Some(format!("Failed to open file: {}", e));
+                            self.set_legacy_message(Some(format!("Failed to open file: {}", e)));
                             return Ok(false);
                         }
                     };
@@ -20160,7 +20279,7 @@ impl Editor {
                     match self.load_or_reuse_file_buffer(file).await {
                         Ok(opened) => opened,
                         Err(e) => {
-                            self.last_error = Some(format!("Failed to open file: {}", e));
+                            self.set_legacy_message(Some(format!("Failed to open file: {}", e)));
                             return Ok(false);
                         }
                     };
@@ -20874,10 +20993,10 @@ impl Editor {
             if count > 2 {
                 if content.kind == ContentKind::Linewise {
                     log!("yanked {} lines", count);
-                    self.last_error = Some(format!("{} lines yanked", count));
+                    self.set_legacy_message(Some(format!("{} lines yanked", count)));
                     needs_update = true;
                 } else if content.kind == ContentKind::Blockwise {
-                    self.last_error = Some(format!("block of {} lines yanked", count));
+                    self.set_legacy_message(Some(format!("block of {} lines yanked", count)));
                     needs_update = true;
                 }
             };
@@ -21469,7 +21588,9 @@ impl Editor {
         force: bool,
     ) -> anyhow::Result<()> {
         if self.current_buffer().is_dirty() && !force {
-            self.last_error = Some("No write since last change (add ! to override)".to_string());
+            self.set_legacy_message(Some(
+                "No write since last change (add ! to override)".to_string(),
+            ));
             self.render(render_buffer)?;
             return Ok(());
         }
@@ -21803,8 +21924,9 @@ impl Editor {
             {
                 self.buffer_manager[index].file = None;
                 identity_changes.push((index, previous_uri));
-                self.last_error =
-                    Some("Removed file kept open as an unsaved scratch buffer".to_string());
+                self.set_legacy_message(Some(
+                    "Removed file kept open as an unsaved scratch buffer".to_string(),
+                ));
             }
         }
 
@@ -22767,7 +22889,9 @@ impl Editor {
 
     fn comment_syntax(&mut self) -> Option<CommentSyntax> {
         let Some(language) = self.current_language_id() else {
-            self.last_error = Some("no comment syntax configured for unnamed buffer".to_string());
+            self.set_legacy_message(Some(
+                "no comment syntax configured for unnamed buffer".to_string(),
+            ));
             return None;
         };
         let extension = self.current_buffer().file_type();
@@ -22787,13 +22911,13 @@ impl Editor {
                 .or_else(|| self.config.commenting.languages.get(&language))
         };
         let Some(template) = template else {
-            self.last_error = Some(format!("no comment syntax configured for {language}"));
+            self.set_legacy_message(Some(format!("no comment syntax configured for {language}")));
             return None;
         };
         let Some(syntax) = CommentSyntax::parse(template) else {
-            self.last_error = Some(format!(
+            self.set_legacy_message(Some(format!(
                 "invalid comment syntax configured for {language}: expected exactly one %s placeholder"
-            ));
+            )));
             return None;
         };
         Some(syntax)
@@ -23119,7 +23243,7 @@ impl Editor {
             self.move_to_text_position(position);
             self.finish_cursor_motion(buffer, false)?;
         } else {
-            self.last_error = Some("character not found".to_string());
+            self.set_legacy_message(Some("character not found".to_string()));
         }
         Ok(())
     }
@@ -23133,7 +23257,7 @@ impl Editor {
             self.move_to_text_position(motion.target);
             self.finish_cursor_motion(buffer, false)?;
         } else {
-            self.last_error = Some("match not found".to_string());
+            self.set_legacy_message(Some("match not found".to_string()));
         }
         Ok(())
     }
@@ -23147,7 +23271,7 @@ impl Editor {
             self.move_to_text_position(motion.target);
             self.finish_cursor_motion(buffer, false)?;
         } else {
-            self.last_error = Some("match not found".to_string());
+            self.set_legacy_message(Some("match not found".to_string()));
         }
         Ok(())
     }
@@ -23249,7 +23373,7 @@ impl Editor {
         buffer.refresh_dirty_from_history();
 
         let Some((cursor, edits)) = outcome else {
-            self.last_error = Some("already at oldest change".to_string());
+            self.set_legacy_message(Some("already at oldest change".to_string()));
             self.draw_commandline(render_buffer);
             return Ok(());
         };
@@ -23280,7 +23404,7 @@ impl Editor {
         buffer.refresh_dirty_from_history();
 
         let Some((cursor, edits)) = outcome else {
-            self.last_error = Some("already at newest change".to_string());
+            self.set_legacy_message(Some("already at newest change".to_string()));
             self.draw_commandline(render_buffer);
             return Ok(());
         };
@@ -23587,18 +23711,18 @@ impl Editor {
                 true
             };
             if snapshot.agent_conversation.is_none() && !snapshot.agent_session_resumable {
-                self.last_error = Some(if transcript_persisted {
+                self.set_legacy_message(Some(if transcript_persisted {
                     "Recovered agent transcript as archived context; start a new session to continue"
                         .to_string()
                 } else {
                     "Recovered agent transcript as archived context, but it could not be persisted; start a new session to continue"
                         .to_string()
-                });
+                }));
             } else if !transcript_persisted {
-                self.last_error = Some(
+                self.set_legacy_message(Some(
                     "Recovered buffers and agent transcript; transcript could not be persisted"
                         .to_string(),
-                );
+                ));
             }
         }
         if !divergences.is_empty() {
@@ -23613,16 +23737,17 @@ impl Editor {
             {
                 warning.push_str("; agent transcript could not be persisted");
             }
-            self.last_error = Some(warning);
+            self.set_legacy_message(Some(warning));
         }
         if duplicate_file_count > 0 {
             let warning = format!(
                 "Recovered {duplicate_file_count} duplicate file buffer(s) as unnamed buffers to preserve their contents"
             );
-            self.last_error = Some(match self.last_error.take() {
+            let message = match self.last_error.take() {
                 Some(existing) => format!("{existing}; {warning}"),
                 None => warning,
-            });
+            };
+            self.set_legacy_message(Some(message));
         }
         self.recompute_window_cursor_goals();
         self.sync_with_window();
@@ -23995,7 +24120,11 @@ impl Editor {
                 );
             }
         }
-        previous_warning != self.session_manager.warning()
+        let changed = previous_warning != self.session_manager.warning();
+        if changed {
+            self.sync_persistent_notifications();
+        }
+        changed
     }
 
     fn editor_state_snapshot(&mut self) -> EditorStateSnapshot {
@@ -24768,13 +24897,17 @@ impl Editor {
         let uri = match self.current_buffer().uri() {
             Ok(uri) => uri,
             Err(error) => {
-                self.last_error = Some(format!("could not resolve completion document: {error}"));
+                self.set_legacy_message(Some(format!(
+                    "could not resolve completion document: {error}"
+                )));
                 return Ok(displayed_immediately);
             }
         };
         if let Some(uri) = uri {
             if let Err(error) = self.ensure_current_buffer_lsp_opened().await {
-                self.last_error = Some(format!("could not open LSP completion document: {error}"));
+                self.set_legacy_message(Some(format!(
+                    "could not open LSP completion document: {error}"
+                )));
                 return Ok(displayed_immediately);
             }
             let position = self.cursor_lsp_position();
@@ -24790,7 +24923,9 @@ impl Editor {
             {
                 Ok(request_id) => request_id,
                 Err(error) => {
-                    self.last_error = Some(format!("LSP completion request failed: {error}"));
+                    self.set_legacy_message(Some(format!(
+                        "LSP completion request failed: {error}"
+                    )));
                     return Ok(displayed_immediately);
                 }
             };
@@ -24822,7 +24957,7 @@ impl Editor {
             .as_ref()
             .is_some_and(|snapshot| !self.completion_snapshot_is_current(snapshot))
         {
-            self.last_error = Some("completion item is stale; buffer changed".to_string());
+            self.set_legacy_message(Some("completion item is stale; buffer changed".to_string()));
             return Ok(());
         }
 
@@ -24850,8 +24985,9 @@ impl Editor {
             Some(edit) => match rebase_edit(edit, true) {
                 Some(edit) => Some(edit),
                 None => {
-                    self.last_error =
-                        Some("completion edit could not be rebased after typing".to_string());
+                    self.set_legacy_message(Some(
+                        "completion edit could not be rebased after typing".to_string(),
+                    ));
                     return Ok(());
                 }
             },
@@ -24860,9 +24996,9 @@ impl Editor {
         let mut additional_text_edits = Vec::new();
         for edit in item.additional_text_edits.iter().flatten() {
             let Some(edit) = rebase_edit(edit, false) else {
-                self.last_error = Some(
+                self.set_legacy_message(Some(
                     "additional completion edit could not be rebased after typing".to_string(),
-                );
+                ));
                 return Ok(());
             };
             additional_text_edits.push(edit);
@@ -24873,7 +25009,7 @@ impl Editor {
             .cloned()
             .collect::<Vec<_>>();
         if let Err(error) = crate::lsp::apply_text_edits(&contents, &validation_edits) {
-            self.last_error = Some(format!("invalid LSP completion edit: {error}"));
+            self.set_legacy_message(Some(format!("invalid LSP completion edit: {error}")));
             return Ok(());
         }
         let resume_insert_transaction = self.transaction_active();
@@ -25033,7 +25169,7 @@ impl Editor {
             let reason = format!(
                 "LSP workspace edit exceeds {MAX_WORKSPACE_EDIT_TOTAL_BYTES} bytes of open-buffer content"
             );
-            self.last_error = Some(reason.clone());
+            self.set_legacy_message(Some(reason.clone()));
             if let Some(response) = response {
                 self.lsp
                     .respond_workspace_edit(response, false, Some(&reason))
@@ -25099,7 +25235,7 @@ impl Editor {
             let reason =
                 "LSP workspace edit cannot be applied because its originating server is unavailable"
                     .to_string();
-            self.last_error = Some(reason.clone());
+            self.set_legacy_message(Some(reason.clone()));
             if let Some(response) = response {
                 self.lsp
                     .respond_workspace_edit(response, false, Some(&reason))
@@ -25116,7 +25252,7 @@ impl Editor {
             Ok(prepared) => prepared,
             Err(error) => {
                 let reason = format!("invalid LSP workspace edit: {error}");
-                self.last_error = Some(reason.clone());
+                self.set_legacy_message(Some(reason.clone()));
                 if let Some(response) = response {
                     self.lsp
                         .respond_workspace_edit(response, false, Some(&reason))
@@ -25141,7 +25277,7 @@ impl Editor {
             .collect::<Result<Vec<_>, _>>()?;
         if let Err(error) = apply_workspace_resource_operations(&prepared) {
             let reason = format!("LSP resource operation failed: {error}");
-            self.last_error = Some(reason.clone());
+            self.set_legacy_message(Some(reason.clone()));
             if let Some(response) = response {
                 self.lsp
                     .respond_workspace_edit(response, false, Some(&reason))
@@ -25204,8 +25340,9 @@ impl Editor {
         for (uri, file, index) in &renamed {
             if let Ok(file) = lsp_file_path(uri) {
                 if let Err(error) = self.lsp.did_close(&file).await {
-                    self.last_error =
-                        Some(format!("failed to close renamed LSP document: {error}"));
+                    self.set_legacy_message(Some(format!(
+                        "failed to close renamed LSP document: {error}"
+                    )));
                 }
             }
             self.lsp_coordinator.mark_document_closed(uri);
@@ -25220,7 +25357,9 @@ impl Editor {
                 .did_open(file, &self.buffer_manager[*index].contents())
                 .await
             {
-                self.last_error = Some(format!("failed to open renamed LSP document: {error}"));
+                self.set_legacy_message(Some(format!(
+                    "failed to open renamed LSP document: {error}"
+                )));
             } else if let Some(new_uri) = new_uri {
                 self.lsp_coordinator.mark_document_opened(new_uri);
             }
@@ -25229,8 +25368,9 @@ impl Editor {
         for index in changed {
             self.select_buffer_for_lsp_edit(index);
             if let Err(error) = self.notify_change(runtime).await {
-                self.last_error =
-                    Some(format!("LSP edit applied but notification failed: {error}"));
+                self.set_legacy_message(Some(format!(
+                    "LSP edit applied but notification failed: {error}"
+                )));
             }
         }
         self.select_buffer_for_lsp_edit(original_index);
@@ -25244,7 +25384,9 @@ impl Editor {
                 )
                 .await
             {
-                self.last_error = Some(format!("LSP edit applied but command failed: {error}"));
+                self.set_legacy_message(Some(format!(
+                    "LSP edit applied but command failed: {error}"
+                )));
             }
         }
         if let Some(response) = response {
@@ -25266,14 +25408,15 @@ impl Editor {
                 )
                 .await?;
             } else {
-                self.last_error =
-                    Some("formatted buffer is no longer open; save cancelled".to_string());
+                self.set_legacy_message(Some(
+                    "formatted buffer is no longer open; save cancelled".to_string(),
+                ));
             }
         } else if newly_opened > 0 && self.last_error.is_none() {
-            self.last_error = Some(format!(
+            self.set_legacy_message(Some(format!(
                 "LSP edit opened {newly_opened} unsaved buffer{}",
                 if newly_opened == 1 { "" } else { "s" }
-            ));
+            )));
         }
         self.render(render_buffer)?;
         Ok(())
@@ -25308,8 +25451,9 @@ impl Editor {
                     .as_deref()
                     .is_some_and(|candidate| candidate == uri)
         }) else {
-            self.last_error =
-                Some("formatted buffer is no longer open; save cancelled".to_string());
+            self.set_legacy_message(Some(
+                "formatted buffer is no longer open; save cancelled".to_string(),
+            ));
             return Ok(());
         };
         let original = self.buffer_manager.active_index();
@@ -25323,7 +25467,7 @@ impl Editor {
         };
         match result {
             Ok(message) => {
-                self.last_error = Some(warning.unwrap_or(&message).to_string());
+                self.set_legacy_message(Some(warning.unwrap_or(&message).to_string()));
                 self.sync_lsp_document_identity(previous_uri.as_deref(), index)
                     .await?;
                 let file = self.current_buffer().file.clone();
@@ -25340,7 +25484,7 @@ impl Editor {
                     self.restore_lsp_format_save_identity(buffer_id, uri, previous_file)
                         .await;
                 }
-                self.last_error = Some(error.to_string());
+                self.set_legacy_message(Some(error.to_string()));
             }
         }
         self.select_buffer_for_lsp_edit(original);
@@ -25481,8 +25625,12 @@ impl Editor {
 
         match save_result {
             Ok(msg) => {
-                // TODO: use last_message instead of last_error
-                self.last_error = Some(format_warning.unwrap_or(msg));
+                let severity = if format_warning.is_some() {
+                    Severity::Warning
+                } else {
+                    Severity::Success
+                };
+                self.set_notification_message(severity, Some(format_warning.unwrap_or(msg)));
 
                 // Notify plugins about file save
                 if let Some(file) = &self.current_buffer().file {
@@ -25496,7 +25644,7 @@ impl Editor {
                 }
             }
             Err(e) => {
-                self.last_error = Some(e.to_string());
+                self.set_notification_message(Severity::Error, Some(e.to_string()));
             }
         }
         Ok(true)
@@ -25522,8 +25670,9 @@ impl Editor {
             .scratch_buffers
             .contains_key(&self.current_buffer().id())
         {
-            self.last_error =
-                Some("Scratch buffers cannot be written to disk; use :w to submit".to_string());
+            self.set_legacy_message(Some(
+                "Scratch buffers cannot be written to disk; use :w to submit".to_string(),
+            ));
             return Ok(false);
         }
         let target_path = normalized_file_path(new_file_name)?;
@@ -25540,9 +25689,9 @@ impl Editor {
                 same_file_path(Path::new(open_path), &target_path).then_some(open_path)
             })
         {
-            self.last_error = Some(format!(
+            self.set_legacy_message(Some(format!(
                 "Save As cancelled; destination is already open in another buffer: {open_path}"
-            ));
+            )));
             return Ok(false);
         }
         let previous_uri = self.current_buffer().uri()?;
@@ -25591,8 +25740,12 @@ impl Editor {
 
         match save_result {
             Ok(msg) => {
-                // TODO: use last_message instead of last_error
-                self.last_error = Some(format_warning.unwrap_or(msg));
+                let severity = if format_warning.is_some() {
+                    Severity::Warning
+                } else {
+                    Severity::Success
+                };
+                self.set_notification_message(severity, Some(format_warning.unwrap_or(msg)));
                 if let Err(error) = self
                     .sync_lsp_document_identity(
                         previous_uri.as_deref(),
@@ -25622,9 +25775,9 @@ impl Editor {
                             "error": error.to_string(),
                         })
                     );
-                    self.last_error = Some(format!(
+                    self.set_legacy_message(Some(format!(
                         "format-on-save unavailable; saved unformatted: {error}"
-                    ));
+                    )));
                 }
                 let saved_file = self
                     .current_buffer()
@@ -25652,7 +25805,7 @@ impl Editor {
                         .await;
                     }
                 }
-                self.last_error = Some(e.to_string());
+                self.set_notification_message(Severity::Error, Some(e.to_string()));
             }
         }
         Ok(true)
@@ -25682,31 +25835,32 @@ impl Editor {
                 .await
             {
                 Ok(ExternalFormatOutcome::Applied { name }) => {
-                    self.last_error = Some(format!("formatted with {name}"));
+                    self.set_legacy_message(Some(format!("formatted with {name}")));
                     self.render(buffer)?;
                     return Ok(());
                 }
                 Ok(ExternalFormatOutcome::Unchanged { name }) => {
-                    self.last_error = Some(format!("already formatted with {name}"));
+                    self.set_legacy_message(Some(format!("already formatted with {name}")));
                     return Ok(());
                 }
                 Ok(ExternalFormatOutcome::Unavailable { name })
                     if provider == FormattingProvider::External =>
                 {
-                    self.last_error = Some(format!(
+                    self.set_legacy_message(Some(format!(
                         "formatter {name} is not installed or not executable"
-                    ));
+                    )));
                     return Ok(());
                 }
                 Ok(ExternalFormatOutcome::NotConfigured)
                     if provider == FormattingProvider::External =>
                 {
-                    self.last_error =
-                        Some("no external formatter is configured for this language".to_string());
+                    self.set_legacy_message(Some(
+                        "no external formatter is configured for this language".to_string(),
+                    ));
                     return Ok(());
                 }
                 Err(error) => {
-                    self.last_error = Some(error.to_string());
+                    self.set_legacy_message(Some(error.to_string()));
                     return Ok(());
                 }
                 Ok(
@@ -25732,7 +25886,9 @@ impl Editor {
         if request_id > 0 {
             self.pending_lsp_edit_requests.insert(request_id, pending);
         } else {
-            self.last_error = Some("no language server is available for this file".to_string());
+            self.set_legacy_message(Some(
+                "no language server is available for this file".to_string(),
+            ));
         }
         Ok(())
     }
@@ -25883,7 +26039,9 @@ impl Editor {
                 .get(request_id)
                 .is_some_and(|pending| pending.buffer_id == buffer_id)
         }) {
-            self.last_error = Some("format-on-save is already pending for this buffer".to_string());
+            self.set_legacy_message(Some(
+                "format-on-save is already pending for this buffer".to_string(),
+            ));
             return Ok(FormatOnSaveRequest::Pending);
         }
         let previous_uri = self.current_buffer().uri()?;
@@ -25905,10 +26063,10 @@ impl Editor {
                             })
                     });
                 if already_open {
-                    self.last_error = Some(format!(
+                    self.set_legacy_message(Some(format!(
                         "Save As cancelled; destination is already open in another buffer: {}",
                         target.display()
-                    ));
+                    )));
                     return Ok(FormatOnSaveRequest::Cancelled);
                 }
                 self.current_buffer_mut().file = Some(file.clone());
@@ -27317,7 +27475,7 @@ impl Editor {
 
     #[doc(hidden)]
     pub fn test_set_last_error(&mut self, message: &str) {
-        self.last_error = Some(message.to_string());
+        self.set_legacy_message(Some(message.to_string()));
     }
 
     #[doc(hidden)]
@@ -34855,7 +35013,7 @@ builtin = "rust"
             .as_deref()
             .is_some_and(|error| error.contains("UTF-16")));
 
-        editor.last_error = None;
+        editor.set_legacy_message(None);
         editor
             .test_execute_production_action(Action::ApplyLspWorkspaceEdit {
                 documents: vec![
@@ -34887,7 +35045,7 @@ builtin = "rust"
             .as_deref()
             .is_some_and(|error| error.contains("overlap")));
 
-        editor.last_error = None;
+        editor.set_legacy_message(None);
         editor.buffer_manager[1]
             .replace_range_raw(TextRange::insertion(TextPosition::new(0, 0)), "dirty ");
         editor
@@ -35388,7 +35546,7 @@ builtin = "rust"
             .as_deref()
             .is_some_and(|error| error.contains("no-follow filesystem support")));
 
-        editor.last_error = None;
+        editor.set_legacy_message(None);
         let operations = workspace_edit_operations(&serde_json::json!({
             "documentChanges": [{
                 "kind": "rename",

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -110,6 +110,10 @@ use crate::{
         WorkspaceEditOperation as LspWorkspaceEditOperation, MAX_WORKSPACE_EDIT_TOTAL_BYTES,
     },
     matchit::{self, MatchDirection, MatchMotion},
+    notification::{
+        Notice, NotificationCenter, NotificationError, NotificationId, NotificationSource,
+        NotificationTime, Severity,
+    },
     plugin::{self, ComposerHandle, PickerHandle, PluginRegistry, RequestId, Runtime},
     preferences::{PanelLayoutPreference, PreferencesStore},
     session::{
@@ -3138,7 +3142,10 @@ pub struct Editor {
     /// Whether persistent hlsearch rendering has been cleared with :noh.
     search_highlights_suppressed: bool,
 
-    /// Most recent error message
+    /// Session-local notification records, independent of the legacy display slot.
+    notifications: NotificationCenter,
+
+    /// Compatibility display slot while existing producers are migrated.
     last_error: Option<String>,
 
     /// Active dialog/popup component
@@ -3971,6 +3978,20 @@ impl Content {
 }
 
 impl Editor {
+    /// Session-local messages. Reading history does not acknowledge its entries.
+    pub fn notifications(&self) -> &NotificationCenter {
+        &self.notifications
+    }
+
+    /// Records a typed notice without changing the legacy command-line display slot.
+    /// The bottom-line renderer will consume this store after its layout migration.
+    pub fn publish_notification(
+        &mut self,
+        notice: Notice,
+    ) -> Result<NotificationId, NotificationError> {
+        self.notifications.publish(notice, NotificationTime::now())
+    }
+
     pub fn set_config_diagnostics(
         &mut self,
         diagnostics: Vec<ConfigDiagnostic>,
@@ -4394,6 +4415,7 @@ impl Editor {
             active_search: None,
             search_match_cache: None,
             search_highlights_suppressed: false,
+            notifications: NotificationCenter::default(),
             last_error: None,
             current_dialog: None,
             dialog_action_menu: crate::ui::ActionMenu::default(),
@@ -19609,6 +19631,15 @@ impl Editor {
                 self.render(buffer)?;
             }
             Action::Print(msg) => {
+                // Print has no severity or source metadata. Preserve its visible behavior
+                // while recording each message for the upcoming notification UI.
+                if !msg.is_empty() {
+                    let notice = Notice::new(NotificationSource::Editor, Severity::Info, msg)
+                        .with_details(msg);
+                    if let Err(error) = self.publish_notification(notice) {
+                        log!("could not retain legacy notification: {error}");
+                    }
+                }
                 self.last_error = Some(msg.clone());
                 self.draw_commandline(buffer);
             }
@@ -30822,6 +30853,65 @@ builtin = "rust"
             .last()
             .unwrap()
             .contains("fatal: index.lock already exists"));
+        let retained = editor.notifications().records().next().unwrap();
+        assert_eq!(retained.content.summary, "fatal: index.lock already exists");
+        assert_eq!(retained.severity, Severity::Info);
+    }
+
+    #[tokio::test]
+    async fn notification_history_survives_legacy_action_resets() {
+        let mut editor = test_editor(60, 8);
+        let mut buffer = RenderBuffer::new(60, 8, &Style::default());
+        let mut runtime = Runtime::new();
+
+        for message in ["first\nfull details", "second"] {
+            editor
+                .execute(
+                    &Action::Print(message.to_string()),
+                    &mut buffer,
+                    &mut runtime,
+                )
+                .await
+                .unwrap();
+        }
+        editor
+            .execute(&Action::Refresh, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(editor.last_error.is_none());
+        let retained = editor.notifications().records().collect::<Vec<_>>();
+        assert_eq!(retained.len(), 2);
+        assert_eq!(retained[0].content.summary, "first full details");
+        assert_eq!(
+            retained[0].content.details.as_deref(),
+            Some("first\nfull details")
+        );
+        assert_eq!(retained[1].content.summary, "second");
+    }
+
+    #[tokio::test]
+    async fn notification_overflow_preserves_legacy_print_feedback() {
+        let mut editor = test_editor(60, 8);
+        editor.notifications = NotificationCenter::with_capacity(0);
+        let mut buffer = RenderBuffer::new(60, 8, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .execute(
+                &Action::Print("still visible".to_string()),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(editor.last_error.as_deref(), Some("still visible"));
+        assert!(render_text_rows(&buffer)
+            .last()
+            .unwrap()
+            .contains("still visible"));
+        assert_eq!(editor.notifications().records().len(), 0);
     }
 
     #[test]

--- a/src/editor/inline_comments.rs
+++ b/src/editor/inline_comments.rs
@@ -188,8 +188,9 @@ impl Editor {
             .count()
             >= MAX_BUFFER_COMMENTS
         {
-            self.last_error =
-                Some("inline comment limit reached; dismiss existing comments first".into());
+            self.set_legacy_message(Some(
+                "inline comment limit reached; dismiss existing comments first".into(),
+            ));
             return;
         }
         let comment =
@@ -391,7 +392,7 @@ impl Editor {
             .collect::<Vec<_>>();
         indices.sort_by_key(|&(index, start)| (start, index));
         if indices.is_empty() {
-            self.last_error = Some("no inline comments in this buffer".into());
+            self.set_legacy_message(Some("no inline comments in this buffer".into()));
             return;
         }
         let current = self.current_inline_comment_index().and_then(|index| {
@@ -416,11 +417,11 @@ impl Editor {
         self.layout_cache.borrow_mut().clear();
         self.move_to_text_position(TextPosition::new(line, 0));
         self.refresh_cursor_goal();
-        self.last_error = Some(format!(
+        self.set_legacy_message(Some(format!(
             "comment {}/{} · Space v view · Space x dismiss",
             position + 1,
             indices.len()
-        ));
+        )));
     }
 
     pub(super) fn dismiss_inline_comment(&mut self) {
@@ -441,13 +442,13 @@ impl Editor {
             self.active_inline_comment = None;
             self.layout_cache.borrow_mut().clear();
         } else {
-            self.last_error = Some("no inline comment at the cursor".into());
+            self.set_legacy_message(Some("no inline comment at the cursor".into()));
         }
     }
 
     pub(super) fn show_inline_comment(&mut self) {
         let Some(index) = self.current_inline_comment_index() else {
-            self.last_error = Some("no inline comment at the cursor".into());
+            self.set_legacy_message(Some("no inline comment at the cursor".into()));
             return;
         };
         let comment = &self.inline_comments[index];

--- a/src/editor/inline_history.rs
+++ b/src/editor/inline_history.rs
@@ -351,10 +351,11 @@ impl Editor {
                 .open(path)
                 .and_then(|mut file| file.write_all(&contents))
             {
-                Ok(()) => self.last_error = Some(format!("exported inline history to {path}")),
-                Err(error) => {
-                    self.last_error = Some(format!("could not export inline history: {error}"))
+                Ok(()) => {
+                    self.set_legacy_message(Some(format!("exported inline history to {path}")))
                 }
+                Err(error) => self
+                    .set_legacy_message(Some(format!("could not export inline history: {error}"))),
             }
             return self.render(buffer);
         }
@@ -426,10 +427,10 @@ impl Editor {
                     }
                 }
             }
-            self.last_error = Some(
+            self.set_legacy_message(Some(
                 "source is detached; select the intended code and start a new inline request"
                     .into(),
-            );
+            ));
             return self.render(buffer);
         }
         let Some(browser) = &mut self.inline_history_browser else {

--- a/src/editor/notifications.rs
+++ b/src/editor/notifications.rs
@@ -48,7 +48,9 @@ pub(super) struct MessageBrowser {
     feedback: Option<String>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+/// Last observed notification state. The default matches a new, empty center so
+/// its first background poll does not invalidate otherwise reusable surfaces.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub(super) struct NotificationPresentation {
     revision: u64,
     counts: NotificationCounts,
@@ -114,7 +116,10 @@ impl Editor {
     }
 
     pub(super) fn notification_presentation_changed(&mut self) -> bool {
-        let now = Instant::now();
+        self.notification_presentation_changed_at(Instant::now())
+    }
+
+    fn notification_presentation_changed_at(&mut self, now: Instant) -> bool {
         let mut counts = self.notifications.counts(now);
         counts.active += usize::from(self.notification_fallback.is_some());
         let frame = if !self.has_term()
@@ -123,7 +128,8 @@ impl Editor {
                 .primary(now)
                 .is_some_and(Notification::is_running)
         {
-            self.notification_animation_start.elapsed().as_millis() as u64
+            now.saturating_duration_since(self.notification_animation_start)
+                .as_millis() as u64
                 / crate::ui::SPINNER_FRAME_INTERVAL_MS
         } else {
             0
@@ -133,10 +139,10 @@ impl Editor {
             counts,
             frame,
         };
-        if self.notification_presentation == Some(presentation) {
+        if self.notification_presentation == presentation {
             return false;
         }
-        self.notification_presentation = Some(presentation);
+        self.notification_presentation = presentation;
         if self
             .current_dialog
             .as_ref()
@@ -416,6 +422,39 @@ mod tests {
         .unwrap();
         editor.test_disable_terminal_output();
         editor
+    }
+
+    #[test]
+    fn presentation_ignores_an_empty_center_but_detects_arrivals_and_expiry() {
+        let mut editor = editor(90, 12);
+        assert!(!editor.notification_presentation_changed());
+        assert!(!editor.notification_presentation_changed());
+
+        let id = editor
+            .publish_notification(Notice::new(
+                NotificationSource::Editor,
+                Severity::Error,
+                "save failed",
+            ))
+            .unwrap();
+        assert!(editor.notification_presentation_changed());
+        assert!(!editor.notification_presentation_changed());
+        editor.notifications.acknowledge(id).unwrap();
+        assert!(editor.notification_presentation_changed());
+        assert!(!editor.notification_presentation_changed());
+
+        let now = NotificationTime::now();
+        editor
+            .notifications
+            .publish(
+                Notice::new(NotificationSource::Editor, Severity::Info, "saved"),
+                now,
+            )
+            .unwrap();
+        assert!(editor.notification_presentation_changed_at(now.monotonic));
+        let after_expiry = now.monotonic + Duration::from_secs(4);
+        assert!(editor.notification_presentation_changed_at(after_expiry));
+        assert!(!editor.notification_presentation_changed_at(after_expiry));
     }
 
     #[tokio::test]

--- a/src/editor/notifications.rs
+++ b/src/editor/notifications.rs
@@ -1,0 +1,656 @@
+//! Editor-owned notification adapters and message-browser coordination.
+
+use super::*;
+use crate::{
+    notification::{MessageAction, Notification, NotificationCounts, NotificationState},
+    ui::{MessageRow, MessagesPanel, MessagesView},
+};
+
+#[derive(Clone, Copy, Default)]
+enum MessageFilter {
+    #[default]
+    All,
+    Active,
+    Problems,
+}
+
+impl MessageFilter {
+    fn next(self) -> Self {
+        match self {
+            Self::All => Self::Active,
+            Self::Active => Self::Problems,
+            Self::Problems => Self::All,
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Active => "active",
+            Self::Problems => "warnings/errors",
+        }
+    }
+    fn includes(self, record: &Notification, now: Instant) -> bool {
+        match self {
+            Self::All => true,
+            Self::Active => record.is_active(now),
+            Self::Problems => matches!(record.severity, Severity::Warning | Severity::Error),
+        }
+    }
+}
+
+pub(super) struct MessageBrowser {
+    return_dialog: Option<Box<dyn Component>>,
+    selected: Option<NotificationId>,
+    query: String,
+    searching: bool,
+    filter: MessageFilter,
+    scroll: usize,
+    feedback: Option<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) struct NotificationPresentation {
+    revision: u64,
+    counts: NotificationCounts,
+    frame: u64,
+}
+
+fn record_state(record: &Notification, now: Instant) -> &'static str {
+    match record.state {
+        NotificationState::Running { .. } => "running",
+        NotificationState::Finished(crate::notification::ProgressOutcome::Succeeded) => "succeeded",
+        NotificationState::Finished(crate::notification::ProgressOutcome::Failed) => "failed",
+        NotificationState::Finished(crate::notification::ProgressOutcome::Cancelled) => "cancelled",
+        NotificationState::Notice if record.is_active(now) => "active",
+        NotificationState::Notice => "history",
+    }
+}
+
+fn record_details(record: &Notification, now: Instant) -> String {
+    let timestamp: chrono::DateTime<chrono::Local> = record.updated_at.into();
+    let body = record
+        .content
+        .details
+        .as_deref()
+        .unwrap_or(&record.content.summary);
+    format!(
+        "{} · {} · {}\n{} · {} occurrence{}\n\n{}{}",
+        record.source.label(),
+        record.severity.label(),
+        record_state(record, now),
+        timestamp.format("%Y-%m-%d %H:%M:%S"),
+        record.occurrences,
+        if record.occurrences == 1 { "" } else { "s" },
+        crate::notification::detail_text(body),
+        if record.content.truncated {
+            "\n\n[Message truncated by Red]"
+        } else {
+            ""
+        }
+    )
+}
+
+impl Editor {
+    /// Transitional operation-local result plus durable notification publication.
+    /// Clearing the old slot never clears notification history or active work.
+    pub(super) fn set_legacy_message(&mut self, message: Option<String>) {
+        self.set_notification_message(Severity::Info, message);
+    }
+
+    pub(super) fn set_notification_message(&mut self, severity: Severity, message: Option<String>) {
+        if let Some(message) = message.as_ref().filter(|message| !message.is_empty()) {
+            let notice =
+                Notice::new(NotificationSource::Editor, severity, message).with_details(message);
+            if let Err(error) = self.publish_notification(notice) {
+                self.notification_fallback = Some(crate::notification::single_line(
+                    truncate_chars(message, 4_096),
+                ));
+                log!("could not retain notification: {error}");
+            } else {
+                self.notification_fallback = None;
+            }
+        }
+        self.last_error = message;
+    }
+
+    pub(super) fn notification_presentation_changed(&mut self) -> bool {
+        let now = Instant::now();
+        let mut counts = self.notifications.counts(now);
+        counts.active += usize::from(self.notification_fallback.is_some());
+        let frame = if !self.has_term()
+            && self
+                .notifications
+                .primary(now)
+                .is_some_and(Notification::is_running)
+        {
+            self.notification_animation_start.elapsed().as_millis() as u64
+                / crate::ui::SPINNER_FRAME_INTERVAL_MS
+        } else {
+            0
+        };
+        let presentation = NotificationPresentation {
+            revision: self.notifications.revision(),
+            counts,
+            frame,
+        };
+        if self.notification_presentation == Some(presentation) {
+            return false;
+        }
+        self.notification_presentation = Some(presentation);
+        if self
+            .current_dialog
+            .as_ref()
+            .is_some_and(|dialog| dialog.is_message_history())
+        {
+            self.refresh_message_browser();
+        }
+        true
+    }
+
+    pub(super) fn sync_persistent_notifications(&mut self) {
+        let config = self.config_diagnostics_banner();
+        self.sync_persistent_notification("configuration", config, true);
+        let recovery = self.session_manager.warning().map(str::to_string);
+        self.sync_persistent_notification("session-snapshot", recovery, false);
+    }
+
+    fn sync_persistent_notification(&mut self, key: &str, message: Option<String>, config: bool) {
+        let index = usize::from(!config);
+        if self.persistent_notification_messages[index] == message {
+            return;
+        }
+        let current = if config {
+            self.config_notification
+        } else {
+            self.session_notification
+        };
+        let previous_message = message.clone();
+        let next = match message {
+            Some(message) => {
+                if let Some(id) = current {
+                    let _ = self.notifications.resolve(id);
+                }
+                self.publish_notification(
+                    Notice::new(NotificationSource::Editor, Severity::Warning, message)
+                        .with_key(key),
+                )
+                .ok()
+            }
+            None => {
+                if let Some(id) = current {
+                    let _ = self.notifications.resolve(id);
+                }
+                None
+            }
+        };
+        if next.is_some() || previous_message.is_none() {
+            self.persistent_notification_messages[index] = previous_message;
+        }
+        if config {
+            self.config_notification = next;
+        } else {
+            self.session_notification = next;
+        }
+    }
+
+    fn message_ids(&self, now: Instant) -> Vec<NotificationId> {
+        let Some(browser) = &self.message_browser else {
+            return Vec::new();
+        };
+        let query = browser.query.to_lowercase();
+        let mut records = self
+            .notifications
+            .records()
+            .filter(|record| {
+                browser.filter.includes(record, now)
+                    && (query.is_empty()
+                        || record.source.label().to_lowercase().contains(&query)
+                        || record.severity.label().contains(&query)
+                        || record.content.summary.to_lowercase().contains(&query)
+                        || record
+                            .content
+                            .details
+                            .as_ref()
+                            .is_some_and(|details| details.to_lowercase().contains(&query)))
+            })
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| std::cmp::Reverse((record.is_active(now), record.id)));
+        records.into_iter().map(|record| record.id).collect()
+    }
+
+    pub(super) fn open_messages(&mut self) {
+        if self.message_browser.is_none() {
+            self.message_browser = Some(MessageBrowser {
+                return_dialog: self.current_dialog.take(),
+                selected: None,
+                query: String::new(),
+                searching: false,
+                filter: MessageFilter::All,
+                scroll: 0,
+                feedback: None,
+            });
+        }
+        self.refresh_message_browser();
+    }
+
+    pub(super) fn close_messages(&mut self) {
+        if let Some(browser) = self.message_browser.take() {
+            self.current_dialog = browser.return_dialog;
+        }
+    }
+
+    pub(super) fn refresh_message_browser(&mut self) {
+        let now = Instant::now();
+        let ids = self.message_ids(now);
+        let Some(browser) = &mut self.message_browser else {
+            return;
+        };
+        let selected = browser
+            .selected
+            .and_then(|id| ids.iter().position(|candidate| *candidate == id))
+            .unwrap_or(0);
+        browser.selected = ids.get(selected).copied();
+        if let Some(id) = browser.selected {
+            let _ = self.notifications.mark_read(id);
+        }
+        let rows = ids
+            .iter()
+            .filter_map(|id| self.notifications.get(*id))
+            .map(|record| {
+                let timestamp: chrono::DateTime<chrono::Local> = record.updated_at.into();
+                MessageRow {
+                    summary: format!("{} {}", record.severity.marker(), record.content.summary),
+                    metadata: format!(
+                        "{} · {} · {}{}",
+                        record.source.label(),
+                        timestamp.format("%H:%M:%S"),
+                        record_state(record, now),
+                        if record.occurrences > 1 {
+                            format!(" · ×{}", record.occurrences)
+                        } else {
+                            String::new()
+                        }
+                    ),
+                }
+            })
+            .collect();
+        let mut detail = browser
+            .selected
+            .and_then(|id| self.notifications.get(id))
+            .map(|record| record_details(record, now))
+            .unwrap_or_else(|| {
+                "Messages will appear here as you work. Press f to change the filter.".to_string()
+            });
+        let mut counts = self.notifications.counts(now);
+        if let Some(fallback) = &self.notification_fallback {
+            counts.active += 1;
+            detail = format!("Latest message could not be retained:\n{fallback}\n\n{detail}");
+        }
+        let view = MessagesView {
+            rows,
+            selected,
+            detail,
+            scroll: browser.scroll,
+            query: browser.query.clone(),
+            searching: browser.searching,
+            filter: browser.filter.label(),
+            counts,
+            feedback: browser.feedback.clone().or_else(|| {
+                self.notification_fallback
+                    .as_ref()
+                    .map(|_| "History full; latest message was not retained".to_string())
+            }),
+        };
+        self.current_dialog = Some(Box::new(MessagesPanel::new(
+            view,
+            usize::from(self.size.0),
+            usize::from(self.size.1.saturating_sub(2)),
+            &self.theme,
+        )));
+    }
+
+    pub(super) fn handle_message_action(&mut self, action: &MessageAction) {
+        if matches!(action, MessageAction::Close) {
+            self.close_messages();
+            return;
+        }
+        let now = Instant::now();
+        let ids = self.message_ids(now);
+        let Some(browser) = &mut self.message_browser else {
+            return;
+        };
+        browser.feedback = None;
+        let selected = browser
+            .selected
+            .and_then(|id| ids.iter().position(|candidate| *candidate == id))
+            .unwrap_or(0);
+        match action {
+            MessageAction::Next | MessageAction::Previous => {
+                let next = if matches!(action, MessageAction::Next) {
+                    selected.saturating_add(1).min(ids.len().saturating_sub(1))
+                } else {
+                    selected.saturating_sub(1)
+                };
+                browser.selected = ids.get(next).copied();
+                browser.scroll = 0;
+            }
+            MessageAction::Search => browser.searching = true,
+            MessageAction::Query(text) => {
+                let text = text.replace(['\r', '\n'], " ");
+                if browser.query.len().saturating_add(text.len()) <= 4_096 {
+                    browser.query.push_str(&text);
+                }
+                browser.scroll = 0;
+            }
+            MessageAction::Backspace => {
+                browser.query.pop();
+                browser.scroll = 0;
+            }
+            MessageAction::EndSearch => browser.searching = false,
+            MessageAction::ClearSearch => {
+                browser.query.clear();
+                browser.searching = false;
+                browser.scroll = 0;
+            }
+            MessageAction::CycleFilter => {
+                browser.filter = browser.filter.next();
+                browser.scroll = 0;
+            }
+            MessageAction::Acknowledge => {
+                self.notification_fallback = None;
+                if let Some(id) = browser.selected {
+                    let running = self
+                        .notifications
+                        .get(id)
+                        .is_some_and(Notification::is_running);
+                    let _ = self.notifications.acknowledge(id);
+                    browser.feedback = Some(
+                        if running {
+                            "Marked read; operation is still running"
+                        } else {
+                            "Acknowledged"
+                        }
+                        .to_string(),
+                    );
+                }
+            }
+            MessageAction::ClearInactive => {
+                let removed = self.notifications.clear_inactive(now);
+                browser.feedback = Some(format!("Cleared {removed} inactive messages"));
+            }
+            MessageAction::Copy => {
+                if let Some(record) = browser.selected.and_then(|id| self.notifications.get(id)) {
+                    let text = record
+                        .content
+                        .details
+                        .as_ref()
+                        .unwrap_or(&record.content.summary)
+                        .clone();
+                    browser.feedback = Some("Copied message".to_string());
+                    self.set_default_register(Content::charwise(text));
+                }
+            }
+            MessageAction::ScrollDown => browser.scroll = browser.scroll.saturating_add(5),
+            MessageAction::ScrollUp => browser.scroll = browser.scroll.saturating_sub(5),
+            MessageAction::Close => unreachable!(),
+        }
+        self.refresh_message_browser();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn editor(width: usize, height: usize) -> Editor {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size(
+            lsp,
+            width,
+            height,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, "hello".to_string())],
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor
+    }
+
+    #[tokio::test]
+    async fn bottom_line_keeps_multiple_messages_after_unrelated_actions() {
+        let mut editor = editor(90, 12);
+        let mut buffer = RenderBuffer::new(90, 12, &Style::default());
+        let mut runtime = Runtime::new();
+        for message in ["first message", "second message"] {
+            editor
+                .execute(
+                    &Action::Print(message.to_string()),
+                    &mut buffer,
+                    &mut runtime,
+                )
+                .await
+                .unwrap();
+        }
+        editor
+            .execute(&Action::Refresh, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        let row = render_text_rows(&buffer).pop().unwrap();
+        assert!(row.contains("second message"), "{row}");
+        assert!(row.contains("2 active"), "{row}");
+        assert!(editor.last_error.is_none());
+
+        editor.mode = Mode::Command;
+        editor.command = "write pending.txt".to_string();
+        editor.draw_commandline(&mut buffer);
+        let row = render_text_rows(&buffer).pop().unwrap();
+        assert!(row.starts_with(":write pending.txt"));
+        assert!(row.contains("2 active"));
+    }
+
+    #[test]
+    fn bottom_line_prioritizes_errors_and_reports_concurrent_progress() {
+        use crate::notification::{MessageContent, ProgressPriority};
+        let mut editor = editor(100, 12);
+        let now = NotificationTime::now();
+        editor
+            .notifications
+            .begin_progress(
+                NotificationSource::Editor,
+                "index",
+                MessageContent::new("indexing"),
+                ProgressPriority::Background,
+                now,
+            )
+            .unwrap();
+        let push = editor
+            .notifications
+            .begin_progress(
+                NotificationSource::Editor,
+                "push",
+                MessageContent::new("pushing commits"),
+                ProgressPriority::UserInitiated,
+                now,
+            )
+            .unwrap();
+        editor
+            .notifications
+            .update_progress(push, MessageContent::new("pushing commits"), Some(40), now)
+            .unwrap();
+        let error = editor
+            .publish_notification(Notice::new(
+                NotificationSource::Editor,
+                Severity::Error,
+                "save failed",
+            ))
+            .unwrap();
+        let mut buffer = RenderBuffer::new(100, 12, &Style::default());
+        editor.draw_commandline(&mut buffer);
+        let row = render_text_rows(&buffer).pop().unwrap();
+        assert!(
+            row.contains("save failed") && row.contains("3 active"),
+            "{row}"
+        );
+        editor.notifications.acknowledge(error).unwrap();
+        editor.draw_commandline(&mut buffer);
+        let row = render_text_rows(&buffer).pop().unwrap();
+        assert!(
+            row.contains("pushing commits (40%)") && row.contains("2 active"),
+            "{row}"
+        );
+    }
+
+    #[test]
+    fn ordinary_command_errors_are_retained_and_messages_is_discoverable() {
+        let mut editor = editor(100, 24);
+        let runtime = Runtime::new();
+        assert!(editor
+            .handle_command("DefinitelyNotACommand", &runtime)
+            .is_empty());
+        assert_eq!(
+            editor.notifications.records().next().unwrap().severity,
+            Severity::Error
+        );
+        assert_eq!(
+            editor.handle_command("messages", &runtime),
+            vec![Action::OpenMessages]
+        );
+        let entries = command_palette::entries(&editor.config.keys, &[]);
+        assert!(entries
+            .iter()
+            .any(|entry| entry.action == Action::OpenMessages));
+        let defaults: Config = toml::from_str(crate::assets::DEFAULT_CONFIG).unwrap();
+        let Some(KeyAction::Nested(leader)) = defaults.keys.normal.get(" ") else {
+            panic!("missing leader");
+        };
+        assert_eq!(
+            leader.get("m"),
+            Some(&KeyAction::Single(Action::OpenMessages))
+        );
+    }
+
+    #[test]
+    fn browser_searches_details_and_keeps_selection_when_messages_arrive() {
+        let mut editor = editor(100, 24);
+        let first = editor
+            .publish_notification(
+                Notice::new(NotificationSource::Editor, Severity::Error, "first")
+                    .with_details("hidden diagnostic needle"),
+            )
+            .unwrap();
+        editor.open_messages();
+        assert_eq!(
+            editor.message_browser.as_ref().unwrap().selected,
+            Some(first)
+        );
+        editor
+            .publish_notification(Notice::new(
+                NotificationSource::Editor,
+                Severity::Warning,
+                "newer",
+            ))
+            .unwrap();
+        editor.notification_presentation_changed();
+        assert_eq!(
+            editor.message_browser.as_ref().unwrap().selected,
+            Some(first)
+        );
+        editor.handle_message_action(&MessageAction::Search);
+        editor.handle_message_action(&MessageAction::Query("needle".to_string()));
+        assert_eq!(editor.message_ids(Instant::now()), vec![first]);
+        editor.handle_message_action(&MessageAction::EndSearch);
+        editor.handle_message_action(&MessageAction::Acknowledge);
+        assert!(!editor
+            .notifications
+            .get(first)
+            .unwrap()
+            .is_active(Instant::now()));
+        editor.handle_message_action(&MessageAction::ClearInactive);
+        assert!(editor.notifications.get(first).is_none());
+    }
+
+    struct RetainedDraft;
+    impl Component for RetainedDraft {
+        fn draw(&self, _buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn is_sensitive_input(&self) -> bool {
+            true
+        }
+        fn cursor_position(&self) -> Option<(usize, usize)> {
+            Some((7, 3))
+        }
+    }
+
+    #[test]
+    fn browser_restores_the_exact_suspended_input_surface() {
+        let mut editor = editor(100, 24);
+        editor.current_dialog = Some(Box::new(RetainedDraft));
+        editor.open_messages();
+        assert!(editor.current_dialog.as_ref().unwrap().is_message_history());
+        editor.close_messages();
+        let restored = editor.current_dialog.as_ref().unwrap();
+        assert!(restored.is_sensitive_input());
+        assert_eq!(restored.cursor_position(), Some((7, 3)));
+    }
+
+    #[test]
+    fn acknowledged_persistent_warning_is_not_republished_when_history_is_cleared() {
+        let mut editor = editor(100, 24);
+        editor.session_manager.set_warning(Some("snapshot failed"));
+        editor.sync_persistent_notifications();
+        let id = editor.session_notification.unwrap();
+        editor.notifications.acknowledge(id).unwrap();
+        editor.notifications.clear_inactive(Instant::now());
+        editor.sync_persistent_notifications();
+        assert_eq!(editor.notifications.records().len(), 0);
+        editor.session_manager.set_warning(None);
+        editor.sync_persistent_notifications();
+        editor.session_manager.set_warning(Some("snapshot failed"));
+        editor.sync_persistent_notifications();
+        assert_ne!(editor.session_notification, Some(id));
+        assert_eq!(editor.notifications.counts(Instant::now()).active, 1);
+    }
+
+    #[test]
+    fn browser_renders_at_narrow_and_tiny_sizes_without_using_global_chrome() {
+        for (width, height) in [(120, 30), (60, 16), (24, 8), (8, 4), (1, 1)] {
+            let mut editor = editor(width, height);
+            editor.set_legacy_message(Some("A long message with 界 and several words".to_string()));
+            editor.open_messages();
+            let mut buffer = RenderBuffer::new(width, height, &Style::default());
+            editor
+                .current_dialog
+                .as_ref()
+                .unwrap()
+                .draw(&mut buffer)
+                .unwrap();
+            for row in render_text_rows(&buffer)
+                .iter()
+                .skip(height.saturating_sub(2))
+            {
+                assert!(row.trim().is_empty(), "{width}x{height}: {row}");
+            }
+        }
+    }
+
+    #[test]
+    fn bottom_line_click_opens_history_over_a_workspace() {
+        let mut editor = editor(100, 24);
+        editor.set_legacy_message(Some("message".to_string()));
+        editor
+            .workspace_manager
+            .open("git".to_string(), plugin::WorkspaceConfig::default());
+        let action = editor
+            .handle_event(&Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 80,
+                row: 23,
+                modifiers: KeyModifiers::NONE,
+            }))
+            .unwrap();
+        assert_eq!(action, Some(KeyAction::Single(Action::OpenMessages)));
+    }
+}

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -31,6 +31,7 @@ use crate::{
     config::{CursorShape, FormattingProvider, KeyAction, PickerIconStyle, StatuslineSection},
     editor::RenderCommand,
     lsp::{Diagnostic, DiagnosticSeverity},
+    notification::{NotificationCounts, NotificationState, Severity},
     plugin::DecorationAnchor,
     splash,
     theme::{SelectionForegroundPriority, Style, Theme},
@@ -79,6 +80,37 @@ fn diagnostic_row(diagnostics: &[&Diagnostic], available_width: usize) -> Option
     let mut row = truncate_display_width(&row, available_width - 1);
     row.push('…');
     Some(fit_display_width(&row, available_width))
+}
+
+fn notification_badge(counts: NotificationCounts, width: usize, has_message: bool) -> String {
+    let full = if counts.active > 0 {
+        format!("[{} active · :messages]", counts.active)
+    } else if counts.unread > 0 {
+        format!("[{} unread · :messages]", counts.unread)
+    } else if counts.total > 0 {
+        "[:messages]".to_string()
+    } else {
+        return String::new();
+    };
+    let reserve = if has_message { 16 } else { 0 };
+    if display_width(&full) + reserve <= width {
+        return full;
+    }
+    if counts.active > 1 {
+        let compact = format!("[{}]", counts.active);
+        if display_width(&compact) + usize::from(has_message) < width {
+            return compact;
+        }
+    }
+    String::new()
+}
+
+fn notification_summary(text: &str, width: usize) -> String {
+    if width >= 10 && display_width(text) > width {
+        format!("{}…", truncate_display_width(text, width - 1))
+    } else {
+        truncate_display_width(text, width)
+    }
 }
 
 fn diagnostics_by_visible_line(
@@ -1246,13 +1278,6 @@ impl Editor {
         // and overlays so prompts and transient menus stay interactive.
         self.workspace_manager
             .render(buffer, &self.theme, self.picker_icons());
-        if self.workspace_manager.is_active()
-            && (self.last_error.is_some()
-                || self.session_manager.warning().is_some()
-                || self.config_diagnostics_banner().is_some())
-        {
-            self.draw_commandline(buffer);
-        }
         self.render_dialog(buffer)?;
 
         // Render all plugins
@@ -1262,6 +1287,8 @@ impl Editor {
         // Update overlay positions and render them
         let overlays_span = super::perf::PerfSpan::start("render:overlays+cursor");
         self.update_and_render_overlays(buffer)?;
+        // The final row belongs to the editor, including inside modal workspaces.
+        self.draw_commandline(buffer);
 
         self.update_terminal_cursor_surface(buffer);
         self.render_cursor_cell(buffer);
@@ -3321,22 +3348,74 @@ impl Editor {
             };
             let wc_width = if wc.is_empty() { 0 } else { 10.min(width) };
 
-            let mut messages = Vec::new();
-            if let Some(error) = self.last_error.as_deref() {
-                messages.push(error.to_string());
+            let now = Instant::now();
+            let mut counts = self.notifications.counts(now);
+            let primary = self.notifications.primary(now);
+            let (message, severity) = if let Some(fallback) = &self.notification_fallback {
+                counts.active += 1;
+                (
+                    format!("! {fallback} [not retained]"),
+                    Some(Severity::Error),
+                )
+            } else if let Some(record) = primary {
+                let prefix = if record.is_running() {
+                    format!(
+                        "{} ",
+                        crate::ui::spinner_frame(
+                            self.notification_animation_start.elapsed().as_millis() as u64
+                        )
+                    )
+                } else if record.severity != Severity::Info {
+                    format!("{} ", record.severity.marker())
+                } else {
+                    String::new()
+                };
+                let source = if matches!(
+                    record.source,
+                    crate::notification::NotificationSource::Editor
+                ) {
+                    String::new()
+                } else {
+                    format!("{}: ", record.source.label())
+                };
+                let percentage = match record.state {
+                    NotificationState::Running {
+                        percentage: Some(value),
+                    } => format!(" ({value}%)"),
+                    _ => String::new(),
+                };
+                (
+                    format!("{prefix}{source}{}{percentage}", record.content.summary),
+                    Some(record.severity),
+                )
+            } else {
+                (String::new(), None)
+            };
+            let available = width.saturating_sub(wc_width);
+            let badge = notification_badge(counts, available, !message.is_empty());
+            let badge_width = display_width(&badge);
+            let message_width =
+                available.saturating_sub(badge_width + usize::from(badge_width > 0));
+            let mut message_style = style.clone();
+            let color = match severity {
+                Some(Severity::Error) => Some("notificationsErrorIcon.foreground"),
+                Some(Severity::Warning) => Some("notificationsWarningIcon.foreground"),
+                Some(Severity::Success) => Some("gitDecoration.addedResourceForeground"),
+                _ => None,
+            };
+            if let Some(color) = color.and_then(|key| self.theme.colors.get(key)).copied() {
+                message_style.fg = Some(color);
             }
-            if let Some(warning) = self.session_manager.warning() {
-                messages.push(warning.to_string());
-            }
-            if let Some(warning) = self.config_diagnostics_banner() {
-                messages.push(warning);
-            }
-            let last_error = (!messages.is_empty()).then(|| messages.join(" | "));
-            if let Some(last_error) = last_error {
-                let width = width.saturating_sub(wc_width);
-                let last_error = last_error.replace(['\r', '\n'], " ");
-                let last_error = fit_display_width(&last_error, width);
-                buffer.set_text(0, y, &last_error, style);
+            buffer.set_text(
+                0,
+                y,
+                &notification_summary(&message, message_width),
+                &message_style,
+            );
+            if badge_width > 0 {
+                let mut badge_style = style.clone();
+                badge_style.fg = self.theme.ui_style.muted.fg.or(style.fg);
+                buffer.set_text(available - badge_width, y, &badge, &badge_style);
             }
 
             if wc_width > 0 {
@@ -3359,6 +3438,13 @@ impl Editor {
         };
         let cmdline = format!("{}{}", prefix, text);
         buffer.set_text(0, y, &cmdline, style);
+        let badge = notification_badge(self.notifications.counts(Instant::now()), width, false);
+        let badge_width = display_width(&badge);
+        if badge_width > 0 && display_width(&cmdline).saturating_add(badge_width + 2) <= width {
+            let mut badge_style = style.clone();
+            badge_style.fg = self.theme.ui_style.muted.fg.or(style.fg);
+            buffer.set_text(width - badge_width, y, &badge, &badge_style);
+        }
     }
 
     /// Renders the gutter with line numbers for a specific window
@@ -3685,7 +3771,7 @@ mod tests {
             },
             &editor.theme,
         );
-        editor.last_error = Some("fatal: index.lock already exists".to_string());
+        editor.set_legacy_message(Some("fatal: index.lock already exists".to_string()));
         let mut buffer = RenderBuffer::new(60, 12, &Style::default());
 
         editor.render(&mut buffer).unwrap();
@@ -3700,6 +3786,15 @@ mod tests {
             .collect::<String>();
         assert!(commandline.contains("fatal: index.lock already exists"));
         assert!(!commandline.contains("s stage"));
+        let actionline = buffer
+            .cells
+            .chunks(buffer.width)
+            .nth(buffer.height - 2)
+            .unwrap()
+            .iter()
+            .map(|cell| cell.text.as_str())
+            .collect::<String>();
+        assert!(actionline.contains("s stage"), "{actionline}");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod language;
 pub mod logger;
 pub mod lsp;
 pub mod matchit;
+pub mod notification;
 pub mod onboarding;
 pub mod plugin;
 pub mod preferences;

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::VecDeque,
+    fmt,
     time::{Duration, Instant, SystemTime},
 };
 
@@ -16,8 +17,36 @@ const MAX_DETAILS_BYTES: usize = 64 * 1_024;
 const MAX_KEY_BYTES: usize = 1_024;
 
 /// Identity of one history entry. IDs are never reused by a center.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(transparent)]
 pub struct NotificationId(u64);
+
+impl fmt::Display for NotificationId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Commands returned by the message-history surface.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum MessageAction {
+    Close,
+    Next,
+    Previous,
+    Search,
+    Query(String),
+    Backspace,
+    EndSearch,
+    ClearSearch,
+    CycleFilter,
+    Acknowledge,
+    ClearInactive,
+    Copy,
+    ScrollDown,
+    ScrollUp,
+}
 
 /// Producer-local identity. Numeric LSP tokens never alias text tokens such as "1".
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -70,6 +99,15 @@ pub enum NotificationSource {
     },
 }
 
+impl NotificationSource {
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Editor => "Red",
+            Self::Plugin { name, .. } | Self::LanguageServer { name, .. } => name,
+        }
+    }
+}
+
 /// Semantic importance, independent of whether an operation is still running.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
@@ -77,6 +115,26 @@ pub enum Severity {
     Success,
     Warning,
     Error,
+}
+
+impl Severity {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Success => "success",
+            Self::Warning => "warning",
+            Self::Error => "error",
+        }
+    }
+
+    pub fn marker(self) -> &'static str {
+        match self {
+            Self::Info => "i",
+            Self::Success => "✓",
+            Self::Warning => "!",
+            Self::Error => "×",
+        }
+    }
 }
 
 /// A monotonic reading for lifetimes paired with a wall-clock history timestamp.
@@ -118,13 +176,33 @@ impl MessageContent {
     }
 
     fn bounded(mut self) -> Self {
-        self.summary = self.summary.replace(['\r', '\n'], " ");
+        self.summary = single_line(&self.summary);
         self.truncated |= truncate_text(&mut self.summary, MAX_SUMMARY_BYTES);
         if let Some(details) = &mut self.details {
             self.truncated |= truncate_text(details, MAX_DETAILS_BYTES);
         }
         self
     }
+}
+
+/// Terminal-safe summary text; original multiline details remain available for copy.
+pub(crate) fn single_line(text: &str) -> String {
+    text.chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect()
+}
+
+pub(crate) fn detail_text(text: &str) -> String {
+    text.replace('\t', "    ")
+        .chars()
+        .map(|ch| {
+            if ch != '\n' && ch.is_control() {
+                '�'
+            } else {
+                ch
+            }
+        })
+        .collect()
 }
 
 fn truncate_text(text: &mut String, max_bytes: usize) -> bool {
@@ -315,6 +393,7 @@ pub struct NotificationCenter {
     records: VecDeque<Notification>,
     capacity: usize,
     next_id: u64,
+    revision: u64,
 }
 
 impl Default for NotificationCenter {
@@ -329,7 +408,16 @@ impl NotificationCenter {
             records: VecDeque::new(),
             capacity,
             next_id: 1,
+            revision: 0,
         }
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    fn changed(&mut self) {
+        self.revision = self.revision.wrapping_add(1);
     }
 
     /// Entries in creation order; callers may reverse this iterator for history UI.
@@ -409,6 +497,7 @@ impl NotificationCenter {
             record.updated_at = now.wall;
             record.occurrences = record.occurrences.saturating_add(1);
             record.read = false;
+            self.changed();
             return Ok(id);
         }
         let id = self.allocate(now.monotonic)?;
@@ -426,6 +515,7 @@ impl NotificationCenter {
             priority: ProgressPriority::Background,
             display,
         });
+        self.changed();
         Ok(id)
     }
 
@@ -457,6 +547,7 @@ impl NotificationCenter {
             priority,
             display: DisplayState::UntilAcknowledged,
         });
+        self.changed();
         Ok(id)
     }
 
@@ -483,6 +574,7 @@ impl NotificationCenter {
         record.content = content;
         record.state = state;
         record.updated_at = now.wall;
+        self.changed();
         Ok(true)
     }
 
@@ -503,11 +595,16 @@ impl NotificationCenter {
         record.updated_at = now.wall;
         record.display = NoticeLifetime::for_severity(record.severity).display_state(now.monotonic);
         record.read = false;
+        self.changed();
         Ok(())
     }
 
     pub fn mark_read(&mut self, id: NotificationId) -> Result<(), NotificationError> {
-        self.get_mut(id)?.read = true;
+        let record = self.get_mut(id)?;
+        if !record.read {
+            record.read = true;
+            self.changed();
+        }
         Ok(())
     }
 
@@ -518,6 +615,7 @@ impl NotificationCenter {
         if !record.is_running() {
             record.display = DisplayState::Hidden;
         }
+        self.changed();
         Ok(())
     }
 
@@ -529,6 +627,7 @@ impl NotificationCenter {
             return Err(NotificationError::StillRunning);
         }
         record.display = DisplayState::Hidden;
+        self.changed();
         Ok(())
     }
 
@@ -555,7 +654,11 @@ impl NotificationCenter {
     pub fn clear_inactive(&mut self, now: Instant) -> usize {
         let before = self.records.len();
         self.records.retain(|record| record.is_active(now));
-        before - self.records.len()
+        let removed = before - self.records.len();
+        if removed > 0 {
+            self.changed();
+        }
+        removed
     }
 }
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,0 +1,563 @@
+//! Session-local notification history and lifecycle, owned by the editor.
+//!
+//! Presentation is deliberately separate: expiry removes a message from the active
+//! set, not from history, and acknowledging progress never cancels the work. Callers
+//! supply one clock reading per mutation so expiry and ordering are deterministic.
+
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant, SystemTime},
+};
+
+const DEFAULT_CAPACITY: usize = 1_024;
+const DEFAULT_NOTICE_DURATION: Duration = Duration::from_secs(4);
+const MAX_SUMMARY_BYTES: usize = 4 * 1_024;
+const MAX_DETAILS_BYTES: usize = 64 * 1_024;
+const MAX_KEY_BYTES: usize = 1_024;
+
+/// Identity of one history entry. IDs are never reused by a center.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NotificationId(u64);
+
+/// Producer-local identity. Numeric LSP tokens never alias text tokens such as "1".
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NotificationKey {
+    Text(String),
+    Number(u64),
+}
+
+impl From<String> for NotificationKey {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<&str> for NotificationKey {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_string())
+    }
+}
+
+impl From<u64> for NotificationKey {
+    fn from(value: u64) -> Self {
+        Self::Number(value)
+    }
+}
+
+impl NotificationKey {
+    fn validate(&self) -> Result<(), NotificationError> {
+        match self {
+            Self::Text(value) if value.is_empty() || value.len() > MAX_KEY_BYTES => {
+                Err(NotificationError::InvalidKey)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Producer identity. Generations distinguish restarted plugin/server instances.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NotificationSource {
+    Editor,
+    Plugin {
+        name: String,
+        generation: u64,
+    },
+    LanguageServer {
+        name: String,
+        workspace_root: String,
+        generation: u64,
+    },
+}
+
+/// Semantic importance, independent of whether an operation is still running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Info,
+    Success,
+    Warning,
+    Error,
+}
+
+/// A monotonic reading for lifetimes paired with a wall-clock history timestamp.
+#[derive(Debug, Clone, Copy)]
+pub struct NotificationTime {
+    pub monotonic: Instant,
+    pub wall: SystemTime,
+}
+
+impl NotificationTime {
+    pub fn now() -> Self {
+        Self {
+            monotonic: Instant::now(),
+            wall: SystemTime::now(),
+        }
+    }
+}
+
+/// Bounded text retained in history. Details retain their original line breaks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageContent {
+    pub summary: String,
+    pub details: Option<String>,
+    pub truncated: bool,
+}
+
+impl MessageContent {
+    pub fn new(summary: impl Into<String>) -> Self {
+        Self {
+            summary: summary.into(),
+            details: None,
+            truncated: false,
+        }
+    }
+
+    pub fn with_details(mut self, details: impl Into<String>) -> Self {
+        self.details = Some(details.into());
+        self
+    }
+
+    fn bounded(mut self) -> Self {
+        self.summary = self.summary.replace(['\r', '\n'], " ");
+        self.truncated |= truncate_text(&mut self.summary, MAX_SUMMARY_BYTES);
+        if let Some(details) = &mut self.details {
+            self.truncated |= truncate_text(details, MAX_DETAILS_BYTES);
+        }
+        self
+    }
+}
+
+fn truncate_text(text: &mut String, max_bytes: usize) -> bool {
+    if text.len() <= max_bytes {
+        if text.capacity() > max_bytes {
+            text.shrink_to_fit();
+        }
+        return false;
+    }
+    let mut end = max_bytes - '…'.len_utf8();
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text.truncate(end);
+    text.push('…');
+    text.shrink_to_fit();
+    true
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoticeLifetime {
+    Transient(Duration),
+    UntilAcknowledged,
+}
+
+impl NoticeLifetime {
+    fn for_severity(severity: Severity) -> Self {
+        match severity {
+            Severity::Info | Severity::Success => Self::Transient(DEFAULT_NOTICE_DURATION),
+            Severity::Warning | Severity::Error => Self::UntilAcknowledged,
+        }
+    }
+
+    fn display_state(self, now: Instant) -> DisplayState {
+        match self {
+            Self::Transient(duration) => now
+                .checked_add(duration)
+                .map_or(DisplayState::UntilAcknowledged, DisplayState::Until),
+            Self::UntilAcknowledged => DisplayState::UntilAcknowledged,
+        }
+    }
+}
+
+/// A one-shot notice, optionally coalesced by a producer-scoped key.
+#[derive(Debug, Clone)]
+pub struct Notice {
+    pub source: NotificationSource,
+    pub severity: Severity,
+    pub content: MessageContent,
+    pub key: Option<NotificationKey>,
+    pub lifetime: NoticeLifetime,
+}
+
+impl Notice {
+    pub fn new(source: NotificationSource, severity: Severity, summary: impl Into<String>) -> Self {
+        Self {
+            source,
+            severity,
+            content: MessageContent::new(summary),
+            key: None,
+            lifetime: NoticeLifetime::for_severity(severity),
+        }
+    }
+
+    pub fn with_key(mut self, key: impl Into<NotificationKey>) -> Self {
+        self.key = Some(key.into());
+        self
+    }
+
+    pub fn with_details(mut self, details: impl Into<String>) -> Self {
+        self.content = self.content.with_details(details);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressPriority {
+    Background,
+    UserInitiated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressOutcome {
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl ProgressOutcome {
+    fn severity(self) -> Severity {
+        match self {
+            Self::Succeeded => Severity::Success,
+            Self::Failed => Severity::Error,
+            Self::Cancelled => Severity::Info,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationState {
+    Notice,
+    Running { percentage: Option<u8> },
+    Finished(ProgressOutcome),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DisplayState {
+    Until(Instant),
+    UntilAcknowledged,
+    Hidden,
+}
+
+/// Read-only history entry; lifecycle changes go through [`NotificationCenter`].
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub id: NotificationId,
+    pub source: NotificationSource,
+    pub key: Option<NotificationKey>,
+    pub severity: Severity,
+    pub content: MessageContent,
+    pub state: NotificationState,
+    pub created_at: SystemTime,
+    pub updated_at: SystemTime,
+    pub occurrences: u64,
+    pub read: bool,
+    priority: ProgressPriority,
+    display: DisplayState,
+}
+
+impl Notification {
+    pub fn is_running(&self) -> bool {
+        matches!(self.state, NotificationState::Running { .. })
+    }
+
+    pub fn is_active(&self, now: Instant) -> bool {
+        self.is_running()
+            || match self.display {
+                DisplayState::Until(deadline) => now < deadline,
+                DisplayState::UntilAcknowledged => true,
+                DisplayState::Hidden => false,
+            }
+    }
+
+    fn rank(&self) -> u8 {
+        match self.severity {
+            Severity::Error => 4,
+            Severity::Warning => 3,
+            _ if self.is_running() => match self.priority {
+                ProgressPriority::UserInitiated => 2,
+                ProgressPriority::Background => 1,
+            },
+            Severity::Info | Severity::Success => 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NotificationCounts {
+    pub total: usize,
+    pub active: usize,
+    pub running: usize,
+    pub unread: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum NotificationError {
+    #[error("notification text key must contain 1 to 1024 bytes")]
+    InvalidKey,
+    #[error("notification history is full of active messages")]
+    CapacityReached,
+    #[error("notification key belongs to another active message")]
+    KeyInUse,
+    #[error("notification no longer exists")]
+    UnknownId,
+    #[error("notification is no longer running")]
+    NotRunning,
+    #[error("running notifications must be completed with an outcome")]
+    StillRunning,
+}
+
+/// Bounded history with explicit overflow: active entries are never evicted.
+///
+/// When full, the oldest inactive entry is discarded. If every retained entry is
+/// active, publication returns [`NotificationError::CapacityReached`] so the caller
+/// can report the failure instead of silently losing an operation.
+#[derive(Debug)]
+pub struct NotificationCenter {
+    records: VecDeque<Notification>,
+    capacity: usize,
+    next_id: u64,
+}
+
+impl Default for NotificationCenter {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+}
+
+impl NotificationCenter {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            records: VecDeque::new(),
+            capacity,
+            next_id: 1,
+        }
+    }
+
+    /// Entries in creation order; callers may reverse this iterator for history UI.
+    pub fn records(&self) -> impl DoubleEndedIterator<Item = &Notification> + ExactSizeIterator {
+        self.records.iter()
+    }
+
+    pub fn get(&self, id: NotificationId) -> Option<&Notification> {
+        self.records.iter().find(|record| record.id == id)
+    }
+
+    fn get_mut(&mut self, id: NotificationId) -> Result<&mut Notification, NotificationError> {
+        self.records
+            .iter_mut()
+            .find(|record| record.id == id)
+            .ok_or(NotificationError::UnknownId)
+    }
+
+    fn active_key(
+        &self,
+        source: &NotificationSource,
+        key: &NotificationKey,
+        now: Instant,
+    ) -> Option<NotificationId> {
+        self.records
+            .iter()
+            .find(|record| {
+                &record.source == source
+                    && record.key.as_ref() == Some(key)
+                    && !matches!(record.state, NotificationState::Finished(_))
+                    && record.is_active(now)
+            })
+            .map(|record| record.id)
+    }
+
+    fn allocate(&mut self, now: Instant) -> Result<NotificationId, NotificationError> {
+        if self.records.len() >= self.capacity {
+            let Some(index) = self
+                .records
+                .iter()
+                .position(|record| !record.is_active(now))
+            else {
+                return Err(NotificationError::CapacityReached);
+            };
+            self.records.remove(index);
+        }
+        let id = NotificationId(self.next_id);
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .expect("notification ID exhausted");
+        Ok(id)
+    }
+
+    pub fn publish(
+        &mut self,
+        notice: Notice,
+        now: NotificationTime,
+    ) -> Result<NotificationId, NotificationError> {
+        if let Some(key) = &notice.key {
+            key.validate()?;
+        }
+        let content = notice.content.bounded();
+        let display = notice.lifetime.display_state(now.monotonic);
+        if let Some(id) = notice
+            .key
+            .as_ref()
+            .and_then(|key| self.active_key(&notice.source, key, now.monotonic))
+        {
+            let record = self.get_mut(id)?;
+            if record.state != NotificationState::Notice {
+                return Err(NotificationError::KeyInUse);
+            }
+            record.severity = notice.severity;
+            record.content = content;
+            record.display = display;
+            record.updated_at = now.wall;
+            record.occurrences = record.occurrences.saturating_add(1);
+            record.read = false;
+            return Ok(id);
+        }
+        let id = self.allocate(now.monotonic)?;
+        self.records.push_back(Notification {
+            id,
+            source: notice.source,
+            key: notice.key,
+            severity: notice.severity,
+            content,
+            state: NotificationState::Notice,
+            created_at: now.wall,
+            updated_at: now.wall,
+            occurrences: 1,
+            read: false,
+            priority: ProgressPriority::Background,
+            display,
+        });
+        Ok(id)
+    }
+
+    pub fn begin_progress(
+        &mut self,
+        source: NotificationSource,
+        key: impl Into<NotificationKey>,
+        content: MessageContent,
+        priority: ProgressPriority,
+        now: NotificationTime,
+    ) -> Result<NotificationId, NotificationError> {
+        let key = key.into();
+        key.validate()?;
+        if self.active_key(&source, &key, now.monotonic).is_some() {
+            return Err(NotificationError::KeyInUse);
+        }
+        let id = self.allocate(now.monotonic)?;
+        self.records.push_back(Notification {
+            id,
+            source,
+            key: Some(key),
+            severity: Severity::Info,
+            content: content.bounded(),
+            state: NotificationState::Running { percentage: None },
+            created_at: now.wall,
+            updated_at: now.wall,
+            occurrences: 1,
+            read: false,
+            priority,
+            display: DisplayState::UntilAcknowledged,
+        });
+        Ok(id)
+    }
+
+    /// Replaces progress content in place. `None` means indeterminate progress.
+    /// Percentages above 100 are clamped at this boundary.
+    pub fn update_progress(
+        &mut self,
+        id: NotificationId,
+        content: MessageContent,
+        percentage: Option<u8>,
+        now: NotificationTime,
+    ) -> Result<bool, NotificationError> {
+        let record = self.get_mut(id)?;
+        if !record.is_running() {
+            return Err(NotificationError::NotRunning);
+        }
+        let content = content.bounded();
+        let state = NotificationState::Running {
+            percentage: percentage.map(|value| value.min(100)),
+        };
+        if record.content == content && record.state == state {
+            return Ok(false);
+        }
+        record.content = content;
+        record.state = state;
+        record.updated_at = now.wall;
+        Ok(true)
+    }
+
+    pub fn finish_progress(
+        &mut self,
+        id: NotificationId,
+        outcome: ProgressOutcome,
+        content: MessageContent,
+        now: NotificationTime,
+    ) -> Result<(), NotificationError> {
+        let record = self.get_mut(id)?;
+        if !record.is_running() {
+            return Err(NotificationError::NotRunning);
+        }
+        record.state = NotificationState::Finished(outcome);
+        record.severity = outcome.severity();
+        record.content = content.bounded();
+        record.updated_at = now.wall;
+        record.display = NoticeLifetime::for_severity(record.severity).display_state(now.monotonic);
+        record.read = false;
+        Ok(())
+    }
+
+    pub fn mark_read(&mut self, id: NotificationId) -> Result<(), NotificationError> {
+        self.get_mut(id)?.read = true;
+        Ok(())
+    }
+
+    /// Hides a notice/completion. Running work is only marked read, never cancelled.
+    pub fn acknowledge(&mut self, id: NotificationId) -> Result<(), NotificationError> {
+        let record = self.get_mut(id)?;
+        record.read = true;
+        if !record.is_running() {
+            record.display = DisplayState::Hidden;
+        }
+        Ok(())
+    }
+
+    /// Resolves a condition without claiming the user has read it.
+    /// Running operations must be finished with their actual outcome instead.
+    pub fn resolve(&mut self, id: NotificationId) -> Result<(), NotificationError> {
+        let record = self.get_mut(id)?;
+        if record.is_running() {
+            return Err(NotificationError::StillRunning);
+        }
+        record.display = DisplayState::Hidden;
+        Ok(())
+    }
+
+    pub fn counts(&self, now: Instant) -> NotificationCounts {
+        let mut counts = NotificationCounts::default();
+        for record in &self.records {
+            counts.total += 1;
+            counts.active += usize::from(record.is_active(now));
+            counts.running += usize::from(record.is_running());
+            counts.unread += usize::from(!record.read);
+        }
+        counts
+    }
+
+    /// Highest-priority active entry. Updates do not change creation-order ties.
+    pub fn primary(&self, now: Instant) -> Option<&Notification> {
+        self.records
+            .iter()
+            .filter(|record| record.is_active(now))
+            .max_by_key(|record| (record.rank(), record.id))
+    }
+
+    /// Explicit history clearing never removes active messages or running work.
+    pub fn clear_inactive(&mut self, now: Instant) -> usize {
+        let before = self.records.len();
+        self.records.retain(|record| record.is_active(now));
+        before - self.records.len()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/notification/tests.rs
+++ b/src/notification/tests.rs
@@ -1,0 +1,407 @@
+use super::*;
+
+fn later(now: NotificationTime, seconds: u64) -> NotificationTime {
+    let elapsed = Duration::from_secs(seconds);
+    NotificationTime {
+        monotonic: now.monotonic + elapsed,
+        wall: now.wall + elapsed,
+    }
+}
+
+fn notice(severity: Severity, summary: &str) -> Notice {
+    Notice::new(NotificationSource::Editor, severity, summary)
+}
+
+fn start(
+    center: &mut NotificationCenter,
+    key: &str,
+    priority: ProgressPriority,
+    now: NotificationTime,
+) -> NotificationId {
+    center
+        .begin_progress(
+            NotificationSource::Editor,
+            key,
+            MessageContent::new(key),
+            priority,
+            now,
+        )
+        .unwrap()
+}
+
+#[test]
+fn expiry_removes_a_notice_from_active_messages_but_not_history() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let id = center
+        .publish(notice(Severity::Info, "saved"), now)
+        .unwrap();
+
+    assert_eq!(center.primary(now.monotonic).unwrap().id, id);
+    assert_eq!(center.counts(later(now, 4).monotonic).active, 0);
+    assert_eq!(center.counts(later(now, 4).monotonic).unread, 1);
+    assert_eq!(center.get(id).unwrap().content.summary, "saved");
+}
+
+#[test]
+fn acknowledgement_hides_an_error_without_deleting_it() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let id = center
+        .publish(notice(Severity::Error, "failed"), now)
+        .unwrap();
+
+    center.mark_read(id).unwrap();
+    assert_eq!(center.counts(later(now, 600).monotonic).active, 1);
+    assert_eq!(center.counts(now.monotonic).unread, 0);
+    center.acknowledge(id).unwrap();
+    assert_eq!(center.counts(now.monotonic).active, 0);
+    assert!(center.get(id).is_some());
+}
+
+#[test]
+fn progress_updates_and_completion_retain_one_identity() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let id = start(&mut center, "push", ProgressPriority::UserInitiated, now);
+    center.mark_read(id).unwrap();
+
+    assert!(center
+        .update_progress(id, MessageContent::new("pushing"), Some(20), later(now, 1))
+        .unwrap());
+    assert!(!center
+        .update_progress(id, MessageContent::new("pushing"), Some(20), later(now, 2))
+        .unwrap());
+    assert_eq!(center.get(id).unwrap().updated_at, later(now, 1).wall);
+    assert_eq!(center.counts(now.monotonic).unread, 0);
+    center.acknowledge(id).unwrap();
+    assert_eq!(center.counts(now.monotonic).running, 1);
+    assert_eq!(center.resolve(id), Err(NotificationError::StillRunning));
+
+    center
+        .finish_progress(
+            id,
+            ProgressOutcome::Succeeded,
+            MessageContent::new("pushed"),
+            later(now, 3),
+        )
+        .unwrap();
+
+    assert_eq!(center.records().len(), 1);
+    assert_eq!(center.get(id).unwrap().created_at, now.wall);
+    assert_eq!(center.counts(later(now, 3).monotonic).running, 0);
+    assert_eq!(center.counts(later(now, 3).monotonic).unread, 1);
+    assert_eq!(center.counts(later(now, 7).monotonic).active, 0);
+    assert_eq!(
+        center.update_progress(id, MessageContent::new("late"), None, later(now, 8)),
+        Err(NotificationError::NotRunning)
+    );
+}
+
+#[test]
+fn failed_progress_stays_active_until_acknowledged() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let id = start(&mut center, "push", ProgressPriority::UserInitiated, now);
+    center
+        .finish_progress(
+            id,
+            ProgressOutcome::Failed,
+            MessageContent::new("push rejected").with_details("remote error\nfull output"),
+            now,
+        )
+        .unwrap();
+
+    assert_eq!(center.get(id).unwrap().severity, Severity::Error);
+    assert_eq!(center.counts(later(now, 600).monotonic).active, 1);
+    center.acknowledge(id).unwrap();
+    assert_eq!(center.counts(now.monotonic).active, 0);
+    assert_eq!(
+        center.get(id).unwrap().content.details.as_deref(),
+        Some("remote error\nfull output")
+    );
+}
+
+#[test]
+fn keyed_notices_coalesce_only_while_active() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let id = center
+        .publish(
+            notice(Severity::Warning, "snapshot failed").with_key("snapshot"),
+            now,
+        )
+        .unwrap();
+    center.mark_read(id).unwrap();
+    let repeated = center
+        .publish(
+            notice(Severity::Warning, "snapshot still failing").with_key("snapshot"),
+            later(now, 1),
+        )
+        .unwrap();
+
+    assert_eq!(repeated, id);
+    assert_eq!(center.get(id).unwrap().occurrences, 2);
+    assert!(!center.get(id).unwrap().read);
+    center.resolve(id).unwrap();
+    assert!(!center.get(id).unwrap().read);
+    let recurrence = center
+        .publish(
+            notice(Severity::Warning, "snapshot failed").with_key("snapshot"),
+            later(now, 2),
+        )
+        .unwrap();
+    assert_ne!(recurrence, id);
+    assert_eq!(center.records().len(), 2);
+}
+
+#[test]
+fn identical_unkeyed_notices_remain_distinct() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let first = center
+        .publish(notice(Severity::Info, "saved"), now)
+        .unwrap();
+    let second = center
+        .publish(notice(Severity::Info, "saved"), now)
+        .unwrap();
+    assert_ne!(first, second);
+    assert_eq!(center.counts(now.monotonic).active, 2);
+}
+
+#[test]
+fn producer_keys_do_not_collide_across_sources_or_generations() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let sources = [
+        NotificationSource::Plugin {
+            name: "git".into(),
+            generation: 1,
+        },
+        NotificationSource::Plugin {
+            name: "git".into(),
+            generation: 2,
+        },
+        NotificationSource::LanguageServer {
+            name: "rust-analyzer".into(),
+            workspace_root: "/one".into(),
+            generation: 1,
+        },
+        NotificationSource::LanguageServer {
+            name: "rust-analyzer".into(),
+            workspace_root: "/two".into(),
+            generation: 1,
+        },
+    ];
+    for source in sources {
+        center
+            .begin_progress(
+                source,
+                "1",
+                MessageContent::new("working"),
+                ProgressPriority::Background,
+                now,
+            )
+            .unwrap();
+    }
+    assert_eq!(center.counts(now.monotonic).running, 4);
+}
+
+#[test]
+fn numeric_and_text_progress_tokens_are_distinct() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let text = start(&mut center, "1", ProgressPriority::Background, now);
+    let number = center
+        .begin_progress(
+            NotificationSource::Editor,
+            1_u64,
+            MessageContent::new("numeric token"),
+            ProgressPriority::Background,
+            now,
+        )
+        .unwrap();
+    assert_ne!(text, number);
+    assert_eq!(center.counts(now.monotonic).running, 2);
+}
+
+#[test]
+fn invalid_keys_are_rejected_instead_of_truncated_into_collisions() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    for key in [String::new(), "x".repeat(MAX_KEY_BYTES + 1)] {
+        assert_eq!(
+            center.publish(
+                notice(Severity::Warning, "warning").with_key(key.clone()),
+                now
+            ),
+            Err(NotificationError::InvalidKey)
+        );
+        assert_eq!(
+            center.begin_progress(
+                NotificationSource::Editor,
+                key,
+                MessageContent::new("working"),
+                ProgressPriority::Background,
+                now
+            ),
+            Err(NotificationError::InvalidKey)
+        );
+    }
+    assert_eq!(center.records().len(), 0);
+}
+
+#[test]
+fn a_key_cannot_replace_running_work_and_a_retry_gets_a_new_id() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let original = start(&mut center, "push", ProgressPriority::UserInitiated, now);
+    assert_eq!(
+        center.publish(notice(Severity::Error, "collision").with_key("push"), now),
+        Err(NotificationError::KeyInUse)
+    );
+    assert_eq!(
+        center.begin_progress(
+            NotificationSource::Editor,
+            "push",
+            MessageContent::new("again"),
+            ProgressPriority::UserInitiated,
+            now
+        ),
+        Err(NotificationError::KeyInUse)
+    );
+    center
+        .finish_progress(
+            original,
+            ProgressOutcome::Cancelled,
+            MessageContent::new("cancelled"),
+            now,
+        )
+        .unwrap();
+    let retry = start(&mut center, "push", ProgressPriority::UserInitiated, now);
+    assert_ne!(retry, original);
+    assert_eq!(
+        center.finish_progress(
+            original,
+            ProgressOutcome::Succeeded,
+            MessageContent::new("late completion"),
+            now
+        ),
+        Err(NotificationError::NotRunning)
+    );
+    assert!(center.get(retry).unwrap().is_running());
+}
+
+#[test]
+fn capacity_evicts_oldest_inactive_entry_and_never_active_work() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::with_capacity(2);
+    let running = start(&mut center, "index", ProgressPriority::Background, now);
+    let expired = center
+        .publish(notice(Severity::Info, "saved"), now)
+        .unwrap();
+    assert_eq!(
+        center.publish(notice(Severity::Error, "cannot fit"), now),
+        Err(NotificationError::CapacityReached)
+    );
+    let warning = center
+        .publish(notice(Severity::Warning, "warning"), later(now, 4))
+        .unwrap();
+    assert!(center.get(expired).is_none());
+    assert!(center.get(running).is_some());
+    assert!(center.get(warning).is_some());
+    assert_eq!(center.clear_inactive(later(now, 60).monotonic), 0);
+    center.acknowledge(warning).unwrap();
+    assert_eq!(center.clear_inactive(later(now, 60).monotonic), 1);
+    assert!(center.get(running).is_some());
+    assert_eq!(center.mark_read(expired), Err(NotificationError::UnknownId));
+}
+
+#[test]
+fn zero_capacity_returns_explicit_overflow() {
+    let mut center = NotificationCenter::with_capacity(0);
+    assert_eq!(
+        center.publish(notice(Severity::Info, "message"), NotificationTime::now()),
+        Err(NotificationError::CapacityReached)
+    );
+}
+
+#[test]
+fn primary_prefers_severity_then_user_work_and_does_not_rotate_on_updates() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let background = start(&mut center, "index", ProgressPriority::Background, now);
+    let user = start(&mut center, "push", ProgressPriority::UserInitiated, now);
+    center
+        .publish(notice(Severity::Success, "saved"), now)
+        .unwrap();
+    assert_eq!(center.primary(now.monotonic).unwrap().id, user);
+    center
+        .update_progress(
+            background,
+            MessageContent::new("indexing"),
+            Some(10),
+            later(now, 1),
+        )
+        .unwrap();
+    assert_eq!(center.primary(now.monotonic).unwrap().id, user);
+    let error = center
+        .publish(notice(Severity::Error, "failed"), now)
+        .unwrap();
+    assert_eq!(center.primary(now.monotonic).unwrap().id, error);
+    center.acknowledge(error).unwrap();
+    assert_eq!(center.primary(now.monotonic).unwrap().id, user);
+}
+
+#[test]
+fn retained_text_is_utf8_safe_bounded_and_keeps_multiline_details() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let message = "界\n".repeat(MAX_DETAILS_BYTES);
+    let id = center
+        .publish(
+            notice(Severity::Error, &message).with_details(&message),
+            now,
+        )
+        .unwrap();
+    let content = &center.get(id).unwrap().content;
+    assert!(content.truncated);
+    assert!(content.summary.len() <= MAX_SUMMARY_BYTES);
+    assert!(content.summary.capacity() <= MAX_SUMMARY_BYTES);
+    assert!(!content.summary.contains('\n'));
+    assert!(content.summary.ends_with('…'));
+    assert!(content.details.as_ref().unwrap().len() <= MAX_DETAILS_BYTES);
+    assert!(content.details.as_ref().unwrap().capacity() <= MAX_DETAILS_BYTES);
+    assert!(content.details.as_ref().unwrap().contains('\n'));
+}
+
+#[test]
+fn short_details_do_not_retain_an_oversized_producer_allocation() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let mut details = String::with_capacity(MAX_DETAILS_BYTES * 4);
+    details.push_str("short details");
+    let id = center
+        .publish(notice(Severity::Info, "summary").with_details(details), now)
+        .unwrap();
+    let content = &center.get(id).unwrap().content;
+    assert!(!content.truncated);
+    assert_eq!(content.details.as_deref(), Some("short details"));
+    assert!(content.details.as_ref().unwrap().capacity() <= MAX_DETAILS_BYTES);
+}
+
+#[test]
+fn progress_percentage_is_clamped() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let id = start(&mut center, "index", ProgressPriority::Background, now);
+    center
+        .update_progress(id, MessageContent::new("index"), Some(255), now)
+        .unwrap();
+    assert_eq!(
+        center.get(id).unwrap().state,
+        NotificationState::Running {
+            percentage: Some(100)
+        }
+    );
+}

--- a/src/notification/tests.rs
+++ b/src/notification/tests.rs
@@ -405,3 +405,23 @@ fn progress_percentage_is_clamped() {
         }
     );
 }
+
+#[test]
+fn notification_text_is_safe_to_paint_without_losing_copyable_details() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let original = "line\n\u{1b}[31m\ttext";
+    let id = center
+        .publish(
+            notice(Severity::Error, original).with_details(original),
+            now,
+        )
+        .unwrap();
+    let content = &center.get(id).unwrap().content;
+    assert!(!content.summary.chars().any(char::is_control));
+    assert_eq!(content.details.as_deref(), Some(original));
+    let painted = detail_text(original);
+    assert!(!painted.contains('\u{1b}'));
+    assert!(!painted.contains('\t'));
+    assert!(painted.contains('\n'));
+}

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -192,7 +192,7 @@ impl WorkspaceLayout {
             x: 0,
             y: 2,
             width,
-            height: height.saturating_sub(3),
+            height: height.saturating_sub(4),
         };
         if let Some(focus) = workspace.zoomed {
             return Self {
@@ -1438,7 +1438,7 @@ impl WorkspaceManager {
             return;
         };
         let editor_style = &theme.style;
-        for y in 0..buffer.height {
+        for y in 0..buffer.height.saturating_sub(1) {
             buffer.set_text(0, y, &" ".repeat(buffer.width), editor_style);
         }
         if buffer.width < 4 || buffer.height < 4 {
@@ -1503,7 +1503,7 @@ impl WorkspaceManager {
         if workspace.model.actions.is_empty() {
             render_segments(
                 buffer,
-                (1, buffer.height - 1, buffer.width - 2),
+                (1, buffer.height - 2, buffer.width - 2),
                 &workspace.model.footer,
                 editor_style,
                 theme,
@@ -1528,7 +1528,7 @@ impl WorkspaceManager {
                 .render(
                     buffer,
                     1,
-                    buffer.height - 1,
+                    buffer.height - 2,
                     buffer.width - 2,
                     theme,
                     editor_style,
@@ -2547,7 +2547,7 @@ mod tests {
                 assert!(!event.notify_plugin);
                 let zoomed = WorkspaceLayout::calculate(&workspace, height, width);
                 assert_eq!(zoomed.pane(focus).unwrap().width, width);
-                assert_eq!(zoomed.pane(focus).unwrap().height, height - 3);
+                assert_eq!(zoomed.pane(focus).unwrap().height, height - 4);
                 assert!(zoomed.separator.is_none());
                 assert_eq!(workspace.rows_width, Some(31));
                 workspace.handle_action("toggle_zoom".to_string(), height, width);

--- a/src/ui/inline_history.rs
+++ b/src/ui/inline_history.rs
@@ -9,7 +9,7 @@ use crate::{
     editor::{Action, Editor, RenderBuffer},
     inline_history::HistoryAction,
     theme::Theme,
-    unicode_utils::truncate_display_width,
+    unicode_utils::{fit_display_width, truncate_display_width},
 };
 use crossterm::event::{Event, KeyCode, KeyModifiers};
 
@@ -129,7 +129,7 @@ impl Component for InlineHistoryPanel {
             let marker = if offset == self.selected { "> " } else { "  " };
             let row_y = y + 1 + (offset - first) * 2;
             let mut lines = row.lines();
-            let text = truncate_display_width(
+            let text = fit_display_width(
                 &format!("{marker}{}", lines.next().unwrap_or_default()),
                 list_width,
             );
@@ -140,7 +140,7 @@ impl Component for InlineHistoryPanel {
                 buffer.set_text(
                     1,
                     row_y + 1,
-                    &truncate_display_width(
+                    &fit_display_width(
                         &format!("  {}", lines.next().unwrap_or_default()),
                         list_width,
                     ),
@@ -263,5 +263,66 @@ impl Component for InlineHistoryPanel {
             KeyCode::Char('D') => HistoryAction::Forget,
             _ => return None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::Color;
+
+    #[test]
+    fn selection_fills_both_lines_without_crossing_pane_boundary() {
+        let mut theme = Theme::default();
+        theme.ui_style.picker_selected_item.bg = Some(Color::Rgb {
+            r: 91,
+            g: 42,
+            b: 73,
+        });
+        let height = 30;
+
+        for (viewport_width, list_width) in [(120, 47), (64, 62)] {
+            let mut panel = InlineHistoryPanel {
+                rows: vec![
+                    "short\ndetails".into(),
+                    format!("{}\n{}", "界".repeat(80), "👋".repeat(80)),
+                ],
+                selected: 0,
+                detail: "preview".into(),
+                scroll: 0,
+                searching: false,
+                query: String::new(),
+                confirm_forget: false,
+                title: "History".into(),
+                width: viewport_width,
+                height,
+                theme: theme.clone(),
+            };
+            let mut buffer = RenderBuffer::new(viewport_width, height, &theme.style);
+
+            for selected in 0..2 {
+                panel.selected = selected;
+                panel.draw(&mut buffer).unwrap();
+
+                let row_y = 14
+                    + if viewport_width >= 72 {
+                        selected * 2
+                    } else {
+                        0
+                    };
+                for row_y in row_y..row_y + 2 {
+                    for column in 1..=list_width {
+                        assert_eq!(
+                            buffer.cells[row_y * viewport_width + column].style,
+                            theme.ui_style.picker_selected_item,
+                            "viewport={viewport_width}, selected={selected}, cell=({column},{row_y})"
+                        );
+                    }
+                    let boundary = &buffer.cells[row_y * viewport_width + list_width + 1];
+                    assert_eq!(boundary.c, '│');
+                    assert_ne!(boundary.style.bg, theme.ui_style.picker_selected_item.bg);
+                }
+            }
+        }
     }
 }

--- a/src/ui/messages.rs
+++ b/src/ui/messages.rs
@@ -1,0 +1,333 @@
+//! Read-only notification history with a stable selection and a full-text detail pane.
+
+use crossterm::event::{Event, KeyCode, KeyModifiers};
+
+use super::{
+    dialog::{BorderStyle, Dialog, SurfaceRole},
+    wrap_text, ActionBar, ActionPriority, Component, UiAction,
+};
+use crate::{
+    config::KeyAction,
+    editor::{Action, RenderBuffer},
+    notification::{MessageAction, NotificationCounts},
+    theme::Theme,
+    unicode_utils::{fit_display_width, truncate_display_width},
+};
+
+pub(crate) struct MessageRow {
+    pub summary: String,
+    pub metadata: String,
+}
+
+pub(crate) struct MessagesView {
+    pub rows: Vec<MessageRow>,
+    pub selected: usize,
+    pub detail: String,
+    pub scroll: usize,
+    pub query: String,
+    pub searching: bool,
+    pub filter: &'static str,
+    pub counts: NotificationCounts,
+    pub feedback: Option<String>,
+}
+
+pub(crate) struct MessagesPanel {
+    view: MessagesView,
+    width: usize,
+    height: usize,
+    theme: Theme,
+}
+
+impl MessagesPanel {
+    pub(crate) fn new(view: MessagesView, width: usize, height: usize, theme: &Theme) -> Self {
+        Self {
+            view,
+            width,
+            height,
+            theme: theme.clone(),
+        }
+    }
+
+    fn action(action: MessageAction) -> Option<KeyAction> {
+        Some(KeyAction::Single(Action::MessageHistory(action)))
+    }
+}
+
+impl Component for MessagesPanel {
+    fn is_message_history(&self) -> bool {
+        true
+    }
+
+    fn surface_actions(&self) -> Vec<UiAction> {
+        let essential =
+            |id, key, label| UiAction::new(id, key, label).with_priority(ActionPriority::Essential);
+        if self.view.searching {
+            return vec![
+                essential("done", "Enter", "done"),
+                essential("clear", "Esc", "clear"),
+            ];
+        }
+        vec![
+            UiAction::new("browse", "j/k", "browse"),
+            UiAction::new("search", "/", "search"),
+            UiAction::new("filter", "f", "filter"),
+            essential("acknowledge", "Enter", "acknowledge"),
+            UiAction::new("copy", "y", "copy"),
+            UiAction::new("clear", "D", "clear inactive").with_priority(ActionPriority::Secondary),
+            UiAction::new("scroll", "Ctrl-d/u", "details").with_priority(ActionPriority::Secondary),
+            essential("close", "Esc", "return"),
+        ]
+    }
+
+    fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        let width = self.width.saturating_sub(4).min(116);
+        let height = self.height.saturating_sub(2).min(24);
+        if width < 4 || height < 3 {
+            return Ok(());
+        }
+        let x = self.width.saturating_sub(width + 2) / 2;
+        let y = self.height.saturating_sub(height + 2) / 2;
+        let title = if self.view.searching {
+            format!("Messages /{}", self.view.query)
+        } else {
+            format!(
+                "Messages · {} · {} active · {} retained",
+                self.view.filter, self.view.counts.active, self.view.counts.total
+            )
+        };
+        let dialog = Dialog::new(
+            Some(truncate_display_width(&title, width.saturating_sub(2))),
+            x,
+            y,
+            width,
+            height,
+            &self.theme.ui_style.dialog,
+            BorderStyle::Single,
+            &self.theme,
+        )
+        .with_surface_theme(&self.theme, SurfaceRole::Dialog);
+        dialog.draw(buffer)?;
+
+        let body = height.saturating_sub(1);
+        let wide = width >= 72;
+        let list_width = if wide { (width * 2 / 5).min(48) } else { width };
+        let list_height = if wide { body } else { (body / 2).max(1) };
+        let visible = (list_height / 2).max(1);
+        let first = self.view.selected.saturating_sub(visible.saturating_sub(1));
+        if self.view.rows.is_empty() {
+            buffer.set_text(
+                x + 1,
+                y + 1,
+                &truncate_display_width("No matching messages", list_width),
+                &self.theme.ui_style.muted,
+            );
+        }
+        for (index, row) in self.view.rows.iter().enumerate().skip(first).take(visible) {
+            let selected = index == self.view.selected;
+            let style = if selected {
+                &self.theme.ui_style.picker_selected_item
+            } else {
+                &self.theme.ui_style.picker_item
+            };
+            let marker = if selected { "> " } else { "  " };
+            let row_y = y + 1 + (index - first) * 2;
+            if row_y < y + 1 + list_height {
+                buffer.set_text(
+                    x + 1,
+                    row_y,
+                    &fit_display_width(&format!("{marker}{}", row.summary), list_width),
+                    style,
+                );
+            }
+            if row_y + 1 < y + 1 + list_height {
+                buffer.set_text(
+                    x + 1,
+                    row_y + 1,
+                    &fit_display_width(&format!("  {}", row.metadata), list_width),
+                    if selected {
+                        style
+                    } else {
+                        &self.theme.ui_style.muted
+                    },
+                );
+            }
+        }
+        let (detail_x, detail_y, detail_width, detail_height) = if wide {
+            for offset in 0..body {
+                buffer.set_text(
+                    x + list_width + 1,
+                    y + 1 + offset,
+                    "│",
+                    &self.theme.ui_style.muted,
+                );
+            }
+            (
+                x + list_width + 3,
+                y + 1,
+                width.saturating_sub(list_width + 2),
+                body,
+            )
+        } else {
+            (
+                x + 1,
+                y + 1 + list_height,
+                width,
+                body.saturating_sub(list_height),
+            )
+        };
+        let detail = wrap_text(&self.view.detail, detail_width.max(1));
+        let scroll = self
+            .view
+            .scroll
+            .min(detail.rows.len().saturating_sub(detail_height));
+        for (offset, row) in detail
+            .rows
+            .iter()
+            .skip(scroll)
+            .take(detail_height)
+            .enumerate()
+        {
+            buffer.set_text(
+                detail_x,
+                detail_y + offset,
+                &truncate_display_width(row, detail_width),
+                &self.theme.ui_style.dialog,
+            );
+        }
+        ActionBar::new(&self.surface_actions())
+            .with_context(if self.view.searching {
+                "SEARCH"
+            } else {
+                "MESSAGES"
+            })
+            .with_status(self.view.feedback.as_deref())
+            .render(
+                buffer,
+                x + 1,
+                y + height,
+                width,
+                &self.theme,
+                &self.theme.ui_style.dialog,
+            );
+        Ok(())
+    }
+
+    fn resize(&mut self, width: usize, height: usize) -> bool {
+        self.width = width;
+        self.height = height;
+        true
+    }
+
+    fn set_theme(&mut self, theme: &Theme) {
+        self.theme = theme.clone();
+    }
+
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        if self.view.searching {
+            return match event {
+                Event::Paste(text) => Self::action(MessageAction::Query(text.clone())),
+                Event::Key(key) => match key.code {
+                    KeyCode::Esc => Self::action(MessageAction::ClearSearch),
+                    KeyCode::Enter => Self::action(MessageAction::EndSearch),
+                    KeyCode::Backspace => Self::action(MessageAction::Backspace),
+                    KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        Self::action(MessageAction::Query(ch.to_string()))
+                    }
+                    _ => None,
+                },
+                _ => None,
+            };
+        }
+        let Event::Key(key) = event else {
+            return None;
+        };
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            return match key.code {
+                KeyCode::Char('d') => Self::action(MessageAction::ScrollDown),
+                KeyCode::Char('u') => Self::action(MessageAction::ScrollUp),
+                _ => None,
+            };
+        }
+        Self::action(match key.code {
+            KeyCode::Char('j') | KeyCode::Down => MessageAction::Next,
+            KeyCode::Char('k') | KeyCode::Up => MessageAction::Previous,
+            KeyCode::Char('/') => MessageAction::Search,
+            KeyCode::Char('f') => MessageAction::CycleFilter,
+            KeyCode::Enter | KeyCode::Char('d') => MessageAction::Acknowledge,
+            KeyCode::Char('D') => MessageAction::ClearInactive,
+            KeyCode::Char('y') => MessageAction::Copy,
+            KeyCode::PageDown => MessageAction::ScrollDown,
+            KeyCode::PageUp => MessageAction::ScrollUp,
+            KeyCode::Esc | KeyCode::Char('q') => MessageAction::Close,
+            _ => return None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::Color;
+
+    #[test]
+    fn selection_fills_both_lines_without_crossing_pane_boundary() {
+        let mut theme = Theme::default();
+        theme.ui_style.picker_selected_item.bg = Some(Color::Rgb {
+            r: 91,
+            g: 42,
+            b: 73,
+        });
+        let height = 30;
+
+        for (viewport_width, list_width) in [(120, 46), (64, 60)] {
+            let mut panel = MessagesPanel::new(
+                MessagesView {
+                    rows: vec![
+                        MessageRow {
+                            summary: "short".into(),
+                            metadata: "details".into(),
+                        },
+                        MessageRow {
+                            summary: "界".repeat(80),
+                            metadata: "👋".repeat(80),
+                        },
+                    ],
+                    selected: 0,
+                    detail: "preview".into(),
+                    scroll: 0,
+                    query: String::new(),
+                    searching: false,
+                    filter: "all",
+                    counts: NotificationCounts::default(),
+                    feedback: None,
+                },
+                viewport_width,
+                height,
+                &theme,
+            );
+            let mut buffer = RenderBuffer::new(viewport_width, height, &theme.style);
+            let list_x = 2;
+            let list_y = 3;
+
+            for selected in 0..2 {
+                panel.view.selected = selected;
+                panel.draw(&mut buffer).unwrap();
+
+                for row_y in list_y..list_y + 4 {
+                    let is_selected = (row_y - list_y) / 2 == selected;
+                    for column in list_x..list_x + list_width {
+                        let style = &buffer.cells[row_y * viewport_width + column].style;
+                        assert_eq!(
+                            style.bg == theme.ui_style.picker_selected_item.bg,
+                            is_selected,
+                            "viewport={viewport_width}, selected={selected}, cell=({column},{row_y})"
+                        );
+                    }
+                    let boundary = &buffer.cells[row_y * viewport_width + list_x + list_width];
+                    assert_eq!(boundary.c, '│');
+                    assert_ne!(boundary.style.bg, theme.ui_style.picker_selected_item.bg);
+                }
+            }
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -22,6 +22,7 @@ mod inline_history;
 mod input_prompt;
 mod keymap_hints;
 mod list;
+mod messages;
 mod picker;
 mod prompt_buffer;
 mod rich_text;
@@ -52,6 +53,7 @@ pub(crate) use inline_history::InlineHistoryPanel;
 pub use input_prompt::InputPrompt;
 pub(crate) use keymap_hints::draw_keymap_hints;
 use list::List;
+pub(crate) use messages::{MessageRow, MessagesPanel, MessagesView};
 pub(crate) use picker::MAX_UNFOCUSED_PREVIEW_BYTES;
 pub use picker::{
     LegacyPickerOptions, Picker, PickerIcon, PickerItem, PickerOptions, PickerPresentation,
@@ -77,6 +79,10 @@ use crate::{
 
 pub trait Component: Send {
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()>;
+
+    fn is_message_history(&self) -> bool {
+        false
+    }
 
     /// Actions for the surface-local F1 menu. The default keeps passive popups unchanged.
     fn surface_actions(&self) -> Vec<UiAction> {

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -15,6 +15,7 @@ use red::{
     config::{Config, KeyAction, LanguageConfig, MatchitLanguageConfig},
     editor::{Action, Content, Editor, Mode, SearchDirection},
     lsp::LspClient,
+    notification::{MessageAction, Notice, NotificationSource, Severity},
     plugin::{
         PanelConfig, PanelRow, PanelRowKind, PanelSegment, PanelSide, Runtime, TextPanelBlock,
         TextPanelBlockFormat, TextPanelBlockKind, TextPanelComposerConfig,
@@ -28,7 +29,7 @@ use std::{
     env, fs,
     path::PathBuf,
     sync::{Arc, Mutex, MutexGuard},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 static COMMAND_COMPLETION_CWD_LOCK: Mutex<()> = Mutex::new(());
@@ -1573,13 +1574,49 @@ async fn unchanged_recovery_snapshots_are_skipped_and_failures_back_off() {
 
     let warning = harness.commandline_row();
     assert!(warning.contains("Crash recovery is not being saved"));
+    let warning_id = harness
+        .editor
+        .notifications()
+        .primary(Instant::now())
+        .unwrap()
+        .id;
 
-    harness.editor.test_set_last_error("a newer LSP error");
+    let error_id = harness
+        .editor
+        .publish_notification(Notice::new(
+            NotificationSource::Editor,
+            Severity::Error,
+            "a newer LSP error",
+        ))
+        .unwrap();
     let status = harness.commandline_row();
     assert!(status.contains("a newer LSP error"));
-    assert!(status.contains("Crash recovery is not being saved"));
+    assert!(status.contains("2 active"));
+    assert!(harness
+        .editor
+        .notifications()
+        .get(warning_id)
+        .unwrap()
+        .is_active(Instant::now()));
     harness.editor.test_set_size(/*width*/ 8, /*height*/ 4);
-    assert_eq!(harness.commandline_row(), "a newer ");
+    assert_eq!(harness.commandline_row(), "× a  [2]");
+    harness.editor.test_set_size(/*width*/ 120, /*height*/ 24);
+
+    harness.execute_action(Action::OpenMessages).await.unwrap();
+    harness
+        .execute_action(Action::MessageHistory(MessageAction::Acknowledge))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::MessageHistory(MessageAction::Close))
+        .await
+        .unwrap();
+    assert!(!harness
+        .editor
+        .notifications()
+        .get(error_id)
+        .unwrap()
+        .is_active(Instant::now()));
 
     harness
         .execute_action(Action::Command("1".to_string()))
@@ -5700,8 +5737,8 @@ async fn focused_agent_panel_keeps_global_leader_until_the_composer_is_focused()
     let Some(KeyAction::Nested(leader)) = action else {
         panic!("expected Space to start the leader sequence from the conversation, got {action:?}");
     };
-    assert_eq!(leader.len(), 6);
-    for global in ["A", "?", "d", "e", "P", "s"] {
+    assert_eq!(leader.len(), 7);
+    for global in ["A", "?", "d", "e", "m", "P", "s"] {
         assert!(
             leader.contains_key(global),
             "global leader branch {global:?} must remain available"
@@ -5713,6 +5750,10 @@ async fn focused_agent_panel_keeps_global_leader_until_the_composer_is_focused()
             "contextual leader branch {contextual:?} must be filtered"
         );
     }
+    assert_eq!(
+        leader.get("m"),
+        Some(&KeyAction::Single(Action::OpenMessages))
+    );
     assert_eq!(
         leader.get("A"),
         Some(&KeyAction::Single(Action::PluginCommand(

--- a/tests/notifications.rs
+++ b/tests/notifications.rs
@@ -1,0 +1,79 @@
+mod common;
+
+use std::time::Instant;
+
+use common::EditorHarness;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use red::{buffer::Buffer, config::Config, editor::RenderBuffer, theme::Style};
+
+async fn key(harness: &mut EditorHarness, code: KeyCode) {
+    harness
+        .execute_event(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+}
+
+async fn text(harness: &mut EditorHarness, text: &str) {
+    for character in text.chars() {
+        key(harness, KeyCode::Char(character)).await;
+    }
+}
+
+fn dialog_text(harness: &mut EditorHarness) -> String {
+    let mut buffer = RenderBuffer::new(100, 24, &Style::default());
+    harness.editor.render(&mut buffer).unwrap();
+    buffer
+        .cells
+        .chunks(buffer.width)
+        .take(buffer.height - 2)
+        .flat_map(|row| row.iter().map(|cell| cell.c).chain(['\n']))
+        .collect()
+}
+
+#[tokio::test]
+async fn message_history_routes_real_keys_through_search_acknowledgement_and_clear() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let mut harness = EditorHarness::with_config_and_size(
+        Buffer::new(None, "unchanged buffer".to_string()),
+        config,
+        100,
+        24,
+    );
+
+    for command in [":bad-one", ":bad-two"] {
+        text(&mut harness, command).await;
+        key(&mut harness, KeyCode::Enter).await;
+    }
+    let status = harness.commandline_row();
+    assert!(status.contains("unknown command \"bad-two\""), "{status}");
+    assert!(status.contains("2 active"), "{status}");
+
+    text(&mut harness, " m").await;
+    let dialog = dialog_text(&mut harness);
+    assert!(dialog.contains("2 active · 2 retained"), "{dialog}");
+    assert!(dialog.contains("bad-one") && dialog.contains("bad-two"));
+
+    text(&mut harness, "/bad-one").await;
+    key(&mut harness, KeyCode::Enter).await;
+    let dialog = dialog_text(&mut harness);
+    assert!(dialog.contains("bad-one") && !dialog.contains("bad-two"));
+    key(&mut harness, KeyCode::Enter).await;
+    let counts = harness.editor.notifications().counts(Instant::now());
+    assert_eq!((counts.active, counts.total), (1, 2));
+
+    key(&mut harness, KeyCode::Char('f')).await;
+    assert!(dialog_text(&mut harness).contains("No matching messages"));
+    key(&mut harness, KeyCode::Char('D')).await;
+    let counts = harness.editor.notifications().counts(Instant::now());
+    assert_eq!((counts.active, counts.total), (1, 1));
+    key(&mut harness, KeyCode::Esc).await;
+
+    text(&mut harness, " m").await;
+    let dialog = dialog_text(&mut harness);
+    assert!(dialog.contains("bad-two") && !dialog.contains("bad-one"));
+    key(&mut harness, KeyCode::Enter).await;
+    key(&mut harness, KeyCode::Char('D')).await;
+    assert!(dialog_text(&mut harness).contains("0 active · 0 retained"));
+    key(&mut harness, KeyCode::Esc).await;
+    harness.assert_buffer_contents("unchanged buffer");
+}


### PR DESCRIPTION
Messages currently compete for a single transient slot, so an unrelated action can erase useful feedback and there is no way to recover earlier messages or tell that several are still active.

## What changed

- Add an editor-owned, session-local notification store with stable IDs, severity and progress lifecycles, active/unread counts, keyed coalescing, bounded history, and explicit overflow handling.
- Route existing editor messages and configuration/session warnings into that store. Keep the final terminal row available for the highest-priority notification and an active-count/history indicator, including inside modal workspaces.
- Add a searchable Messages browser through `:messages`, `Space m`, the command palette, or a click on the message line. It supports filters, full details, acknowledgment, copying, and clearing inactive entries, and restores an input dialog when closed.
- Fill the complete selected row in Messages and inline history, including narrow layouts and wide Unicode text.

This is the store-and-UI slice of notification consolidation. The dedicated Git and LSP/Fidget progress overlays are unchanged and will be migrated separately.

## How to Test

1. Run `cargo run -p red --bin red -- README.md`. Enter `:not-a-command`, then `:another-bad-command`. The bottom row should show the latest error and an active count of at least two; ordinary movement should not erase them.
2. Open `:messages` or press `Space m`. Browse with `j`/`k`, search with `/`, and cycle filters with `f`. Both errors should be retained, with their full text and state in the detail pane.
3. Press `Enter` to acknowledge an error. Its active count should decrease while the entry remains in the all-messages view. `D` should remove inactive entries without removing other active errors. `Esc` should return to the previous surface.
4. Resize to a narrow terminal and move the selection. Both lines of a selected entry should fill the list width without crossing the divider or border. Check `Space H` for the same inline-history regression.
5. Open the Git workspace with `Space G`. Its actions should remain one row above the global message line; clicking that last row should open Messages without closing the workspace.

Focused local validation passed:

- `cargo test -p red --lib notification -- --test-threads=1`
- `cargo test -p red --lib plugin::workspace::tests -- --test-threads=1`
- `editor::rendering::tests::workspace_render_keeps_commandline_messages_visible`, `editor::test::unknown_colon_command_leaves_a_visible_error`, and `editor::test::print_action_draws_its_message_immediately`
- `cargo test -p red --lib selection_fills_both_lines_without_crossing_pane_boundary -- --test-threads=1`
- `cargo clippy -p red --lib -- -D warnings`, formatting checks, and `cargo build -p red --bin red`

No e2e tests were run.