### PR TITLE
perf(editor): improve terminal resize rendering

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -28,6 +28,8 @@ mod notifications;
 pub(crate) mod perf;
 pub mod render_buffer;
 pub mod rendering;
+#[cfg(test)]
+mod resize_tests;
 mod session_manager;
 
 use std::{
@@ -3228,6 +3230,7 @@ pub struct DetachedEditorCore {
     rows: Vec<String>,
     row_spans: Vec<Vec<crate::headless::StyledSpan>>,
     cursor: (usize, usize),
+    cursor_state: crate::terminal_output::CursorState,
     stopped: bool,
     pending_paste: String,
 }
@@ -3266,6 +3269,7 @@ impl DetachedEditorCore {
         let cursor = editor
             .render_cursor_position()
             .unwrap_or((editor.cx, editor.cy));
+        let cursor_state = editor.terminal_cursor_state();
         Ok(Self {
             editor,
             runtime,
@@ -3274,6 +3278,7 @@ impl DetachedEditorCore {
             rows,
             row_spans,
             cursor,
+            cursor_state,
             stopped: false,
             pending_paste: String::new(),
         })
@@ -3297,6 +3302,7 @@ impl DetachedEditorCore {
                     .collect()
             },
             cursor: self.cursor,
+            cursor_state: Some(self.cursor_state),
         }
     }
 
@@ -3449,9 +3455,11 @@ impl DetachedEditorCore {
             .editor
             .render_cursor_position()
             .unwrap_or((self.editor.cx, self.editor.cy));
+        let next_cursor_state = self.editor.terminal_cursor_state();
         let changed = next_rows != self.rows
             || next_row_spans != self.row_spans
-            || next_cursor != self.cursor;
+            || next_cursor != self.cursor
+            || next_cursor_state != self.cursor_state;
         if changed {
             self.revision = self.revision.saturating_add(1);
         }
@@ -3472,10 +3480,12 @@ impl DetachedEditorCore {
         self.rows = next_rows;
         self.row_spans = next_row_spans;
         self.cursor = next_cursor;
+        self.cursor_state = next_cursor_state;
         Ok(crate::headless::RenderDelta {
             revision: self.revision,
             lines,
             cursor: self.cursor,
+            cursor_state: Some(self.cursor_state),
         })
     }
 }
@@ -5366,9 +5376,23 @@ impl Editor {
         self.size = (width, height);
         self.divider_drag = None;
         self.pane_resize_mode = None;
-        let max_y = (height as usize).saturating_sub(2);
-        self.cy = self.cy.min(max_y.saturating_sub(1));
         self.resize_window_layout((width as usize, height as usize));
+
+        // A smaller viewport must scroll to the cursor, not move the cursor
+        // to an earlier buffer line. Preserve inactive split positions too.
+        for window in self.window_manager.windows_mut() {
+            let cursor_line = window.vtop.saturating_add(window.cy);
+            let height = window
+                .inner_height()
+                .saturating_sub(self.window_bar_manager.reserved_top_height(window.id));
+            let cursor_row = window.cy.min(height.saturating_sub(1));
+            if cursor_row != window.cy {
+                window.vtop = cursor_line.saturating_sub(cursor_row);
+                window.cy = cursor_row;
+                window.skipcol = 0;
+            }
+        }
+        self.sync_with_window();
         self.invalidate_terminal_render_state(buffer);
 
         let viewport_width = self.vwidth();
@@ -8138,6 +8162,12 @@ impl Editor {
             let input_started = Instant::now();
             let mut serviced_background = false;
             while let Some(ev) = Self::read_ready_event(&mut pending_events)? {
+                // The tty may have reflowed through intermediate dimensions,
+                // even when a coalesced resize ends at the last painted size.
+                // Its screen contents are no longer safe to diff against.
+                if matches!(ev, Event::Resize(_, _)) {
+                    self.force_full_redraw = true;
+                }
                 if self.can_batch_scroll(&ev) {
                     let events = Self::read_scroll_batch(ev, &mut pending_events)?;
                     if self
@@ -10335,19 +10365,36 @@ impl Editor {
         if mouse_moved && self.current_dialog.is_none() {
             return Ok(ProcessedEvent::default());
         }
+        if !self.force_full_redraw
+            && matches!(ev, Event::Resize(width, height) if self.size == (width, height))
+        {
+            perf::increment("resize:duplicate_events", 1);
+            return Ok(ProcessedEvent::default());
+        }
         let initial_bounds_span = perf::PerfSpan::start("event:initial_bounds");
         self.check_bounds();
         drop(initial_bounds_span);
 
         if let event::Event::Resize(width, height) = ev {
+            let _span = perf::PerfSpan::start("resize:publish");
             self.resize_terminal_surface(width, height, buffer);
-            self.render(buffer)?;
-
-            let action = Action::NotifyPlugins(
-                "editor:resize".to_string(),
-                serde_json::to_value(self.size)?,
-            );
-            self.execute(&action, buffer, runtime).await?;
+            let was_deferring = self.defer_motion_render;
+            self.defer_motion_render = true;
+            self.request_motion_render(MotionRender::Full);
+            let result = async {
+                let action = Action::NotifyPlugins(
+                    "editor:resize".to_string(),
+                    serde_json::to_value(self.size)?,
+                );
+                self.execute(&action, buffer, runtime).await?;
+                self.service_background(buffer, runtime).await
+            }
+            .await;
+            self.defer_motion_render = was_deferring;
+            result?;
+            if !was_deferring {
+                self.flush_deferred_motion_render(buffer)?;
+            }
             return Ok(ProcessedEvent {
                 quit: false,
                 drain_repeated_motion: false,
@@ -10661,41 +10708,8 @@ impl Editor {
         Ok(quit)
     }
 
-    /// Reads the next ready terminal event while collapsing only adjacent
-    /// resize notifications. Crossterm can emit resize events in batches;
-    /// rendering every intermediate size makes terminal divider drags laggy.
-    /// Keeping non-resize events queued preserves their original ordering.
     fn read_ready_event(pending_events: &mut VecDeque<Event>) -> anyhow::Result<Option<Event>> {
-        let first = if let Some(event) = pending_events.pop_front() {
-            event
-        } else {
-            if !event::poll(Duration::from_millis(0))? {
-                return Ok(None);
-            }
-            event::read()?
-        };
-
-        if matches!(first, Event::Resize(_, _)) {
-            while event::poll(Duration::from_millis(0))? {
-                pending_events.push_back(event::read()?);
-            }
-        }
-
-        Ok(Some(Self::coalesce_resize_run(first, pending_events)))
-    }
-
-    fn coalesce_resize_run(first: Event, pending_events: &mut VecDeque<Event>) -> Event {
-        let Event::Resize(mut width, mut height) = first else {
-            return first;
-        };
-
-        while let Some(Event::Resize(next_width, next_height)) = pending_events.front() {
-            width = *next_width;
-            height = *next_height;
-            pending_events.pop_front();
-        }
-
-        Event::Resize(width, height)
+        crate::terminal_input::read_ready_event(pending_events)
     }
 
     fn flush_deferred_motion_render(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
@@ -16167,7 +16181,7 @@ impl Editor {
     }
 
     fn invalidate_terminal_render_state(&mut self, buffer: &mut RenderBuffer) {
-        *buffer = RenderBuffer::new(
+        buffer.reset(
             self.size.0 as usize,
             self.size.1 as usize,
             &Style::default(),
@@ -30245,7 +30259,7 @@ builtin = "rust"
         ]);
 
         assert_eq!(
-            Editor::coalesce_resize_run(Event::Resize(80, 24), &mut pending),
+            crate::terminal_input::coalesce_resize_run(Event::Resize(80, 24), &mut pending),
             Event::Resize(120, 40)
         );
         assert_eq!(pending.pop_front(), Some(key));
@@ -30258,7 +30272,7 @@ builtin = "rust"
         let mut pending = VecDeque::from([key.clone(), Event::Resize(120, 40)]);
 
         assert_eq!(
-            Editor::coalesce_resize_run(Event::Resize(80, 24), &mut pending),
+            crate::terminal_input::coalesce_resize_run(Event::Resize(80, 24), &mut pending),
             Event::Resize(80, 24)
         );
         assert_eq!(pending.pop_front(), Some(key));

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10321,6 +10321,25 @@ impl Editor {
         Ok(())
     }
 
+    // Resize publication includes the large background-service future. Keep
+    // its construction and polling out of ordinary input/replay stack frames,
+    // which can nest deeply enough to overflow the default Windows stack.
+    #[inline(never)]
+    fn publish_resize<'a>(
+        &'a mut self,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async move {
+            let action = Action::NotifyPlugins(
+                "editor:resize".to_string(),
+                serde_json::to_value(self.size)?,
+            );
+            self.execute(&action, buffer, runtime).await?;
+            self.service_background(buffer, runtime).await
+        })
+    }
+
     async fn process_editor_event(
         &mut self,
         ev: event::Event,
@@ -10381,15 +10400,7 @@ impl Editor {
             let was_deferring = self.defer_motion_render;
             self.defer_motion_render = true;
             self.request_motion_render(MotionRender::Full);
-            let result = async {
-                let action = Action::NotifyPlugins(
-                    "editor:resize".to_string(),
-                    serde_json::to_value(self.size)?,
-                );
-                self.execute(&action, buffer, runtime).await?;
-                self.service_background(buffer, runtime).await
-            }
-            .await;
+            let result = self.publish_resize(buffer, runtime).await;
             self.defer_motion_render = was_deferring;
             result?;
             if !was_deferring {

--- a/src/editor/render_buffer.rs
+++ b/src/editor/render_buffer.rs
@@ -117,7 +117,18 @@ impl RenderBuffer {
 
     /// Clears the buffer with the given style
     pub fn clear(&mut self) {
-        self.cells = vec![Cell::new(' ', Style::default()); self.width * self.height];
+        self.reset(self.width, self.height, &Style::default());
+    }
+
+    /// Resizes and clears the grid while retaining reusable cell allocations.
+    pub(crate) fn reset(&mut self, width: usize, height: usize, style: &Style) {
+        self.cells
+            .resize_with(width * height, || Cell::new(' ', style.clone()));
+        self.width = width;
+        self.height = height;
+        for cell in &mut self.cells {
+            cell.set_char_in_place(' ', style);
+        }
     }
 
     pub fn write_string(
@@ -456,6 +467,34 @@ impl RenderBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resetting_a_frame_reuses_cell_storage_and_clears_wide_text() {
+        let mut buffer = RenderBuffer::new(8, 2, &Style::default());
+        buffer.set_text(0, 0, "👩‍💻界", &Style::default());
+        buffer.cells[0].text.reserve(32);
+        let storage = buffer.cells.as_ptr();
+        let text_capacity = buffer.cells[0].text.capacity();
+        let style = Style {
+            bold: true,
+            ..Style::default()
+        };
+        buffer.reset(4, 3, &style);
+        assert_eq!(buffer.cells.as_ptr(), storage);
+        assert_eq!(buffer.cells[0].text.capacity(), text_capacity);
+        assert_eq!(
+            (buffer.width, buffer.height, buffer.cells.len()),
+            (4, 3, 12)
+        );
+        assert!(buffer
+            .cells
+            .iter()
+            .all(|cell| cell.text == " " && cell.style == style));
+        buffer.reset(0, 0, &Style::default());
+        assert!(buffer.cells.is_empty());
+        buffer.reset(2, 2, &Style::default());
+        assert_eq!(buffer.cells.len(), 4);
+    }
 
     #[test]
     fn applying_changes_reuses_cell_text_capacity() {

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -12,8 +12,7 @@
 use std::{
     collections::{HashMap, HashSet},
     ffi::OsStr,
-    fs,
-    io::{self, Write as _},
+    fs, io,
     path::{Path, PathBuf},
     process::Command,
     time::{Duration, Instant},
@@ -1073,6 +1072,7 @@ fn queue_diff_cells(
     output: &mut impl io::Write,
     change_set: &[Change<'_>],
     theme: &Style,
+    terminal_width: usize,
 ) -> anyhow::Result<()> {
     let mut previous_style = None;
     let mut cursor_position = None;
@@ -1108,8 +1108,21 @@ fn queue_diff_cells(
                 i += 1;
             }
         }
-        output.queue(style::Print(text.as_str()))?;
-        cursor_position = Some((next_x, y));
+        // A blank suffix can be erased in three bytes instead of printing
+        // hundreds of spaces. EL uses the current background color and does
+        // not advance the cursor. Never erase beyond this changed run.
+        let visible = text.trim_end_matches(' ');
+        let trailing_spaces = text.len() - visible.len();
+        if next_x == terminal_width && trailing_spaces > 3 {
+            if !visible.is_empty() {
+                output.queue(style::Print(visible))?;
+            }
+            output.queue(terminal::Clear(terminal::ClearType::UntilNewLine))?;
+            cursor_position = Some((next_x - trailing_spaces, y));
+        } else {
+            output.queue(style::Print(text.as_str()))?;
+            cursor_position = Some((next_x, y));
+        }
     }
     Ok(())
 }
@@ -1131,28 +1144,21 @@ pub(super) fn resolve_cell_colors(cell_style: &Style, theme_style: &Style) -> (C
     (fg, bg)
 }
 
-fn cursor_style_for_shape(shape: CursorShape) -> cursor::SetCursorStyle {
-    match shape {
-        CursorShape::Default => cursor::SetCursorStyle::DefaultUserShape,
-        CursorShape::BlinkingBlock => cursor::SetCursorStyle::BlinkingBlock,
-        CursorShape::SteadyBlock => cursor::SetCursorStyle::SteadyBlock,
-        CursorShape::BlinkingUnderscore => cursor::SetCursorStyle::BlinkingUnderScore,
-        CursorShape::SteadyUnderscore => cursor::SetCursorStyle::SteadyUnderScore,
-        CursorShape::BlinkingBar => cursor::SetCursorStyle::BlinkingBar,
-        CursorShape::SteadyBar => cursor::SetCursorStyle::SteadyBar,
-    }
-}
-
 impl Editor {
-    fn queue_theme_cursor_color(&mut self) -> anyhow::Result<()> {
+    pub(crate) fn terminal_cursor_state(&self) -> crate::terminal_output::CursorState {
+        let position = (self.is_focused && !self.uses_synthetic_block_cursor())
+            .then(|| self.render_cursor_position())
+            .flatten()
+            .filter(|&(x, y)| x < usize::from(self.size.0) && y < usize::from(self.size.1));
         let surface = self
             .last_rendered_cursor_surface
             .as_ref()
             .unwrap_or(&self.theme.style);
-        let cursor_color = self.theme.terminal_cursor_color(surface);
-        write!(self.stdout, "\x1b]12;{}\x1b\\", cursor_color)?;
-
-        Ok(())
+        crate::terminal_output::CursorState {
+            position,
+            shape: self.active_cursor_shape(),
+            color: Some(self.theme.terminal_cursor_color(surface)),
+        }
     }
 
     fn update_terminal_cursor_surface(&mut self, buffer: &RenderBuffer) {
@@ -1175,7 +1181,7 @@ impl Editor {
         });
 
         if previous.width != buffer.width || previous.height != buffer.height {
-            *previous = RenderBuffer::new(buffer.width, buffer.height, &Style::default());
+            previous.reset(buffer.width, buffer.height, &Style::default());
         }
 
         if self.force_full_redraw {
@@ -1220,7 +1226,7 @@ impl Editor {
         self.update_gutter_width();
         self.apply_panel_layout();
         if self.force_full_redraw {
-            *buffer = RenderBuffer::new(
+            buffer.reset(
                 usize::from(self.size.0),
                 usize::from(self.size.1),
                 &self.theme.style,
@@ -2969,7 +2975,6 @@ impl Editor {
         }
 
         if change_set.is_empty() {
-            self.set_cursor_style()?;
             self.draw_cursor_preserving_cursor_goal()?;
             self.flush_terminal_output()?;
             return Ok(());
@@ -2982,8 +2987,12 @@ impl Editor {
             self.stdout.queue(terminal::BeginSynchronizedUpdate)?;
             self.stdout.queue(cursor::Hide)?;
             self.stdout.queue(terminal::DisableLineWrap)?;
-            queue_diff_cells(&mut self.stdout, change_set, &self.theme.style)?;
-            self.set_cursor_style()?;
+            queue_diff_cells(
+                &mut self.stdout,
+                change_set,
+                &self.theme.style,
+                usize::from(self.size.0),
+            )?;
             self.draw_cursor_preserving_cursor_goal()?;
             Ok(())
         })();
@@ -3487,41 +3496,14 @@ impl Editor {
             return Ok(());
         }
 
-        if !self.is_focused {
-            self.stdout.queue(cursor::Hide)?;
-            #[cfg(test)]
-            {
-                self.pending_terminal_cursor = Some(super::TerminalCursorState::Hidden);
-            }
-            return Ok(());
-        }
-
-        self.set_cursor_style()?;
-
-        if self.uses_synthetic_block_cursor() {
-            self.stdout.queue(cursor::Hide)?;
-            #[cfg(test)]
-            {
-                self.pending_terminal_cursor = Some(super::TerminalCursorState::Hidden);
-            }
-            return Ok(());
-        }
-
-        let cursor_pos = self.render_cursor_position();
-
-        if let Some((x, y)) = cursor_pos {
-            self.stdout.queue(cursor::Show)?;
-            self.stdout.queue(cursor::MoveTo(x as u16, y as u16))?;
-            #[cfg(test)]
-            {
-                self.pending_terminal_cursor = Some(super::TerminalCursorState::Visible((x, y)));
-            }
-        } else {
-            self.stdout.queue(cursor::Hide)?;
-            #[cfg(test)]
-            {
-                self.pending_terminal_cursor = Some(super::TerminalCursorState::Hidden);
-            }
+        let state = self.terminal_cursor_state();
+        state.queue(&mut self.stdout)?;
+        #[cfg(test)]
+        {
+            self.pending_terminal_cursor = Some(state.position.map_or(
+                super::TerminalCursorState::Hidden,
+                super::TerminalCursorState::Visible,
+            ));
         }
 
         Ok(())
@@ -3635,18 +3617,6 @@ impl Editor {
             Mode::VisualLine => self.config.cursor.visual_line,
             Mode::VisualBlock => self.config.cursor.visual_block,
         }
-    }
-
-    fn set_cursor_style(&mut self) -> anyhow::Result<()> {
-        if !self.terminal_output_enabled {
-            return Ok(());
-        }
-
-        self.queue_theme_cursor_color()?;
-        self.stdout
-            .queue(cursor_style_for_shape(self.active_cursor_shape()))?;
-
-        Ok(())
     }
 
     fn update_gutter_width(&mut self) {
@@ -4835,7 +4805,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let mut output = Vec::new();
-        queue_diff_cells(&mut output, &changes, &Style::default()).unwrap();
+        queue_diff_cells(&mut output, &changes, &Style::default(), buffer.width).unwrap();
         let mut expected = Vec::new();
         expected.queue(MoveTo(0, 0)).unwrap();
         TerminalCellStyle::resolve(&first, &Style::default())
@@ -4882,6 +4852,55 @@ mod tests {
     }
 
     #[test]
+    fn terminal_diff_erases_only_a_complete_blank_suffix() {
+        let background = Style {
+            bg: Some(Color::Rgb {
+                r: 10,
+                g: 20,
+                b: 30,
+            }),
+            ..Style::default()
+        };
+        let mut buffer = RenderBuffer::new(20, 2, &background);
+        buffer.set_text(0, 0, "界A", &background);
+        let changes = buffer
+            .cells
+            .iter()
+            .enumerate()
+            .map(|(index, cell)| Change {
+                x: index % buffer.width,
+                y: index / buffer.width,
+                cell,
+            })
+            .collect::<Vec<_>>();
+        let mut output = Vec::new();
+        queue_diff_cells(&mut output, &changes, &Style::default(), buffer.width).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("界A\x1b[K\x1b[2;1H\x1b[K"));
+        let mut background_command = Vec::new();
+        background_command
+            .queue(style::SetBackgroundColor(background.bg.unwrap().into()))
+            .unwrap();
+        assert!(output.contains(std::str::from_utf8(&background_command).unwrap()));
+        assert!(!output.contains("    "));
+
+        let interior = changes
+            .iter()
+            .filter(|change| change.y == 1 && (3..15).contains(&change.x))
+            .map(|change| Change {
+                x: change.x,
+                y: change.y,
+                cell: change.cell,
+            })
+            .collect::<Vec<_>>();
+        let mut output = Vec::new();
+        queue_diff_cells(&mut output, &interior, &Style::default(), buffer.width).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(!output.contains("\x1b[K"));
+        assert!(output.ends_with(&" ".repeat(12)));
+    }
+
+    #[test]
     fn terminal_style_delta_compares_resolved_theme_colors() {
         let theme = Style {
             fg: Some(Color::Rgb { r: 1, g: 2, b: 3 }),
@@ -4919,6 +4938,54 @@ mod tests {
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn resize_experience_native_cursor_moves_before_it_is_shown() {
+        let mut editor = rendering_test_editor(Buffer::new(None, "text".into()));
+        editor.mode = Mode::Insert;
+        editor.terminal_output_enabled = true;
+        let bytes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        editor.stdout = std::io::BufWriter::new(Box::new(CapturedOutput {
+            bytes: bytes.clone(),
+            fail_at: None,
+        }) as super::super::TerminalOutput);
+        let source = RenderBuffer::new_with_contents(4, 1, Style::default(), vec!["test".into()]);
+        let changes = source
+            .cells
+            .iter()
+            .enumerate()
+            .map(|(x, cell)| Change { x, y: 0, cell })
+            .collect::<Vec<_>>();
+
+        editor.render_diff(&changes).unwrap();
+
+        let output = String::from_utf8(bytes.lock().unwrap().clone()).unwrap();
+        let (x, y) = editor.render_cursor_position().unwrap();
+        let cursor_move = format!("\x1b[{};{}H", y + 1, x + 1);
+        assert!(output.rfind(&cursor_move).unwrap() < output.rfind("\x1b[?25h").unwrap());
+        assert_eq!(output.matches("\x1b]12;").count(), 1);
+        assert!(output.starts_with("\x1b[?2026h\x1b[?25l"));
+        assert!(output.ends_with("\x1b[?2026l"));
+    }
+
+    #[test]
+    fn resize_experience_empty_surface_keeps_native_cursor_hidden() {
+        let mut editor = rendering_test_editor(Buffer::new(None, "text".into()));
+        editor.mode = Mode::Insert;
+        editor.size = (0, 0);
+        editor.terminal_output_enabled = true;
+        let bytes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        editor.stdout = std::io::BufWriter::new(Box::new(CapturedOutput {
+            bytes: bytes.clone(),
+            fail_at: None,
+        }) as super::super::TerminalOutput);
+
+        editor.render_diff(&[]).unwrap();
+
+        let output = String::from_utf8(bytes.lock().unwrap().clone()).unwrap();
+        assert!(output.ends_with("\x1b[?25l"));
+        assert!(!output.contains("\x1b[?25h"));
     }
 
     #[test]

--- a/src/editor/resize_tests.rs
+++ b/src/editor/resize_tests.rs
@@ -1,0 +1,415 @@
+use super::*;
+use crate::terminal_input::RESIZE_EVENTS_PER_BATCH;
+
+#[derive(Default)]
+struct BenchOutput {
+    bytes: Vec<u8>,
+    flushes: usize,
+}
+
+struct BenchSink(Arc<std::sync::Mutex<BenchOutput>>);
+
+impl std::io::Write for BenchSink {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.lock().unwrap().flushes += 1;
+        Ok(())
+    }
+}
+
+/// Runs the production resize/render/encode path without a terminal process.
+/// Keep this ignored: timings are workstation evidence, not a CI assertion.
+#[tokio::test]
+#[ignore = "manual release-mode resize measurement"]
+async fn resize_output_benchmark() {
+    use sha2::{Digest as _, Sha256};
+
+    for scenario in ["editor", "dense", "workspace"] {
+        let mut config = Config::default();
+        config.lsp.enabled = false;
+        config.statusline.left = vec![crate::config::StatuslineSection::Filename];
+        config.statusline.right = vec![crate::config::StatuslineSection::Position];
+        let source = (0..400)
+            .map(|line| {
+                if scenario == "dense" {
+                    format!("let value_{line} = \"{}\";\n", "abcdefghij".repeat(28))
+                } else {
+                    format!("fn value_{line}() -> usize {{ {line} }} // 界 👩‍💻\n")
+                }
+            })
+            .collect::<String>();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size(
+            lsp,
+            314,
+            64,
+            config,
+            Theme::default(),
+            vec![Buffer::new(Some("resize-fixture.rs".into()), source)],
+        )
+        .unwrap();
+        if scenario == "workspace" {
+            editor.panel_manager.create_text_panel(
+                "agent".into(),
+                plugin::PanelConfig {
+                    side: plugin::PanelSide::Right,
+                    width: 60,
+                    title: Some("Agent".into()),
+                    ..Default::default()
+                },
+            );
+            editor.panel_manager.update_text_panel(
+                "agent",
+                vec![plugin::TextPanelBlock {
+                    id: "answer".into(),
+                    kind: Default::default(),
+                    format: Default::default(),
+                    text:
+                        "An unchanged conversation with several lines.\nSecond line.\nThird line."
+                            .into(),
+                }],
+                60,
+                314,
+            );
+            editor.apply_panel_layout();
+            editor.update_window_layout(|windows| windows.split_horizontal(0));
+            editor.set_active_window(0);
+        }
+        let captured = Arc::new(std::sync::Mutex::new(BenchOutput::default()));
+        editor.stdout = std::io::BufWriter::with_capacity(
+            1 << 20,
+            Box::new(BenchSink(captured.clone())) as TerminalOutput,
+        );
+        let mut buffer = RenderBuffer::new(314, 64, &Style::default());
+        let mut runtime = Runtime::new();
+        editor.render(&mut buffer).unwrap();
+        let mut elapsed = Vec::new();
+        let mut bytes = 0;
+        let mut flushes = 0;
+        let mut frame_hash = Sha256::new();
+        for index in 0..68 {
+            let size = [(157, 64), (314, 64), (200, 48), (314, 64)][index % 4];
+            *captured.lock().unwrap() = BenchOutput::default();
+            let started = Instant::now();
+            editor
+                .process_editor_event(
+                    Event::Resize(size.0, size.1),
+                    &mut buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+            editor
+                .service_background(&mut buffer, &mut runtime)
+                .await
+                .unwrap();
+            let micros = started.elapsed().as_micros();
+            if index >= 8 {
+                elapsed.push(micros);
+                let output = captured.lock().unwrap();
+                bytes += output.bytes.len();
+                flushes += output.flushes;
+                frame_hash.update(format!("{:?}", buffer.cells).as_bytes());
+            }
+        }
+        elapsed.sort_unstable();
+        eprintln!(
+            "RESIZE_BENCH {}",
+            serde_json::json!({
+                "scenario": scenario, "samples": elapsed.len(), "bytes": bytes,
+                "flushes": flushes, "p50_us": elapsed[(elapsed.len()-1)*50/100],
+                "p95_us": elapsed[(elapsed.len()-1)*95/100], "max_us": elapsed.last(),
+                "screen_sha256": format!("{:x}", frame_hash.finalize()),
+            })
+        );
+    }
+}
+
+fn resize_editor(width: usize, height: usize) -> (Editor, RenderBuffer) {
+    let config = Config::default();
+    let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+    let contents = (0..160)
+        .map(|line| format!("line {line:03}: abcdefghijklmnopqrstuvwxyz\n"))
+        .collect::<String>();
+    let mut editor = Editor::with_size(
+        lsp,
+        width,
+        height,
+        config,
+        Theme::default(),
+        vec![Buffer::new(None, contents)],
+    )
+    .unwrap();
+    editor.test_disable_terminal_output();
+    let buffer = RenderBuffer::new(width, height, &Style::default());
+    (editor, buffer)
+}
+
+#[tokio::test]
+async fn resize_experience_preserves_logical_cursor_through_shrink_and_grow() {
+    for wrap in [false, true] {
+        for scrolloff in [0, 3] {
+            let (mut editor, mut buffer) = resize_editor(100, 40);
+            editor.wrap = wrap;
+            editor.config.scrolloff = Some(scrolloff);
+            editor.vtop = 40;
+            editor.cy = 25;
+            editor.cx = 18;
+            editor.refresh_cursor_goal();
+            editor.render(&mut buffer).unwrap();
+            let logical_cursor = (editor.cx, editor.buffer_line());
+            let cursor_goal = editor.cursor_goal;
+            let mut runtime = Runtime::new();
+
+            for (width, height) in [(25, 10), (12, 4), (0, 0), (1, 2), (100, 40)] {
+                editor
+                    .process_editor_event(
+                        Event::Resize(width, height),
+                        &mut buffer,
+                        &mut runtime,
+                        EventRenderMode::Immediate,
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(
+                    (editor.cx, editor.buffer_line()),
+                    logical_cursor,
+                    "wrap={wrap}, scrolloff={scrolloff}, size={width}x{height}"
+                );
+                assert_eq!(editor.cursor_goal, cursor_goal);
+                assert_eq!(
+                    (buffer.width, buffer.height),
+                    (width as usize, height as usize)
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn resize_experience_preserves_inactive_split_cursor_lines() {
+    let (mut editor, mut buffer) = resize_editor(120, 60);
+    editor.window_manager.split_horizontal(0).unwrap();
+    for (index, window) in editor.window_manager.windows_mut().into_iter().enumerate() {
+        window.wrap = false;
+        window.vtop = 30 + index * 40;
+        window.cy = 20;
+        window.cx = 5;
+    }
+    editor.sync_with_window();
+    editor.refresh_cursor_goal();
+    editor.render(&mut buffer).unwrap();
+    let positions = |editor: &Editor| {
+        editor
+            .window_manager
+            .windows()
+            .into_iter()
+            .map(|window| (window.id, window.vtop + window.cy, window.cx))
+            .collect::<Vec<_>>()
+    };
+    let expected = positions(&editor);
+    let mut runtime = Runtime::new();
+
+    for (width, height) in [(80, 12), (2, 1), (120, 60)] {
+        editor
+            .process_editor_event(
+                Event::Resize(width, height),
+                &mut buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert_eq!(positions(&editor), expected);
+    }
+}
+
+#[tokio::test]
+async fn resize_experience_detached_cursor_tracks_mode_and_focus() {
+    let (editor, _) = resize_editor(80, 24);
+    let mut core = DetachedEditorCore::new(editor).await.unwrap();
+    assert_eq!(core.snapshot(None).cursor_state.unwrap().position, None);
+    core.editor.mode = Mode::Insert;
+    core.editor.render(&mut core.render_buffer).unwrap();
+    let insert = core.finish_render().unwrap();
+    assert!(insert.cursor_state.unwrap().position.is_some());
+    assert_eq!(
+        insert.cursor_state.unwrap().shape,
+        crate::config::CursorShape::SteadyBar
+    );
+    let unfocused = core.focus(false).await.unwrap();
+    assert!(unfocused.revision > insert.revision);
+    assert_eq!(unfocused.cursor_state.unwrap().position, None);
+}
+
+#[tokio::test]
+async fn resize_experience_duplicate_size_does_not_repaint() {
+    let (mut editor, mut buffer) = resize_editor(80, 24);
+    editor.render(&mut buffer).unwrap();
+    let generation = editor.render_generation;
+    let full_renders = editor.full_render_count;
+    let mut runtime = Runtime::new();
+
+    editor
+        .process_editor_event(
+            Event::Resize(80, 24),
+            &mut buffer,
+            &mut runtime,
+            EventRenderMode::Immediate,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(editor.render_generation, generation);
+    assert_eq!(editor.full_render_count, full_renders);
+    assert!(!editor.force_full_redraw);
+}
+
+#[tokio::test]
+async fn resize_experience_publishes_plugin_effects_in_one_frame() {
+    let directory = tempfile::tempdir().unwrap();
+    let plugin_path = directory.path().join("resize-probe.hk");
+    std::fs::write(
+        &plugin_path,
+        r#"
+        pub fn activate() { red::on("editor:resize", resized); }
+        fn resized(event: Json) { red::execute("Print", "resize observed"); }
+    "#,
+    )
+    .unwrap();
+    let (mut editor, mut buffer) = resize_editor(80, 24);
+    let mut runtime = Runtime::new();
+    editor
+        .plugin_registry
+        .add("resize_probe", plugin_path.to_str().unwrap());
+    editor
+        .plugin_registry
+        .initialize(&mut runtime)
+        .await
+        .unwrap();
+    editor
+        .service_background(&mut buffer, &mut runtime)
+        .await
+        .unwrap();
+    editor.render(&mut buffer).unwrap();
+    let full_renders = editor.full_render_count;
+
+    editor
+        .process_editor_event(
+            Event::Resize(100, 30),
+            &mut buffer,
+            &mut runtime,
+            EventRenderMode::Immediate,
+        )
+        .await
+        .unwrap();
+    editor
+        .service_background(&mut buffer, &mut runtime)
+        .await
+        .unwrap();
+
+    assert_eq!(editor.full_render_count, full_renders + 1);
+    assert!(render_text_rows(&buffer)
+        .last()
+        .unwrap()
+        .contains("resize observed"));
+    assert!(!editor.defer_motion_render);
+    assert_eq!(editor.deferred_motion_render, MotionRender::None);
+}
+
+#[test]
+fn resize_experience_batch_collects_arrivals_and_preserves_input_boundary() {
+    let key = Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+    let mut pending = VecDeque::from([Event::Resize(90, 25)]);
+    let mut arrivals =
+        VecDeque::from([Event::Resize(100, 30), key.clone(), Event::Resize(120, 40)]);
+    let latest = crate::terminal_input::read_resize_batch(
+        Event::Resize(80, 24),
+        &mut pending,
+        Duration::from_secs(1),
+        |timeout| {
+            assert!(!timeout.is_zero());
+            assert!(timeout <= Duration::from_millis(2));
+            Ok(arrivals.pop_front())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(latest, Event::Resize(100, 30));
+    assert_eq!(pending.pop_front(), Some(key));
+    assert_eq!(arrivals.pop_front(), Some(Event::Resize(120, 40)));
+}
+
+#[tokio::test]
+async fn resize_experience_same_size_still_repaints_an_invalidated_surface() {
+    let (mut editor, mut buffer) = resize_editor(80, 24);
+    editor.render(&mut buffer).unwrap();
+    let generation = editor.render_generation;
+    let mut runtime = Runtime::new();
+    let mut pending = VecDeque::from([Event::Resize(80, 24)]);
+    let event = crate::terminal_input::read_resize_batch(
+        Event::Resize(40, 12),
+        &mut pending,
+        Duration::ZERO,
+        |_| panic!("must not read after the batch deadline"),
+    )
+    .unwrap();
+
+    // Native resize delivery invalidates the physical screen independently
+    // of whether the final dimensions differ from the last rendered frame.
+    editor.force_full_redraw = true;
+    editor
+        .process_editor_event(event, &mut buffer, &mut runtime, EventRenderMode::Immediate)
+        .await
+        .unwrap();
+
+    assert_eq!(editor.render_generation, generation + 1);
+    assert!(!editor.force_full_redraw);
+}
+
+#[test]
+fn resize_experience_batch_respects_queued_boundary_and_time_budget() {
+    let paste = Event::Paste("keep me".into());
+    let mut pending = VecDeque::from([Event::Resize(90, 25), paste.clone()]);
+    let latest = crate::terminal_input::read_resize_batch(
+        Event::Resize(80, 24),
+        &mut pending,
+        Duration::from_secs(1),
+        |_| panic!("must not read past a queued input boundary"),
+    )
+    .unwrap();
+    assert_eq!(latest, Event::Resize(90, 25));
+    assert_eq!(pending.pop_front(), Some(paste));
+
+    let latest = crate::terminal_input::read_resize_batch(
+        Event::Resize(80, 24),
+        &mut pending,
+        Duration::ZERO,
+        |_| panic!("must not read after the batch deadline"),
+    )
+    .unwrap();
+    assert_eq!(latest, Event::Resize(80, 24));
+}
+
+#[test]
+fn resize_experience_batch_has_a_fixed_event_limit() {
+    let mut count = 1;
+    let latest = crate::terminal_input::read_resize_batch(
+        Event::Resize(1, 24),
+        &mut VecDeque::new(),
+        Duration::from_secs(1),
+        |_| {
+            count += 1;
+            Ok(Some(Event::Resize(count as u16, 24)))
+        },
+    )
+    .unwrap();
+    assert_eq!(count, RESIZE_EVENTS_PER_BATCH);
+    assert_eq!(latest, Event::Resize(RESIZE_EVENTS_PER_BATCH as u16, 24));
+}

--- a/src/editor/resize_tests.rs
+++ b/src/editor/resize_tests.rs
@@ -150,6 +150,28 @@ fn resize_editor(width: usize, height: usize) -> (Editor, RenderBuffer) {
     (editor, buffer)
 }
 
+#[test]
+fn resize_experience_keeps_input_event_future_small() {
+    let (mut editor, mut buffer) = resize_editor(80, 24);
+    let mut runtime = Runtime::new();
+    let background_bytes =
+        std::mem::size_of_val(&editor.service_background(&mut buffer, &mut runtime));
+    let event = Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+    let event_bytes = std::mem::size_of_val(&editor.process_editor_event(
+        event,
+        &mut buffer,
+        &mut runtime,
+        EventRenderMode::Immediate,
+    ));
+
+    // Every input future reserves space for its largest branch. Keep the
+    // resize-only background service out of nested editing and replay calls.
+    assert!(
+        event_bytes <= 4 * 1024,
+        "input event future is {event_bytes} bytes; background future is {background_bytes} bytes"
+    );
+}
+
 #[tokio::test]
 async fn resize_experience_preserves_logical_cursor_through_shrink_and_grow() {
     for wrap in [false, true] {

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -234,6 +234,9 @@ pub struct RenderDelta {
     pub lines: Vec<LinePatch>,
     /// Cursor as `(character column, zero-based row)`.
     pub cursor: (usize, usize),
+    /// Native cursor visibility and appearance; absent on older owners.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor_state: Option<crate::terminal_output::CursorState>,
 }
 
 /// Owner-to-client protocol messages.
@@ -317,6 +320,7 @@ impl HeadlessOwner {
             revision: self.revision,
             lines,
             cursor: self.cursor,
+            cursor_state: None,
         }
     }
 
@@ -384,6 +388,7 @@ impl HeadlessOwner {
                 })
                 .collect(),
             cursor: self.cursor,
+            cursor_state: None,
         })
     }
 
@@ -1493,6 +1498,7 @@ mod tests {
                     })
                     .collect(),
                 cursor: (0, 0),
+                cursor_state: None,
             },
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ mod self_check;
 pub mod session;
 pub mod splash;
 pub mod sync;
+pub mod terminal_input;
+pub mod terminal_output;
 pub mod text_layout;
 mod textobjects;
 pub mod theme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -600,7 +600,7 @@ async fn attach_session(session: &str) -> anyhow::Result<()> {
         let mut rows = Vec::new();
         terminal::enable_raw_mode()?;
         let mut terminal_guard = DetachedTerminalGuard::default();
-        let mut output = stdout();
+        let mut output = std::io::BufWriter::with_capacity(1 << 20, stdout());
         output
             .execute(event::EnableBracketedPaste)?
             .execute(event::EnableFocusChange)?
@@ -613,12 +613,17 @@ async fn attach_session(session: &str) -> anyhow::Result<()> {
         output
             .execute(terminal::DisableLineWrap)?
             .execute(terminal::Clear(terminal::ClearType::All))?;
-        let result = async {
+        let result: anyhow::Result<()> = async {
             paint_detached_delta(&mut output, &mut rows, &client.initial_render)?;
+            let mut last_revision = client.initial_render.revision;
             let mut last_heartbeat = Instant::now();
+            let mut pending_events = std::collections::VecDeque::new();
             loop {
-                if event::poll(DETACHED_POLL_INTERVAL)? {
-                    match event::read()? {
+                if pending_events.is_empty() {
+                    event::poll(DETACHED_POLL_INTERVAL)?;
+                }
+                if let Some(event) = red::terminal_input::read_ready_event(&mut pending_events)? {
+                    match event {
                         event::Event::Key(key) if is_detach_key(&key) => {
                             client.detach().await?;
                             return Ok(());
@@ -626,41 +631,73 @@ async fn attach_session(session: &str) -> anyhow::Result<()> {
                         event::Event::Resize(columns, rows_count) => {
                             let delta = client.resize(columns, rows_count).await?;
                             paint_detached_resize(&mut output, &mut rows, &delta, rows_count)?;
+                            last_revision = delta.revision;
                         }
                         event::Event::FocusGained => {
                             let delta = client.focus(/*focused*/ true).await?;
-                            paint_detached_delta(&mut output, &mut rows, &delta)?;
+                            paint_detached_if_changed(
+                                &mut output,
+                                &mut rows,
+                                &delta,
+                                &mut last_revision,
+                            )?;
                         }
                         event::Event::FocusLost => {
                             let delta = client.focus(/*focused*/ false).await?;
-                            paint_detached_delta(&mut output, &mut rows, &delta)?;
+                            paint_detached_if_changed(
+                                &mut output,
+                                &mut rows,
+                                &delta,
+                                &mut last_revision,
+                            )?;
                         }
                         event::Event::Paste(text) => {
                             let delta = send_detached_paste(&mut client, text).await?;
-                            paint_detached_delta(&mut output, &mut rows, &delta)?;
+                            paint_detached_if_changed(
+                                &mut output,
+                                &mut rows,
+                                &delta,
+                                &mut last_revision,
+                            )?;
                         }
                         event::Event::Mouse(event) => {
                             let delta = client.input(DetachedInput::Mouse { event }).await?;
-                            paint_detached_delta(&mut output, &mut rows, &delta)?;
+                            paint_detached_if_changed(
+                                &mut output,
+                                &mut rows,
+                                &delta,
+                                &mut last_revision,
+                            )?;
                         }
                         event::Event::Key(key) => {
                             if let Some(input) = detached_key_input(key) {
                                 let delta = client.input(input).await?;
-                                paint_detached_delta(&mut output, &mut rows, &delta)?;
+                                paint_detached_if_changed(
+                                    &mut output,
+                                    &mut rows,
+                                    &delta,
+                                    &mut last_revision,
+                                )?;
                             }
                         }
                     }
                 }
                 if last_heartbeat.elapsed() >= DETACHED_RENDER_POLL_INTERVAL {
                     let delta = client.heartbeat().await?;
-                    paint_detached_delta(&mut output, &mut rows, &delta)?;
+                    paint_detached_if_changed(&mut output, &mut rows, &delta, &mut last_revision)?;
                     last_heartbeat = Instant::now();
                 }
             }
         }
         .await;
+        let flush = output.flush();
+        // Discard any bytes retained after a failed write before the guard
+        // restores the real terminal. BufWriter::drop must not replay them.
+        let _ = output.into_parts();
         drop(terminal_guard);
-        result
+        result?;
+        flush?;
+        Ok(())
     }
     #[cfg(not(unix))]
     {
@@ -781,6 +818,43 @@ where
 }
 
 #[cfg(any(unix, test))]
+fn paint_detached_if_changed(
+    output: &mut impl std::io::Write,
+    rows: &mut Vec<red::headless::LinePatch>,
+    delta: &red::headless::RenderDelta,
+    last_revision: &mut u64,
+) -> anyhow::Result<()> {
+    if delta.revision == *last_revision && delta.lines.is_empty() {
+        return Ok(());
+    }
+    paint_detached_delta(output, rows, delta)?;
+    *last_revision = delta.revision;
+    Ok(())
+}
+
+#[cfg(any(unix, test))]
+fn detached_frame<W: std::io::Write>(
+    output: &mut W,
+    paint: impl FnOnce(&mut W) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    let result = (|| {
+        output
+            .queue(terminal::BeginSynchronizedUpdate)?
+            .queue(cursor::Hide)?
+            .queue(terminal::DisableLineWrap)?;
+        paint(output)
+    })();
+    let wrap = output.queue(terminal::EnableLineWrap).map(|_| ());
+    let end = output.queue(terminal::EndSynchronizedUpdate).map(|_| ());
+    let flush = output.flush();
+    result?;
+    wrap?;
+    end?;
+    flush?;
+    Ok(())
+}
+
+#[cfg(any(unix, test))]
 fn paint_detached_delta(
     output: &mut impl std::io::Write,
     rows: &mut Vec<red::headless::LinePatch>,
@@ -795,26 +869,27 @@ fn paint_detached_delta(
             });
         }
         rows[patch.row] = patch.clone();
-        paint_detached_row(output, patch)?;
     }
-    finish_detached_paint(output, delta.cursor)
+    detached_frame(output, |output| {
+        for patch in &delta.lines {
+            paint_detached_row(output, patch)?;
+        }
+        finish_detached_paint(output, delta)
+    })
 }
 
 #[cfg(any(unix, test))]
 fn finish_detached_paint(
     output: &mut impl std::io::Write,
-    cursor: (usize, usize),
+    delta: &red::headless::RenderDelta,
 ) -> anyhow::Result<()> {
     output
         .queue(style::ResetColor)?
         .queue(style::SetAttribute(style::Attribute::Reset))?;
-    write!(
-        output,
-        "\x1b[{};{}H",
-        cursor.1.saturating_add(1),
-        cursor.0.saturating_add(1)
-    )?;
-    output.flush()?;
+    delta
+        .cursor_state
+        .unwrap_or_else(|| red::terminal_output::CursorState::visible(delta.cursor))
+        .queue(output)?;
     Ok(())
 }
 
@@ -823,28 +898,59 @@ fn paint_detached_row(
     output: &mut impl std::io::Write,
     row: &red::headless::LinePatch,
 ) -> anyhow::Result<()> {
+    // Establish the final span's background before clearing. Its blank suffix
+    // is then already painted, including on terminals with colored erasure.
+    let background = row.spans.last().and_then(|span| span.style.bg);
+    output
+        .queue(style::ResetColor)?
+        .queue(style::SetAttribute(style::Attribute::Reset))?;
+    if let Some(background) = background {
+        output.queue(style::SetBackgroundColor(background.into()))?;
+    }
     write!(output, "\x1b[{};1H\x1b[2K", row.row.saturating_add(1))?;
     if row.spans.is_empty() {
-        write!(output, "{}", row.text)?;
+        write!(output, "{}", row.text.trim_end_matches(' '))?;
         return Ok(());
     }
-    for span in &row.spans {
-        output
-            .queue(style::ResetColor)?
-            .queue(style::SetAttribute(style::Attribute::Reset))?;
-        if let Some(foreground) = span.style.fg {
-            output.queue(style::SetForegroundColor(foreground.into()))?;
+    let mut previous = red::theme::Style {
+        bg: background,
+        ..Default::default()
+    };
+    for (index, span) in row.spans.iter().enumerate() {
+        let text = if index + 1 == row.spans.len() {
+            span.text.trim_end_matches(' ')
+        } else {
+            span.text.as_str()
+        };
+        if text.is_empty() {
+            continue;
         }
-        if let Some(background) = span.style.bg {
-            output.queue(style::SetBackgroundColor(background.into()))?;
+        if span.style.fg != previous.fg {
+            output.queue(style::SetForegroundColor(
+                span.style.fg.map(Into::into).unwrap_or(style::Color::Reset),
+            ))?;
         }
-        if span.style.bold {
-            output.queue(style::SetAttribute(style::Attribute::Bold))?;
+        if span.style.bg != previous.bg {
+            output.queue(style::SetBackgroundColor(
+                span.style.bg.map(Into::into).unwrap_or(style::Color::Reset),
+            ))?;
         }
-        if span.style.italic {
-            output.queue(style::SetAttribute(style::Attribute::Italic))?;
+        if span.style.bold != previous.bold {
+            output.queue(style::SetAttribute(if span.style.bold {
+                style::Attribute::Bold
+            } else {
+                style::Attribute::NormalIntensity
+            }))?;
         }
-        write!(output, "{}", span.text)?;
+        if span.style.italic != previous.italic {
+            output.queue(style::SetAttribute(if span.style.italic {
+                style::Attribute::Italic
+            } else {
+                style::Attribute::NoItalic
+            }))?;
+        }
+        write!(output, "{text}")?;
+        previous = span.style.clone();
     }
     Ok(())
 }
@@ -867,11 +973,13 @@ fn paint_detached_resize(
         }
         rows[patch.row] = patch.clone();
     }
-    write!(output, "\x1b[H\x1b[2J")?;
-    for row in rows {
-        paint_detached_row(output, row)?;
-    }
-    finish_detached_paint(output, delta.cursor)
+    detached_frame(output, |output| {
+        write!(output, "\x1b[H\x1b[2J")?;
+        for row in rows {
+            paint_detached_row(output, row)?;
+        }
+        finish_detached_paint(output, delta)
+    })
 }
 
 fn print_error(error: &anyhow::Error) {
@@ -1347,6 +1455,76 @@ mod tests {
     }
 
     #[test]
+    fn detached_row_omits_blank_suffix_and_resets_changed_attributes() {
+        let emphasized = red::theme::Style {
+            bold: true,
+            italic: true,
+            ..Default::default()
+        };
+        let row = red::headless::LinePatch {
+            row: 0,
+            text: "ab                    ".into(),
+            spans: vec![
+                red::headless::StyledSpan {
+                    text: "a".into(),
+                    style: emphasized,
+                },
+                red::headless::StyledSpan {
+                    text: "b                    ".into(),
+                    style: Default::default(),
+                },
+            ],
+        };
+        let mut output = Vec::new();
+        paint_detached_row(&mut output, &row).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("\x1b[1m\x1b[3ma\x1b[22m\x1b[23mb"));
+        assert!(!output.contains("    "));
+    }
+
+    #[test]
+    fn detached_cursor_state_is_atomic_and_legacy_payloads_still_decode() {
+        let mut delta: red::headless::RenderDelta = serde_json::from_value(serde_json::json!({
+            "revision": 1, "lines": [], "cursor": [5, 1]
+        }))
+        .unwrap();
+        assert_eq!(delta.cursor_state, None);
+        let mut rows = Vec::new();
+        let mut output = Vec::new();
+        paint_detached_delta(&mut output, &mut rows, &delta).unwrap();
+        let text = String::from_utf8(output.clone()).unwrap();
+        assert!(text.starts_with("\x1b[?2026h\x1b[?25l\x1b[?7l"));
+        assert!(text.contains("\x1b[2;6H\x1b[?25h"));
+        assert!(text.ends_with("\x1b[?7h\x1b[?2026l"));
+
+        delta.cursor_state = Some(red::terminal_output::CursorState {
+            position: None,
+            shape: red::config::CursorShape::SteadyBar,
+            color: None,
+        });
+        output.clear();
+        paint_detached_delta(&mut output, &mut rows, &delta).unwrap();
+        let text = String::from_utf8(output.clone()).unwrap();
+        assert!(!text.contains("\x1b[?25h"));
+        output.clear();
+        let mut revision = delta.revision;
+        paint_detached_if_changed(&mut output, &mut rows, &delta, &mut revision).unwrap();
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn detached_frame_restores_terminal_modes_after_paint_failure() {
+        let mut output = Vec::new();
+        let error = detached_frame(&mut output, |output| {
+            output.extend_from_slice(b"partial frame");
+            anyhow::bail!("injected paint failure")
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("injected paint failure"));
+        assert!(output.ends_with(b"\x1b[?7h\x1b[?2026l"));
+    }
+
+    #[test]
     fn detached_resize_drops_rows_below_the_new_terminal_height() {
         let mut rows = (0..5)
             .map(|row| red::headless::LinePatch {
@@ -1365,6 +1543,7 @@ mod tests {
                 })
                 .collect(),
             cursor: (0, 0),
+            cursor_state: None,
         };
         let mut output = Vec::new();
 
@@ -1400,6 +1579,7 @@ mod tests {
                 spans: Vec::new(),
             }],
             cursor: (0, 1),
+            cursor_state: None,
         };
         let mut output = Vec::new();
 
@@ -1433,6 +1613,7 @@ mod tests {
                 spans: Vec::new(),
             }],
             cursor: (0, 0),
+            cursor_state: None,
         };
         let mut output = Vec::new();
 

--- a/src/terminal_input.rs
+++ b/src/terminal_input.rs
@@ -1,0 +1,88 @@
+//! Bounded, order-preserving terminal event collection shared by both clients.
+
+use crate::editor::perf;
+use crossterm::event::{self, Event};
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+const RESIZE_BATCH_BUDGET: Duration = Duration::from_millis(16);
+const RESIZE_QUIET_PERIOD: Duration = Duration::from_millis(2);
+pub(crate) const RESIZE_EVENTS_PER_BATCH: usize = 64;
+
+/// Reads the next ready terminal event while collapsing only adjacent
+/// resize notifications. A short, bounded collection window also catches
+/// sizes that arrive while a terminal divider is still moving. A key,
+/// paste, or other event ends the run without changing input order.
+pub fn read_ready_event(pending_events: &mut VecDeque<Event>) -> anyhow::Result<Option<Event>> {
+    let first = if let Some(event) = pending_events.pop_front() {
+        event
+    } else {
+        if !event::poll(Duration::from_millis(0))? {
+            return Ok(None);
+        }
+        event::read()?
+    };
+
+    if !matches!(first, Event::Resize(_, _)) {
+        return Ok(Some(first));
+    }
+
+    read_resize_batch(first, pending_events, RESIZE_BATCH_BUDGET, |timeout| {
+        if event::poll(timeout)? {
+            Ok(Some(event::read()?))
+        } else {
+            Ok(None)
+        }
+    })
+    .map(Some)
+}
+
+pub(crate) fn read_resize_batch(
+    first: Event,
+    pending_events: &mut VecDeque<Event>,
+    budget: Duration,
+    mut read: impl FnMut(Duration) -> anyhow::Result<Option<Event>>,
+) -> anyhow::Result<Event> {
+    let started = Instant::now();
+    let queued_before = pending_events.len();
+    let mut latest = coalesce_resize_run(first, pending_events);
+    let mut count = 1 + queued_before - pending_events.len();
+    while pending_events.is_empty() && count < RESIZE_EVENTS_PER_BATCH {
+        let remaining = budget.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            break;
+        }
+        // An isolated resize should not pay the full frame budget. Keep
+        // collecting only while more sizes arrive in the same short burst.
+        match read(remaining.min(RESIZE_QUIET_PERIOD))? {
+            Some(event @ Event::Resize(_, _)) => {
+                latest = event;
+                count += 1;
+            }
+            Some(event) => {
+                pending_events.push_front(event);
+                break;
+            }
+            None => break,
+        }
+    }
+    perf::increment("resize:batches", 1);
+    perf::increment("resize:events_coalesced", count.saturating_sub(1) as u64);
+    Ok(latest)
+}
+
+pub(crate) fn coalesce_resize_run(first: Event, pending_events: &mut VecDeque<Event>) -> Event {
+    let Event::Resize(mut width, mut height) = first else {
+        return first;
+    };
+
+    while let Some(Event::Resize(next_width, next_height)) = pending_events.front() {
+        width = *next_width;
+        height = *next_height;
+        pending_events.pop_front();
+    }
+
+    Event::Resize(width, height)
+}

--- a/src/terminal_output.rs
+++ b/src/terminal_output.rs
@@ -1,0 +1,81 @@
+//! Terminal cursor state shared by native and detached renderers.
+
+use std::io::{self, Write};
+
+use crossterm::{cursor, QueueableCommand as _};
+use serde::{Deserialize, Serialize};
+
+use crate::{color::Color, config::CursorShape};
+
+/// The native cursor to display after a complete frame. `None` means hidden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CursorState {
+    /// Zero-based terminal coordinates, or no native cursor.
+    pub position: Option<(usize, usize)>,
+    /// Shape requested by the focused editing surface.
+    pub shape: CursorShape,
+    /// Optional theme-derived cursor color.
+    pub color: Option<Color>,
+}
+
+impl CursorState {
+    /// Compatibility state for owners that only send a cursor position.
+    pub fn visible(position: (usize, usize)) -> Self {
+        Self {
+            position: Some(position),
+            shape: CursorShape::Default,
+            color: None,
+        }
+    }
+
+    /// Queue the final cursor without making its intermediate position visible.
+    pub fn queue(self, output: &mut impl Write) -> io::Result<()> {
+        let position = self
+            .position
+            .and_then(|(x, y)| Some((u16::try_from(x).ok()?, u16::try_from(y).ok()?)));
+        let Some((x, y)) = position else {
+            output.queue(cursor::Hide)?;
+            return Ok(());
+        };
+        if let Some(color) = self.color {
+            write!(output, "\x1b]12;{color}\x1b\\")?;
+        }
+        let shape = match self.shape {
+            CursorShape::Default => cursor::SetCursorStyle::DefaultUserShape,
+            CursorShape::BlinkingBlock => cursor::SetCursorStyle::BlinkingBlock,
+            CursorShape::SteadyBlock => cursor::SetCursorStyle::SteadyBlock,
+            CursorShape::BlinkingUnderscore => cursor::SetCursorStyle::BlinkingUnderScore,
+            CursorShape::SteadyUnderscore => cursor::SetCursorStyle::SteadyUnderScore,
+            CursorShape::BlinkingBar => cursor::SetCursorStyle::BlinkingBar,
+            CursorShape::SteadyBar => cursor::SetCursorStyle::SteadyBar,
+        };
+        output
+            .queue(shape)?
+            .queue(cursor::MoveTo(x, y))?
+            .queue(cursor::Show)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hidden_cursor_emits_no_style_or_position_commands() {
+        let mut output = Vec::new();
+        CursorState {
+            position: None,
+            shape: CursorShape::SteadyBar,
+            color: Some(Color::Rgb { r: 1, g: 2, b: 3 }),
+        }
+        .queue(&mut output)
+        .unwrap();
+        assert_eq!(output, b"\x1b[?25l");
+        output.clear();
+        CursorState::visible((usize::MAX, 0))
+            .queue(&mut output)
+            .unwrap();
+        assert_eq!(output, b"\x1b[?25l");
+    }
+}


### PR DESCRIPTION
## Why

Dragging a terminal divider could expose intermediate editor repaints, move the logical cursor when the viewport shrank, and leave the native cursor visible at the wrong time. Attached sessions also repainted unchanged heartbeat responses and used a separate cursor/output path.

## What changed

- Share bounded, order-preserving resize batching between native and attached clients. Publish resize callbacks and background effects in one final frame, while still repainting a physical screen invalidated by an intermediate resize.
- Preserve the logical cursor line across shrinking/growing terminals, including inactive splits.
- Reuse render-buffer storage and encode uniform blank row suffixes with erase-to-end-of-line.
- Share cursor visibility, shape, color, and position through an optional, backward-compatible detached protocol field. Buffer attached output, hide the cursor during synchronized frames, restore terminal modes on errors, and skip unchanged heartbeats.
- Add focused regressions and an ignored release-mode benchmark in `src/editor/resize_tests.rs`.

## Measurements

Compared with the first manually tested checkpoint, using three alternating release-mode pairs per fixture and 60 measured resizes after warmup:

| Fixture | Output bytes before → after | Flushes before → after | p95 CPU before → after |
| --- | ---: | ---: | ---: |
| Plain editor | 966,840 → 245,415 | 60 → 60 | 1.690 → 0.913 ms |
| Dense text | 932,040 → 872,205 | 60 → 60 | 2.168 → 1.269 ms |
| Split + Agent panel | 1,009,230 → 804,735 | 120 → 60 | 2.133 → 0.927 ms |

Every before/after rendered-cell hash matched. These are local measurements of the production resize/render/ANSI-encoding path, not terminal-emulator display latency or input-batching delay.

## How to Test

1. Build with `cargo build --release`, then run `RED_PERF=summary target/release/red src/editor.rs`. Go to line 100 with `100G` and drag the terminal narrower, wider, shorter, and taller. Expect a complete, correctly colored editor with the cursor still on the same buffer line.
2. Repeat with a split or Agent panel open. Shrink to a very small terminal (the smoke test used 8×3), then restore it. Expect no stale rows, misplaced split cursors, or visible cursor movement during painting. With the default cursor settings, the native cursor should remain hidden in normal mode and appear at the correct position in insert mode.
3. On macOS/Linux, repeat using `target/release/red --detach resize-pr src/editor.rs`. Expect the same restored screen and cursor behavior as the native client. Stop the disposable session afterward with `target/release/red --stop resize-pr`.
4. Run the focused regressions:
   ```sh
   cargo test --lib resize_experience -- --test-threads=1
   cargo test --lib terminal_diff_erases_only_a_complete_blank_suffix -- --test-threads=1
   cargo test --bin red detached_ -- --test-threads=1
   ```
   To collect local performance samples, run `cargo test --release --lib resize_output_benchmark -- --ignored --nocapture --test-threads=1`.

Verified locally: 22 focused library tests and 8 detached-painter tests passed; strict all-target/all-feature Clippy passed. The final native/attached tmux smoke passed Unicode rendering, tiny-terminal recovery, cursor modes, balanced synchronized frames, and restored-screen equivalence.