### PR TITLE
fix(editor): exit empty command mode on backspace

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -14582,7 +14582,9 @@ impl Editor {
             let _modifiers = event.modifiers;
 
             match code {
-                KeyCode::Esc => {
+                KeyCode::Esc | KeyCode::Backspace
+                    if code == KeyCode::Esc || self.command.is_empty() =>
+                {
                     self.command = String::new();
                     self.reset_command_history_navigation();
                     self.reset_command_completion();

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1718,6 +1718,47 @@ async fn command_key(harness: &mut EditorHarness, code: KeyCode) {
         .unwrap();
 }
 
+#[tokio::test]
+async fn command_backspace_exits_an_empty_prompt() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "unchanged".to_string()),
+        default_key_config(),
+    );
+    command_key(&mut harness, KeyCode::Char(':')).await;
+    harness.assert_mode(Mode::Command);
+    assert_eq!(harness.commandline_row().trim_end(), ":");
+
+    command_key(&mut harness, KeyCode::Backspace).await;
+
+    harness.assert_mode(Mode::Normal);
+    assert_eq!(harness.commandline_text(), "");
+    assert_eq!(harness.commandline_row().trim_end(), "");
+    harness.assert_buffer_contents("unchanged");
+}
+
+#[tokio::test]
+async fn command_backspace_deletes_text_before_exiting() {
+    for character in ['x', 'é', ' '] {
+        let mut harness = EditorHarness::with_config(
+            Buffer::new(None, "unchanged".to_string()),
+            default_key_config(),
+        );
+        command_key(&mut harness, KeyCode::Char(':')).await;
+        command_key(&mut harness, KeyCode::Char(character)).await;
+
+        command_key(&mut harness, KeyCode::Backspace).await;
+
+        harness.assert_mode(Mode::Command);
+        assert_eq!(harness.commandline_text(), "");
+        assert_eq!(harness.commandline_row().trim_end(), ":");
+
+        command_key(&mut harness, KeyCode::Backspace).await;
+        harness.assert_mode(Mode::Normal);
+        assert_eq!(harness.commandline_row().trim_end(), "");
+        harness.assert_buffer_contents("unchanged");
+    }
+}
+
 struct CurrentDirGuard {
     original: PathBuf,
     _lock: MutexGuard<'static, ()>,


### PR DESCRIPTION
Pressing Backspace at an empty `:` prompt currently does nothing, leaving command mode open. This makes clearing a command feel incomplete.

Treat Backspace on an already-empty command line like Escape, including clearing command-history navigation and completion state. Backspace on a non-empty command still deletes one character; deleting the final character leaves `:` open until the next Backspace. Add integration coverage for prompt dismissal, unchanged buffer contents, and ordinary, Unicode, and whitespace characters.

## How to Test

1. From normal mode, press `:`, then Backspace. Expect normal mode, no command prompt, and unchanged buffer contents.
2. Enter `:x` and press Backspace once. Expect the empty `:` prompt to remain open. Press Backspace again and expect normal mode. Repeat with `é` or a space.
3. Run `cargo test --test editing command_backspace -- --test-threads=1`. Both regression tests should pass.

## Validation

- `cargo test --test editing -- --test-threads=1` — 341 passed.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --all --check` — passed.
