### PR TITLE
fix(editor): keep cursor visible on matching brackets

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -31997,14 +31997,111 @@ builtin = "rust"
         let partner_y = editor.window_to_terminal_y(window, partner_y);
         let partner_x = editor.window_to_terminal_x(window, partner_x);
         let partner = &render_buffer.cells[partner_y * render_buffer.width + partner_x];
-        let expected = editor.theme.selected_style(
-            &editor.theme.style,
-            &editor.theme.editor_bracket_match_style(),
-            crate::theme::SelectionForegroundPriority::Content,
-        );
+        let expected = editor.theme.matched_bracket_style(&editor.theme.style);
 
         assert_eq!(partner.c, '}');
         assert_eq!(partner.style.bg, expected.bg);
+    }
+
+    #[test]
+    fn bracket_matching_keeps_block_cursor_stable_across_themes_and_render_paths() {
+        for theme_name in [
+            "kanagawa",
+            "rose-pine-moon",
+            "mocha",
+            "latte",
+            "github-dark-default",
+        ] {
+            let mut editor = bracket_test_editor("x()y", 30, 8);
+            editor.theme = parse_vscode_theme(&format!("themes/{theme_name}.json")).unwrap();
+            let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+            editor.render(&mut render_buffer).unwrap();
+            let (x, y) = editor.render_cursor_position().unwrap();
+            let start_index = y * render_buffer.width + x;
+            let cursor_style = render_buffer.cells[start_index].style.clone();
+            let surface_bg = editor.last_rendered_cursor_surface.as_ref().unwrap().bg;
+
+            for column in [1, 2, 3] {
+                editor.cx = column;
+                editor.cursor_goal = CursorGoal::DisplayCol(column);
+                editor
+                    .render_cursor_motion_delta(&mut render_buffer)
+                    .unwrap();
+                let (x, y) = editor.render_cursor_position().unwrap();
+                let cursor_index = y * render_buffer.width + x;
+                assert_eq!(
+                    render_buffer.cells[cursor_index].style, cursor_style,
+                    "{theme_name}: cursor changed at column {column}"
+                );
+                assert_eq!(
+                    editor.last_rendered_cursor_surface.as_ref().unwrap().bg,
+                    surface_bg,
+                    "{theme_name}: bracket decoration reached the cursor surface"
+                );
+                if column < 3 {
+                    let partner_index = start_index + (3 - column);
+                    assert!(render_buffer.cells[partner_index].style.underline);
+                } else {
+                    for bracket_index in [start_index + 1, start_index + 2] {
+                        assert_eq!(render_buffer.cells[bracket_index].style.bg, surface_bg);
+                        assert!(!render_buffer.cells[bracket_index].style.underline);
+                    }
+                }
+
+                let delta_cells = render_buffer.cells.clone();
+                editor.render(&mut render_buffer).unwrap();
+                assert_eq!(
+                    render_buffer.cells, delta_cells,
+                    "{theme_name}: full and delta renders differ at column {column}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bracket_matching_does_not_change_visual_mode_cursor_style() {
+        for mode in [Mode::Visual, Mode::VisualLine, Mode::VisualBlock] {
+            let mut editor = bracket_test_editor("(value)", 30, 8);
+            editor.theme = parse_vscode_theme("themes/kanagawa.json").unwrap();
+            editor.mode = mode;
+            editor.selection_start = Some(Point::new(0, 0));
+            let pairs = std::mem::take(&mut editor.config.matchit.pairs);
+            let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+            editor.render(&mut render_buffer).unwrap();
+            let (x, y) = editor.render_cursor_position().unwrap();
+            let index = y * render_buffer.width + x;
+            let expected = render_buffer.cells[index].style.clone();
+
+            editor.config.matchit.pairs = pairs;
+            editor.render(&mut render_buffer).unwrap();
+
+            assert_eq!(render_buffer.cells[index].style, expected, "{mode:?}");
+        }
+    }
+
+    #[test]
+    fn insert_mode_bracket_matching_keeps_both_decorations_and_cursor_contrast() {
+        let mut editor = bracket_test_editor("()", 30, 8);
+        editor.theme = parse_vscode_theme("themes/kanagawa.json").unwrap();
+        editor.mode = Mode::Insert;
+        let mut render_buffer = RenderBuffer::new(30, 8, &Style::default());
+        editor.render(&mut render_buffer).unwrap();
+        let (x, y) = editor.render_cursor_position().unwrap();
+        let index = y * render_buffer.width + x;
+
+        assert!(!editor.uses_synthetic_block_cursor());
+        assert!(render_buffer.cells[index].style.underline);
+        assert!(render_buffer.cells[index + 1].style.underline);
+        assert_eq!(
+            editor.last_rendered_cursor_surface.as_ref(),
+            Some(&render_buffer.cells[index].style)
+        );
+        assert!(
+            crate::color::contrast_ratio(
+                editor.terminal_cursor_state().color.unwrap(),
+                render_buffer.cells[index].style.bg.unwrap(),
+            ) >= crate::theme::MINIMUM_CURSOR_STATE_CONTRAST
+        );
     }
 
     #[tokio::test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -2740,12 +2740,23 @@ impl Editor {
             return;
         }
 
-        buffer.apply_selection_for_points(
-            points,
-            &self.theme.editor_bracket_match_style(),
-            &self.theme,
-            SelectionForegroundPriority::Content,
-        );
+        // A software block cursor replaces its cell's background. Decorating
+        // that cell first would make cursor contrast depend on a hidden fill.
+        let block_cursor = self
+            .uses_synthetic_block_cursor()
+            .then(|| self.render_cursor_position())
+            .flatten();
+        for point in points {
+            if block_cursor == Some((point.x, point.y))
+                || point.x >= buffer.width
+                || point.y >= buffer.height
+            {
+                continue;
+            }
+            if let Some(cell) = buffer.cells.get_mut(point.y * buffer.width + point.x) {
+                cell.style = self.theme.matched_bracket_style(&cell.style);
+            }
+        }
     }
 
     fn render_search_highlights_in_window(

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -234,6 +234,24 @@ impl Theme {
             .unwrap_or_else(|| self.editor_selection_style())
     }
 
+    /// Keeps bracket decorations secondary to the cursor and visual selection.
+    pub(crate) fn matched_bracket_style(&self, content: &Style) -> Style {
+        let highlight = self.editor_bracket_match_style();
+        let editor_bg = blend_color(self.style.bg.unwrap_or_default(), Color::default());
+        let surface_bg = blend_color(content.bg.unwrap_or(editor_bg), editor_bg);
+        let background = blend_color(highlight.bg.unwrap_or(surface_bg), surface_bg);
+
+        // Preserve subtle theme fills. An underline stands in for a GUI bracket
+        // border, including when the theme supplies no distinct background.
+        self.ensure_text_contrast(&Style {
+            fg: highlight.fg.or(content.fg),
+            bg: Some(background),
+            bold: content.bold || highlight.bold,
+            italic: content.italic || highlight.italic,
+            underline: true,
+        })
+    }
+
     pub(crate) fn list_selection_style(&self) -> Style {
         Style {
             fg: self
@@ -1093,6 +1111,50 @@ mod tests {
         assert_eq!(active.fg, Some(blue));
         assert!(contrast_ratio(blue, white) >= MINIMUM_SELECTION_STATE_CONTRAST);
         assert_eq!(active.bg, inactive.bg);
+    }
+
+    #[test]
+    fn bracket_match_style_preserves_subtle_fill_and_readable_text() {
+        let theme = parse_vscode_theme("themes/mocha.json").unwrap();
+        let content = Style {
+            bg: theme
+                .line_highlight_style
+                .as_ref()
+                .and_then(|style| style.bg),
+            italic: true,
+            ..theme.style.clone()
+        };
+        let surface = blend_color(content.bg.unwrap(), theme.style.bg.unwrap());
+        let requested = theme.editor_bracket_match_style();
+        let expected_bg = blend_color(requested.bg.unwrap(), surface);
+
+        let matched = theme.matched_bracket_style(&content);
+
+        assert_eq!(matched.bg, Some(expected_bg));
+        assert!(contrast_ratio(expected_bg, surface) < MINIMUM_SELECTION_STATE_CONTRAST);
+        assert!(
+            contrast_ratio(matched.fg.unwrap(), expected_bg) >= MINIMUM_SELECTION_TEXT_CONTRAST
+        );
+        assert!(matched.italic);
+        assert!(matched.underline);
+    }
+
+    #[test]
+    fn bracket_match_style_marks_border_only_themes() {
+        let theme = parse_vscode_theme_contents(
+            r##"{"colors": {
+                "editor.background": "#101010",
+                "editor.foreground": "#ffffff",
+                "editorBracketMatch.border": "#00ffff"
+            }, "tokenColors": []}"##,
+        )
+        .unwrap();
+
+        let matched = theme.matched_bracket_style(&theme.style);
+
+        assert_eq!(matched.bg, theme.style.bg);
+        assert_eq!(matched.fg, theme.editor_bracket_match_style().fg);
+        assert!(matched.underline);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Bracket matching used selection-strength background contrast. The software block cursor then chose its color against that highlight, even though the cursor replaced the highlighted cell. On themes such as Kanagawa, moving onto a bracket could turn the cursor almost the same color as the surrounding line.

## What changed

- Skip bracket decoration beneath the software block cursor so its normal appearance stays stable.
- Preserve the theme's bracket fill and use an underline to identify the matching bracket without making it look like a second cursor.
- Keep both bracket decorations in Insert mode and preserve the terminal cursor's contrast against the visible cell.
- Add regression coverage for dark and light themes, full and incremental redraws, Visual modes, and subtle or border-only theme styles.

## How to Test

1. Run `cargo test -p red --lib bracket -- --test-threads=1`. The bracket-matching and cursor-contrast regressions should pass.
2. Run `cargo run -p red --bin red -- src/editor.rs`. In Normal mode, press `Space t`, choose Kanagawa, and move onto and off a matched parenthesis or brace. The block cursor should retain its normal color; the partner should have a subtler fill and underline. Repeat with a light theme such as Latte.
3. Enter Insert mode next to a bracket pair, then move away from it. Both brackets should be decorated while matched, the terminal cursor should remain visible, and the decorations should clear when the pair is no longer active. Also check that entering Visual mode does not change the cursor color merely because it is on a bracket.

## Validation

The full Red test suite passed locally: 2,692 passed, 1 ignored. Strict Clippy (`cargo clippy --all-targets --all-features -- -D warnings`), formatting, diff checks, and the Red binary build also passed.
