### PR TITLE
feat(lsp): show signature help while typing

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -96,6 +96,12 @@ debounce_ms = 0
 buffer_words = true
 max_buffer_words = 100
 
+[signature_help]
+# Show a non-modal call signature while entering arguments. Ctrl-k reopens it.
+auto_trigger = true
+debounce_ms = 120
+show_documentation = true
+
 [copilot]
 # Opt in before any source code is sent to GitHub Copilot. Install the official
 # @github/copilot-language-server separately, then use :Copilot signin.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -102,7 +102,7 @@ Patterns use Rust regular-expression syntax. `incsearch`, `hlsearch`,
 | `K` | Hover documentation |
 | `gd` | Go to definition |
 | `Ctrl-Space` | Trigger completion in Insert mode |
-| `Ctrl-k` | Show signature help in Insert mode |
+| `Ctrl-k` | Show signature help in Insert mode; cycle available overloads |
 | `Ctrl-t` | Find document symbols |
 | `Space w` | Find workspace symbols |
 | `Space k` | Find references |
@@ -123,6 +123,16 @@ on_save = false
 `provider = "auto"`, `"external"`, or `"lsp"`. The legacy
 `lsp.format_on_save` setting remains supported; `formatting.on_save` wins if
 both are present in the same config layer.
+
+When a language server supports signature help, Red shows a small popup while
+you enter call arguments. The current parameter is highlighted, and typing,
+completion, and cursor movement continue normally. `Ctrl-k` reopens the popup
+or cycles through overloads. Leaving Insert mode closes it.
+
+Use `[signature_help]` in `config.toml` to set `auto_trigger = false`, adjust
+`debounce_ms` (120 by default), or hide the extra documentation line with
+`show_documentation = false`. Manual `Ctrl-k` remains available when automatic
+help is disabled.
 
 Husk's first-party server is included and starts for `.hk` and `.husk` files.
 Built-in defaults also cover Rust, TypeScript/JavaScript, Markdown, JSON, TOML,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1864,6 +1864,7 @@ fn known_top_level_field(field: &str) -> bool {
             | "persist_inline_history"
             | "search"
             | "completion"
+            | "signature_help"
             | "copilot"
             | "picker"
             | "statusline"
@@ -2025,6 +2026,12 @@ fn known_schema_path(path: &[String]) -> bool {
                 | "buffer_words"
                 | "max_buffer_words"
         ),
+        ["signature_help", field] => {
+            matches!(
+                *field,
+                "auto_trigger" | "debounce_ms" | "show_documentation"
+            )
+        }
         ["copilot", field] => matches!(
             *field,
             "enabled" | "command" | "args" | "debounce_ms" | "max_file_bytes" | "excluded_patterns"
@@ -4036,6 +4043,20 @@ max_buffer_words = 20
         assert_eq!(config.completion.debounce_ms, 250);
         assert!(!config.completion.buffer_words);
         assert_eq!(config.completion.max_buffer_words, 20);
+    }
+
+    #[test]
+    fn signature_help_configuration_accepts_user_settings_and_overrides() {
+        let defaults = Config::from_user_toml_with_overrides("", &[]).unwrap();
+        assert_eq!(defaults.signature_help, SignatureHelpConfig::default());
+        let config = Config::from_user_toml_with_overrides(
+            "[signature_help]\nauto_trigger = false\ndebounce_ms = 350\nshow_documentation = false\n",
+            &["signature_help.debounce_ms = 75".to_owned()],
+        ).unwrap();
+        assert!(!config.signature_help.auto_trigger);
+        assert!(!config.signature_help.show_documentation);
+        assert_eq!(config.signature_help.debounce_ms, 75);
+        assert!(known_top_level_field("signature_help"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,6 +255,9 @@ pub struct Config {
     /// Insert-mode completion sources and automatic triggering.
     #[serde(default)]
     pub completion: CompletionConfig,
+    /// Non-modal callable signatures shown near the Insert-mode cursor.
+    #[serde(default)]
+    pub signature_help: SignatureHelpConfig,
     /// Opt-in AI inline completion, independent of ordinary language servers.
     #[serde(default)]
     pub copilot: crate::copilot::CopilotConfig,
@@ -783,6 +786,25 @@ impl Default for CompletionConfig {
 
 fn default_completion_min_prefix_length() -> usize {
     1
+}
+
+/// Automatic signature-help presentation; explicit invocation remains available.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct SignatureHelpConfig {
+    pub auto_trigger: bool,
+    pub debounce_ms: u64,
+    pub show_documentation: bool,
+}
+
+impl Default for SignatureHelpConfig {
+    fn default() -> Self {
+        Self {
+            auto_trigger: true,
+            debounce_ms: 120,
+            show_documentation: true,
+        }
+    }
 }
 
 fn default_completion_debounce_ms() -> u64 {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -43,6 +43,7 @@ pub mod rendering;
 #[cfg(test)]
 mod resize_tests;
 mod session_manager;
+mod signature_help;
 mod snippet;
 
 use std::{
@@ -145,7 +146,7 @@ use crate::{
     ui::{
         AgentComposer, CompletionUI, Component, Confirmation, CopilotSignInDialog,
         CopilotSignInModel, CopilotSignInPhase, DiagnosticInfo, FilePicker, HoverInfo,
-        HoverInfoFormat, Info, InlineAssistPopup, InlineAssistPopupState, InputPrompt,
+        HoverInfoFormat, InlineAssistPopup, InlineAssistPopupState, InputPrompt,
         LegacyPickerOptions, OverlayLayout, Picker, PickerItem, PickerOptions, PickerPreview,
         PickerUpdate, ScreenRect, StatuslineLayoutPanel, WhatsNewPanel,
     },
@@ -3294,6 +3295,7 @@ pub struct Editor {
 
     /// Active dialog/popup component
     current_dialog: Option<Box<dyn Component>>,
+    signature_help: signature_help::SignatureHelpState,
     keyboard_shortcuts: Option<crate::ui::KeyboardShortcuts>,
     shortcut_help_regions: Vec<crate::ui::ShortcutHelpRegion>,
 
@@ -4580,6 +4582,7 @@ impl Editor {
             persistent_notification_messages: [None, None],
             last_error: None,
             current_dialog: None,
+            signature_help: signature_help::SignatureHelpState::default(),
             keyboard_shortcuts: None,
             shortcut_help_regions: Vec::new(),
             repeater: None,
@@ -9282,6 +9285,7 @@ impl Editor {
 
         self.refresh_live_inline_history(buffer, runtime).await?;
 
+        let signature_help_changed = self.service_signature_help().await?;
         let inline_completion_changed = self.service_inline_completion();
         let completion_changed = if self
             .scheduled_completion
@@ -9329,7 +9333,8 @@ impl Editor {
         let overlay_animation_changed = self.overlay_manager.poll_animation();
         let inline_activity_changed = self.poll_inline_activity_animation(Instant::now());
         let inline_notice_changed = self.poll_inline_completion_notice(Instant::now());
-        let full_animation_changed = inline_notice_changed
+        let full_animation_changed = signature_help_changed
+            || inline_notice_changed
             || completion_changed
             || startup_release_changed
             || dialog_changed
@@ -12377,30 +12382,6 @@ impl Editor {
         Some(Action::ShowDialog)
     }
 
-    fn signature_help_action(&mut self, response: &ResponseMessage) -> Option<Action> {
-        let signatures = response.result.get("signatures")?.as_array()?;
-        let active = response
-            .result
-            .get("activeSignature")
-            .and_then(Value::as_u64)
-            .unwrap_or(0) as usize;
-        let signature = signatures.get(active).or_else(|| signatures.first())?;
-        let label = signature.get("label")?.as_str()?;
-        let documentation = signature.get("documentation").and_then(|documentation| {
-            documentation
-                .as_str()
-                .or_else(|| documentation.get("value").and_then(Value::as_str))
-        });
-        let text = match documentation {
-            Some(documentation) if !documentation.is_empty() => {
-                format!("{label}\n\n{documentation}")
-            }
-            _ => label.to_string(),
-        };
-        self.current_dialog = Some(Box::new(Info::new(self, text)));
-        Some(Action::ShowDialog)
-    }
-
     fn hover_action(&mut self, value: &Value) -> Option<Action> {
         let value = match value {
             Value::Array(values) => values.first()?,
@@ -12882,6 +12863,9 @@ impl Editor {
             InboundMessage::Error(error_msg) => {
                 log!("got an error: {error_msg:?}");
                 let id = error_msg.id?;
+                if method.as_deref() == Some("textDocument/signatureHelp") {
+                    return self.signature_help_error(id);
+                }
                 if let Some(request_id) = self.take_pending_plugin_request(method.as_deref()?, id) {
                     return Some(Action::ResolvePluginRequest(
                         request_id.get(),
@@ -12951,6 +12935,9 @@ impl Editor {
                 None
             }
             InboundMessage::RequestError { id, error } => {
+                if method.as_deref() == Some("textDocument/signatureHelp") {
+                    return self.signature_help_error(*id);
+                }
                 if let Some(request_id) = method
                     .as_deref()
                     .and_then(|method| self.take_pending_plugin_request(method, *id))
@@ -16859,6 +16846,7 @@ impl Editor {
             self.render(buffer)?;
         }
         let action_buffer_id = self.current_buffer().id();
+        let signature_snapshot = self.signature_snapshot();
         let action_buffer_revision = self.current_buffer().revision();
         self.lsp_coordinator
             .ensure_notified_revision(action_buffer_id, action_buffer_revision);
@@ -18462,12 +18450,8 @@ impl Editor {
                 }
             }
             Action::SignatureHelp => {
-                if let Some(file) = self.current_buffer().file.clone() {
-                    let position = self.cursor_lsp_position();
-                    self.ensure_current_buffer_lsp_opened().await?;
-                    self.lsp
-                        .signature_help(&file, position.character, position.line)
-                        .await?;
+                if self.invoke_signature_help().await? {
+                    self.render(buffer)?;
                 }
             }
             Action::StartRename => {
@@ -20259,6 +20243,10 @@ impl Editor {
             && self.current_buffer().revision() != action_buffer_revision
         {
             self.flush_change_notification(runtime).await?;
+        }
+
+        if self.observe_signature_help_action(action, signature_snapshot) {
+            self.render(buffer)?;
         }
 
         // Sync editor state back to the active window after executing actions
@@ -35007,7 +34995,7 @@ builtin = "rust"
     }
 
     #[test]
-    fn signature_help_response_opens_documentation_dialog() {
+    fn unsolicited_signature_help_response_does_not_open_a_dialog() {
         let mut editor = lsp_test_editor(vec![Buffer::new(None, "call(".to_string())]);
         let message = InboundMessage::Message(ResponseMessage {
             id: 44,
@@ -35027,8 +35015,8 @@ builtin = "rust"
         let action =
             editor.handle_lsp_message(&message, Some("textDocument/signatureHelp".to_string()));
 
-        assert!(matches!(action, Some(Action::ShowDialog)));
-        assert!(editor.current_dialog.is_some());
+        assert!(action.is_none());
+        assert!(editor.current_dialog.is_none());
     }
 
     #[tokio::test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1435,6 +1435,7 @@ impl Editor {
 
     fn can_reuse_editor_surfaces(&self) -> bool {
         self.previous_render_buffer.is_some()
+            && !self.signature_help.is_visible()
             && self.learn_session.is_none()
             && !self.force_full_redraw
             && self.last_rendered_window == self.window_manager.active_stable_window_id()
@@ -3134,6 +3135,7 @@ impl Editor {
     }
 
     fn render_dialog(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.render_signature_help(buffer)?;
         if let Some(current_dialog) = &self.current_dialog {
             if current_dialog.has_shortcut_context() {
                 buffer.shortcut_help_regions.clear();

--- a/src/editor/signature_help.rs
+++ b/src/editor/signature_help.rs
@@ -1,0 +1,580 @@
+//! Signature-help lifecycle. The popup never owns editor input or `current_dialog`.
+
+use super::*;
+use crate::lsp::{SignatureHelp, SignatureHelpContext};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct Snapshot {
+    buffer: BufferId,
+    revision: u64,
+    cursor: TextPosition,
+    mode: Mode,
+    window: Option<crate::window::WindowId>,
+}
+
+struct Scheduled {
+    deadline: Instant,
+    snapshot: Snapshot,
+    context: SignatureHelpContext,
+}
+
+struct Pending {
+    id: i64,
+    snapshot: Snapshot,
+}
+
+#[derive(Default)]
+pub(super) struct SignatureHelpState {
+    scheduled: Option<Scheduled>,
+    pending: Option<Pending>,
+    visible: Option<SignatureHelp>,
+}
+
+impl SignatureHelpState {
+    pub(super) fn is_visible(&self) -> bool {
+        self.visible.is_some()
+    }
+    fn is_active(&self) -> bool {
+        self.visible.is_some() || self.pending.is_some() || self.scheduled.is_some()
+    }
+    fn clear(&mut self) -> bool {
+        let visible = self.visible.take().is_some();
+        self.pending = None;
+        self.scheduled = None;
+        visible
+    }
+}
+
+impl Editor {
+    pub(super) fn signature_snapshot(&self) -> Snapshot {
+        Snapshot {
+            buffer: self.current_buffer().id(),
+            revision: self.current_buffer().revision(),
+            cursor: self.cursor_text_position(),
+            mode: self.mode,
+            window: self.window_manager.active_stable_window_id(),
+        }
+    }
+
+    fn signature_context_available(&self) -> bool {
+        !self.has_term()
+            && !self.panel_manager.has_focused_panel()
+            && !self.workspace_manager.is_active()
+            && self
+                .current_dialog
+                .as_ref()
+                .is_none_or(|dialog| dialog.allows_event_passthrough())
+    }
+
+    fn signature_context(&self, trigger: Option<char>, manual: bool) -> SignatureHelpContext {
+        SignatureHelpContext {
+            trigger_kind: if manual {
+                1
+            } else if trigger.is_some() {
+                2
+            } else {
+                3
+            },
+            trigger_character: trigger.map(|ch| ch.to_string()),
+            is_retrigger: self.signature_help.is_visible(),
+            active_signature_help: self.signature_help.visible.clone(),
+        }
+    }
+
+    /// Called after the canonical edit and LSP didChange notification have completed.
+    pub(super) fn observe_signature_help_action(
+        &mut self,
+        action: &Action,
+        before: Snapshot,
+    ) -> bool {
+        let after = self.signature_snapshot();
+        if !self.signature_context_available() {
+            return self.signature_help.clear();
+        }
+        if before == after {
+            return false;
+        }
+        if !self.is_insert() || before.buffer != after.buffer || before.window != after.window {
+            return self.signature_help.clear();
+        }
+        let Some(options) = self
+            .current_buffer()
+            .file
+            .as_deref()
+            .and_then(|file| self.lsp.server_capabilities_for_file(file))
+            .and_then(|capabilities| capabilities.signature_help_provider.as_ref())
+        else {
+            return self.signature_help.clear();
+        };
+        let active = self.signature_help.is_active();
+        let typed = match action {
+            Action::InsertCharAtCursorPos(ch) => Some(*ch),
+            _ => None,
+        };
+        let trigger = typed.filter(|ch| {
+            let text = ch.to_string();
+            options
+                .trigger_characters
+                .as_ref()
+                .is_some_and(|chars| chars.contains(&text))
+                || active
+                    && options
+                        .retrigger_characters
+                        .as_ref()
+                        .is_some_and(|chars| chars.contains(&text))
+        });
+        let completion = matches!(action, Action::ApplyCompletion { .. });
+        if !(active || self.config.signature_help.auto_trigger && (trigger.is_some() || completion))
+        {
+            return false;
+        }
+        let context = self.signature_context(trigger, completion && !active && trigger.is_none());
+        self.signature_help.pending = None;
+        self.signature_help.scheduled = Some(Scheduled {
+            deadline: Instant::now()
+                + Duration::from_millis(self.config.signature_help.debounce_ms.min(5_000)),
+            snapshot: after,
+            context,
+        });
+        // A closing delimiter may return to an outer call. Hide the inner signature
+        // immediately, then let the server identify the enclosing callable.
+        if typed.is_some_and(|ch| matches!(ch, ')' | ']' | '}')) {
+            return self.signature_help.visible.take().is_some();
+        }
+        false
+    }
+
+    pub(super) async fn invoke_signature_help(&mut self) -> anyhow::Result<bool> {
+        if !self.signature_context_available() {
+            return Ok(false);
+        }
+        if let Some(help) = self
+            .signature_help
+            .visible
+            .as_mut()
+            .filter(|help| help.signatures.len() > 1)
+        {
+            help.active_signature =
+                Some((help.active_signature.unwrap_or(0) + 1) % help.signatures.len());
+            return Ok(true);
+        }
+        let context = self.signature_context(None, true);
+        self.signature_help.scheduled = None;
+        self.send_signature_help(context).await
+    }
+
+    pub(super) async fn service_signature_help(&mut self) -> anyhow::Result<bool> {
+        if self
+            .signature_help
+            .scheduled
+            .as_ref()
+            .is_none_or(|request| Instant::now() < request.deadline)
+        {
+            return Ok(false);
+        }
+        let scheduled = self.signature_help.scheduled.take().unwrap();
+        if scheduled.snapshot != self.signature_snapshot()
+            || !self.signature_context_available()
+            || !self.is_insert()
+        {
+            return Ok(self.signature_help.clear());
+        }
+        self.send_signature_help(scheduled.context).await
+    }
+
+    async fn send_signature_help(&mut self, context: SignatureHelpContext) -> anyhow::Result<bool> {
+        let Some(file) = self.current_buffer().file.clone() else {
+            return Ok(false);
+        };
+        self.ensure_current_buffer_lsp_opened().await?;
+        if self
+            .lsp
+            .server_capabilities_for_file(&file)
+            .is_some_and(|cap| cap.signature_help_provider.is_none())
+        {
+            return Ok(self.signature_help.clear());
+        }
+        let position = self.cursor_lsp_position();
+        let snapshot = self.signature_snapshot();
+        match self
+            .lsp
+            .signature_help_with_context(&file, position.character, position.line, Some(context))
+            .await
+        {
+            Ok(id) if id > 0 => self.signature_help.pending = Some(Pending { id, snapshot }),
+            Ok(_) => return Ok(self.signature_help.clear()),
+            Err(error) => {
+                log!("signature help unavailable: {error}");
+                return Ok(self.signature_help.clear());
+            }
+        }
+        Ok(false)
+    }
+
+    pub(super) fn signature_help_action(&mut self, response: &ResponseMessage) -> Option<Action> {
+        if self
+            .signature_help
+            .pending
+            .as_ref()
+            .is_none_or(|pending| pending.id != response.id)
+        {
+            return None;
+        }
+        let pending = self.signature_help.pending.take().unwrap();
+        if pending.snapshot != self.signature_snapshot() || !self.signature_context_available() {
+            return None;
+        }
+        let help = serde_json::from_value::<SignatureHelp>(response.result.clone())
+            .ok()
+            .filter(|help| !help.signatures.is_empty());
+        self.signature_help.visible = help;
+        Some(Action::Refresh)
+    }
+
+    pub(super) fn signature_help_error(&mut self, id: i64) -> Option<Action> {
+        if self
+            .signature_help
+            .pending
+            .as_ref()
+            .is_some_and(|pending| pending.id == id)
+        {
+            self.signature_help.clear().then_some(Action::Refresh)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn render_signature_help(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        let Some(help) = &self.signature_help.visible else {
+            return Ok(());
+        };
+        if !self.signature_context_available() {
+            return Ok(());
+        }
+        let Some(window) = self.active_window_with_editor_view() else {
+            return Ok(());
+        };
+        let Some(anchor) = self.render_cursor_position() else {
+            return Ok(());
+        };
+        let viewport = ScreenRect {
+            x: window.position.x,
+            y: window.position.y + self.window_content_top(&window),
+            width: window.inner_width(),
+            height: self.window_content_height(&window),
+        };
+        let completion = self
+            .current_dialog
+            .as_ref()
+            .and_then(|dialog| dialog.completion_popup_bounds())
+            .map(|(x, y, width, height)| ScreenRect {
+                x,
+                y,
+                width,
+                height,
+            });
+        crate::ui::signature_help::render(
+            buffer,
+            &self.theme,
+            help,
+            OverlayLayout {
+                viewport,
+                anchor,
+                avoid_rows: None,
+                protected_rows: Some((anchor.1, anchor.1)),
+            },
+            completion,
+            self.config.signature_help.show_documentation,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn editor(text: &str) -> Editor {
+        let mut config = Config::default();
+        config.lsp.enabled = false;
+        let mut editor = Editor::with_size(
+            Box::new(crate::lsp::LspManager::new(config.lsp.clone())),
+            60,
+            12,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, text.to_owned())],
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor.mode = Mode::Insert;
+        editor.cx = grapheme_len(text);
+        editor
+    }
+
+    fn result(id: i64, label: &str) -> ResponseMessage {
+        ResponseMessage {
+            id,
+            result: json!({"signatures":[{"label":label,"parameters":[{"label":"x: f32"}]}]}),
+            request: None,
+        }
+    }
+
+    fn pending(editor: &mut Editor, id: i64) {
+        editor.signature_help.pending = Some(Pending {
+            id,
+            snapshot: editor.signature_snapshot(),
+        });
+    }
+
+    #[test]
+    fn response_is_non_modal_and_stale_ids_positions_and_modes_are_rejected() {
+        let mut editor = editor("call(");
+        pending(&mut editor, 1);
+        assert!(editor.signature_help_action(&result(2, "wrong")).is_none());
+        assert!(matches!(
+            editor.signature_help_action(&result(1, "call(x: f32)")),
+            Some(Action::Refresh)
+        ));
+        assert!(editor.signature_help.is_visible());
+        assert!(editor.current_dialog.is_none());
+        pending(&mut editor, 3);
+        editor.cx -= 1;
+        assert!(editor.signature_help_action(&result(3, "stale")).is_none());
+        pending(&mut editor, 4);
+        editor.mode = Mode::Normal;
+        assert!(editor.signature_help_action(&result(4, "stale")).is_none());
+        assert_eq!(
+            editor.signature_help.visible.as_ref().unwrap().signatures[0].label,
+            "call(x: f32)"
+        );
+    }
+
+    #[test]
+    fn null_response_and_matching_error_close_help_without_notifications() {
+        let mut editor = editor("call(");
+        pending(&mut editor, 1);
+        editor.signature_help_action(&result(1, "call(x: f32)"));
+        pending(&mut editor, 2);
+        assert!(matches!(
+            editor.signature_help_action(&ResponseMessage {
+                id: 2,
+                result: Value::Null,
+                request: None
+            }),
+            Some(Action::Refresh)
+        ));
+        assert!(!editor.signature_help.is_visible());
+        pending(&mut editor, 3);
+        editor.signature_help_action(&result(3, "call(x: f32)"));
+        pending(&mut editor, 4);
+        assert!(editor.signature_help_error(3).is_none());
+        assert!(matches!(
+            editor.signature_help_error(4),
+            Some(Action::Refresh)
+        ));
+        assert!(editor.last_error.is_none());
+        assert!(!editor.signature_help.is_active());
+    }
+
+    #[tokio::test]
+    async fn manual_invocation_cycles_overloads_without_stealing_input() {
+        let mut editor = editor("call(");
+        editor.signature_help.visible = Some(
+            serde_json::from_value(
+                json!({"signatures":[{"label":"first()"},{"label":"second()"}]}),
+            )
+            .unwrap(),
+        );
+        assert!(editor.invoke_signature_help().await.unwrap());
+        assert_eq!(
+            editor
+                .signature_help
+                .visible
+                .as_ref()
+                .unwrap()
+                .active_signature,
+            Some(1)
+        );
+        assert!(editor.invoke_signature_help().await.unwrap());
+        assert_eq!(
+            editor
+                .signature_help
+                .visible
+                .as_ref()
+                .unwrap()
+                .active_signature,
+            Some(0)
+        );
+        let action = editor
+            .handle_event(&Event::Key(KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::NONE,
+            )))
+            .unwrap();
+        assert!(matches!(
+            action,
+            Some(KeyAction::Single(Action::InsertCharAtCursorPos('a')))
+        ));
+    }
+
+    #[cfg(unix)]
+    async fn pump_until(editor: &mut Editor, predicate: impl Fn(&Editor) -> bool) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while !predicate(editor) {
+                if let Some((message, method)) = editor.lsp.recv_response().await.unwrap() {
+                    if let Some(action) = editor.handle_lsp_message(&message, method) {
+                        editor.test_execute_production_action(action).await.unwrap();
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("signature-help server should respond");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn real_transport_tracks_arguments_nested_calls_and_document_changes() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("example.sigtest");
+        let script = root.path().join("server.py");
+        let events = root.path().join("events.jsonl");
+        fs::write(&path, "outer").unwrap();
+        fs::write(
+            &script,
+            include_str!("../../tests/fixtures/signature_help_lsp.py"),
+        )
+        .unwrap();
+        let file = path.to_string_lossy().into_owned();
+        let mut config = Config::default();
+        config.completion.auto_trigger = false;
+        config.signature_help.debounce_ms = 0;
+        config.lsp.servers = HashMap::from([("signature-test".to_owned(), serde_json::from_value(json!({
+            "command":"python3", "args":[script, events], "language_id":"rust", "file_extensions":["sigtest"]
+        })).unwrap())]);
+        let mut editor = Editor::with_size(
+            Box::new(crate::lsp::LspManager::new(config.lsp.clone())),
+            60,
+            12,
+            config,
+            Theme::default(),
+            vec![Buffer::new(Some(file.clone()), "outer".to_owned())],
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor.mode = Mode::Insert;
+        editor.cx = 5;
+        editor.ensure_current_buffer_lsp_opened().await.unwrap();
+        pump_until(&mut editor, |editor| {
+            editor.lsp.server_capabilities_for_file(&file).is_some()
+        })
+        .await;
+        async fn type_and_request(editor: &mut Editor, text: &str) {
+            for ch in text.chars() {
+                editor
+                    .test_execute_production_action(Action::InsertCharAtCursorPos(ch))
+                    .await
+                    .unwrap();
+            }
+            editor.service_signature_help().await.unwrap();
+            pump_until(editor, |editor| editor.signature_help.pending.is_none()).await;
+        }
+        type_and_request(&mut editor, "(").await;
+        assert_eq!(
+            crate::ui::signature_help::active_parameter(
+                editor.signature_help.visible.as_ref().unwrap()
+            )
+            .unwrap()
+            .1,
+            0
+        );
+        assert!(editor.current_dialog.is_none());
+        type_and_request(&mut editor, "1, ").await;
+        assert_eq!(
+            crate::ui::signature_help::active_parameter(
+                editor.signature_help.visible.as_ref().unwrap()
+            )
+            .unwrap()
+            .1,
+            1
+        );
+        type_and_request(&mut editor, "inner(").await;
+        assert!(
+            editor.signature_help.visible.as_ref().unwrap().signatures[0]
+                .label
+                .contains("inner(")
+        );
+        type_and_request(&mut editor, "2)").await;
+        assert!(
+            editor.signature_help.visible.as_ref().unwrap().signatures[0]
+                .label
+                .contains("outer(")
+        );
+        type_and_request(&mut editor, ")").await;
+        assert!(!editor.signature_help.is_visible());
+        let messages = fs::read_to_string(&events)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        let requests = messages
+            .iter()
+            .enumerate()
+            .filter(|(_, message)| message["method"] == "textDocument/signatureHelp")
+            .collect::<Vec<_>>();
+        assert_eq!(requests.len(), 5);
+        assert_eq!(requests[0].1["params"]["context"]["triggerKind"], 2);
+        assert_eq!(requests[0].1["params"]["context"]["triggerCharacter"], "(");
+        assert_eq!(requests[0].1["params"]["context"]["isRetrigger"], false);
+        assert_eq!(requests[1].1["params"]["context"]["isRetrigger"], true);
+        assert!(requests[1].1["params"]["context"]["activeSignatureHelp"].is_object());
+        for (index, _) in requests {
+            assert!(messages[..index]
+                .iter()
+                .rev()
+                .any(|message| message["method"] == "textDocument/didChange"));
+        }
+        editor.config.signature_help.auto_trigger = false;
+        type_and_request(&mut editor, " + outer(").await;
+        assert!(!editor.signature_help.is_active());
+        editor.invoke_signature_help().await.unwrap();
+        pump_until(&mut editor, |editor| {
+            editor.signature_help.pending.is_none()
+        })
+        .await;
+        assert!(editor.signature_help.is_visible());
+        editor
+            .test_execute_production_action(Action::EnterMode(Mode::Normal))
+            .await
+            .unwrap();
+        assert!(!editor.signature_help.is_active());
+
+        editor.mode = Mode::Insert;
+        editor.cx = grapheme_len(&editor.current_buffer().contents());
+        editor.config.signature_help.auto_trigger = true;
+        editor
+            .test_execute_production_action(Action::ApplyCompletion {
+                item: Box::new(
+                    serde_json::from_value(json!({
+                        "label":"inner", "insertText":"inner(${1:0})", "insertTextFormat":2
+                    }))
+                    .unwrap(),
+                ),
+                commit_character: None,
+            })
+            .await
+            .unwrap();
+        assert!(editor.signature_help.scheduled.is_some());
+        editor.service_signature_help().await.unwrap();
+        pump_until(&mut editor, |editor| {
+            editor.signature_help.pending.is_none()
+        })
+        .await;
+        assert!(
+            editor.signature_help.visible.as_ref().unwrap().signatures[0]
+                .label
+                .contains("inner(")
+        );
+    }
+}

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1591,7 +1591,17 @@ impl LspClient for RealLspClient {
     }
 
     async fn signature_help(&mut self, file: &str, x: usize, y: usize) -> Result<i64, LspError> {
-        let params = json!({
+        self.signature_help_with_context(file, x, y, None).await
+    }
+
+    async fn signature_help_with_context(
+        &mut self,
+        file: &str,
+        x: usize,
+        y: usize,
+        context: Option<super::SignatureHelpContext>,
+    ) -> Result<i64, LspError> {
+        let mut params = json!({
             "textDocument": {
                 "uri": file_uri(file)?,
             },
@@ -1601,6 +1611,9 @@ impl LspClient for RealLspClient {
             }
         });
 
+        if let Some(context) = context {
+            params["context"] = serde_json::to_value(context)?;
+        }
         self.send_request("textDocument/signatureHelp", params, false)
             .await
     }

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -495,6 +495,21 @@ impl LspClient for LspManager {
         Ok(0)
     }
 
+    async fn signature_help_with_context(
+        &mut self,
+        file: &str,
+        x: usize,
+        y: usize,
+        context: Option<super::SignatureHelpContext>,
+    ) -> Result<i64, LspError> {
+        if let Some(client) = self.client_for_file(file).await? {
+            return client
+                .signature_help_with_context(file, x, y, context)
+                .await;
+        }
+        Ok(0)
+    }
+
     async fn rename(
         &mut self,
         file: &str,

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -355,6 +355,16 @@ pub trait LspClient: std::any::Any + Send {
     ) -> Result<i64, LspError>;
     /// Requests callable signature help at an editor position.
     async fn signature_help(&mut self, file: &str, x: usize, y: usize) -> Result<i64, LspError>;
+    /// Requests signature help with automatic-trigger and retrigger context.
+    async fn signature_help_with_context(
+        &mut self,
+        file: &str,
+        x: usize,
+        y: usize,
+        _context: Option<SignatureHelpContext>,
+    ) -> Result<i64, LspError> {
+        self.signature_help(file, x, y).await
+    }
     /// Requests a workspace rename from an editor position.
     async fn rename(
         &mut self,

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -535,6 +535,50 @@ pub struct SignatureHelpOptions {
     pub retrigger_characters: Option<Vec<String>>,
 }
 
+/// Callable signatures returned for the current cursor position.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureHelp {
+    pub signatures: Vec<SignatureHelpSignature>,
+    pub active_signature: Option<usize>,
+    pub active_parameter: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureHelpSignature {
+    pub label: String,
+    pub documentation: Option<Documentation>,
+    pub parameters: Option<Vec<SignatureHelpParameter>>,
+    pub active_parameter: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SignatureHelpParameter {
+    pub label: SignatureHelpParameterLabel,
+    pub documentation: Option<Documentation>,
+}
+
+/// LSP label offsets are UTF-16 code units, not UTF-8 byte offsets.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SignatureHelpParameterLabel {
+    Offsets([usize; 2]),
+    Text(String),
+}
+
+/// Why signature help was requested, including the displayed overload on retrigger.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureHelpContext {
+    pub trigger_kind: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_character: Option<String>,
+    pub is_retrigger: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_signature_help: Option<SignatureHelp>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeActionOptions {

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -582,6 +582,11 @@ impl CompletionUI {
 }
 
 impl Component for CompletionUI {
+    fn completion_popup_bounds(&self) -> Option<(usize, usize, usize, usize)> {
+        self.has_shortcut_context()
+            .then_some((self.x, self.y, self.width, self.visible_rows + 2))
+    }
+
     fn has_shortcut_context(&self) -> bool {
         self.visible && !self.items.is_empty() && self.width >= 2 && self.visible_rows > 0
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -31,6 +31,7 @@ mod prompt_buffer;
 mod rich_text;
 mod selection;
 mod shortcut_catalog;
+pub(crate) mod signature_help;
 mod spinner;
 mod statusline_layout;
 mod whats_new;
@@ -211,6 +212,11 @@ pub trait Component: Send {
 
     fn allows_event_passthrough(&self) -> bool {
         false
+    }
+
+    /// Absolute bounds of an interactive completion popup, including its border.
+    fn completion_popup_bounds(&self) -> Option<(usize, usize, usize, usize)> {
+        None
     }
 
     fn is_sensitive_input(&self) -> bool {

--- a/src/ui/signature_help.rs
+++ b/src/ui/signature_help.rs
@@ -1,0 +1,331 @@
+//! Compact, non-interactive signature help. All coordinates are terminal cells.
+
+use std::ops::Range;
+
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::{
+    editor::RenderBuffer,
+    lsp::{Documentation, SignatureHelp, SignatureHelpParameterLabel, SignatureHelpSignature},
+    theme::{SelectionForegroundPriority, Theme},
+    unicode_utils::{display_width, truncate_display_width},
+};
+
+use super::{
+    dialog::{BorderStyle, Dialog, SurfaceRole},
+    geometry::anchored_popup_geometry_avoiding_rows,
+    Component, OverlayLayout, ScreenRect,
+};
+
+fn utf16_boundary(text: &str, offset: usize) -> Option<usize> {
+    let mut units = 0;
+    for (byte, ch) in text.char_indices() {
+        if units == offset {
+            return Some(byte);
+        }
+        units += ch.len_utf16();
+        if units > offset {
+            return None;
+        }
+    }
+    (units == offset).then_some(text.len())
+}
+
+pub(crate) fn active_parameter(help: &SignatureHelp) -> Option<(&SignatureHelpSignature, usize)> {
+    let signature = help
+        .signatures
+        .get(help.active_signature.unwrap_or(0))
+        .or_else(|| help.signatures.first())?;
+    let parameters = signature.parameters.as_deref().unwrap_or_default();
+    let index = signature
+        .active_parameter
+        .or(help.active_parameter)
+        .unwrap_or(0);
+    Some((signature, if index < parameters.len() { index } else { 0 }))
+}
+
+fn parameter_range(signature: &SignatureHelpSignature, index: usize) -> Option<Range<usize>> {
+    let parameter = signature.parameters.as_ref()?.get(index)?;
+    match &parameter.label {
+        SignatureHelpParameterLabel::Offsets([start, end]) => {
+            let range =
+                utf16_boundary(&signature.label, *start)?..utf16_boundary(&signature.label, *end)?;
+            (range.start <= range.end).then_some(range)
+        }
+        SignatureHelpParameterLabel::Text(label) => {
+            // String labels may repeat (for example two parameters both labelled `int`).
+            let mut after = 0;
+            for previous in signature.parameters.as_ref()?.iter().take(index) {
+                if let SignatureHelpParameterLabel::Text(text) = &previous.label {
+                    if let Some(start) = signature.label[after..].find(text) {
+                        after += start + text.len();
+                    }
+                }
+            }
+            let start = signature.label[after..].find(label)? + after;
+            Some(start..start + label.len())
+        }
+    }
+}
+
+fn documentation_text(documentation: &Documentation) -> &str {
+    match documentation {
+        Documentation::String(text) => text,
+        Documentation::MarkupContent(markup) => &markup.value,
+    }
+}
+
+#[derive(Default)]
+struct Row {
+    parts: Vec<(String, bool)>,
+    width: usize,
+    active: bool,
+}
+
+fn signature_rows(label: &str, active: Option<Range<usize>>, width: usize) -> Vec<Row> {
+    let mut rows = vec![Row::default()];
+    for (byte, grapheme) in label.grapheme_indices(true).take(4096) {
+        let text = if grapheme.chars().any(char::is_control) {
+            " "
+        } else {
+            grapheme
+        };
+        let cells = display_width(text);
+        if cells > width {
+            continue;
+        }
+        if rows.last().unwrap().width + cells > width {
+            rows.push(Row::default());
+        }
+        let selected = active
+            .as_ref()
+            .is_some_and(|range| byte < range.end && byte + grapheme.len() > range.start);
+        let row = rows.last_mut().unwrap();
+        row.parts.push((text.to_owned(), selected));
+        row.width += cells;
+        row.active |= selected;
+    }
+    rows
+}
+
+fn intersects(a: ScreenRect, b: ScreenRect) -> bool {
+    a.x < b.x.saturating_add(b.width)
+        && b.x < a.x.saturating_add(a.width)
+        && a.y < b.y.saturating_add(b.height)
+        && b.y < a.y.saturating_add(a.height)
+}
+
+pub(crate) fn render(
+    buffer: &mut RenderBuffer,
+    theme: &Theme,
+    help: &SignatureHelp,
+    layout: OverlayLayout,
+    completion: Option<ScreenRect>,
+    show_documentation: bool,
+) -> anyhow::Result<()> {
+    let Some((signature, parameter)) = active_parameter(help) else {
+        return Ok(());
+    };
+    let width = layout.viewport.width.saturating_sub(2).min(88);
+    if width < 8 || layout.viewport.height < 3 {
+        return Ok(());
+    }
+    let rows = signature_rows(
+        &signature.label,
+        parameter_range(signature, parameter),
+        width,
+    );
+    let active_row = rows.iter().position(|row| row.active).unwrap_or(0);
+    let docs = if show_documentation {
+        signature
+            .parameters
+            .as_ref()
+            .and_then(|p| p.get(parameter))
+            .and_then(|p| p.documentation.as_ref())
+            .or(signature.documentation.as_ref())
+            .map(documentation_text)
+            .unwrap_or("")
+            .split_whitespace()
+            .take(80)
+            .collect::<Vec<_>>()
+            .join(" ")
+    } else {
+        String::new()
+    };
+    let width = rows
+        .iter()
+        .map(|row| row.width)
+        .max()
+        .unwrap_or(0)
+        .max(display_width(&docs).min(width))
+        .max(20)
+        .min(width);
+    let desired_height = rows.len().min(3) + usize::from(!docs.is_empty());
+    let avoid_rows = completion
+        .map(|rect| {
+            (
+                rect.y.min(layout.anchor.1),
+                rect.y
+                    .saturating_add(rect.height)
+                    .saturating_sub(1)
+                    .max(layout.anchor.1),
+            )
+        })
+        .unwrap_or((layout.anchor.1, layout.anchor.1));
+    let viewport = layout.viewport;
+    let local_row = |row: usize| {
+        row.saturating_sub(viewport.y)
+            .min(viewport.height.saturating_sub(1))
+    };
+    let (x, y, height) = anchored_popup_geometry_avoiding_rows(
+        (
+            layout.anchor.0.saturating_sub(viewport.x),
+            local_row(layout.anchor.1),
+        ),
+        (local_row(avoid_rows.0), local_row(avoid_rows.1)),
+        viewport.width,
+        viewport.height,
+        width,
+        desired_height,
+    );
+    let (x, y) = (x + viewport.x, y + viewport.y);
+    let rect = ScreenRect {
+        x,
+        y,
+        width: width + 2,
+        height: height + 2,
+    };
+    if height == 0 || completion.is_some_and(|other| intersects(rect, other)) {
+        return Ok(());
+    }
+    // On short panes the active parameter matters more than preceding rows or docs.
+    let row_count = rows.len().min(3).min(height);
+    let first = active_row
+        .saturating_sub(row_count.saturating_sub(1) / 2)
+        .min(rows.len().saturating_sub(row_count));
+    let rows = &rows[first..first + row_count];
+    let index = help
+        .active_signature
+        .unwrap_or(0)
+        .min(help.signatures.len() - 1);
+    let title = if help.signatures.len() > 1 {
+        format!(
+            "Signature {}/{} · Ctrl-k next",
+            index + 1,
+            help.signatures.len()
+        )
+    } else {
+        "Signature".to_owned()
+    };
+    Dialog::new(
+        Some(title),
+        x,
+        y,
+        width,
+        height,
+        &theme.ui_style.popup,
+        BorderStyle::Rounded,
+        theme,
+    )
+    .with_surface_theme(theme, SurfaceRole::Popup)
+    .draw(buffer)?;
+    let base = &theme.ui_style.popup;
+    let mut selected = theme.selected_style(
+        base,
+        &theme.ui_style.picker_selected_item,
+        SelectionForegroundPriority::Selection,
+    );
+    selected.bold = true;
+    for (row_index, row) in rows.iter().take(height).enumerate() {
+        let mut column = x + 1;
+        for (text, active) in &row.parts {
+            buffer.set_text(
+                column,
+                y + 1 + row_index,
+                text,
+                if *active { &selected } else { base },
+            );
+            column += display_width(text);
+        }
+    }
+    if !docs.is_empty() && height > rows.len() {
+        buffer.set_text(
+            x + 1,
+            y + 1 + rows.len(),
+            &truncate_display_width(&docs, width),
+            &theme.ui_style.muted.clone().fallback_bg(base),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parameter_offsets_are_utf16_and_signature_override_wins() {
+        let help: SignatureHelp = serde_json::from_value(json!({"activeParameter":0,"signatures":[{"label":"f(😀: T, y: U)","activeParameter":1,"parameters":[{"label":[2,7]},{"label":[9,13]}]}]})).unwrap();
+        let (signature, index) = active_parameter(&help).unwrap();
+        let range = parameter_range(signature, index).unwrap();
+        assert_eq!(&signature.label[range], "y: U");
+        assert_eq!(utf16_boundary("😀", 1), None);
+    }
+
+    #[test]
+    fn repeated_string_labels_highlight_the_right_occurrence() {
+        let help: SignatureHelp = serde_json::from_value(json!({"activeParameter":1,"signatures":[{"label":"f(int, int)","parameters":[{"label":"int"},{"label":"int"}]}]})).unwrap();
+        let (signature, index) = active_parameter(&help).unwrap();
+        assert_eq!(parameter_range(signature, index), Some(7..10));
+    }
+
+    #[test]
+    fn narrow_rows_keep_wide_graphemes_and_active_parameter() {
+        let rows = signature_rows("f(界界, argument)", Some(10..18), 8);
+        assert!(rows.iter().all(|row| row.width <= 8));
+        assert!(rows.iter().any(|row| row.active));
+    }
+
+    #[test]
+    fn short_split_keeps_active_parameter_visible_and_avoids_completion() {
+        let help: SignatureHelp = serde_json::from_value(json!({"activeParameter":2,"signatures":[{
+            "label":"call(first: LongType, second: LongType, last: U)",
+            "parameters":[{"label":"first: LongType"},{"label":"second: LongType"},{"label":"last: U"}]
+        }]})).unwrap();
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(60, 12, &theme.style);
+        let viewport = ScreenRect {
+            x: 25,
+            y: 2,
+            width: 30,
+            height: 9,
+        };
+        let completion = ScreenRect {
+            x: 27,
+            y: 6,
+            width: 24,
+            height: 5,
+        };
+        let layout = OverlayLayout {
+            viewport,
+            anchor: (28, 5),
+            avoid_rows: None,
+            protected_rows: Some((5, 5)),
+        };
+        render(&mut buffer, &theme, &help, layout, Some(completion), false).unwrap();
+        let text = buffer.cells.iter().map(|cell| cell.c).collect::<String>();
+        assert!(text.contains("last: U"));
+        for y in 0..12 {
+            for x in 0..60 {
+                if !viewport.contains(x, y) || completion.contains(x, y) || y == 5 {
+                    assert_eq!(buffer.cells[y * 60 + x].c, ' ');
+                }
+            }
+        }
+        assert!(buffer
+            .cells
+            .iter()
+            .any(|cell| cell.c == 'U' && cell.style.bold));
+    }
+}

--- a/tests/fixtures/signature_help_lsp.py
+++ b/tests/fixtures/signature_help_lsp.py
@@ -1,0 +1,86 @@
+"""Deterministic LSP peer for signature-help transport and UI tests."""
+import json
+import pathlib
+import re
+import sys
+
+events = pathlib.Path(sys.argv[1])
+documents = {}
+
+
+def read_message():
+    headers = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        key, value = line.decode().split(":", 1)
+        headers[key.lower()] = value.strip()
+    return json.loads(sys.stdin.buffer.read(int(headers["content-length"])))
+
+
+def send(message):
+    body = json.dumps(message).encode()
+    sys.stdout.buffer.write(b"Content-Length: %d\r\n\r\n" % len(body) + body)
+    sys.stdout.buffer.flush()
+
+
+def signature(params):
+    text = documents.get(params["textDocument"]["uri"], "")
+    position = params["position"]
+    lines = text.splitlines(keepends=True)
+    line = lines[position["line"]] if position["line"] < len(lines) else ""
+    prefix = "".join(lines[:position["line"]]) + line.encode("utf-16-le")[:position["character"] * 2].decode("utf-16-le")
+    stack = []
+    for match in re.finditer(r"([\w:]+)\s*\(|[(),]", prefix):
+        token = match.group()
+        if token.endswith("("):
+            stack.append([match.group(1) or "", 0])
+        elif token == ")" and stack:
+            stack.pop()
+        elif token == "," and stack:
+            stack[-1][1] += 1
+    if not stack:
+        return None
+    name, active = stack[-1]
+    names = ["value: f32"] if name == "inner" else ["x: f32", "y: f32"]
+    label = "fn " + name + "(" + ", ".join(names) + ") -> f32"
+    parameters = []
+    for parameter in names:
+        start = len(label[:label.index(parameter)].encode("utf-16-le")) // 2
+        parameters.append({"label": [start, start + len(parameter)], "documentation": "Current " + parameter})
+    result = {"label": label, "parameters": parameters, "activeParameter": min(active, len(names) - 1)}
+    return {"activeSignature": 0, "signatures": [result]}
+
+
+while True:
+    message = read_message()
+    if message is None:
+        break
+    with events.open("a") as output:
+        output.write(json.dumps(message) + "\n")
+    method = message.get("method")
+    params = message.get("params", {})
+    if method == "initialize":
+        result = {"capabilities": {"textDocumentSync": 1, "signatureHelpProvider": {"triggerCharacters": ["(", ","], "retriggerCharacters": [")"]}}}
+    elif method == "textDocument/didOpen":
+        documents[params["textDocument"]["uri"]] = params["textDocument"]["text"]
+        continue
+    elif method == "textDocument/didChange":
+        documents[params["textDocument"]["uri"]] = params["contentChanges"][-1]["text"]
+        continue
+    elif method == "textDocument/signatureHelp":
+        result = signature(params)
+    elif method == "textDocument/diagnostic":
+        result = {"kind": "full", "items": []}
+    elif method == "shutdown":
+        result = None
+    elif method == "exit":
+        break
+    elif "id" in message:
+        result = None
+    else:
+        continue
+    send({"jsonrpc": "2.0", "id": message["id"], "result": result})


### PR DESCRIPTION
## Summary

The existing signature-help command opens a regular information dialog, so users have to interrupt typing to check a call's parameters. Show the signature beside the caret instead, without taking focus from the editor or completion menu.

- Request help automatically after server-advertised trigger characters and callable completion, then update the active parameter as the cursor or arguments change.
- Follow nested calls, highlight UTF-16 parameter-label ranges correctly, and keep the active parameter visible in narrow panes. `Ctrl-k` reopens help or cycles available overloads.
- Track request IDs, buffer revisions, cursor positions, modes, and panes so stale responses cannot reopen an unrelated popup.
- Add default-on `[signature_help]` settings for automatic triggering, debounce delay, and documentation display. Full hover documentation remains available separately.
- Cover the lifecycle, renderer, configuration, and real JSON-RPC transport with focused regression tests and a deterministic LSP fixture.

## How to Test

1. Build with `cargo build --locked --all-features --bin red`. Open a Rust crate with rust-analyzer installed and wait for it to finish loading. Add functions such as `fn inner(value: f32) -> f32 { value }` and `fn outer(x: f32, y: f32) {}`.
2. In `main`, type `outer(`. Expect a Signature popup with `x: f32` highlighted while remaining in Insert mode. Type `0.0, ` and confirm the highlight moves to `y: f32`.
3. Type `inner(`, then `1.0)`. Expect the inner signature first, followed by the outer signature again. Finish with `);`; help should close. Escape should retain its normal mode-switching behavior.
4. Reopen help with `Ctrl-k`, then invoke completion with `Ctrl-Space`. Both surfaces should remain usable without overlapping. Repeat in a narrow split. With a server that returns multiple overloads, repeated `Ctrl-k` should cycle them.
5. Start with `-c 'signature_help.auto_trigger = false'`. Typing `(` should no longer open help automatically, but `Ctrl-k` should still work. Move or switch buffers before a delayed response arrives; an old popup must not reopen.

Targeted coverage: `cargo test --all-features signature_help -- --test-threads=1`.

## Validation

- Formatting and strict all-targets/all-features Clippy passed.
- Full all-targets/all-features suite: **2,696 passed, 0 failed, 1 ignored**.
- Locked all-features build passed.
- Retained real rust-analyzer terminal smoke: **11/11 checks passed**, including active-parameter styling, nested calls, manual help with automatic help disabled, a 44-column pane, and completion-menu coexistence. All 37 frozen evidence checksums verified at `180997d`.
