### PR TITLE
feat(notifications): distinguish attention from routine feedback

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -219,9 +219,14 @@ Enter Command mode with `:` or `;`.
 | `:commands` | Open the command palette |
 | `:messages` | Browse active notifications and recent messages |
 
-The bottom line shows the current notification and how many are active. Open
+The bottom line shows the current notification. Routine feedback such as saves
+and copies fades away without leaving a badge. The badge counts warnings or
+errors needing acknowledgment, meaningful messages you may have missed, and
+concurrent running operations. Informational messages count as seen after about
+one second on the focused message line; every message remains in history. Open
 the history with `Space m`, `:messages`, or a click on the message line. Use
-`j`/`k` to browse, `/` to search full message text, `f` to switch filters,
+`j`/`k` to browse, `/` to search full message text, `f` to switch between all,
+active, needs-attention, and warning/error filters,
 `Enter` to acknowledge, `y` to copy, and `Esc` to return. `Ctrl-d`/`Ctrl-u`
 scroll long details; `D` clears inactive history. Messages are retained for
 the current Red session, subject to the history limit.

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -114,8 +114,8 @@ use crate::{
     },
     matchit::{self, MatchDirection, MatchMotion},
     notification::{
-        MessageAction, Notice, NotificationCenter, NotificationError, NotificationId,
-        NotificationSource, NotificationTime, Severity,
+        AttentionPolicy, MessageAction, Notice, NotificationCenter, NotificationError,
+        NotificationId, NotificationSource, NotificationTime, Severity,
     },
     plugin::{self, ComposerHandle, PickerHandle, PluginRegistry, RequestId, Runtime},
     preferences::{PanelLayoutPreference, PreferencesStore},
@@ -3151,6 +3151,9 @@ pub struct Editor {
     notifications: NotificationCenter,
     message_browser: Option<notifications::MessageBrowser>,
     notification_presentation: notifications::NotificationPresentation,
+    notification_frame_candidate: Option<notifications::NotificationExposureKey>,
+    notification_exposure: Option<notifications::NotificationExposure>,
+    notification_client_attached: bool,
     notification_animation_start: Instant,
     notification_fallback: Option<String>,
     config_notification: Option<NotificationId>,
@@ -3242,6 +3245,7 @@ impl DetachedEditorCore {
     /// while retaining all editor, LSP, recovery, and Codex state.
     pub async fn new(mut editor: Editor) -> anyhow::Result<Self> {
         editor.terminal_output_enabled = false;
+        editor.notification_exposure = None;
         let mut runtime =
             Runtime::try_new_with_permissions(editor.config.plugin_permissions.clone())?;
         runtime.set_typecheck_enabled(!editor.config.disable_plugin_typecheck);
@@ -3441,6 +3445,21 @@ impl DetachedEditorCore {
     /// Claims the version only after its first frame reaches an attached client.
     pub fn mark_whats_new_presented(&mut self) {
         self.editor.mark_whats_new_presented();
+    }
+
+    /// Starts exposure only for the exact frame successfully sent to a client.
+    pub fn mark_frame_presented(&mut self, revision: u64) {
+        self.editor.notification_client_attached = true;
+        if self.revision == revision {
+            self.editor.notification_frame_presented(Instant::now());
+        } else {
+            self.editor.notification_exposure = None;
+        }
+    }
+
+    pub fn client_disconnected(&mut self) {
+        self.editor.notification_client_attached = false;
+        self.editor.notification_exposure = None;
     }
 
     pub async fn shutdown(&mut self) {
@@ -4440,6 +4459,9 @@ impl Editor {
             notifications: NotificationCenter::default(),
             message_browser: None,
             notification_presentation: notifications::NotificationPresentation::default(),
+            notification_frame_candidate: None,
+            notification_exposure: None,
+            notification_client_attached: false,
             notification_animation_start: Instant::now(),
             notification_fallback: None,
             config_notification: None,
@@ -8851,7 +8873,7 @@ impl Editor {
             Ok(None) => {}
             Err(err) => {
                 log!("ERROR: Lsp error: {err}");
-                self.set_legacy_message(Some(err.to_string()));
+                self.set_notification_message(Severity::Error, Some(err.to_string()));
                 needs_render = true;
             }
         }
@@ -12339,7 +12361,7 @@ impl Editor {
                 {
                     return Some(Action::ShowDialog);
                 }
-                self.set_legacy_message(Some(error_msg.message.clone()));
+                self.set_notification_message(Severity::Error, Some(error_msg.message.clone()));
                 let save_as = save.as_ref().is_some_and(|save| save.save_as.is_some());
                 if (error_msg.code == -32601 || save_as)
                     && method.as_deref() == Some("textDocument/formatting")
@@ -12898,7 +12920,7 @@ impl Editor {
                         Content::charwise(yank.text)
                     };
                     self.set_default_register(content);
-                    self.set_legacy_message(Some(if yank.linewise {
+                    self.set_quiet_message(Some(if yank.linewise {
                         format!("{} lines yanked", lines.max(1))
                     } else {
                         format!("{length} characters yanked")
@@ -12916,7 +12938,7 @@ impl Editor {
                         .focused_text_for_copy(copy_all, usize::from(self.size.0))
                     {
                         self.set_default_register(Content::charwise(text));
-                        self.set_legacy_message(Some(if copy_all {
+                        self.set_quiet_message(Some(if copy_all {
                             "conversation copied".to_string()
                         } else {
                             "answer copied".to_string()
@@ -19684,7 +19706,7 @@ impl Editor {
                     Ok(()) => {
                         self.config.statusline = statusline.clone();
                         self.current_dialog = None;
-                        self.set_legacy_message(Some("saved status-line layout".to_string()));
+                        self.set_quiet_message(Some("saved status-line layout".to_string()));
                     }
                     Err(error) => {
                         self.set_legacy_message(Some(format!(
@@ -19872,7 +19894,7 @@ impl Editor {
                     .text_turn_for_copy(panel_id, prompt_id, *part)
                 {
                     self.set_default_register(Content::charwise(text));
-                    self.set_legacy_message(Some(
+                    self.set_quiet_message(Some(
                         match part {
                             plugin::panel::TextPanelTurnPart::Prompt => "prompt copied",
                             plugin::panel::TextPanelTurnPart::Answer => "answer copied",
@@ -19898,7 +19920,7 @@ impl Editor {
                     *expected_draft,
                 ) {
                     Ok(plugin::panel::TextPanelReuseOutcome::Loaded) => {
-                        self.set_legacy_message(Some(
+                        self.set_quiet_message(Some(
                             "prompt loaded for editing; nothing sent".to_string(),
                         ));
                     }
@@ -21020,10 +21042,10 @@ impl Editor {
             if count > 2 {
                 if content.kind == ContentKind::Linewise {
                     log!("yanked {} lines", count);
-                    self.set_legacy_message(Some(format!("{} lines yanked", count)));
+                    self.set_quiet_message(Some(format!("{} lines yanked", count)));
                     needs_update = true;
                 } else if content.kind == ContentKind::Blockwise {
-                    self.set_legacy_message(Some(format!("block of {} lines yanked", count)));
+                    self.set_quiet_message(Some(format!("block of {} lines yanked", count)));
                     needs_update = true;
                 }
             };
@@ -25507,7 +25529,14 @@ impl Editor {
         };
         match result {
             Ok(message) => {
-                self.set_legacy_message(Some(warning.unwrap_or(&message).to_string()));
+                self.set_notification_message(
+                    if warning.is_some() {
+                        Severity::Warning
+                    } else {
+                        Severity::Success
+                    },
+                    Some(warning.unwrap_or(&message).to_string()),
+                );
                 self.sync_lsp_document_identity(previous_uri.as_deref(), index)
                     .await?;
                 let file = self.current_buffer().file.clone();
@@ -25875,12 +25904,12 @@ impl Editor {
                 .await
             {
                 Ok(ExternalFormatOutcome::Applied { name }) => {
-                    self.set_legacy_message(Some(format!("formatted with {name}")));
+                    self.set_quiet_message(Some(format!("formatted with {name}")));
                     self.render(buffer)?;
                     return Ok(());
                 }
                 Ok(ExternalFormatOutcome::Unchanged { name }) => {
-                    self.set_legacy_message(Some(format!("already formatted with {name}")));
+                    self.set_quiet_message(Some(format!("already formatted with {name}")));
                     return Ok(());
                 }
                 Ok(ExternalFormatOutcome::Unavailable { name })
@@ -37250,11 +37279,11 @@ while True:
             ("w", true, "No file name", "× "),
             ("xyz", false, "unknown command \"xyz\"", "× "),
         ] {
-            let mut editor = test_editor(80, 5);
+            let mut editor = test_editor(100, 5);
             editor.current_buffer_mut().dirty = dirty;
             editor.mode = Mode::Command;
             editor.command = command.to_string();
-            let mut render_buffer = RenderBuffer::new(80, 5, &Style::default());
+            let mut render_buffer = RenderBuffer::new(100, 5, &Style::default());
             let mut runtime = Runtime::new();
 
             let processed = editor
@@ -37270,10 +37299,14 @@ while True:
             assert!(!processed.quit, "command {command:?} unexpectedly quit");
             assert_eq!(editor.last_error.as_deref(), Some(expected));
             let row = render_row(&render_buffer, 4);
-            let message = row
-                .trim_end()
-                .strip_suffix("[1 active · :messages]")
-                .expect("command feedback should include the active-message badge");
+            let message = if marker.is_empty() {
+                assert!(!row.contains(":messages"));
+                row.trim_end()
+            } else {
+                row.trim_end()
+                    .strip_suffix("[1 needs attention · :messages]")
+                    .expect("errors should include the attention badge")
+            };
             assert_eq!(message.trim_end(), format!("{marker}{expected}"));
         }
     }

--- a/src/editor/notifications.rs
+++ b/src/editor/notifications.rs
@@ -11,6 +11,7 @@ enum MessageFilter {
     #[default]
     All,
     Active,
+    Attention,
     Problems,
 }
 
@@ -18,7 +19,8 @@ impl MessageFilter {
     fn next(self) -> Self {
         match self {
             Self::All => Self::Active,
-            Self::Active => Self::Problems,
+            Self::Active => Self::Attention,
+            Self::Attention => Self::Problems,
             Self::Problems => Self::All,
         }
     }
@@ -26,6 +28,7 @@ impl MessageFilter {
         match self {
             Self::All => "all",
             Self::Active => "active",
+            Self::Attention => "needs attention",
             Self::Problems => "warnings/errors",
         }
     }
@@ -33,6 +36,7 @@ impl MessageFilter {
         match self {
             Self::All => true,
             Self::Active => record.is_active(now),
+            Self::Attention => record.needs_attention(now),
             Self::Problems => matches!(record.severity, Severity::Warning | Severity::Error),
         }
     }
@@ -41,6 +45,8 @@ impl MessageFilter {
 pub(super) struct MessageBrowser {
     return_dialog: Option<Box<dyn Component>>,
     selected: Option<NotificationId>,
+    // Keep the viewed item in the attention filter until the user moves away.
+    viewed_attention: Option<NotificationId>,
     query: String,
     searching: bool,
     filter: MessageFilter,
@@ -55,6 +61,28 @@ pub(super) struct NotificationPresentation {
     revision: u64,
     counts: NotificationCounts,
     frame: u64,
+}
+
+const NOTIFICATION_SEEN_AFTER: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) struct NotificationExposureKey {
+    id: NotificationId,
+    version: u64,
+}
+
+impl NotificationExposureKey {
+    pub(super) fn for_record(record: &Notification) -> Option<Self> {
+        record.is_unseen().then_some(Self {
+            id: record.id,
+            version: record.content_version,
+        })
+    }
+}
+
+pub(super) struct NotificationExposure {
+    key: NotificationExposureKey,
+    since: Instant,
 }
 
 fn record_state(record: &Notification, now: Instant) -> &'static str {
@@ -99,10 +127,24 @@ impl Editor {
         self.set_notification_message(Severity::Info, message);
     }
 
+    pub(super) fn set_quiet_message(&mut self, message: Option<String>) {
+        self.set_message_with_attention(Severity::Info, AttentionPolicy::Quiet, message);
+    }
+
     pub(super) fn set_notification_message(&mut self, severity: Severity, message: Option<String>) {
+        self.set_message_with_attention(severity, AttentionPolicy::for_severity(severity), message);
+    }
+
+    fn set_message_with_attention(
+        &mut self,
+        severity: Severity,
+        attention: AttentionPolicy,
+        message: Option<String>,
+    ) {
         if let Some(message) = message.as_ref().filter(|message| !message.is_empty()) {
-            let notice =
-                Notice::new(NotificationSource::Editor, severity, message).with_details(message);
+            let notice = Notice::new(NotificationSource::Editor, severity, message)
+                .with_attention(attention)
+                .with_details(message);
             if let Err(error) = self.publish_notification(notice) {
                 self.notification_fallback = Some(crate::notification::single_line(
                     truncate_chars(message, 4_096),
@@ -119,7 +161,61 @@ impl Editor {
         self.notification_presentation_changed_at(Instant::now())
     }
 
+    /// Called only after a native frame flush or a detached-client delivery succeeds.
+    pub(super) fn notification_frame_presented(&mut self, now: Instant) {
+        self.advance_notification_exposure(now);
+        let candidate = self.notification_frame_candidate.filter(|key| {
+            (self.terminal_output_enabled || self.notification_client_attached)
+                && self.is_focused
+                && !self.has_term()
+                && self
+                    .notifications
+                    .get(key.id)
+                    .and_then(NotificationExposureKey::for_record)
+                    == Some(*key)
+        });
+        if self
+            .notification_exposure
+            .as_ref()
+            .map(|exposure| exposure.key)
+            != candidate
+        {
+            self.notification_exposure =
+                candidate.map(|key| NotificationExposure { key, since: now });
+        }
+    }
+
+    fn advance_notification_exposure(&mut self, now: Instant) {
+        if (!self.terminal_output_enabled && !self.notification_client_attached)
+            || !self.is_focused
+            || self.has_term()
+        {
+            self.notification_exposure = None;
+            return;
+        }
+        let Some(exposure) = &self.notification_exposure else {
+            return;
+        };
+        let Some(record) = self
+            .notifications
+            .get(exposure.key.id)
+            .filter(|record| NotificationExposureKey::for_record(record) == Some(exposure.key))
+        else {
+            self.notification_exposure = None;
+            return;
+        };
+        let until = record
+            .visible_until()
+            .map_or(now, |deadline| now.min(deadline));
+        if until.saturating_duration_since(exposure.since) >= NOTIFICATION_SEEN_AFTER {
+            let id = exposure.key.id;
+            self.notification_exposure = None;
+            let _ = self.notifications.mark_read(id);
+        }
+    }
+
     fn notification_presentation_changed_at(&mut self, now: Instant) -> bool {
+        self.advance_notification_exposure(now);
         let mut counts = self.notifications.counts(now);
         counts.active += usize::from(self.notification_fallback.is_some());
         let frame = if !self.has_term()
@@ -208,7 +304,11 @@ impl Editor {
             .notifications
             .records()
             .filter(|record| {
-                browser.filter.includes(record, now)
+                (browser.filter.includes(record, now)
+                    || (matches!(browser.filter, MessageFilter::Attention)
+                        && browser.viewed_attention == Some(record.id)
+                        && browser.selected == Some(record.id)
+                        && !record.is_dismissed()))
                     && (query.is_empty()
                         || record.source.label().to_lowercase().contains(&query)
                         || record.severity.label().contains(&query)
@@ -229,6 +329,7 @@ impl Editor {
             self.message_browser = Some(MessageBrowser {
                 return_dialog: self.current_dialog.take(),
                 selected: None,
+                viewed_attention: None,
                 query: String::new(),
                 searching: false,
                 filter: MessageFilter::All,
@@ -257,6 +358,14 @@ impl Editor {
             .unwrap_or(0);
         browser.selected = ids.get(selected).copied();
         if let Some(id) = browser.selected {
+            if matches!(browser.filter, MessageFilter::Attention)
+                && self
+                    .notifications
+                    .get(id)
+                    .is_some_and(Notification::is_unseen)
+            {
+                browser.viewed_attention = Some(id);
+            }
             let _ = self.notifications.mark_read(id);
         }
         let rows = ids
@@ -364,16 +473,22 @@ impl Editor {
             }
             MessageAction::CycleFilter => {
                 browser.filter = browser.filter.next();
+                browser.viewed_attention = None;
+                browser.selected = None;
                 browser.scroll = 0;
             }
             MessageAction::Acknowledge => {
                 self.notification_fallback = None;
+                browser.viewed_attention = None;
                 if let Some(id) = browser.selected {
                     let running = self
                         .notifications
                         .get(id)
                         .is_some_and(Notification::is_running);
                     let _ = self.notifications.acknowledge(id);
+                    if matches!(browser.filter, MessageFilter::Attention) {
+                        browser.selected = None;
+                    }
                     browser.feedback = Some(
                         if running {
                             "Marked read; operation is still running"
@@ -449,6 +564,189 @@ mod tests {
         editor
     }
 
+    fn publish_info(editor: &mut Editor, text: &str, now: NotificationTime) -> NotificationId {
+        editor
+            .notifications
+            .publish(
+                Notice::new(NotificationSource::Editor, Severity::Info, text),
+                now,
+            )
+            .unwrap()
+    }
+
+    fn present(editor: &mut Editor, now: Instant) {
+        let mut buffer = RenderBuffer::new(
+            usize::from(editor.size.0),
+            usize::from(editor.size.1),
+            &Style::default(),
+        );
+        editor.draw_commandline(&mut buffer);
+        editor.notification_frame_presented(now);
+    }
+
+    #[test]
+    fn only_delivered_information_becomes_seen_after_one_second() {
+        let mut editor = editor(100, 24);
+        let now = NotificationTime::now();
+        let id = publish_info(&mut editor, "meaningful result", now);
+        present(&mut editor, now.monotonic);
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(2));
+        assert!(editor.notifications.get(id).unwrap().is_unseen());
+
+        editor.notification_client_attached = true;
+        present(&mut editor, now.monotonic);
+        assert!(editor.notification_presentation_changed_at(now.monotonic));
+        assert!(!editor
+            .notification_presentation_changed_at(now.monotonic + Duration::from_millis(999)));
+        assert!(editor.notifications.get(id).unwrap().is_unseen());
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(1));
+        assert!(!editor.notifications.get(id).unwrap().is_unseen());
+        assert!(editor
+            .notifications
+            .get(id)
+            .unwrap()
+            .is_active(now.monotonic));
+        assert!(editor.notification_presentation_changed_at(now.monotonic + Duration::from_secs(1)));
+        assert!(
+            !editor.notification_presentation_changed_at(now.monotonic + Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn a_message_too_narrow_to_read_remains_missed() {
+        let mut editor = editor(7, 4);
+        editor.notification_client_attached = true;
+        let now = NotificationTime::now();
+        let id = publish_info(&mut editor, "meaningful result", now);
+        present(&mut editor, now.monotonic);
+        assert!(editor.notification_frame_candidate.is_none());
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(2));
+        assert!(editor.notifications.get(id).unwrap().is_unseen());
+
+        editor.size = (100, 24);
+        present(&mut editor, now.monotonic + Duration::from_secs(2));
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(3));
+        assert!(!editor.notifications.get(id).unwrap().is_unseen());
+    }
+
+    #[test]
+    fn replaced_or_obscured_information_remains_missed() {
+        let mut editor = editor(100, 24);
+        editor.notification_client_attached = true;
+        let now = NotificationTime::now();
+        let first = publish_info(&mut editor, "first result", now);
+        present(&mut editor, now.monotonic);
+        let second = publish_info(&mut editor, "second result", now);
+        present(&mut editor, now.monotonic + Duration::from_millis(400));
+        editor.advance_notification_exposure(now.monotonic + Duration::from_millis(1400));
+        assert!(editor.notifications.get(first).unwrap().is_unseen());
+        assert!(!editor.notifications.get(second).unwrap().is_unseen());
+
+        let third = publish_info(&mut editor, "third result", now);
+        present(&mut editor, now.monotonic);
+        editor.mode = Mode::Command;
+        present(&mut editor, now.monotonic + Duration::from_millis(400));
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(2));
+        assert!(editor.notifications.get(third).unwrap().is_unseen());
+        editor.mode = Mode::Normal;
+        present(&mut editor, now.monotonic + Duration::from_secs(2));
+        editor.is_focused = false;
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(3));
+        assert!(editor.notifications.get(third).unwrap().is_unseen());
+    }
+
+    #[test]
+    fn keyed_replacement_starts_a_fresh_exposure_interval() {
+        let mut editor = editor(100, 24);
+        editor.notification_client_attached = true;
+        let now = NotificationTime::now();
+        let notice =
+            || Notice::new(NotificationSource::Editor, Severity::Info, "result").with_key("job");
+        let id = editor.notifications.publish(notice(), now).unwrap();
+        present(&mut editor, now.monotonic);
+        assert_eq!(editor.notifications.publish(notice(), now).unwrap(), id);
+        present(&mut editor, now.monotonic + Duration::from_millis(700));
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(1));
+        assert!(editor.notifications.get(id).unwrap().is_unseen());
+        editor.advance_notification_exposure(now.monotonic + Duration::from_millis(1700));
+        assert!(!editor.notifications.get(id).unwrap().is_unseen());
+    }
+
+    #[test]
+    fn expiry_caps_exposure_and_warnings_are_never_auto_acknowledged() {
+        let mut editor = editor(100, 24);
+        editor.notification_client_attached = true;
+        let now = NotificationTime::now();
+        let info = publish_info(&mut editor, "late result", now);
+        present(&mut editor, now.monotonic + Duration::from_millis(3500));
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(10));
+        assert!(editor.notifications.get(info).unwrap().is_unseen());
+
+        let warning = editor
+            .notifications
+            .publish(
+                Notice::new(NotificationSource::Editor, Severity::Warning, "check this"),
+                now,
+            )
+            .unwrap();
+        present(&mut editor, now.monotonic);
+        editor.advance_notification_exposure(now.monotonic + Duration::from_secs(10));
+        assert!(editor
+            .notifications
+            .get(warning)
+            .unwrap()
+            .needs_acknowledgment(now.monotonic));
+    }
+
+    #[tokio::test]
+    async fn detached_delivery_and_disconnect_bound_exposure() {
+        let mut core = DetachedEditorCore::new(editor(100, 24)).await.unwrap();
+        let first = publish_info(&mut core.editor, "detached result", NotificationTime::now());
+        core.editor.render(&mut core.render_buffer).unwrap();
+        core.finish_render().unwrap();
+        assert!(core.editor.notification_exposure.is_none());
+        core.mark_frame_presented(core.revision.saturating_add(1));
+        assert!(core.editor.notification_exposure.is_none());
+        core.mark_frame_presented(core.revision);
+        let since = core.editor.notification_exposure.as_ref().unwrap().since;
+        core.editor
+            .advance_notification_exposure(since + Duration::from_secs(1));
+        assert!(!core.editor.notifications.get(first).unwrap().is_unseen());
+
+        core.client_disconnected();
+        let second = publish_info(&mut core.editor, "another result", NotificationTime::now());
+        core.editor.render(&mut core.render_buffer).unwrap();
+        core.editor
+            .advance_notification_exposure(Instant::now() + Duration::from_secs(2));
+        assert!(core.editor.notifications.get(second).unwrap().is_unseen());
+    }
+
+    #[test]
+    fn quiet_feedback_leaves_no_badge_and_attention_filter_keeps_the_viewed_item() {
+        let mut editor = editor(100, 24);
+        editor.set_notification_message(Severity::Success, Some("file saved".into()));
+        editor.set_quiet_message(Some("copied".into()));
+        let mut buffer = RenderBuffer::new(100, 24, &Style::default());
+        editor.draw_commandline(&mut buffer);
+        let row = render_text_rows(&buffer).pop().unwrap();
+        assert!(row.contains("copied"));
+        assert!(!row.contains(":messages"));
+        assert_eq!(editor.notifications.counts(Instant::now()).unread, 0);
+
+        let first = publish_info(&mut editor, "first result", NotificationTime::now());
+        let second = publish_info(&mut editor, "second result", NotificationTime::now());
+        editor.open_messages(); // Viewing the newest item marks only that item read.
+        assert!(!editor.notifications.get(second).unwrap().is_unseen());
+        editor.handle_message_action(&MessageAction::CycleFilter);
+        editor.handle_message_action(&MessageAction::CycleFilter);
+        assert_eq!(editor.message_ids(Instant::now()), vec![first]);
+        assert!(!editor.notifications.get(first).unwrap().is_unseen());
+        editor.refresh_message_browser();
+        assert_eq!(editor.message_ids(Instant::now()), vec![first]);
+        editor.handle_message_action(&MessageAction::Acknowledge);
+        assert!(editor.message_ids(Instant::now()).is_empty());
+    }
+
     #[test]
     fn presentation_ignores_an_empty_center_but_detects_arrivals_and_expiry() {
         let mut editor = editor(90, 12);
@@ -503,7 +801,7 @@ mod tests {
             .unwrap();
         let row = render_text_rows(&buffer).pop().unwrap();
         assert!(row.contains("second message"), "{row}");
-        assert!(row.contains("2 active"), "{row}");
+        assert!(row.contains("1 missed"), "{row}");
         assert!(editor.last_error.is_none());
 
         editor.mode = Mode::Command;
@@ -511,7 +809,7 @@ mod tests {
         editor.draw_commandline(&mut buffer);
         let row = render_text_rows(&buffer).pop().unwrap();
         assert!(row.starts_with(":write pending.txt"));
-        assert!(row.contains("2 active"));
+        assert!(row.contains("2 missed"));
     }
 
     #[test]
@@ -529,6 +827,18 @@ mod tests {
                 now,
             )
             .unwrap();
+        let mut buffer = RenderBuffer::new(100, 12, &Style::default());
+        editor.draw_commandline(&mut buffer);
+        let row = render_text_rows(&buffer).pop().unwrap();
+        assert!(
+            row.contains("indexing") && !row.contains(":messages"),
+            "{row}"
+        );
+        editor.mode = Mode::Command;
+        editor.draw_commandline(&mut buffer);
+        let row = render_text_rows(&buffer).pop().unwrap();
+        assert!(row.contains("1 running"), "{row}");
+        editor.mode = Mode::Normal;
         let push = editor
             .notifications
             .begin_progress(
@@ -550,18 +860,19 @@ mod tests {
                 "save failed",
             ))
             .unwrap();
-        let mut buffer = RenderBuffer::new(100, 12, &Style::default());
         editor.draw_commandline(&mut buffer);
         let row = render_text_rows(&buffer).pop().unwrap();
         assert!(
-            row.contains("save failed") && row.contains("3 active"),
+            row.contains("save failed")
+                && row.contains("1 needs attention")
+                && row.contains("2 running"),
             "{row}"
         );
         editor.notifications.acknowledge(error).unwrap();
         editor.draw_commandline(&mut buffer);
         let row = render_text_rows(&buffer).pop().unwrap();
         assert!(
-            row.contains("pushing commits (40%)") && row.contains("2 active"),
+            row.contains("pushing commits (40%)") && row.contains("2 running"),
             "{row}"
         );
     }

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -82,21 +82,35 @@ fn diagnostic_row(diagnostics: &[&Diagnostic], available_width: usize) -> Option
 }
 
 fn notification_badge(counts: NotificationCounts, width: usize, has_message: bool) -> String {
-    let full = if counts.active > 0 {
-        format!("[{} active · :messages]", counts.active)
-    } else if counts.unread > 0 {
-        format!("[{} unread · :messages]", counts.unread)
-    } else if counts.total > 0 {
-        "[:messages]".to_string()
-    } else {
+    let mut parts = Vec::new();
+    if counts.needs_acknowledgment > 0 {
+        parts.push(format!(
+            "{} need{} attention",
+            counts.needs_acknowledgment,
+            if counts.needs_acknowledgment == 1 {
+                "s"
+            } else {
+                ""
+            }
+        ));
+    }
+    if counts.unseen > 0 {
+        parts.push(format!("{} missed", counts.unseen));
+    }
+    if counts.running > 1 || (counts.running > 0 && (!has_message || !parts.is_empty())) {
+        parts.push(format!("{} running", counts.running));
+    }
+    if parts.is_empty() {
         return String::new();
-    };
+    }
+    let full = format!("[{} · :messages]", parts.join(" · "));
     let reserve = if has_message { 16 } else { 0 };
     if display_width(&full) + reserve <= width {
         return full;
     }
-    if counts.active > 1 {
-        let compact = format!("[{}]", counts.active);
+    let pending = counts.needs_acknowledgment + counts.unseen + counts.running;
+    if pending > 0 {
+        let compact = format!("[{pending}]");
         if display_width(&compact) + usize::from(has_message) < width {
             return compact;
         }
@@ -1207,6 +1221,9 @@ impl Editor {
             .apply_changes(changes);
         self.force_full_redraw = false;
         self.last_rendered_viewport = self.rendered_viewport();
+        if self.terminal_output_enabled {
+            self.notification_frame_presented(Instant::now());
+        }
     }
 
     /// Renders the entire editor state to the terminal
@@ -3337,6 +3354,7 @@ impl Editor {
     }
 
     pub fn draw_commandline(&mut self, buffer: &mut RenderBuffer) {
+        self.notification_frame_candidate = None;
         let style = &self.theme.style;
         let width = self.size.0 as usize;
         if width == 0 || self.size.1 == 0 {
@@ -3360,51 +3378,79 @@ impl Editor {
             let now = Instant::now();
             let mut counts = self.notifications.counts(now);
             let primary = self.notifications.primary(now);
-            let (message, severity) = if let Some(fallback) = &self.notification_fallback {
-                counts.active += 1;
-                (
-                    format!("! {fallback} [not retained]"),
-                    Some(Severity::Error),
-                )
-            } else if let Some(record) = primary {
-                let prefix = if record.is_running() {
-                    format!(
-                        "{} ",
-                        crate::ui::spinner_frame(
-                            self.notification_animation_start.elapsed().as_millis() as u64
-                        )
+            let (message, severity, summary_offset) =
+                if let Some(fallback) = &self.notification_fallback {
+                    counts.active += 1;
+                    counts.needs_acknowledgment += 1;
+                    (
+                        format!("! {fallback} [not retained]"),
+                        Some(Severity::Error),
+                        0,
                     )
-                } else if record.severity != Severity::Info {
-                    format!("{} ", record.severity.marker())
+                } else if let Some(record) = primary {
+                    let prefix = if record.is_running() {
+                        format!(
+                            "{} ",
+                            crate::ui::spinner_frame(
+                                self.notification_animation_start.elapsed().as_millis() as u64
+                            )
+                        )
+                    } else if record.severity != Severity::Info {
+                        format!("{} ", record.severity.marker())
+                    } else {
+                        String::new()
+                    };
+                    let source = if matches!(
+                        record.source,
+                        crate::notification::NotificationSource::Editor
+                    ) {
+                        String::new()
+                    } else {
+                        format!("{}: ", record.source.label())
+                    };
+                    let percentage = match record.state {
+                        NotificationState::Running {
+                            percentage: Some(value),
+                        } => format!(" ({value}%)"),
+                        _ => String::new(),
+                    };
+                    (
+                        format!("{prefix}{source}{}{percentage}", record.content.summary),
+                        Some(record.severity),
+                        display_width(&prefix) + display_width(&source),
+                    )
                 } else {
-                    String::new()
+                    (String::new(), None, 0)
                 };
-                let source = if matches!(
-                    record.source,
-                    crate::notification::NotificationSource::Editor
-                ) {
-                    String::new()
-                } else {
-                    format!("{}: ", record.source.label())
-                };
-                let percentage = match record.state {
-                    NotificationState::Running {
-                        percentage: Some(value),
-                    } => format!(" ({value}%)"),
-                    _ => String::new(),
-                };
-                (
-                    format!("{prefix}{source}{}{percentage}", record.content.summary),
-                    Some(record.severity),
-                )
-            } else {
-                (String::new(), None)
-            };
             let available = width.saturating_sub(wc_width);
-            let badge = notification_badge(counts, available, !message.is_empty());
-            let badge_width = display_width(&badge);
-            let message_width =
+            let candidate = primary
+                .filter(|_| self.notification_fallback.is_none())
+                .and_then(|record| {
+                    super::notifications::NotificationExposureKey::for_record(record).map(|key| {
+                        (
+                            key,
+                            summary_offset + display_width(&record.content.summary).clamp(1, 8),
+                        )
+                    })
+                });
+            if candidate.is_some() {
+                counts.unseen = counts.unseen.saturating_sub(1);
+            }
+            let mut badge = notification_badge(counts, available, !message.is_empty());
+            let mut badge_width = display_width(&badge);
+            let mut message_width =
                 available.saturating_sub(badge_width + usize::from(badge_width > 0));
+            if let Some((key, required_width)) = candidate {
+                if message_width >= required_width {
+                    self.notification_frame_candidate = Some(key);
+                } else {
+                    counts.unseen += 1;
+                    badge = notification_badge(counts, available, !message.is_empty());
+                    badge_width = display_width(&badge);
+                    message_width =
+                        available.saturating_sub(badge_width + usize::from(badge_width > 0));
+                }
+            }
             let mut message_style = style.clone();
             let color = match severity {
                 Some(Severity::Error) => Some("notificationsErrorIcon.foreground"),

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -740,7 +740,9 @@ pub async fn serve_editor_session(
                             let stop = serve_editor_connection(stream, &token, Rc::clone(&core))
                                 .await
                                 .unwrap_or(false);
-                            core.lock().await.clear_pending_paste();
+                            let mut core = core.lock().await;
+                            core.clear_pending_paste();
+                            core.client_disconnected();
                             attached.set(false);
                             if stop {
                                 _ = stop_sender.send(());
@@ -842,6 +844,7 @@ async fn serve_editor_connection(
     if displayed_whats_new {
         core.lock().await.mark_whats_new_presented();
     }
+    core.lock().await.mark_frame_presented(client_revision);
 
     loop {
         let message = tokio::time::timeout(CLIENT_HEARTBEAT_LEASE, read_frame(&mut reader)).await;
@@ -927,6 +930,7 @@ async fn serve_editor_connection(
                 .await?;
             }
         }
+        core.lock().await.mark_frame_presented(client_revision);
     }
 }
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -247,6 +247,27 @@ impl NoticeLifetime {
     }
 }
 
+/// Whether retained feedback should ask for the user's attention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttentionPolicy {
+    /// Routine feedback stays in history without creating an unread obligation.
+    Quiet,
+    /// Informational feedback is unread until it has actually been displayed.
+    IfMissed,
+    /// Reading does not resolve the condition or acknowledge the notice.
+    RequiresAcknowledgment,
+}
+
+impl AttentionPolicy {
+    pub(crate) fn for_severity(severity: Severity) -> Self {
+        match severity {
+            Severity::Success => Self::Quiet,
+            Severity::Info => Self::IfMissed,
+            Severity::Warning | Severity::Error => Self::RequiresAcknowledgment,
+        }
+    }
+}
+
 /// A one-shot notice, optionally coalesced by a producer-scoped key.
 #[derive(Debug, Clone)]
 pub struct Notice {
@@ -255,6 +276,7 @@ pub struct Notice {
     pub content: MessageContent,
     pub key: Option<NotificationKey>,
     pub lifetime: NoticeLifetime,
+    pub attention: AttentionPolicy,
 }
 
 impl Notice {
@@ -265,11 +287,20 @@ impl Notice {
             content: MessageContent::new(summary),
             key: None,
             lifetime: NoticeLifetime::for_severity(severity),
+            attention: AttentionPolicy::for_severity(severity),
         }
     }
 
     pub fn with_key(mut self, key: impl Into<NotificationKey>) -> Self {
         self.key = Some(key.into());
+        self
+    }
+
+    pub fn with_attention(mut self, attention: AttentionPolicy) -> Self {
+        self.attention = attention;
+        if attention == AttentionPolicy::RequiresAcknowledgment {
+            self.lifetime = NoticeLifetime::UntilAcknowledged;
+        }
         self
     }
 
@@ -329,11 +360,44 @@ pub struct Notification {
     pub updated_at: SystemTime,
     pub occurrences: u64,
     pub read: bool,
+    pub attention: AttentionPolicy,
+    pub(crate) content_version: u64,
     priority: ProgressPriority,
     display: DisplayState,
 }
 
 impl Notification {
+    /// An unresolved notice that must be acknowledged even if it was read.
+    pub fn needs_acknowledgment(&self, now: Instant) -> bool {
+        self.attention == AttentionPolicy::RequiresAcknowledgment
+            && !self.is_running()
+            && self.is_active(now)
+    }
+
+    /// Meaningful information that has not been seen or explicitly dismissed.
+    /// Expiration removes it from the message line, not from this count.
+    pub fn is_unseen(&self) -> bool {
+        self.attention == AttentionPolicy::IfMissed
+            && !self.read
+            && !self.is_running()
+            && !matches!(self.display, DisplayState::Hidden)
+    }
+
+    pub fn needs_attention(&self, now: Instant) -> bool {
+        self.needs_acknowledgment(now) || self.is_unseen()
+    }
+
+    pub(crate) fn visible_until(&self) -> Option<Instant> {
+        match self.display {
+            DisplayState::Until(deadline) => Some(deadline),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn is_dismissed(&self) -> bool {
+        matches!(self.display, DisplayState::Hidden)
+    }
+
     pub fn is_running(&self) -> bool {
         matches!(self.state, NotificationState::Running { .. })
     }
@@ -366,6 +430,10 @@ pub struct NotificationCounts {
     pub active: usize,
     pub running: usize,
     pub unread: usize,
+    /// Unresolved notices whose policy requires explicit acknowledgment.
+    pub needs_acknowledgment: usize,
+    /// Unseen informational notices/completions, excluding running work.
+    pub unseen: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -493,11 +561,13 @@ impl NotificationCenter {
                 return Err(NotificationError::KeyInUse);
             }
             record.severity = notice.severity;
+            record.attention = notice.attention;
+            record.content_version = record.content_version.wrapping_add(1);
             record.content = content;
             record.display = display;
             record.updated_at = now.wall;
             record.occurrences = record.occurrences.saturating_add(1);
-            record.read = false;
+            record.read = notice.attention == AttentionPolicy::Quiet;
             self.changed();
             return Ok(id);
         }
@@ -507,12 +577,14 @@ impl NotificationCenter {
             source: notice.source,
             key: notice.key,
             severity: notice.severity,
+            attention: notice.attention,
+            content_version: 0,
             content,
             state: NotificationState::Notice,
             created_at: now.wall,
             updated_at: now.wall,
             occurrences: 1,
-            read: false,
+            read: notice.attention == AttentionPolicy::Quiet,
             priority: ProgressPriority::Background,
             display,
         });
@@ -539,6 +611,8 @@ impl NotificationCenter {
             source,
             key: Some(key),
             severity: Severity::Info,
+            attention: AttentionPolicy::IfMissed,
+            content_version: 0,
             content: content.bounded(),
             state: NotificationState::Running { percentage: None },
             created_at: now.wall,
@@ -592,6 +666,11 @@ impl NotificationCenter {
         }
         record.state = NotificationState::Finished(outcome);
         record.severity = outcome.severity();
+        record.attention = match outcome {
+            ProgressOutcome::Failed => AttentionPolicy::RequiresAcknowledgment,
+            ProgressOutcome::Succeeded | ProgressOutcome::Cancelled => AttentionPolicy::IfMissed,
+        };
+        record.content_version = record.content_version.wrapping_add(1);
         record.content = content.bounded();
         record.updated_at = now.wall;
         record.display = NoticeLifetime::for_severity(record.severity).display_state(now.monotonic);
@@ -639,6 +718,8 @@ impl NotificationCenter {
             counts.active += usize::from(record.is_active(now));
             counts.running += usize::from(record.is_running());
             counts.unread += usize::from(!record.read);
+            counts.needs_acknowledgment += usize::from(record.needs_acknowledgment(now));
+            counts.unseen += usize::from(record.is_unseen());
         }
         counts
     }

--- a/src/notification/tests.rs
+++ b/src/notification/tests.rs
@@ -12,6 +12,65 @@ fn notice(severity: Severity, summary: &str) -> Notice {
     Notice::new(NotificationSource::Editor, severity, summary)
 }
 
+#[test]
+fn quiet_feedback_is_retained_without_unread_attention() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    for notice in [
+        notice(Severity::Success, "saved"),
+        notice(Severity::Info, "copied").with_attention(AttentionPolicy::Quiet),
+    ] {
+        center.publish(notice, now).unwrap();
+    }
+    for at in [now, later(now, 10)] {
+        let counts = center.counts(at.monotonic);
+        assert_eq!(counts.total, 2);
+        assert_eq!(counts.unread, 0);
+        assert_eq!(counts.unseen, 0);
+        assert_eq!(counts.needs_acknowledgment, 0);
+    }
+}
+
+#[test]
+fn reading_information_does_not_acknowledge_a_warning() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let info = center
+        .publish(notice(Severity::Info, "finished"), now)
+        .unwrap();
+    let warning = center
+        .publish(notice(Severity::Warning, "check this"), now)
+        .unwrap();
+    assert_eq!(center.counts(now.monotonic).unseen, 1);
+    assert_eq!(center.counts(now.monotonic).needs_acknowledgment, 1);
+    center.mark_read(info).unwrap();
+    center.mark_read(warning).unwrap();
+    assert_eq!(center.counts(now.monotonic).unseen, 0);
+    assert_eq!(center.counts(now.monotonic).needs_acknowledgment, 1);
+    center.resolve(warning).unwrap();
+    assert_eq!(center.counts(now.monotonic).needs_acknowledgment, 0);
+}
+
+#[test]
+fn successful_progress_is_only_attention_worthy_if_missed() {
+    let now = NotificationTime::now();
+    let mut center = NotificationCenter::default();
+    let id = start(&mut center, "push", ProgressPriority::UserInitiated, now);
+    assert_eq!(center.counts(now.monotonic).unseen, 0);
+    center
+        .finish_progress(
+            id,
+            ProgressOutcome::Succeeded,
+            MessageContent::new("pushed"),
+            now,
+        )
+        .unwrap();
+    assert_eq!(center.get(id).unwrap().attention, AttentionPolicy::IfMissed);
+    assert_eq!(center.counts(later(now, 10).monotonic).unseen, 1);
+    center.mark_read(id).unwrap();
+    assert_eq!(center.counts(later(now, 10).monotonic).unseen, 0);
+}
+
 fn start(
     center: &mut NotificationCenter,
     key: &str,

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1591,7 +1591,7 @@ async fn unchanged_recovery_snapshots_are_skipped_and_failures_back_off() {
         .unwrap();
     let status = harness.commandline_row();
     assert!(status.contains("a newer LSP error"));
-    assert!(status.contains("2 active"));
+    assert!(status.contains("2 need attention"));
     assert!(harness
         .editor
         .notifications()

--- a/tests/notifications.rs
+++ b/tests/notifications.rs
@@ -46,7 +46,7 @@ async fn message_history_routes_real_keys_through_search_acknowledgement_and_cle
     }
     let status = harness.commandline_row();
     assert!(status.contains("unknown command \"bad-two\""), "{status}");
-    assert!(status.contains("2 active"), "{status}");
+    assert!(status.contains("2 need attention"), "{status}");
 
     text(&mut harness, " m").await;
     let dialog = dialog_text(&mut harness);


### PR DESCRIPTION
## Why

The notification center introduced in #245 retains useful history, but routine feedback such as a successful save also leaves an unread badge. That makes the badge feel like a chore instead of a signal that something needs attention.

## What changed

- Add explicit quiet, if-missed, and requires-acknowledgment policies in `src/notification.rs`. Saves, copies, yanks, and routine formatting remain in history without creating an unread obligation.
- Mark meaningful information seen after about one second visibly displayed in a focused editor. Interrupted, obscured, unreadably narrow, or undelivered detached-session messages remain missed. Reading a warning or error does not acknowledge it.
- Show separate needs-attention, missed, and running counts. Avoid a redundant badge for a lone visible progress spinner or retained history alone.
- Add a Needs attention history filter, preserve the selected message while reading it, and cover exposure timing, detached delivery, narrow rendering, and acknowledgment regressions.

## How to Test

1. Build and launch with `cargo run --bin red`. In a fresh session, save a named file, copy text, or yank several lines. The feedback should appear briefly without leaving an unread badge; `Space m` should still show it in history.
2. Run `:bad` and `:worse`. Expect `2 need attention`. Open `Space m`, press `f` until the Needs attention filter appears, and browse both errors. Reading them must not clear the count; press Enter to acknowledge each one.
3. With a meaningful informational message or background-operation completion, leave it visible for about one second. It should not leave a missed badge. If another message or the command prompt obscures it before that interval, it should remain available as missed.
4. Run `cargo test -p red --lib notification -- --test-threads=1`. The focused tests cover quiet feedback, interrupted and detached display, narrow windows, progress counts, and stable history selection.

Validation: manual review passed; 48 focused unit tests passed, including command-feedback, redraw, and format-on-save regressions. `cargo clippy --all-targets --all-features -- -D warnings` and `cargo build -p red --bin red` passed. E2e tests remain deferred and were not run for this change.
