### PR TITLE
fix(agent): focus composer when opening conversation

### DIFF
--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -398,7 +398,7 @@ fn open_conversation() {
     if !was_created {
         render_conversation();
     }
-    red::execute("FocusPanel", "agent-conversation");
+    red::execute("FocusTextPanelComposer", "agent-conversation");
 }
 
 fn ensure_conversation_panel() {
@@ -509,7 +509,7 @@ fn stage_pending_prompt(text: String) {
     render_conversation();
     if state().focus_panel_on_first_prompt {
         red::state_patch(AgentState { focus_panel_on_first_prompt: false });
-        red::execute("FocusPanel", "agent-conversation");
+        red::execute("FocusTextPanelComposer", "agent-conversation");
     }
     set_phase("waiting", "Starting agent…");
     red::execute("Refresh");
@@ -583,7 +583,7 @@ fn dispatch_prompt_block(text: String, block_id: String) {
     append_transcript_block("You", text, block_id);
     if focus_conversation {
         red::state_patch(AgentState { focus_panel_on_first_prompt: false });
-        red::execute("FocusPanel", "agent-conversation");
+        red::execute("FocusTextPanelComposer", "agent-conversation");
     }
     set_phase("waiting", "Waiting for agent…");
     red::execute("Refresh");

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -4360,7 +4360,7 @@ mod tests {
                     );
                     rendered = true;
                 }
-                PluginRequest::FocusPanel { id } => {
+                PluginRequest::FocusTextPanelComposer { id } => {
                     assert_eq!(id, "agent-conversation");
                     focused = true;
                 }
@@ -6735,7 +6735,7 @@ mod tests {
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
-            PluginRequest::FocusPanel { id } if id == "agent-conversation"
+            PluginRequest::FocusTextPanelComposer { id } if id == "agent-conversation"
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
@@ -7263,7 +7263,7 @@ mod tests {
                     rendered |= id == "agent-conversation"
                         && blocks.iter().any(|block| block.text == "first prompt");
                 }
-                PluginRequest::FocusPanel { id } => {
+                PluginRequest::FocusTextPanelComposer { id } => {
                     focused |= id == "agent-conversation";
                 }
                 PluginRequest::SetTextPanelStatus {
@@ -7541,7 +7541,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bundled_agent_open_creates_and_focuses_panel_without_starting_a_session() {
+    async fn bundled_agent_open_creates_and_focuses_composer_without_starting_a_session() {
         drain_requests();
         let mut runtime = Runtime::new();
         runtime
@@ -7563,14 +7563,14 @@ mod tests {
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
-            PluginRequest::FocusPanel { id } if id == "agent-conversation"
+            PluginRequest::FocusTextPanelComposer { id } if id == "agent-conversation"
         ));
         assert!(ACTION_DISPATCHER.try_recv_request().is_none());
 
         runtime.execute_command("AgentOpen").await.unwrap();
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
-            PluginRequest::FocusPanel { id } if id == "agent-conversation"
+            PluginRequest::FocusTextPanelComposer { id } if id == "agent-conversation"
         ));
         assert!(ACTION_DISPATCHER.try_recv_request().is_none());
     }
@@ -7657,7 +7657,7 @@ mod tests {
         ));
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
-            PluginRequest::FocusPanel { id } if id == "agent-conversation"
+            PluginRequest::FocusTextPanelComposer { id } if id == "agent-conversation"
         ));
         assert!(ACTION_DISPATCHER.try_recv_request().is_none());
 


### PR DESCRIPTION
## Why

Opening the agent conversation or submitting its first prompt placed keyboard focus in the transcript. That left the cursor in scrollback instead of the composer, so users could not immediately type a follow-up.

## What changed

- Focus the agent composer when opening or reopening the conversation pane and when staging or dispatching its first prompt.
- Preserve existing transcript focus while session restoration intentionally disables the composer.
- Update bundled-agent regression coverage and the shared optimistic-start helper to require composer focus.

## How to Test

1. Open the agent pane with `Ctrl-w a` and confirm the cursor starts in the composer; type immediately without clicking the transcript.
2. Start a fresh agent conversation, submit the first prompt, and confirm the composer remains focused while the response begins.
3. Close and reopen the conversation pane; confirm the composer receives focus again. Restore a session with temporarily disabled input and confirm restoration still focuses the pane without activating the disabled composer.
4. Run `cargo test --all-features --lib plugin::runtime::tests::bundled_agent -- --test-threads=1` and confirm all 28 bundled-agent tests pass.
