### PR TITLE
feat(ui): support word backspace in dialogs

### DIFF
--- a/almanac/reference/editor/ui-components.md
+++ b/almanac/reference/editor/ui-components.md
@@ -72,6 +72,14 @@ Red's modal UI components implement a common `Component` trait above the editor 
 
 `InputPrompt` is a single-line prompt. It can be normal, secret, or callback-owned, masks secret rendering with asterisks, returns submitted values through an action or composer callback, cancels empty submissions, and keeps cursor edits grapheme-aware [@input-prompt]. It exposes `composer_handle()` for callback prompts and computes cursor position differently for masked and unmasked input, using grapheme count for masked values and display width for visible values [@input-prompt].
 
+Editable dialogs accept `Alt-Backspace` (Option-Delete on macOS) and
+`Ctrl-Backspace` (Windows) to remove the preceding word. Both shortcuts work
+on either platform when the terminal reports the modifier. Selected initial
+values in single-line prompts are cleared as a whole. Composers retain
+`Ctrl-W`; active search fields edit their own query instead of the underlying
+draft. Word boundaries remain whitespace-delimited, including punctuation
+and paths within a word.
+
 ## Resource Ownership
 
 Plugin-owned pickers and composers are identified by handles returned from `picker_handle()` and `composer_handle()` [@ui-core]. [Plugin resource ownership](../../architecture/plugins/resource-ownership) covers the lifecycle around those handles, while [callback-scoped dialogs](../../concepts/plugins/callback-scoped-dialogs) explains why callback-owned dialogs close by notifying the handle owner instead of sending global plugin events.

--- a/src/editing/textarea.rs
+++ b/src/editing/textarea.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{
@@ -12,9 +12,13 @@ use super::{
 use crate::{
     buffer::Buffer,
     editor::Mode,
+    keyboard::is_word_backspace,
     text_layout::{LayoutOptions, TextLayout},
     undo::{CursorSnapshot, TextPosition, TextRange},
-    unicode_utils::{char_to_grapheme, grapheme_len, grapheme_to_byte, trim_line_ending},
+    unicode_utils::{
+        char_to_grapheme, delete_last_word, grapheme_len, grapheme_to_byte, previous_word_start,
+        trim_line_ending,
+    },
 };
 
 const DEFAULT_MAX_BYTES: usize = 128 * 1024;
@@ -313,16 +317,7 @@ impl TextArea {
         }
         let text = self.text();
         let end = grapheme_to_byte(&text, self.state.cursor);
-        let mut start = self.state.cursor;
-        let mut seen_word = false;
-        for grapheme in text[..end].graphemes(true).rev() {
-            let whitespace = grapheme.chars().all(char::is_whitespace);
-            if seen_word && whitespace {
-                break;
-            }
-            seen_word |= !whitespace;
-            start -= 1;
-        }
+        let start = grapheme_len(&text[..previous_word_start(&text[..end])]);
         self.replace_graphemes(start, self.state.cursor, "", start, "delete previous word")
     }
 
@@ -393,6 +388,9 @@ impl TextArea {
     }
 
     fn handle_key(&mut self, key: KeyEvent, layout: LayoutOptions) -> TextAreaOutcome {
+        if key.kind == KeyEventKind::Release {
+            return TextAreaOutcome::Changed;
+        }
         if self.state.mode == Mode::Search {
             return self.handle_search_key(key);
         }
@@ -455,6 +453,10 @@ impl TextArea {
             }
             KeyCode::End => {
                 self.set_cursor(grapheme_len(&self.text()));
+                return TextAreaOutcome::Changed;
+            }
+            KeyCode::Backspace if is_word_backspace(key) => {
+                self.delete_previous_word();
                 return TextAreaOutcome::Changed;
             }
             KeyCode::Backspace => {
@@ -1411,6 +1413,15 @@ impl TextArea {
     }
 
     fn handle_search_key(&mut self, key: KeyEvent) -> TextAreaOutcome {
+        if is_word_backspace(key)
+            || (matches!(key.code, KeyCode::Char('w' | 'W'))
+                && key.modifiers.contains(KeyModifiers::CONTROL))
+        {
+            if let Some(search) = self.state.search.as_mut() {
+                delete_last_word(&mut search.pattern);
+            }
+            return TextAreaOutcome::Changed;
+        }
         match key.code {
             KeyCode::Esc => {
                 if let Some(search) = self.state.search.take() {
@@ -1826,6 +1837,23 @@ fn unnamed_buffer(text: &str) -> Buffer {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn word_backspace_in_search_edits_only_the_search_pattern() {
+        for key in [
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        ] {
+            let mut area = normal("keep this draft");
+            keys(&mut area, "/first second");
+            assert_eq!(area.mode(), Mode::Search);
+            area.handle_event(&Event::Key(key), 80);
+            assert_eq!(area.state.search.as_ref().unwrap().pattern, "first ");
+            assert_eq!(area.text(), "keep this draft");
+            assert_eq!(area.mode(), Mode::Search);
+        }
+    }
 
     #[test]
     fn empty_textarea_has_an_exact_clean_baseline() {

--- a/src/editor/inline_history.rs
+++ b/src/editor/inline_history.rs
@@ -472,6 +472,10 @@ impl Editor {
                 browser.query.pop();
                 browser.selected = None;
             }
+            HistoryAction::DeletePreviousWord => {
+                crate::unicode_utils::delete_last_word(&mut browser.query);
+                browser.selected = None;
+            }
             HistoryAction::EndSearch => browser.searching = false,
             HistoryAction::ClearSearch => {
                 browser.searching = false;

--- a/src/editor/inline_history/tests.rs
+++ b/src/editor/inline_history/tests.rs
@@ -1,6 +1,45 @@
 use super::*;
 use crate::{inline_assist::InlineCommentInput, lsp::LspManager};
 
+#[tokio::test]
+async fn word_backspace_updates_the_editor_owned_inline_history_query() {
+    for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+        let mut editor = editor("unchanged\n");
+        let mut frame = RenderBuffer::new(100, 30, &Style::default());
+        let mut runtime = Runtime::new();
+        editor
+            .open_inline_history(&mut frame, &mut runtime)
+            .await
+            .unwrap();
+        editor
+            .handle_inline_history_action(&HistoryAction::Search, &mut frame, &mut runtime)
+            .await
+            .unwrap();
+        editor
+            .handle_inline_history_action(
+                &HistoryAction::Query("one 👨‍👩‍👧e\u{301}".into()),
+                &mut frame,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        let event = Event::Key(KeyEvent::new(KeyCode::Backspace, modifiers));
+        let Some(KeyAction::Single(Action::InlineHistoryAction(action))) =
+            editor.current_dialog.as_mut().unwrap().handle_event(&event)
+        else {
+            panic!("inline history search did not handle word backspace");
+        };
+        editor
+            .handle_inline_history_action(&action, &mut frame, &mut runtime)
+            .await
+            .unwrap();
+        let browser = editor.inline_history_browser.as_ref().unwrap();
+        assert_eq!(browser.query, "one ");
+        assert!(browser.searching);
+        assert_eq!(editor.current_buffer().contents(), "unchanged\n");
+    }
+}
+
 fn editor(text: &str) -> Editor {
     let config = Config::default();
     let mut editor = Editor::with_size(

--- a/src/editor/notifications.rs
+++ b/src/editor/notifications.rs
@@ -352,6 +352,10 @@ impl Editor {
                 browser.query.pop();
                 browser.scroll = 0;
             }
+            MessageAction::DeletePreviousWord => {
+                crate::unicode_utils::delete_last_word(&mut browser.query);
+                browser.scroll = 0;
+            }
             MessageAction::EndSearch => browser.searching = false,
             MessageAction::ClearSearch => {
                 browser.query.clear();
@@ -407,6 +411,27 @@ impl Editor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn word_backspace_updates_the_editor_owned_message_query() {
+        for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+            let mut editor = editor(100, 24);
+            editor.open_messages();
+            editor.handle_message_action(&MessageAction::Search);
+            editor.handle_message_action(&MessageAction::Query("one 👨‍👩‍👧e\u{301}".into()));
+            let event = Event::Key(KeyEvent::new(KeyCode::Backspace, modifiers));
+            let Some(KeyAction::Single(Action::MessageHistory(action))) =
+                editor.current_dialog.as_mut().unwrap().handle_event(&event)
+            else {
+                panic!("message search did not handle word backspace");
+            };
+            editor.handle_message_action(&action);
+            let browser = editor.message_browser.as_ref().unwrap();
+            assert_eq!(browser.query, "one ");
+            assert!(browser.searching);
+            assert_eq!(browser.scroll, 0);
+        }
+    }
 
     fn editor(width: usize, height: usize) -> Editor {
         let config = Config::default();

--- a/src/inline_history.rs
+++ b/src/inline_history.rs
@@ -20,6 +20,7 @@ pub enum HistoryAction {
     Search,
     Query(String),
     Backspace,
+    DeletePreviousWord,
     EndSearch,
     ClearSearch,
     ScrollDown,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -36,6 +36,15 @@ pub enum KeyboardProtocol {
 // the active mode before leaving the alternate screen, without a double pop.
 static ACTIVE_PROTOCOL: AtomicU8 = AtomicU8::new(0);
 
+/// Recognizes the macOS and Windows word-backspace shortcuts on either platform.
+/// Terminal protocols and remote sessions can report either modifier.
+pub(crate) fn is_word_backspace(key: KeyEvent) -> bool {
+    key.code == KeyCode::Backspace
+        && key
+            .modifiers
+            .intersects(KeyModifiers::ALT | KeyModifiers::CONTROL)
+}
+
 impl KeyboardProtocol {
     /// Negotiate before starting the event loop; capability queries share its reader.
     pub fn start(output: &mut impl Write, preference: KeyboardPreference) -> io::Result<Self> {
@@ -167,7 +176,7 @@ pub fn inspect_keys(preference: KeyboardPreference, count: Option<usize>) -> any
     )?;
     writeln!(
         output,
-        "Press Enter, modified Enter, or Ctrl+J; Esc/Ctrl+C exits. Text is not recorded.\r"
+        "Press Enter, Backspace, or their modified shortcuts; Esc/Ctrl+C exits. Text is not recorded.\r"
     )?;
     output.flush()?;
     let mut seen = 0;
@@ -191,6 +200,7 @@ pub fn inspect_keys(preference: KeyboardPreference, count: Option<usize>) -> any
 fn describe_key(key: KeyEvent) -> String {
     let code = match key.code {
         KeyCode::Enter => "Enter",
+        KeyCode::Backspace => "Backspace",
         KeyCode::Char('\r') => "CR",
         KeyCode::Char('\n') => "LF",
         KeyCode::Char('j' | 'J') if key.modifiers.contains(KeyModifiers::CONTROL) => "Ctrl+J",
@@ -206,6 +216,32 @@ fn describe_key(key: KeyEvent) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn word_backspace_recognizes_both_platform_shortcuts() {
+        for modifiers in [
+            KeyModifiers::ALT,
+            KeyModifiers::CONTROL,
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        ] {
+            assert!(is_word_backspace(KeyEvent::new(
+                KeyCode::Backspace,
+                modifiers
+            )));
+        }
+        for (code, modifiers) in [
+            (KeyCode::Backspace, KeyModifiers::NONE),
+            (KeyCode::Backspace, KeyModifiers::SHIFT),
+            (KeyCode::Delete, KeyModifiers::CONTROL),
+            (KeyCode::Char('h'), KeyModifiers::CONTROL),
+        ] {
+            assert!(!is_word_backspace(KeyEvent::new(code, modifiers)));
+        }
+        assert!(
+            describe_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT))
+                .contains("code=Backspace modifiers=KeyModifiers(ALT)")
+        );
+    }
 
     #[test]
     fn protocol_commands_are_balanced_and_minimal() {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -38,6 +38,7 @@ pub enum MessageAction {
     Search,
     Query(String),
     Backspace,
+    DeletePreviousWord,
     EndSearch,
     ClearSearch,
     CycleFilter,

--- a/src/ui/agent_composer.rs
+++ b/src/ui/agent_composer.rs
@@ -438,6 +438,33 @@ mod tests {
         AgentComposer::new(editor, title, id, query, history, "agent".to_string())
     }
 
+    #[test]
+    fn word_backspace_preserves_the_composer_submission_contract() {
+        let editor = editor(60, 18);
+        let handle = ComposerHandle::from_raw(42);
+        for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+            let mut composer = AgentComposer::new_callback(
+                &editor,
+                Some("Prompt".into()),
+                "first second".into(),
+                vec![],
+                handle,
+            );
+            composer.handle_event(&key(KeyCode::Backspace, modifiers));
+            assert_eq!(composer.prompt.text(), "first ");
+            assert_eq!(
+                submit(&mut composer),
+                Some(KeyAction::Multiple(vec![
+                    Action::NotifyComposer(
+                        handle,
+                        Box::new(ComposerCallback::Submitted("first ".into()))
+                    ),
+                    Action::CloseDialog,
+                ]))
+            );
+        }
+    }
+
     fn rendered_row(buffer: &RenderBuffer, y: usize) -> String {
         buffer.cells[y * buffer.width..(y + 1) * buffer.width]
             .iter()

--- a/src/ui/inline_assist.rs
+++ b/src/ui/inline_assist.rs
@@ -1,10 +1,11 @@
 //! Cursor-anchored prompt and result controls for bounded inline code edits.
 
-use crossterm::event::{Event, KeyCode, KeyModifiers, MouseEventKind};
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
 
 use crate::{
     config::KeyAction,
     editor::{Action, Editor, Mode, RenderBuffer},
+    keyboard::is_word_backspace,
     theme::{Style, Theme},
     unicode_utils::{grapheme_len, truncate_display_width},
 };
@@ -410,6 +411,9 @@ impl Component for InlineAssistPopup {
     }
 
     fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        if matches!(event, Event::Key(key) if key.kind == KeyEventKind::Release) {
+            return None;
+        }
         if let Event::Mouse(mouse) = event {
             if matches!(mouse.kind, MouseEventKind::Down(_))
                 && !self.inside(mouse.column as usize, mouse.row as usize)
@@ -463,7 +467,11 @@ impl Component for InlineAssistPopup {
                         Self::refresh_action()
                     }
                     (KeyCode::Backspace, _) => {
-                        self.prompt.backspace();
+                        if is_word_backspace(*key) {
+                            self.prompt.delete_previous_word();
+                        } else {
+                            self.prompt.backspace();
+                        }
                         self.prompt_changed()
                     }
                     (KeyCode::Delete, _) => {
@@ -634,6 +642,35 @@ mod tests {
                 popup.handle_event(&Event::Key(KeyEvent::new(key, KeyModifiers::NONE))),
                 Some(KeyAction::Single(action))
             );
+        }
+    }
+
+    #[test]
+    fn word_backspace_edits_inline_assist_without_submitting() {
+        let editor = editor();
+        for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+            let mut popup = InlineAssistPopup::new(
+                &editor,
+                "line 1",
+                InlineAssistPopupState::Prompt {
+                    initial: "first second".into(),
+                    refining: false,
+                },
+            );
+            assert_eq!(
+                popup.handle_event(&Event::Key(KeyEvent::new_with_kind(
+                    KeyCode::Backspace,
+                    modifiers,
+                    KeyEventKind::Release,
+                ))),
+                None
+            );
+            assert_eq!(popup.prompt.text(), "first second");
+            assert_eq!(
+                popup.handle_event(&Event::Key(KeyEvent::new(KeyCode::Backspace, modifiers,))),
+                Some(KeyAction::Single(Action::Refresh))
+            );
+            assert_eq!(popup.prompt.text(), "first ");
         }
     }
 

--- a/src/ui/inline_history.rs
+++ b/src/ui/inline_history.rs
@@ -8,10 +8,11 @@ use crate::{
     config::KeyAction,
     editor::{Action, Editor, RenderBuffer},
     inline_history::HistoryAction,
+    keyboard::is_word_backspace,
     theme::Theme,
     unicode_utils::{fit_display_width, truncate_display_width},
 };
-use crossterm::event::{Event, KeyCode, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 
 pub(crate) struct InlineHistoryPanel {
     rows: Vec<String>,
@@ -213,12 +214,18 @@ impl Component for InlineHistoryPanel {
         self.theme = theme.clone();
     }
     fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        if matches!(event, Event::Key(key) if key.kind == KeyEventKind::Release) {
+            return None;
+        }
         if self.searching {
             return match event {
                 Event::Paste(text) => Self::action(HistoryAction::Query(text.clone())),
                 Event::Key(key) => match key.code {
                     KeyCode::Esc => Self::action(HistoryAction::ClearSearch),
                     KeyCode::Enter => Self::action(HistoryAction::EndSearch),
+                    KeyCode::Backspace if is_word_backspace(*key) => {
+                        Self::action(HistoryAction::DeletePreviousWord)
+                    }
                     KeyCode::Backspace => Self::action(HistoryAction::Backspace),
                     KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                         Self::action(HistoryAction::Query(ch.to_string()))
@@ -270,6 +277,47 @@ impl Component for InlineHistoryPanel {
 mod tests {
     use super::*;
     use crate::color::Color;
+
+    #[test]
+    fn word_backspace_routes_only_active_inline_history_search() {
+        let mut panel = InlineHistoryPanel {
+            rows: vec![],
+            selected: 0,
+            detail: String::new(),
+            scroll: 0,
+            searching: true,
+            query: "one two".into(),
+            confirm_forget: false,
+            title: "History".into(),
+            width: 80,
+            height: 24,
+            theme: Theme::default(),
+        };
+        for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+            let key = crossterm::event::KeyEvent::new(KeyCode::Backspace, modifiers);
+            assert_eq!(
+                panel.handle_event(&Event::Key(key)),
+                Some(KeyAction::Single(Action::InlineHistoryAction(
+                    HistoryAction::DeletePreviousWord
+                )))
+            );
+            assert_eq!(
+                panel.handle_event(&Event::Key(crossterm::event::KeyEvent {
+                    kind: KeyEventKind::Release,
+                    ..key
+                })),
+                None
+            );
+        }
+        panel.searching = false;
+        assert_eq!(
+            panel.handle_event(&Event::Key(crossterm::event::KeyEvent::new(
+                KeyCode::Backspace,
+                KeyModifiers::CONTROL,
+            ))),
+            None
+        );
+    }
 
     #[test]
     fn selection_fills_both_lines_without_crossing_pane_boundary() {

--- a/src/ui/input_prompt.rs
+++ b/src/ui/input_prompt.rs
@@ -6,11 +6,12 @@
 //! [`Component::is_sensitive_input`] so
 //! performance traces do not include their contents.
 
-use crossterm::event::{Event, KeyCode, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 
 use crate::{
     config::KeyAction,
     editor::{Action, ComposerCallback, Editor, RenderBuffer},
+    keyboard::is_word_backspace,
     plugin::ComposerHandle,
     theme::{Style, Theme},
     unicode_utils::{display_width, grapheme_len, grapheme_to_byte, truncate_display_width},
@@ -150,6 +151,9 @@ impl Component for InputPrompt {
     }
 
     fn handle_event(&mut self, ev: &Event) -> Option<KeyAction> {
+        if matches!(ev, Event::Key(key) if key.kind == KeyEventKind::Release) {
+            return None;
+        }
         match ev {
             Event::Paste(text) => {
                 self.insert(text);
@@ -196,6 +200,8 @@ impl Component for InputPrompt {
                     if self.selected {
                         self.prompt.clear();
                         self.selected = false;
+                    } else if is_word_backspace(*key) {
+                        self.prompt.delete_previous_word();
                     } else {
                         self.prompt.backspace();
                     }
@@ -272,6 +278,33 @@ mod tests {
 
     fn key(code: KeyCode) -> Event {
         Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn word_backspace_respects_selection_cursor_and_secret_input() {
+        let editor = editor();
+        for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+            let shortcut = Event::Key(KeyEvent::new(KeyCode::Backspace, modifiers));
+            let mut selected = InputPrompt::new(&editor, "Rename", "old name", Action::Print);
+            selected.handle_event(&shortcut);
+            assert_eq!(selected.prompt.text(), "");
+            assert!(!selected.selected);
+
+            let mut prompt = InputPrompt::secret(&editor, "Secret", Action::Print);
+            prompt.handle_event(&Event::Paste("one 👨‍👩‍👧e\u{301} rest".into()));
+            prompt.prompt.set_cursor(6);
+            prompt.handle_event(&Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Backspace,
+                modifiers,
+                KeyEventKind::Release,
+            )));
+            assert_eq!(prompt.prompt.text(), "one 👨‍👩‍👧e\u{301} rest");
+            prompt.handle_event(&shortcut);
+            assert_eq!(prompt.prompt.text(), "one  rest");
+            assert_eq!(prompt.prompt.cursor(), 4);
+            assert!(prompt.prompt.undo());
+            assert_eq!(prompt.prompt.text(), "one 👨‍👩‍👧e\u{301} rest");
+        }
     }
 
     #[test]

--- a/src/ui/messages.rs
+++ b/src/ui/messages.rs
@@ -1,6 +1,6 @@
 //! Read-only notification history with a stable selection and a full-text detail pane.
 
-use crossterm::event::{Event, KeyCode, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 
 use super::{
     dialog::{BorderStyle, Dialog, SurfaceRole},
@@ -9,6 +9,7 @@ use super::{
 use crate::{
     config::KeyAction,
     editor::{Action, RenderBuffer},
+    keyboard::is_word_backspace,
     notification::{MessageAction, NotificationCounts},
     theme::Theme,
     unicode_utils::{fit_display_width, truncate_display_width},
@@ -223,12 +224,18 @@ impl Component for MessagesPanel {
     }
 
     fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        if matches!(event, Event::Key(key) if key.kind == KeyEventKind::Release) {
+            return None;
+        }
         if self.view.searching {
             return match event {
                 Event::Paste(text) => Self::action(MessageAction::Query(text.clone())),
                 Event::Key(key) => match key.code {
                     KeyCode::Esc => Self::action(MessageAction::ClearSearch),
                     KeyCode::Enter => Self::action(MessageAction::EndSearch),
+                    KeyCode::Backspace if is_word_backspace(*key) => {
+                        Self::action(MessageAction::DeletePreviousWord)
+                    }
                     KeyCode::Backspace => Self::action(MessageAction::Backspace),
                     KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                         Self::action(MessageAction::Query(ch.to_string()))
@@ -268,6 +275,50 @@ impl Component for MessagesPanel {
 mod tests {
     use super::*;
     use crate::color::Color;
+
+    #[test]
+    fn word_backspace_routes_only_active_message_search() {
+        let mut panel = MessagesPanel::new(
+            MessagesView {
+                rows: vec![],
+                selected: 0,
+                detail: String::new(),
+                scroll: 0,
+                query: "one two".into(),
+                searching: true,
+                filter: "all",
+                counts: NotificationCounts::default(),
+                feedback: None,
+            },
+            80,
+            24,
+            &Theme::default(),
+        );
+        for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+            let key = crossterm::event::KeyEvent::new(KeyCode::Backspace, modifiers);
+            assert_eq!(
+                panel.handle_event(&Event::Key(key)),
+                Some(KeyAction::Single(Action::MessageHistory(
+                    MessageAction::DeletePreviousWord
+                )))
+            );
+            assert_eq!(
+                panel.handle_event(&Event::Key(crossterm::event::KeyEvent {
+                    kind: KeyEventKind::Release,
+                    ..key
+                })),
+                None
+            );
+        }
+        panel.view.searching = false;
+        assert_eq!(
+            panel.handle_event(&Event::Key(crossterm::event::KeyEvent::new(
+                KeyCode::Backspace,
+                KeyModifiers::ALT,
+            ))),
+            None
+        );
+    }
 
     #[test]
     fn selection_fills_both_lines_without_crossing_pane_boundary() {

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -8,7 +8,7 @@
 //! terminal display columns. Selection actions are returned to the editor or plugin
 //! owner and never applied directly by this module.
 
-use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use ropey::{Rope, RopeSlice};
@@ -31,10 +31,12 @@ use crate::{
     config::{KeyAction, PickerIconStyle, PickerIconsConfig, PickerInputPosition},
     editor::{Action, Editor, PickerCallback, RenderBuffer, StyleInfo},
     highlighter::{Highlighter, LanguageRegistry},
+    keyboard::is_word_backspace,
     plugin::PickerHandle,
     theme::{SelectionForegroundPriority, Style, Theme},
     unicode_utils::{
-        byte_to_char, char_slice, display_width, fit_display_width, truncate_display_width,
+        byte_to_char, char_slice, delete_last_word, display_width, fit_display_width,
+        truncate_display_width,
     },
 };
 
@@ -3150,6 +3152,9 @@ impl Component for Picker {
     }
 
     fn handle_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
+        if matches!(ev, Event::Key(key) if key.kind == KeyEventKind::Release) {
+            return None;
+        }
         self.sync_list_bounds();
         match ev {
             Event::Paste(text) => {
@@ -3244,7 +3249,11 @@ impl Component for Picker {
                     KeyCode::Backspace => {
                         self.reset_history_navigation();
                         let previous = self.selected_item();
-                        if let Some((start, _)) = self.search.grapheme_indices(true).next_back() {
+                        if is_word_backspace(*event) {
+                            delete_last_word(&mut self.search);
+                        } else if let Some((start, _)) =
+                            self.search.grapheme_indices(true).next_back()
+                        {
                             self.search.truncate(start);
                         }
                         let search = self.search.clone();
@@ -3792,6 +3801,59 @@ mod tests {
         picker.handle_event(&key(KeyCode::Backspace, KeyModifiers::NONE));
 
         assert_eq!(picker.search, "prefix");
+    }
+
+    #[test]
+    fn word_backspace_refilters_and_detaches_picker_history() {
+        let editor = test_editor();
+        let items = vec!["alpha beta".into(), "alpha gamma".into(), "other".into()];
+        for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+            let mut picker = Picker::new(Some("Items".into()), &editor, &items, None);
+            picker.set_history("items", vec!["alpha beta".into()]);
+            picker.handle_event(&key(KeyCode::Char('h'), KeyModifiers::CONTROL));
+            assert_eq!(picker.search, "alpha beta");
+            picker.handle_event(&Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Backspace,
+                modifiers,
+                crossterm::event::KeyEventKind::Release,
+            )));
+            assert_eq!(picker.search, "alpha beta");
+            picker.handle_event(&key(KeyCode::Backspace, modifiers));
+            assert_eq!(picker.search, "alpha ");
+            assert_eq!(picker.list.items().len(), 2);
+            assert_eq!(
+                picker.handle_event(&key(KeyCode::Char('l'), KeyModifiers::CONTROL)),
+                None
+            );
+            assert_eq!(picker.search, "alpha ");
+        }
+    }
+
+    #[test]
+    fn word_backspace_notifies_live_picker_query_once() {
+        let editor = test_editor();
+        let handle = PickerHandle::from_raw(42);
+        for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+            let mut picker = Picker::new_callback(
+                Some("Live".into()),
+                &editor,
+                vec![],
+                handle,
+                PickerOptions::default(),
+            );
+            picker.set_search("first second".into());
+            let expected =
+                Action::NotifyPicker(handle, Box::new(PickerCallback::Query("first ".into())));
+            let actions = match picker.handle_event(&key(KeyCode::Backspace, modifiers)) {
+                Some(KeyAction::Single(action)) => vec![action],
+                Some(KeyAction::Multiple(actions)) => actions,
+                other => panic!("missing query callback: {other:?}"),
+            };
+            assert_eq!(
+                actions.iter().filter(|action| **action == expected).count(),
+                1
+            );
+        }
     }
 
     #[test]

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -282,7 +282,9 @@ impl PromptBuffer {
                 self.history_next();
                 PromptInput::Changed
             }
-            KeyCode::Char('w' | 'W') if modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char('w' | 'W')
+                if modifiers.contains(KeyModifiers::CONTROL) && self.mode() != Mode::Search =>
+            {
                 self.delete_previous_word();
                 PromptInput::Changed
             }
@@ -417,6 +419,41 @@ mod tests {
 
     fn composer(text: &str) -> PromptBuffer {
         PromptBuffer::new(text).with_key_policy(PromptKeyPolicy::EnterSends)
+    }
+
+    #[test]
+    fn word_backspace_detaches_history_under_both_prompt_policies() {
+        for policy in [PromptKeyPolicy::Vim, PromptKeyPolicy::EnterSends] {
+            for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+                let mut prompt =
+                    PromptBuffer::with_history("unsent draft", vec!["recalled entry".to_string()])
+                        .with_key_policy(policy);
+                assert!(prompt.history_previous());
+                prompt.handle_event(&key(KeyCode::Backspace, modifiers), 40);
+                assert_eq!(prompt.text(), "recalled ");
+                assert!(!prompt.history_next());
+                assert!(prompt.undo());
+                assert_eq!(prompt.text(), "recalled entry");
+            }
+        }
+    }
+
+    #[test]
+    fn word_backspace_does_not_delete_the_draft_during_embedded_search() {
+        for shortcut in [
+            key(KeyCode::Backspace, KeyModifiers::ALT),
+            key(KeyCode::Backspace, KeyModifiers::CONTROL),
+            key(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        ] {
+            let mut prompt = composer("keep this draft");
+            prompt.set_mode(Mode::Normal);
+            for character in "/first second".chars() {
+                prompt.handle_event(&key(KeyCode::Char(character), KeyModifiers::NONE), 40);
+            }
+            prompt.handle_event(&shortcut, 40);
+            assert_eq!(prompt.text(), "keep this draft");
+            assert_eq!(prompt.mode(), Mode::Search);
+        }
     }
 
     #[test]

--- a/src/unicode_utils.rs
+++ b/src/unicode_utils.rs
@@ -29,6 +29,28 @@ pub fn display_width(s: &str) -> usize {
     s.width()
 }
 
+/// Returns the byte boundary before trailing whitespace and the preceding word.
+/// Words use the prompt editor's existing whitespace-delimited semantics, and
+/// the result always falls on an extended-grapheme boundary.
+pub(crate) fn previous_word_start(text: &str) -> usize {
+    let mut start = text.len();
+    let mut seen_word = false;
+    for (index, grapheme) in text.grapheme_indices(true).rev() {
+        let whitespace = grapheme.chars().all(char::is_whitespace);
+        if seen_word && whitespace {
+            break;
+        }
+        seen_word |= !whitespace;
+        start = index;
+    }
+    start
+}
+
+/// Removes the last whitespace-delimited word without splitting a grapheme.
+pub(crate) fn delete_last_word(text: &mut String) {
+    text.truncate(previous_word_start(text));
+}
+
 /// Calculate terminal display width while expanding tabs to the next tab stop.
 pub fn display_width_with_tabs(s: &str, tab_width: usize) -> usize {
     display_width_with_tabs_from_column(s, 0, tab_width)
@@ -380,6 +402,24 @@ pub fn column_to_grapheme_with_tabs(line: &str, target_column: usize, tab_width:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn word_backspace_preserves_graphemes_and_existing_word_boundaries() {
+        for (input, expected) in [
+            ("", ""),
+            (" \t\n", ""),
+            ("one two   ", "one "),
+            ("one\nsecond", "one\n"),
+            ("one\n", ""),
+            ("one path/to/file.rs", "one "),
+            ("one 👨‍👩‍👧e\u{301}\u{2003}", "one "),
+            ("中文\u{3000}下一个", "中文\u{3000}"),
+        ] {
+            let mut text = input.to_string();
+            delete_last_word(&mut text);
+            assert_eq!(text, expected, "{input:?}");
+        }
+    }
 
     #[test]
     fn test_display_width() {

--- a/tests/modal_textarea.rs
+++ b/tests/modal_textarea.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::EditorHarness;
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use red::{
     buffer::Buffer,
     config::Config,
@@ -38,6 +38,43 @@ fn word_wrapped_vertical_motion_uses_the_display_projection() {
     // The old API remains character-wrapped for every caller that has not opted in.
     area.handle_event(&down, 7);
     assert_eq!(area.cursor(), 7);
+}
+
+#[test]
+fn word_backspace_is_grapheme_safe_undoable_and_ignores_release() {
+    for modifiers in [KeyModifiers::ALT, KeyModifiers::CONTROL] {
+        let original = "one 👨‍👩‍👧e\u{301} rest";
+        let mut area = TextArea::new(original);
+        area.set_cursor(6);
+        let press = Event::Key(KeyEvent::new(KeyCode::Backspace, modifiers));
+        let release = Event::Key(KeyEvent::new_with_kind(
+            KeyCode::Backspace,
+            modifiers,
+            KeyEventKind::Release,
+        ));
+        area.handle_event(&release, 80);
+        assert_eq!(area.text(), original);
+        area.handle_event(&press, 80);
+        assert_eq!(area.text(), "one  rest");
+        assert_eq!(area.cursor(), 4);
+        assert!(area.undo());
+        assert_eq!(area.text(), original);
+        assert_eq!(area.cursor(), 6);
+        assert!(area.redo());
+        assert_eq!(area.text(), "one  rest");
+        area.handle_event(
+            &Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Backspace,
+                modifiers,
+                KeyEventKind::Repeat,
+            )),
+            80,
+        );
+        assert_eq!(area.text(), " rest");
+        area.set_cursor(0);
+        area.handle_event(&press, 80);
+        assert_eq!(area.text(), " rest");
+    }
 }
 
 #[test]

--- a/vendor/crossterm/src/event/sys/unix/parse.rs
+++ b/vendor/crossterm/src/event/sys/unix/parse.rs
@@ -1055,6 +1055,34 @@ mod tests {
     }
 
     #[test]
+    fn red_word_backspace_protocols() {
+        for (sequence, modifiers) in [
+            (&b"\x7f"[..], KeyModifiers::NONE),
+            (&b"\x1b\x7f"[..], KeyModifiers::ALT),
+            (&b"\x1b[127;3u"[..], KeyModifiers::ALT),
+            (&b"\x1b[127;5u"[..], KeyModifiers::CONTROL),
+            (&b"\x1b[27;3;127~"[..], KeyModifiers::ALT),
+            (&b"\x1b[27;5;127~"[..], KeyModifiers::CONTROL),
+        ] {
+            assert_eq!(
+                parse_event(sequence, false).unwrap(),
+                Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                    KeyCode::Backspace,
+                    modifiers,
+                )))),
+                "{sequence:?}"
+            );
+            for length in 1..sequence.len() {
+                assert_eq!(
+                    parse_event(&sequence[..length], true).unwrap(),
+                    None,
+                    "{sequence:?} prefix {length}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn red_modified_enter_protocols() {
         for (sequence, modifiers) in [
             (&b"\r"[..], KeyModifiers::NONE),

--- a/vendor/crossterm/src/event/sys/windows/parse.rs
+++ b/vendor/crossterm/src/event/sys/windows/parse.rs
@@ -85,6 +85,48 @@ mod red_keyboard_tests {
             }
         }
     }
+
+    #[test]
+    fn red_native_word_backspace_preserves_modifiers_and_release() {
+        for (state, modifiers) in [
+            (0, KeyModifiers::NONE),
+            (SHIFT_PRESSED, KeyModifiers::SHIFT),
+            (LEFT_ALT_PRESSED, KeyModifiers::ALT),
+            (RIGHT_ALT_PRESSED, KeyModifiers::ALT),
+            (LEFT_CTRL_PRESSED, KeyModifiers::CONTROL),
+            (RIGHT_CTRL_PRESSED, KeyModifiers::CONTROL),
+        ] {
+            for (down, kind) in [
+                (true, KeyEventKind::Press),
+                (false, KeyEventKind::Release),
+            ] {
+                // INPUT_RECORD is a Windows POD record. Initialize its key-event
+                // union arm before converting through the public WinAPI wrapper.
+                let mut raw: INPUT_RECORD = unsafe { std::mem::zeroed() };
+                raw.EventType = KEY_EVENT;
+                unsafe {
+                    let key = raw.Event.KeyEvent_mut();
+                    key.bKeyDown = i32::from(down);
+                    key.wRepeatCount = 1;
+                    key.wVirtualKeyCode = VK_BACK as u16;
+                    *key.uChar.UnicodeChar_mut() = 8;
+                    key.dwControlKeyState = state;
+                }
+                let record = match InputRecord::from(raw) {
+                    InputRecord::KeyEvent(record) => record,
+                    _ => panic!("expected a key record"),
+                };
+                assert_eq!(
+                    handle_key_event(record, &mut None),
+                    Some(Event::Key(KeyEvent::new_with_kind(
+                        KeyCode::Backspace,
+                        modifiers,
+                        kind,
+                    )))
+                );
+            }
+        }
+    }
 }
 
 pub(crate) fn handle_key_event(


### PR DESCRIPTION
## Summary

Editable dialogs treated modified Backspace like ordinary Backspace, even though the shared prompt editor already supported deleting the previous word. This makes the expected macOS Option-Delete and Windows Ctrl-Backspace shortcuts work consistently across single-line and secret prompts, inline assist, agent composers, picker filters, and message/inline-history searches.

- Recognize both shortcuts on either platform and reuse the existing grapheme-safe, whitespace-delimited word boundaries.
- Preserve selected initial values, undo, prompt history detachment, picker filtering, and plugin callbacks. Ignore key-release events.
- Keep embedded searches in control of their own query, including the existing Ctrl-W shortcut, without deleting the underlying draft.
- Show Backspace in `red keys` diagnostics and add Unix-protocol and native Windows decoder regression tests. No production decoder change is needed.

## How to Test

1. Run `cargo run --bin red`. Open a single-line prompt or an agent composer, enter `first second`, and press Option-Delete on macOS or Ctrl-Backspace on Windows. Expect `first `, with no submission or dialog closure. Plain Backspace should retain its existing behavior.
2. Open a prompt with a selected initial value. Modified Backspace should clear the selection. In a composer, try deleting a word containing emoji or combining marks, then undo; the complete text and cursor should be restored.
3. Enter a multiword picker filter or search in Messages/InlineHistory, then delete the last word. Results should refresh. In a composer's embedded `/` search, modified Backspace and Ctrl-W must edit only the query, leaving the draft unchanged.
4. Run `cargo test --all-features --lib word_backspace -- --test-threads=1` and `cargo test --all-features --test modal_textarea word_backspace -- --test-threads=1` for the focused regressions. Run `cargo test --locked --manifest-path vendor/crossterm/Cargo.toml --lib red_` for terminal decoding.

## Validation

- Passed: all 2,463 tests from `cargo test --all-targets --all-features -- --test-threads=1`.
- Passed: strict Clippy on all targets/features, formatting, and the Red build.
- Passed: the Unix decoder regression suite and a production-decoder cross-check for `x86_64-pc-windows-msvc`.
- Native Windows test execution remains for Windows CI. Cross-checking the test target on macOS was blocked by a dependency requiring the Windows SDK header `winsock2.h`.
- The final interactive E2E was left for manual testing; no result is claimed here.
