### PR TITLE
feat(indent): add query-driven language indentation

### DIFF
--- a/docs/LANGUAGES.md
+++ b/docs/LANGUAGES.md
@@ -267,3 +267,40 @@ previews, preserves open and unsaved buffers, and restarts only language-server
 processes whose definitions actually changed. Invalid reloads leave the current
 language configuration active. There is no automatic filesystem watching or
 implicit native-code approval.
+
+## Indentation queries
+
+Red owns newline edits, cursor movement, indentation width, and undo. A language
+pack supplies declarative Tree-sitter rules, without a running language server:
+
+```toml
+[languages.example.grammar]
+indents = ["queries/indents.scm"]
+```
+
+This field requires host API `^0.12.0`. Explicit query lists replace bundled
+indentation rules. Query files use Red's version-1 capture contract:
+
+- `@indent.begin`: opens one indentation level.
+- `@indent.end`: closes the matching level and aligns with its opener.
+- `@indent.branch`: aligns with an opener without closing its level.
+- `@indent.ignore`: makes a comment or literal opaque, preserving multiline text.
+- `@indent.zero`: aligns a leading token at column zero.
+- `@indent.match`: supplies a dynamic matching key, such as a tag name.
+- `@indent.continuation`: marks an explicit line continuation; consecutive
+  continuations share one indentation level and the completed statement resets it.
+
+Brackets match automatically. For keywords or tag nodes, use
+`(#set! indent.match "group")` on both matching patterns. Unknown captures,
+properties, or custom predicates are rejected. Multiple openers on one source
+line contribute one level. New lines inherit nearby actual indentation plus
+the structural difference; leading closers align with their matching opener.
+Unfinished syntax is supported, and size/time limits fall back to ordinary
+auto-indent. Python retains its established provider during migration.
+
+Use `red language check-indent fixtures.json` to test the effective, installed
+language configuration. Native grammars still require explicit trust. Fixtures
+are a JSON array with `name`, `language`, `source`, zero-based `line`,
+`expected` display columns, and optional `width` (default 4). Include a blank
+target line in `source` to test opening a line; include a closing token on the
+target to test dedenting.

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.11.0` is defined by
+Red host API version `0.12.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -24,9 +24,16 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 annotations use `HUSK-A0004`. `--no-typecheck` is an unsupported development
 escape hatch; compatibility guarantees do not apply while it is enabled.
 
-Red `0.11.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
-and `0.10.0` contracts, so existing packages that declare those minors continue to
-load. New packages should target `"red_api_version": "^0.11.0"`.
+Red `0.12.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
+`0.10.0`, and `0.11.0` contracts, so existing packages that declare those minors continue to
+load. New packages should target `"red_api_version": "^0.12.0"`.
+
+## Language-pack indentation
+
+Host API `0.12.0` adds `languages.<id>.grammar.indents`, an ordered list of
+package-relative query files. Packs using it must require `^0.12.0` or later.
+See [the indentation query contract](LANGUAGES.md#indentation-queries) for captures,
+fallback behavior, and portable fixtures. Older packs remain supported.
 
 ## Command arguments and completion
 

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.11.0",
+  "api_version": "0.12.0",
   "changes": [
+    {
+      "version": "0.12.0",
+      "kind": "introduced",
+      "symbols": ["languages.*.grammar.indents", "red language check-indent"],
+      "migration_note": "docs/PLUGIN_API.md#language-pack-indentation"
+    },
     {
       "version": "0.11.0",
       "kind": "introduced",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,6 +125,14 @@ pub enum LanguageCommand {
     Trust(LanguageTrustArgs),
     /// Revoke the current approval associated with a native grammar path or id.
     Untrust(LanguageTrustArgs),
+    /// Check portable indentation fixtures using the effective language configuration.
+    CheckIndent(LanguageIndentArgs),
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct LanguageIndentArgs {
+    /// JSON fixture file. Native grammars must already be explicitly trusted.
+    pub fixtures: PathBuf,
 }
 
 #[derive(Debug, ClapArgs)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -977,6 +977,9 @@ pub struct LanguageGrammarConfig {
     /// Ordered paths to Tree-sitter structural text-object query files.
     #[serde(default)]
     pub textobjects: Vec<PathBuf>,
+    /// Ordered paths to Red indentation query files.
+    #[serde(default)]
+    pub indents: Vec<PathBuf>,
     /// Optional Tree-sitter injection query file.
     #[serde(default)]
     pub injections: Option<PathBuf>,
@@ -2041,6 +2044,7 @@ fn known_schema_path(path: &[String]) -> bool {
                 | "symbol"
                 | "highlights"
                 | "textobjects"
+                | "indents"
                 | "injections"
                 | "trusted"
                 | "targets"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3020,6 +3020,7 @@ pub struct Editor {
 
     /// Full-document structural queries, independent from viewport highlighting.
     syntax_textobjects: SyntaxTextObjectService,
+    syntax_indentation: crate::syntax_indent::SyntaxIndentation,
 
     /// Cached syntax highlight spans per buffer for the most recently parsed
     /// viewport-plus-margin slice.
@@ -4242,6 +4243,7 @@ impl Editor {
         self.sync_persistent_notifications();
         self.highlighter = highlighter;
         self.syntax_textobjects.reset(Arc::clone(&registry));
+        self.syntax_indentation.reset(Arc::clone(&registry));
         self.indentation = indentation;
         self.highlight_cache.clear();
         self.bracket_match_cache = None;
@@ -4417,6 +4419,8 @@ impl Editor {
             &Config::config_dir(),
         )?);
         let highlighter = Highlighter::with_registry(&theme, Arc::clone(&registry))?;
+        let syntax_indentation =
+            crate::syntax_indent::SyntaxIndentation::new(Arc::clone(&registry));
         let syntax_textobjects = SyntaxTextObjectService::new(registry);
 
         let mut plugin_registry = PluginRegistry::new();
@@ -4468,6 +4472,7 @@ impl Editor {
             )),
             highlighter,
             syntax_textobjects,
+            syntax_indentation,
             highlight_cache: HashMap::new(),
             bracket_match_cache: None,
             layout_cache: std::cell::RefCell::new(HashMap::new()),
@@ -16594,13 +16599,41 @@ impl Editor {
         })
     }
 
-    fn indentation_decision_for_line(&self, line: usize) -> IndentDecision {
+    fn indentation_decision_for_line(&mut self, line: usize) -> IndentDecision {
+        self.indentation_decision(line, crate::syntax_indent::IndentReason::NewLine)
+    }
+
+    fn indentation_decision(
+        &mut self,
+        line: usize,
+        reason: crate::syntax_indent::IndentReason,
+    ) -> IndentDecision {
         let indentation = self.indentation();
         let language =
             self.highlight_language_id_for_buffer_index(self.buffer_manager.active_index());
+        let document = self.current_buffer().contents();
+        if let Some(language) = language.as_deref() {
+            let id = self.current_buffer().id();
+            let revision = self.current_buffer().revision();
+            let decision = self
+                .syntax_indentation
+                .indent(crate::syntax_indent::IndentRequest {
+                    id,
+                    revision,
+                    language,
+                    source: &document,
+                    line,
+                    shift_width: indentation.shift_width,
+                    tab_width: indentation.tab_width,
+                    reason,
+                });
+            if decision != IndentDecision::Keep {
+                return decision;
+            }
+        }
         indent::indent_for_line(
             language.as_deref(),
-            &self.current_buffer().contents(),
+            &document,
             line,
             indentation.shift_width,
             indentation.tab_width,
@@ -17286,10 +17319,12 @@ impl Editor {
                         language.as_deref(),
                         *c,
                         contents.trim_end_matches(&['\r', '\n'][..]),
-                    )
+                    ) || (language.as_deref() != Some("python")
+                        && crate::syntax_indent::is_reindent_candidate(*c, &contents))
                 });
                 if should_reindent {
-                    let decision = self.indentation_decision_for_line(line);
+                    let decision =
+                        self.indentation_decision(line, crate::syntax_indent::IndentReason::Typed);
                     self.apply_indentation_to_line(line, decision);
                 }
                 self.notify_change(runtime).await?;
@@ -17705,14 +17740,43 @@ impl Editor {
                 let before_cursor = char_prefix(current_line_for_split, cursor_char).to_string();
                 let after_cursor = char_suffix(current_line_for_split, cursor_char).to_string();
 
+                let split_pair = if let Some(language) =
+                    self.highlight_language_id_for_buffer_index(self.buffer_manager.active_index())
+                {
+                    let document = self.current_buffer().contents();
+                    let byte = document
+                        .split_inclusive('\n')
+                        .take(source_line)
+                        .map(str::len)
+                        .sum::<usize>()
+                        + before_cursor.len();
+                    let id = self.current_buffer().id();
+                    let revision = self.current_buffer().revision();
+                    self.syntax_indentation
+                        .split_pair(id, revision, &language, &document, byte)
+                } else {
+                    false
+                };
+
                 let line = self.buffer_line();
                 let fallback_indent = self.indentation().whitespace_for_columns(fallback_columns);
+                let replacement = if split_pair {
+                    format!(
+                        "{}\n{}\n{}{}",
+                        before_cursor.trim_end(),
+                        fallback_indent,
+                        fallback_indent,
+                        after_cursor.trim_start()
+                    )
+                } else {
+                    format!("{}\n{}{}", before_cursor, fallback_indent, after_cursor)
+                };
                 self.replace_range(
                     TextRange::new(
                         TextPosition::new(line, 0),
                         TextPosition::new(line, current_line_without_ending.chars().count()),
                     ),
-                    &format!("{}\n{}{}", before_cursor, fallback_indent, after_cursor),
+                    &replacement,
                 );
 
                 self.cx = grapheme_len(&fallback_indent);
@@ -17721,6 +17785,10 @@ impl Editor {
                 let target_line = line + 1;
                 let decision = self.indentation_decision_for_line(target_line);
                 let target_columns = self.apply_indentation_to_line(target_line, decision);
+                if split_pair {
+                    let closer = self.indentation_decision_for_line(target_line + 1);
+                    self.apply_indentation_to_line(target_line + 1, closer);
+                }
                 self.mark_generated_indent(target_line, target_columns);
                 self.notify_change(runtime).await?;
 

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -66,6 +66,7 @@ struct RuntimeLanguageDefinition {
     grammar: Option<GrammarSource>,
     highlight_queries: Vec<String>,
     textobject_queries: Vec<String>,
+    indent_queries: Vec<String>,
     injection_query: Option<String>,
     specialized: Option<SpecializedHighlighter>,
 }
@@ -118,6 +119,10 @@ impl LanguageRegistry {
                     .iter()
                     .map(ToString::to_string)
                     .collect(),
+                indent_queries: bundled_indent_query(definition.id)
+                    .into_iter()
+                    .map(ToString::to_string)
+                    .collect(),
                 injection_query: definition.injection_query.map(ToString::to_string),
                 specialized: definition.specialized,
             });
@@ -163,6 +168,7 @@ impl LanguageRegistry {
             grammar: None,
             highlight_queries: Vec::new(),
             textobject_queries: Vec::new(),
+            indent_queries: Vec::new(),
             injection_query: None,
             specialized: None,
         });
@@ -190,6 +196,9 @@ impl LanguageRegistry {
                 definition
                     .textobject_queries
                     .clone_from(&bundled.textobject_queries);
+                definition
+                    .indent_queries
+                    .clone_from(&bundled.indent_queries);
                 definition
                     .injection_query
                     .clone_from(&bundled.injection_query);
@@ -223,11 +232,22 @@ impl LanguageRegistry {
                     .map(|path| read_query(path, config_dir, "text object"))
                     .collect::<anyhow::Result<_>>()?;
             }
+            if !grammar.indents.is_empty() {
+                definition.indent_queries = grammar
+                    .indents
+                    .iter()
+                    .map(|path| read_query(path, config_dir, "indentation"))
+                    .collect::<anyhow::Result<_>>()?;
+            }
             if let Some(path) = &grammar.injections {
                 definition.injection_query = Some(read_query(path, config_dir, "injection")?);
             }
         }
 
+        anyhow::ensure!(
+            definition.indent_queries.is_empty() || definition.grammar.is_some(),
+            "language `{id}` declares indentation queries without a grammar"
+        );
         if let Some(source) = &definition.grammar {
             let language = grammar_language(source);
             let mut parser = Parser::new();
@@ -259,6 +279,11 @@ impl LanguageRegistry {
                         );
                     }
                 }
+            }
+            if !definition.indent_queries.is_empty() {
+                let query = Query::new(&language, &definition.indent_queries.join("\n"))
+                    .with_context(|| format!("language `{id}` has an invalid indentation query"))?;
+                crate::syntax_indent::validate_query(&query)?;
             }
             if let Some(query) = &definition.injection_query {
                 Query::new(&language, query)
@@ -292,6 +317,17 @@ impl LanguageRegistry {
         self.languages.insert(id, definition);
     }
 
+    pub(crate) fn indentation_language(&self, id: &str) -> Option<(Language, String)> {
+        let definition = self.languages.get(id)?;
+        let source = definition.grammar.as_ref()?;
+        (!definition.indent_queries.is_empty()).then(|| {
+            (
+                grammar_language(source),
+                definition.indent_queries.join("\n"),
+            )
+        })
+    }
+
     /// Returns the grammar and normalized structural queries for one language.
     pub(crate) fn textobject_language(&self, id: &str) -> Option<(Language, String)> {
         let definition = self.languages.get(id)?;
@@ -302,6 +338,24 @@ impl LanguageRegistry {
                 definition.textobject_queries.join("\n"),
             )
         })
+    }
+}
+
+fn bundled_indent_query(id: &str) -> Option<&'static str> {
+    match id {
+        "rust" => Some(include_str!("queries/indents/rust.scm")),
+        "javascript" | "jsx" | "typescript" | "tsx" => {
+            Some(include_str!("queries/indents/ecma.scm"))
+        }
+        "json" => Some(include_str!("queries/indents/json.scm")),
+        "toml" => Some(include_str!("queries/indents/toml.scm")),
+        "powershell" => Some(include_str!("queries/indents/powershell.scm")),
+        "bash" => Some(include_str!("queries/indents/bash.scm")),
+        "fish" => Some(include_str!("queries/indents/fish.scm")),
+        "lua" => Some(include_str!("queries/indents/lua.scm")),
+        "yaml" => Some(include_str!("queries/indents/yaml.scm")),
+
+        _ => None,
     }
 }
 
@@ -1664,6 +1718,36 @@ mod tests {
         let (_, loaded_query) = registry.textobject_language("buildspec").unwrap();
 
         assert_eq!(loaded_query, query_source);
+    }
+
+    #[test]
+    fn configurable_indentation_queries_inherit_override_and_validate() {
+        let directory = tempfile::tempdir().unwrap();
+        let query_path = directory.path().join("indents.scm");
+        let mut definition = LanguageConfig {
+            grammar: Some(LanguageGrammarConfig {
+                builtin: Some("rust".into()),
+                ..LanguageGrammarConfig::default()
+            }),
+            ..LanguageConfig::default()
+        };
+        let mut languages = HashMap::from([("buildspec".to_string(), definition.clone())]);
+        let inherited = LanguageRegistry::from_config(&languages, directory.path()).unwrap();
+        assert!(inherited
+            .indentation_language("buildspec")
+            .unwrap()
+            .1
+            .contains("@indent.begin"));
+        fs::write(&query_path, "(line_comment) @indent.ignore").unwrap();
+        definition.grammar.as_mut().unwrap().indents = vec![query_path.clone()];
+        languages.insert("buildspec".into(), definition);
+        let registry = LanguageRegistry::from_config(&languages, directory.path()).unwrap();
+        assert_eq!(
+            registry.indentation_language("buildspec").unwrap().1,
+            "(line_comment) @indent.ignore"
+        );
+        fs::write(&query_path, "(block) @indent.unsupported").unwrap();
+        assert!(LanguageRegistry::from_config(&languages, directory.path()).is_err());
     }
 
     #[test]

--- a/src/language.rs
+++ b/src/language.rs
@@ -66,6 +66,9 @@ pub fn merge_package_languages(
             for path in &mut grammar.textobjects {
                 *path = package_root.join(&*path);
             }
+            for path in &mut grammar.indents {
+                *path = package_root.join(&*path);
+            }
             if let Some(path) = grammar.injections.as_mut() {
                 *path = package_root.join(&*path);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod self_check;
 pub mod session;
 pub mod splash;
 pub mod sync;
+pub mod syntax_indent;
 pub mod terminal_input;
 pub mod terminal_output;
 pub mod text_layout;

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,10 +454,23 @@ async fn run_plugin_command(command: &PluginCommand) -> anyhow::Result<()> {
 }
 
 fn run_language_command(command: &LanguageCommand, overrides: &[String]) -> anyhow::Result<()> {
+    if let LanguageCommand::CheckIndent(arguments) = command {
+        let config_dir = Config::config_dir();
+        let mut loaded = Config::load_user_file(&Config::path("config.toml"), overrides)?;
+        red::language::finalize_language_configuration(&mut loaded, &config_dir)?;
+        let registry = std::sync::Arc::new(red::highlighter::LanguageRegistry::from_config(
+            &loaded.config.languages,
+            &config_dir,
+        )?);
+        let count = red::syntax_indent::check_fixtures(&arguments.fixtures, registry)?;
+        println!("Passed {count} indentation fixtures");
+        return Ok(());
+    }
     let value = match command {
         LanguageCommand::Trust(arguments) | LanguageCommand::Untrust(arguments) => {
             arguments.language_or_path.as_str()
         }
+        LanguageCommand::CheckIndent(_) => unreachable!(),
     };
     let config_dir = Config::config_dir();
     let loaded = Config::load_user_file(&Config::path("config.toml"), overrides)?;
@@ -507,6 +520,7 @@ fn run_language_command(command: &LanguageCommand, overrides: &[String]) -> anyh
             trust.revoke_path(&path)?;
             println!("Revoked native grammar trust for {}", path.display());
         }
+        LanguageCommand::CheckIndent(_) => unreachable!(),
     }
     Ok(())
 }

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.0",
+  "version": "0.12.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },

--- a/src/plugin/package.rs
+++ b/src/plugin/package.rs
@@ -44,6 +44,7 @@ const MAX_PACKAGE_ARCHIVE_FILES: usize = 1024;
 const MAX_CATALOG_GRAMMAR_BYTES: u64 = 64 * 1024 * 1024;
 const COMMAND_SCOPE_API_VERSION: &str = "0.7.0";
 const COMMAND_ARGUMENTS_API_VERSION: &str = "0.11.0";
+const INDENTATION_API_VERSION: &str = "0.12.0";
 
 /// A parsed and validated stable plugin identifier.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -319,11 +320,21 @@ impl PluginPackageManifest {
             let Some(grammar) = &language.grammar else {
                 continue;
             };
+            if !grammar.indents.is_empty() {
+                anyhow::ensure!(
+                    host_api_requirement_requires_at_least(
+                        &self.plugin.red_api,
+                        INDENTATION_API_VERSION
+                    )?,
+                    "indentation queries require red_api = \"^{INDENTATION_API_VERSION}\" or later"
+                );
+            }
             for relative in grammar
                 .path
                 .iter()
                 .chain(grammar.highlights.iter())
                 .chain(grammar.textobjects.iter())
+                .chain(grammar.indents.iter())
                 .chain(grammar.injections.iter())
             {
                 validate_package_file(package_root, relative)?;
@@ -2180,9 +2191,11 @@ symbol = "tree_sitter_buildspec"
             "(function_item) @function.outer",
         )
         .unwrap();
+        fs::write(query_dir.join("indents.scm"), "\"{\" @indent.begin").unwrap();
         let manifest_path = package.path().join(PLUGIN_MANIFEST_FILE);
         let mut source = fs::read_to_string(&manifest_path).unwrap();
         source.push_str("textobjects = [\"queries/textobjects.scm\"]\n");
+        source.push_str("indents = [\"queries/indents.scm\"]\n");
         fs::write(&manifest_path, source).unwrap();
         let manager = PluginPackageManager::new(config.path());
 
@@ -2206,6 +2219,22 @@ symbol = "tree_sitter_buildspec"
                 .textobjects,
             [installed.package_root.join("queries/textobjects.scm")]
         );
+        assert_eq!(
+            loaded.config.languages["buildspec"]
+                .grammar
+                .as_ref()
+                .unwrap()
+                .indents,
+            [installed.package_root.join("queries/indents.scm")]
+        );
+        let old_api = fs::read_to_string(&manifest_path)
+            .unwrap()
+            .replace(&format!("^{RED_HOST_API_VERSION}"), "^0.11.0");
+        fs::write(&manifest_path, old_api).unwrap();
+        assert!(PluginPackageManifest::load(package.path())
+            .unwrap_err()
+            .to_string()
+            .contains(INDENTATION_API_VERSION));
     }
 
     #[tokio::test]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -33,7 +33,7 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.11.0";
+pub const RED_HOST_API_VERSION: &str = "0.12.0";
 pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
     "0.4.0",
     "0.6.0",
@@ -41,6 +41,7 @@ pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
     "0.8.0",
     "0.9.0",
     "0.10.0",
+    "0.11.0",
     RED_HOST_API_VERSION,
 ];
 

--- a/src/queries/indents/bash.scm
+++ b/src/queries/indents/bash.scm
@@ -1,0 +1,11 @@
+; Red-owned indentation query v1.
+["{" "(" "["] @indent.begin
+["}" ")" "]"] @indent.end
+((if_statement "then" @indent.begin) (#set! indent.match "fi"))
+("fi" @indent.end (#set! indent.match "fi"))
+(["elif" "else"] @indent.branch (#set! indent.match "fi"))
+("do" @indent.begin (#set! indent.match "done"))
+("done" @indent.end (#set! indent.match "done"))
+("case" @indent.begin (#set! indent.match "esac"))
+("esac" @indent.end (#set! indent.match "esac"))
+[(ansi_c_string) (comment) (heredoc_body) (raw_string) (regex) (string) (translated_string)] @indent.ignore

--- a/src/queries/indents/ecma.scm
+++ b/src/queries/indents/ecma.scm
@@ -1,0 +1,4 @@
+; Red-owned indentation query v1.
+["{" "(" "["] @indent.begin
+["}" ")" "]"] @indent.end
+[(comment) (regex) (string) (template_string)] @indent.ignore

--- a/src/queries/indents/fish.scm
+++ b/src/queries/indents/fish.scm
@@ -1,0 +1,7 @@
+; Red-owned indentation query v1.
+["{" "(" "["] @indent.begin
+["}" ")" "]"] @indent.end
+([(if_statement "if" @indent.begin) (for_statement "for" @indent.begin) (while_statement "while" @indent.begin) (function_definition "function" @indent.begin) (begin_statement "begin" @indent.begin) (switch_statement "switch" @indent.begin)] (#set! indent.match "end"))
+("end" @indent.end (#set! indent.match "end"))
+(["else" "case"] @indent.branch (#set! indent.match "end"))
+[(comment) (double_quote_string) (single_quote_string)] @indent.ignore

--- a/src/queries/indents/json.scm
+++ b/src/queries/indents/json.scm
@@ -1,0 +1,4 @@
+; Red-owned indentation query v1.
+["{" "["] @indent.begin
+["}" "]"] @indent.end
+[(comment) (string)] @indent.ignore

--- a/src/queries/indents/lua.scm
+++ b/src/queries/indents/lua.scm
@@ -1,0 +1,9 @@
+; Red-owned indentation query v1.
+["{" "(" "["] @indent.begin
+["}" ")" "]"] @indent.end
+([(function_declaration "function" @indent.begin) (function_definition "function" @indent.begin) (if_statement "then" @indent.begin) (do_statement "do" @indent.begin) (for_statement "do" @indent.begin) (while_statement "do" @indent.begin)] (#set! indent.match "end"))
+("end" @indent.end (#set! indent.match "end"))
+(["else" "elseif"] @indent.branch (#set! indent.match "end"))
+("repeat" @indent.begin (#set! indent.match "until"))
+("until" @indent.end (#set! indent.match "until"))
+[(comment) (string)] @indent.ignore

--- a/src/queries/indents/powershell.scm
+++ b/src/queries/indents/powershell.scm
@@ -1,0 +1,4 @@
+; Red-owned indentation query v1.
+["{" "(" "["] @indent.begin
+["}" ")" "]"] @indent.end
+[(comment) (expandable_here_string_literal) (expandable_string_literal) (string_literal) (verbatim_here_string_characters) (verbatim_string_characters)] @indent.ignore

--- a/src/queries/indents/rust.scm
+++ b/src/queries/indents/rust.scm
@@ -1,0 +1,4 @@
+; Red indentation query v1. Strings and comments are opaque to delimiter rules.
+["{" "(" "["] @indent.begin
+["}" ")" "]"] @indent.end
+[(line_comment) (block_comment) (string_literal) (raw_string_literal) (char_literal)] @indent.ignore

--- a/src/queries/indents/toml.scm
+++ b/src/queries/indents/toml.scm
@@ -1,0 +1,4 @@
+; Red-owned indentation query v1.
+["{" "["] @indent.begin
+["}" "]"] @indent.end
+[(comment) (string)] @indent.ignore

--- a/src/queries/indents/yaml.scm
+++ b/src/queries/indents/yaml.scm
@@ -1,0 +1,4 @@
+; Red-owned indentation query v1.
+["{" "["] @indent.begin
+["}" "]"] @indent.end
+[(block_scalar) (comment) (string_scalar)] @indent.ignore

--- a/src/syntax_indent.rs
+++ b/src/syntax_indent.rs
@@ -1,0 +1,715 @@
+//! Bounded, editor-owned indentation driven by language-pack Tree-sitter queries.
+//!
+//! Queries describe structure, never edits. Display-column decisions are applied by
+//! the editor's existing transaction boundary. Unknown query features are rejected.
+
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Range,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use anyhow::{anyhow, Context as _};
+use tree_sitter::{
+    InputEdit, ParseOptions, Parser, Point, Query, QueryCursor, QueryCursorOptions,
+    StreamingIterator, Tree,
+};
+
+use crate::{
+    buffer::BufferId, highlighter::LanguageRegistry, indent::IndentDecision,
+    unicode_utils::display_width_with_tabs,
+};
+
+const MAX_BYTES: usize = 2 * 1024 * 1024;
+const MAX_EVENTS: usize = 100_000;
+const PARSE_BUDGET: Duration = Duration::from_millis(25);
+const QUERY_BUDGET: Duration = Duration::from_millis(15);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IndentReason {
+    NewLine,
+    Typed,
+}
+
+pub(crate) struct IndentRequest<'a> {
+    pub id: BufferId,
+    pub revision: u64,
+    pub language: &'a str,
+    pub source: &'a str,
+    pub line: usize,
+    pub shift_width: usize,
+    pub tab_width: usize,
+    pub reason: IndentReason,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Begin,
+    End,
+    Branch,
+    Ignore,
+    Zero,
+    Continuation,
+}
+
+#[derive(Clone)]
+struct Event {
+    kind: Kind,
+    bytes: Range<usize>,
+    line: usize,
+    key: String,
+}
+
+struct Document {
+    revision: u64,
+    language: String,
+    source: String,
+    parser: Parser,
+    tree: Tree,
+}
+
+/// Keeps native grammar owners alive for every cached tree and compiled query.
+pub(crate) struct SyntaxIndentation {
+    queries: HashMap<String, Arc<Query>>,
+    documents: HashMap<BufferId, Document>,
+    // Fields drop in declaration order: native grammar libraries must outlive
+    // the queries, parsers, and trees that refer to their static tables.
+    registry: Arc<LanguageRegistry>,
+}
+
+pub(crate) fn validate_query(query: &Query) -> anyhow::Result<()> {
+    for name in query.capture_names() {
+        anyhow::ensure!(
+            matches!(
+                *name,
+                "indent.begin"
+                    | "indent.end"
+                    | "indent.branch"
+                    | "indent.ignore"
+                    | "indent.zero"
+                    | "indent.match"
+                    | "indent.continuation"
+            ),
+            "unsupported indentation capture @{name}"
+        );
+    }
+    for pattern in 0..query.pattern_count() {
+        anyhow::ensure!(
+            query.general_predicates(pattern).is_empty()
+                && query.property_predicates(pattern).is_empty(),
+            "unsupported indentation predicate in pattern {pattern}"
+        );
+        for property in query.property_settings(pattern) {
+            anyhow::ensure!(
+                property.capture_id.is_none()
+                    && property.key.as_ref() == "indent.match"
+                    && property
+                        .value
+                        .as_deref()
+                        .is_some_and(|value| !value.is_empty()),
+                "unsupported indentation property {}",
+                property.key
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Avoid reparsing ordinary text while allowing keyword closers such as `end`.
+pub(crate) fn is_reindent_candidate(inserted: char, line: &str) -> bool {
+    let text = line.trim();
+    matches!(inserted, '}' | ')' | ']' | '>')
+        || (inserted.is_ascii_alphabetic()
+            && !text.is_empty()
+            && text.len() <= 32
+            && text.chars().all(|c| c.is_ascii_alphabetic()))
+}
+
+impl SyntaxIndentation {
+    pub(crate) fn new(registry: Arc<LanguageRegistry>) -> Self {
+        Self {
+            registry,
+            queries: HashMap::new(),
+            documents: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn reset(&mut self, registry: Arc<LanguageRegistry>) {
+        self.documents.clear();
+        self.queries.clear();
+        self.registry = registry;
+    }
+
+    pub(crate) fn indent(&mut self, request: IndentRequest<'_>) -> IndentDecision {
+        self.try_indent(request).unwrap_or(IndentDecision::Keep)
+    }
+
+    fn try_indent(&mut self, request: IndentRequest<'_>) -> anyhow::Result<IndentDecision> {
+        let IndentRequest {
+            id,
+            revision,
+            language,
+            source,
+            line,
+            shift_width,
+            tab_width,
+            reason,
+        } = request;
+        let widths = (shift_width, tab_width);
+        if source.len() > MAX_BYTES {
+            return Ok(IndentDecision::Keep);
+        }
+        let lines = source.split('\n').collect::<Vec<_>>();
+        let Some(target) = lines.get(line) else {
+            return Ok(IndentDecision::Keep);
+        };
+        let start = lines[..line].iter().map(|s| s.len() + 1).sum::<usize>();
+        let first = start + target.len() - target.trim_start().len();
+        let Some(events) = self.events(id, revision, language, source, start + target.len())?
+        else {
+            return Ok(IndentDecision::Keep);
+        };
+        if events
+            .iter()
+            .any(|e| e.kind == Kind::Ignore && e.bytes.start < first && first < e.bytes.end)
+        {
+            return Ok(IndentDecision::Keep);
+        }
+        let events = significant_events(events);
+        if events.is_empty() {
+            return Ok(IndentDecision::Keep);
+        }
+        let target_event = events.iter().find(|e| {
+            e.bytes.start == first && matches!(e.kind, Kind::End | Kind::Branch | Kind::Zero)
+        });
+        if reason == IndentReason::Typed && target_event.is_none() {
+            return Ok(IndentDecision::Keep);
+        }
+        if target_event.is_some_and(|e| e.kind == Kind::Zero) {
+            return Ok(IndentDecision::Columns(0));
+        }
+
+        let mut stack: Vec<&Event> = Vec::new();
+        for event in events.iter().take_while(|e| e.bytes.start < first) {
+            apply_event(&mut stack, event);
+        }
+        if let Some(closer) = target_event {
+            if let Some(opener) = stack.iter().rev().find(|e| e.key == closer.key) {
+                return Ok(IndentDecision::Columns(columns(
+                    lines[opener.line],
+                    widths.1,
+                )));
+            }
+            return Ok(IndentDecision::Keep);
+        }
+        let target_depth = depth(&stack);
+        let Some(previous) = (0..line).rev().find(|i| !lines[*i].trim().is_empty()) else {
+            return Ok(IndentDecision::Columns(0));
+        };
+        let continuation_lines = events
+            .iter()
+            .filter(|e| e.kind == Kind::Continuation)
+            .map(|e| e.line)
+            .collect::<HashSet<_>>();
+        let continued = |line| continuation_lines.contains(&line);
+        if continued(previous) || previous.checked_sub(1).is_some_and(continued) {
+            let mut anchor = previous;
+            while anchor > 0 && continued(anchor - 1) {
+                anchor -= 1;
+            }
+            let extra = if continued(previous) {
+                widths.0.max(1)
+            } else {
+                0
+            };
+            return Ok(IndentDecision::Columns(
+                columns(lines[anchor], widths.1) + extra,
+            ));
+        }
+        let previous_start = lines[..previous].iter().map(|s| s.len() + 1).sum::<usize>();
+        let previous_first =
+            previous_start + lines[previous].len() - lines[previous].trim_start().len();
+        stack.clear();
+        for event in events
+            .iter()
+            .take_while(|e| e.bytes.start <= previous_first)
+        {
+            if event.bytes.start == previous_first && event.kind == Kind::Branch {
+                if let Some(index) = stack.iter().rposition(|open| open.key == event.key) {
+                    stack.truncate(index);
+                }
+                break;
+            }
+            if event.bytes.start == previous_first && event.kind != Kind::End {
+                break;
+            }
+            apply_event(&mut stack, event);
+        }
+        let delta = target_depth as isize - depth(&stack) as isize;
+        let expected = columns(lines[previous], widths.1)
+            .saturating_add_signed(delta.saturating_mul(widths.0.max(1) as isize));
+        Ok(IndentDecision::Columns(expected))
+    }
+
+    /// Only split an empty, syntactically recognized pair. Never split string text.
+    pub(crate) fn split_pair(
+        &mut self,
+        id: BufferId,
+        revision: u64,
+        language: &str,
+        source: &str,
+        cursor: usize,
+    ) -> bool {
+        let Ok(Some(events)) = self.events(id, revision, language, source, source.len()) else {
+            return false;
+        };
+        let events = significant_events(events);
+        let before = events.iter().rev().find(|e| e.bytes.end <= cursor);
+        let after = events.iter().find(|e| e.bytes.start >= cursor);
+        match (before, after) {
+            (Some(before), Some(after)) => {
+                before.kind == Kind::Begin
+                    && after.kind == Kind::End
+                    && before.key == after.key
+                    && source[before.bytes.end..after.bytes.start]
+                        .chars()
+                        .all(|c| c == ' ' || c == '\t')
+            }
+            _ => false,
+        }
+    }
+
+    fn events(
+        &mut self,
+        id: BufferId,
+        revision: u64,
+        language_id: &str,
+        source: &str,
+        end: usize,
+    ) -> anyhow::Result<Option<Vec<Event>>> {
+        if source.len() > MAX_BYTES {
+            return Ok(None);
+        }
+        let query = if let Some(query) = self.queries.get(language_id) {
+            Arc::clone(query)
+        } else {
+            let Some((language, text)) = self.registry.indentation_language(language_id) else {
+                return Ok(None);
+            };
+            let query = Query::new(&language, &text)?;
+            validate_query(&query)?;
+            let query = Arc::new(query);
+            self.queries
+                .insert(language_id.to_owned(), Arc::clone(&query));
+            query
+        };
+        let current = self.documents.get(&id).is_some_and(|d| {
+            d.revision == revision && d.language == language_id && d.source == source
+        });
+        if !current {
+            let previous = self
+                .documents
+                .remove(&id)
+                .filter(|d| d.language == language_id);
+            let (mut parser, old_tree) = if let Some(mut previous) = previous {
+                previous
+                    .tree
+                    .edit(&replacement_edit(&previous.source, source));
+                (previous.parser, Some(previous.tree))
+            } else {
+                let (language, _) = self
+                    .registry
+                    .indentation_language(language_id)
+                    .ok_or_else(|| anyhow!("missing indentation grammar"))?;
+                let mut parser = Parser::new();
+                parser.set_language(&language)?;
+                (parser, None)
+            };
+            let started = Instant::now();
+            let mut cancel = |_: &tree_sitter::ParseState| started.elapsed() > PARSE_BUDGET;
+            let tree = parser
+                .parse_with_options(
+                    &mut |offset, _| source.as_bytes().get(offset..).unwrap_or_default(),
+                    old_tree.as_ref(),
+                    Some(ParseOptions::new().progress_callback(&mut cancel)),
+                )
+                .ok_or_else(|| anyhow!("indentation parse budget exceeded"))?;
+            if self.documents.len() >= 16 {
+                self.documents.clear();
+            }
+            self.documents.insert(
+                id,
+                Document {
+                    revision,
+                    language: language_id.to_owned(),
+                    source: source.to_owned(),
+                    parser,
+                    tree,
+                },
+            );
+        }
+        let document = &self.documents[&id];
+        let mut cursor = QueryCursor::new();
+        cursor.set_byte_range(0..end.saturating_add(1));
+        let started = Instant::now();
+        let mut cancelled = false;
+        let mut cancel = |_: &tree_sitter::QueryCursorState| {
+            cancelled = started.elapsed() > QUERY_BUDGET;
+            cancelled
+        };
+        let mut matches = cursor.matches_with_options(
+            &query,
+            document.tree.root_node(),
+            source.as_bytes(),
+            QueryCursorOptions::new().progress_callback(&mut cancel),
+        );
+        let mut events = Vec::new();
+        while let Some(matched) = matches.next() {
+            let captured_group = matched
+                .captures
+                .iter()
+                .find(|c| query.capture_names()[c.index as usize] == "indent.match")
+                .and_then(|c| c.node.utf8_text(source.as_bytes()).ok());
+            let group = captured_group.or_else(|| {
+                query
+                    .property_settings(matched.pattern_index)
+                    .iter()
+                    .find(|p| p.key.as_ref() == "indent.match")
+                    .and_then(|p| p.value.as_deref())
+            });
+            for capture in matched.captures {
+                let kind = match query.capture_names()[capture.index as usize] {
+                    "indent.begin" => Kind::Begin,
+                    "indent.end" => Kind::End,
+                    "indent.branch" => Kind::Branch,
+                    "indent.ignore" => Kind::Ignore,
+                    "indent.zero" => Kind::Zero,
+                    "indent.continuation" => Kind::Continuation,
+                    _ => continue,
+                };
+                let node = capture.node;
+                if node.is_missing() {
+                    continue;
+                }
+                let text = node.utf8_text(source.as_bytes()).unwrap_or_default();
+                let key = if matches!(kind, Kind::Ignore | Kind::Zero | Kind::Continuation) {
+                    ""
+                } else {
+                    group.unwrap_or_else(|| {
+                        if kind == Kind::Begin {
+                            match text {
+                                "{" => "}",
+                                "(" => ")",
+                                "[" => "]",
+                                _ => text,
+                            }
+                        } else {
+                            text
+                        }
+                    })
+                };
+                events.push(Event {
+                    kind,
+                    bytes: node.byte_range(),
+                    line: node.start_position().row,
+                    key: key.to_owned(),
+                });
+                anyhow::ensure!(events.len() <= MAX_EVENTS, "too many indentation captures");
+            }
+        }
+        drop(matches);
+        anyhow::ensure!(
+            !cancelled && !cursor.did_exceed_match_limit(),
+            "indentation query budget exceeded"
+        );
+        events.sort_by_key(|e| (e.bytes.start, e.bytes.end));
+        Ok(Some(events))
+    }
+}
+
+fn significant_events(events: Vec<Event>) -> Vec<Event> {
+    let mut ignored: Vec<Range<usize>> = Vec::new();
+    for event in events.iter().filter(|e| e.kind == Kind::Ignore) {
+        if let Some(last) = ignored
+            .last_mut()
+            .filter(|last| event.bytes.start <= last.end)
+        {
+            last.end = last.end.max(event.bytes.end);
+        } else {
+            ignored.push(event.bytes.clone());
+        }
+    }
+    let mut result = events
+        .into_iter()
+        .filter(|e| {
+            if e.kind == Kind::Ignore {
+                return false;
+            }
+            let index = ignored.partition_point(|range| range.start <= e.bytes.start);
+            index == 0 || e.bytes.end > ignored[index - 1].end
+        })
+        .collect::<Vec<_>>();
+    result.dedup_by(|a, b| a.kind == b.kind && a.bytes == b.bytes && a.key == b.key);
+    result
+}
+
+fn apply_event<'a>(stack: &mut Vec<&'a Event>, event: &'a Event) {
+    match event.kind {
+        Kind::Begin => stack.push(event),
+        Kind::End => {
+            if let Some(index) = stack.iter().rposition(|open| open.key == event.key) {
+                stack.truncate(index);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn depth(stack: &[&Event]) -> usize {
+    stack.iter().map(|e| e.line).collect::<HashSet<_>>().len()
+}
+
+fn columns(line: &str, tab_width: usize) -> usize {
+    let whitespace = &line[..line.len() - line.trim_start_matches([' ', '\t']).len()];
+    display_width_with_tabs(whitespace, tab_width.max(1))
+}
+
+fn point(source: &str, byte: usize) -> Point {
+    let prefix = &source[..byte];
+    Point::new(
+        prefix.bytes().filter(|b| *b == b'\n').count(),
+        prefix.rfind('\n').map_or(byte, |i| byte - i - 1),
+    )
+}
+
+fn replacement_edit(old: &str, new: &str) -> InputEdit {
+    let mut start = old
+        .bytes()
+        .zip(new.bytes())
+        .take_while(|(a, b)| a == b)
+        .count();
+    while !old.is_char_boundary(start) || !new.is_char_boundary(start) {
+        start -= 1;
+    }
+    let mut suffix = old[start..]
+        .bytes()
+        .rev()
+        .zip(new[start..].bytes().rev())
+        .take_while(|(a, b)| a == b)
+        .count();
+    while !old.is_char_boundary(old.len() - suffix) || !new.is_char_boundary(new.len() - suffix) {
+        suffix -= 1;
+    }
+    let old_end = old.len() - suffix;
+    let new_end = new.len() - suffix;
+    InputEdit {
+        start_byte: start,
+        old_end_byte: old_end,
+        new_end_byte: new_end,
+        start_position: point(old, start),
+        old_end_position: point(old, old_end),
+        new_end_position: point(new, new_end),
+    }
+}
+
+/// Runs portable indentation fixtures against the same provider used by the editor.
+pub fn check_fixtures(
+    path: &std::path::Path,
+    registry: Arc<LanguageRegistry>,
+) -> anyhow::Result<usize> {
+    #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct Fixture {
+        name: String,
+        language: String,
+        source: String,
+        line: usize,
+        expected: usize,
+        #[serde(default = "four")]
+        width: usize,
+    }
+    fn four() -> usize {
+        4
+    }
+    let fixtures: Vec<Fixture> = serde_json::from_str(&std::fs::read_to_string(path)?)
+        .context("invalid indentation fixtures")?;
+    for fixture in &fixtures {
+        anyhow::ensure!(
+            registry.indentation_language(&fixture.language).is_some(),
+            "{}: no indentation queries loaded for {}",
+            fixture.name,
+            fixture.language
+        );
+    }
+    let mut service = SyntaxIndentation::new(registry);
+    for fixture in &fixtures {
+        let buffer = crate::buffer::Buffer::new(None, fixture.source.clone());
+        let mut decision = service.indent(IndentRequest {
+            id: buffer.id(),
+            revision: buffer.revision(),
+            language: &fixture.language,
+            source: &fixture.source,
+            line: fixture.line,
+            shift_width: fixture.width,
+            tab_width: fixture.width,
+            reason: IndentReason::NewLine,
+        });
+        if decision == IndentDecision::Keep {
+            decision = crate::indent::indent_for_line(
+                Some(&fixture.language),
+                &fixture.source,
+                fixture.line,
+                fixture.width,
+                fixture.width,
+            );
+        }
+        if decision == IndentDecision::Keep {
+            let line = fixture
+                .source
+                .split('\n')
+                .nth(fixture.line)
+                .ok_or_else(|| anyhow!("{}: target line is out of range", fixture.name))?;
+            decision = IndentDecision::Columns(columns(line, fixture.width));
+        }
+        anyhow::ensure!(
+            decision == IndentDecision::Columns(fixture.expected),
+            "{}: expected {} columns, got {:?}",
+            fixture.name,
+            fixture.expected,
+            decision
+        );
+    }
+    Ok(fixtures.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::Buffer;
+
+    #[test]
+    fn bundled_language_behavior_fixtures() {
+        let path = std::path::Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/indent/bundled.json"
+        ));
+        assert_eq!(
+            check_fixtures(path, Arc::new(LanguageRegistry::bundled())).unwrap(),
+            14
+        );
+    }
+
+    #[test]
+    fn every_bundled_indentation_query_compiles() {
+        let registry = LanguageRegistry::bundled();
+        for language in [
+            "rust",
+            "javascript",
+            "jsx",
+            "typescript",
+            "tsx",
+            "json",
+            "toml",
+            "powershell",
+            "bash",
+            "fish",
+            "lua",
+            "yaml",
+        ] {
+            let (grammar, source) = registry.indentation_language(language).unwrap();
+            let query =
+                Query::new(&grammar, &source).unwrap_or_else(|error| panic!("{language}: {error}"));
+            validate_query(&query).unwrap();
+        }
+    }
+
+    fn decision(source: &str, line: usize) -> IndentDecision {
+        let buffer = Buffer::new(Some("sample.rs".into()), source.into());
+        SyntaxIndentation::new(Arc::new(LanguageRegistry::bundled())).indent(IndentRequest {
+            id: buffer.id(),
+            revision: buffer.revision(),
+            language: "rust",
+            source,
+            line,
+            shift_width: 4,
+            tab_width: 4,
+            reason: IndentReason::NewLine,
+        })
+    }
+
+    #[test]
+    fn rust_nested_incomplete_blocks_and_closers() {
+        for (source, line, expected) in [
+            ("fn wrap() {\n    if pos.x > 0 {\n\n}", 2, 8),
+            ("fn wrap() {\n    if ready {\n        work();\n\n}", 3, 8),
+            (
+                "fn wrap() {\n    if ready {\n        work();\n        }\n}",
+                3,
+                4,
+            ),
+            (
+                "fn wrap() {\n    if ready {\n        work();\n    }\n\n}",
+                4,
+                4,
+            ),
+            ("fn wrap() {\n    call(\n\n    );\n}", 2, 8),
+            ("fn wrap() {\n\n\n}", 2, 4),
+            ("fn wrap() {\n    let s = r###\"{[(\"###;\n\n}", 2, 4),
+            ("fn wrap() {\n    // {[(\n\n}", 2, 4),
+            ("fn wrap() {\n    if ready {}\n\n}", 2, 4),
+        ] {
+            assert_eq!(
+                decision(source, line),
+                IndentDecision::Columns(expected),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn rust_multiline_literals_keep_manual_whitespace() {
+        assert_eq!(
+            decision("fn f() {\n    let s = r#\"hello\n  world\n\"#;\n}", 2),
+            IndentDecision::Keep
+        );
+    }
+
+    #[test]
+    fn incremental_parse_handles_unicode_and_revisions() {
+        let buffer = Buffer::new(None, String::new());
+        let mut service = SyntaxIndentation::new(Arc::new(LanguageRegistry::bundled()));
+        for (revision, source, expected) in [
+            (1, "fn f() {\n    // café\n\n}", 4),
+            (2, "fn f() {\n    if café {\n\n}", 8),
+            (3, "fn f() {\n    // 🦀\n\n}", 4),
+        ] {
+            assert_eq!(
+                service.indent(IndentRequest {
+                    id: buffer.id(),
+                    revision,
+                    language: "rust",
+                    source,
+                    line: 2,
+                    shift_width: 4,
+                    tab_width: 4,
+                    reason: IndentReason::NewLine
+                }),
+                IndentDecision::Columns(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_query_features_fail_closed() {
+        let language = tree_sitter_rust::LANGUAGE.into();
+        for source in [
+            "(block) @indent.unknown",
+            "((block) @indent.begin (#set! unsupported \"yes\"))",
+            "((block) @indent.begin (#unknown? @indent.begin))",
+        ] {
+            let query = Query::new(&language, source).unwrap();
+            assert!(validate_query(&query).is_err());
+        }
+    }
+}

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -481,6 +481,81 @@ fn python_harness(contents: &str) -> EditorHarness {
 }
 
 #[tokio::test]
+async fn rust_syntax_indentation_open_lines_closer_and_undo() {
+    let source = "fn wrap() {\n    if pos.x > 0 {\n}\n";
+    let mut harness = comment_harness("main.rs", source);
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(8, 2);
+    harness.type_text("pos.x += SCREEN_WIDTH;").await.unwrap();
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(8, 3);
+    harness.type_text("}").await.unwrap();
+    harness.assert_cursor_at(5, 3);
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents(
+        "fn wrap() {\n    if pos.x > 0 {\n        pos.x += SCREEN_WIDTH;\n    }\n}\n",
+    );
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents(
+        "fn wrap() {\n    if pos.x > 0 {\n        pos.x += SCREEN_WIDTH;\n}\n",
+    );
+    harness.execute_action(Action::Redo).await.unwrap();
+    harness.assert_buffer_contents(
+        "fn wrap() {\n    if pos.x > 0 {\n        pos.x += SCREEN_WIDTH;\n    }\n}\n",
+    );
+}
+
+#[tokio::test]
+async fn rust_syntax_indentation_enter_splits_empty_pair() {
+    let mut harness = comment_harness("main.rs", "fn f() {}");
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::SetCursor(8, 0))
+        .await
+        .unwrap();
+    harness.execute_action(Action::InsertNewLine).await.unwrap();
+    harness.assert_cursor_at(4, 1);
+    harness.assert_buffer_contents("fn f() {\n    \n}");
+    harness.type_text("work();").await.unwrap();
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("fn f() {}");
+}
+
+#[tokio::test]
+async fn rust_syntax_indentation_open_above_closer() {
+    let mut harness = comment_harness("main.rs", "fn f() {\n}");
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness
+        .execute_action(Action::InsertLineAtCursor)
+        .await
+        .unwrap();
+    harness.assert_cursor_at(4, 1);
+    harness.type_text("work();").await.unwrap();
+    harness.assert_buffer_contents("fn f() {\n    work();\n}");
+}
+
+#[tokio::test]
 async fn comment_gcc_toggles_the_current_line() {
     let mut harness = comment_harness("main.rs", "    let value = 1;");
 

--- a/tests/fixtures/indent/bundled.json
+++ b/tests/fixtures/indent/bundled.json
@@ -1,0 +1,16 @@
+[
+  {"name":"javascript block","language":"javascript","source":"function f() {\n  if (ready) {\n\n  }\n}","line":2,"expected":4,"width":2},
+  {"name":"typescript block","language":"typescript","source":"function f(): void {\n  if (ready) {\n\n  }\n}","line":2,"expected":4,"width":2},
+  {"name":"jsx block","language":"jsx","source":"function f() {\n\n}","line":1,"expected":2,"width":2},
+  {"name":"tsx block","language":"tsx","source":"function f(): void {\n\n}","line":1,"expected":2,"width":2},
+  {"name":"json array","language":"json","source":"{\n  \"items\": [\n\n  ]\n}","line":2,"expected":4,"width":2},
+  {"name":"toml array","language":"toml","source":"items = [\n\n]","line":1,"expected":2,"width":2},
+  {"name":"yaml flow array","language":"yaml","source":"items: [\n\n]","line":1,"expected":2,"width":2},
+  {"name":"powershell block","language":"powershell","source":"function Test-Thing {\n\n}","line":1,"expected":4},
+  {"name":"bash if","language":"bash","source":"if true; then\n\nfi","line":1,"expected":2,"width":2},
+  {"name":"bash else","language":"bash","source":"if true; then\n  echo yes\nelse\n\nfi","line":3,"expected":2,"width":2},
+  {"name":"fish if","language":"fish","source":"if true\n\nend","line":1,"expected":4},
+  {"name":"fish else","language":"fish","source":"if true\n    echo yes\nelse\n\nend","line":3,"expected":4},
+  {"name":"lua function","language":"lua","source":"function f()\n\nend","line":1,"expected":4},
+  {"name":"lua branch","language":"lua","source":"if ready then\n    work()\nelse\n\nend","line":3,"expected":4}
+]


### PR DESCRIPTION
## Why

Opening a line after a nested Rust block copied the current line's indentation instead of entering the block. Python had language-aware indentation, but other languages lacked a shared way to describe it. This also left Enter and typed closing delimiters inconsistent.

## What changed

- Add a bounded, cached Tree-sitter indentation engine shared by `o`, `O`, Enter, and closing-token edits. It handles unfinished syntax, ignores comments and strings, splits empty pairs, and falls back to ordinary indentation when syntax information is unavailable.
- Bundle indentation queries for Rust and the other built-in grammars while preserving the existing Python provider.
- Add package-relative `grammar.indents` queries, validation, and the documented indentation capture contract. Advance the host API to 0.12.0 while retaining compatibility with older supported API minors.
- Add `red language check-indent`, behavior fixtures, and editor regressions covering the reported sequence, undo, empty pairs, and opening above a closer.

The companion [language-pack PR](https://github.com/codersauce/red-language-packs/pull/6) requires API 0.12.0. Release a compatible Red version before publishing those new pack versions.

## How to Test

1. Open a Rust file containing a function and a nested `if ... {`. Disable LSP and format-on-save so they cannot hide editor behavior.
2. On the `if` line, press `o`. The new line should have eight spaces. Type `pos.x += SCREEN_WIDTH;`, return to normal mode, and press `o` again. Indentation should remain at eight spaces. Type `}`; it should align with the `if` at four spaces.
3. Press Enter between `{}`. Expect an indented body line and a separate closing line. Check that braces inside a raw string or comment do not change indentation, and that undo restores the insertion session.
4. Run the focused regressions:
   ```sh
   cargo test --all-features rust_syntax_indentation -- --test-threads=1
   cargo test --all-features syntax_indent::tests -- --test-threads=1
   cargo run -- language check-indent tests/fixtures/indent/bundled.json
   ```
   Expect all editor/provider regressions and all 14 bundled fixture cases to pass.

## Validation

- Full all-targets/all-features suite: 2,697 passed, 0 failed, 1 ignored.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- All 17 external language-pack grammars built; all 36 pack indentation fixtures passed against this editor.
- Four real TUI smoke cases passed: the reported Rust sequence, raw-string braces, empty-pair splitting, and an installed external C pack.

Validation was run at `d91648e`. The target branch has since advanced; the merged result has not been tested locally.