### PR TITLE
feat(commands): add argument completion

### DIFF
--- a/almanac/architecture/commands/command-discovery.md
+++ b/almanac/architecture/commands/command-discovery.md
@@ -6,6 +6,9 @@ sources:
   - id: command-parser
     type: file
     path: src/command.rs
+  - id: command-completion
+    type: file
+    path: src/command_completion.rs
   - id: command-palette
     type: file
     path: src/command_palette.rs
@@ -40,7 +43,7 @@ Advertising a built-in colon form is a parser and dispatch change, not only pale
 
 ## Completion Names
 
-Colon completion uses the palette module's command-name inventory rather than the parser alone. `colon_completion_names` starts with built-in colon commands, adds special built-ins such as `commands`, `command-palette`, debug commands, registers, undotree, `j`, and `join`, and then appends plugin command names that do not collide with built-in colon names [@command-palette]. The editor uses that list for command-line completion when the current command fragment has no whitespace and is not in a file or syntax completion context [@editor-dispatch].
+Colon completion uses the palette module's command-name inventory rather than the parser alone. `colon_completion_names` starts with built-in colon commands, adds special built-ins such as `commands`, `command-palette`, debug commands, registers, undotree, `j`, and `join`, and then appends plugin command names that do not collide with built-in colon names [@command-palette]. The editor uses that list for command-name completion. `src/command_completion.rs` selects argument providers after a space: fixed choices for commands such as `set`, `languages`, and `Copilot`, file paths for file commands, and language ids for syntax commands. `Tab` cycles forward and `Shift-Tab` cycles backward through the original matches; typing resets the cycle. Positional choices replace only the current argument; file completion retains its existing whole-path replacement behavior. Completion never executes a command or plugin callback [@command-completion] [@editor-dispatch].
 
 Built-in precedence is intentional. `colon_name_is_builtin` treats special names and anything the built-in parser can resolve as reserved, so plugin commands with those names can still be active internally but do not create alternate colon command entries in discovery surfaces [@command-palette]. This matches the plugin API boundary described in [Red Host API](../plugins/red-host-api).
 
@@ -66,6 +69,8 @@ The panel-global allowlist currently admits command/search entry, file picker, c
 
 ## Plugin Command Metadata
 
-Plugins register command discovery data through the runtime's `CommandMetadata`, which carries optional title, category, description, aliases, visibility, and panel key-dispatch scope [@plugin-runtime]. Declarative `#[red::command]` metadata accepts `scope = "editor"` or `scope = "global"` and defaults to editor scope, while imperative `red::add_command` metadata is deserialized into the same runtime structure [@plugin-api] [@plugin-runtime]. `Runtime::registered_commands` returns active command records with command name, owning plugin, callback, and metadata sorted by command name for stable discovery UI, and `Runtime::command_scope` is the editor's lookup path when deciding whether a plugin command may run from focused panels [@plugin-runtime] [@editor-dispatch]. Because palette entries retain the owning plugin in their ids, duplicate command names have deterministic runtime behavior before discovery surfaces display them [@plugin-runtime].
+Plugins register command discovery data through the runtime's `CommandMetadata`, which carries optional title, category, description, aliases, visibility, panel key-dispatch scope, and opt-in argument/completion metadata [@plugin-runtime]. Declarative `#[red::command]` metadata accepts `scope = "editor"` or `scope = "global"` and defaults to editor scope, while imperative `red::add_command` metadata is deserialized into the same runtime structure [@plugin-api] [@plugin-runtime]. `Runtime::registered_commands` returns active command records with command name, owning plugin, callback, and metadata sorted by command name for stable discovery UI, and `Runtime::command_scope` is the editor's lookup path when deciding whether a plugin command may run from focused panels [@plugin-runtime] [@editor-dispatch]. Because palette entries retain the owning plugin in their ids, duplicate command names have deterministic runtime behavior before discovery surfaces display them [@plugin-runtime].
 
 This command system does not make colon syntax a general shell. Arguments are split simply, command names are case-sensitive where plugin names are involved, and plugin command execution stays behind the plugin host boundary [@command-parser] [@editor-dispatch]. The CLI-level command surface is documented in [Red Command](../../reference/cli/red-command), and exact default keymaps and plugin command bindings belong in [Default Config](../../reference/configuration/default-config).
+
+Plugin commands may opt in with `arguments = true` and positional `completions = [["enable", "disable"]]`. They receive one `CommandInvocation` record containing the registered name, split arguments, and raw argument text. Legacy callbacks still receive no arguments; exact registered names and built-in precedence are preserved. See [Plugin Host API](../../reference/plugins/host-api) for compatibility requirements [@plugin-api] [@plugin-runtime].

--- a/almanac/guides/agent/copilot-completion.md
+++ b/almanac/guides/agent/copilot-completion.md
@@ -39,6 +39,9 @@ excluded_patterns = [".env", ".env.*", "*.pem", "*.key", "**/.git/**"]
 ```
 
 Alternatively, use `:Copilot enable` to opt in for the current editor session.
+Type `:Copilot ` and press `Tab` to cycle through subcommands, or complete a
+prefix such as `:Copilot en`. `Shift-Tab` cycles backward. Completion does not
+enable Copilot or start authentication.
 Then run `:Copilot signin`, copy the displayed device code, and approve opening
 GitHub's sign-in page. Use `:Copilot status` to inspect the latest provider
 status, `:Copilot restart` after changing the executable, and `:Copilot signout`

--- a/almanac/guides/agent/copilot-completion.md
+++ b/almanac/guides/agent/copilot-completion.md
@@ -1,0 +1,73 @@
+---
+title: "Copilot Inline Completion"
+summary: "Enable, authenticate, and use optional GitHub Copilot ghost-text suggestions without replacing ordinary language-server completion."
+topics: [guides, agent, completion]
+sources:
+  - id: defaults
+    type: file
+    path: default_config.toml
+  - id: transport
+    type: file
+    path: src/copilot.rs
+  - id: editor
+    type: file
+    path: src/editor/inline_completion.rs
+---
+
+# Copilot Inline Completion
+
+Copilot is optional and disabled by default. Enabling it permits the official
+GitHub Copilot language server to process eligible source code. It runs beside
+the normal language server; it does not replace rust-analyzer, TypeScript's
+server, or other language intelligence [@transport] [@editor].
+
+## Set Up
+
+Install GitHub's official `@github/copilot-language-server` package or a native
+binary from its [release repository](https://github.com/github/copilot-language-server-release).
+Make `copilot-language-server` available on `PATH`, or configure its absolute
+path. Red does not download or update this executable automatically.
+
+```toml
+[copilot]
+enabled = true
+command = "copilot-language-server"
+args = ["--stdio"]
+debounce_ms = 150
+max_file_bytes = 262144
+excluded_patterns = [".env", ".env.*", "*.pem", "*.key", "**/.git/**"]
+```
+
+Alternatively, use `:Copilot enable` to opt in for the current editor session.
+Then run `:Copilot signin`, copy the displayed device code, and approve opening
+GitHub's sign-in page. Use `:Copilot status` to inspect the latest provider
+status, `:Copilot restart` after changing the executable, and `:Copilot signout`
+or `:Copilot disable` when finished [@defaults] [@editor].
+
+`disable_ai = true` takes precedence over both configuration and session-level
+enablement. Excluded, oversized, and outside-workspace files are not submitted
+by Red. Exclusion patterns use gitignore syntax; replacing the list also
+replaces its defaults. Provider-side account, content-exclusion, and data-use
+settings still apply [@transport] [@editor].
+
+These checks govern documents Red sends directly. The language server is a
+separate process with normal filesystem access, not a sandbox [@transport].
+
+## Use Suggestions
+
+Type in Insert mode and pause briefly. `Tab` accepts a visible suggestion as
+one undo step. `Esc` dismisses it and returns to Normal mode. Typing, moving the
+cursor, or changing buffers invalidates stale suggestions. `Alt-\` requests a
+suggestion explicitly; `:Copilot complete` enters Insert mode and requests one
+at the current cursor [@editor].
+
+With Copilot enabled, idle identifier typing prefers ghost text over the
+automatic word-completion popup. `Ctrl-Space` still opens ordinary completion,
+and language-server trigger characters still work. An open completion popup
+takes priority over AI suggestions; `Alt-\` switches from that popup to an
+explicit AI request [@editor].
+
+This first integration supports single-line and multiline insertions at the
+cursor. Suggestions that would rewrite existing code are not accepted. Copilot
+next-edit suggestions require a separate review/preview interface and are not
+part of this feature [@editor].

--- a/almanac/reference/configuration/default-config.md
+++ b/almanac/reference/configuration/default-config.md
@@ -78,6 +78,11 @@ Comment templates are keyed by language or extension and use a single `%s` place
 
 ## Agent Configuration
 
+`[copilot]` configures optional inline AI completion separately from the Codex
+agent. It defaults to disabled; `disable_ai = true` also blocks it. See
+[Copilot Inline Completion](../../guides/agent/copilot-completion) for setup,
+privacy controls, commands, and key bindings.
+
 `[agent]` contains an optional `command` override, plus optional `args` and `env` fields in the code schema [@config]. When `command` is absent, the agent check and runtime Codex integration use `codex` from `PATH` [@config]. Setting `disable_ai = true` removes the bundled agent plugin, resets agent configuration during recovered loading paths, and prevents Red from launching Codex [@defaults] [@config].
 
 See [Agent Check](../agent/agent-check) for the command-line readiness report that reads these agent settings.

--- a/almanac/reference/plugins/host-api.md
+++ b/almanac/reference/plugins/host-api.md
@@ -20,7 +20,7 @@ sources:
     path: docs/plugin_api_changes.json
 ---
 
-The Plugin Host API reference identifies the files that define Red's Husk plugin contract and the rules for changing it. The canonical schema is `src/plugin/host_api.json`; it declares version `0.9.0` and lists host calls by `name`, `kind`, `signature`, and `introduced` [@schema]. The implementation embeds that schema in `src/plugin/api.rs`, validates literal plugin calls against it, and tests that runtime dispatch remains covered by the schema [@api]. This page does not copy the full schema; open the schema when exact call names or signatures are needed.
+The Plugin Host API reference identifies the files that define Red's Husk plugin contract and the rules for changing it. The canonical schema is `src/plugin/host_api.json`; it declares version `0.11.0` and lists host calls by `name`, `kind`, `signature`, and `introduced` [@schema]. The implementation embeds that schema in `src/plugin/api.rs`, validates literal plugin calls against it, and tests that runtime dispatch remains covered by the schema [@api]. This page does not copy the full schema; open the schema when exact call names or signatures are needed.
 
 ## Source Of Truth
 

--- a/default_config.toml
+++ b/default_config.toml
@@ -96,6 +96,16 @@ debounce_ms = 0
 buffer_words = true
 max_buffer_words = 100
 
+[copilot]
+# Opt in before any source code is sent to GitHub Copilot. Install the official
+# @github/copilot-language-server separately, then use :Copilot signin.
+enabled = false
+command = "copilot-language-server"
+args = ["--stdio"]
+debounce_ms = 150
+max_file_bytes = 262144
+excluded_patterns = [".env", ".env.*", "*.pem", "*.key", "**/.git/**"]
+
 [picker]
 # Query input position in picker dialogs. Supported values are "bottom" and
 # "top". Bottom matches the default command-line-oriented picker layout.
@@ -244,6 +254,7 @@ Enter = "InsertNewLine"
 Backspace = "DeletePreviousChar"
 Tab = "InsertTab"
 "Ctrl-Space" = "RequestCompletion"
+"Alt-\\" = "RequestInlineCompletion"
 "Ctrl-k" = "SignatureHelp"
 Esc = { EnterMode = "Normal" }
 

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.10.0` is defined by
+Red host API version `0.11.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -24,9 +24,39 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 annotations use `HUSK-A0004`. `--no-typecheck` is an unsupported development
 escape hatch; compatibility guarantees do not apply while it is enabled.
 
-Red `0.10.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, and `0.9.0`
-contracts, so existing packages that declare those minors continue to load. New
-packages should target `"red_api_version": "^0.10.0"`.
+Red `0.11.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
+and `0.10.0` contracts, so existing packages that declare those minors continue to
+load. New packages should target `"red_api_version": "^0.11.0"`.
+
+## Command arguments and completion
+
+Host API `0.11.0` adds opt-in arguments to plugin commands:
+
+```husk
+#[red::command(
+    name = "Service",
+    arguments = true,
+    completions = [["enable", "disable", "status"], ["local", "workspace"]],
+)]
+fn service(command: CommandInvocation) {
+    red::execute("Print", command.raw_args);
+}
+```
+
+`CommandInvocation` contains the exact registered `name`, whitespace-separated
+`args: [String]`, and unexpanded `raw_args: String`. A callback may also accept
+`Json` when it does not need the typed record. A palette or keymap invocation
+without arguments receives an empty argument list. Existing commands continue to
+take no parameters unless they opt in. The same `arguments` and `completions`
+fields are accepted by `red::add_command` metadata.
+
+Each inner completion array describes one argument position. Choices must be
+nonempty strings without whitespace; an empty array leaves that position without
+suggestions. Choices are hints, not validation: the callback must validate its
+arguments. `Tab` and `Shift-Tab` cycle matching choices without invoking the
+callback. Hidden commands stay out of completion, and built-in colon commands
+retain precedence. There is no shell quoting, expansion, or completion callback.
+Packages using these fields must target `^0.11.0` or later.
 
 ## Language-pack formatters
 
@@ -176,7 +206,7 @@ fn stop_background_work() {
 }
 ```
 
-`#[red::command]` requires a nonempty `name`, a zero-argument function, and
+`#[red::command]` requires a nonempty `name`, a zero-argument function by default, and
 optional string `title`, `category`, and `description` fields plus an optional
 string-array `aliases` field. `visible = false` hides a command from the command
 palette and colon completion without disabling direct invocation or keymaps.

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.10.0",
+  "api_version": "0.11.0",
   "changes": [
+    {
+      "version": "0.11.0",
+      "kind": "introduced",
+      "symbols": ["CommandInvocation", "CommandMetadata.arguments", "CommandMetadata.completions", "#[red::command(arguments, completions)]"],
+      "migration_note": "docs/PLUGIN_API.md#command-arguments-and-completion"
+    },
     {
       "version": "0.10.0",
       "kind": "introduced",

--- a/src/command.rs
+++ b/src/command.rs
@@ -41,6 +41,16 @@ impl ParsedCommand {
     pub fn is_forced(&self) -> bool {
         self.flags.contains(&CommandFlag::Force)
     }
+
+    /// Reassembles the single unexpanded path consumed by file commands.
+    ///
+    /// Splitting and joining on literal spaces preserves whitespace inside the
+    /// path, including repeated spaces returned by command completion.
+    pub(crate) fn file_argument(&self) -> Option<String> {
+        let path = self.args.join(" ");
+        let path = path.trim_start();
+        (!path.is_empty()).then(|| path.to_string())
+    }
 }
 
 /// Resolves a command line against the supplied canonical command names.
@@ -48,9 +58,8 @@ impl ParsedCommand {
 /// Returns `None` when any command in a chain is unknown. Arguments are split on spaces
 /// without shell quoting or expansion.
 pub fn parse(commands: &[&str], input: &str) -> Option<ParsedCommand> {
-    let (flags, input) = parse_flags(input);
     let mut parts = input.splitn(2, ' ');
-    let input = parts.next()?;
+    let (flags, input) = parse_flags(parts.next()?);
     let args = parts
         .next()
         .map(|s| s.split(' ').map(|s| s.to_string()).collect())
@@ -158,6 +167,24 @@ mod test {
                 flags: vec![]
             })
         );
+    }
+
+    #[test]
+    fn file_arguments_preserve_spaces_and_literal_bangs() {
+        let commands = ["edit", "write", "split", "vsplit"];
+        let path = "dir/name  with spaces.txt!";
+
+        for command in commands {
+            let parsed = parse(&commands, &format!("{command} {path}")).unwrap();
+            assert_eq!(parsed.file_argument().as_deref(), Some(path));
+            assert!(!parsed.is_forced());
+
+            let forced = parse(&commands, &format!("{command}! {path}")).unwrap();
+            assert_eq!(forced.file_argument().as_deref(), Some(path));
+            assert!(forced.is_forced());
+        }
+
+        assert_eq!(parse(&commands, "edit   ").unwrap().file_argument(), None);
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -5,6 +5,19 @@
 //! arguments are returned; unknown input fails as a whole so a partially recognized
 //! chain cannot execute unintended commands.
 
+/// Accepted values for the first `:set` argument.
+pub(crate) const SET_OPTIONS: &[&str] = &["relativenumber", "rnu", "norelativenumber", "nornu"];
+
+/// Accepted `:languages` operations.
+pub(crate) const LANGUAGE_COMMANDS: &[&str] = &["reload"];
+
+/// Splits an exact plugin command name from its unexpanded argument text.
+pub(crate) fn split_invocation(input: &str) -> (&str, &str) {
+    input
+        .split_once(char::is_whitespace)
+        .map_or((input, ""), |(name, args)| (name, args.trim_start()))
+}
+
 /// Modifier parsed from a built-in colon command.
 #[derive(Debug, PartialEq)]
 pub enum CommandFlag {

--- a/src/command_completion.rs
+++ b/src/command_completion.rs
@@ -1,0 +1,456 @@
+//! Side-effect-free completion for Red's colon command line.
+//!
+//! The editor owns input and execution. This module selects a completion source,
+//! replaces one argument, and retains the original candidate set while cycling.
+
+use std::{fs, ops::Range, path::PathBuf};
+
+use crate::{
+    command, command_palette, copilot::CopilotCommand, plugin::RegisteredPluginCommand,
+    utils::expand_user_path,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompletionDirection {
+    Next,
+    Previous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommandCompletionState {
+    replacement: Range<usize>,
+    candidates: Vec<String>,
+    selected: usize,
+    needs_leading_space: bool,
+}
+
+impl CommandCompletionState {
+    fn apply(&mut self, line: &mut String) {
+        let candidate = &self.candidates[self.selected];
+        let replacement = if self.needs_leading_space {
+            format!(" {candidate}")
+        } else {
+            candidate.clone()
+        };
+        line.replace_range(self.replacement.clone(), &replacement);
+        self.replacement.end = self.replacement.start + replacement.len();
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ArgumentContext<'a> {
+    command: &'a str,
+    command_end: usize,
+    preceding: Vec<&'a str>,
+    fragment: &'a str,
+    replacement: Range<usize>,
+    needs_leading_space: bool,
+}
+
+impl<'a> ArgumentContext<'a> {
+    fn parse(line: &'a str) -> Option<Self> {
+        let start = line.find(|ch: char| !ch.is_whitespace())?;
+        let end = line[start..]
+            .find(char::is_whitespace)
+            .map_or(line.len(), |offset| start + offset);
+        let command = &line[start..end];
+        if end == line.len() {
+            return Some(Self {
+                command,
+                command_end: end,
+                preceding: Vec::new(),
+                fragment: "",
+                replacement: end..end,
+                needs_leading_space: true,
+            });
+        }
+        let argument_start = line[end..]
+            .char_indices()
+            .rev()
+            .find(|(_, ch)| ch.is_whitespace())
+            .map_or(end, |(offset, ch)| end + offset + ch.len_utf8());
+        Some(Self {
+            command,
+            command_end: end,
+            preceding: line[end..argument_start].split_whitespace().collect(),
+            fragment: &line[argument_start..],
+            replacement: argument_start..line.len(),
+            needs_leading_space: false,
+        })
+    }
+}
+
+enum Source {
+    Choices(Vec<String>),
+    Files,
+    Syntax,
+}
+
+fn choices(values: &[&str]) -> Source {
+    Source::Choices(values.iter().map(|value| (*value).to_string()).collect())
+}
+
+fn builtin_source(name: &str, argument_index: usize) -> Option<Source> {
+    // Use the execution parser's abbreviations, but never complete a command chain.
+    let parsed = command::parse(
+        command_palette::BUILTIN_COLON_COMMANDS,
+        name.trim_end_matches('!'),
+    );
+    let canonical = match parsed.as_ref().map(|parsed| parsed.commands.as_slice()) {
+        Some([command]) => command.as_str(),
+        _ => name,
+    };
+    match canonical {
+        "edit" | "write" | "split" | "sp" | "vsplit" | "vs" | "InlineHistoryExport" => {
+            Some(Source::Files)
+        }
+        _ if argument_index != 0 => None,
+        "syntax" | "syn" | "ft" => Some(Source::Syntax),
+        "set" => Some(choices(command::SET_OPTIONS)),
+        "languages" => Some(choices(command::LANGUAGE_COMMANDS)),
+        "Copilot" => Some(Source::Choices(
+            CopilotCommand::ALL
+                .iter()
+                .map(|(_, name)| (*name).to_string())
+                .collect(),
+        )),
+        _ => None,
+    }
+}
+
+fn source(context: &ArgumentContext<'_>, plugins: &[RegisteredPluginCommand]) -> Option<Source> {
+    if command_palette::colon_name_is_builtin(context.command) {
+        return builtin_source(context.command, context.preceding.len());
+    }
+    plugins
+        .iter()
+        .find(|command| {
+            command.name == context.command
+                && command.metadata.visible
+                && command.metadata.arguments
+        })?
+        .metadata
+        .completions
+        .get(context.preceding.len())
+        .cloned()
+        .map(Source::Choices)
+}
+
+/// Completes without invoking commands, plugin callbacks, or external processes.
+pub(crate) fn complete(
+    state: &mut Option<CommandCompletionState>,
+    line: &mut String,
+    direction: CompletionDirection,
+    plugins: &[RegisteredPluginCommand],
+    language_matches: impl FnOnce(&str) -> Vec<String>,
+) {
+    if let Some(mut current) = state.take() {
+        if current.candidates.len() > 1 {
+            current.selected = match direction {
+                CompletionDirection::Next => (current.selected + 1) % current.candidates.len(),
+                CompletionDirection::Previous => current
+                    .selected
+                    .checked_sub(1)
+                    .unwrap_or(current.candidates.len() - 1),
+            };
+            current.apply(line);
+            *state = Some(current);
+            return;
+        }
+    }
+    let Some(context) = ArgumentContext::parse(line) else {
+        return;
+    };
+    let argument_source = source(&context, plugins);
+    // Retain the established bare :e<Tab> and :syntax<Tab> shortcuts. Other
+    // commands enter argument completion only after a separating space.
+    let (replacement, needs_leading_space, candidates) = if context.needs_leading_space
+        && !matches!(argument_source, Some(Source::Files | Source::Syntax))
+    {
+        let start = context.replacement.start - context.command.len();
+        let names = command_palette::colon_completion_names(plugins)
+            .into_iter()
+            .filter(|name| name.starts_with(context.command))
+            .collect();
+        (start..line.len(), false, names)
+    } else {
+        // File completion has historically owned the entire remaining path,
+        // including spaces. Keep that behavior separate from positional choices.
+        let (replacement, needs_leading_space, fragment) =
+            if matches!(argument_source, Some(Source::Files)) {
+                match line[context.command_end..].find(|ch: char| !ch.is_whitespace()) {
+                    Some(offset) => {
+                        let start = context.command_end + offset;
+                        (start..line.len(), false, &line[start..])
+                    }
+                    None => (context.command_end..line.len(), true, ""),
+                }
+            } else {
+                (
+                    context.replacement,
+                    context.needs_leading_space,
+                    context.fragment,
+                )
+            };
+        let candidates = match argument_source {
+            Some(Source::Files) => path_candidates(fragment),
+            Some(Source::Syntax) => {
+                let fragment = fragment.to_ascii_lowercase();
+                let mut candidates = ["auto", "off"]
+                    .into_iter()
+                    .filter(|name| name.starts_with(&fragment))
+                    .map(str::to_string)
+                    .chain(language_matches(&fragment))
+                    .collect::<Vec<_>>();
+                candidates.sort_unstable();
+                candidates.dedup();
+                candidates
+            }
+            Some(Source::Choices(values)) => {
+                let mut candidates = values
+                    .into_iter()
+                    .filter(|value| value.starts_with(fragment))
+                    .collect::<Vec<_>>();
+                candidates.sort_unstable();
+                candidates.dedup();
+                candidates
+            }
+            None => return,
+        };
+        (replacement, needs_leading_space, candidates)
+    };
+    if candidates.is_empty() {
+        return;
+    }
+    let selected = match direction {
+        CompletionDirection::Next => 0,
+        CompletionDirection::Previous => candidates.len() - 1,
+    };
+    let mut current = CommandCompletionState {
+        replacement,
+        candidates,
+        selected,
+        needs_leading_space,
+    };
+    current.apply(line);
+    *state = Some(current);
+}
+
+fn path_candidates(fragment: &str) -> Vec<String> {
+    match fragment {
+        "." => return vec!["./".into()],
+        ".." => return vec!["../".into()],
+        "~" if expand_user_path("~").is_ok() => return vec!["~/".into()],
+        _ => {}
+    }
+    let (directory, prefix) = fragment.rfind('/').map_or(("", fragment), |index| {
+        (&fragment[..=index], &fragment[index + 1..])
+    });
+    let path = if directory.is_empty() {
+        PathBuf::from(".")
+    } else {
+        expand_user_path(directory).unwrap_or_else(|_| PathBuf::from(directory))
+    };
+    let Ok(entries) = fs::read_dir(path) else {
+        return Vec::new();
+    };
+    let mut candidates = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !name.starts_with(prefix) {
+                return None;
+            }
+            let is_dir = entry.file_type().is_ok_and(|kind| kind.is_dir());
+            let suffix = if is_dir { "/" } else { "" };
+            Some((!is_dir, format!("{directory}{name}{suffix}")))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_unstable();
+    candidates.into_iter().map(|(_, name)| name).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::CommandMetadata;
+
+    fn tab(
+        state: &mut Option<CommandCompletionState>,
+        line: &mut String,
+        direction: CompletionDirection,
+        plugins: &[RegisteredPluginCommand],
+    ) {
+        complete(state, line, direction, plugins, |fragment| {
+            ["rust", "yaml"]
+                .into_iter()
+                .filter(|name| name.starts_with(fragment))
+                .map(str::to_string)
+                .collect()
+        });
+    }
+
+    fn completed(input: &str) -> String {
+        let mut line = input.to_string();
+        tab(&mut None, &mut line, CompletionDirection::Next, &[]);
+        line
+    }
+
+    fn plugin(name: &str, choices: &[&[&str]]) -> RegisteredPluginCommand {
+        RegisteredPluginCommand {
+            name: name.into(),
+            plugin: "test".into(),
+            metadata: CommandMetadata {
+                arguments: true,
+                completions: choices
+                    .iter()
+                    .map(|values| values.iter().map(|value| (*value).to_string()).collect())
+                    .collect(),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn builtin_arguments_complete_without_execution() {
+        for (input, expected) in [
+            ("Copilot en", "Copilot enable"),
+            ("Copilot ", "Copilot complete"),
+            ("Copilot", "Copilot"),
+            ("Copilot enable ", "Copilot enable "),
+            ("Copilot Enable", "Copilot Enable"),
+            ("copilot en", "copilot en"),
+            ("languages re", "languages reload"),
+            ("set norn", "set nornu"),
+            ("set rnu ", "set rnu "),
+            ("syntax RU", "syntax rust"),
+            ("syn ru", "syn rust"),
+            ("ft ", "ft auto"),
+            ("syntax rust extra", "syntax rust extra"),
+            ("q sr", "q sr"),
+            ("wq sr", "wq sr"),
+            ("  Copilot   en", "  Copilot   enable"),
+        ] {
+            assert_eq!(completed(input), expected, "{input:?}");
+        }
+    }
+
+    #[test]
+    fn cycles_original_choices_in_both_directions() {
+        let mut state = None;
+        let mut line = "Copilot sign".to_string();
+        tab(&mut state, &mut line, CompletionDirection::Next, &[]);
+        assert_eq!(line, "Copilot signin");
+        tab(&mut state, &mut line, CompletionDirection::Next, &[]);
+        assert_eq!(line, "Copilot signout");
+        tab(&mut state, &mut line, CompletionDirection::Previous, &[]);
+        assert_eq!(line, "Copilot signin");
+        state = None;
+        line = "Copilot sign".into();
+        tab(&mut state, &mut line, CompletionDirection::Previous, &[]);
+        assert_eq!(line, "Copilot signout");
+    }
+
+    #[test]
+    fn command_names_keep_their_existing_cycle() {
+        let mut state = None;
+        let mut line = "wr".to_string();
+        tab(&mut state, &mut line, CompletionDirection::Next, &[]);
+        assert_eq!(line, "wrap");
+        tab(&mut state, &mut line, CompletionDirection::Next, &[]);
+        assert_eq!(line, "write");
+        tab(&mut state, &mut line, CompletionDirection::Previous, &[]);
+        assert_eq!(line, "wrap");
+        assert_eq!(completed("Wr"), "Wr");
+    }
+
+    #[test]
+    fn plugin_positions_replace_only_the_active_unicode_argument() {
+        let plugins = [plugin(
+            "Service",
+            &[&["enable", "disable"], &["équipe", "écran"]],
+        )];
+        let mut state = None;
+        let mut line = "Service enable  é".to_string();
+        tab(&mut state, &mut line, CompletionDirection::Next, &plugins);
+        assert_eq!(line, "Service enable  écran");
+        tab(&mut state, &mut line, CompletionDirection::Next, &plugins);
+        assert_eq!(line, "Service enable  équipe");
+        state = None;
+        line.push(' ');
+        let original = line.clone();
+        tab(&mut state, &mut line, CompletionDirection::Next, &plugins);
+        assert_eq!(line, original);
+    }
+
+    #[test]
+    fn hidden_legacy_and_shadowed_plugin_commands_have_no_argument_choices() {
+        let mut hidden = plugin("Hidden", &[&["value"]]);
+        hidden.metadata.visible = false;
+        let mut legacy = plugin("Legacy", &[&["value"]]);
+        legacy.metadata.arguments = false;
+        let plugins = [
+            hidden,
+            legacy,
+            plugin("Copilot", &[&["evil"]]),
+            plugin("quit", &[&["value"]]),
+        ];
+        for input in ["Hidden v", "Legacy v", "Copilot ev", "quit v"] {
+            let mut line = input.to_string();
+            tab(&mut None, &mut line, CompletionDirection::Next, &plugins);
+            assert_eq!(line, input);
+        }
+    }
+
+    #[test]
+    fn file_completion_preserves_aliases_prefixes_and_directory_order() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::create_dir(directory.path().join("zdir")).unwrap();
+        fs::write(directory.path().join("afile"), "").unwrap();
+        for command in [
+            "e", "edit", "w", "write", "sp", "split", "vs", "vsplit", "e!",
+        ] {
+            let mut state = None;
+            let mut line = format!("{command} {}/", directory.path().display());
+            tab(&mut state, &mut line, CompletionDirection::Next, &[]);
+            assert_eq!(
+                line,
+                format!("{command} {}/zdir/", directory.path().display())
+            );
+            tab(&mut state, &mut line, CompletionDirection::Next, &[]);
+            assert_eq!(
+                line,
+                format!("{command} {}/afile", directory.path().display())
+            );
+        }
+        assert_eq!(completed("e ."), "e ./");
+        assert_eq!(completed("e .."), "e ../");
+    }
+
+    #[test]
+    fn file_completion_keeps_paths_containing_spaces() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::create_dir(directory.path().join("a directory")).unwrap();
+        fs::write(directory.path().join("a directory/file.rs"), "").unwrap();
+        let mut state = None;
+        let mut line = format!("e {}/a d", directory.path().display());
+        tab(&mut state, &mut line, CompletionDirection::Next, &[]);
+        assert_eq!(
+            line,
+            format!("e {}/a directory/", directory.path().display())
+        );
+        tab(&mut state, &mut line, CompletionDirection::Next, &[]);
+        assert_eq!(
+            line,
+            format!("e {}/a directory/file.rs", directory.path().display())
+        );
+    }
+
+    #[test]
+    fn context_preserves_whitespace_and_byte_boundaries() {
+        let context = ArgumentContext::parse("Service  one\u{2003}é").unwrap();
+        assert_eq!(context.preceding, ["one"]);
+        assert_eq!(context.fragment, "é");
+        assert_eq!(&"Service  one\u{2003}é"[context.replacement], "é");
+    }
+}

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -1344,23 +1344,9 @@ fn display_key(key: &str) -> &str {
     }
 }
 
-fn colon_name_is_builtin(name: &str) -> bool {
-    matches!(
-        name,
-        "commands"
-            | "command-palette"
-            | "whats-new"
-            | "changelog"
-            | "db"
-            | "dh"
-            | "di"
-            | "dc"
-            | "dt"
-            | "registers"
-            | "undotree"
-            | "j"
-            | "join"
-    ) || command::parse(BUILTIN_COLON_COMMANDS, name).is_some()
+pub(crate) fn colon_name_is_builtin(name: &str) -> bool {
+    SPECIAL_BUILTIN_COLON_COMMANDS.contains(&name)
+        || command::parse(BUILTIN_COLON_COMMANDS, name).is_some()
 }
 
 fn humanize_identifier(identifier: &str) -> String {

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -48,6 +48,7 @@ pub(crate) const BUILTIN_COLON_COMMANDS: &[&str] = &[
 ];
 
 const SPECIAL_BUILTIN_COLON_COMMANDS: &[&str] = &[
+    "Copilot",
     "InlineHistory",
     "inline-history",
     "InlineHistoryExport",
@@ -391,6 +392,33 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Some(":messages"),
             &["notifications", "message history", "errors"],
             Action::OpenMessages,
+        ),
+        builtin(
+            "ai.copilot",
+            "Copilot status",
+            "AI",
+            "Manage inline AI completions",
+            Some(":Copilot status"),
+            &["autocomplete", "ghost text"],
+            Action::Copilot("status".into()),
+        ),
+        builtin(
+            "ai.copilot_signin",
+            "Sign in to Copilot",
+            "AI",
+            "Authenticate the official GitHub Copilot language server",
+            Some(":Copilot signin"),
+            &[],
+            Action::Copilot("signin".into()),
+        ),
+        builtin(
+            "ai.inline_completion",
+            "Request inline completion",
+            "AI",
+            "Request an AI suggestion at the cursor",
+            Some(":Copilot complete"),
+            &[],
+            Action::Command("Copilot complete".into()),
         ),
         builtin(
             "editor.inline_history",

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,6 +255,9 @@ pub struct Config {
     /// Insert-mode completion sources and automatic triggering.
     #[serde(default)]
     pub completion: CompletionConfig,
+    /// Opt-in AI inline completion, independent of ordinary language servers.
+    #[serde(default)]
+    pub copilot: crate::copilot::CopilotConfig,
     /// Picker layout behavior.
     #[serde(default)]
     pub picker: PickerConfig,
@@ -1826,6 +1829,7 @@ fn known_top_level_field(field: &str) -> bool {
             | "persist_inline_history"
             | "search"
             | "completion"
+            | "copilot"
             | "picker"
             | "statusline"
             | "key_hints"
@@ -1985,6 +1989,10 @@ fn known_schema_path(path: &[String]) -> bool {
                 | "debounce_ms"
                 | "buffer_words"
                 | "max_buffer_words"
+        ),
+        ["copilot", field] => matches!(
+            *field,
+            "enabled" | "command" | "args" | "debounce_ms" | "max_file_bytes" | "excluded_patterns"
         ),
         ["picker", "input_position"] => true,
         ["picker", "icons", field] => matches!(*field, "style" | "color"),
@@ -3967,6 +3975,21 @@ max_buffer_words = 20
         assert_eq!(config.completion.debounce_ms, 250);
         assert!(!config.completion.buffer_words);
         assert_eq!(config.completion.max_buffer_words, 20);
+    }
+
+    #[test]
+    fn copilot_configuration_is_opt_in_and_accepts_overrides() {
+        let defaults = Config::from_user_toml_with_overrides("", &[]).unwrap();
+        assert!(!defaults.copilot.enabled);
+        let config = Config::from_user_toml_with_overrides(
+            "[copilot]\nenabled = true\ncommand = 'custom-copilot'\ndebounce_ms = 250\n",
+            &[],
+        )
+        .unwrap();
+        assert!(config.copilot.enabled);
+        assert_eq!(config.copilot.command, "custom-copilot");
+        assert_eq!(config.copilot.debounce_ms, 250);
+        assert!(known_top_level_field("copilot"));
     }
 
     #[test]

--- a/src/copilot.rs
+++ b/src/copilot.rs
@@ -25,6 +25,50 @@ use crate::{
     undo::TextPosition,
 };
 
+/// Operations accepted by the `:Copilot` command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CopilotCommand {
+    Enable,
+    Disable,
+    SignIn,
+    SignOut,
+    Status,
+    Restart,
+    Complete,
+}
+
+impl CopilotCommand {
+    pub(crate) const ALL: &[(Self, &str)] = &[
+        (Self::Enable, "enable"),
+        (Self::Disable, "disable"),
+        (Self::SignIn, "signin"),
+        (Self::SignOut, "signout"),
+        (Self::Status, "status"),
+        (Self::Restart, "restart"),
+        (Self::Complete, "complete"),
+    ];
+
+    pub(crate) fn parse(input: &str) -> Option<Self> {
+        if input.is_empty() {
+            return Some(Self::Status);
+        }
+        Self::ALL
+            .iter()
+            .find_map(|(command, name)| (*name == input).then_some(*command))
+    }
+
+    pub(crate) fn usage() -> String {
+        format!(
+            "Usage: Copilot {}",
+            Self::ALL
+                .iter()
+                .map(|(_, name)| *name)
+                .collect::<Vec<_>>()
+                .join("|")
+        )
+    }
+}
+
 const MAX_SUGGESTION_BYTES: usize = 64 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 

--- a/src/copilot.rs
+++ b/src/copilot.rs
@@ -107,10 +107,25 @@ impl Default for CopilotConfig {
 
 impl CopilotConfig {
     pub(crate) fn allows(&self, root: &Path, path: &Path, bytes: usize) -> bool {
-        if bytes > self.max_file_bytes || !path.starts_with(root) {
+        if bytes > self.max_file_bytes {
             return false;
         }
-        let mut builder = GitignoreBuilder::new(root);
+        let Ok(canonical_root) = root.canonicalize() else {
+            return false;
+        };
+        // Windows canonical paths have a verbatim prefix, while document URIs
+        // round-trip to ordinary drive paths. Compare both lexical names in the
+        // same document-path form, without resolving away excluded aliases.
+        let Some(lexical_root) = normalized_document_path(root) else {
+            return false;
+        };
+        let Some(lexical_path) = normalized_document_path(path) else {
+            return false;
+        };
+        let Ok(relative_path) = lexical_path.strip_prefix(&lexical_root) else {
+            return false;
+        };
+        let mut builder = GitignoreBuilder::new(&canonical_root);
         builder.allow_unclosed_class(false);
         for pattern in &self.excluded_patterns {
             if builder.add_line(None, pattern).is_err() {
@@ -120,7 +135,10 @@ impl CopilotConfig {
         let Ok(ignore) = builder.build() else {
             return false;
         };
-        if ignore.matched_path_or_any_parents(path, false).is_ignore() {
+        if ignore
+            .matched_path_or_any_parents(relative_path, false)
+            .is_ignore()
+        {
             return false;
         }
         // A harmless-looking symlink must not bypass either workspace confinement
@@ -134,15 +152,24 @@ impl CopilotConfig {
                 .join(path.file_name().unwrap_or_default()))
         });
         match resolved {
-            Ok(resolved) => {
-                resolved.starts_with(root)
-                    && !ignore
-                        .matched_path_or_any_parents(&resolved, false)
+            Ok(resolved) => resolved
+                .strip_prefix(&canonical_root)
+                .is_ok_and(|relative| {
+                    !ignore
+                        .matched_path_or_any_parents(relative, false)
                         .is_ignore()
-            }
+                }),
             Err(_) => false,
         }
     }
+}
+
+/// Uses the same lexical path representation as buffer document URIs.
+fn normalized_document_path(path: &Path) -> Option<PathBuf> {
+    let uri = file_uri(path).ok()?;
+    crate::lsp::normalized_file_path(&uri)
+        .ok()
+        .map(PathBuf::from)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -696,6 +723,55 @@ mod tests {
         config.excluded_patterns.push("[".into());
         assert!(!config.allows(root, &root.join("main.rs"), 100));
     }
+    #[test]
+    fn document_uri_paths_preserve_workspace_privacy() {
+        let config = CopilotConfig::default();
+        let directory = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = directory.path().canonicalize().unwrap();
+        std::fs::create_dir(root.join("src")).unwrap();
+        std::fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(root.join(".env.local"), "secret").unwrap();
+        let document_path = |path: &Path| {
+            PathBuf::from(crate::lsp::normalized_file_path(&file_uri(path).unwrap()).unwrap())
+        };
+        let uri_root = document_path(&root);
+        let existing = document_path(&root.join("src/main.rs"));
+        let unsaved = document_path(&root.join("src/new.rs"));
+        let excluded = document_path(&root.join(".env.local"));
+        let outside_file = document_path(&outside.path().join("main.rs"));
+        for workspace in [&root, &uri_root] {
+            assert!(
+                config.allows(workspace, &existing, 100),
+                "{workspace:?}: {existing:?}"
+            );
+            assert!(config.allows(workspace, &unsaved, 100));
+            assert!(!config.allows(workspace, &excluded, 100));
+            assert!(!config.allows(workspace, &outside_file, 100));
+            assert!(!config.allows(workspace, &existing, config.max_file_bytes + 1));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_aliases_keep_lexical_and_resolved_exclusions() {
+        use std::os::unix::fs::symlink;
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("workspace");
+        let alias = directory.path().join("alias");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("main.rs"), "source").unwrap();
+        std::fs::write(root.join(".env.local"), "secret").unwrap();
+        symlink(&root, &alias).unwrap();
+        symlink(root.join("main.rs"), root.join(".env")).unwrap();
+        symlink(root.join(".env.local"), root.join("looks-safe.rs")).unwrap();
+        let config = CopilotConfig::default();
+        assert!(config.allows(&alias, &alias.join("main.rs"), 6));
+        assert!(config.allows(&alias, &alias.join("new.rs"), 6));
+        assert!(!config.allows(&alias, &alias.join(".env"), 6));
+        assert!(!config.allows(&alias, &alias.join("looks-safe.rs"), 6));
+    }
+
     #[test]
     fn document_end_uses_utf16() {
         assert_eq!(

--- a/src/copilot.rs
+++ b/src/copilot.rs
@@ -1,0 +1,866 @@
+//! Opt-in Copilot transport. The editor owns consent, snapshots, and text mutation;
+//! this worker owns the official language server and its JSON-RPC lifecycle.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use ignore::gitignore::GitignoreBuilder;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::{
+    io::{AsyncWrite, AsyncWriteExt, BufReader},
+    process::Command,
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
+
+use crate::{
+    buffer::BufferId,
+    lsp::{file_uri, Position, Range},
+    undo::TextPosition,
+};
+
+const MAX_SUGGESTION_BYTES: usize = 64 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct CopilotConfig {
+    /// Enables transmission of eligible source files to GitHub Copilot.
+    pub enabled: bool,
+    /// Official language-server executable, invoked without a shell.
+    pub command: String,
+    pub args: Vec<String>,
+    pub debounce_ms: u64,
+    pub max_file_bytes: usize,
+    /// Gitignore-style patterns for documents Red never syncs to the provider.
+    pub excluded_patterns: Vec<String>,
+}
+
+impl Default for CopilotConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            command: "copilot-language-server".into(),
+            args: vec!["--stdio".into()],
+            debounce_ms: 150,
+            max_file_bytes: 256 * 1024,
+            excluded_patterns: vec![
+                ".env".into(),
+                ".env.*".into(),
+                "*.pem".into(),
+                "*.key".into(),
+                "**/.git/**".into(),
+            ],
+        }
+    }
+}
+
+impl CopilotConfig {
+    pub(crate) fn allows(&self, root: &Path, path: &Path, bytes: usize) -> bool {
+        if bytes > self.max_file_bytes || !path.starts_with(root) {
+            return false;
+        }
+        let mut builder = GitignoreBuilder::new(root);
+        builder.allow_unclosed_class(false);
+        for pattern in &self.excluded_patterns {
+            if builder.add_line(None, pattern).is_err() {
+                return false;
+            }
+        }
+        let Ok(ignore) = builder.build() else {
+            return false;
+        };
+        if ignore.matched_path_or_any_parents(path, false).is_ignore() {
+            return false;
+        }
+        // A harmless-looking symlink must not bypass either workspace confinement
+        // or exclusions on its real target. New files resolve through their parent.
+        let resolved: std::io::Result<PathBuf> = path.canonicalize().or_else(|_| {
+            let parent = path
+                .parent()
+                .ok_or_else(|| std::io::Error::other("missing parent"))?;
+            Ok(parent
+                .canonicalize()?
+                .join(path.file_name().unwrap_or_default()))
+        });
+        match resolved {
+            Ok(resolved) => {
+                resolved.starts_with(root)
+                    && !ignore
+                        .matched_path_or_any_parents(&resolved, false)
+                        .is_ignore()
+            }
+            Err(_) => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Snapshot {
+    pub generation: u64,
+    pub buffer_id: BufferId,
+    pub revision: u64,
+    pub cursor: TextPosition,
+    pub uri: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CompletionRequest {
+    pub snapshot: Snapshot,
+    pub language_id: String,
+    pub contents: String,
+    pub position: Position,
+    pub tab_size: usize,
+    pub insert_spaces: bool,
+    pub automatic: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CompletionItem {
+    pub insert_text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<Value>,
+    /// Preserve provider extensions when reporting the full displayed item.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug)]
+pub(crate) enum Control {
+    SignIn,
+    FinishSignIn(Value),
+    SignOut,
+    Shown(CompletionItem),
+    Accepted(CompletionItem),
+    Respond { id: Value, result: Value },
+}
+
+#[derive(Debug)]
+pub(crate) enum Event {
+    Status(String),
+    SignIn {
+        user_code: String,
+        command: Value,
+    },
+    Message {
+        id: Value,
+        message: String,
+        actions: Vec<Value>,
+    },
+    Completion {
+        snapshot: Snapshot,
+        items: Vec<CompletionItem>,
+    },
+    Stopped(String),
+}
+
+pub(crate) struct Bridge {
+    desired: watch::Sender<Option<CompletionRequest>>,
+    controls: mpsc::Sender<Control>,
+    events: mpsc::Receiver<Event>,
+    worker: JoinHandle<()>,
+}
+
+impl Bridge {
+    #[cfg(test)]
+    pub(crate) fn test_channels() -> (
+        Self,
+        watch::Receiver<Option<CompletionRequest>>,
+        mpsc::Receiver<Control>,
+        mpsc::Sender<Event>,
+    ) {
+        let (desired, requests) = watch::channel(None);
+        let (controls, commands) = mpsc::channel(32);
+        let (events_tx, events) = mpsc::channel(32);
+        let worker = tokio::spawn(std::future::pending());
+        (
+            Self {
+                desired,
+                controls,
+                events,
+                worker,
+            },
+            requests,
+            commands,
+            events_tx,
+        )
+    }
+    pub fn start(config: CopilotConfig, root: PathBuf) -> Self {
+        let (desired, requests) = watch::channel(None);
+        let (controls, commands) = mpsc::channel(32);
+        let (events_tx, events) = mpsc::channel(32);
+        let worker = tokio::spawn(async move {
+            let result = run(config, root, requests, commands, events_tx.clone()).await;
+            let message = match result {
+                Ok(()) => "Copilot stopped".to_string(),
+                Err(error) => format!("Copilot: {error:#}"),
+            };
+            let _ = events_tx.send(Event::Stopped(message)).await;
+        });
+        Self {
+            desired,
+            controls,
+            events,
+            worker,
+        }
+    }
+
+    pub fn request(&self, request: CompletionRequest) {
+        self.desired.send_replace(Some(request));
+    }
+    pub fn cancel(&self) {
+        self.desired.send_replace(None);
+    }
+    pub fn control(&self, command: Control) -> Result<()> {
+        self.controls
+            .try_send(command)
+            .map_err(|_| anyhow!("Copilot is busy or stopped"))
+    }
+    pub fn poll(&mut self) -> Option<Event> {
+        self.events.try_recv().ok()
+    }
+}
+
+impl Drop for Bridge {
+    fn drop(&mut self) {
+        self.worker.abort();
+    }
+}
+
+struct ReaderTask(JoinHandle<()>);
+impl Drop for ReaderTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+struct Document {
+    uri: String,
+    contents: String,
+    version: u64,
+}
+enum Pending {
+    Initialize,
+    SignIn,
+    Completion(Snapshot),
+    Other,
+}
+
+struct Protocol<W> {
+    writer: W,
+    next_id: u64,
+    pending: HashMap<u64, Pending>,
+    completion: Option<(u64, tokio::time::Instant)>,
+    document: Option<Document>,
+}
+
+impl<W: AsyncWrite + Unpin> Protocol<W> {
+    async fn send(&mut self, value: Value) -> Result<()> {
+        let body = serde_json::to_vec(&value)?;
+        self.writer
+            .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
+            .await?;
+        self.writer.write_all(&body).await?;
+        self.writer.flush().await?;
+        Ok(())
+    }
+    async fn notify(&mut self, method: &str, params: Value) -> Result<()> {
+        self.send(json!({"jsonrpc":"2.0", "method":method, "params":params}))
+            .await
+    }
+    async fn request(&mut self, method: &str, params: Value, pending: Pending) -> Result<u64> {
+        self.next_id += 1;
+        let id = self.next_id;
+        self.send(json!({"jsonrpc":"2.0", "id":id, "method":method, "params":params}))
+            .await?;
+        if !matches!(pending, Pending::Other) {
+            self.pending.insert(id, pending);
+        }
+        Ok(id)
+    }
+    async fn respond(&mut self, id: Value, result: Value) -> Result<()> {
+        self.send(json!({"jsonrpc":"2.0", "id":id, "result":result}))
+            .await
+    }
+    async fn cancel(&mut self) -> Result<()> {
+        if let Some((id, _)) = self.completion.take() {
+            self.pending.remove(&id);
+            self.notify("$/cancelRequest", json!({"id":id})).await?;
+        }
+        Ok(())
+    }
+    async fn complete(&mut self, request: CompletionRequest) -> Result<()> {
+        self.cancel().await?;
+        let uri = &request.snapshot.uri;
+        if self
+            .document
+            .as_ref()
+            .is_some_and(|document| &document.uri != uri)
+        {
+            let old = self.document.take().expect("document exists");
+            self.notify(
+                "textDocument/didClose",
+                json!({"textDocument":{"uri":old.uri}}),
+            )
+            .await?;
+        }
+        if let Some(document) = self.document.as_ref() {
+            if document.contents != request.contents {
+                let end = end_position(&document.contents);
+                let version = document.version + 1;
+                self.notify("textDocument/didChange", json!({
+                    "textDocument":{"uri":uri,"version":version},
+                    "contentChanges":[{"range":{"start":{"line":0,"character":0},"end":end},"text":request.contents}]
+                })).await?;
+                self.document = Some(Document {
+                    uri: uri.clone(),
+                    contents: request.contents,
+                    version,
+                });
+            }
+        } else {
+            self.notify(
+                "textDocument/didOpen",
+                json!({"textDocument":{
+                    "uri":uri,"languageId":request.language_id,"version":1,"text":request.contents
+                }}),
+            )
+            .await?;
+            self.document = Some(Document {
+                uri: uri.clone(),
+                contents: request.contents,
+                version: 1,
+            });
+        }
+        self.notify("textDocument/didFocus", json!({"textDocument":{"uri":uri}}))
+            .await?;
+        let version = self
+            .document
+            .as_ref()
+            .expect("document was synchronized")
+            .version;
+        let id = self.request("textDocument/inlineCompletion", json!({
+            "textDocument":{"uri":uri,"version":version},"position":request.position,
+            "context":{"triggerKind":if request.automatic {2} else {1}},
+            "formattingOptions":{"tabSize":request.tab_size,"insertSpaces":request.insert_spaces}
+        }), Pending::Completion(request.snapshot)).await?;
+        self.completion = Some((id, tokio::time::Instant::now() + REQUEST_TIMEOUT));
+        Ok(())
+    }
+    async fn control(&mut self, control: Control) -> Result<()> {
+        match control {
+            Control::SignIn => {
+                self.request("signIn", json!({}), Pending::SignIn).await?;
+            }
+            Control::SignOut => {
+                self.cancel().await?;
+                self.request("signOut", json!({}), Pending::Other).await?;
+            }
+            Control::FinishSignIn(command) => {
+                if command.get("command").and_then(Value::as_str)
+                    == Some("github.copilot.finishDeviceFlow")
+                {
+                    self.request("workspace/executeCommand", command, Pending::Other)
+                        .await?;
+                }
+            }
+            Control::Shown(item) => {
+                self.notify("textDocument/didShowCompletion", json!({"item":item}))
+                    .await?
+            }
+            Control::Accepted(item) => {
+                if let Some(command) = item.command.filter(|command| {
+                    command.get("command").and_then(Value::as_str)
+                        == Some("github.copilot.didAcceptCompletionItem")
+                }) {
+                    self.request("workspace/executeCommand", command, Pending::Other)
+                        .await?;
+                }
+            }
+            Control::Respond { id, result } => self.respond(id, result).await?,
+        }
+        Ok(())
+    }
+}
+
+fn end_position(text: &str) -> Position {
+    let line = text.bytes().filter(|byte| *byte == b'\n').count();
+    let tail = text.rsplit('\n').next().unwrap_or_default();
+    Position {
+        line,
+        character: tail.encode_utf16().count(),
+    }
+}
+
+async fn run(
+    config: CopilotConfig,
+    root: PathBuf,
+    mut requests: watch::Receiver<Option<CompletionRequest>>,
+    mut controls: mpsc::Receiver<Control>,
+    events: mpsc::Sender<Event>,
+) -> Result<()> {
+    let mut child = Command::new(&config.command).args(&config.args).current_dir(&root)
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null()).kill_on_drop(true)
+        .spawn().with_context(|| format!("could not start {}; install @github/copilot-language-server or configure [copilot].command", config.command))?;
+    let stdout = child.stdout.take().context("missing Copilot stdout")?;
+    let writer = child.stdin.take().context("missing Copilot stdin")?;
+    let (messages_tx, mut messages) = mpsc::channel(32);
+    let _reader = ReaderTask(tokio::spawn(async move {
+        let mut reader = BufReader::new(stdout);
+        loop {
+            let result = match crate::lsp::client::read_lsp_frame(&mut reader).await {
+                Ok(Some(body)) => {
+                    serde_json::from_slice::<Value>(&body).map_err(anyhow::Error::from)
+                }
+                Ok(None) => break,
+                Err(error) => Err(error.into()),
+            };
+            let failed = result.is_err();
+            if messages_tx.send(result).await.is_err() || failed {
+                break;
+            }
+        }
+    }));
+    let mut protocol = Protocol {
+        writer,
+        next_id: 0,
+        pending: HashMap::new(),
+        completion: None,
+        document: None,
+    };
+    protocol.request("initialize",json!({
+        "processId":std::process::id(),"rootUri":file_uri(&root)?,
+        "workspaceFolders":[{"uri":file_uri(&root)?,"name":root.file_name().unwrap_or_default().to_string_lossy()}],
+        "capabilities":{"workspace":{"workspaceFolders":true,"configuration":true}},
+        "initializationOptions":{"editorInfo":{"name":"Red","version":env!("CARGO_PKG_VERSION")},"editorPluginInfo":{"name":"Red Copilot","version":env!("CARGO_PKG_VERSION")}}
+    }),Pending::Initialize).await?;
+    let mut initialized = false;
+    let mut deferred_controls = Vec::new();
+    let initialize_deadline = tokio::time::Instant::now() + REQUEST_TIMEOUT;
+    let mut tick = tokio::time::interval(Duration::from_millis(100));
+    loop {
+        tokio::select! {
+            changed = requests.changed(), if initialized => {
+                if changed.is_err() { break; }
+                let request = requests.borrow_and_update().clone();
+                if let Some(request) = request { protocol.complete(request).await?; }
+                else { protocol.cancel().await?; }
+            }
+            command = controls.recv() => {
+                let Some(command) = command else { break; };
+                if initialized { protocol.control(command).await?; }
+                else if deferred_controls.len() < 32 { deferred_controls.push(command); }
+            }
+            message = messages.recv() => {
+                let value = message.context("language server closed its output")??;
+                if handle_message(&mut protocol, value, &events).await? {
+                    initialized = true;
+                    for control in deferred_controls.drain(..) {
+                        protocol.control(control).await?;
+                    }
+                }
+            }
+            _ = tick.tick() => {
+                if !initialized && tokio::time::Instant::now()>=initialize_deadline {bail!("initialization timed out");}
+                if protocol.completion.is_some_and(|(_,deadline)|tokio::time::Instant::now()>=deadline) {protocol.cancel().await?;}
+                if let Some(status)=child.try_wait()? {bail!("language server exited with {status}");}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn provider_settings() -> Value {
+    json!({"telemetry": {"telemetryLevel": "off"}})
+}
+
+/// Returns true only after processing a successful initialization response.
+async fn handle_message<W: AsyncWrite + Unpin>(
+    protocol: &mut Protocol<W>,
+    value: Value,
+    events: &mpsc::Sender<Event>,
+) -> Result<bool> {
+    if let Some(method) = value.get("method").and_then(Value::as_str) {
+        let params = &value["params"];
+        if let Some(id) = value.get("id") {
+            match method {
+                "workspace/configuration" => {
+                    let settings = provider_settings();
+                    let result = params["items"]
+                        .as_array()
+                        .into_iter()
+                        .flatten()
+                        .map(|item| match item["section"].as_str() {
+                            Some("telemetry") => settings["telemetry"].clone(),
+                            Some("telemetry.telemetryLevel") => json!("off"),
+                            None => settings.clone(),
+                            _ => Value::Null,
+                        })
+                        .collect::<Vec<_>>();
+                    protocol.respond(id.clone(), json!(result)).await?;
+                }
+                "window/showMessageRequest" => {
+                    events
+                        .send(Event::Message {
+                            id: id.clone(),
+                            message: bounded_message(
+                                params["message"].as_str().unwrap_or("Copilot notification"),
+                            ),
+                            actions: params["actions"]
+                                .as_array()
+                                .into_iter()
+                                .flatten()
+                                .take(16)
+                                .cloned()
+                                .collect(),
+                        })
+                        .await?;
+                }
+                "window/showDocument" => {
+                    protocol
+                        .respond(id.clone(), json!({"success": false}))
+                        .await?;
+                }
+                "workspace/applyEdit" => {
+                    protocol
+                        .respond(
+                            id.clone(),
+                            json!({
+                                "applied": false,
+                                "failureReason": "Copilot edits require explicit user acceptance",
+                            }),
+                        )
+                        .await?;
+                }
+                _ => {
+                    protocol
+                        .send(json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "error": {"code": -32601, "message": "unsupported client request"},
+                        }))
+                        .await?;
+                }
+            }
+        } else if matches!(method, "didChangeStatus" | "window/showMessage") {
+            let message = params["message"]
+                .as_str()
+                .filter(|text| !text.is_empty())
+                .or_else(|| params["kind"].as_str())
+                .unwrap_or("Ready");
+            events.send(Event::Status(bounded_message(message))).await?;
+        }
+        return Ok(false);
+    }
+    let Some(id) = value["id"].as_u64() else {
+        return Ok(false);
+    };
+    let Some(pending) = protocol.pending.remove(&id) else {
+        return Ok(false);
+    };
+    if protocol
+        .completion
+        .is_some_and(|(current, _)| current == id)
+    {
+        protocol.completion = None;
+    }
+    if !value["error"].is_null() {
+        let message = bounded_message(
+            value["error"]["message"]
+                .as_str()
+                .unwrap_or("request failed"),
+        );
+        if matches!(pending, Pending::Initialize) {
+            bail!("initialization failed: {message}");
+        }
+        events.send(Event::Status(message)).await?;
+        return Ok(false);
+    }
+    let result = &value["result"];
+    match pending {
+        Pending::Initialize => {
+            protocol.notify("initialized", json!({})).await?;
+            protocol
+                .notify(
+                    "workspace/didChangeConfiguration",
+                    json!({"settings": provider_settings()}),
+                )
+                .await?;
+            events.send(Event::Status("Ready".into())).await?;
+            return Ok(true);
+        }
+        Pending::SignIn => {
+            if let Some(code) = result["userCode"].as_str() {
+                events
+                    .send(Event::SignIn {
+                        user_code: bounded_message(code),
+                        command: result["command"].clone(),
+                    })
+                    .await?;
+            } else {
+                events
+                    .send(Event::Status("Already signed in".into()))
+                    .await?;
+            }
+        }
+        Pending::Completion(snapshot) => {
+            let items = result["items"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .take(8)
+                .filter_map(|item| serde_json::from_value::<CompletionItem>(item.clone()).ok())
+                .filter(|item| item.insert_text.len() <= MAX_SUGGESTION_BYTES)
+                .collect();
+            events.send(Event::Completion { snapshot, items }).await?;
+        }
+        Pending::Other => {}
+    }
+    Ok(false)
+}
+
+fn bounded_message(message: &str) -> String {
+    message
+        .chars()
+        .filter(|ch| !ch.is_control() || matches!(ch, '\n' | '\t'))
+        .take(1000)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn privacy_defaults_and_invalid_patterns_fail_closed() {
+        let mut config = CopilotConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let root = root.as_path();
+        assert!(!config.enabled);
+        assert!(config.allows(root, &root.join("main.rs"), 100));
+        assert!(!config.allows(root, &root.join(".env.local"), 100));
+        assert!(!config.allows(root, Path::new("/outside/main.rs"), 100));
+        assert!(!config.allows(root, &root.join("main.rs"), config.max_file_bytes + 1));
+        config.excluded_patterns.push("[".into());
+        assert!(!config.allows(root, &root.join("main.rs"), 100));
+    }
+    #[test]
+    fn document_end_uses_utf16() {
+        assert_eq!(
+            end_position("a\r\n😀"),
+            Position {
+                line: 1,
+                character: 2
+            }
+        );
+        assert_eq!(
+            end_position("a\n"),
+            Position {
+                line: 1,
+                character: 0
+            }
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_cannot_bypass_exclusions_or_workspace_boundary() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        std::fs::write(root.join(".env"), "secret").unwrap();
+        std::fs::write(outside.path().join("source.rs"), "private").unwrap();
+        symlink(root.join(".env"), root.join("looks-safe.rs")).unwrap();
+        symlink(outside.path().join("source.rs"), root.join("outside.rs")).unwrap();
+        let config = CopilotConfig::default();
+        assert!(!config.allows(&root, &root.join("looks-safe.rs"), 6));
+        assert!(!config.allows(&root, &root.join("outside.rs"), 7));
+    }
+
+    fn request(generation: u64, uri: &str, text: &str) -> CompletionRequest {
+        CompletionRequest {
+            snapshot: Snapshot {
+                generation,
+                buffer_id: crate::buffer::Buffer::new(None, String::new()).id(),
+                revision: generation,
+                cursor: TextPosition::new(0, 0),
+                uri: uri.into(),
+            },
+            language_id: "rust".into(),
+            contents: text.into(),
+            position: Position {
+                line: 0,
+                character: 0,
+            },
+            tab_size: 4,
+            insert_spaces: true,
+            automatic: true,
+        }
+    }
+
+    async fn read(reader: &mut BufReader<tokio::io::DuplexStream>) -> Value {
+        let body = crate::lsp::client::read_lsp_frame(reader)
+            .await
+            .unwrap()
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn protocol_syncs_cancels_and_closes_documents() {
+        let (writer, reader) = tokio::io::duplex(64 * 1024);
+        let mut reader = BufReader::new(reader);
+        let mut protocol = Protocol {
+            writer,
+            next_id: 0,
+            pending: HashMap::new(),
+            completion: None,
+            document: None,
+        };
+        protocol
+            .complete(request(1, "file:///workspace/a.rs", "😀"))
+            .await
+            .unwrap();
+        assert_eq!(read(&mut reader).await["method"], "textDocument/didOpen");
+        assert_eq!(read(&mut reader).await["method"], "textDocument/didFocus");
+        let first = read(&mut reader).await;
+        assert_eq!(first["method"], "textDocument/inlineCompletion");
+        assert_eq!(first["params"]["textDocument"]["version"], 1);
+        protocol
+            .complete(request(2, "file:///workspace/a.rs", "😀x"))
+            .await
+            .unwrap();
+        let cancel = read(&mut reader).await;
+        assert_eq!(cancel["method"], "$/cancelRequest");
+        assert_eq!(cancel["params"]["id"], first["id"]);
+        let change = read(&mut reader).await;
+        assert_eq!(
+            change["params"]["contentChanges"][0]["range"]["end"]["character"],
+            2
+        );
+        assert_eq!(change["params"]["textDocument"]["version"], 2);
+        assert_eq!(read(&mut reader).await["method"], "textDocument/didFocus");
+        assert_eq!(
+            read(&mut reader).await["method"],
+            "textDocument/inlineCompletion"
+        );
+        protocol
+            .complete(request(3, "file:///workspace/b.rs", "fn b() {}"))
+            .await
+            .unwrap();
+        assert_eq!(read(&mut reader).await["method"], "$/cancelRequest");
+        assert_eq!(read(&mut reader).await["method"], "textDocument/didClose");
+        assert_eq!(read(&mut reader).await["method"], "textDocument/didOpen");
+        assert_eq!(read(&mut reader).await["method"], "textDocument/didFocus");
+        assert_eq!(
+            read(&mut reader).await["params"]["textDocument"]["version"],
+            1
+        );
+        assert_eq!(protocol.pending.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn completion_commands_are_allowlisted() {
+        let (writer, reader) = tokio::io::duplex(4096);
+        let mut reader = BufReader::new(reader);
+        let mut protocol = Protocol {
+            writer,
+            next_id: 0,
+            pending: HashMap::new(),
+            completion: None,
+            document: None,
+        };
+        let mut item = CompletionItem {
+            insert_text: "hello".into(),
+            range: None,
+            command: Some(json!({"command":"dangerous.command"})),
+            extra: serde_json::Map::from_iter([("data".into(), json!({"id":"opaque"}))]),
+        };
+        protocol
+            .control(Control::Accepted(item.clone()))
+            .await
+            .unwrap();
+        assert!(protocol.pending.is_empty());
+        item.command =
+            Some(json!({"command":"github.copilot.didAcceptCompletionItem","arguments":["id"]}));
+        protocol
+            .control(Control::Shown(item.clone()))
+            .await
+            .unwrap();
+        let shown = read(&mut reader).await;
+        assert_eq!(shown["method"], "textDocument/didShowCompletion");
+        assert_eq!(shown["params"]["item"]["data"]["id"], "opaque");
+        protocol.control(Control::Accepted(item)).await.unwrap();
+        assert_eq!(
+            read(&mut reader).await["params"]["command"],
+            "github.copilot.didAcceptCompletionItem"
+        );
+    }
+
+    #[tokio::test]
+    async fn initialization_authentication_and_server_requests_follow_protocol() {
+        let (writer, reader) = tokio::io::duplex(8192);
+        let mut reader = BufReader::new(reader);
+        let mut protocol = Protocol {
+            writer,
+            next_id: 0,
+            pending: HashMap::new(),
+            completion: None,
+            document: None,
+        };
+        let (events, mut received) = mpsc::channel(8);
+        let id = protocol
+            .request("initialize", json!({}), Pending::Initialize)
+            .await
+            .unwrap();
+        assert_eq!(read(&mut reader).await["method"], "initialize");
+        assert!(handle_message(
+            &mut protocol,
+            json!({"id":id,"result":{"capabilities":{}}}),
+            &events
+        )
+        .await
+        .unwrap());
+        assert_eq!(read(&mut reader).await["method"], "initialized");
+        let configuration = read(&mut reader).await;
+        assert_eq!(
+            configuration["params"]["settings"]["telemetry"]["telemetryLevel"],
+            "off"
+        );
+        assert!(matches!(received.recv().await, Some(Event::Status(_))));
+        protocol.control(Control::SignIn).await.unwrap();
+        let signin = read(&mut reader).await;
+        let command = json!({"command":"github.copilot.finishDeviceFlow","arguments":[]});
+        handle_message(
+            &mut protocol,
+            json!({"id":signin["id"],"result":{"userCode":"ABCD-EFGH","command":command}}),
+            &events,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(received.recv().await,Some(Event::SignIn{user_code,..}) if user_code=="ABCD-EFGH")
+        );
+        handle_message(
+            &mut protocol,
+            json!({"id":"edit","method":"workspace/applyEdit","params":{}}),
+            &events,
+        )
+        .await
+        .unwrap();
+        assert_eq!(read(&mut reader).await["result"]["applied"], false);
+        handle_message(&mut protocol,json!({"id":"message","method":"window/showMessageRequest","params":{"message":"Account issue","actions":[{"title":"First"},{"title":"Second"}]}}),&events).await.unwrap();
+        assert!(
+            matches!(received.recv().await,Some(Event::Message{actions,..}) if actions.len()==2)
+        );
+    }
+}

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -83,7 +83,9 @@ use crate::{
     clipboard::{ClipboardProvider, DisabledClipboardProvider, NativeClipboardProvider},
     codex::{start_codex, CodexBridge, CodexCommand, CodexEvent, CodexProcessSpec},
     color::Color,
-    command, command_palette,
+    command,
+    command_completion::{self, CommandCompletionState, CompletionDirection},
+    command_palette,
     comment::CommentSyntax,
     config::{
         Config, ConfigDiagnostic, ConfigDiagnosticSource, ConfigRecovery, FormattingProvider,
@@ -3645,35 +3647,6 @@ impl PromptHistoryNavigation {
         *navigation = Some(state);
         changed
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct CommandCompletionState {
-    replacement_start: usize,
-    replacement_end: usize,
-    candidates: Vec<String>,
-    selected: usize,
-    needs_leading_space: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct CommandCompletionContext {
-    replacement_start: usize,
-    replacement_end: usize,
-    fragment: String,
-    needs_leading_space: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CompletionDirection {
-    Next,
-    Previous,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PathCompletionCandidate {
-    replacement: String,
-    is_dir: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -13580,7 +13553,9 @@ impl Editor {
 
         if cmd == "Copilot" || cmd.starts_with("Copilot ") {
             let command = cmd.strip_prefix("Copilot").unwrap_or_default().trim();
-            return if command == "complete" {
+            return if crate::copilot::CopilotCommand::parse(command)
+                == Some(crate::copilot::CopilotCommand::Complete)
+            {
                 vec![
                     Action::EnterMode(Mode::Insert),
                     Action::RequestInlineCompletion,
@@ -14336,244 +14311,24 @@ impl Editor {
         self.update_search_preview();
     }
 
-    fn command_accepts_file_completion(command: &str) -> bool {
-        matches!(
-            command.trim_end_matches('!'),
-            "e" | "edit" | "w" | "write" | "sp" | "split" | "vs" | "vsplit"
-        )
-    }
-
-    fn command_accepts_syntax_completion(command: &str) -> bool {
-        matches!(command.trim_end_matches('!'), "syntax" | "syn" | "ft")
-    }
-
-    fn command_completion_context(
-        command: &str,
-        accepts_completion: fn(&str) -> bool,
-    ) -> Option<CommandCompletionContext> {
-        let command_start = command
-            .char_indices()
-            .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index))?;
-        let after_leading = &command[command_start..];
-        let command_end = after_leading
-            .char_indices()
-            .find_map(|(index, ch)| ch.is_whitespace().then_some(command_start + index))
-            .unwrap_or(command.len());
-        let command_name = &command[command_start..command_end];
-        if !accepts_completion(command_name) {
-            return None;
-        }
-
-        let args_start = command[command_end..]
-            .char_indices()
-            .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(command_end + index));
-
-        if let Some(replacement_start) = args_start {
-            Some(CommandCompletionContext {
-                replacement_start,
-                replacement_end: command.len(),
-                fragment: command[replacement_start..].to_string(),
-                needs_leading_space: false,
-            })
-        } else {
-            Some(CommandCompletionContext {
-                replacement_start: command_end,
-                replacement_end: command.len(),
-                fragment: String::new(),
-                needs_leading_space: true,
-            })
-        }
-    }
-
-    fn dot_directory_candidate(fragment: &str) -> Option<PathCompletionCandidate> {
-        match fragment {
-            "." => Some(PathCompletionCandidate {
-                replacement: "./".to_string(),
-                is_dir: true,
-            }),
-            ".." => Some(PathCompletionCandidate {
-                replacement: "../".to_string(),
-                is_dir: true,
-            }),
-            "~" if expand_user_path("~").is_ok() => Some(PathCompletionCandidate {
-                replacement: "~/".to_string(),
-                is_dir: true,
-            }),
-            _ => None,
-        }
-    }
-
-    fn path_completion_candidates(fragment: &str) -> Vec<PathCompletionCandidate> {
-        if let Some(candidate) = Self::dot_directory_candidate(fragment) {
-            return vec![candidate];
-        }
-
-        let (directory_fragment, file_prefix) = fragment
-            .rfind('/')
-            .map(|index| (&fragment[..=index], &fragment[index + 1..]))
-            .unwrap_or(("", fragment));
-        let directory_path = if directory_fragment.is_empty() {
-            PathBuf::from(".")
-        } else {
-            expand_user_path(directory_fragment)
-                .unwrap_or_else(|_| PathBuf::from(directory_fragment))
-        };
-
-        let Ok(read_dir) = fs::read_dir(directory_path) else {
-            return Vec::new();
-        };
-
-        let mut candidates = read_dir
-            .filter_map(Result::ok)
-            .filter_map(|entry| {
-                let name = entry.file_name().to_string_lossy().into_owned();
-                if !name.starts_with(file_prefix) {
-                    return None;
-                }
-
-                let is_dir = entry
-                    .file_type()
-                    .map(|file_type| file_type.is_dir())
-                    .unwrap_or(false);
-                let suffix = if is_dir { "/" } else { "" };
-                Some(PathCompletionCandidate {
-                    replacement: format!("{directory_fragment}{name}{suffix}"),
-                    is_dir,
-                })
-            })
-            .collect::<Vec<_>>();
-
-        candidates.sort_by(|a, b| match (a.is_dir, b.is_dir) {
-            (true, false) => Ordering::Less,
-            (false, true) => Ordering::Greater,
-            _ => a.replacement.cmp(&b.replacement),
-        });
-        candidates
-    }
-
-    fn apply_command_completion_candidate(&mut self, candidate: &str) {
-        let Some(completion) = self.command_completion.as_mut() else {
-            return;
-        };
-        let replacement = if completion.needs_leading_space {
-            format!(" {candidate}")
-        } else {
-            candidate.to_string()
-        };
-        self.command.replace_range(
-            completion.replacement_start..completion.replacement_end,
-            &replacement,
-        );
-        completion.replacement_end = completion.replacement_start + replacement.len();
-    }
-
     fn complete_command_line(
         &mut self,
         direction: CompletionDirection,
         plugin_commands: &[plugin::RegisteredPluginCommand],
     ) {
-        if let Some(mut completion) = self.command_completion.take() {
-            if completion.candidates.len() > 1 {
-                completion.selected = match direction {
-                    CompletionDirection::Next => {
-                        (completion.selected + 1) % completion.candidates.len()
-                    }
-                    CompletionDirection::Previous => completion
-                        .selected
-                        .checked_sub(1)
-                        .unwrap_or_else(|| completion.candidates.len() - 1),
-                };
-                self.command_completion = Some(completion);
-                let candidate = self
-                    .command_completion
-                    .as_ref()
-                    .and_then(|state| state.candidates.get(state.selected).cloned());
-                if let Some(candidate) = candidate {
-                    self.apply_command_completion_candidate(&candidate);
-                }
-                return;
-            }
-        }
-
-        let (context, candidates) = if let Some(context) =
-            Self::command_completion_context(&self.command, Self::command_accepts_file_completion)
-        {
-            let candidates = Self::path_completion_candidates(&context.fragment)
-                .into_iter()
-                .map(|candidate| candidate.replacement)
-                .collect::<Vec<_>>();
-            (context, candidates)
-        } else if let Some(context) =
-            Self::command_completion_context(&self.command, Self::command_accepts_syntax_completion)
-        {
-            let fragment = context.fragment.to_ascii_lowercase();
-            let mut candidates = if fragment.chars().any(char::is_whitespace) {
-                Vec::new()
-            } else {
-                ["auto", "off"]
+        command_completion::complete(
+            &mut self.command_completion,
+            &mut self.command,
+            direction,
+            plugin_commands,
+            |fragment| {
+                self.highlighter
+                    .matching_language_ids(fragment)
                     .into_iter()
-                    .filter(|language| language.starts_with(&fragment))
                     .map(str::to_string)
-                    .chain(
-                        self.highlighter
-                            .matching_language_ids(&fragment)
-                            .into_iter()
-                            .map(str::to_string),
-                    )
-                    .collect::<Vec<_>>()
-            };
-            candidates.sort_unstable();
-            candidates.dedup();
-            (context, candidates)
-        } else {
-            let command_start = self
-                .command
-                .char_indices()
-                .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index))
-                .unwrap_or(self.command.len());
-            let fragment = &self.command[command_start..];
-            if fragment.is_empty() || fragment.chars().any(char::is_whitespace) {
-                self.command_completion = None;
-                return;
-            }
-            let candidates = command_palette::colon_completion_names(plugin_commands)
-                .into_iter()
-                .filter(|command| command.starts_with(fragment))
-                .collect::<Vec<_>>();
-            (
-                CommandCompletionContext {
-                    replacement_start: command_start,
-                    replacement_end: self.command.len(),
-                    fragment: fragment.to_string(),
-                    needs_leading_space: false,
-                },
-                candidates,
-            )
-        };
-        if candidates.is_empty() {
-            self.command_completion = None;
-            return;
-        }
-
-        let selected = match direction {
-            CompletionDirection::Next => 0,
-            CompletionDirection::Previous => candidates.len() - 1,
-        };
-
-        self.command_completion = Some(CommandCompletionState {
-            replacement_start: context.replacement_start,
-            replacement_end: context.replacement_end,
-            candidates,
-            selected,
-            needs_leading_space: context.needs_leading_space,
-        });
-        let candidate = self
-            .command_completion
-            .as_ref()
-            .and_then(|state| state.candidates.get(state.selected).cloned());
-        if let Some(candidate) = candidate {
-            self.apply_command_completion_candidate(&candidate);
-        }
+                    .collect()
+            },
+        );
     }
 
     fn record_command_history(&mut self, command: &str) {
@@ -28630,6 +28385,56 @@ builtin = "rust"
             editor.last_error.as_deref(),
             Some("reloaded 1 configured language")
         );
+    }
+
+    #[tokio::test]
+    async fn command_argument_completion_runs_plugin_only_after_enter() {
+        drain_plugin_requests();
+        let mut editor = test_editor(80, 12);
+        let mut buffer = RenderBuffer::new(80, 12, &Style::default());
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin(
+                "argument_completion",
+                r#"
+            #[red::command(name = "Service", arguments = true,
+                completions = [["enable", "disable"], ["local", "workspace"]])]
+            fn service(command: CommandInvocation) {
+                red::execute("Print", format("received: {}", command.raw_args));
+            }
+        "#,
+            )
+            .await
+            .unwrap();
+        editor.test_set_commandline(Mode::Command, "Service en");
+        for key in [
+            KeyCode::Tab,
+            KeyCode::Char(' '),
+            KeyCode::Char('l'),
+            KeyCode::Tab,
+        ] {
+            editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(key, KeyModifiers::NONE)),
+                    &mut buffer,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(editor.command, "Service enable local");
+        assert!(collect_print_requests().is_empty());
+        assert_eq!(editor.last_error, None);
+
+        enter_colon_command(
+            &mut editor,
+            &mut buffer,
+            &mut runtime,
+            "Service enable local",
+        )
+        .await;
+        assert_eq!(editor.last_error.as_deref(), Some("received: enable local"));
     }
 
     #[tokio::test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -13803,8 +13803,8 @@ impl Editor {
             }
 
             if cmd == "write" {
-                if let Some(file) = parsed.args.first() {
-                    actions.push(Action::SaveAs(file.clone()));
+                if let Some(file) = parsed.file_argument() {
+                    actions.push(Action::SaveAs(file));
                 } else {
                     actions.push(Action::Save);
                 }
@@ -13823,8 +13823,8 @@ impl Editor {
             }
 
             if cmd == "edit" {
-                if let Some(file) = parsed.args.first() {
-                    actions.push(Action::OpenFile(file.clone()));
+                if let Some(file) = parsed.file_argument() {
+                    actions.push(Action::OpenFile(file));
                 } else {
                     actions.push(Action::ReloadFile(parsed.is_forced()));
                 }
@@ -13836,8 +13836,8 @@ impl Editor {
                     cmd,
                     parsed.args
                 );
-                if let Some(file) = parsed.args.first() {
-                    actions.push(Action::SplitHorizontalWithFile(file.clone()));
+                if let Some(file) = parsed.file_argument() {
+                    actions.push(Action::SplitHorizontalWithFile(file));
                 } else {
                     actions.push(Action::SplitHorizontal);
                 }
@@ -13849,8 +13849,8 @@ impl Editor {
                     cmd,
                     parsed.args
                 );
-                if let Some(file) = parsed.args.first() {
-                    actions.push(Action::SplitVerticalWithFile(file.clone()));
+                if let Some(file) = parsed.file_argument() {
+                    actions.push(Action::SplitVerticalWithFile(file));
                 } else {
                     actions.push(Action::SplitVertical);
                 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -20,6 +20,7 @@ mod buffer_manager;
 mod diagnostics_picker;
 mod display_layout;
 mod inline_comments;
+mod inline_completion;
 mod inline_history;
 mod lsp_coordinator;
 #[cfg(test)]
@@ -2468,6 +2469,15 @@ pub enum Action {
     BufferText(Value),
 
     RequestCompletion,
+    Copilot(String),
+    RequestInlineCompletion,
+    AcceptInlineCompletion,
+    DismissInlineCompletion,
+    CopilotFinishSignIn(Value),
+    CopilotRespond {
+        id: Value,
+        result: Value,
+    },
     RequestCompletionWithTrigger(char),
     ApplyCompletion {
         item: Box<CompletionResponseItem>,
@@ -2655,6 +2665,7 @@ struct LayoutCacheKey {
     content_height: usize,
     line_count_override: Option<usize>,
     break_indent: BreakIndentOptions,
+    inline_prediction: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -3214,6 +3225,7 @@ pub struct Editor {
     pending_lsp_revision_snapshots: HashMap<i64, Vec<(String, u64)>>,
     pending_completions: HashMap<i64, PendingCompletion>,
     scheduled_completion: Option<ScheduledCompletion>,
+    inline_completion: inline_completion::InlineCompletionState,
     completion_snapshot: Option<CompletionSnapshot>,
 }
 
@@ -3737,6 +3749,7 @@ struct PendingCompletion {
     buffer_items: Vec<CompletionResponseItem>,
     snapshot: CompletionSnapshot,
     displayed_immediately: bool,
+    superseded: bool,
 }
 
 impl From<PendingLspEdit> for CompletionSnapshot {
@@ -4463,6 +4476,7 @@ impl Editor {
             pending_lsp_revision_snapshots: HashMap::new(),
             pending_completions: HashMap::new(),
             scheduled_completion: None,
+            inline_completion: inline_completion::InlineCompletionState::default(),
             completion_snapshot: None,
         })
     }
@@ -5613,6 +5627,9 @@ impl Editor {
         }
 
         let break_indent = self.break_indent_options_for_buffer_index(window.buffer_index);
+        let prediction = self
+            .visible_inline_suggestion()
+            .filter(|suggestion| window.active && suggestion.snapshot.buffer_id == buffer.id());
         let key = LayoutCacheKey {
             buffer_index: window.buffer_index,
             buffer_id: buffer.id(),
@@ -5626,6 +5643,7 @@ impl Editor {
             content_height: self.window_content_height(window),
             line_count_override,
             break_indent,
+            inline_prediction: prediction.map(|suggestion| suggestion.snapshot.generation),
         };
         if let Some(layout) = self.layout_cache.borrow().get(&key) {
             return layout.clone();
@@ -5645,26 +5663,37 @@ impl Editor {
             .iter()
             .map(|(line, message)| (*line, message.as_str()))
             .collect::<Vec<_>>();
-        let layout = std::sync::Arc::new(
-            layout_lines(
-                &lines,
-                line_count,
-                LayoutConfig {
-                    content_width: self.window_content_width(window),
-                    height: self.window_content_height(window),
-                    wrap: window.wrap,
-                    vtop: window.vtop,
-                    vleft: window.vleft,
-                    skipcol: window.skipcol,
-                    break_indent,
-                },
-            )
-            .with_inline_comments(
-                &comments,
-                self.window_content_width(window),
-                self.window_content_height(window),
-            ),
+        let layout_config = LayoutConfig {
+            content_width: self.window_content_width(window),
+            height: self.window_content_height(window),
+            wrap: window.wrap,
+            vtop: window.vtop,
+            vleft: window.vleft,
+            skipcol: window.skipcol,
+            break_indent,
+        };
+        let mut layout = layout_lines(&lines, line_count, layout_config).with_inline_comments(
+            &comments,
+            self.window_content_width(window),
+            self.window_content_height(window),
         );
+        if let Some(suggestion) = prediction {
+            if let Some(line) = buffer.get(suggestion.snapshot.cursor.line) {
+                let line = trim_line_ending(&line);
+                let cursor_byte = line
+                    .char_indices()
+                    .nth(suggestion.snapshot.cursor.character)
+                    .map_or(line.len(), |(byte, _)| byte);
+                layout = layout.with_inline_prediction(
+                    suggestion.snapshot.cursor.line,
+                    line,
+                    cursor_byte,
+                    &suggestion.insertion,
+                    layout_config,
+                );
+            }
+        }
+        let layout = std::sync::Arc::new(layout);
 
         let mut cache = self.layout_cache.borrow_mut();
         if cache.len() >= 32 {
@@ -8720,6 +8749,7 @@ impl Editor {
             }
         }
 
+        let inline_completion_changed = self.service_inline_completion();
         let completion_changed = if self
             .scheduled_completion
             .is_some_and(|scheduled| Instant::now() >= scheduled.deadline)
@@ -8764,7 +8794,8 @@ impl Editor {
         }
         let panel_animation_changed = self.panel_manager.poll_animation();
         let overlay_animation_changed = self.overlay_manager.poll_animation();
-        if completion_changed
+        if inline_completion_changed
+            || completion_changed
             || startup_release_changed
             || dialog_changed
             || keymap_hints_changed
@@ -11551,6 +11582,9 @@ impl Editor {
         &self,
         pending: &PendingCompletion,
     ) -> Option<CompletionSnapshot> {
+        if pending.superseded {
+            return None;
+        }
         if pending.displayed_immediately {
             let active = self.completion_snapshot.as_ref()?;
             let same_session = active.buffer_id == pending.snapshot.buffer_id
@@ -12192,8 +12226,12 @@ impl Editor {
                                         .map(CompletionSnapshot::from)
                                         .unwrap_or_else(|| self.completion_snapshot()),
                                     displayed_immediately: false,
+                                    superseded: false,
                                 }
                             });
+                        if pending.superseded {
+                            return None;
+                        }
                         if pending.displayed_immediately && self.completion_snapshot.is_none() {
                             return None;
                         }
@@ -12308,6 +12346,12 @@ impl Editor {
                 let pending_completion = self.pending_completions.remove(&id);
                 let save = self.pending_lsp_format_saves.remove(&id);
                 self.pending_lsp_revision_snapshots.remove(&id);
+                if pending_completion
+                    .as_ref()
+                    .is_some_and(|pending| pending.superseded)
+                {
+                    return None;
+                }
                 if method.as_deref() == Some("textDocument/completion")
                     && pending_completion
                         .is_some_and(|pending| self.show_completion_fallback(pending))
@@ -12374,6 +12418,12 @@ impl Editor {
                     let pending_completion = self.pending_completions.remove(id);
                     let save = self.pending_lsp_format_saves.remove(id);
                     self.pending_lsp_revision_snapshots.remove(id);
+                    if pending_completion
+                        .as_ref()
+                        .is_some_and(|pending| pending.superseded)
+                    {
+                        return None;
+                    }
                     if method.as_deref() == Some("textDocument/completion")
                         && pending_completion
                             .is_some_and(|pending| self.show_completion_fallback(pending))
@@ -12455,6 +12505,9 @@ impl Editor {
         ev: &event::Event,
         runtime: Option<&Runtime>,
     ) -> anyhow::Result<Option<KeyAction>> {
+        if let Some(action) = self.handle_inline_completion_event(ev) {
+            return Ok(Some(action));
+        }
         // Pointer motion has no editor/pane action. Let dialogs opt into hover
         // handling without clearing an in-progress key sequence or its hints.
         if matches!(
@@ -13524,6 +13577,18 @@ impl Editor {
         self.waiting_command = None;
         self.repeater = None;
         self.set_legacy_message(None);
+
+        if cmd == "Copilot" || cmd.starts_with("Copilot ") {
+            let command = cmd.strip_prefix("Copilot").unwrap_or_default().trim();
+            return if command == "complete" {
+                vec![
+                    Action::EnterMode(Mode::Insert),
+                    Action::RequestInlineCompletion,
+                ]
+            } else {
+                vec![Action::Copilot(command.to_string())]
+            };
+        }
 
         if let Some(commands) = self.scratch_buffers.get(&self.current_buffer().id()) {
             let routed = match cmd.trim() {
@@ -16419,6 +16484,10 @@ impl Editor {
         // log!("Action: {action:?}");
         self.set_legacy_message(None);
         let sensitive_action = matches!(action, Action::NotifyPlugin(_, _, _))
+            || matches!(
+                action,
+                Action::CopilotFinishSignIn(_) | Action::CopilotRespond { .. }
+            )
             || matches!(action, Action::SubmitInlineAssist(_))
             || matches!(action, Action::NotifyPlugins(method, _) if method.starts_with("composer:"));
         if !sensitive_action {
@@ -20109,6 +20178,38 @@ impl Editor {
                     self.render(buffer)?;
                 }
             }
+            Action::Copilot(command) => {
+                add_to_history = false;
+                self.handle_copilot_command(command);
+                self.render(buffer)?;
+            }
+            Action::RequestInlineCompletion => {
+                add_to_history = false;
+                self.request_inline_completion(false);
+                self.render(buffer)?;
+            }
+            Action::AcceptInlineCompletion => {
+                self.accept_inline_completion(runtime).await?;
+                self.render(buffer)?;
+            }
+            Action::DismissInlineCompletion => {
+                add_to_history = false;
+                self.dismiss_inline_completion();
+                self.render(buffer)?;
+            }
+            Action::CopilotFinishSignIn(command) => {
+                add_to_history = false;
+                self.copilot_control(crate::copilot::Control::FinishSignIn(command.clone()));
+                self.render(buffer)?;
+            }
+            Action::CopilotRespond { id, result } => {
+                add_to_history = false;
+                self.copilot_control(crate::copilot::Control::Respond {
+                    id: id.clone(),
+                    result: result.clone(),
+                });
+                self.render(buffer)?;
+            }
             Action::RequestCompletionWithTrigger(trigger_character) => {
                 if self.request_completion(Some(*trigger_character)).await? {
                     self.render(buffer)?;
@@ -21499,6 +21600,7 @@ impl Editor {
             return Ok(());
         }
 
+        self.schedule_inline_completion();
         let file = self.current_buffer().file.clone();
 
         // Notify LSP if enabled and the buffer has a file.
@@ -24574,7 +24676,8 @@ impl Editor {
             self.scheduled_completion = None;
             return;
         };
-        if !self.config.completion.auto_trigger
+        if self.prefers_inline_completion()
+            || !self.config.completion.auto_trigger
             || prefix.chars().count() < self.config.completion.min_prefix_length
         {
             self.scheduled_completion = None;
@@ -24884,6 +24987,7 @@ impl Editor {
             return Ok(false);
         }
 
+        self.dismiss_inline_completion();
         self.scheduled_completion = None;
         let buffer_items = self.buffer_completion_items();
         let snapshot = self.completion_snapshot();
@@ -24937,6 +25041,7 @@ impl Editor {
                         buffer_items,
                         snapshot: pending_snapshot,
                         displayed_immediately,
+                        superseded: false,
                     },
                 );
                 return Ok(displayed_immediately);
@@ -33025,6 +33130,7 @@ builtin = "rust"
                 buffer_items,
                 snapshot: pending_snapshot,
                 displayed_immediately: true,
+                superseded: false,
             },
         );
         let mut render_buffer = RenderBuffer::new(80, 24, &Style::default());
@@ -33074,6 +33180,7 @@ builtin = "rust"
                 buffer_items,
                 snapshot: pending_snapshot,
                 displayed_immediately: true,
+                superseded: false,
             },
         );
         let mut render_buffer = RenderBuffer::new(80, 24, &Style::default());

--- a/src/editor/display_layout.rs
+++ b/src/editor/display_layout.rs
@@ -231,17 +231,31 @@ pub struct InlineCommentRow {
     pub text_offset: usize,
 }
 
+/// One row in a transient insertion preview. Byte offsets refer to the projected
+/// logical line; removing the insertion maps them back to source highlighting.
+#[derive(Debug, Clone)]
+pub(super) struct InlinePredictionRow {
+    pub row: usize,
+    pub text: String,
+    pub display_col: usize,
+    pub visual_offset: usize,
+    pub projected_start: usize,
+    pub insertion: std::ops::Range<usize>,
+    pub source_offset: usize,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct DisplayLayout {
     /// Source segments only. `segment.row` is the physical screen row and may
     /// have gaps occupied by inline comments.
     pub rows: Vec<LineSegment>,
     pub inline_comments: Vec<InlineCommentRow>,
+    pub(super) inline_prediction: Vec<InlinePredictionRow>,
 }
 
 impl DisplayLayout {
     pub fn row(&self, row: usize) -> Option<&LineSegment> {
-        if self.inline_comments.is_empty() {
+        if self.inline_comments.is_empty() && self.inline_prediction.is_empty() {
             return self.rows.get(row);
         }
         self.rows
@@ -258,11 +272,109 @@ impl DisplayLayout {
     }
 
     pub fn screen_height(&self) -> usize {
-        self.rows.last().map_or(0, |segment| segment.row + 1).max(
-            self.inline_comments
-                .last()
-                .map_or(0, |comment| comment.row + 1),
-        )
+        self.rows
+            .last()
+            .map_or(0, |segment| segment.row + 1)
+            .max(
+                self.inline_comments
+                    .last()
+                    .map_or(0, |comment| comment.row + 1),
+            )
+            .max(self.inline_prediction.last().map_or(0, |row| row.row + 1))
+    }
+
+    /// Projects an insertion without putting virtual bytes into source segments.
+    /// Source motions dismiss the preview before consulting this layout.
+    pub(super) fn with_inline_prediction(
+        mut self,
+        line_index: usize,
+        line: &str,
+        cursor_byte: usize,
+        insertion: &str,
+        config: LayoutConfig,
+    ) -> Self {
+        if insertion.is_empty() || !line.is_char_boundary(cursor_byte) {
+            return self;
+        }
+        let cursor_col = crate::unicode_utils::display_width_with_tabs(
+            &line[..cursor_byte],
+            config.break_indent.tab_width,
+        );
+        let Some(mut anchor) = self.segment_for_cursor(line_index, cursor_col).copied() else {
+            return self;
+        };
+        let start_row = anchor.row;
+        let old_end = self
+            .rows
+            .iter()
+            .filter(|row| row.line == line_index)
+            .map(|row| row.row + 1)
+            .max()
+            .unwrap_or(start_row + 1);
+        let insertion = insertion.replace("\r\n", "\n");
+        let projected = format!(
+            "{}{}{}",
+            &line[..cursor_byte],
+            insertion,
+            &line[cursor_byte..]
+        );
+        let lines = projected
+            .split('\n')
+            .map(|line| format!("{line}\n"))
+            .collect::<Vec<_>>();
+        let preview = layout_lines(
+            &lines,
+            lines.len(),
+            LayoutConfig {
+                vtop: 0,
+                vleft: if config.wrap { 0 } else { anchor.start_col },
+                skipcol: if config.wrap { anchor.start_col } else { 0 },
+                height: config.height.saturating_sub(start_row),
+                ..config
+            },
+        );
+        let insertion_range = cursor_byte..cursor_byte + insertion.len();
+        self.inline_prediction = preview
+            .rows
+            .into_iter()
+            .map(|segment| {
+                let text = trim_line_ending(&lines[segment.line]);
+                InlinePredictionRow {
+                    row: start_row + segment.row,
+                    text: text[segment.start_byte..segment.end_byte].to_string(),
+                    display_col: segment.start_grapheme_col,
+                    visual_offset: segment.visual_offset
+                        + segment.start_grapheme_col.saturating_sub(segment.start_col),
+                    projected_start: segment.source_offset + segment.start_byte,
+                    insertion: insertion_range.clone(),
+                    source_offset: anchor.source_offset,
+                }
+            })
+            .collect();
+        if self.inline_prediction.is_empty() {
+            return self;
+        }
+        let new_end = start_row + self.inline_prediction.len();
+        let shift = |row: usize| new_end + row.saturating_sub(old_end);
+        self.rows
+            .retain(|row| row.row < start_row || row.row >= old_end);
+        for row in &mut self.rows {
+            if row.row >= old_end {
+                row.row = shift(row.row);
+            }
+        }
+        anchor.end_col = cursor_col;
+        anchor.last_segment = true;
+        self.rows.push(anchor);
+        self.rows.sort_unstable_by_key(|row| row.row);
+        self.rows.retain(|row| row.row < config.height);
+        for comment in &mut self.inline_comments {
+            if comment.row >= old_end {
+                comment.row = shift(comment.row);
+            }
+        }
+        self.inline_comments.retain(|row| row.row < config.height);
+        self
     }
 
     /// Inserts bounded display-only comments without changing syntax offsets
@@ -605,6 +717,64 @@ fn nowrap_line_segment(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inline_prediction_inserts_virtual_rows_and_preserves_source_offsets() {
+        let config = LayoutConfig {
+            content_width: 12,
+            height: 10,
+            wrap: true,
+            vtop: 0,
+            vleft: 0,
+            skipcol: 0,
+            break_indent: BreakIndentOptions::disabled(),
+        };
+        let lines = vec!["foo()\n".into(), "after\n".into()];
+        let layout = layout_lines(&lines, 2, config).with_inline_prediction(
+            0,
+            "foo()",
+            3,
+            "bar\nnext",
+            config,
+        );
+        assert_eq!(
+            layout
+                .inline_prediction
+                .iter()
+                .map(|row| row.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["foobar", "next()"]
+        );
+        assert_eq!(layout.row(0).unwrap().line, 0);
+        assert!(layout.row(1).is_none());
+        assert_eq!(layout.row(2).unwrap().line, 1);
+        assert_eq!(layout.row(2).unwrap().source_offset, 6);
+        assert_eq!(layout.segment_for_cursor(0, 3).unwrap().row, 0);
+    }
+
+    #[test]
+    fn inline_prediction_wraps_unicode_and_keeps_later_comments_aligned() {
+        let config = LayoutConfig {
+            content_width: 5,
+            height: 12,
+            wrap: true,
+            vtop: 0,
+            vleft: 0,
+            skipcol: 0,
+            break_indent: BreakIndentOptions::disabled(),
+        };
+        let lines = vec!["a界z\n".into(), "after\n".into()];
+        let original = layout_lines(&lines, 2, config).with_inline_comments(&[(1, "note")], 5, 12);
+        let original_comment = original.inline_comments[0].row;
+        let layout = original.with_inline_prediction(0, "a界z", "a界".len(), "12\n😀", config);
+        assert!(layout
+            .inline_prediction
+            .iter()
+            .all(|row| display_width(&row.text) <= 5));
+        assert!(layout.inline_comments[0].row > original_comment);
+        assert_eq!(layout.segment_for_cursor(0, 3).unwrap().row, 0);
+        assert_eq!(layout.rows.last().unwrap().line, 1);
+    }
 
     #[test]
     fn wraps_ascii_line_at_width() {

--- a/src/editor/inline_completion.rs
+++ b/src/editor/inline_completion.rs
@@ -250,8 +250,9 @@ impl Editor {
     }
 
     pub(super) fn handle_copilot_command(&mut self, command: &str) {
-        match command {
-            "enable" => {
+        use crate::copilot::CopilotCommand;
+        match CopilotCommand::parse(command) {
+            Some(CopilotCommand::Enable) => {
                 if self.config.disable_ai {
                     self.last_error = Some("Copilot is disabled by disable_ai = true".into());
                     return;
@@ -264,7 +265,7 @@ impl Editor {
                         .into(),
                 );
             }
-            "disable" => {
+            Some(CopilotCommand::Disable) => {
                 self.dismiss_inline_completion();
                 self.inline_completion.enabled_override = Some(false);
                 self.inline_completion.bridge = None;
@@ -272,7 +273,7 @@ impl Editor {
                 self.inline_completion.status = "Disabled".into();
                 self.last_error = Some("Copilot disabled".into());
             }
-            "signin" | "restart" => {
+            Some(CopilotCommand::SignIn | CopilotCommand::Restart) => {
                 self.inline_completion.failed = false;
                 if command == "restart" {
                     self.inline_completion.bridge = None;
@@ -281,11 +282,11 @@ impl Editor {
                     self.copilot_control(Control::SignIn);
                 }
             }
-            "signout" => {
+            Some(CopilotCommand::SignOut) => {
                 self.dismiss_inline_completion();
                 self.copilot_control(Control::SignOut);
             }
-            "" | "status" => {
+            Some(CopilotCommand::Status) => {
                 self.last_error = Some(format!(
                     "Copilot: {}",
                     if !self.copilot_enabled() {
@@ -297,11 +298,7 @@ impl Editor {
                     }
                 ))
             }
-            _ => {
-                self.last_error = Some(
-                    "Usage: Copilot enable|disable|signin|signout|status|restart|complete".into(),
-                )
-            }
+            _ => self.last_error = Some(CopilotCommand::usage()),
         }
     }
 

--- a/src/editor/inline_completion.rs
+++ b/src/editor/inline_completion.rs
@@ -1,0 +1,935 @@
+//! Editor-owned scheduling, preview validation, and acceptance for inline AI.
+
+use super::*;
+use crate::{
+    agent_tools::EditorPosition,
+    copilot::{
+        Bridge, CompletionItem, CompletionRequest, Control, Event as CopilotEvent, Snapshot,
+    },
+};
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+#[derive(Default)]
+pub(super) struct InlineCompletionState {
+    bridge: Option<Bridge>,
+    enabled_override: Option<bool>,
+    generation: u64,
+    scheduled: Option<(Instant, Snapshot)>,
+    requested: Option<Snapshot>,
+    pub(super) suggestion: Option<Suggestion>,
+    status: String,
+    failed: bool,
+    prompts: VecDeque<CopilotEvent>,
+}
+
+pub(super) struct Suggestion {
+    pub snapshot: Snapshot,
+    pub insertion: String,
+    item: CompletionItem,
+    shown: bool,
+}
+
+/// Reuses the normal picker while ensuring dismissal answers the server request.
+struct CopilotMessagePicker {
+    picker: Picker,
+    id: Value,
+}
+
+impl CopilotMessagePicker {
+    fn new(editor: &Editor, id: Value, message: String, actions: Vec<Value>) -> Self {
+        let mut choices = HashMap::new();
+        let mut labels = Vec::new();
+        for (index, action) in actions.into_iter().enumerate() {
+            let title = action["title"].as_str().unwrap_or("Continue");
+            let title = title
+                .chars()
+                .filter(|ch| !ch.is_control())
+                .take(120)
+                .collect::<String>();
+            let label = format!("{}. {title}", index + 1);
+            labels.push(label.clone());
+            choices.insert(label, action);
+        }
+        labels.push("Dismiss".into());
+        let response_id = id.clone();
+        let picker = Picker::builder()
+            .title("GitHub Copilot")
+            .items(labels)
+            .status(message)
+            .content_sized(80, 12)
+            .select_action(move |label| Action::CopilotRespond {
+                id: response_id.clone(),
+                result: choices.get(&label).cloned().unwrap_or(Value::Null),
+            })
+            .build(editor);
+        Self { picker, id }
+    }
+}
+
+impl Component for CopilotMessagePicker {
+    fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.picker.draw(buffer)
+    }
+    fn resize(&mut self, width: usize, height: usize) -> bool {
+        self.picker.resize(width, height)
+    }
+    fn set_theme(&mut self, theme: &Theme) {
+        self.picker.set_theme(theme);
+    }
+    fn cursor_position(&self) -> Option<(usize, usize)> {
+        self.picker.cursor_position()
+    }
+    fn cursor_mode(&self) -> Option<Mode> {
+        self.picker.cursor_mode()
+    }
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        match self.picker.handle_event(event) {
+            Some(KeyAction::Single(Action::CloseDialog)) => Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::CopilotRespond {
+                    id: self.id.clone(),
+                    result: Value::Null,
+                },
+            ])),
+            action => action,
+        }
+    }
+}
+
+impl Editor {
+    pub(super) fn handle_inline_completion_event(&mut self, event: &Event) -> Option<KeyAction> {
+        let mapping = Self::key_string_for_event(event)
+            .and_then(|key| self.config.keys.insert.get(&key))
+            .cloned();
+        if self.inline_editor_focused()
+            && self.copilot_enabled()
+            && mapping == Some(KeyAction::Single(Action::RequestInlineCompletion))
+            && self
+                .current_dialog
+                .as_ref()
+                .is_none_or(|dialog| dialog.allows_event_passthrough())
+        {
+            return Some(KeyAction::Single(Action::RequestInlineCompletion));
+        }
+        self.visible_inline_suggestion()?;
+        if matches!(
+            mapping,
+            Some(KeyAction::Single(
+                Action::AcceptInlineCompletion | Action::DismissInlineCompletion
+            ))
+        ) {
+            return mapping;
+        }
+        match event {
+            Event::Key(KeyEvent {
+                code: KeyCode::Tab,
+                modifiers: KeyModifiers::NONE,
+                ..
+            }) if mapping == Some(KeyAction::Single(Action::InsertTab)) => {
+                Some(KeyAction::Single(Action::AcceptInlineCompletion))
+            }
+            Event::Key(KeyEvent {
+                code: KeyCode::Esc, ..
+            }) if mapping == Some(KeyAction::Single(Action::EnterMode(Mode::Normal))) => {
+                Some(KeyAction::Multiple(vec![
+                    Action::DismissInlineCompletion,
+                    Action::EnterMode(Mode::Normal),
+                ]))
+            }
+            Event::Key(_)
+            | Event::Paste(_)
+            | Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(_),
+                ..
+            }) => {
+                self.dismiss_inline_completion();
+                None
+            }
+            _ => None,
+        }
+    }
+    pub(super) fn copilot_enabled(&self) -> bool {
+        !self.config.disable_ai
+            && self
+                .inline_completion
+                .enabled_override
+                .unwrap_or(self.config.copilot.enabled)
+    }
+
+    pub(super) fn prefers_inline_completion(&self) -> bool {
+        self.copilot_enabled() && !self.inline_completion.failed && self.copilot_file_allowed()
+    }
+
+    fn copilot_file_allowed(&self) -> bool {
+        self.current_buffer()
+            .uri()
+            .ok()
+            .flatten()
+            .and_then(|uri| lsp_normalized_file_path(&uri).ok())
+            .is_some_and(|path| {
+                self.config.copilot.allows(
+                    &get_workspace_path(),
+                    Path::new(&path),
+                    self.current_buffer().byte_len(),
+                )
+            })
+    }
+
+    fn inline_snapshot(&self) -> Option<Snapshot> {
+        Some(Snapshot {
+            generation: self.inline_completion.generation,
+            buffer_id: self.current_buffer().id(),
+            revision: self.current_buffer().revision(),
+            cursor: self.cursor_text_position(),
+            uri: self.current_buffer().uri().ok()??,
+        })
+    }
+
+    fn inline_snapshot_current(&self, snapshot: &Snapshot) -> bool {
+        self.is_insert()
+            && self.copilot_enabled()
+            && self.inline_snapshot().as_ref() == Some(snapshot)
+    }
+
+    fn inline_editor_focused(&self) -> bool {
+        self.is_insert()
+            && !self.workspace_manager.is_active()
+            && !self.panel_manager.has_focused_panel()
+    }
+
+    pub(super) fn visible_inline_suggestion(&self) -> Option<&Suggestion> {
+        self.inline_completion
+            .suggestion
+            .as_ref()
+            .filter(|suggestion| {
+                self.inline_editor_focused()
+                    && self.current_dialog.is_none()
+                    && self.inline_snapshot_current(&suggestion.snapshot)
+            })
+    }
+
+    fn ensure_copilot(&mut self) -> bool {
+        if self.config.disable_ai {
+            self.last_error = Some("Copilot is disabled by disable_ai = true".into());
+            return false;
+        }
+        if !self.copilot_enabled() {
+            self.last_error = Some(
+                "Copilot is disabled; use :Copilot enable to allow source-code transmission".into(),
+            );
+            return false;
+        }
+        if self.inline_completion.failed {
+            return false;
+        }
+        if self.inline_completion.bridge.is_none() {
+            self.inline_completion.bridge = Some(Bridge::start(
+                self.config.copilot.clone(),
+                get_workspace_path(),
+            ));
+            self.inline_completion.status = "Starting".into();
+        }
+        true
+    }
+
+    pub(super) fn copilot_control(&mut self, control: Control) {
+        if !self.ensure_copilot() {
+            return;
+        }
+        if let Some(Err(error)) = self
+            .inline_completion
+            .bridge
+            .as_ref()
+            .map(|bridge| bridge.control(control))
+        {
+            self.last_error = Some(error.to_string());
+        }
+    }
+
+    pub(super) fn handle_copilot_command(&mut self, command: &str) {
+        match command {
+            "enable" => {
+                if self.config.disable_ai {
+                    self.last_error = Some("Copilot is disabled by disable_ai = true".into());
+                    return;
+                }
+                self.inline_completion.enabled_override = Some(true);
+                self.inline_completion.failed = false;
+                self.ensure_copilot();
+                self.last_error = Some(
+                    "Copilot enabled for this session; eligible source files may be sent to GitHub"
+                        .into(),
+                );
+            }
+            "disable" => {
+                self.dismiss_inline_completion();
+                self.inline_completion.enabled_override = Some(false);
+                self.inline_completion.bridge = None;
+                self.inline_completion.prompts.clear();
+                self.inline_completion.status = "Disabled".into();
+                self.last_error = Some("Copilot disabled".into());
+            }
+            "signin" | "restart" => {
+                self.inline_completion.failed = false;
+                if command == "restart" {
+                    self.inline_completion.bridge = None;
+                }
+                if self.ensure_copilot() && command == "signin" {
+                    self.copilot_control(Control::SignIn);
+                }
+            }
+            "signout" => {
+                self.dismiss_inline_completion();
+                self.copilot_control(Control::SignOut);
+            }
+            "" | "status" => {
+                self.last_error = Some(format!(
+                    "Copilot: {}",
+                    if !self.copilot_enabled() {
+                        "Disabled"
+                    } else if self.inline_completion.status.is_empty() {
+                        "Not started"
+                    } else {
+                        &self.inline_completion.status
+                    }
+                ))
+            }
+            _ => {
+                self.last_error = Some(
+                    "Usage: Copilot enable|disable|signin|signout|status|restart|complete".into(),
+                )
+            }
+        }
+    }
+
+    pub(super) fn dismiss_inline_completion(&mut self) {
+        self.inline_completion.generation = self.inline_completion.generation.wrapping_add(1);
+        self.inline_completion.scheduled = None;
+        self.inline_completion.requested = None;
+        if self.inline_completion.suggestion.take().is_some() {
+            self.layout_cache.borrow_mut().clear();
+            self.force_full_redraw = true;
+        }
+        if let Some(bridge) = &self.inline_completion.bridge {
+            bridge.cancel();
+        }
+    }
+
+    pub(super) fn schedule_inline_completion(&mut self) {
+        self.dismiss_inline_completion();
+        if self.copilot_enabled() && self.inline_editor_focused() {
+            if let Some(snapshot) = self.inline_snapshot() {
+                self.inline_completion.scheduled = Some((
+                    Instant::now() + Duration::from_millis(self.config.copilot.debounce_ms),
+                    snapshot,
+                ));
+            }
+        }
+    }
+
+    pub(super) fn request_inline_completion(&mut self, automatic: bool) {
+        if !self.inline_editor_focused() {
+            return;
+        }
+        if !automatic {
+            self.dismiss_inline_completion();
+            self.scheduled_completion = None;
+            for pending in self.pending_completions.values_mut() {
+                pending.superseded = true;
+            }
+            if self
+                .current_dialog
+                .as_ref()
+                .is_some_and(|dialog| dialog.allows_event_passthrough())
+            {
+                self.current_dialog = None;
+                self.completion_snapshot = None;
+            }
+        }
+        let Some(snapshot) = self.inline_snapshot() else {
+            return;
+        };
+        if !self.copilot_file_allowed() {
+            if !automatic {
+                self.last_error =
+                    Some("Copilot: file excluded, outside workspace, or too large".into());
+            }
+            return;
+        }
+        let request = CompletionRequest {
+            snapshot: snapshot.clone(),
+            language_id: self
+                .current_language_id()
+                .unwrap_or_else(|| "plaintext".into()),
+            contents: self.current_buffer().contents(),
+            position: self.cursor_lsp_position(),
+            tab_size: self.indentation().shift_width,
+            insert_spaces: self.indentation().expand_tab,
+            automatic,
+        };
+        if !self.ensure_copilot() {
+            return;
+        }
+        self.inline_completion.requested = Some(snapshot);
+        self.inline_completion
+            .bridge
+            .as_ref()
+            .expect("Copilot started")
+            .request(request);
+    }
+
+    pub(super) fn service_inline_completion(&mut self) -> bool {
+        let mut changed = false;
+        if !self.copilot_enabled() && self.inline_completion.bridge.is_some() {
+            self.dismiss_inline_completion();
+            self.inline_completion.bridge = None;
+            self.inline_completion.prompts.clear();
+            changed = true;
+        }
+        if self
+            .inline_completion
+            .requested
+            .as_ref()
+            .is_some_and(|snapshot| !self.inline_snapshot_current(snapshot))
+            || self
+                .inline_completion
+                .suggestion
+                .as_ref()
+                .is_some_and(|suggestion| !self.inline_snapshot_current(&suggestion.snapshot))
+        {
+            self.dismiss_inline_completion();
+            changed = true;
+        }
+        if let Some((deadline, snapshot)) = self.inline_completion.scheduled.clone() {
+            if Instant::now() >= deadline {
+                self.inline_completion.scheduled = None;
+                if self.inline_snapshot_current(&snapshot) {
+                    self.request_inline_completion(true);
+                }
+            }
+        }
+        for _ in 0..32 {
+            let Some(event) = self
+                .inline_completion
+                .bridge
+                .as_mut()
+                .and_then(Bridge::poll)
+            else {
+                break;
+            };
+            match event {
+                CopilotEvent::Status(status) => self.inline_completion.status = status,
+                CopilotEvent::Stopped(status) => {
+                    self.inline_completion.status = status.clone();
+                    self.inline_completion.failed = true;
+                    self.inline_completion.bridge = None;
+                    self.dismiss_inline_completion();
+                    self.last_error = Some(status);
+                    changed = true;
+                    break;
+                }
+                CopilotEvent::Completion { snapshot, items } => {
+                    if self.inline_completion.requested.as_ref() != Some(&snapshot)
+                        || !self.inline_snapshot_current(&snapshot)
+                    {
+                        continue;
+                    }
+                    self.inline_completion.requested = None;
+                    let contents = self.current_buffer().contents();
+                    let position = self.cursor_lsp_position();
+                    if let Some((item, insertion)) = items.into_iter().find_map(|item| {
+                        insertion_for_item(&contents, position, &item)
+                            .map(|insertion| (item, insertion))
+                    }) {
+                        self.inline_completion.suggestion = Some(Suggestion {
+                            snapshot,
+                            insertion,
+                            item,
+                            shown: false,
+                        });
+                        self.layout_cache.borrow_mut().clear();
+                        self.force_full_redraw = true;
+                        changed = true;
+                    }
+                }
+                prompt @ (CopilotEvent::SignIn { .. } | CopilotEvent::Message { .. }) => {
+                    if self.inline_completion.prompts.len() < 32 {
+                        self.inline_completion.prompts.push_back(prompt);
+                    } else if let CopilotEvent::Message { id, .. } = prompt {
+                        self.copilot_control(Control::Respond {
+                            id,
+                            result: Value::Null,
+                        });
+                    }
+                }
+            }
+        }
+        if self.current_dialog.is_none() {
+            if let Some(prompt) = self.inline_completion.prompts.pop_front() {
+                self.current_dialog = Some(match prompt {
+                    CopilotEvent::SignIn { user_code, command } => {
+                        Box::new(Confirmation::new_actions(
+                            self,
+                            "Sign in to GitHub Copilot",
+                            format!("Enter code {user_code} in GitHub’s device activation page."),
+                            "Open browser",
+                            "Dismiss",
+                            Action::CopilotFinishSignIn(command),
+                            Action::Refresh,
+                        ))
+                    }
+                    CopilotEvent::Message {
+                        id,
+                        message,
+                        actions,
+                    } => Box::new(CopilotMessagePicker::new(self, id, message, actions)),
+                    _ => unreachable!("only prompts are queued"),
+                });
+                changed = true;
+            }
+        }
+        if self
+            .visible_inline_suggestion()
+            .is_some_and(|suggestion| !suggestion.shown)
+        {
+            if let Some(suggestion) = self.inline_completion.suggestion.as_mut() {
+                suggestion.shown = true;
+                let item = suggestion.item.clone();
+                self.copilot_control(Control::Shown(item));
+            }
+        }
+        changed
+    }
+
+    pub(super) async fn accept_inline_completion(
+        &mut self,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let Some(suggestion) = self.inline_completion.suggestion.take() else {
+            return Ok(());
+        };
+        if !self.inline_snapshot_current(&suggestion.snapshot) {
+            self.dismiss_inline_completion();
+            return Ok(());
+        }
+        let resume_insert = self.transaction_active();
+        if resume_insert {
+            self.commit_transaction(self.cursor_snapshot());
+        }
+        self.begin_transaction("accept Copilot completion");
+        let start = suggestion.snapshot.cursor;
+        let end = self
+            .current_buffer()
+            .range_for_text(start, &suggestion.insertion)
+            .end;
+        self.replace_range(TextRange::insertion(start), &suggestion.insertion);
+        self.move_to_insert_text_position(end);
+        self.commit_transaction(self.cursor_snapshot());
+        self.notify_change(runtime).await?;
+        if resume_insert && self.is_insert() {
+            self.begin_transaction("insert");
+        }
+        self.copilot_control(Control::Accepted(suggestion.item));
+        Ok(())
+    }
+}
+
+fn insertion_for_item(
+    contents: &str,
+    cursor: LspPosition,
+    item: &CompletionItem,
+) -> Option<String> {
+    let offset = |position: LspPosition| {
+        utf16_byte_offset(
+            contents,
+            EditorPosition {
+                line: position.line,
+                character: position.character,
+            },
+        )
+        .ok()
+    };
+    let cursor = offset(cursor)?;
+    let (start, end) = item
+        .range
+        .as_ref()
+        .map(|range| Some((offset(range.start)?, offset(range.end)?)))
+        .unwrap_or(Some((cursor, cursor)))?;
+    if start > cursor || cursor > end {
+        return None;
+    }
+    let before = contents.get(start..cursor)?;
+    let after = contents.get(cursor..end)?;
+    let inserted = item.insert_text.strip_prefix(before)?.strip_suffix(after)?;
+    if inserted.is_empty()
+        || inserted
+            .chars()
+            .any(|ch| ch.is_control() && !matches!(ch, '\n' | '\r' | '\t'))
+    {
+        return None;
+    }
+    let inserted = inserted.replace("\r\n", "\n");
+    if inserted.contains('\r') {
+        return None;
+    }
+    Some(if contents.contains("\r\n") {
+        inserted.replace('\n', "\r\n")
+    } else {
+        inserted
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::EditorTestExt;
+
+    fn editor(text: &str) -> Editor {
+        let mut config = Config::from_user_toml_with_overrides("", &[]).unwrap();
+        config.lsp.enabled = false;
+        config.copilot.enabled = true;
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let file = get_workspace_path()
+            .join("src/main.rs")
+            .to_string_lossy()
+            .into_owned();
+        let mut editor = Editor::with_size(
+            lsp,
+            60,
+            16,
+            config,
+            Theme::default(),
+            vec![Buffer::new(Some(file), text.into())],
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor.inline_completion.failed = true;
+        editor
+    }
+
+    async fn show(editor: &mut Editor, text: &str, cursor: usize) {
+        editor
+            .test_execute_action(Action::EnterMode(Mode::Insert))
+            .await
+            .unwrap();
+        editor
+            .test_execute_action(Action::SetCursor(cursor, 0))
+            .await
+            .unwrap();
+        let snapshot = editor.inline_snapshot().unwrap();
+        editor.inline_completion.suggestion = Some(Suggestion {
+            snapshot,
+            insertion: text.into(),
+            item: CompletionItem {
+                insert_text: text.into(),
+                range: None,
+                command: None,
+                extra: Default::default(),
+            },
+            shown: true,
+        });
+        editor.layout_cache.borrow_mut().clear();
+    }
+
+    fn rendered_rows(editor: &mut Editor) -> Vec<String> {
+        let mut output = RenderBuffer::new(60, 16, &editor.theme.style);
+        editor.render(&mut output).unwrap();
+        output
+            .cells
+            .chunks(output.width)
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.text.as_str())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+    fn item(text: &str, start: usize, end: usize) -> CompletionItem {
+        CompletionItem {
+            insert_text: text.into(),
+            range: Some(Range {
+                start: LspPosition {
+                    line: 0,
+                    character: start,
+                },
+                end: LspPosition {
+                    line: 0,
+                    character: end,
+                },
+            }),
+            command: None,
+            extra: Default::default(),
+        }
+    }
+    #[test]
+    fn only_insertion_equivalent_edits_are_accepted() {
+        let cursor = LspPosition {
+            line: 0,
+            character: 3,
+        };
+        assert_eq!(
+            insertion_for_item("foo()", cursor, &item("foobar()", 0, 5)),
+            Some("bar".into())
+        );
+        assert_eq!(
+            insertion_for_item("foo()", cursor, &item("other()", 0, 5)),
+            None
+        );
+        assert_eq!(
+            insertion_for_item("foo()", cursor, &item("foo\u{1b}[31m()", 0, 5)),
+            None
+        );
+    }
+    #[test]
+    fn utf16_boundaries_and_crlf_are_preserved() {
+        let cursor = LspPosition {
+            line: 0,
+            character: 2,
+        };
+        assert_eq!(
+            insertion_for_item("😀\r\n", cursor, &item("😀x\ny", 0, 2)),
+            Some("x\r\ny".into())
+        );
+        assert_eq!(insertion_for_item("😀", cursor, &item("x", 1, 2)), None);
+    }
+
+    #[test]
+    fn account_message_picker_preserves_all_actions_and_answers_dismissal() {
+        let editor = editor("foo");
+        let id = json!("request-id");
+        let second = json!({"title":"Second","extra":"preserved"});
+        let mut picker = CopilotMessagePicker::new(
+            &editor,
+            id.clone(),
+            "Account issue".into(),
+            vec![json!({"title":"First"}), second.clone()],
+        );
+        picker.handle_event(&Event::Key(KeyEvent::new(
+            KeyCode::Down,
+            KeyModifiers::NONE,
+        )));
+        let Some(KeyAction::Multiple(actions)) = picker.handle_event(&Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        ))) else {
+            panic!("expected selection");
+        };
+        assert!(actions.contains(&Action::CopilotRespond {
+            id: id.clone(),
+            result: second
+        }));
+        assert_eq!(
+            picker.handle_event(&Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))),
+            Some(KeyAction::Multiple(vec![
+                Action::CloseDialog,
+                Action::CopilotRespond {
+                    id,
+                    result: Value::Null
+                }
+            ]))
+        );
+    }
+
+    #[tokio::test]
+    async fn multiline_preview_preserves_source_and_accepts_as_one_undo_step() {
+        let mut editor = editor("foo()\nafter\n");
+        show(&mut editor, "bar\nnext", 3).await;
+        let before = editor.current_buffer().revision();
+        let rows = rendered_rows(&mut editor);
+        let first = rows.iter().position(|row| row.contains("foobar")).unwrap();
+        assert!(rows[first + 1].contains("next()"), "{rows:?}");
+        assert!(rows[first + 2].contains("after"), "{rows:?}");
+        assert_eq!(editor.current_buffer().contents(), "foo()\nafter\n");
+        assert_eq!(editor.current_buffer().revision(), before);
+        assert_eq!(
+            editor
+                .handle_event(&Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)))
+                .unwrap(),
+            Some(KeyAction::Single(Action::AcceptInlineCompletion))
+        );
+        editor
+            .test_execute_action(Action::AcceptInlineCompletion)
+            .await
+            .unwrap();
+        assert_eq!(
+            editor.current_buffer().contents(),
+            "foobar\nnext()\nafter\n"
+        );
+        editor
+            .test_execute_action(Action::EnterMode(Mode::Normal))
+            .await
+            .unwrap();
+        editor.test_execute_action(Action::Undo).await.unwrap();
+        assert_eq!(editor.current_buffer().contents(), "foo()\nafter\n");
+    }
+
+    #[tokio::test]
+    async fn stale_preview_cannot_mutate_and_escape_keeps_vim_behavior() {
+        let mut editor = editor("foo");
+        show(&mut editor, "bar", 3).await;
+        assert_eq!(
+            editor
+                .handle_event(&Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)))
+                .unwrap(),
+            Some(KeyAction::Multiple(vec![
+                Action::DismissInlineCompletion,
+                Action::EnterMode(Mode::Normal)
+            ]))
+        );
+        editor
+            .current_buffer_mut()
+            .replace_range_raw(TextRange::insertion(TextPosition::new(0, 0)), "x");
+        editor
+            .test_execute_action(Action::AcceptInlineCompletion)
+            .await
+            .unwrap();
+        assert_eq!(editor.current_buffer().contents(), "xfoo");
+    }
+
+    #[tokio::test]
+    async fn late_responses_are_discarded_and_global_disable_wins() {
+        let mut editor = editor("foo");
+        let (bridge, requests, _controls, events) = Bridge::test_channels();
+        editor.inline_completion.bridge = Some(bridge);
+        editor.inline_completion.failed = false;
+        editor
+            .test_execute_action(Action::EnterMode(Mode::Insert))
+            .await
+            .unwrap();
+        editor
+            .test_execute_action(Action::SetCursor(3, 0))
+            .await
+            .unwrap();
+        editor.request_inline_completion(false);
+        let snapshot = requests.borrow().as_ref().unwrap().snapshot.clone();
+        editor.dismiss_inline_completion();
+        events
+            .send(CopilotEvent::Completion {
+                snapshot,
+                items: vec![item("foobar", 0, 3)],
+            })
+            .await
+            .unwrap();
+        editor.service_inline_completion();
+        assert!(editor.inline_completion.suggestion.is_none());
+        editor.config.disable_ai = true;
+        editor.handle_copilot_command("enable");
+        editor.service_inline_completion();
+        assert!(!editor.copilot_enabled());
+        assert!(editor.inline_completion.bridge.is_none());
+    }
+
+    #[tokio::test]
+    async fn palette_request_enters_insert_mode() {
+        let mut editor = editor("foo");
+        let (bridge, requests, _controls, _events) = Bridge::test_channels();
+        editor.inline_completion.bridge = Some(bridge);
+        editor.inline_completion.failed = false;
+        let action = command_palette::entries(&editor.config.keys, &[])
+            .into_iter()
+            .find(|entry| entry.id == "ai.inline_completion")
+            .unwrap()
+            .action;
+        editor.test_execute_action(action).await.unwrap();
+        assert!(editor.is_insert());
+        assert!(requests.borrow().is_some());
+    }
+
+    #[tokio::test]
+    async fn inline_completion_respects_remapped_insert_keys() {
+        let mut editor = editor("foo");
+        show(&mut editor, "bar", 3).await;
+        editor
+            .config
+            .keys
+            .insert
+            .insert("Tab".into(), KeyAction::Single(Action::MoveRight));
+        assert_eq!(
+            editor.handle_inline_completion_event(&Event::Key(KeyEvent::new(
+                KeyCode::Tab,
+                KeyModifiers::NONE,
+            ))),
+            None,
+        );
+        assert!(editor.inline_completion.suggestion.is_none());
+        show(&mut editor, "bar", 3).await;
+        editor.config.keys.insert.insert(
+            "Ctrl-y".into(),
+            KeyAction::Single(Action::AcceptInlineCompletion),
+        );
+        assert_eq!(
+            editor.handle_inline_completion_event(&Event::Key(KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::CONTROL,
+            ))),
+            Some(KeyAction::Single(Action::AcceptInlineCompletion)),
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_inline_request_supersedes_old_popup_responses_only() {
+        let mut editor = editor("foo foobar");
+        let (bridge, _requests, _controls, _events) = Bridge::test_channels();
+        editor.inline_completion.bridge = Some(bridge);
+        editor.inline_completion.failed = false;
+        editor
+            .test_execute_action(Action::EnterMode(Mode::Insert))
+            .await
+            .unwrap();
+        editor
+            .test_execute_action(Action::SetCursor(3, 0))
+            .await
+            .unwrap();
+        let snapshot = editor.completion_snapshot();
+        editor.pending_completions.insert(
+            41,
+            PendingCompletion {
+                buffer_items: Vec::new(),
+                snapshot,
+                displayed_immediately: false,
+                superseded: false,
+            },
+        );
+        editor.request_inline_completion(false);
+        let response = InboundMessage::Message(ResponseMessage {
+            id: 41,
+            result: json!([{"label":"foobar"}]),
+            request: None,
+        });
+        assert!(editor
+            .handle_lsp_message(&response, Some("textDocument/completion".into()))
+            .is_none());
+        assert!(editor.current_dialog.is_none());
+        assert!(editor.inline_completion.requested.is_some());
+        editor
+            .test_execute_action(Action::RequestCompletion)
+            .await
+            .unwrap();
+        assert!(editor.current_dialog.is_some());
+        assert!(editor.inline_completion.requested.is_none());
+    }
+
+    #[tokio::test]
+    async fn ordinary_completion_remains_explicitly_available() {
+        let mut editor = editor("foo foobar");
+        editor.inline_completion.failed = false;
+        editor
+            .test_execute_action(Action::EnterMode(Mode::Insert))
+            .await
+            .unwrap();
+        editor
+            .test_execute_action(Action::SetCursor(3, 0))
+            .await
+            .unwrap();
+        editor.schedule_automatic_completion();
+        assert!(editor.scheduled_completion.is_none());
+        editor
+            .test_execute_action(Action::RequestCompletion)
+            .await
+            .unwrap();
+        assert!(editor.current_dialog.is_some());
+    }
+}

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1421,6 +1421,7 @@ impl Editor {
 
     pub(crate) fn can_render_cursor_motion_delta(&self) -> bool {
         self.terminal_output_enabled
+            && self.visible_inline_suggestion().is_none()
             && self.can_reuse_editor_surfaces()
             && self.last_rendered_viewport.is_some()
             && self.last_rendered_viewport == self.rendered_viewport()
@@ -1933,8 +1934,80 @@ impl Editor {
 
             // Render overlays within window bounds
             self.render_overlays_in_window(buffer, &window)?;
+            self.render_inline_prediction_in_window(buffer, &window)?;
         }
 
+        Ok(())
+    }
+
+    fn render_inline_prediction_in_window(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        window: &crate::window::Window,
+    ) -> anyhow::Result<()> {
+        let layout = self.layout_for_window(window);
+        if layout.inline_prediction.is_empty() {
+            return Ok(());
+        }
+        let spans = self.viewport_highlight_spans(
+            window.buffer_index,
+            window.vtop,
+            self.window_content_height(window),
+        )?;
+        let mut styles = StyleCursor::new(&spans);
+        let normal = self.theme.style.clone();
+        let ghost = Style {
+            fg: self
+                .theme
+                .colors
+                .get("editorGhostText.foreground")
+                .copied()
+                .or_else(|| self.theme.get_style("comment").and_then(|style| style.fg))
+                .or(self.theme.ui_style.muted.fg)
+                .or(normal.fg),
+            bg: normal.bg,
+            italic: true,
+            ..Style::default()
+        };
+        let width = self.window_content_width(window);
+        let start_x = self.window_to_terminal_x(window, self.gutter_width_for_window(window) + 1);
+        let tab_width = self.tab_width_for_buffer_index(window.buffer_index).max(1);
+        for row in &layout.inline_prediction {
+            let y = self.window_to_terminal_y(window, row.row);
+            self.fill_line_in_window(buffer, start_x, y, width, &normal);
+            let mut x = row.visual_offset;
+            let mut col = row.display_col;
+            for (offset, grapheme) in row.text.grapheme_indices(true) {
+                let projected = row.projected_start + offset;
+                let style = if row.insertion.contains(&projected) {
+                    &ghost
+                } else {
+                    let source = if projected >= row.insertion.end {
+                        projected - row.insertion.len()
+                    } else {
+                        projected
+                    };
+                    styles
+                        .style_at(row.source_offset + source)
+                        .unwrap_or(&normal)
+                };
+                let cells = if grapheme == "\t" {
+                    tab_width - col % tab_width
+                } else {
+                    display_width(grapheme)
+                };
+                if x.saturating_add(cells) > width {
+                    break;
+                }
+                if grapheme == "\t" {
+                    buffer.set_text(start_x + x, y, &" ".repeat(cells), style);
+                } else {
+                    buffer.set_text(start_x + x, y, grapheme, style);
+                }
+                x += cells;
+                col += cells;
+            }
+        }
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod clipboard;
 pub mod codex;
 pub mod color;
 pub mod command;
+mod command_completion;
 pub mod command_palette;
 mod comment;
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod command;
 pub mod command_palette;
 mod comment;
 pub mod config;
+pub mod copilot;
 pub mod dispatcher;
 pub mod editing;
 pub mod editor;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -378,7 +378,7 @@ impl RealLspClient {
     }
 }
 
-async fn read_lsp_frame(
+pub(crate) async fn read_lsp_frame(
     reader: &mut (impl AsyncBufRead + Unpin),
 ) -> Result<Option<Vec<u8>>, LspError> {
     let mut header_bytes = 0usize;

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -71,6 +71,8 @@ pub(crate) enum RedFunctionAnnotation {
         aliases: Vec<String>,
         visible: bool,
         scope: CommandScope,
+        arguments: bool,
+        completions: Vec<Vec<String>>,
     },
     Event {
         name: String,
@@ -122,12 +124,6 @@ pub(crate) fn red_function_annotations(
             continue;
         }
         if attribute.matches_path(&["red", "command"]) {
-            if parameter_count != 0 {
-                return Err(annotation_error(
-                    attribute,
-                    "`#[red::command]` requires a function without parameters",
-                ));
-            }
             let Some(arguments) = attribute.arguments.as_ref() else {
                 return Err(annotation_error(
                     attribute,
@@ -149,6 +145,8 @@ pub(crate) fn red_function_annotations(
             let mut aliases = Vec::new();
             let mut visible = true;
             let mut scope = CommandScope::Editor;
+            let mut accepts_arguments = false;
+            let mut completions = Vec::new();
             for argument in arguments {
                 let AttributeArgumentKind::Named { name: key, value } = &argument.kind else {
                     return Err(annotation_value_error(
@@ -208,6 +206,42 @@ pub(crate) fn red_function_annotations(
                             aliases.push(text.to_string());
                         }
                     }
+                    "arguments" => {
+                        let AttributeValueKind::Bool(enabled) = &value.kind else {
+                            return Err(annotation_value_error(
+                                &value.span,
+                                "command metadata `arguments` must be a boolean",
+                            ));
+                        };
+                        accepts_arguments = *enabled;
+                    }
+                    "completions" => {
+                        let AttributeValueKind::Array(positions) = &value.kind else {
+                            return Err(annotation_value_error(
+                                &value.span,
+                                "command metadata `completions` must be an array of string arrays",
+                            ));
+                        };
+                        for position in positions {
+                            let AttributeValueKind::Array(values) = &position.kind else {
+                                return Err(annotation_value_error(
+                                    &position.span,
+                                    "command completions must be an array of string arrays",
+                                ));
+                            };
+                            let mut choices = Vec::new();
+                            for choice in values {
+                                let Some(text) = choice.as_str() else {
+                                    return Err(annotation_value_error(
+                                        &choice.span,
+                                        "command completion choices must be strings",
+                                    ));
+                                };
+                                choices.push(text.to_string());
+                            }
+                            completions.push(choices);
+                        }
+                    }
                     "visible" => {
                         let AttributeValueKind::Bool(visible_value) = &value.kind else {
                             return Err(annotation_value_error(
@@ -243,6 +277,18 @@ pub(crate) fn red_function_annotations(
                     }
                 }
             }
+            if parameter_count != usize::from(accepts_arguments) {
+                return Err(annotation_error(
+                    attribute,
+                    if accepts_arguments {
+                        "`#[red::command(arguments = true)]` requires one CommandInvocation parameter"
+                    } else {
+                        "`#[red::command]` requires a function without parameters"
+                    },
+                ));
+            }
+            super::runtime::validate_command_arguments(accepts_arguments, &completions)
+                .map_err(|error| annotation_error(attribute, error.to_string()))?;
             let Some(name) = name else {
                 return Err(annotation_error(
                     attribute,
@@ -257,6 +303,8 @@ pub(crate) fn red_function_annotations(
                 aliases,
                 visible,
                 scope,
+                arguments: accepts_arguments,
+                completions,
             });
         } else if attribute.matches_path(&["red", "on"]) {
             if parameter_count != 1 {
@@ -448,13 +496,16 @@ struct HostCallSite<'a> {
 struct RedSourceSites<'a> {
     host_calls: Vec<HostCallSite<'a>>,
     uses_command_scope: bool,
+    uses_command_arguments: bool,
 }
 
 #[derive(Default)]
 struct RedSourceVisitor<'a> {
     host_calls: Vec<HostCallSite<'a>>,
     uses_command_scope: bool,
+    uses_command_arguments: bool,
     command_metadata_bindings: HashMap<String, bool>,
+    command_argument_metadata_bindings: HashMap<String, bool>,
 }
 
 fn red_source_sites(file: &File) -> RedSourceSites<'_> {
@@ -463,6 +514,8 @@ fn red_source_sites(file: &File) -> RedSourceSites<'_> {
         match &item.kind {
             ItemKind::Fn { body, .. } => {
                 visitor.uses_command_scope |= command_attribute_uses_scope(&item.attributes);
+                visitor.uses_command_arguments |=
+                    command_attribute_uses_arguments(&item.attributes);
                 visitor.visit_body(body);
             }
             ItemKind::Trait(definition) => {
@@ -491,6 +544,7 @@ fn red_source_sites(file: &File) -> RedSourceSites<'_> {
     RedSourceSites {
         host_calls: visitor.host_calls,
         uses_command_scope: visitor.uses_command_scope,
+        uses_command_arguments: visitor.uses_command_arguments,
     }
 }
 
@@ -508,6 +562,23 @@ fn command_attribute_uses_scope(attributes: &[Attribute]) -> bool {
     })
 }
 
+fn command_attribute_uses_arguments(attributes: &[Attribute]) -> bool {
+    attributes.iter().any(|attribute| {
+        attribute.matches_path(&["red", "command"])
+            && attribute.arguments.as_ref().is_some_and(|arguments| {
+                arguments.iter().any(|argument| {
+                    matches!(&argument.kind,
+                    AttributeArgumentKind::Named { name, .. }
+                        if matches!(name.name.as_str(), "arguments" | "completions"))
+                })
+            })
+    })
+}
+
+pub(crate) fn source_uses_command_arguments(file: &File) -> bool {
+    red_source_sites(file).uses_command_arguments
+}
+
 pub(crate) fn source_uses_command_scope(file: &File) -> bool {
     red_source_sites(file).uses_command_scope
 }
@@ -519,6 +590,7 @@ fn host_call_sites(file: &File) -> Vec<HostCallSite<'_>> {
 impl<'a> RedSourceVisitor<'a> {
     fn visit_body(&mut self, statements: &'a [Stmt]) {
         self.command_metadata_bindings.clear();
+        self.command_argument_metadata_bindings.clear();
         self.visit_statements(statements);
     }
 
@@ -541,6 +613,10 @@ impl<'a> RedSourceVisitor<'a> {
                         self.command_metadata_bindings.insert(
                             binding.name.clone(),
                             self.command_metadata_expression_uses_scope(value),
+                        );
+                        self.command_argument_metadata_bindings.insert(
+                            binding.name.clone(),
+                            self.command_metadata_expression_uses_arguments(value),
                         );
                     }
                     self.visit_expression(value);
@@ -610,6 +686,13 @@ impl<'a> RedSourceVisitor<'a> {
                         })
                     {
                         self.uses_command_scope = true;
+                    }
+                    if matches!(segments.as_slice(), [module, method] if module.name == "red" && method.name == "add_command")
+                        && args.get(2).is_some_and(|metadata| {
+                            self.command_metadata_expression_uses_arguments(metadata)
+                        })
+                    {
+                        self.uses_command_arguments = true;
                     }
                     let kind = match segments.as_slice() {
                         [module, method] if module.name == "red" && method.name == "execute" => {
@@ -715,6 +798,24 @@ impl<'a> RedSourceVisitor<'a> {
                 binding.name.clone(),
                 self.command_metadata_expression_uses_scope(value),
             );
+            self.command_argument_metadata_bindings.insert(
+                binding.name.clone(),
+                self.command_metadata_expression_uses_arguments(value),
+            );
+        }
+    }
+
+    fn command_metadata_expression_uses_arguments(&self, expression: &Expr) -> bool {
+        match &expression.kind {
+            ExprKind::Struct { fields, .. } => fields
+                .iter()
+                .any(|field| matches!(field.name.name.as_str(), "arguments" | "completions")),
+            ExprKind::Ident(binding) => self
+                .command_argument_metadata_bindings
+                .get(&binding.name)
+                .copied()
+                .unwrap_or(false),
+            _ => false,
         }
     }
 
@@ -1121,6 +1222,8 @@ mod tests {
                 aliases: vec!["outline".to_string(), "symbols".to_string()],
                 visible: true,
                 scope: CommandScope::Global,
+                arguments: false,
+                completions: Vec::new(),
             }]
         );
         assert_eq!(
@@ -1195,6 +1298,8 @@ mod tests {
                 aliases: Vec::new(),
                 visible: false,
                 scope: CommandScope::Editor,
+                arguments: false,
+                completions: Vec::new(),
             }]
         );
         validate_source("valid", "plugins/valid.hk", source).unwrap();

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0",
+  "version": "0.11.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },

--- a/src/plugin/package.rs
+++ b/src/plugin/package.rs
@@ -43,6 +43,7 @@ const MAX_PACKAGE_UNPACKED_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_PACKAGE_ARCHIVE_FILES: usize = 1024;
 const MAX_CATALOG_GRAMMAR_BYTES: u64 = 64 * 1024 * 1024;
 const COMMAND_SCOPE_API_VERSION: &str = "0.7.0";
+const COMMAND_ARGUMENTS_API_VERSION: &str = "0.11.0";
 
 /// A parsed and validated stable plugin identifier.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -268,6 +269,12 @@ impl PluginPackageManifest {
                 target.display()
             );
         }
+        if self.uses_command_arguments(package_root) {
+            anyhow::ensure!(host_api_requirement_requires_at_least(
+                &self.plugin.red_api, COMMAND_ARGUMENTS_API_VERSION)?,
+                "plugin uses command arguments introduced in Red host API {COMMAND_ARGUMENTS_API_VERSION}, but manifest range `{}` includes an older supported API; declare `red_api = \"^{COMMAND_ARGUMENTS_API_VERSION}\"` or later",
+                self.plugin.red_api);
+        }
         if self.uses_command_scope(package_root) {
             anyhow::ensure!(
                 host_api_requirement_requires_at_least(
@@ -349,6 +356,24 @@ impl PluginPackageManifest {
         }
         validate_keymaps(&self.keymaps)?;
         Ok(())
+    }
+
+    fn uses_command_arguments(&self, package_root: &Path) -> bool {
+        if let Some(manifest) = &self.plugin.husk_manifest {
+            return ResolvedPackage::open(package_root.join(manifest), PackageLimits::default())
+                .is_ok_and(|package| {
+                    package
+                        .modules
+                        .iter()
+                        .any(|module| super::api::source_uses_command_arguments(&module.syntax))
+                });
+        }
+        self.plugin.entry.as_ref().is_some_and(|entry| {
+            fs::read_to_string(package_root.join(entry))
+                .ok()
+                .and_then(|source| husk_parser::parse_str(&source).file)
+                .is_some_and(|file| super::api::source_uses_command_arguments(&file))
+        })
     }
 
     fn uses_command_scope(&self, package_root: &Path) -> bool {
@@ -1827,6 +1852,39 @@ symbol = "tree_sitter_buildspec"
             manifest.plugin.red_api,
             VersionReq::parse("^0.6.0").unwrap()
         );
+    }
+
+    #[test]
+    fn package_manifest_requires_current_api_for_command_arguments() {
+        for (label, source) in [
+            (
+                "declarative",
+                r#"#[red::command(name = "Test", arguments = true)] fn test(command: CommandInvocation) {}"#,
+            ),
+            (
+                "imperative",
+                r#"pub fn activate() { red::add_command("Test", test, Json { arguments: true }); } fn test(command: CommandInvocation) {}"#,
+            ),
+            (
+                "variable",
+                r#"pub fn activate() { let metadata = Json { arguments: true }; red::add_command("Test", test, metadata); } fn test(command: CommandInvocation) {}"#,
+            ),
+        ] {
+            let package = tempfile::tempdir().unwrap();
+            write_package(package.path(), &format!("{label}-arguments"), "1.0.0");
+            fs::write(package.path().join("src/main.hk"), source).unwrap();
+            PluginPackageManifest::load(package.path()).unwrap();
+            let path = package.path().join(PLUGIN_MANIFEST_FILE);
+            let manifest = fs::read_to_string(&path)
+                .unwrap()
+                .replace(&format!("^{RED_HOST_API_VERSION}"), "^0.10.0");
+            fs::write(path, manifest).unwrap();
+            let error = PluginPackageManifest::load(package.path()).unwrap_err();
+            assert!(
+                error.to_string().contains("command arguments introduced"),
+                "{label}: {error}"
+            );
+        }
     }
 
     #[test]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -33,13 +33,14 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.10.0";
+pub const RED_HOST_API_VERSION: &str = "0.11.0";
 pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
     "0.4.0",
     "0.6.0",
     "0.7.0",
     "0.8.0",
     "0.9.0",
+    "0.10.0",
     RED_HOST_API_VERSION,
 ];
 
@@ -319,13 +320,19 @@ impl PluginRegistry {
         if runtime.command_plugin(command).is_some() {
             return;
         }
-        if let Some((name, path)) = self.pending_command_plugin(command) {
+        if let Some((name, path)) = self
+            .pending_command_plugin(command)
+            .or_else(|| self.pending_command_plugin(crate::command::split_invocation(command).0))
+        {
             self.activate_one(runtime, &name, &path).await;
         }
     }
 
     pub(crate) fn has_pending_command(&self, command: &str) -> bool {
         self.pending_command_plugin(command).is_some()
+            || self
+                .pending_command_plugin(crate::command::split_invocation(command).0)
+                .is_some()
     }
 
     fn pending_command_plugin(&self, command: &str) -> Option<(String, String)> {

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -72,6 +72,10 @@ pub struct CommandMetadata {
     pub aliases: Vec<String>,
     pub visible: bool,
     pub scope: CommandScope,
+    /// Opt in to receiving one `CommandInvocation` callback argument.
+    pub arguments: bool,
+    /// Optional literal completion choices, indexed by argument position.
+    pub completions: Vec<Vec<String>>,
 }
 
 impl Default for CommandMetadata {
@@ -83,8 +87,28 @@ impl Default for CommandMetadata {
             aliases: Vec::new(),
             visible: true,
             scope: CommandScope::Editor,
+            arguments: false,
+            completions: Vec::new(),
         }
     }
+}
+
+pub(crate) fn validate_command_arguments(
+    arguments: bool,
+    completions: &[Vec<String>],
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        arguments || completions.is_empty(),
+        "command completions require arguments = true"
+    );
+    anyhow::ensure!(
+        completions
+            .iter()
+            .flatten()
+            .all(|value| !value.is_empty() && !value.chars().any(char::is_whitespace)),
+        "command completion choices must be nonempty single arguments"
+    );
+    Ok(())
 }
 
 /// Surfaces from which a registered plugin command may be invoked by keymap.
@@ -156,6 +180,13 @@ struct CommandMetadata {
     aliases: [String],
     visible: bool,
     scope: String,
+    arguments: bool,
+    completions: [[String]],
+}
+struct CommandInvocation {
+    name: String,
+    args: [String],
+    raw_args: String,
 }
 struct Position {
     line: i32,
@@ -2187,6 +2218,7 @@ impl RedHost {
                         anyhow::anyhow!("invalid metadata for command `{command}`: {error}")
                     })?
                     .unwrap_or_default();
+                validate_command_registration(self, &callback, &metadata)?;
                 if let Some(existing) = self.policy().commands.get(command) {
                     if existing.callback.plugin() != plugin {
                         anyhow::bail!(
@@ -2924,6 +2956,8 @@ impl Host for RedHost {
                     aliases,
                     visible,
                     scope,
+                    arguments,
+                    completions,
                 } => {
                     if let Some(existing) = self.policy().commands.get(&name) {
                         if existing.callback.plugin() == plugin {
@@ -2934,18 +2968,22 @@ impl Host for RedHost {
                             existing.callback.plugin()
                         );
                     }
+                    let metadata = CommandMetadata {
+                        title,
+                        category,
+                        description,
+                        aliases,
+                        visible,
+                        scope,
+                        arguments,
+                        completions,
+                    };
+                    validate_command_registration(self, function.callback(), &metadata)?;
                     self.policy_mut().commands.insert(
                         name,
                         RedCommand {
                             callback: function.callback().clone(),
-                            metadata: CommandMetadata {
-                                title,
-                                category,
-                                description,
-                                aliases,
-                                visible,
-                                scope,
-                            },
+                            metadata,
                         },
                     );
                 }
@@ -3677,27 +3715,17 @@ impl Runtime {
 
     #[must_use]
     pub fn command_plugin(&self, command: &str) -> Option<String> {
-        self.inner
-            .lock()
-            .unwrap()
-            .host
-            .policy()
-            .commands
-            .get(command)
-            .map(|command| command.callback.plugin().to_string())
+        let inner = self.inner.lock().unwrap();
+        resolve_command(&inner.host.policy().commands, command)
+            .map(|(_, command, _)| command.callback.plugin().to_string())
     }
 
     /// Returns the key-dispatch scope declared by an active plugin command.
     #[must_use]
     pub fn command_scope(&self, command: &str) -> Option<CommandScope> {
-        self.inner
-            .lock()
-            .unwrap()
-            .host
-            .policy()
-            .commands
-            .get(command)
-            .map(|command| command.metadata.scope)
+        let inner = self.inner.lock().unwrap();
+        resolve_command(&inner.host.policy().commands, command)
+            .map(|(_, command, _)| command.metadata.scope)
     }
 
     /// Returns the active plugin commands in a stable order for discovery UI.
@@ -3736,13 +3764,16 @@ impl Runtime {
         let _span = crate::editor::perf::PerfSpan::with_detail("husk:command", command);
         let mut inner = self.inner.lock().unwrap();
         let RuntimeInner { plugins, host, .. } = &mut *inner;
-        let callback = host
-            .policy()
-            .commands
-            .get(command)
-            .map(|command| command.callback.clone())
+        let (name, registered, raw_args) = resolve_command(&host.policy().commands, command)
             .ok_or_else(|| anyhow::anyhow!("unknown Husk plugin command `{command}`"))?;
-        call_plugin_callback(plugins, host, &callback, Vec::new()).map(drop)
+        let callback = registered.callback.clone();
+        let args = if registered.metadata.arguments {
+            let payload = command_invocation_payload(name, raw_args);
+            vec![decoded_callback_payload(host, &callback, 0, &payload)?]
+        } else {
+            Vec::new()
+        };
+        call_plugin_callback(plugins, host, &callback, args).map(drop)
     }
 
     pub async fn notify(&mut self, event: &str, args: serde_json::Value) -> anyhow::Result<()> {
@@ -4024,6 +4055,54 @@ fn call_plugin_callback(
         )
     })?;
     vm.call_callback(callback, args, host)
+}
+
+/// Exact legacy command names win over argument-aware prefix resolution.
+fn resolve_command<'a>(
+    commands: &'a HashMap<String, RedCommand>,
+    input: &'a str,
+) -> Option<(&'a str, &'a RedCommand, &'a str)> {
+    if let Some((name, command)) = commands.get_key_value(input) {
+        return Some((name, command, ""));
+    }
+    let (name, raw_args) = crate::command::split_invocation(input);
+    let (name, command) = commands.get_key_value(name)?;
+    command
+        .metadata
+        .arguments
+        .then_some((name, command, raw_args))
+}
+
+fn command_invocation_payload(name: &str, raw_args: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "args": raw_args.split_whitespace().collect::<Vec<_>>(),
+        "raw_args": raw_args,
+    })
+}
+
+fn validate_command_registration(
+    host: &RedHost,
+    callback: &Callback,
+    metadata: &CommandMetadata,
+) -> anyhow::Result<()> {
+    validate_command_arguments(metadata.arguments, &metadata.completions)?;
+    if metadata.arguments {
+        if let Some(parameters) = host
+            .policy()
+            .payload_schemas
+            .get(callback.plugin())
+            .and_then(|schema| schema.callback_parameters.get(callback.function()))
+        {
+            anyhow::ensure!(
+                matches!(parameters.as_slice(), [TypeExpr { kind: TypeExprKind::Named(name), .. }]
+                    if matches!(name.name.as_str(), "CommandInvocation" | "Json" | "JsValue")),
+                "argument-aware command callback must take one CommandInvocation or Json parameter"
+            );
+        }
+        decoded_callback_payload(host, callback, 0, &command_invocation_payload("", ""))?;
+    }
+    Ok(())
 }
 
 fn decoded_callback_payload(
@@ -5067,6 +5146,85 @@ mod tests {
             runtime.command_scope("ProjectSearch"),
             Some(CommandScope::Global)
         );
+    }
+
+    #[tokio::test]
+    async fn command_arguments_dispatch_typed_payloads_and_keep_legacy_commands() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime.load_plugin("command_arguments", r#"
+            #[red::command(name = "Service", arguments = true,
+                completions = [["enable", "disable"], ["local", "workspace"]], scope = "global")]
+            fn service(command: CommandInvocation) {
+                red::execute("Print", format("{}|{}|{}", command.name, command.args.len(), command.raw_args));
+            }
+            fn imperative(command: CommandInvocation) {
+                red::execute("Print", command.args[0]);
+            }
+            fn legacy() { red::execute("Print", "legacy"); }
+            pub fn activate() {
+                red::add_command("Imperative", imperative,
+                    Json { arguments: true, completions: [["status"]] });
+                red::add_command("Legacy", legacy);
+                red::add_command("Service exact", legacy);
+            }
+        "#).await.unwrap();
+        let commands = runtime.registered_commands();
+        let service = commands
+            .iter()
+            .find(|command| command.name == "Service")
+            .unwrap();
+        assert!(service.metadata.arguments);
+        assert_eq!(
+            service.metadata.completions,
+            [vec!["enable", "disable"], vec!["local", "workspace"]]
+        );
+        assert_eq!(
+            runtime.command_scope("Service enable"),
+            Some(CommandScope::Global)
+        );
+        for (input, expected) in [
+            ("Service", "Service|0|"),
+            (
+                "Service  enable   workspace",
+                "Service|2|enable   workspace",
+            ),
+            ("Imperative status", "status"),
+            ("Legacy", "legacy"),
+            ("Service exact", "legacy"),
+        ] {
+            runtime.execute_command(input).await.unwrap();
+            assert!(
+                matches!(ACTION_DISPATCHER.recv_request(),
+                PluginRequest::Action(Action::Print(message)) if message == expected),
+                "{input}"
+            );
+        }
+        assert!(runtime.execute_command("Legacy extra").await.is_err());
+        assert!(runtime.command_plugin("Legacy extra").is_none());
+        assert!(runtime.command_plugin("Legacy").is_some());
+    }
+
+    #[tokio::test]
+    async fn command_arguments_reject_invalid_metadata_before_activation() {
+        for source in [
+            r#"#[red::command(name = "Bad", arguments = true)] fn bad() {}"#,
+            r#"#[red::command(name = "Bad", completions = [["one"]])] fn bad() {}"#,
+            r#"#[red::command(name = "Bad", arguments = true, completions = [["two words"]])] fn bad(command: CommandInvocation) {}"#,
+            r#"pub fn activate() { red::add_command("Bad", bad, Json { arguments: true }); } fn bad() {}"#,
+            r#"pub fn activate() { red::add_command("Bad", bad, Json { arguments: true, completions: [[""]] }); } fn bad(command: CommandInvocation) {}"#,
+            r#"#[red::command(name = "Bad", arguments = true)] fn bad(value: i32) {}"#,
+        ] {
+            let mut runtime = Runtime::new();
+            assert!(
+                runtime
+                    .load_plugin("invalid_command_arguments", source)
+                    .await
+                    .is_err(),
+                "{source}"
+            );
+            assert!(runtime.command_plugin("Bad").is_none());
+        }
     }
 
     #[tokio::test]

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -2094,6 +2094,22 @@ async fn command_tab_completes_builtin_names_and_cycles_matches() {
 }
 
 #[tokio::test]
+async fn command_tab_completes_arguments_without_executing_them() {
+    let mut harness = EditorHarness::with_content("");
+    harness.set_commandline(Mode::Command, "Copilot sign");
+    command_key(&mut harness, KeyCode::Tab).await;
+    assert_eq!(harness.commandline_text(), "Copilot signin");
+    command_key(&mut harness, KeyCode::Tab).await;
+    assert_eq!(harness.commandline_text(), "Copilot signout");
+    command_key(&mut harness, KeyCode::BackTab).await;
+    assert_eq!(harness.commandline_text(), "Copilot signin");
+    command_key(&mut harness, KeyCode::Char('x')).await;
+    command_key(&mut harness, KeyCode::Tab).await;
+    assert_eq!(harness.commandline_text(), "Copilot signinx");
+    assert_eq!(harness.last_error(), None);
+}
+
+#[tokio::test]
 async fn command_tab_completion_remains_case_sensitive() {
     let mut harness = EditorHarness::with_content("");
     harness.set_commandline(Mode::Command, "Wr");

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1928,6 +1928,67 @@ fn command_tab_completes_edit_file_argument() {
     fs::remove_dir_all(root).unwrap();
 }
 
+#[tokio::test]
+async fn command_tab_opens_completed_paths_with_spaces() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("name  with spaces.txt!");
+    let command_directory = directory.path().to_string_lossy().replace('\\', "/");
+    let command_path = format!("{command_directory}/name  with spaces.txt!");
+    fs::write(&path, "completed file contents\n").unwrap();
+
+    for command in ["e", "edit", "e!", "split", "sp", "vsplit", "vs"] {
+        let mut harness = EditorHarness::with_content("");
+        harness.set_commandline(
+            Mode::Command,
+            &format!("{command} {command_directory}/name"),
+        );
+
+        command_key(&mut harness, KeyCode::Tab).await;
+        assert_eq!(
+            harness.commandline_text(),
+            format!("{command} {command_path}")
+        );
+        command_key(&mut harness, KeyCode::Enter).await;
+
+        assert_eq!(
+            harness.buffer_contents(),
+            "completed file contents\n",
+            "{command} did not open the completed path"
+        );
+    }
+}
+
+#[tokio::test]
+async fn command_tab_writes_completed_paths_with_spaces() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("name  with spaces.txt!");
+    let command_directory = directory.path().to_string_lossy().replace('\\', "/");
+    let command_path = format!("{command_directory}/name  with spaces.txt!");
+
+    for command in ["w", "write", "w!", "write!"] {
+        fs::write(&path, "old contents\n").unwrap();
+        let mut harness = EditorHarness::with_content("saved contents\n");
+        harness.set_commandline(
+            Mode::Command,
+            &format!("{command} {command_directory}/name"),
+        );
+
+        command_key(&mut harness, KeyCode::Tab).await;
+        assert_eq!(
+            harness.commandline_text(),
+            format!("{command} {command_path}")
+        );
+        command_key(&mut harness, KeyCode::Enter).await;
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "saved contents\n",
+            "{command} did not write the completed path"
+        );
+        assert!(!directory.path().join("name").exists());
+    }
+}
+
 #[test]
 fn command_tab_preserves_relative_path_prefix() {
     let (root, _guard) = command_completion_temp_dir("relative-prefix");


### PR DESCRIPTION
Colon-command completion currently handles command names, file paths, and syntax names, but users must remember other arguments. Commands such as `:Copilot signin` need discoverable values without running the command while the user is still editing it.

**Dependency:** #249 owns the Copilot integration. This branch includes a cherry-pick of its initial implementation so the real Copilot commands can be tested. The current diff therefore also includes the opt-in language-server transport, privacy controls, ghost-text rendering, and acceptance behavior. Merge #249 first, then replay the completion commit `f5f9d8c` onto updated `main` before merging this PR, preserving #249's newer sign-in fixes.

The completion change:

- extracts a shared, side-effect-free completion engine for fixed choices, paths, and syntax names
- completes Copilot subcommands, `languages reload`, and supported `set` options; preserves Tab/Shift-Tab cycling, case sensitivity, and existing whole-path completion
- adds opt-in plugin command arguments and positional completion choices through both annotations and `red::add_command`; existing zero-argument callbacks remain compatible
- introduces host API `0.11.0`, validates callback signatures and metadata, and documents the migration in `docs/PLUGIN_API.md`

## How to Test

1. Run `cargo run --bin red -- -c 'copilot.enabled = false'`. Type `:Copilot en` and press Tab. Expect `:Copilot enable`; completion itself must not enable Copilot or start sign-in.
2. Type `:Copilot sign` and press Tab twice, then Shift-Tab. Expect `signin`, `signout`, then `signin`. Type an extra character and press Tab; an unmatched argument must remain unchanged. `:Copilot enable ` must not suggest a second argument.
3. Check `:languages re<Tab>`, `:set norn<Tab>`, `:syntax ru<Tab>`, and `:e ./sr<Tab>`. Expect the matching argument or path, with existing directory-first/path cycling behavior preserved.
4. Load the `Service` plugin example from `docs/PLUGIN_API.md#command-arguments-and-completion`. Complete its first and second arguments, then press Enter. Expect the callback to receive the arguments only on execution. Existing zero-argument plugin commands must still work.

At `f5f9d8c`, 48 focused library tests passed across `command::test`, `command_palette::tests`, `command_completion::tests`, `plugin::api::tests`, and the `command_arguments` tests. Strict Clippy, formatting, and `cargo build --bin red` also passed. Editor/end-to-end tests were added but remain unrun at the requested manual-test checkpoint.