### PR TITLE
fix(neotree): show symlinks as their targets

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -26573,6 +26573,17 @@ fn directory_listing(path: &str) -> Value {
         let kind = match entry.file_type() {
             Some(file_type) if file_type.is_dir() => "directory",
             Some(file_type) if file_type.is_file() => "file",
+            Some(file_type) if file_type.is_symlink() => {
+                // Present links as their targets without replacing the lexical path.
+                // Unresolved links remain visible as files; only directory expansion
+                // follows a link, so a listing never recursively walks a cycle.
+                match std::fs::metadata(entry.path()) {
+                    Ok(metadata) if metadata.is_dir() => "directory",
+                    Ok(metadata) if metadata.is_file() => "file",
+                    Ok(_) => "other",
+                    Err(_) => "file",
+                }
+            }
             _ => "other",
         };
         if kind == "other" {
@@ -38493,6 +38504,93 @@ while True:
         assert_eq!(entries[1]["name"], "README.md");
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_listing_presents_symlinks_as_targets_and_sorts_by_alias() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("Zulu")).unwrap();
+        std::fs::write(root.path().join("z-file.txt"), "file").unwrap();
+        std::fs::write(outside.path().join("child.txt"), "external file").unwrap();
+        symlink(outside.path(), root.path().join("alpha")).unwrap();
+        symlink("Zulu", root.path().join("Beta")).unwrap();
+        symlink("z-file.txt", root.path().join("a-file.txt")).unwrap();
+        symlink("missing", root.path().join("broken")).unwrap();
+        symlink("loop", root.path().join("loop")).unwrap();
+        let _socket = std::os::unix::net::UnixListener::bind(root.path().join("socket")).unwrap();
+        symlink("socket", root.path().join("socket-link")).unwrap();
+
+        let listing = directory_listing(&root.path().to_string_lossy());
+        let entries = listing["entries"].as_array().unwrap();
+        let names_and_kinds = entries
+            .iter()
+            .map(|entry| {
+                (
+                    entry["name"].as_str().unwrap(),
+                    entry["kind"].as_str().unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names_and_kinds,
+            [
+                ("alpha", "directory"),
+                ("Beta", "directory"),
+                ("Zulu", "directory"),
+                ("a-file.txt", "file"),
+                ("broken", "file"),
+                ("loop", "file"),
+                ("z-file.txt", "file"),
+            ]
+        );
+        for entry in entries {
+            let expected = root.path().join(entry["name"].as_str().unwrap());
+            assert_eq!(entry["path"].as_str().unwrap(), expected.to_str().unwrap());
+        }
+        assert_eq!(listing["truncated"], false);
+        assert!(listing["error"].is_null());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_listing_expands_linked_directories_without_resolving_aliases() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("child.txt"), "external file").unwrap();
+        symlink(root.path(), outside.path().join("back")).unwrap();
+        let alias = root.path().join("linked");
+        symlink(outside.path(), &alias).unwrap();
+
+        let listing = directory_listing(&alias.to_string_lossy());
+        assert_eq!(
+            listing,
+            json!({
+                "path": alias,
+                "entries": [
+                    { "name": "back", "path": alias.join("back"), "kind": "directory" },
+                    { "name": "child.txt", "path": alias.join("child.txt"), "kind": "file" },
+                ],
+                "truncated": false,
+                "error": null,
+            })
+        );
+        assert_eq!(
+            std::fs::read_to_string(alias.join("child.txt")).unwrap(),
+            "external file"
+        );
+
+        let back = alias.join("back");
+        let listing = directory_listing(&back.to_string_lossy());
+        assert_eq!(
+            listing["entries"],
+            json!([{ "name": "linked", "path": back.join("linked"), "kind": "directory" }])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Neo-tree currently drops symlinks because directory listings accept only regular files and directories. This makes linked folders, such as shared skill directories, disappear from the tree.

Classify symlinks by their target while keeping the link's original path. Linked folders now expand and use the existing folder-first alphabetical sort; linked files open normally. Unresolved links remain visible as files, while links to sockets and other unsupported file types remain hidden. Directory scans stay shallow, and file-operation safeguards are unchanged.

## How to Test

1. Create a directory containing a regular folder, a symlink to another folder, and a symlink to a file. Run `cargo run -- --root <directory>` and press `Ctrl-e`.
2. Confirm both folders appear in alphabetical order before files. Expand the linked folder and open a child; the tree should retain the link's path.
3. Add a broken link and a self-referential link. Refresh with `R`; both should remain visible without hanging the tree.

Automated validation passed:

- `cargo test --locked --lib directory_listing_ -- --test-threads=1` — 5 tests, including alias sorting, external directories, broken links, loops, and socket filtering.
- `cargo test --locked --lib plugin::runtime::tests::neotree_ -- --test-threads=1` — 10 interaction tests.
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --locked --bin red`
