### PR TITLE
feat(completion): accept selected item with enter

### DIFF
--- a/almanac/reference/editor/ui-components.md
+++ b/almanac/reference/editor/ui-components.md
@@ -56,7 +56,7 @@ Red's modal UI components implement a common `Component` trait above the editor 
 
 ## Completion UI
 
-`CompletionUI` is the completion menu for LSP items. It draws rows produced by its internal renderer, moves selection with arrow keys, `Tab`, `BackTab`, `Ctrl-J`, `Ctrl-K`, and page keys, applies the selected completion on `Enter`, and can apply a completion with an LSP commit character [@completion]. When filtering leaves no selected item, `Enter` closes the dialog and inserts a newline, while `Esc` closes the dialog and enters Normal mode whether or not candidates are visible [@completion]. It returns `allows_event_passthrough() == true`, so normal typed characters and backspace can continue into editor input while the completion menu updates its filter [@completion].
+`CompletionUI` is the completion menu for LSP items. It draws rows produced by its internal renderer, moves selection with arrow keys, `Ctrl-P`, `Ctrl-N`, and page keys, applies the selected completion on `Tab` or `Enter`, and can apply a completion with an LSP commit character [@completion]. When filtering leaves no selected item, `Enter` closes the dialog and inserts a newline, while `Esc` closes the dialog and enters Normal mode whether or not candidates are visible [@completion]. It returns `allows_event_passthrough() == true`, so normal typed characters and backspace can continue into editor input while the completion menu updates its filter [@completion].
 
 ## Diagnostic Popup
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -32916,6 +32916,33 @@ builtin = "rust"
     }
 
     #[tokio::test]
+    async fn enter_accepts_completion_without_inserting_a_newline() {
+        let mut editor = completion_typing_editor();
+        let response = completion_response("manual_seed", None);
+        assert!(matches!(
+            editor.handle_lsp_message(&response, Some("textDocument/completion".to_string())),
+            Some(Action::ShowDialog)
+        ));
+        let mut render_buffer = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+
+        type_completion_suffix(&mut editor, "ual", &mut render_buffer, &mut runtime).await;
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(editor.current_buffer().contents(), "torch.manual_seed");
+        assert!(editor.current_dialog.is_none());
+        assert_eq!(editor.mode, Mode::Insert);
+    }
+
+    #[tokio::test]
     async fn refreshing_open_completion_preserves_ranges_for_typing_and_acceptance() {
         let mut editor = completion_typing_editor();
         let initial_snapshot = editor.completion_snapshot();

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -650,10 +650,10 @@ impl Component for CompletionUI {
                 Some(KeyAction::None)
             }
             Event::Key(KeyEvent {
-                code: KeyCode::Tab,
+                code: KeyCode::Tab | KeyCode::Enter,
                 modifiers: KeyModifiers::NONE,
                 ..
-            }) => self.selected_item().map(|item| {
+            }) if self.selected_item().is_some() => self.selected_item().map(|item| {
                 KeyAction::Multiple(vec![
                     Action::ApplyCompletion {
                         item: Box::new(item.clone()),
@@ -1117,7 +1117,7 @@ mod tests {
     }
 
     #[test]
-    fn tab_accepts_the_selected_completion() {
+    fn tab_and_enter_accept_the_selected_completion() {
         let mut ui = CompletionUI::new();
         ui.show(
             vec![
@@ -1129,17 +1129,21 @@ mod tests {
             0,
         );
 
+        ui.move_selection(1);
         let selected = ui.selected_item().unwrap().clone();
-        assert_eq!(
-            ui.handle_event(&Event::Key(KeyEvent::from(KeyCode::Tab))),
-            Some(KeyAction::Multiple(vec![
-                Action::ApplyCompletion {
-                    item: Box::new(selected),
-                    commit_character: None,
-                },
-                Action::CloseDialog,
-            ]))
-        );
+        assert_eq!(selected.label, "beta");
+        for code in [KeyCode::Tab, KeyCode::Enter] {
+            assert_eq!(
+                ui.handle_event(&key(code, KeyModifiers::NONE)),
+                Some(KeyAction::Multiple(vec![
+                    Action::ApplyCompletion {
+                        item: Box::new(selected.clone()),
+                        commit_character: None,
+                    },
+                    Action::CloseDialog,
+                ]))
+            );
+        }
     }
 
     #[test]
@@ -1163,10 +1167,16 @@ mod tests {
     }
 
     #[test]
-    fn enter_inserts_a_newline_and_ctrl_e_only_dismisses_completion() {
+    fn enter_inserts_a_newline_when_no_completion_is_selected() {
         let mut ui = CompletionUI::new();
         ui.show(vec![item("alpha", Some(CompletionItemKind::Text))], 0, 0);
+        ui.set_filter("no_match");
 
+        assert!(ui.selected_item().is_none());
+        assert_eq!(
+            ui.handle_event(&key(KeyCode::Tab, KeyModifiers::NONE)),
+            None
+        );
         assert_eq!(
             ui.handle_event(&key(KeyCode::Enter, KeyModifiers::NONE)),
             Some(KeyAction::Multiple(vec![
@@ -1174,6 +1184,33 @@ mod tests {
                 Action::InsertNewLine,
             ]))
         );
+    }
+
+    #[test]
+    fn modified_enter_keeps_inserting_a_newline() {
+        let mut ui = CompletionUI::new();
+        ui.show(vec![item("alpha", Some(CompletionItemKind::Text))], 0, 0);
+
+        for modifiers in [
+            KeyModifiers::SHIFT,
+            KeyModifiers::CONTROL,
+            KeyModifiers::ALT,
+        ] {
+            assert_eq!(
+                ui.handle_event(&key(KeyCode::Enter, modifiers)),
+                Some(KeyAction::Multiple(vec![
+                    Action::CloseDialog,
+                    Action::InsertNewLine,
+                ]))
+            );
+        }
+    }
+
+    #[test]
+    fn ctrl_e_only_dismisses_completion() {
+        let mut ui = CompletionUI::new();
+        ui.show(vec![item("alpha", Some(CompletionItemKind::Text))], 0, 0);
+
         assert_eq!(
             ui.handle_event(&key(KeyCode::Char('e'), KeyModifiers::CONTROL)),
             Some(KeyAction::Single(Action::CloseDialog))

--- a/src/ui/shortcut_catalog.rs
+++ b/src/ui/shortcut_catalog.rs
@@ -214,12 +214,7 @@ pub(crate) fn completion_reference_actions() -> Vec<UiAction> {
             "PageUp / PageDown",
             "Previous / next completion page",
         ),
-        ("Completion", "Tab", "Accept selected completion"),
-        (
-            "Completion",
-            "Enter",
-            "Close completions and insert a new line",
-        ),
+        ("Completion", "Tab / Enter", "Accept selected completion"),
         ("Completion", "Ctrl+e", "Close completions"),
         (
             "Completion",


### PR DESCRIPTION
When the completion menu is open, Enter currently dismisses it and inserts a newline. Users should be able to accept the highlighted suggestion with either Enter or Tab.

Plain Enter now uses the same completion-application path as Tab. If filtering leaves no selected item, Enter still closes the menu and inserts a newline. Modified Enter and Ctrl+e keep their existing behavior. The shortcut help and completion reference now describe the updated keys.

## How to Test

1. In Insert mode, open a completion menu, select a suggestion, and press Enter. The selected text should replace the completion prefix, the menu should close, and no newline should be inserted. Repeat with Tab.
2. Open the menu again and type until no suggestions match. Press Enter. The menu should close and a newline should be inserted.
3. Run `cargo test --lib completion -- --test-threads=1`. This includes `enter_accepts_completion_without_inserting_a_newline`, `tab_and_enter_accept_the_selected_completion`, and the filtered-out completion regression. All 108 matching tests passed locally.

`cargo clippy --all-targets --all-features -- -D warnings` also passed.
