### PR TITLE
fix(editor): clear dirty state when contents match saved text

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -76,6 +76,12 @@ pub struct Buffer {
     /// The text content stored as a rope for efficient editing
     content: Rope,
 
+    /// Last loaded or successfully saved text. Unknown recovered baselines stay dirty.
+    saved_content: Option<Rope>,
+
+    /// Content revision for which `dirty` was last computed.
+    dirty_revision: u64,
+
     /// Whether the buffer has unsaved changes
     pub dirty: bool,
 
@@ -104,10 +110,16 @@ impl Buffer {
             contents
         };
 
+        Self::with_content(file, Rope::from_str(&contents))
+    }
+
+    fn with_content(file: Option<String>, content: Rope) -> Self {
         Self {
             id: BufferId::next(),
             file,
-            content: Rope::from_str(&contents),
+            saved_content: Some(content.clone()),
+            content,
+            dirty_revision: 0,
             dirty: false,
             pos: (0, 0),
             vtop: 0,
@@ -221,6 +233,11 @@ impl Buffer {
         self.content.clone()
     }
 
+    /// Returns the last saved text without flattening it on the editor thread.
+    pub(crate) fn saved_contents_snapshot(&self) -> Option<Rope> {
+        self.saved_content.clone()
+    }
+
     /// Gets the exact contents of the half-open line range `[start, end)`.
     ///
     /// Line endings are preserved and no separators are synthesized.
@@ -286,14 +303,19 @@ impl Buffer {
     pub fn from_session_snapshot(
         file: Option<String>,
         contents: String,
+        saved_contents: Option<String>,
         dirty: bool,
         revision: u64,
         undo_history: UndoHistory,
     ) -> Self {
-        let mut buffer = Self::new(file, contents);
-        buffer.dirty = dirty;
+        let mut buffer = Self::with_content(file, Rope::from_str(&contents));
+        buffer.saved_content = saved_contents
+            .map(|contents| Rope::from_str(&contents))
+            .or_else(|| (!dirty).then(|| buffer.content.clone()));
         buffer.revision = revision;
+        buffer.dirty_revision = revision.wrapping_sub(1);
         buffer.undo_history = undo_history;
+        buffer.refresh_dirty();
         buffer
     }
 
@@ -400,8 +422,8 @@ impl Buffer {
     }
 
     fn mark_changed(&mut self) {
-        self.dirty = true;
         self.revision = self.revision.wrapping_add(1);
+        self.refresh_dirty();
     }
 
     /// Saves the buffer contents to its associated file
@@ -589,9 +611,9 @@ impl Buffer {
 
     /// Applies a replacement directly and advances the buffer revision.
     ///
-    /// This method does not record undo history, update marks, refresh dirty state, or
-    /// notify external consumers. Using it from a new action handler would create an
-    /// untracked edit; production changes must go through `Editor::replace_range`.
+    /// This method updates content-based dirty state, but does not record undo history,
+    /// update marks, or notify external consumers. Using it from a new action handler
+    /// would create an untracked edit; production changes must use `Editor::replace_range`.
     pub fn replace_range_raw(&mut self, range: TextRange, text: &str) {
         let start_char = self.position_to_char_idx(range.start);
         let end_char = self.position_to_char_idx(range.end);
@@ -1029,15 +1051,31 @@ impl Buffer {
         self.dirty
     }
 
-    /// Recomputes the public dirty flag from undo history's saved revision.
-    pub fn refresh_dirty_from_history(&mut self) {
-        self.dirty = self.undo_history.is_dirty();
+    /// Refreshes dirty state once per content revision, independently of undo history.
+    ///
+    /// An open transaction can change the text without advancing its history revision.
+    /// Compare exact Rope contents so manually restoring saved text is clean as well.
+    /// Recovery without a trustworthy baseline remains dirty until save or reload.
+    pub fn refresh_dirty(&mut self) {
+        if self.dirty_revision == self.revision {
+            return;
+        }
+        self.dirty = match &self.saved_content {
+            Some(saved) => {
+                !self.content.is_instance(saved)
+                    && (self.content.len_bytes() != saved.len_bytes() || self.content != *saved)
+            }
+            None => true,
+        };
+        self.dirty_revision = self.revision;
     }
 
-    /// Marks the current history revision as saved and clears the public dirty flag.
+    /// Records the current contents and history revision as the saved state.
     pub fn mark_saved(&mut self) {
+        self.saved_content = Some(self.content.clone());
         self.undo_history.mark_saved();
-        self.refresh_dirty_from_history();
+        self.dirty = false;
+        self.dirty_revision = self.revision;
     }
 
     // Helper method to convert (x,y) coordinates to character index in the rope
@@ -1175,6 +1213,147 @@ mod test {
 
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
+
+    fn replace_all(buffer: &mut Buffer, text: &str) {
+        let end = buffer.char_idx_to_position(buffer.content.len_chars());
+        buffer.replace_range_raw(TextRange::new(TextPosition::new(0, 0), end), text);
+    }
+
+    fn commit_text(buffer: &mut Buffer, text: &str) {
+        use crate::undo::CursorSnapshot;
+        buffer
+            .undo_history
+            .begin_transaction("replace text", CursorSnapshot::default());
+        let end = buffer.char_idx_to_position(buffer.content.len_chars());
+        crate::editing::apply_transactional_replacement(
+            buffer,
+            TextRange::new(TextPosition::new(0, 0), end),
+            text,
+        );
+        buffer
+            .undo_history
+            .commit_transaction(CursorSnapshot::default());
+        buffer.refresh_dirty();
+    }
+
+    #[test]
+    fn dirty_tracks_exact_contents_during_an_open_transaction() {
+        let original = "a👋\r\nbeta\n";
+        let mut buffer = Buffer::new(None, original.to_string());
+        buffer
+            .undo_history
+            .begin_transaction("insert session", crate::undo::CursorSnapshot::default());
+        let revision = buffer.revision();
+        for changed in ["a🙂\r\nbeta\n", "a👋\nbeta\n", "a👋\r\nbeta"] {
+            replace_all(&mut buffer, changed);
+            assert!(buffer.is_dirty());
+            assert!(!buffer.undo_history.is_dirty());
+            replace_all(&mut buffer, original);
+            assert!(!buffer.is_dirty());
+        }
+        assert!(buffer.revision() > revision);
+        assert!(buffer.undo_history.is_transaction_active());
+    }
+
+    #[test]
+    fn dirty_clears_on_an_equivalent_undo_branch_and_after_history_pruning() {
+        let mut buffer = Buffer::new(None, "abc".to_string());
+        commit_text(&mut buffer, "saved");
+        buffer.mark_saved();
+        let mut history = std::mem::take(&mut buffer.undo_history);
+        assert!(history.undo(&mut buffer).is_some());
+        buffer.undo_history = history;
+        assert!(buffer.is_dirty());
+
+        commit_text(&mut buffer, "saved");
+        assert!(buffer.undo_history.is_dirty());
+        assert_eq!(buffer.undo_history.node_count(), 2);
+        assert!(!buffer.is_dirty());
+
+        buffer.undo_history.set_max_nodes(1);
+        commit_text(&mut buffer, "other");
+        commit_text(&mut buffer, "saved");
+        assert_eq!(buffer.undo_history.node_count(), 1);
+        assert!(!buffer.is_dirty());
+    }
+
+    #[test]
+    fn dirty_baseline_moves_only_after_a_successful_save() {
+        let directory = tempfile::tempdir().unwrap();
+        let first = directory.path().join("first.txt");
+        let second = directory.path().join("second.txt");
+        fs::write(&first, "abc").unwrap();
+        let mut buffer = Buffer::new(Some(first.to_string_lossy().into_owned()), "abc".into());
+
+        replace_all(&mut buffer, "def");
+        let invalid = directory.path().join("missing/failed.txt");
+        assert!(buffer.save_as(&invalid.to_string_lossy()).is_err());
+        assert_eq!(buffer.file.as_deref(), first.to_str());
+        assert!(buffer.is_dirty());
+        replace_all(&mut buffer, "abc");
+        assert!(!buffer.is_dirty());
+
+        replace_all(&mut buffer, "def");
+        buffer.save().unwrap();
+        assert!(!buffer.is_dirty());
+        replace_all(&mut buffer, "abc");
+        assert!(buffer.is_dirty());
+        buffer.save_as(&second.to_string_lossy()).unwrap();
+        replace_all(&mut buffer, "def");
+        assert!(buffer.is_dirty());
+        replace_all(&mut buffer, "abc");
+        assert!(!buffer.is_dirty());
+        assert_eq!(fs::read_to_string(first).unwrap(), "def");
+        assert_eq!(fs::read_to_string(second).unwrap(), "abc");
+    }
+
+    #[test]
+    fn dirty_recovery_uses_the_saved_baseline_and_preserves_unknown_state() {
+        let mut restored = Buffer::from_session_snapshot(
+            None,
+            "modified".into(),
+            Some("saved".into()),
+            true,
+            19,
+            UndoHistory::default(),
+        );
+        assert!(restored.is_dirty());
+        replace_all(&mut restored, "saved");
+        assert!(!restored.is_dirty());
+
+        let mut unknown = Buffer::from_session_snapshot(
+            None,
+            "recovered".into(),
+            None,
+            true,
+            0,
+            UndoHistory::default(),
+        );
+        unknown.refresh_dirty();
+        assert!(unknown.is_dirty());
+        replace_all(&mut unknown, "different");
+        replace_all(&mut unknown, "recovered");
+        assert!(unknown.is_dirty());
+        unknown.mark_saved();
+        assert!(!unknown.is_dirty());
+    }
+
+    #[test]
+    fn dirty_recovery_preserves_an_empty_unnamed_buffer() {
+        let mut buffer = Buffer::from_session_snapshot(
+            None,
+            String::new(),
+            None,
+            false,
+            0,
+            UndoHistory::default(),
+        );
+        assert_eq!(buffer.contents(), "");
+        replace_all(&mut buffer, "x");
+        assert!(buffer.is_dirty());
+        replace_all(&mut buffer, "");
+        assert!(!buffer.is_dirty());
+    }
 
     #[test]
     fn syntax_selection_is_buffer_local_and_does_not_change_revision() {

--- a/src/editing/textarea.rs
+++ b/src/editing/textarea.rs
@@ -336,7 +336,7 @@ impl TextArea {
             return false;
         };
         self.restore_cursor(cursor);
-        self.buffer.refresh_dirty_from_history();
+        self.buffer.refresh_dirty();
         true
     }
 
@@ -350,7 +350,7 @@ impl TextArea {
             return false;
         };
         self.restore_cursor(cursor);
-        self.buffer.refresh_dirty_from_history();
+        self.buffer.refresh_dirty();
         true
     }
 
@@ -1072,7 +1072,7 @@ impl TextArea {
             } else {
                 let after = self.cursor_snapshot();
                 self.buffer.undo_history.commit_transaction(after);
-                self.buffer.refresh_dirty_from_history();
+                self.buffer.refresh_dirty();
                 self.record_change(keys);
                 self.set_mode(Mode::Normal);
             }
@@ -1500,7 +1500,7 @@ impl TextArea {
         if self.buffer.undo_history.is_transaction_active() {
             let after = self.cursor_snapshot();
             self.buffer.undo_history.commit_transaction(after);
-            self.buffer.refresh_dirty_from_history();
+            self.buffer.refresh_dirty();
         }
         if let Some(mut recipe) = self.insert_recipe.take() {
             if recipe.len() > 1 {
@@ -1750,7 +1750,7 @@ impl TextArea {
         if started_transaction {
             let after = self.cursor_snapshot();
             self.buffer.undo_history.commit_transaction(after);
-            self.buffer.refresh_dirty_from_history();
+            self.buffer.refresh_dirty();
         }
         true
     }
@@ -1820,12 +1820,24 @@ fn unnamed_buffer(text: &str) -> Buffer {
         TextRange::new(TextPosition::new(0, 0), TextPosition::new(1, 0)),
         "",
     );
-    buffer.dirty = false;
+    buffer.mark_saved();
     buffer
 }
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn empty_textarea_has_an_exact_clean_baseline() {
+        let mut buffer = super::unnamed_buffer("");
+        assert!(!buffer.is_dirty());
+        buffer.insert_str(0, 0, "x");
+        assert!(buffer.is_dirty());
+        buffer.remove(0, 0);
+        assert_eq!(buffer.contents(), "");
+        assert!(!buffer.is_dirty());
+    }
+
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
     use super::{TextArea, TextAreaOutcome};

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -23346,7 +23346,7 @@ impl Editor {
             .current_buffer_mut()
             .undo_history
             .commit_transaction(after_cursor);
-        self.current_buffer_mut().refresh_dirty_from_history();
+        self.current_buffer_mut().refresh_dirty();
         committed
     }
 
@@ -23370,7 +23370,7 @@ impl Editor {
         let mut history = std::mem::take(&mut buffer.undo_history);
         let outcome = history.undo(buffer);
         buffer.undo_history = history;
-        buffer.refresh_dirty_from_history();
+        buffer.refresh_dirty();
 
         let Some((cursor, edits)) = outcome else {
             self.set_legacy_message(Some("already at oldest change".to_string()));
@@ -23401,7 +23401,7 @@ impl Editor {
         let mut history = std::mem::take(&mut buffer.undo_history);
         let outcome = history.redo(buffer);
         buffer.undo_history = history;
-        buffer.refresh_dirty_from_history();
+        buffer.refresh_dirty();
 
         let Some((cursor, edits)) = outcome else {
             self.set_legacy_message(Some("already at newest change".to_string()));
@@ -23502,6 +23502,11 @@ impl Editor {
                 let mut buffer = Buffer::from_session_snapshot(
                     path,
                     saved.contents.clone(),
+                    if detached_duplicate {
+                        None
+                    } else {
+                        saved.saved_contents.clone()
+                    },
                     saved.dirty || detached_duplicate,
                     saved.revision,
                     saved.undo_history.clone(),
@@ -23856,6 +23861,13 @@ impl Editor {
                         } else {
                             String::new()
                         },
+                        saved_contents: if include_disk_contents {
+                            buffer
+                                .saved_contents_snapshot()
+                                .map(|contents| contents.to_string())
+                        } else {
+                            None
+                        },
                         dirty: buffer.dirty,
                         revision: buffer.revision(),
                         cursor_x,
@@ -24052,18 +24064,19 @@ impl Editor {
         let content_snapshots = self
             .buffer_manager
             .iter()
-            .map(Buffer::contents_snapshot)
+            .map(|buffer| (buffer.contents_snapshot(), buffer.saved_contents_snapshot()))
             .collect::<Vec<_>>();
         let (mut snapshot, disk_fingerprints) =
             self.durable_session_snapshot(/*include_disk_contents*/ false);
         let writer = std::thread::spawn(move || {
-            for ((buffer, fingerprint), contents) in snapshot
+            for ((buffer, fingerprint), (contents, saved_contents)) in snapshot
                 .buffers
                 .iter_mut()
                 .zip(disk_fingerprints)
                 .zip(content_snapshots)
             {
                 buffer.contents = contents.to_string();
+                buffer.saved_contents = saved_contents.map(|contents| contents.to_string());
                 buffer.disk_contents =
                     buffer
                         .path

--- a/src/session.rs
+++ b/src/session.rs
@@ -153,6 +153,10 @@ pub struct SessionBufferSnapshot {
     pub path: Option<String>,
     /// Full in-memory text at capture time.
     pub contents: String,
+    /// Last loaded or successfully saved text, independent of later disk changes.
+    /// Older dirty snapshots may not have a trustworthy saved baseline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub saved_contents: Option<String>,
     /// Whether the in-memory text differed from its saved state.
     pub dirty: bool,
     /// Buffer revision used to correlate derived state.
@@ -2287,6 +2291,7 @@ mod tests {
                 index: 0,
                 path: None,
                 contents: contents.to_string(),
+                saved_contents: None,
                 dirty: true,
                 revision: 1,
                 cursor_x: 0,
@@ -2348,6 +2353,18 @@ mod tests {
             encoded.get("former_plugin"),
             Some(&serde_json::json!({ "version": 1, "reviews": [1, 2] }))
         );
+    }
+
+    #[test]
+    fn older_session_snapshots_default_missing_saved_contents() {
+        let mut value = serde_json::to_value(snapshot("recovered")).unwrap();
+        value["buffers"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("saved_contents");
+        let restored: SessionSnapshot = serde_json::from_value(value).unwrap();
+        assert!(restored.buffers[0].saved_contents.is_none());
+        assert!(crate::editor::Editor::buffers_from_session_snapshot(&restored)[0].is_dirty());
     }
 
     #[test]

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -5297,6 +5297,114 @@ async fn test_preview_theme_reports_missing_theme_without_changing_buffer() {
 }
 
 #[tokio::test]
+async fn test_dirty_clears_after_manual_same_length_replacement() {
+    let mut harness = EditorHarness::with_content("abc");
+    for (character, dirty) in [('z', true), ('a', false)] {
+        harness
+            .execute_action(Action::ReplaceCharsAtCursor {
+                character,
+                count: 1,
+            })
+            .await
+            .unwrap();
+        assert_eq!(harness.is_dirty(), dirty);
+    }
+    harness.assert_buffer_contents("abc");
+    assert!(harness.editor.test_current_buffer().undo_history.is_dirty());
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("zbc");
+    assert!(harness.is_dirty());
+    harness.execute_action(Action::Redo).await.unwrap();
+    harness.assert_buffer_contents("abc");
+    assert!(!harness.is_dirty());
+}
+
+#[tokio::test]
+async fn test_dirty_clears_before_leaving_insert_mode() {
+    let mut harness =
+        EditorHarness::with_config(Buffer::new(None, "abc".to_string()), default_key_config());
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    harness.type_text("z").await.unwrap();
+    assert!(harness.is_dirty());
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Backspace,
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("abc");
+    assert!(harness.is_insert());
+    assert!(!harness.is_dirty());
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    assert!(!harness.is_dirty());
+}
+
+#[tokio::test]
+async fn test_dirty_session_baseline_survives_external_disk_changes() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("saved.txt");
+    fs::write(&path, "abc").unwrap();
+    let buffer = Buffer::new(Some(path.to_string_lossy().into_owned()), "abc".into());
+    let mut source = EditorHarness::with_buffer(buffer);
+    source
+        .execute_action(Action::ReplaceCharsAtCursor {
+            character: 'z',
+            count: 1,
+        })
+        .await
+        .unwrap();
+    fs::write(&path, "external").unwrap();
+    let snapshot = source.editor.test_session_snapshot();
+    assert_eq!(snapshot.buffers[0].saved_contents.as_deref(), Some("abc"));
+    assert_eq!(
+        snapshot.buffers[0].disk_contents.as_deref(),
+        Some("external")
+    );
+    let encoded = serde_json::to_vec(&snapshot).unwrap();
+    let snapshot = serde_json::from_slice(&encoded).unwrap();
+    let mut buffers = Editor::buffers_from_session_snapshot(&snapshot);
+    let mut restored = EditorHarness::with_buffer(buffers.remove(0));
+    assert!(restored.is_dirty());
+    restored
+        .execute_action(Action::ReplaceCharsAtCursor {
+            character: 'a',
+            count: 1,
+        })
+        .await
+        .unwrap();
+    assert!(!restored.is_dirty());
+    assert_eq!(fs::read_to_string(&path).unwrap(), "external");
+}
+
+#[tokio::test]
+async fn test_dirty_background_session_writer_keeps_the_saved_baseline() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = red::session::SessionStore::for_owner(directory.path(), "dirty-baseline").unwrap();
+    let mut harness = EditorHarness::with_content("abc");
+    harness.editor.set_session_store(store.clone());
+    harness
+        .execute_action(Action::ReplaceCharsAtCursor {
+            character: 'z',
+            count: 1,
+        })
+        .await
+        .unwrap();
+    harness
+        .editor
+        .test_persist_session_snapshot(/*force*/ true, /*due*/ true);
+    let snapshot = store.load().unwrap();
+    assert_eq!(snapshot.buffers[0].contents, "zbc");
+    assert_eq!(snapshot.buffers[0].saved_contents.as_deref(), Some("abc"));
+}
+
+#[tokio::test]
 async fn test_dirty_clears_when_undo_returns_to_clean_revision() {
     let mut harness = EditorHarness::with_content("abc");
     assert!(!harness.is_dirty());


### PR DESCRIPTION
## Summary

The dirty indicator currently follows the saved undo revision. Manually restoring the exact saved text therefore leaves a buffer marked as modified, even though there is nothing new to write.

Track the last loaded or successfully saved contents in a shared Rope snapshot and compare exact text once per content revision. This clears dirty state during active insert sessions and after equivalent edits on another undo branch, while preserving undo history and render-cache revisions.

Persist the saved baseline separately from current text and recovery-time disk contents. Older dirty snapshots without a trustworthy baseline, and detached duplicate recovery buffers, remain dirty until saved or reloaded. Empty embedded textareas also retain an exact clean baseline.

## How to Test

1. Open a saved file containing `abc`. At the first character, type `rz`, then `ra`. The dirty mark should appear and then clear without using undo. Undo and redo should still work and update the mark correctly.
2. Enter insert mode, type one character, then press Backspace. The dirty mark should clear before leaving insert mode.
3. Make a change and save it. Undo past that save: the buffer should become dirty. Redo back to the saved contents: it should become clean.
4. Run `cargo test --lib dirty_ -- --test-threads=1` and `cargo test --test editing test_dirty_ -- --test-threads=1`. These cover exact content matching, undo branches and pruning, failed save-as, session recovery, and external disk changes.

## Validation

- 26 focused library and headless editor tests passed, including save-during-insert, reload guards, recovery aliases, older session snapshots, and empty textareas.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- Formatting, `git diff --check`, and `cargo build --bin red` passed.
- Full/end-to-end tests remain deferred at the requested manual-test checkpoint.