### PR TITLE
fix(lsp): refresh and preserve diagnostics after saving

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -17,6 +17,7 @@
 
 mod agent_manager;
 mod buffer_manager;
+mod diagnostics;
 mod diagnostics_picker;
 mod display_layout;
 mod inline_actions;
@@ -3314,6 +3315,7 @@ pub struct Editor {
 
     /// Map of diagnostics per file uri
     diagnostics: HashMap<String, Vec<Diagnostic>>,
+    diagnostic_reports: diagnostics::DiagnosticReports,
 
     /// Indentation rules per file type
     indentation: HashMap<String, Indentation>,
@@ -4239,6 +4241,7 @@ impl Editor {
             if route_changed {
                 self.lsp_coordinator.mark_document_closed(&uri);
                 self.diagnostics.remove(&uri);
+                self.diagnostic_reports.remove(&uri);
             }
             self.lsp_coordinator.mark_document_opened(uri);
         }
@@ -4588,6 +4591,7 @@ impl Editor {
             registers: HashMap::new(),
             clipboard,
             diagnostics: HashMap::new(),
+            diagnostic_reports: diagnostics::DiagnosticReports::default(),
             indentation,
             render_commands: VecDeque::new(),
             overlay_manager: plugin::OverlayManager::new(),
@@ -8011,6 +8015,21 @@ impl Editor {
         Ok((self.buffer_manager.len() - 1, true, normalized))
     }
 
+    /// A failed LSP notification must not turn a successful disk write into a failed save.
+    async fn notify_lsp_saved(&mut self) {
+        let Some(file) = self.current_buffer().file.clone() else {
+            return;
+        };
+        let contents = self.current_buffer().contents();
+        if let Err(error) = self.lsp.did_save(&file, &contents).await {
+            log!("[lsp] saved {file}, but didSave failed: {error}");
+            self.set_notification_message(
+                Severity::Warning,
+                Some(format!("file saved, but LSP notification failed: {error}")),
+            );
+        }
+    }
+
     async fn save_current_agent_buffer(
         &mut self,
         root: &Path,
@@ -8039,6 +8058,7 @@ impl Editor {
         };
         match result {
             Ok(message) => {
+                self.notify_lsp_saved().await;
                 self.sync_inline_change_summaries();
                 if let Some(file) = self.current_buffer().file.clone() {
                     let _ = self
@@ -11971,6 +11991,15 @@ impl Editor {
     }
 
     fn add_diagnostics(&mut self, uri: Option<&str>, diagnostics: &[Diagnostic]) -> Option<Action> {
+        self.update_diagnostics(uri, diagnostics, diagnostics::DiagnosticReportKind::Push)
+    }
+
+    fn update_diagnostics(
+        &mut self,
+        uri: Option<&str>,
+        diagnostics: &[Diagnostic],
+        kind: diagnostics::DiagnosticReportKind,
+    ) -> Option<Action> {
         let Some(uri) = uri else {
             log!("WARN: no uri provided for diagnostics - {diagnostics:?}");
             return None;
@@ -11981,7 +12010,8 @@ impl Editor {
             .and_then(|path| crate::lsp::file_uri(path).ok())
             .unwrap_or_else(|| uri.to_string());
         log!("Adding diagnostics for {uri}: {diagnostics:#?}");
-        self.diagnostics.insert(uri, diagnostics.to_vec());
+        let merged = self.diagnostic_reports.update(&uri, kind, diagnostics);
+        self.diagnostics.insert(uri, merged);
         self.sync_diagnostic_gutter_signs();
 
         Some(Action::Refresh)
@@ -12694,7 +12724,11 @@ impl Editor {
 
                     if method == "textDocument/diagnostic" && self.config.show_diagnostics {
                         if let Some((uri, diagnostics)) = parse_diagnostics(msg) {
-                            return self.add_diagnostics(Some(&uri), &diagnostics);
+                            return self.update_diagnostics(
+                                Some(&uri),
+                                &diagnostics,
+                                diagnostics::DiagnosticReportKind::Pull,
+                            );
                         }
                     }
 
@@ -21384,6 +21418,7 @@ impl Editor {
                     self.lsp.did_close(&file).await?;
                 }
                 self.diagnostics.remove(uri);
+                self.diagnostic_reports.remove(uri);
             }
         }
         self.lsp_coordinator.forget_buffer(removed_id);
@@ -21510,6 +21545,8 @@ impl Editor {
                     self.lsp.did_close(&file).await?;
                 }
             }
+            self.diagnostic_reports
+                .rename(previous_uri, current_uri.as_deref());
             if let Some(diagnostics) = self.diagnostics.remove(previous_uri) {
                 if let Some(current_uri) = current_uri.as_ref() {
                     self.diagnostics.insert(current_uri.clone(), diagnostics);
@@ -25160,6 +25197,7 @@ impl Editor {
             self.lsp_coordinator.mark_document_closed(uri);
             let new_uri = crate::lsp::file_uri(file).ok();
             if let Some(new_uri) = &new_uri {
+                self.diagnostic_reports.rename(uri, Some(new_uri));
                 if let Some(diagnostics) = self.diagnostics.remove(uri) {
                     self.diagnostics.insert(new_uri.clone(), diagnostics);
                 }
@@ -25289,6 +25327,7 @@ impl Editor {
                 );
                 self.sync_lsp_document_identity(previous_uri.as_deref(), index)
                     .await?;
+                self.notify_lsp_saved().await;
                 let file = self.current_buffer().file.clone();
                 self.plugin_registry
                     .notify(
@@ -25452,6 +25491,7 @@ impl Editor {
                 };
                 self.set_notification_message(severity, Some(format_warning.unwrap_or(msg)));
 
+                self.notify_lsp_saved().await;
                 // Notify plugins about file save
                 if let Some(file) = &self.current_buffer().file {
                     let save_info = serde_json::json!({
@@ -25599,6 +25639,7 @@ impl Editor {
                         "format-on-save unavailable; saved unformatted: {error}"
                     )));
                 }
+                self.notify_lsp_saved().await;
                 let saved_file = self
                     .current_buffer()
                     .file

--- a/src/editor/diagnostics.rs
+++ b/src/editor/diagnostics.rs
@@ -1,0 +1,263 @@
+//! Independent push and pull reports, combined only for display.
+//!
+//! A server can publish compiler diagnostics and return its own native diagnostics
+//! from a pull request. An empty report clears only the channel that produced it.
+
+use std::collections::HashMap;
+
+use crate::lsp::Diagnostic;
+
+#[derive(Clone, Copy)]
+pub(super) enum DiagnosticReportKind {
+    Push,
+    Pull,
+}
+
+#[derive(Default)]
+struct DocumentReports {
+    push: Vec<Diagnostic>,
+    pull: Vec<Diagnostic>,
+}
+
+#[derive(Default)]
+pub(super) struct DiagnosticReports {
+    documents: HashMap<String, DocumentReports>,
+}
+
+impl DiagnosticReports {
+    pub(super) fn update(
+        &mut self,
+        uri: &str,
+        kind: DiagnosticReportKind,
+        diagnostics: &[Diagnostic],
+    ) -> Vec<Diagnostic> {
+        let reports = self.documents.entry(uri.to_string()).or_default();
+        match kind {
+            DiagnosticReportKind::Push => reports.push = diagnostics.to_vec(),
+            DiagnosticReportKind::Pull => reports.pull = diagnostics.to_vec(),
+        }
+        let mut merged = reports.push.clone();
+        for diagnostic in &reports.pull {
+            if !merged.contains(diagnostic) {
+                merged.push(diagnostic.clone());
+            }
+        }
+        merged
+    }
+
+    pub(super) fn remove(&mut self, uri: &str) {
+        self.documents.remove(uri);
+    }
+
+    pub(super) fn rename(&mut self, previous: &str, current: Option<&str>) {
+        if let Some(reports) = self.documents.remove(previous) {
+            if let Some(current) = current {
+                self.documents.insert(current.to_string(), reports);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        buffer::Buffer,
+        config::Config,
+        editor::{Action, Editor},
+        lsp::{
+            InboundMessage, LspManager, ParsedNotification, Request, ResponseMessage,
+            TextDocumentPublishDiagnostics,
+        },
+        theme::Theme,
+        undo::{TextPosition, TextRange},
+    };
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn diagnostic(message: &str) -> Diagnostic {
+        serde_json::from_value(json!({
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } },
+            "severity": 1, "source": "rustc", "message": message
+        })).unwrap()
+    }
+
+    fn editor(file: String, contents: &str, enabled: bool) -> Editor {
+        let mut config = Config::default();
+        config.lsp.enabled = enabled;
+        config.show_diagnostics = true;
+        config.formatting.on_save = false;
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size(
+            lsp,
+            60,
+            12,
+            config,
+            Theme::default(),
+            vec![Buffer::new(Some(file), contents.to_string())],
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor
+    }
+
+    fn push(editor: &mut Editor, uri: &str, items: Vec<Diagnostic>) {
+        editor.handle_lsp_message(
+            &InboundMessage::Notification(ParsedNotification::PublishDiagnostics(
+                TextDocumentPublishDiagnostics {
+                    uri: Some(uri.to_string()),
+                    diagnostics: items,
+                },
+            )),
+            None,
+        );
+    }
+
+    fn pull(editor: &mut Editor, uri: &str, report: serde_json::Value) {
+        editor.handle_lsp_message(
+            &InboundMessage::Message(ResponseMessage {
+                id: 1,
+                result: report,
+                request: Some(Request::new(
+                    "textDocument/diagnostic",
+                    json!({ "textDocument": { "uri": uri } }),
+                )),
+            }),
+            Some("textDocument/diagnostic".to_string()),
+        );
+    }
+
+    #[test]
+    fn pushed_and_pulled_diagnostics_replace_only_their_own_reports() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("main.rs");
+        let mut editor = editor(path.to_string_lossy().into_owned(), "x", false);
+        let uri = crate::lsp::file_uri(&path).unwrap();
+        let compiler = diagnostic("compiler error");
+        let native = diagnostic("native error");
+        push(&mut editor, &uri, vec![compiler.clone()]);
+        pull(&mut editor, &uri, json!({ "kind": "full", "items": [] }));
+        assert_eq!(editor.diagnostics[&uri], vec![compiler.clone()]);
+        pull(
+            &mut editor,
+            &uri,
+            json!({ "kind": "full", "items": [compiler, native] }),
+        );
+        assert_eq!(
+            editor.diagnostics[&uri],
+            vec![compiler.clone(), native.clone()]
+        );
+        pull(
+            &mut editor,
+            &uri,
+            json!({ "kind": "unchanged", "resultId": "same" }),
+        );
+        assert_eq!(editor.diagnostics[&uri].len(), 2);
+        push(&mut editor, &uri, vec![]);
+        assert_eq!(editor.diagnostics[&uri], vec![compiler, native]);
+        pull(&mut editor, &uri, json!({ "kind": "full", "items": [] }));
+        assert!(editor.diagnostics[&uri].is_empty());
+    }
+
+    #[test]
+    fn diagnostic_report_rename_and_close_do_not_resurrect_old_items() {
+        let mut reports = DiagnosticReports::default();
+        let compiler = diagnostic("compiler");
+        reports.update(
+            "old",
+            DiagnosticReportKind::Push,
+            std::slice::from_ref(&compiler),
+        );
+        reports.rename("old", Some("new"));
+        assert!(reports
+            .update("old", DiagnosticReportKind::Pull, &[])
+            .is_empty());
+        assert_eq!(
+            reports.update("new", DiagnosticReportKind::Pull, &[]),
+            vec![compiler]
+        );
+        reports.remove("new");
+        assert!(reports
+            .update("new", DiagnosticReportKind::Pull, &[])
+            .is_empty());
+    }
+
+    async fn wait_for_compiler_report(editor: &mut Editor, uri: &str, message: Option<&str>) {
+        tokio::time::timeout(Duration::from_secs(45), async {
+            loop {
+                if let Some((incoming, method)) = editor.lsp.recv_response().await.unwrap() {
+                    let expected = match &incoming {
+                        InboundMessage::Notification(ParsedNotification::PublishDiagnostics(
+                            report,
+                        )) if report.uri.as_deref() == Some(uri) => match message {
+                            Some(message) => report
+                                .diagnostics
+                                .iter()
+                                .any(|d| d.message.contains(message)),
+                            None => report.diagnostics.is_empty(),
+                        },
+                        _ => false,
+                    };
+                    if let Some(action) = editor.handle_lsp_message(&incoming, method) {
+                        editor.test_execute_production_action(action).await.unwrap();
+                    }
+                    if expected {
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("rust-analyzer should publish the updated compiler report");
+    }
+
+    async fn replace_and_save(editor: &mut Editor, contents: &str) {
+        let end = editor.current_buffer().char_idx_to_position(usize::MAX);
+        editor
+            .current_buffer_mut()
+            .replace_range_raw(TextRange::new(TextPosition::new(0, 0), end), contents);
+        let file = editor.current_buffer().file.clone().unwrap();
+        editor
+            .lsp
+            .did_change(&file, contents.to_string())
+            .await
+            .unwrap();
+        editor
+            .test_execute_production_action(Action::Save)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn real_rust_analyzer_refreshes_compiler_errors_after_repeated_saves() {
+        if std::env::var_os("RED_RUN_REAL_LSP_TESTS").is_none() {
+            return;
+        }
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("Cargo.toml"),
+            "[package]\nname = \"red-diagnostics-repro\"\nversion = \"0.1.0\"\nedition = \"2021\"\n").unwrap();
+        let path = root.path().join("src/main.rs");
+        let good = "fn main() {}\n";
+        let bad = "fn main() { let _ = 0.5f; }\n";
+        std::fs::write(&path, bad).unwrap();
+        let mut editor = editor(path.to_string_lossy().into_owned(), bad, true);
+        let uri = crate::lsp::file_uri(&path).unwrap();
+        editor.ensure_buffer_lsp_opened(0).await.unwrap();
+        wait_for_compiler_report(&mut editor, &uri, Some("invalid suffix")).await;
+        replace_and_save(&mut editor, good).await;
+        wait_for_compiler_report(&mut editor, &uri, None).await;
+        for _ in 0..2 {
+            replace_and_save(&mut editor, bad).await;
+            wait_for_compiler_report(&mut editor, &uri, Some("invalid suffix")).await;
+            pull(&mut editor, &uri, json!({ "kind": "full", "items": [] }));
+            assert!(editor.diagnostics[&uri]
+                .iter()
+                .any(|d| d.message.contains("invalid suffix")));
+            replace_and_save(&mut editor, good).await;
+            wait_for_compiler_report(&mut editor, &uri, None).await;
+        }
+        editor.lsp.shutdown().await.unwrap();
+    }
+}

--- a/src/lsp/capabilities.rs
+++ b/src/lsp/capabilities.rs
@@ -28,7 +28,7 @@ pub fn get_client_capabilities_with_options(
                 .dynamic_registration(false)
                 .will_save(false)
                 .will_save_wait_until(false)
-                .did_save(false)
+                .did_save(true)
                 .build(),
         )
         .completion(
@@ -591,7 +591,7 @@ mod tests {
         assert!(flags.into_iter().all(|flag| !flag));
         assert_eq!(synchronization["willSave"], json!(false));
         assert_eq!(synchronization["willSaveWaitUntil"], json!(false));
-        assert_eq!(synchronization["didSave"], json!(false));
+        assert_eq!(synchronization["didSave"], json!(true));
         assert_eq!(
             capabilities["textDocument"]["completion"]["completionItem"]["insertReplaceSupport"],
             json!(false)

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -57,6 +57,22 @@ const PROCESS_EXIT_GRACE: Duration = Duration::from_secs(5);
 /// diagnostics for each is wasted server work.
 const DIAGNOSTICS_DEBOUNCE: Duration = Duration::from_millis(250);
 
+/// Apply the negotiated save options, including to saves queued before initialize.
+fn prepare_did_save(params: &mut Value, capabilities: Option<&ServerCapabilities>) -> bool {
+    let Some(include_text) = capabilities
+        .and_then(|caps| caps.text_document_sync.as_ref())
+        .and_then(TextDocumentSyncCapability::save_include_text)
+    else {
+        return false;
+    };
+    if !include_text {
+        if let Some(params) = params.as_object_mut() {
+            params.remove("text");
+        }
+    }
+    true
+}
+
 fn bytecount_newlines(text: &str) -> usize {
     text.as_bytes().iter().filter(|&&b| b == b'\n').count()
 }
@@ -1046,6 +1062,16 @@ impl LspClient for RealLspClient {
                                     self.pending_messages.len()
                                 );
                                 for mut msg in self.pending_messages.drain(..) {
+                                    if let OutboundMessage::Notification(notification) = &mut msg {
+                                        if notification.method == "textDocument/didSave"
+                                            && !prepare_did_save(
+                                                &mut notification.params,
+                                                self.server_capabilities.as_ref(),
+                                            )
+                                        {
+                                            continue;
+                                        }
+                                    }
                                     if let OutboundMessage::Request(request) = &mut msg {
                                         request.timestamp = Instant::now();
                                         self.pending_responses.insert(request.id, request.clone());
@@ -1286,6 +1312,19 @@ impl LspClient for RealLspClient {
             .await?;
 
         Ok(())
+    }
+
+    async fn did_save(&mut self, file: &str, contents: &str) -> Result<(), LspError> {
+        let uri = file_uri(file)?;
+        self.pending_diagnostics
+            .insert(uri.clone(), Instant::now() + DIAGNOSTICS_DEBOUNCE);
+        // Keep the saved snapshot until initialization tells us whether text is needed.
+        let mut params = json!({ "textDocument": { "uri": uri }, "text": contents });
+        if self.initialized && !prepare_did_save(&mut params, self.server_capabilities.as_ref()) {
+            return Ok(());
+        }
+        self.send_notification("textDocument/didSave", params, false)
+            .await
     }
 
     async fn did_close(&mut self, file: &str) -> Result<(), LspError> {
@@ -2705,6 +2744,87 @@ mod test {
         assert_eq!(id, 801);
         assert_eq!(method.as_deref(), Some("textDocument/formatting"));
         assert!(error.to_string().contains("invalid stdout frame"));
+    }
+
+    #[tokio::test]
+    async fn did_save_honors_negotiated_options_and_queued_initialization() {
+        for (sync, expected_text) in [
+            (json!({ "save": true }), Some(false)),
+            (json!({ "save": { "includeText": true } }), Some(true)),
+            (json!({ "save": {} }), Some(false)),
+            (json!({ "save": false }), None),
+            (json!({ "change": 2 }), None),
+            (json!(2), Some(false)),
+            (json!(0), None),
+        ] {
+            for queued in [false, true] {
+                let (request_tx, mut requests) = mpsc::channel(8);
+                let (responses, response_rx) = mpsc::channel(8);
+                let config = default_language_servers().remove("rust").unwrap();
+                let mut client = RealLspClient::with_test_channels(
+                    request_tx,
+                    response_rx,
+                    config,
+                    std::env::current_dir().unwrap(),
+                );
+                let capabilities = json!({ "textDocumentSync": sync });
+                client.initialized = !queued;
+                client.server_capabilities = if queued {
+                    None
+                } else {
+                    Some(serde_json::from_value(capabilities.clone()).unwrap())
+                };
+                if queued {
+                    client.initialize().await.unwrap();
+                    requests.recv().await.unwrap();
+                }
+                client.did_open("/tmp/saved.rs", "before").await.unwrap();
+                client
+                    .did_change("/tmp/saved.rs", "saved".to_string())
+                    .await
+                    .unwrap();
+                client.did_save("/tmp/saved.rs", "saved").await.unwrap();
+                if queued {
+                    assert!(requests.try_recv().is_err());
+                    responses
+                        .send(InboundMessage::Message(ResponseMessage {
+                            id: client.initialize_id.unwrap(),
+                            result: json!({ "capabilities": capabilities }),
+                            request: None,
+                        }))
+                        .await
+                        .unwrap();
+                    client.recv_response().await.unwrap();
+                }
+                let mut methods = Vec::new();
+                let mut saved = None;
+                while let Ok(message) = requests.try_recv() {
+                    if let OutboundMessage::Notification(notification) = message {
+                        methods.push(notification.method.clone());
+                        if notification.method == "textDocument/didSave" {
+                            saved = Some(notification.params);
+                        }
+                    }
+                }
+                let mut expected = Vec::new();
+                if queued {
+                    expected.push("initialized");
+                }
+                expected.extend(["textDocument/didOpen", "textDocument/didChange"]);
+                if let Some(include_text) = expected_text {
+                    expected.push("textDocument/didSave");
+                    let mut params =
+                        json!({ "textDocument": { "uri": file_uri("/tmp/saved.rs").unwrap() } });
+                    if include_text {
+                        params["text"] = json!("saved");
+                    }
+                    assert_eq!(saved, Some(params));
+                } else {
+                    assert!(saved.is_none());
+                }
+                assert_eq!(methods, expected);
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -407,6 +407,16 @@ impl LspClient for LspManager {
         result
     }
 
+    async fn did_save(&mut self, file: &str, contents: &str) -> Result<(), LspError> {
+        self.did_open(file, contents).await?;
+        if let Some(key) = self.document_clients.get(file) {
+            if let Some(client) = self.clients.get_mut(key) {
+                client.did_save(file, contents).await?;
+            }
+        }
+        Ok(())
+    }
+
     async fn did_close(&mut self, file: &str) -> Result<(), LspError> {
         self.document_clients.remove(file);
         let Some(document) = self.resolve_document(file) else {

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -321,6 +321,10 @@ pub trait LspClient: std::any::Any + Send {
     async fn did_open(&mut self, file: &str, contents: &str) -> Result<(), LspError>;
     /// Publishes the current full document text as the next version.
     async fn did_change(&mut self, file: &str, contents: String) -> Result<(), LspError>;
+    /// Notifies the server after the supplied document contents were saved successfully.
+    async fn did_save(&mut self, _file: &str, _contents: &str) -> Result<(), LspError> {
+        Ok(())
+    }
     /// Closes a document if this client tracks document lifecycles.
     async fn did_close(&mut self, _file: &str) -> Result<(), LspError> {
         Ok(())

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -26,7 +26,7 @@ pub struct TextDocumentPublishDiagnostics {
     pub diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Diagnostic {
     pub range: Range,
@@ -206,7 +206,7 @@ macro_rules! impl_numeric_lsp_enum {
     };
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "i32", into = "i32")]
 pub enum DiagnosticSeverity {
     Error = 1,
@@ -228,7 +228,7 @@ impl_numeric_lsp_enum!(DiagnosticSeverity {
     4 => Hint,
 });
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DiagnosticCode {
     Int(usize),
@@ -250,7 +250,7 @@ pub struct DiagnosticCodeDescription {
     pub href: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticRelatedInformation {
     pub location: Location,
@@ -264,7 +264,7 @@ pub struct Location {
     pub range: Range,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "i32", into = "i32")]
 pub enum DiagnosticTag {
     Unnecessary = 1,
@@ -407,6 +407,21 @@ pub enum TextDocumentSyncCapability {
 }
 
 impl TextDocumentSyncCapability {
+    /// Whether saves are supported, and whether the notification must include text.
+    pub fn save_include_text(&self) -> Option<bool> {
+        match self {
+            Self::Kind(TextDocumentSyncKind::None) => None,
+            Self::Kind(_) => Some(false),
+            Self::Options(options) => match options.save.as_ref()? {
+                TextDocumentSyncSaveOptions::Supported(true) => Some(false),
+                TextDocumentSyncSaveOptions::Supported(false) => None,
+                TextDocumentSyncSaveOptions::Options(options) => {
+                    Some(options.include_text.unwrap_or(false))
+                }
+            },
+        }
+    }
+
     pub fn change_kind(&self) -> Option<TextDocumentSyncKind> {
         match self {
             TextDocumentSyncCapability::Kind(kind) => Some(kind.clone()),

--- a/tests/common/mock_lsp.rs
+++ b/tests/common/mock_lsp.rs
@@ -65,8 +65,16 @@ pub enum LspEvent {
     },
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SavedDocument {
+    pub file: String,
+    pub text: String,
+    pub disk_text: Option<String>,
+}
+
 #[derive(Clone, Default)]
 pub struct RecordingLsp {
+    saves: Arc<Mutex<Vec<SavedDocument>>>,
     events: Arc<Mutex<Vec<LspEvent>>>,
     reconfigurations: Arc<Mutex<Vec<LspConfig>>>,
     workspace_root: Option<PathBuf>,
@@ -77,6 +85,7 @@ pub struct RecordingLsp {
 impl RecordingLsp {
     pub fn with_workspace_root(root: &Path) -> Self {
         Self {
+            saves: Arc::default(),
             events: Arc::default(),
             reconfigurations: Arc::default(),
             workspace_root: Some(root.to_path_buf()),
@@ -84,6 +93,10 @@ impl RecordingLsp {
             fail_next_did_change: false,
         }
     }
+    pub fn saves(&self) -> Arc<Mutex<Vec<SavedDocument>>> {
+        Arc::clone(&self.saves)
+    }
+
     pub fn events(&self) -> Arc<Mutex<Vec<LspEvent>>> {
         Arc::clone(&self.events)
     }
@@ -306,6 +319,15 @@ impl LspClient for RecordingLsp {
                 "injected didChange failure".to_string(),
             ));
         }
+        Ok(())
+    }
+
+    async fn did_save(&mut self, file: &str, contents: &str) -> Result<(), LspError> {
+        self.saves.lock().unwrap().push(SavedDocument {
+            file: file.to_string(),
+            text: contents.to_string(),
+            disk_text: std::fs::read_to_string(file).ok(),
+        });
         Ok(())
     }
 

--- a/tests/lsp_save.rs
+++ b/tests/lsp_save.rs
@@ -1,0 +1,93 @@
+mod common;
+
+use common::mock_lsp::{RecordingLsp, SavedDocument};
+use red::{
+    buffer::Buffer,
+    config::Config,
+    editor::{Action, Editor},
+    test_utils::EditorTestExt,
+    theme::Theme,
+};
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+fn editor(root: &Path, path: &Path, text: &str) -> (Editor, Arc<Mutex<Vec<SavedDocument>>>) {
+    let lsp = RecordingLsp::with_workspace_root(root);
+    let saves = lsp.saves();
+    let mut config = Config::default();
+    config.formatting.on_save = false;
+    let mut editor = Editor::with_size(
+        Box::new(lsp),
+        80,
+        24,
+        config,
+        Theme::default(),
+        vec![Buffer::new(
+            Some(path.to_string_lossy().into_owned()),
+            text.to_string(),
+        )],
+    )
+    .unwrap();
+    editor.test_disable_terminal_output();
+    (editor, saves)
+}
+
+#[tokio::test]
+async fn did_save_follows_successful_save_and_save_as_but_not_failed_writes() {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source.rs");
+    let target = root.path().join("target.rs");
+    let text = "fn main() {}\n";
+    std::fs::write(&source, "old").unwrap();
+    let (mut editor, saves) = editor(root.path(), &source, text);
+    editor.test_execute_action(Action::Save).await.unwrap();
+    editor
+        .test_execute_action(Action::SaveAs(target.to_string_lossy().into_owned()))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::SaveAs(root.path().to_string_lossy().into_owned()))
+        .await
+        .unwrap();
+    let saves = saves.lock().unwrap();
+    assert_eq!(saves.len(), 2);
+    for (saved, path) in saves.iter().zip([source, target]) {
+        assert_eq!(Path::new(&saved.file), path);
+        assert_eq!(saved.text, text);
+        assert_eq!(saved.disk_text.as_deref(), Some(text));
+    }
+}
+
+#[tokio::test]
+async fn did_save_contains_the_final_formatted_text() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("format.rs");
+    std::fs::write(&path, "value   \n").unwrap();
+    let (mut editor, saves) = editor(root.path(), &path, "value   \n");
+    let uri = red::lsp::file_uri(&path).unwrap();
+    let operations = red::lsp::workspace_edit_operations(&serde_json::json!({
+        "changes": { (uri.clone()): [{
+            "range": { "start": { "line": 0, "character": 5 }, "end": { "line": 0, "character": 8 } },
+            "newText": ""
+        }] }
+    })).unwrap();
+    editor
+        .test_execute_action(Action::ApplyLspWorkspaceEditOperations {
+            operations,
+            expected_revisions: Vec::new(),
+            command: None,
+            label: "format".to_string(),
+            response: None,
+            save_after_uri: Some(uri),
+            save_as: None,
+            save_previous_file: None,
+        })
+        .await
+        .unwrap();
+    let saves = saves.lock().unwrap();
+    assert_eq!(saves.len(), 1);
+    assert_eq!(saves[0].text, "value\n");
+    assert_eq!(saves[0].disk_text.as_deref(), Some("value\n"));
+}


### PR DESCRIPTION
## Summary

Rust diagnostics could appear during startup and then disappear even while `cargo check` still reported errors. Red did not send `textDocument/didSave`, and an empty pull-diagnostic response replaced diagnostics published by the compiler.

- Notify language servers after successful normal, save-as, formatted, and agent saves. Honor negotiated save options, including notifications queued before initialization.
- Keep push and pull diagnostic reports separate in `src/editor/diagnostics.rs`, merge them for display, and preserve their lifecycle when files close or change identity.
- Add protocol, editor-save, report-merging, and opt-in real rust-analyzer regression tests. This is independent of the cancellation handling in #261.

## How to Test

1. Open a Rust crate in Red, add `let _ = 0.5f;` inside a function, and save. The invalid-suffix diagnostic should appear and remain visible after subsequent LSP updates. Change it to `0.5f32`, save, and repeat; the error should clear and return each time.
2. Run `RED_RUN_REAL_LSP_TESTS=1 cargo test --lib real_rust_analyzer_refreshes_compiler_errors_after_repeated_saves -- --test-threads=1`. This reproduces the edit/save cycle against an installed rust-analyzer in a disposable crate.
3. Run `cargo test --lib did_save_honors_negotiated_options_and_queued_initialization -- --test-threads=1` and `cargo test --test lsp_save --test lsp_lazy -- --test-threads=1`. Saves should reach the server only after a successful write, formatted saves should contain the final text, and a failed write should send no save notification.

Validated on `c338ed8`: 49 diagnostic tests, the save-capability protocol test, 77 save/lifecycle integration tests, and strict all-target/all-feature Clippy passed. The real rust-analyzer test timed out once while another build was running, then passed when rerun alone.
