### PR TITLE
feat(learn): add track-based learning hub

### DIFF
--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -58,6 +58,9 @@ const SPECIAL_BUILTIN_COLON_COMMANDS: &[&str] = &[
     "keyboard-shortcuts",
     "whats-new",
     "changelog",
+    "learn",
+    "tutorial",
+    "welcome",
     "db",
     "dh",
     "di",
@@ -466,6 +469,15 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Some(":whats-new"),
             &[":changelog", "release notes", "what's new", "updates"],
             Action::OpenWhatsNew,
+        ),
+        builtin(
+            "editor.learn",
+            "Learn Red",
+            "Editor",
+            "Choose a learning track and practice safely",
+            Some(":learn"),
+            &[":tutorial", ":welcome", "getting started", "onboarding"],
+            Action::OpenLearn,
         ),
         builtin(
             "editor.statusline_manager",
@@ -1222,7 +1234,7 @@ pub(crate) fn shortcut_entries(
     output
 }
 
-fn shortcuts_for_action(keys: &Keys, target: &Action) -> Vec<String> {
+pub(crate) fn shortcuts_for_action(keys: &Keys, target: &Action) -> Vec<String> {
     let tables = [
         ("Normal", &keys.normal),
         ("Insert", &keys.insert),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -23,6 +23,7 @@ mod inline_comments;
 mod inline_completion;
 mod inline_history;
 mod keyboard_shortcuts;
+mod learning;
 mod lsp_coordinator;
 #[cfg(test)]
 mod navigation_perf_tests;
@@ -2370,6 +2371,11 @@ pub enum Action {
     OpenSyntaxPicker,
     SetSyntax(String),
     OpenWhatsNew,
+    OpenLearn,
+    StartLearnLesson,
+    ExitLearnLesson,
+    RestartLearnLesson,
+    FinishLearnLesson,
     OpenStatuslineManager,
     OpenDiagnosticsPicker,
     OpenErrorDiagnosticsPicker,
@@ -3137,6 +3143,9 @@ pub struct Editor {
 
     /// Persistent preferences, including command-line history.
     preferences: PreferencesStore,
+
+    /// Owns the protected practice buffer and original window layout.
+    learn_session: Option<learning::LearnSession>,
 
     /// A release has changed, but no visible client has seen its announcement yet.
     whats_new_startup_pending: bool,
@@ -4442,6 +4451,7 @@ impl Editor {
             command: String::new(),
             preferences,
             whats_new_startup_pending,
+            learn_session: None,
             whats_new_auto_presentation_enabled: false,
             whats_new_needs_persistence: false,
             command_history_navigation: None,
@@ -5371,6 +5381,9 @@ impl Editor {
     }
 
     fn resize_window_layout(&mut self, terminal_size: (usize, usize)) {
+        if self.resize_learn_layout(terminal_size) {
+            return;
+        }
         self.sync_to_window();
         self.configure_pane_presentation(terminal_size);
         let (reserved_left, reserved_right) = self.reserved_panel_widths(terminal_size.0);
@@ -5415,7 +5428,12 @@ impl Editor {
         self.invalidate_terminal_render_state(buffer);
 
         let viewport_width = self.vwidth();
-        let viewport_height = if self.inline_history_browser.is_some() {
+        let viewport_height = if self.inline_history_browser.is_some()
+            || self
+                .current_dialog
+                .as_ref()
+                .is_some_and(|dialog| dialog.uses_full_editor_viewport())
+        {
             self.inline_history_viewport_height()
         } else {
             self.vheight()
@@ -13666,6 +13684,16 @@ impl Editor {
         if matches!(cmd, "whats-new" | "changelog") {
             return vec![Action::OpenWhatsNew];
         }
+        if matches!(cmd, "learn" | "tutorial" | "welcome") {
+            return vec![Action::OpenLearn];
+        }
+        match cmd {
+            "tutorial essentials" => return vec![Action::StartLearnLesson],
+            "tutorial quit" => return vec![Action::ExitLearnLesson],
+            "tutorial restart" => return vec![Action::RestartLearnLesson],
+            "tutorial next" => return vec![Action::FinishLearnLesson],
+            _ => {}
+        }
         if cmd == "config-diagnostics" {
             return vec![Action::ConfigDiagnostics];
         }
@@ -16258,6 +16286,9 @@ impl Editor {
     ) -> anyhow::Result<bool> {
         // log!("Action: {action:?}");
         self.set_legacy_message(None);
+        if self.intercept_learn_action(action, buffer, runtime)? {
+            return Ok(false);
+        }
         let sensitive_action = matches!(action, Action::NotifyPlugin(_, _, _))
             || matches!(
                 action,
@@ -19483,6 +19514,17 @@ impl Editor {
                     self.render(buffer)?;
                 }
             }
+            Action::OpenLearn | Action::FinishLearnLesson => {
+                self.finish_learn_lesson(buffer, runtime)?;
+                self.open_learn_hub(runtime);
+                self.render(buffer)?;
+            }
+            Action::StartLearnLesson | Action::RestartLearnLesson => {
+                self.start_learn_lesson(buffer, runtime).await?;
+            }
+            Action::ExitLearnLesson => {
+                self.finish_learn_lesson(buffer, runtime)?;
+            }
             Action::OpenStatuslineManager => {
                 self.release_current_dialog_callbacks(runtime);
                 self.current_dialog = Some(Box::new(StatuslineLayoutPanel::new(self)));
@@ -20424,6 +20466,7 @@ impl Editor {
                 .await?;
         }
 
+        self.observe_learn_action(action, buffer)?;
         Ok(false)
     }
 
@@ -23941,6 +23984,11 @@ impl Editor {
     }
 
     fn persist_session_snapshot(&mut self, force: bool) -> bool {
+        // Learn Red checkpoints the real workspace before opening its scratch
+        // window. Keep that recovery snapshot intact until the lesson exits.
+        if self.learn_session.is_some() {
+            return false;
+        }
         let Some(store) = self.session_manager.store().cloned() else {
             return false;
         };
@@ -27544,6 +27592,140 @@ mod test {
     use super::*;
     use crate::lsp::DiagnosticSeverity;
     use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn learn_red_restores_the_original_workspace_and_protects_files() {
+        let mut editor = test_editor(120, 32);
+        let mut buffer = RenderBuffer::new(120, 32, &Style::default());
+        let mut runtime = Runtime::new();
+        editor
+            .execute(&Action::SplitVertical, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        let original_id = editor.current_buffer().id();
+        let original_text = editor.current_buffer().contents();
+        let original_windows = editor.window_manager.snapshot();
+        let directory = tempfile::tempdir().unwrap();
+        let forbidden = directory.path().join("must-not-exist.rs");
+
+        editor
+            .execute(&Action::StartLearnLesson, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        let practice_id = editor.current_buffer().id();
+        assert_ne!(practice_id, original_id);
+        assert_eq!(editor.window_manager.window_count(), 1);
+        assert!(editor.current_buffer().file.is_none());
+        editor
+            .execute(
+                &Action::SaveAs(forbidden.to_string_lossy().into_owned()),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        editor
+            .execute(&Action::NextBuffer, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert!(!forbidden.exists());
+        assert_eq!(editor.current_buffer().id(), practice_id);
+
+        for action in [
+            Action::EnterMode(Mode::Insert),
+            Action::InsertCharAtCursorPos('x'),
+            Action::EnterMode(Mode::Normal),
+            Action::Undo,
+        ] {
+            editor
+                .execute(&action, &mut buffer, &mut runtime)
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            editor.learn_session.as_ref().unwrap().step,
+            crate::learn::PracticeStep::Complete
+        );
+        assert!(editor
+            .preferences
+            .learn_lesson_completed(crate::learn::FIRST_LESSON_ID));
+        editor
+            .execute(&Action::ExitLearnLesson, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.current_buffer().id(), original_id);
+        assert_eq!(editor.current_buffer().contents(), original_text);
+        assert_eq!(editor.window_manager.snapshot(), original_windows);
+        assert!(!editor
+            .buffer_manager
+            .iter()
+            .any(|candidate| candidate.id() == practice_id));
+    }
+
+    #[test]
+    fn learn_red_commands_are_explicit_and_discoverable() {
+        let mut editor = test_editor(80, 24);
+        let runtime = Runtime::new();
+        for command in ["learn", "tutorial", "welcome"] {
+            assert_eq!(
+                editor.handle_command(command, &runtime),
+                vec![Action::OpenLearn]
+            );
+        }
+        assert_eq!(
+            editor.handle_command("tutorial essentials", &runtime),
+            vec![Action::StartLearnLesson]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial quit", &runtime),
+            vec![Action::ExitLearnLesson]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial restart", &runtime),
+            vec![Action::RestartLearnLesson]
+        );
+    }
+
+    #[tokio::test]
+    async fn learn_red_keeps_the_real_workspace_in_crash_recovery() {
+        let mut editor = test_editor(100, 28);
+        let directory = tempfile::tempdir().unwrap();
+        let store = SessionStore::new(directory.path().join("recovery"));
+        editor.set_session_store(store.clone());
+        let mut buffer = RenderBuffer::new(100, 28, &Style::default());
+        editor.render(&mut buffer).unwrap();
+        let original_windows = editor.window_manager.snapshot();
+        let mut runtime = Runtime::new();
+        editor
+            .execute(&Action::StartLearnLesson, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        let before = store.load().unwrap();
+        assert_eq!(before.window_layout, original_windows);
+        assert_eq!(before.buffers.len(), 1);
+        editor
+            .execute(&Action::EnterMode(Mode::Insert), &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        editor
+            .execute(
+                &Action::InsertCharAtCursorPos('x'),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        editor.persist_session_snapshot(true);
+        assert_eq!(store.load().unwrap().generation, before.generation);
+        editor
+            .execute(&Action::ExitLearnLesson, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        let after = store.load().unwrap();
+        assert_eq!(after.window_layout, original_windows);
+        assert_eq!(after.buffers.len(), 1);
+        assert_eq!(after.buffers[0].contents, "hello");
+    }
 
     #[test]
     fn commit_message_prompt_bounds_context_and_separates_style_from_facts() {

--- a/src/editor/learning.rs
+++ b/src/editor/learning.rs
@@ -1,0 +1,252 @@
+//! Lifecycle for the first Learn Red practice-buffer checkpoint.
+
+use super::*;
+use crate::learn::{practice_action_allowed, PracticeStep, FIRST_LESSON_ID, PRACTICE_CONTENTS};
+use crate::ui::{draw_learn_coach, CoachLayout, LearnHub};
+
+pub(super) struct LearnSession {
+    pub(super) step: PracticeStep,
+    practice_buffer_id: BufferId,
+    original_buffer_id: BufferId,
+    original_windows: WindowManager,
+    original_zoom: Option<FocusTarget>,
+    original_panel_focus: Option<String>,
+    original_repeat: Option<SemanticChange>,
+    original_registers: HashMap<char, Content>,
+}
+
+impl Editor {
+    pub(super) fn open_learn_hub(&mut self, runtime: &mut Runtime) {
+        if self.inline_assist.is_some()
+            || self.workspace_manager.is_active()
+            || self
+                .current_dialog
+                .as_ref()
+                .is_some_and(|dialog| dialog.composer_handle().is_some())
+        {
+            self.set_legacy_message(Some(
+                "finish the current proposal, composer, or workspace before opening Learn Red"
+                    .into(),
+            ));
+            return;
+        }
+        self.release_current_dialog_callbacks(runtime);
+        self.current_dialog = Some(Box::new(LearnHub::new(
+            self,
+            self.preferences.learn_lesson_completed(FIRST_LESSON_ID),
+        )));
+    }
+
+    pub(super) async fn start_learn_lesson(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        if self.learn_session.is_some() {
+            self.finish_learn_lesson(buffer, runtime)?;
+        }
+        if self.size.0 < 32 || self.size.1 < 12 {
+            self.set_legacy_message(Some(
+                "make the terminal at least 32 columns by 12 rows to start a lesson".into(),
+            ));
+            return self.render(buffer);
+        }
+        if self.inline_assist.is_some()
+            || self.workspace_manager.is_active()
+            || self.agent_manager.has_active_sessions()
+        {
+            self.set_legacy_message(Some(
+                "finish the current agent turn, inline assist, or workspace before starting a lesson".into(),
+            ));
+            return self.render(buffer);
+        }
+        self.release_current_dialog_callbacks(runtime);
+        self.current_dialog = None;
+        self.sync_to_window();
+        // The temporary lesson must never replace the user's recovery layout.
+        self.persist_session_snapshot(true);
+        let original_buffer_id = self.current_buffer().id();
+        let original_panel_focus = self.panel_manager.focused_panel_id().map(str::to_string);
+        self.panel_manager.focus_editor();
+        let original_zoom = self.zoomed_pane.take();
+        let original_repeat = self.last_semantic_change.take();
+        let original_registers = self.registers.clone();
+        self.pending_semantic_change = None;
+        let practice = Buffer::new(None, PRACTICE_CONTENTS.to_string());
+        let practice_buffer_id = practice.id();
+        let practice_index = self.buffer_manager.len();
+        self.buffer_manager.push_buffer(practice);
+        let original_windows = std::mem::replace(
+            &mut self.window_manager,
+            WindowManager::new(
+                practice_index,
+                (usize::from(self.size.0), usize::from(self.size.1)),
+            ),
+        );
+        self.learn_session = Some(LearnSession {
+            step: PracticeStep::default(),
+            practice_buffer_id,
+            original_buffer_id,
+            original_windows,
+            original_zoom,
+            original_panel_focus,
+            original_repeat,
+            original_registers,
+        });
+        self.mode = Mode::Normal;
+        self.splash_dismissed = true;
+        self.force_full_redraw = true;
+        self.set_current_buffer(buffer, practice_index).await
+    }
+
+    pub(super) fn finish_learn_lesson(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let Some(session) = self.learn_session.take() else {
+            return Ok(());
+        };
+        self.release_current_dialog_callbacks(runtime);
+        self.current_dialog = None;
+        self.completion_snapshot = None;
+        if let Some(index) = self
+            .buffer_manager
+            .iter()
+            .position(|candidate| candidate.id() == session.practice_buffer_id)
+        {
+            self.buffer_manager.remove_buffer(index);
+        }
+        self.lsp_coordinator
+            .forget_buffer(session.practice_buffer_id);
+        self.window_manager = session.original_windows;
+        if let Some(index) = self
+            .buffer_manager
+            .iter()
+            .position(|candidate| candidate.id() == session.original_buffer_id)
+        {
+            self.buffer_manager.set_active_index(index);
+        }
+        self.zoomed_pane = session.original_zoom;
+        self.last_semantic_change = session.original_repeat;
+        self.pending_semantic_change = None;
+        self.registers = session.original_registers;
+        self.local_marks.remove(&session.practice_buffer_id);
+        self.special_marks
+            .retain(|(id, _), _| *id != session.practice_buffer_id);
+        self.last_visual_selections
+            .remove(&session.practice_buffer_id);
+        self.sync_with_window();
+        self.mode = Mode::Normal;
+        self.waiting_key_action = None;
+        self.command.clear();
+        if let Some(panel) = session.original_panel_focus {
+            self.panel_manager.restore_panel_focus(&panel);
+        }
+        self.highlight_cache.clear();
+        self.layout_cache.borrow_mut().clear();
+        self.force_full_redraw = true;
+        self.render(buffer)?;
+        self.persist_session_snapshot(true);
+        Ok(())
+    }
+
+    /// Returns true when a practice action was handled or safely refused.
+    pub(super) fn intercept_learn_action(
+        &mut self,
+        action: &Action,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        let Some(session) = self.learn_session.as_ref() else {
+            return Ok(false);
+        };
+        if matches!(action, Action::Quit(_)) {
+            self.finish_learn_lesson(buffer, runtime)?;
+            return Ok(true);
+        }
+        if self.current_buffer().id() != session.practice_buffer_id {
+            self.finish_learn_lesson(buffer, runtime)?;
+            self.set_legacy_message(Some(
+                "lesson paused because the active buffer changed".into(),
+            ));
+            self.render(buffer)?;
+            return Ok(true);
+        }
+        if !practice_action_allowed(action) {
+            self.set_legacy_message(Some(
+                "this practice step only edits tutorial text; use :tutorial quit to return".into(),
+            ));
+            self.render(buffer)?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    pub(super) fn observe_learn_action(
+        &mut self,
+        action: &Action,
+        buffer: &mut RenderBuffer,
+    ) -> anyhow::Result<()> {
+        if matches!(
+            action,
+            Action::StartLearnLesson | Action::RestartLearnLesson
+        ) {
+            return Ok(());
+        }
+        let Some(session) = self.learn_session.as_ref() else {
+            return Ok(());
+        };
+        if self.current_buffer().id() != session.practice_buffer_id {
+            return Ok(());
+        }
+        let original_text = self.current_buffer().contents() == PRACTICE_CONTENTS;
+        let mode = self.mode;
+        let session = self
+            .learn_session
+            .as_mut()
+            .expect("the active lesson was checked above");
+        if session.step.observe(action, mode, original_text) {
+            if session.step == PracticeStep::Complete {
+                if let Err(error) = self.preferences.complete_learn_lesson(FIRST_LESSON_ID) {
+                    log!("could not persist Learn Red progress: {error}");
+                }
+            }
+            self.render(buffer)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn resize_learn_layout(&mut self, size: (usize, usize)) -> bool {
+        if self.learn_session.is_none() {
+            return false;
+        }
+        let layout = CoachLayout::new(size.0, size.1);
+        self.sync_to_window();
+        self.window_manager
+            .set_presentation(WindowPresentation::All);
+        self.panel_manager
+            .set_presentation(plugin::panel::PanelPresentation::Hidden);
+        self.window_manager.resize_with_origin(
+            Point::new(0, layout.top),
+            (
+                size.0.saturating_sub(layout.right),
+                size.1.saturating_sub(layout.top + layout.bottom),
+            ),
+        );
+        self.sync_with_window();
+        true
+    }
+
+    pub(super) fn render_learn_coach(&self, buffer: &mut RenderBuffer) {
+        let Some(session) = &self.learn_session else {
+            return;
+        };
+        let shortcut = session.step.suggested_action().and_then(|action| {
+            command_palette::shortcuts_for_action(&self.config.keys, &action)
+                .into_iter()
+                .next()
+        });
+        draw_learn_coach(buffer, &self.theme, session.step, shortcut.as_deref());
+    }
+}

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1311,6 +1311,7 @@ impl Editor {
                 help.context.clone_from(&context);
             }
         }
+        self.render_learn_coach(buffer);
         self.render_dialog(buffer)?;
 
         // Render all plugins
@@ -1414,6 +1415,7 @@ impl Editor {
 
     fn can_reuse_editor_surfaces(&self) -> bool {
         self.previous_render_buffer.is_some()
+            && self.learn_session.is_none()
             && !self.force_full_redraw
             && self.last_rendered_window == self.window_manager.active_stable_window_id()
             && self.current_dialog.is_none()
@@ -1443,6 +1445,7 @@ impl Editor {
             self.render_window(buffer, self.window_manager.active_window_id())?;
         }
         self.render_ui_chrome(buffer)?;
+        self.render_learn_coach(buffer);
         self.render_dialog(buffer)?;
         self.update_and_render_overlays(buffer)?;
         self.update_terminal_cursor_surface(buffer);

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -1,0 +1,248 @@
+//! Curriculum metadata and the first editor-native Learn Red exercise.
+
+use crate::editor::{Action, Mode};
+
+pub(crate) const FIRST_LESSON_ID: &str = "essentials.find-your-footing.v1";
+pub(crate) const PRACTICE_CONTENTS: &str = "// This practice buffer never touches your project.\n\nfn add_score(score: u32, points: u32) -> u32 {\n    score + points\n}\n";
+
+pub(crate) struct Track {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub category: &'static str,
+    pub duration: &'static str,
+    pub description: &'static str,
+    pub outcome: &'static str,
+    pub lessons: &'static [&'static str],
+}
+
+pub(crate) const TRACKS: [Track; 6] = [
+    Track {
+        id: "essentials",
+        title: "Essentials",
+        category: "Start here",
+        duration: "~4 min",
+        description: "Get comfortable, make a change, and know how to get back.",
+        outcome: "Make your first edit without losing your place.",
+        lessons: &[
+            "Find your footing",
+            "Edit with confidence",
+            "Find a command",
+            "Save a practice file",
+        ],
+    },
+    Track {
+        id: "ai",
+        title: "Build with AI",
+        category: "AI coding",
+        duration: "~12 min",
+        description:
+            "Start with a question. Make a focused change. Understand exactly what it did.",
+        outcome: "Use AI to fix a small bug and review the result.",
+        lessons: &[
+            "Understand selected code",
+            "Make a focused change",
+            "Choose what to keep",
+            "Continue in Agent",
+            "Review what changed",
+        ],
+    },
+    Track {
+        id: "ship",
+        title: "Fix & ship",
+        category: "LSP + Git",
+        duration: "~15 min",
+        description: "Follow a defect from the first diagnostic to a clean local commit.",
+        outcome: "Diagnose, repair, and commit one small change.",
+        lessons: &[
+            "Read the diagnostic",
+            "Follow the symbol",
+            "Repair the code",
+            "Stage the right hunk",
+            "Make a local commit",
+        ],
+    },
+    Track {
+        id: "navigation",
+        title: "Find your way",
+        category: "Navigation",
+        duration: "~8 min",
+        description: "Move around a codebase without losing the thread.",
+        outcome: "Find the right code and return to where you started.",
+        lessons: &[
+            "Open a file by name",
+            "Search the project",
+            "Follow symbols",
+            "Arrange your workspace",
+        ],
+    },
+    Track {
+        id: "editing",
+        title: "Edit with precision",
+        category: "Modal editing",
+        duration: "~10 min",
+        description: "Build a small vocabulary of edits you can combine.",
+        outcome: "Make a precise edit, repeat it, and recover confidently.",
+        lessons: &[
+            "Move with intent",
+            "Change a text object",
+            "Repeat and recover",
+            "Find and replace",
+        ],
+    },
+    Track {
+        id: "custom",
+        title: "Make Red yours",
+        category: "Setup + workflow",
+        duration: "~7 min",
+        description: "Tune the parts you use every day, one decision at a time.",
+        outcome: "Leave with a setup you understand and can change.",
+        lessons: &[
+            "Choose a theme",
+            "Discover your keymap",
+            "Check language support",
+            "Keep your place",
+        ],
+    },
+];
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PracticeStep {
+    #[default]
+    Insert,
+    Type,
+    Normal,
+    Undo,
+    Complete,
+}
+
+impl PracticeStep {
+    pub fn suggested_action(self) -> Option<Action> {
+        match self {
+            Self::Insert => Some(Action::EnterMode(Mode::Insert)),
+            Self::Normal => Some(Action::EnterMode(Mode::Normal)),
+            Self::Undo => Some(Action::Undo),
+            Self::Type | Self::Complete => None,
+        }
+    }
+
+    pub fn instruction(self, shortcut: Option<&str>) -> String {
+        match self {
+            Self::Insert => format!("Press {} to enter Insert mode.", shortcut.unwrap_or("i")),
+            Self::Type => "Type a few characters in the practice buffer.".into(),
+            Self::Normal => format!(
+                "Press {} to return to Normal mode.",
+                shortcut.unwrap_or("Esc")
+            ),
+            Self::Undo => format!(
+                "Press {} to undo your practice edit.",
+                shortcut.unwrap_or("u")
+            ),
+            Self::Complete => "Your original text is restored. Nicely done.".into(),
+        }
+    }
+
+    pub const fn completed_steps(self) -> usize {
+        match self {
+            Self::Insert => 0,
+            Self::Type => 1,
+            Self::Normal => 2,
+            Self::Undo => 3,
+            Self::Complete => 4,
+        }
+    }
+
+    /// Progress follows successful editor effects, not just pressed keys.
+    pub fn observe(&mut self, action: &Action, mode: Mode, original_text: bool) -> bool {
+        let next = match (*self, action) {
+            (Self::Insert, _) if mode == Mode::Insert => Self::Type,
+            (Self::Type, _) if !original_text => Self::Normal,
+            (Self::Normal, Action::EnterMode(Mode::Normal)) if mode == Mode::Normal => Self::Undo,
+            (Self::Undo, Action::Undo) if original_text => Self::Complete,
+            _ => return false,
+        };
+        *self = next;
+        true
+    }
+}
+
+/// This first checkpoint permits only edits to its isolated scratch buffer.
+pub(crate) fn practice_action_allowed(action: &Action) -> bool {
+    matches!(
+        action,
+        Action::OpenLearn
+            | Action::StartLearnLesson
+            | Action::ExitLearnLesson
+            | Action::RestartLearnLesson
+            | Action::FinishLearnLesson
+            | Action::Quit(_)
+            | Action::Command(_)
+            | Action::Print(_)
+            | Action::EnterMode(Mode::Normal | Mode::Insert | Mode::Command)
+            | Action::SetWaitingKey(_)
+            | Action::Refresh
+            | Action::CloseDialog
+            | Action::InsertCharAtCursorPos(_)
+            | Action::InsertString(_)
+            | Action::InsertPastedText(_)
+            | Action::InsertNewLine
+            | Action::InsertTab
+            | Action::InsertLineBelowCursor
+            | Action::InsertLineAtCursor
+            | Action::DeletePreviousChar
+            | Action::DeleteCharAtCursorPos
+            | Action::Undo
+            | Action::Redo
+            | Action::MoveUp
+            | Action::MoveDown
+            | Action::MoveLeft
+            | Action::MoveRight
+            | Action::MoveToLineEnd
+            | Action::MoveToLineStart
+            | Action::MoveToFirstLineChar
+            | Action::MoveToNextWord
+            | Action::MoveToPreviousWord
+            | Action::MoveToNextWordEnd
+            | Action::MoveToTop
+            | Action::MoveToBottom
+            | Action::GoToLine(_)
+            | Action::PageDown
+            | Action::PageUp
+            | Action::HalfPageDown(_)
+            | Action::HalfPageUp(_)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lesson_requires_a_real_edit_and_restoring_undo() {
+        let mut step = PracticeStep::default();
+        assert!(!step.observe(&Action::Undo, Mode::Normal, true));
+        assert!(step.observe(&Action::EnterMode(Mode::Insert), Mode::Insert, true));
+        assert!(!step.observe(&Action::Refresh, Mode::Insert, true));
+        assert!(step.observe(&Action::InsertCharAtCursorPos('x'), Mode::Insert, false));
+        assert!(step.observe(&Action::EnterMode(Mode::Normal), Mode::Normal, false));
+        assert!(!step.observe(&Action::Undo, Mode::Normal, false));
+        assert!(step.observe(&Action::Undo, Mode::Normal, true));
+        assert_eq!(step, PracticeStep::Complete);
+    }
+
+    #[test]
+    fn first_checkpoint_never_runs_workspace_actions() {
+        for action in [
+            Action::Save,
+            Action::SaveAs("outside.rs".into()),
+            Action::OpenFile("outside.rs".into()),
+            Action::NextBuffer,
+            Action::PluginCommand("Agent".into()),
+            Action::InlineAssist,
+        ] {
+            assert!(!practice_action_allowed(&action));
+        }
+        assert!(practice_action_allowed(&Action::Command(
+            "tutorial quit".into()
+        )));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod inline_assist;
 pub mod inline_history;
 pub mod keyboard;
 pub mod language;
+mod learn;
 pub mod logger;
 pub mod lsp;
 pub mod matchit;

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -22,12 +22,12 @@ use super::markdown::{
 use super::text_link::{TextPanelLink, TextPanelLinkTarget};
 use crate::{
     buffer::BufferId,
-    color::{blend_color, ensure_minimum_contrast, Color},
+    color::{blend_color, Color},
     editor::{render_buffer::RenderBuffer, Point},
     text_layout::{LayoutOptions, TextLayout},
     theme::{
-        SelectionForegroundPriority, Style, SurfacePalette, Theme, ThemeStyleSpec,
-        MINIMUM_SELECTION_TEXT_CONTRAST,
+        SelectionForegroundPriority, Style, SurfaceCardColors, SurfaceCardPalette, SurfacePalette,
+        Theme, ThemeStyleSpec,
     },
     ui::{
         first_prompt_line, normalize_prompt_newlines, ActionBar, ActionPriority,
@@ -298,74 +298,22 @@ fn text_panel_palette(theme: &Theme, config: &PanelConfig) -> TextPanelPalette {
     SurfacePalette::new(theme, &panel_style(theme, config.surface.as_ref()))
 }
 
-/// Prompt surfaces remain theme-derived, while the half-block caps blend back into
-/// the surrounding pane. The explicit color keys make this exploration tunable.
-struct TextPanelPromptPalette {
-    content: TextPanelPalette,
-    edge: Style,
-    cap: Style,
-}
-
-impl TextPanelPromptPalette {
-    fn new(theme: &Theme, panel: &TextPanelPalette, selected: bool) -> Self {
-        let surface = blend_color(
-            panel.surface.bg.unwrap_or_default(),
-            Color::Rgb { r: 0, g: 0, b: 0 },
-        );
-        let light = surface.is_light();
-        let neutral = if light {
-            Color::Rgb { r: 0, g: 0, b: 0 }
-        } else {
-            Color::Rgb {
-                r: 255,
-                g: 255,
-                b: 255,
-            }
-        };
-        let background = theme_color(theme, &["red.agentPromptBackground"])
-            .map(|color| blend_color(color, surface))
-            .unwrap_or_else(|| tint_color(neutral, surface, if light { 12 } else { 17 }));
-        let accent = panel.accent.fg.unwrap_or(neutral);
-        let background = if selected {
-            theme_color(theme, &["red.agentPromptSelectedBackground"])
-                .map(|color| blend_color(color, surface))
-                .unwrap_or_else(|| tint_color(accent, background, if light { 22 } else { 32 }))
-        } else {
-            background
-        };
-        let edge_color = if selected {
-            theme_color(theme, &["red.agentPromptSelectedBorder"]).unwrap_or(accent)
-        } else {
-            theme_color(theme, &["red.agentPromptBorder"])
-                .or(panel.muted.fg)
-                .unwrap_or(accent)
-        };
-        let edge = Style {
-            fg: Some(ensure_minimum_contrast(
-                edge_color,
-                background,
-                MINIMUM_SELECTION_TEXT_CONTRAST,
-            )),
-            bg: Some(background),
-            bold: selected,
-            ..Style::default()
-        };
-        let mut content = panel.on_background(background);
-        content.accent = edge.clone();
-        Self {
-            content,
-            edge: Style {
-                bg: panel.surface.bg,
-                bold: false,
-                ..edge
-            },
-            cap: Style {
-                fg: Some(background),
-                bg: panel.surface.bg,
-                ..Style::default()
-            },
-        }
-    }
+/// Agent-specific overrides retain the shared surface card's contrast and geometry.
+fn text_panel_prompt_palette(
+    theme: &Theme,
+    panel: &TextPanelPalette,
+    selected: bool,
+) -> SurfaceCardPalette {
+    SurfaceCardPalette::new(
+        panel,
+        selected,
+        SurfaceCardColors {
+            background: theme_color(theme, &["red.agentPromptBackground"]),
+            selected_background: theme_color(theme, &["red.agentPromptSelectedBackground"]),
+            border: theme_color(theme, &["red.agentPromptBorder"]),
+            selected_border: theme_color(theme, &["red.agentPromptSelectedBorder"]),
+        },
+    )
 }
 
 fn tint_color(color: Color, background: Color, alpha: u8) -> Color {
@@ -4565,8 +4513,8 @@ fn render_text_panel(
         )
     });
     let selected_prompt = panel.selected_prompt(&layout);
-    let normal_prompt = TextPanelPromptPalette::new(theme, &palette, false);
-    let active_prompt = TextPanelPromptPalette::new(theme, &palette, true);
+    let normal_prompt = text_panel_prompt_palette(theme, &palette, false);
+    let active_prompt = text_panel_prompt_palette(theme, &palette, true);
     for (offset, line) in layout
         .rendered
         .iter()
@@ -7727,7 +7675,7 @@ mod tests {
             border: None,
         };
         let palette = text_panel_palette(&theme, &config);
-        let prompt_palette = TextPanelPromptPalette::new(&theme, &palette, true);
+        let prompt_palette = text_panel_prompt_palette(&theme, &palette, true);
         let assert_surfaces = |buffer: &RenderBuffer| {
             let label_y = text_position(buffer, "You").unwrap().y;
             let body_y = text_position(buffer, "question").unwrap().y;

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -37,6 +37,8 @@ pub struct Preferences {
     panel_layouts: HashMap<String, HashMap<String, PanelLayoutPreference>>,
     #[serde(default)]
     copilot_setup_hint_seen: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    learn_completed_lessons: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,6 +82,23 @@ impl PreferencesStore {
     #[must_use]
     pub fn is_persistent(&self) -> bool {
         self.path.is_some()
+    }
+
+    /// Whether a stable, versioned Learn Red lesson has been completed.
+    pub(crate) fn learn_lesson_completed(&self, id: &str) -> bool {
+        self.preferences
+            .learn_completed_lessons
+            .iter()
+            .any(|lesson| lesson == id)
+    }
+
+    /// Records completion without changing any project or editor buffer.
+    pub(crate) fn complete_learn_lesson(&mut self, id: &str) -> anyhow::Result<()> {
+        if self.learn_lesson_completed(id) {
+            return Ok(());
+        }
+        self.preferences.learn_completed_lessons.push(id.to_owned());
+        self.save()
     }
 
     /// Loads preferences, falling back to empty state on any read or parse error.

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -8,7 +8,7 @@
 
 mod surface;
 mod vscode;
-pub(crate) use surface::{DiffPalette, SurfacePalette};
+pub(crate) use surface::{DiffPalette, SurfaceCardColors, SurfaceCardPalette, SurfacePalette};
 
 use std::collections::BTreeMap;
 

--- a/src/theme/surface.rs
+++ b/src/theme/surface.rs
@@ -90,6 +90,86 @@ impl SurfacePalette {
     }
 }
 
+/// Optional overrides for a surface card. Unspecified colors use theme-derived tints.
+#[derive(Default)]
+pub(crate) struct SurfaceCardColors {
+    pub background: Option<Color>,
+    pub selected_background: Option<Color>,
+    pub border: Option<Color>,
+    pub selected_border: Option<Color>,
+}
+
+/// A softly tinted card with contrast-safe content, rails, and half-block caps.
+pub(crate) struct SurfaceCardPalette {
+    pub content: SurfacePalette,
+    pub edge: Style,
+    pub cap: Style,
+}
+
+impl SurfaceCardPalette {
+    pub fn new(panel: &SurfacePalette, selected: bool, colors: SurfaceCardColors) -> Self {
+        let surface = blend_color(
+            panel.surface.bg.unwrap_or_default(),
+            Color::Rgb { r: 0, g: 0, b: 0 },
+        );
+        let light = surface.is_light();
+        let neutral = if light {
+            Color::Rgb { r: 0, g: 0, b: 0 }
+        } else {
+            Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255,
+            }
+        };
+        let background = colors
+            .background
+            .map(|color| blend_color(color, surface))
+            .unwrap_or_else(|| blend_color(tint(neutral, if light { 12 } else { 17 }), surface));
+        let accent = panel.accent.fg.unwrap_or(neutral);
+        let background = if selected {
+            colors
+                .selected_background
+                .map(|color| blend_color(color, surface))
+                .unwrap_or_else(|| {
+                    blend_color(tint(accent, if light { 22 } else { 32 }), background)
+                })
+        } else {
+            background
+        };
+        let edge_color = if selected {
+            colors.selected_border.unwrap_or(accent)
+        } else {
+            colors.border.or(panel.muted.fg).unwrap_or(accent)
+        };
+        let edge = Style {
+            fg: Some(ensure_minimum_contrast(
+                edge_color,
+                background,
+                MINIMUM_SELECTION_TEXT_CONTRAST,
+            )),
+            bg: Some(background),
+            bold: selected,
+            ..Style::default()
+        };
+        let mut content = panel.on_background(background);
+        content.accent = edge.clone();
+        Self {
+            content,
+            edge: Style {
+                bg: panel.surface.bg,
+                bold: false,
+                ..edge
+            },
+            cap: Style {
+                fg: Some(background),
+                bg: panel.surface.bg,
+                ..Style::default()
+            },
+        }
+    }
+}
+
 /// Resolved, opaque diff colors. Text colors never carry another surface's background.
 pub(crate) struct DiffPalette {
     pub added: Style,
@@ -214,6 +294,48 @@ fn tint(color: Color, alpha: u8) -> Color {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::color::contrast_ratio;
+
+    #[test]
+    fn surface_cards_keep_overrides_and_text_contrast() {
+        for path in ["themes/kanso.json", "themes/night-owl-light.json"] {
+            let theme = crate::theme::parse_vscode_theme(path).unwrap();
+            let panel = SurfacePalette::new(&theme, &theme.ui_style.dialog);
+            let override_color = Color::Rgba {
+                r: 90,
+                g: 110,
+                b: 130,
+                a: 80,
+            };
+            for selected in [false, true] {
+                let card = SurfaceCardPalette::new(
+                    &panel,
+                    selected,
+                    SurfaceCardColors {
+                        background: Some(override_color),
+                        selected_background: Some(override_color),
+                        ..SurfaceCardColors::default()
+                    },
+                );
+                let background = blend_color(override_color, panel.surface.bg.unwrap());
+                assert_eq!(card.content.surface.bg, Some(background));
+                assert_eq!(card.cap.fg, Some(background));
+                assert_eq!(card.cap.bg, panel.surface.bg);
+                assert_eq!(card.edge.bg, panel.surface.bg);
+                for style in [
+                    &card.content.primary,
+                    &card.content.secondary,
+                    &card.content.accent,
+                ] {
+                    assert_eq!(style.bg, Some(background));
+                    assert!(
+                        contrast_ratio(style.fg.unwrap(), background) >= 4.5,
+                        "{path}"
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn one_dark_has_distinct_opaque_diff_surfaces() {

--- a/src/ui/learn.rs
+++ b/src/ui/learn.rs
@@ -1,0 +1,1048 @@
+//! Full-window learning hub and a nonmodal, space-reserving lesson coach.
+
+use crossterm::event::{Event, KeyCode, KeyModifiers, MouseButton, MouseEventKind};
+
+use crate::{
+    config::KeyAction,
+    editor::{Action, Editor, RenderBuffer},
+    learn::{PracticeStep, TRACKS},
+    theme::{Style, SurfaceCardColors, SurfaceCardPalette, SurfacePalette, Theme},
+    unicode_utils::{display_width, truncate_display_width},
+};
+
+use super::{ActionBar, ActionBarRole, ActionPriority, Component, UiAction};
+
+const WIDE_HUB: usize = 92;
+const LIST_WIDTH: usize = 40;
+
+#[derive(Clone, Copy)]
+struct Region {
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+}
+
+impl Region {
+    fn right(self) -> usize {
+        self.x + self.width
+    }
+    fn bottom(self) -> usize {
+        self.y + self.height
+    }
+}
+
+struct HubLayout {
+    frame: Region,
+    body_y: usize,
+    body_bottom: usize,
+    footer_y: usize,
+    wide: bool,
+}
+
+impl HubLayout {
+    fn new(width: usize, height: usize) -> Self {
+        let frame_width = if width >= 96 {
+            width.saturating_sub(4).min(128)
+        } else {
+            width
+        };
+        let frame_height = height.min(42);
+        let frame = Region {
+            x: (width - frame_width) / 2,
+            y: (height - frame_height) / 2,
+            width: frame_width,
+            height: frame_height,
+        };
+        let footer_y = frame.bottom().saturating_sub(2);
+        Self {
+            frame,
+            body_y: frame.y + if frame.height >= 18 { 8 } else { 4 },
+            body_bottom: footer_y.saturating_sub(1),
+            footer_y,
+            wide: frame.width >= WIDE_HUB && frame.height >= 22,
+        }
+    }
+
+    fn row_height(&self) -> usize {
+        let available = self.body_bottom.saturating_sub(self.body_y);
+        [4, 3, 2, 1]
+            .into_iter()
+            .find(|height| available >= TRACKS.len() * height)
+            .unwrap_or(1)
+    }
+
+    fn visible_tracks(&self, selected: usize) -> (usize, usize) {
+        let slots = (self.body_bottom.saturating_sub(self.body_y) / self.row_height()).max(1);
+        (selected.saturating_sub(slots.saturating_sub(1)), slots)
+    }
+
+    fn tracks(&self) -> Region {
+        Region {
+            x: self.frame.x + 2,
+            y: self.body_y,
+            width: if self.wide {
+                LIST_WIDTH - 2
+            } else {
+                self.frame.width.saturating_sub(4)
+            },
+            height: self.body_bottom.saturating_sub(self.body_y),
+        }
+    }
+}
+
+pub(crate) struct LearnHub {
+    selected: usize,
+    details: bool,
+    completed: bool,
+    width: usize,
+    height: usize,
+    theme: Theme,
+}
+
+impl LearnHub {
+    pub fn new(editor: &Editor, completed: bool) -> Self {
+        Self {
+            selected: 0,
+            details: false,
+            completed,
+            width: editor.vwidth(),
+            height: editor.inline_history_viewport_height().saturating_add(1),
+            theme: editor.theme.clone(),
+        }
+    }
+
+    fn layout(&self) -> HubLayout {
+        HubLayout::new(self.width, self.height)
+    }
+    fn wide(&self) -> bool {
+        self.layout().wide
+    }
+
+    fn actions(&self) -> Vec<UiAction> {
+        let open = if !self.wide() && !self.details {
+            "View track"
+        } else if self.selected == 0 {
+            if self.completed {
+                "Replay lesson"
+            } else {
+                "Start lesson"
+            }
+        } else {
+            "Track planned"
+        };
+        vec![
+            UiAction::new("open", "Enter", open).with_priority(ActionPriority::Essential),
+            UiAction::new(
+                "close",
+                "Esc",
+                if self.details && !self.wide() {
+                    "All tracks"
+                } else {
+                    "Start editing"
+                },
+            )
+            .with_priority(ActionPriority::Essential),
+            UiAction::new("next", "j/k", "Choose track").with_trigger("j"),
+        ]
+    }
+
+    fn open_selected(&mut self) -> KeyAction {
+        if !self.wide() && !self.details {
+            self.details = true;
+            KeyAction::Single(Action::Refresh)
+        } else if TRACKS[self.selected].id == "essentials" {
+            KeyAction::Single(Action::StartLearnLesson)
+        } else {
+            KeyAction::Single(Action::Refresh)
+        }
+    }
+
+    fn move_selection(&mut self, direction: isize) {
+        self.selected = self
+            .selected
+            .saturating_add_signed(direction)
+            .min(TRACKS.len() - 1);
+    }
+
+    fn draw_tracks(&self, buffer: &mut RenderBuffer, layout: &HubLayout, palette: &SurfacePalette) {
+        let area = layout.tracks();
+        let row_height = layout.row_height();
+        let (first, slots) = layout.visible_tracks(self.selected);
+        let card = SurfaceCardPalette::new(palette, true, SurfaceCardColors::default());
+        for (index, track) in TRACKS.iter().enumerate().skip(first).take(slots) {
+            let y = area.y + (index - first) * row_height;
+            if y >= layout.body_bottom {
+                break;
+            }
+            let active = index == self.selected;
+            let framed = row_height >= 4;
+            let content = if active { &card.content } else { palette };
+            if active {
+                let height = if row_height == 3 { 2 } else { row_height };
+                draw_card(buffer, Region { y, height, ..area }, &card, &self.theme);
+            }
+            let title_y = y + usize::from(framed);
+            put(
+                buffer,
+                area.x + 2,
+                title_y,
+                area.width.saturating_sub(4),
+                &format!("{:02}  {}", index + 1, track.title),
+                &Style {
+                    bold: active,
+                    ..content.primary.clone()
+                },
+            );
+            if row_height > 1 {
+                put(
+                    buffer,
+                    area.x + 6,
+                    title_y + 1,
+                    area.width.saturating_sub(8),
+                    &format!("{} · {}", track.category, track.duration),
+                    &content.secondary,
+                );
+            }
+        }
+    }
+
+    fn draw_details(&self, buffer: &mut RenderBuffer, area: Region, palette: &SurfacePalette) {
+        let track = &TRACKS[self.selected];
+        let x = area.x;
+        let width = area.width.min(70);
+        let bottom = area.bottom();
+        let mut y = area.y;
+        put(
+            buffer,
+            x,
+            y,
+            width,
+            &format!("{}  ·  {}", track.category, track.duration),
+            &palette.accent,
+        );
+        y += 1;
+        put(
+            buffer,
+            x,
+            y,
+            width,
+            track.title,
+            &Style {
+                bold: true,
+                ..palette.primary.clone()
+            },
+        );
+        y += 2;
+        y = wrapped(
+            buffer,
+            x,
+            y,
+            width,
+            bottom,
+            track.description,
+            &palette.secondary,
+        );
+        if y + 4 < bottom {
+            y += 1;
+            put(buffer, x, y, width, "YOU WILL", &palette.accent);
+            y = wrapped(
+                buffer,
+                x,
+                y + 1,
+                width,
+                bottom,
+                track.outcome,
+                &palette.primary,
+            );
+        }
+        if y + 4 < bottom {
+            y += 1;
+            put(buffer, x, y, width, "YOUR PATH", &palette.secondary);
+            y += 1;
+            for (index, lesson) in track.lessons.iter().enumerate() {
+                if y >= bottom.saturating_sub(2) {
+                    break;
+                }
+                let mark = if self.selected == 0 && index == 0 && self.completed {
+                    "✓ ".to_string()
+                } else {
+                    format!("{:02}", index + 1)
+                };
+                put(
+                    buffer,
+                    x,
+                    y,
+                    width,
+                    &format!("{mark}  {lesson}"),
+                    &palette.primary,
+                );
+                y += 1;
+            }
+        }
+        if y + 1 < bottom {
+            let status = if self.selected == 0 {
+                if self.completed {
+                    "✓ First lesson complete · Enter to replay"
+                } else {
+                    "Enter  Start the first lesson →"
+                }
+            } else {
+                "Planned · more lessons are on the way"
+            };
+            if y + 3 < bottom {
+                horizontal_rule(buffer, x, y + 1, width, &palette.divider);
+                y += 2;
+            }
+            put(
+                buffer,
+                x,
+                y + 1,
+                width,
+                status,
+                if self.selected == 0 {
+                    &palette.accent
+                } else {
+                    &palette.secondary
+                },
+            );
+        }
+    }
+}
+
+impl Component for LearnHub {
+    fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        let height = buffer.height.saturating_sub(1);
+        if buffer.width < 4 || height < 4 {
+            return Ok(());
+        }
+        let layout = HubLayout::new(buffer.width, height);
+        let frame = layout.frame;
+        let palette = SurfacePalette::new(&self.theme, &self.theme.ui_style.dialog);
+        buffer.fill_rect(
+            0,
+            0,
+            buffer.width,
+            height,
+            ' ',
+            &self.theme.style,
+            &self.theme,
+        );
+        buffer.fill_rect(
+            frame.x,
+            frame.y,
+            frame.width,
+            frame.height,
+            ' ',
+            &palette.surface,
+            &self.theme,
+        );
+        draw_frame(buffer, frame, &palette.divider);
+        put(
+            buffer,
+            frame.x + 3,
+            frame.y + 1,
+            frame.width.saturating_sub(6),
+            "red ●   │   Learn",
+            &palette.primary,
+        );
+        if frame.height >= 18 {
+            put(
+                buffer,
+                frame.x + 3,
+                frame.y + 3,
+                frame.width.saturating_sub(6),
+                "What would you like to do?",
+                &Style {
+                    bold: true,
+                    ..palette.primary.clone()
+                },
+            );
+            put(
+                buffer,
+                frame.x + 3,
+                frame.y + 4,
+                frame.width.saturating_sub(6),
+                "Pick a path. Learn by doing. Come back whenever you like.",
+                &palette.secondary,
+            );
+        }
+        horizontal_rule(
+            buffer,
+            frame.x + 1,
+            layout.body_y.saturating_sub(2),
+            frame.width.saturating_sub(2),
+            &palette.divider,
+        );
+        if layout.wide {
+            self.draw_tracks(buffer, &layout, &palette);
+            let divider_x = frame.x + LIST_WIDTH + 1;
+            for y in layout.body_y.saturating_sub(1)..layout.body_bottom {
+                put(buffer, divider_x, y, 1, "│", &palette.divider);
+            }
+            self.draw_details(
+                buffer,
+                Region {
+                    x: divider_x + 3,
+                    y: layout.body_y,
+                    width: frame.right().saturating_sub(divider_x + 6),
+                    height: layout.body_bottom.saturating_sub(layout.body_y),
+                },
+                &palette,
+            );
+        } else if self.details {
+            self.draw_details(
+                buffer,
+                Region {
+                    x: frame.x + 3,
+                    y: layout.body_y,
+                    width: frame.width.saturating_sub(6),
+                    height: layout.body_bottom.saturating_sub(layout.body_y),
+                },
+                &palette,
+            );
+        } else {
+            self.draw_tracks(buffer, &layout, &palette);
+        }
+        horizontal_rule(
+            buffer,
+            frame.x + 1,
+            layout.footer_y.saturating_sub(1),
+            frame.width.saturating_sub(2),
+            &palette.divider,
+        );
+        let actions = self.actions();
+        let mut x = frame.x + 3;
+        // Keep the shared footer's clickable help region, then apply Learn's
+        // higher-contrast text roles to the same layout.
+        let footer = ActionBar::new(&actions)
+            .with_context(self.shortcut_context())
+            .render(
+                buffer,
+                x,
+                layout.footer_y,
+                frame.width.saturating_sub(6),
+                &self.theme,
+                &palette.surface,
+            );
+        for span in footer.spans {
+            let style = match span.role {
+                ActionBarRole::Key | ActionBarRole::Overflow | ActionBarRole::Mode => {
+                    &palette.accent
+                }
+                ActionBarRole::Separator => &palette.divider,
+                ActionBarRole::Label | ActionBarRole::Status => &palette.secondary,
+            };
+            put(
+                buffer,
+                x,
+                layout.footer_y,
+                frame.right().saturating_sub(x + 1),
+                &span.text,
+                style,
+            );
+            x += display_width(&span.text);
+        }
+        Ok(())
+    }
+
+    fn uses_full_editor_viewport(&self) -> bool {
+        true
+    }
+    fn shortcut_context(&self) -> &str {
+        "Learn Red"
+    }
+    fn surface_actions(&self) -> Vec<UiAction> {
+        self.actions()
+    }
+    fn set_theme(&mut self, theme: &Theme) {
+        self.theme = theme.clone();
+    }
+    fn resize(&mut self, width: usize, height: usize) -> bool {
+        self.width = width;
+        self.height = height.saturating_add(1);
+        true
+    }
+
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        match event {
+            Event::Key(key)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        if self.details && !self.wide() {
+                            self.details = false;
+                            Some(KeyAction::Single(Action::Refresh))
+                        } else {
+                            Some(KeyAction::Single(Action::CloseDialog))
+                        }
+                    }
+                    KeyCode::Enter => Some(self.open_selected()),
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        self.move_selection(1);
+                        Some(KeyAction::Single(Action::Refresh))
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        self.move_selection(-1);
+                        Some(KeyAction::Single(Action::Refresh))
+                    }
+                    KeyCode::Right | KeyCode::Tab => {
+                        self.details = true;
+                        Some(KeyAction::Single(Action::Refresh))
+                    }
+                    KeyCode::Left | KeyCode::BackTab => {
+                        self.details = false;
+                        Some(KeyAction::Single(Action::Refresh))
+                    }
+                    KeyCode::Char(c @ '1'..='6') => {
+                        self.selected = c as usize - '1' as usize;
+                        Some(KeyAction::Single(Action::Refresh))
+                    }
+                    _ => None,
+                }
+            }
+            Event::Mouse(mouse)
+                if matches!(
+                    mouse.kind,
+                    MouseEventKind::ScrollDown | MouseEventKind::ScrollUp
+                ) =>
+            {
+                self.move_selection(if mouse.kind == MouseEventKind::ScrollDown {
+                    1
+                } else {
+                    -1
+                });
+                Some(KeyAction::Single(Action::Refresh))
+            }
+            Event::Mouse(mouse)
+                if mouse.kind == MouseEventKind::Down(MouseButton::Left)
+                    && (!self.details || self.wide()) =>
+            {
+                let x = usize::from(mouse.column);
+                let y = usize::from(mouse.row);
+                let layout = self.layout();
+                let area = layout.tracks();
+                if x >= area.x && x < area.right() && y >= area.y && y < area.bottom() {
+                    let (first, slots) = layout.visible_tracks(self.selected);
+                    let row = (y - area.y) / layout.row_height();
+                    let index = first + row;
+                    if row < slots && index < TRACKS.len() {
+                        self.selected = index;
+                        return Some(KeyAction::Single(Action::Refresh));
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct CoachLayout {
+    pub top: usize,
+    pub right: usize,
+    pub bottom: usize,
+}
+
+impl CoachLayout {
+    pub const fn new(width: usize, height: usize) -> Self {
+        if width >= 104 && height >= 18 {
+            Self {
+                top: 2,
+                right: 40,
+                bottom: 0,
+            }
+        } else if height >= 14 {
+            Self {
+                top: 1,
+                right: 0,
+                bottom: 7,
+            }
+        } else if height >= 8 {
+            Self {
+                top: 1,
+                right: 0,
+                bottom: 3,
+            }
+        } else {
+            Self {
+                top: 0,
+                right: 0,
+                bottom: 0,
+            }
+        }
+    }
+}
+
+pub(crate) fn draw_learn_coach(
+    buffer: &mut RenderBuffer,
+    theme: &Theme,
+    step: PracticeStep,
+    shortcut: Option<&str>,
+) {
+    let layout = CoachLayout::new(buffer.width, buffer.height);
+    let palette = SurfacePalette::new(theme, &theme.ui_style.dialog);
+    if layout.top > 0 {
+        buffer.fill_rect(0, 0, buffer.width, layout.top, ' ', &palette.surface, theme);
+        put(
+            buffer,
+            2,
+            0,
+            buffer.width.saturating_sub(4),
+            "red ●   Learn / Essentials   ·   Practice buffer",
+            &palette.primary,
+        );
+        if layout.top > 1 {
+            horizontal_rule(buffer, 0, 1, buffer.width, &palette.divider);
+        }
+    }
+    let area = if layout.right > 0 {
+        Region {
+            x: buffer.width - layout.right,
+            y: layout.top,
+            width: layout.right,
+            height: buffer.height.saturating_sub(layout.top + 2),
+        }
+    } else if layout.bottom > 0 {
+        Region {
+            x: 0,
+            y: buffer.height.saturating_sub(layout.bottom + 2),
+            width: buffer.width,
+            height: layout.bottom,
+        }
+    } else {
+        return;
+    };
+    buffer.fill_rect(
+        area.x,
+        area.y,
+        area.width,
+        area.height,
+        ' ',
+        &palette.surface,
+        theme,
+    );
+    let left = area.x + 2;
+    let text_width = area.width.saturating_sub(4);
+    let instruction = step.instruction(shortcut);
+    let exit = if step == PracticeStep::Complete {
+        ":tutorial next  →  All tracks"
+    } else {
+        ":tutorial quit  ·  :tutorial restart"
+    };
+    if area.height <= 3 {
+        horizontal_rule(buffer, area.x, area.y, area.width, &palette.divider);
+        put(
+            buffer,
+            left,
+            area.y + 1,
+            text_width,
+            &instruction,
+            &palette.primary,
+        );
+        put(
+            buffer,
+            left,
+            area.y + 2,
+            text_width,
+            exit,
+            &palette.secondary,
+        );
+        return;
+    }
+    draw_frame(buffer, area, &palette.divider);
+    let bottom = area.bottom().saturating_sub(1);
+    let footer_y = bottom.saturating_sub(1);
+    if layout.right == 0 {
+        put(
+            buffer,
+            left,
+            area.y + 1,
+            text_width,
+            "ESSENTIALS  ·  Find your footing",
+            &palette.accent,
+        );
+        wrapped(
+            buffer,
+            left,
+            area.y + 2,
+            text_width,
+            footer_y,
+            &instruction,
+            &palette.primary,
+        );
+        put(buffer, left, footer_y, text_width, exit, &palette.secondary);
+        return;
+    }
+    put(
+        buffer,
+        left,
+        area.y + 1,
+        text_width,
+        "01 / 04  ·  ESSENTIALS",
+        &palette.accent,
+    );
+    put(
+        buffer,
+        left,
+        area.y + 2,
+        text_width,
+        "Find your footing",
+        &Style {
+            bold: true,
+            ..palette.primary.clone()
+        },
+    );
+    horizontal_rule(buffer, left, area.y + 4, text_width, &palette.divider);
+    let next = wrapped(
+        buffer,
+        left,
+        area.y + 6,
+        text_width,
+        footer_y.saturating_sub(1),
+        &instruction,
+        &palette.primary,
+    );
+    if next + 7 < footer_y {
+        put(
+            buffer,
+            left,
+            next + 2,
+            text_width,
+            &format!("CHECKPOINT  ·  {}/4", step.completed_steps()),
+            &palette.secondary,
+        );
+        for (index, text) in [
+            "Enter Insert mode",
+            "Change the practice text",
+            "Return to Normal mode",
+            "Undo back to the original",
+        ]
+        .iter()
+        .enumerate()
+        {
+            let completed = index < step.completed_steps();
+            let active = index == step.completed_steps();
+            let mark = if completed {
+                "✓"
+            } else if active {
+                "›"
+            } else {
+                "○"
+            };
+            put(
+                buffer,
+                left,
+                next + 3 + index,
+                text_width,
+                &format!("{mark} {text}"),
+                if active {
+                    &palette.accent
+                } else if completed {
+                    &palette.primary
+                } else {
+                    &palette.secondary
+                },
+            );
+        }
+    }
+    horizontal_rule(
+        buffer,
+        left,
+        footer_y.saturating_sub(1),
+        text_width,
+        &palette.divider,
+    );
+    put(buffer, left, footer_y, text_width, exit, &palette.accent);
+}
+
+fn horizontal_rule(buffer: &mut RenderBuffer, x: usize, y: usize, width: usize, style: &Style) {
+    put(buffer, x, y, width, &"─".repeat(width), style);
+}
+
+fn draw_frame(buffer: &mut RenderBuffer, area: Region, style: &Style) {
+    if area.width < 2 || area.height < 2 {
+        return;
+    }
+    let last_x = area.right() - 1;
+    let last_y = area.bottom() - 1;
+    horizontal_rule(buffer, area.x + 1, area.y, area.width - 2, style);
+    horizontal_rule(buffer, area.x + 1, last_y, area.width - 2, style);
+    for y in area.y + 1..last_y {
+        put(buffer, area.x, y, 1, "│", style);
+        put(buffer, last_x, y, 1, "│", style);
+    }
+    for (x, y, glyph) in [
+        (area.x, area.y, "╭"),
+        (last_x, area.y, "╮"),
+        (area.x, last_y, "╰"),
+        (last_x, last_y, "╯"),
+    ] {
+        put(buffer, x, y, 1, glyph, style);
+    }
+}
+
+/// Uses the same caps and continuous rails as selected agent-scrollback prompts.
+fn draw_card(buffer: &mut RenderBuffer, area: Region, card: &SurfaceCardPalette, theme: &Theme) {
+    if area.width < 2 || area.height == 0 {
+        return;
+    }
+    buffer.fill_rect(
+        area.x + 1,
+        area.y,
+        area.width - 2,
+        area.height,
+        ' ',
+        &card.content.surface,
+        theme,
+    );
+    for y in area.y..area.bottom() {
+        let cap = if area.height >= 4 && y == area.y {
+            Some(("▄", "╷"))
+        } else if area.height >= 4 && y + 1 == area.bottom() {
+            Some(("▀", "╵"))
+        } else {
+            None
+        };
+        let rail = if let Some((cap, rail)) = cap {
+            put(
+                buffer,
+                area.x + 1,
+                y,
+                area.width - 2,
+                &cap.repeat(area.width - 2),
+                &card.cap,
+            );
+            rail
+        } else {
+            "│"
+        };
+        put(buffer, area.x, y, 1, rail, &card.edge);
+        put(buffer, area.right() - 1, y, 1, rail, &card.edge);
+    }
+}
+
+fn put(buffer: &mut RenderBuffer, x: usize, y: usize, width: usize, text: &str, style: &Style) {
+    if y < buffer.height && x < buffer.width {
+        buffer.set_text(
+            x,
+            y,
+            &truncate_display_width(text, width.min(buffer.width - x)),
+            style,
+        );
+    }
+}
+
+fn wrapped(
+    buffer: &mut RenderBuffer,
+    x: usize,
+    mut y: usize,
+    width: usize,
+    bottom: usize,
+    text: &str,
+    style: &Style,
+) -> usize {
+    if width == 0 {
+        return y;
+    }
+    let mut line = String::new();
+    for word in text.split_whitespace() {
+        if !line.is_empty() && display_width(&line) + 1 + display_width(word) > width {
+            if y >= bottom {
+                return y;
+            }
+            put(buffer, x, y, width, &line, style);
+            y += 1;
+            line.clear();
+        }
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    if !line.is_empty() && y < bottom {
+        put(buffer, x, y, width, &line, style);
+        y += 1;
+    }
+    y
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::contrast_ratio;
+    use crossterm::event::{KeyEvent, MouseEvent};
+
+    fn text_rows(buffer: &RenderBuffer) -> Vec<String> {
+        buffer
+            .cells
+            .chunks(buffer.width)
+            .map(|row| row.iter().map(|cell| cell.text.as_str()).collect())
+            .collect()
+    }
+
+    fn assert_readable_text(buffer: &RenderBuffer, context: &str) {
+        for cell in &buffer.cells {
+            if cell.text.chars().any(char::is_alphanumeric) {
+                assert!(
+                    contrast_ratio(cell.style.fg.unwrap(), cell.style.bg.unwrap()) >= 4.5,
+                    "unreadable {:?} in {context}: {:?}",
+                    cell.text,
+                    cell.style
+                );
+            }
+        }
+    }
+
+    fn panel(width: usize, height: usize) -> LearnHub {
+        LearnHub {
+            selected: 0,
+            details: false,
+            completed: false,
+            width,
+            height: height - 1,
+            theme: Theme::default(),
+        }
+    }
+
+    #[test]
+    fn narrow_hub_opens_details_before_starting() {
+        let mut hub = panel(80, 24);
+        let enter = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            hub.handle_event(&enter),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        assert_eq!(
+            hub.handle_event(&enter),
+            Some(KeyAction::Single(Action::StartLearnLesson))
+        );
+    }
+
+    #[test]
+    fn planned_tracks_cannot_start_a_fake_lesson() {
+        let mut hub = panel(120, 32);
+        hub.selected = 1;
+        assert_eq!(hub.open_selected(), KeyAction::Single(Action::Refresh));
+    }
+
+    #[test]
+    fn learn_footer_registers_contextual_shortcut_help() {
+        let mut hub = panel(120, 32);
+        let mut buffer = RenderBuffer::new(120, 32, &hub.theme.style);
+        hub.draw(&mut buffer).unwrap();
+        let help = buffer.shortcut_help_regions.last().unwrap();
+        assert_eq!(help.context, "Learn Red");
+        assert_eq!(help.rect.y, hub.layout().footer_y);
+        assert!(help.actions.iter().any(|action| action.id == "open"));
+        assert_eq!(
+            hub.activate_surface_action("open"),
+            Some(KeyAction::Single(Action::StartLearnLesson))
+        );
+    }
+
+    #[test]
+    fn hub_and_coach_render_at_small_and_large_sizes() {
+        for (width, height) in [(24, 8), (60, 18), (80, 24), (120, 32)] {
+            let mut buffer = RenderBuffer::new(width, height, &Style::default());
+            panel(width, height).draw(&mut buffer).unwrap();
+            draw_learn_coach(
+                &mut buffer,
+                &Theme::default(),
+                PracticeStep::Insert,
+                Some("i"),
+            );
+        }
+    }
+
+    #[test]
+    fn learn_surfaces_keep_text_readable_and_backgrounds_consistent() {
+        for path in [
+            "themes/kanso.json",
+            "themes/tokyonight-storm.json",
+            "themes/night-owl-light.json",
+            "themes/community-material-theme-lighter-high-contrast.json",
+        ] {
+            let theme = crate::theme::parse_vscode_theme(path).unwrap();
+            let palette = SurfacePalette::new(&theme, &theme.ui_style.dialog);
+            let card = SurfaceCardPalette::new(&palette, true, SurfaceCardColors::default());
+            for (width, height) in [(32, 12), (80, 24), (120, 32), (160, 44)] {
+                let mut hub = panel(width, height);
+                hub.theme = theme.clone();
+                let mut buffer = RenderBuffer::new(width, height, &theme.style);
+                hub.draw(&mut buffer).unwrap();
+                assert_readable_text(&buffer, path);
+                assert!(
+                    buffer.cells.iter().all(|cell| [
+                        theme.style.bg,
+                        palette.surface.bg,
+                        card.content.surface.bg
+                    ]
+                    .contains(&cell.style.bg)),
+                    "stray hub background in {path}"
+                );
+                let frame = hub.layout().frame;
+                assert_eq!(buffer.cells[frame.y * width + frame.x].text, "╭");
+                assert_eq!(
+                    buffer.cells[(frame.bottom() - 1) * width + frame.right() - 1].text,
+                    "╯"
+                );
+
+                let mut buffer = RenderBuffer::new(width, height, &theme.style);
+                draw_learn_coach(&mut buffer, &theme, PracticeStep::Complete, None);
+                assert_readable_text(&buffer, path);
+                assert!(
+                    buffer
+                        .cells
+                        .iter()
+                        .all(|cell| [theme.style.bg, palette.surface.bg].contains(&cell.style.bg)),
+                    "stray coach background in {path}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn roomy_hub_reuses_prompt_caps_and_keeps_action_near_outline() {
+        let hub = panel(160, 44);
+        let mut buffer = RenderBuffer::new(160, 44, &hub.theme.style);
+        hub.draw(&mut buffer).unwrap();
+        let layout = hub.layout();
+        let area = layout.tracks();
+        assert_eq!(buffer.cells[area.y * buffer.width + area.x].text, "╷");
+        assert_eq!(buffer.cells[area.y * buffer.width + area.x + 1].text, "▄");
+        assert_eq!(buffer.cells[(area.y + 3) * buffer.width + area.x].text, "╵");
+        let rows = text_rows(&buffer);
+        let action_y = rows
+            .iter()
+            .position(|row| row.contains("Start the first lesson"))
+            .unwrap();
+        assert!(action_y < layout.footer_y - 2);
+        assert!(rows.iter().any(|row| row.contains("Make Red yours")));
+    }
+
+    #[test]
+    fn clicking_a_scrolled_track_uses_the_visible_index() {
+        let mut hub = panel(32, 12);
+        hub.selected = 5;
+        let layout = hub.layout();
+        let area = layout.tracks();
+        let (first, _) = layout.visible_tracks(hub.selected);
+        assert!(first > 0);
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: area.x as u16,
+            row: area.y as u16,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert_eq!(
+            hub.handle_event(&click),
+            Some(KeyAction::Single(Action::Refresh))
+        );
+        assert_eq!(hub.selected, first);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,6 +23,7 @@ mod inline_history;
 mod input_prompt;
 mod keyboard_shortcuts;
 mod keymap_hints;
+mod learn;
 mod list;
 mod messages;
 mod picker;
@@ -60,6 +61,7 @@ pub(crate) use keyboard_shortcuts::{
     ShortcutHelpRegion, ShortcutTarget,
 };
 pub(crate) use keymap_hints::draw_keymap_hints;
+pub(crate) use learn::{draw_learn_coach, CoachLayout, LearnHub};
 use list::List;
 pub(crate) use messages::{MessageRow, MessagesPanel, MessagesView};
 pub(crate) use picker::MAX_UNFOCUSED_PREVIEW_BYTES;
@@ -91,6 +93,11 @@ use crate::{
 
 pub trait Component: Send {
     fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()>;
+
+    /// Uses the whole terminal's editor area rather than the active split.
+    fn uses_full_editor_viewport(&self) -> bool {
+        false
+    }
 
     fn is_message_history(&self) -> bool {
         false


### PR DESCRIPTION
## Why

New users need a practical way to learn the workflows they care about without risking their project. This adds an optional, editor-native learning hub instead of requiring everyone to follow one long tutorial.

## What changed

- Add `:learn`, `:tutorial`, `:welcome`, and a command-palette entry. The hub presents six tracks covering essentials, AI coding, LSP + Git, navigation, precise editing, and customization.
- Make the first Essentials lesson playable in a protected, unnamed practice buffer. Progress follows real edits and undo; completion is saved in preferences. Exiting restores the original buffers, window layout, focus, zoom, and editing state while preserving the real workspace's recovery snapshot.
- Add a responsive lesson coach and a framed, keyboard- and mouse-navigable hub. Reuse the agent scrollback's card styling through a shared, contrast-safe surface palette; retain the existing agent theme overrides.

This is the first implementation checkpoint. The remaining lessons and tracks are shown as planned, and the hub does not open automatically on startup.

## How to Test

1. Run `cargo run --locked --bin red -- -c 'show_whats_new=false'`. Open a file, create a split with `:vsplit`, then run `:learn`.
2. Move between tracks with `j/k`, arrow keys, or `1`–`6`. Open Essentials with Enter; on a narrow terminal, Enter first opens the track details.
3. Follow the coach: enter Insert mode, type a few characters, return to Normal mode, and undo until the original practice text is restored. Expect the checkpoint to complete. Run `:tutorial next` and confirm the hub offers to replay it.
4. Start the lesson again and try `:w learn-should-not-exist.rs`. Expect the save to be refused and no file to be created. Run `:tutorial quit`; the original file and split layout should return unchanged.
5. Select a planned track and press Enter; it must not start a placeholder lesson. Resize the terminal, try a light theme, and inspect both Learn and agent scrollback selections for readable text and consistent backgrounds.

**Validation:** Build, formatting, 11 Learn-focused tests, four shared-card/agent-panel tests, and `cargo clippy --all-targets --all-features -- -D warnings` passed. End-to-end tests remain deferred.