### PR TITLE
perf(editor): speed up repeated edits

### DIFF
--- a/almanac/architecture/editor/lsp-document-sync.md
+++ b/almanac/architecture/editor/lsp-document-sync.md
@@ -9,16 +9,22 @@ sources:
   - id: editor
     type: file
     path: src/editor.rs
+  - id: edit-batch
+    type: file
+    path: src/editor/edit_batch.rs
+  - id: client
+    type: file
+    path: src/lsp/client.rs
   - id: lazy-tests
     type: file
     path: tests/lsp_lazy.rs
 ---
 
-LSP document sync in Red is owned by the editor, not by the LSP manager. The manager routes requests to server processes, while `LspCoordinator` records which document URIs the editor has told servers are open and which buffer revisions have already been delivered [@coordinator]. The editor opens a file buffer only when an LSP operation needs it, sends full-content change notifications after the editor mutation boundary, stores diagnostics by normalized URI, and closes or reopens documents when buffer identity changes [@editor]. This layer connects user actions from the [event loop](event-loop) to the process routing described by [LSP Client Lifecycle And Routing](../lsp/client-lifecycle-and-routing).
+LSP document sync in Red is owned by the editor, not by the LSP manager. The manager routes requests to server processes, while `LspCoordinator` records which document URIs the editor has told servers are open and which buffer revisions have already been delivered [@coordinator]. The editor opens a file buffer only when an LSP operation needs it, publishes canonical edits or a full-content fallback after the editor mutation boundary, stores diagnostics by normalized URI, and closes or reopens documents when buffer identity changes [@editor]. This layer connects user actions from the [event loop](event-loop) to the process routing described by [LSP Client Lifecycle And Routing](../lsp/client-lifecycle-and-routing).
 
 ## Coordinator State
 
-`LspCoordinator` has two pieces of state: `opened_documents`, a set of URI strings currently reported as open to LSP servers, and `notified_revisions`, a map from `BufferId` to the latest buffer revision delivered to external consumers [@coordinator]. `with_buffers` seeds revision state from existing buffers but starts with no opened documents, so constructing an editor does not imply `didOpen` [@coordinator].
+`LspCoordinator` tracks opened URI strings, the latest delivered revision per `BufferId`, and ordered pending canonical edits with their pre-edit Rope snapshot and revision chain. It also caches whether a revision uses line endings supported by the direct UTF-16 conversion [@coordinator]. `with_buffers` seeds revision state from existing buffers but starts with no opened documents, so constructing an editor does not imply `didOpen` [@coordinator].
 
 The coordinator is deliberately small. It can mark a URI opened or closed, clear all opened documents, record or seed a notified revision, test whether a revision is already notified, and forget a closed buffer [@coordinator]. That gives the editor enough memory to suppress duplicate opens, skip redundant flushes, and discard per-buffer revision state when a buffer is deleted [@coordinator].
 
@@ -30,7 +36,9 @@ Most LSP-facing actions call the lazy-open helper before issuing their request. 
 
 ## Change Delivery
 
-`notify_change` is the editor-side sync point after a content mutation. If block replay is active, it defers the notification; otherwise, when LSP is enabled and the current buffer has a file, it ensures the buffer is open and sends `did_change` with the full current buffer contents [@editor]. The same method then notifies plugins of `buffer:changed` and records the current buffer revision as notified [@editor].
+`notify_change` is the editor-side sync point after a content mutation. Local edit batches queue changed buffers by stable identity; nested dot, macro, counted, and block replay share the outer publication boundary. Unknown or external actions flush first, and mode transitions remain observable to plugins [@edit-batch]. Publication ensures the target buffer is open, sends its document change, emits `buffer:changed`, and records the delivered revision without switching the active window [@editor].
+
+Canonical replacements retain ordered UTF-16 ranges and cheap before/after Rope snapshots. Adjacent same-line insertions can merge. An incremental server receives those ranges only when its cached preimage matches exactly; full-sync servers, revision gaps such as undo, lazy-open mismatches, and unsupported line separators retain the full-text fallback [@coordinator] [@client]. Document versions and debounced diagnostics still advance through the client [@client].
 
 `flush_change_notification` reads the active buffer revision and returns early if the coordinator already recorded that exact revision [@editor]. Otherwise it calls `notify_change`, which keeps delayed or grouped changes from leaving the LSP and plugin observers behind the current buffer state [@editor]. This follows the same canonical mutation boundary described by [Text Mutation Boundary](text-mutation-boundary): direct buffer helpers can change text, but production actions must pass through the editor path that opens transactions and notifies observers.
 

--- a/almanac/architecture/editor/text-mutation-boundary.md
+++ b/almanac/architecture/editor/text-mutation-boundary.md
@@ -6,6 +6,9 @@ sources:
   - id: editor
     type: file
     path: src/editor.rs
+  - id: edit-batch
+    type: file
+    path: src/editor/edit_batch.rs
   - id: buffer
     type: file
     path: src/buffer.rs
@@ -29,13 +32,13 @@ The coordinate rule matters because surrounding systems use different units. The
 
 `begin_transaction` and `begin_transaction_with_origin` capture the current cursor snapshot and open a buffer-local undo transaction, optionally with an attributed origin such as user, plugin, agent, or LSP [@editor]. `replace_range` first reads the old text, returns early for no-op replacements, asserts that a transaction is active, computes the absolute character range, applies `Buffer::replace_range_raw`, updates marks, writes the special `.` mark, and records the old and new text in undo history [@editor]. `commit_transaction` delegates to `UndoHistory::commit_transaction` and refreshes the buffer dirty flag from history state [@editor].
 
-`UndoHistory` makes this a logical edit boundary rather than a raw diff list. A transaction stores ordered replacements, cursor state before and after, attribution, and revisions; commit advances the history revision once for the complete logical change and preserves sibling branches when editing after an undo [@undo]. Empty transactions are discarded, and equal old/new replacement records are ignored [@undo]. The user-facing model is covered by [Undo Tree](../../concepts/editor/undo-tree).
+`UndoHistory` makes this a logical edit boundary rather than a raw diff list. A transaction stores ordered replacements, cursor state before and after, attribution, and revisions; commit advances the history revision once for the complete logical change and preserves sibling branches when editing after an undo [@undo]. Empty transactions are discarded, equal old/new replacement records are ignored, and provably adjacent insertions within one active transaction are compacted without changing undo boundaries [@undo]. The user-facing model is covered by [Undo Tree](../../concepts/editor/undo-tree).
 
 ## Subsystems Updated By A Change
 
 The boundary updates more than text. Anchor maintenance transforms local, global, and special marks across the replacement, then recomputes fallback line/character positions from the buffer after the edit [@editor]. Dirty state is derived from undo history revisions, not from a separate ad hoc flag once the transaction commits [@editor]. Undo and redo temporarily take ownership of the buffer's undo history, replay raw replacements, refresh dirty state, update anchors, restore cursor snapshots, notify change consumers, and render [@editor].
 
-Notification is explicit. `notify_change` opens the current file in LSP if needed, sends `did_change` with full current buffer contents when LSP is enabled, emits a `buffer:changed` plugin notification with buffer identity, file path, revision, line count, and cursor coordinates, and records the delivered revision in `LspCoordinator` [@editor]. `flush_change_notification` skips duplicate notifications when the current buffer revision has already been delivered [@editor].
+Notification is explicit. `notify_change` queues delivery during a local edit batch; publication opens the file in LSP if needed, sends ordered canonical edits or a full-text fallback, emits a `buffer:changed` plugin notification with buffer identity, file path, revision, line count, and cursor coordinates, and records the delivered revision in `LspCoordinator` [@editor]. `flush_change_notification` skips duplicate notifications when the current buffer revision has already been delivered [@editor]. Batching delays only derived notifications and rendering: text, anchors, marks, revisions, modes, and undo state still change synchronously. External actions are publication barriers, and long synthetic replays use bounded checkpoints with Ctrl-C cancellation [@edit-batch].
 
 ## Entry Points
 

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -380,6 +380,17 @@ streaming lines to 256 KiB, and pending process events to 16 (at most roughly 32
 of payload); oversized output is
 reported without letting an untrusted process grow editor memory indefinitely.
 
+## Edit notification boundaries
+
+`buffer:changed`, `cursor:moved`, and `viewport:changed` describe the latest
+editor state. Dot-repeat, macros, counted edits, and visual-block replay may
+coalesce these notifications within a bounded group of source-local actions.
+Do not use their delivery count as an edit log; use the buffer revision and
+read the current document instead. Mode transitions remain observable in order.
+Explicit plugin commands, LSP requests, saves, and document switches flush
+pending changes before they execute. A long replay publishes intermediate
+states and can be interrupted with Ctrl-C without dropping other queued keys.
+
 ## Dynamic JSON boundary
 
 Event listeners and request callbacks decode host payloads according to their declared

--- a/docs/performance-edit-replay-2026-08-17.md
+++ b/docs/performance-edit-replay-2026-08-17.md
@@ -1,0 +1,135 @@
+# Red repeated-edit performance plan
+
+## Evidence
+
+Inspected on 2026-08-17 at `20f4cc2c36012a1399749737922b1faa65fc3506`.
+The primary checkout stayed clean. Local `origin/main` was `311a72e`, eight
+commits ahead; its syntax-indentation and signature-help changes were inspected.
+They do not replace the replay/render paths below. No running editor was touched.
+
+A one-off audit harness linked the inspected debug library and exercised the
+production dispatcher with default keymaps, `RED_PERF=trace`, disabled
+LSP/terminal output, and assertions on resulting text.
+It does not measure a live terminal, real language server, or loaded plugins.
+These are diagnostic samples, not release benchmarks or promised speedups.
+
+| Operation | Fixture | Time | Full renders | Highlight misses |
+| --- | --- | ---: | ---: | ---: |
+| Dot-repeat, 32 characters | 1,487,538-byte Rust source | 143.4 ms | 34 | 32 |
+| Bulk insert, 32 characters | Same source | 4.2 ms | 1 | 1 |
+| Dot-repeat, 128 characters | Same source | 638.6 ms | 130 | 128 |
+| Bulk insert, 128 characters | Same source | 5.5 ms | 1 | 1 |
+| Macro inserting 128 characters | Same source | 637.8 ms | 131 | 129 |
+| Undo that insertion | Same source | 9.6 ms | 1 | 1 |
+| `128x` | 256-character line | 339.6 ms | 131 | 129 |
+| Replicate 32 characters onto 15 more block rows | 16 short Rust lines | 3,441.1 ms | 481 | 480 |
+
+An earlier dot/bulk run measured 654.0 ms versus 5.8 ms for 128 characters.
+The second run spent 476.9 ms inside full-render spans and 9.6 ms inside
+character-replacement spans. Nested spans must not be added together.
+
+## Audit inventory
+
+- **Dot, macros, counts, and chained actions:** the [replay drivers](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L11692)
+  dispatch individual actions. Some operators already accept semantic counts,
+  but the generic fallback still repeats the whole action. Highest priority.
+- **Visual-block insert/change:** [execute_on_block](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L20699)
+  defers notifications and suppresses terminal output, but still constructs
+  scratch frames for each action on each row. Highest priority.
+- **Ordinary typing/deletion and split windows:** [render_edited_window_rows](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor/rendering.rs#L1582)
+  calls the full renderer. The [dispatcher tail](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L20265)
+  can render again for bounds changes or multiple windows.
+  [Highlight caches](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L6237) invalidate
+  on every content revision.
+- **LSP, plugins, inline summaries, and completion:** [notify_change](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L21294)
+  materializes full document text for LSP, awaits `buffer:changed`, refreshes
+  summaries, and schedules inline completion. Incremental LSP sync still
+  [compares old/new full strings](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/lsp/client.rs#L750).
+  Diagnostics are already debounced; document synchronization is not.
+- **Substitute-all, indentation, comments, completion edits, and plugin document
+  transactions:** [substitution](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L14558),
+  [indentation](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L16732),
+  [comments](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L22774), and
+  [plugin transactions](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L21599) are
+  already partly batched. Profile their remaining per-replacement anchor,
+  history, annotation, and dirty-state work before changing them.
+- **Undo/redo and whole-document replacements:** [undo history](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/undo.rs#L356)
+  retains individual replacements. Undo already renders once in this sample.
+  Visual paste, agent whole-file edits, and prepared LSP workspace edits can
+  replace a whole document; smaller edits may reduce copies and undo memory.
+- **Embedded text areas:** [TextArea replay](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editing/textarea.rs#L1530)
+  has a separate key-replay implementation and
+  [whole-text coordinate calculations](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editing/textarea.rs#L1724).
+  Benchmark large composer text separately; this component has no internal LSP
+  or terminal work.
+- **Newer main:** include syntax indentation and signature help in the baseline.
+  Keep indentation decisions that affect later edits synchronous; defer only
+  speculative UI work when safe.
+
+## Implementation order
+
+### 1. Permanent baselines
+
+Refresh main and use branch `fcoury/edit-replay-performance` in durable sibling
+worktree `red.fcoury-edit-replay-performance`. Extend
+`scripts/interaction_bench.py` or add a focused replay benchmark. Add counters
+for renders, highlight misses, replacements, LSP calls/bytes, plugin events,
+and inline-summary refreshes. Measure short/long inserts, large files, LSP and
+plugins off/on, shared-buffer splits, wrapping, and retained inline history.
+
+### 2. Batch replay rendering
+
+Add a small nested execution-batch boundary outside the large recursive
+dispatcher. Keep mutations, marks, revisions, selections, modes, and undo
+transactions exact. Accumulate render invalidation and commit one correct final
+frame for short commands. Apply it to dot, macros, generic counted/chained
+actions, and visual-block replay. Reuse existing navigation/block deferral where
+their semantics agree. Long macros need bounded work slices, cancellation, and
+background-service points. Preserve recursion limits and restore batch state on
+errors. Do not blindly convert arbitrary recorded keys into a paste.
+
+### 3. Batch notifications safely
+
+Track dirty buffers by stable `BufferId` and latest revision. Flush before LSP
+requests requiring current text, saves, document switches/closure, and other
+observable barriers. Define plugin event semantics before coalescing events:
+macros/plugins that depend on intermediate state must still see it. Preserve
+notification retry behavior. A plain single-buffer insertion replay should need
+one final change notification and one completion scheduling pass.
+
+### 4. Make individual edits cheaper
+
+Feed canonical replacements to incremental LSP synchronization, retaining
+full-sync support and correct UTF-16/CRLF conversion. Add safe changed-region
+rendering for interactive edits, with full-redraw fallbacks for syntax context,
+wrapping/layout changes, overlays, and shared-buffer windows. Preserve the
+existing committed-frame and document-aware highlighting invariants.
+
+### 5. Profile and optimize the remaining bulk paths
+
+Candidates: compact provably adjacent undo edits; defer derived history and
+annotation refreshes while transforming live anchors in order; implement more
+direct counted operations; retain smaller edit ranges for whole-document plans;
+cache or use rope-based coordinates in embedded text areas. Make these separate,
+measured changes rather than one editor rewrite.
+
+## Acceptance and validation
+
+- Compare final text, cursor, mode, registers, marks, selection, dirty state,
+  undo/redo, and rendered cells against the existing behavior.
+- Preserve location-relative dot semantics, literal periods, Unicode/emoji,
+  CRLF, tabs, EOF/final-newline edits, autoindent, snippets, visual-block padding,
+  nested macros, error recovery, and multi-buffer save/LSP/plugin barriers.
+- Assert work counts instead of machine-dependent timing thresholds. A short
+  plain-text repeat must not do one full render/highlight per character.
+- Keep the explicit 2 MiB-stack visual-block/dot regression. Avoid increasing
+  the recursive dispatcher frame.
+- Run focused tests, the full suite serially (`--test-threads=1`), formatting,
+  and `cargo clippy --all-targets --all-features -- -D warnings` before pushing.
+- Capture release-build PTY before/after evidence for dot, macros, block change,
+  cancellation, undo, and shared-buffer splits before claiming completion.
+
+Audit validation: `cargo build --locked --lib -p red` passed; all harness
+assertions passed; `cargo test --locked --test editing dot_ -- --test-threads=1`
+passed 12 tests at the inspected commit. The audit changed no production source
+and did not push or open a PR.

--- a/docs/performance-edit-replay-2026-08-17.md
+++ b/docs/performance-edit-replay-2026-08-17.md
@@ -133,3 +133,76 @@ Audit validation: `cargo build --locked --lib -p red` passed; all harness
 assertions passed; `cargo test --locked --test editing dot_ -- --test-threads=1`
 passed 12 tests at the inspected commit. The audit changed no production source
 and did not push or open a PR.
+
+
+## Implementation results
+
+Implemented on `fcoury/edit-replay-performance`, based on `122c0b8`. The
+original audit above remains a debug-build diagnosis; the table below is a
+separate release-build comparison against that exact implementation base.
+
+The shared edit batch keeps canonical mutations and undo boundaries synchronous,
+coalesces derived notifications and rendering, and flushes before external
+operations. Short repeats publish one final frame; long repeats use 16 ms / 512
+step checkpoints and accept Ctrl-C without dropping ordinary queued input.
+Visual-block replay no longer constructs hidden scratch frames. Ordinary edits
+reuse the document-aware editor-window renderer, including all shared-buffer
+windows, with existing full-frame safety fallbacks.
+
+Canonical edits now carry UTF-16 ranges and shared Rope snapshots to incremental
+LSP clients. Exact-preimage checks, revision gaps, full-sync servers, and unusual
+line separators retain the full-text fallback. Adjacent insert undo records are
+compacted within their existing transaction. Embedded text areas batch safe
+ASCII insert runs and retain per-key behavior at Unicode grapheme boundaries.
+
+### Release PTY comparison
+
+Measured on macOS arm64 with Rust 1.94.1, release builds, a 120 × 40 PTY,
+2,000 Rust lines, `RED_PERF=trace`, and isolated configuration. These are single
+local diagnostic samples, not CI timing thresholds. The benchmark verifies the
+saved text for every case.
+
+| Operation | Before | After | Before / after notifications |
+| --- | ---: | ---: | ---: |
+| Dot, 128 characters | 68.453 ms | 7.154 ms | 128 / 1 |
+| Macro, 128 characters | 69.171 ms | 6.309 ms | 128 / 1 |
+| `128x` | 74.732 ms | 23.243 ms | 128 / 2 |
+| Block insert, 16 rows × 128 characters | 1,593.209 ms | 91.423 ms | 1 / 1 |
+| Bracketed paste, 128 characters | 1.342 ms | 1.006 ms | 1 / 1 |
+| Substitute across 2,000 lines | 7.649 ms | 7.977 ms | 1 / 1 |
+| Indent 16 lines | 0.932 ms | 0.924 ms | 1 / 1 |
+| Undo insertion | 1.092 ms | 0.799 ms | 1 / 1 |
+
+Dot and macro full renders fell from 130 to 1. Block full renders fell from
+1,921 to 1. Counted deletion used two bounded publication slices in this run.
+With bundled plugins and a shared split, 64-character dot fell from 95.954 ms
+to 4.879 ms; the corresponding block replay fell from 1,604.028 ms to 40.059 ms.
+For a 32 KiB embedded text area, dot-128 fell from 65.100 ms to 0.764 ms with
+ASCII context, and from 135.057 ms to 2.349 ms with Unicode context.
+
+The local protocol fixture reconstructed the final document for dot, macro,
+counted delete, block, paste, substitute, indent, and undo using an incremental
+server, emoji, and CRLF. Dot used one range/notification instead of 128 and
+measured 10.009 ms versus 113.038 ms. With full synchronization, dot sent
+37,146 text bytes in one notification instead of 4,746,560 bytes in 128.
+The fixture also checks strictly increasing document versions.
+
+Reproduce with `scripts/edit_replay_bench.py`; use `--plugins --split`,
+`--lsp incremental --unicode --crlf`, or `--lsp full` for the additional matrices.
+Use `cargo run --locked --release --example textarea_replay_bench` for the
+embedded text-area comparison. Deterministic tests assert work counts and
+semantic results instead of machine-dependent timing limits.
+
+### Scope of the remaining candidates
+
+Substitute, indentation, paste, and undo already publish efficiently in the
+release baseline. Their existing transaction paths were retained and are covered
+by the PTY/protocol matrix. Anchor transformations still run in edit order;
+rewriting them or whole-document edit plans is not justified by these samples.
+Counted deletion retains its existing register and undo semantics rather than
+silently replacing repeated commands with a different bulk operation. A future
+profile can target those remaining mutation costs independently.
+
+Validation: `cargo test --locked --all-targets --all-features -- --test-threads=1`
+passed 2,784 tests with one ignored. Strict all-target/all-feature Clippy,
+`cargo fmt --all -- --check`, and `git diff --check` passed.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -20,6 +20,27 @@ path instead.
 
 Detached owners expose a separate lightweight render audit. `detach:idle_tick` counts background polls that correctly skipped serialization, `detach:rendered_tick` counts polls that produced a frame, `detach:serialize_frame` measures row/span serialization, and `detach:changed_rows` reports the maximum number of rows sent in one delta. These metrics complement, rather than replace, the native motion-frame gate above.
 
+## Repeated editing
+
+Run `python3 scripts/edit_replay_bench.py --binary target/release/red` for dot,
+macros, counted deletion, visual-block insertion, paste, substitute, indentation,
+and undo. Each case uses a real PTY and verifies the saved result. Add `--plugins`
+and `--split` to include bundled callbacks and shared-buffer windows. Compare
+exact-base and feature binaries on the same machine; the script reports complete
+input-event time, frame counts, highlight misses, and change notifications.
+Use `--lsp incremental` or `--lsp full` to launch a local protocol fixture that
+reconstructs the document and reports notification/payload counts. `--unicode`
+and `--crlf` exercise UTF-16 coordinates and Windows line endings without an
+installed language server.
+
+`cargo run --locked --release --example textarea_replay_bench` separately measures
+large embedded text areas. Neither benchmark imposes a wall-clock CI threshold.
+The deterministic replay tests instead assert publication counts, final frames,
+notification ordering, cancellation, and undo correctness. `RED_PERF=summary`
+also reports `edit:replacements`, `edit:change_notifications`,
+`edit:notifications_deferred`, `edit:replay_slices`, `edit:inline_summary_refreshes`,
+and full/incremental LSP byte counters.
+
 ## Deterministic CI gate
 
 CI runs:

--- a/examples/textarea_replay_bench.rs
+++ b/examples/textarea_replay_bench.rs
@@ -1,0 +1,35 @@
+//! Diagnostic replay timings for large embedded text areas. No timing assertions.
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use red::{editing::TextArea, editor::Mode};
+use std::time::Instant;
+
+fn keys(area: &mut TextArea, text: &str) {
+    for ch in text.chars() {
+        let code = if ch == '\u{1b}' {
+            KeyCode::Esc
+        } else {
+            KeyCode::Char(ch)
+        };
+        area.handle_event(&Event::Key(KeyEvent::new(code, KeyModifiers::NONE)), 80);
+    }
+}
+
+fn main() {
+    red::LOGGER.set(None).ok();
+    for prefix in ["a".repeat(32_768), "λ".repeat(16_384)] {
+        let mut area = TextArea::new(&prefix);
+        area.set_mode(Mode::Normal);
+        keys(&mut area, &format!("i{}\u{1b}", "x".repeat(128)));
+        let before = area.text().len();
+        let start = Instant::now();
+        keys(&mut area, ".");
+        let elapsed = start.elapsed();
+        assert_eq!(area.text().len(), before + 128);
+        println!(
+            "ascii={} dot-128={:.3}ms",
+            prefix.is_ascii(),
+            elapsed.as_secs_f64() * 1000.0
+        );
+    }
+}

--- a/scripts/edit_replay_bench.py
+++ b/scripts/edit_replay_bench.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Measure complete edit commands through a real PTY and verify their saved text.
+
+Example: python3 scripts/edit_replay_bench.py --binary target/release/red
+Use --plugins/--split for bundled callbacks and shared-buffer splits.
+Use --lsp full|incremental to verify document synchronization with a local server.
+"""
+
+import argparse
+from collections import defaultdict
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import pty
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import threading
+import time
+import tomllib
+
+ROOT = Path(__file__).resolve().parent.parent
+EVENT = re.compile(r"\[PERF\] event (?:Key\(|Paste\().*?: (\d+)us$")
+TIMING = re.compile(r"\[PERF\] ([\w:+-]+)(?: (.*?))?: (\d+)us$")
+SCENARIOS = ("dot", "macro", "delete", "block", "paste", "substitute", "indent", "undo")
+
+
+def run(args, scenario):
+    text = "x" * args.chars
+    newline = "\r\n" if args.crlf else "\n"
+    body = ' let emoji = "😀"; ' if args.unicode else ""
+    ordinary = "".join(f"fn value_{i}() {{{body}}}{newline}" for i in range(args.lines))
+    source = "z" * (args.chars * 2) + newline + ordinary if scenario == "delete" else ordinary
+    with tempfile.TemporaryDirectory(prefix="red-edit-replay-") as name:
+        root = Path(name)
+        config = root / "config" / "red"
+        config.mkdir(parents=True)
+        log = root / "red.log"
+        fixture = root / "fixture.rs"
+        fixture.write_bytes(source.encode())
+        lsp_state = root / "lsp-state.json"
+        server_config = ""
+        if args.lsp != "off":
+            server_args = [str(ROOT / "scripts/edit_replay_lsp.py"), "--mode", args.lsp, "--state", str(lsp_state)]
+            server_config = (
+                f"[lsp.servers.rust]\ncommand = {json.dumps(sys.executable)}\n"
+                f'args = {json.dumps(server_args)}\nlanguage_id = "rust"\n'
+                'file_extensions = ["rs"]\nroot_markers = []\n'
+            )
+        disabled = [] if args.plugins else list(tomllib.loads((ROOT / "default_config.toml").read_text())["plugins"])
+        (config / "config.toml").write_text(
+            f"log_file = {json.dumps(str(log))}\n"
+            f"disabled_plugins = {json.dumps(disabled)}\n"
+            "disable_ai = true\nshow_whats_new = false\nfetch_release_notes = false\n"
+            f"[lsp]\nenabled = {str(args.lsp != 'off').lower()}\n"
+            "[formatting]\non_save = false\n[completion]\nauto_trigger = false\n"
+            + server_config
+        )
+        master, slave = pty.openpty()
+        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", args.rows, args.cols, 0, 0))
+        process = subprocess.Popen(
+            [str(args.binary), "--root", str(root), str(fixture)],
+            stdin=slave, stdout=slave, stderr=slave,
+            env=dict(os.environ, XDG_CONFIG_HOME=str(root / "config"), RED_PERF="trace"),
+            close_fds=True,
+        )
+        os.close(slave)
+        drained = [0]
+
+        def drain():
+            while True:
+                try:
+                    data = os.read(master, 1 << 20)
+                except OSError:
+                    return
+                if not data:
+                    return
+                drained[0] += len(data)
+
+        thread = threading.Thread(target=drain, daemon=True)
+        thread.start()
+
+        def contents():
+            return log.read_text(errors="replace") if log.exists() else ""
+
+        def wait_for(predicate, description):
+            deadline = time.monotonic() + args.timeout
+            while time.monotonic() < deadline:
+                result = predicate()
+                if result:
+                    return result
+                if process.poll() is not None:
+                    raise RuntimeError(f"editor exited during {description}: {process.returncode}")
+                time.sleep(0.005)
+            raise TimeoutError(f"timed out during {description}")
+
+        def synced(expected):
+            expected_hash = hashlib.sha256(expected.encode()).hexdigest()
+
+            def read_state():
+                if not lsp_state.exists():
+                    return None
+                state = json.loads(lsp_state.read_text())
+                if "error" in state:
+                    raise AssertionError(f"LSP fixture: {state['error']}")
+                return state if state["sha256"] == expected_hash else None
+
+            return wait_for(read_state, "LSP document synchronization")
+
+        def send(data, events=None):
+            offset = len(contents())
+            os.write(master, data)
+            expected = len(data) if events is None else events
+
+            def completed():
+                segment = contents()[offset:]
+                return segment if sum(bool(EVENT.search(line)) for line in segment.splitlines()) >= expected else None
+
+            return wait_for(completed, repr(data[:40]))
+
+        try:
+            wait_for(lambda: "[PERF] startup:interactive:" in contents(), "startup")
+            if args.lsp != "off":
+                synced(source)
+            if args.split:
+                send(b"\x17v")
+            expected_before = source
+            if scenario in ("dot", "undo"):
+                send(b"i" + text.encode())
+                send(b"\x1b")
+                expected_before = text + source
+                trigger = b"." if scenario == "dot" else b"u"
+                expected = text * 2 + source if scenario == "dot" else source
+            elif scenario == "macro":
+                send(b"qai" + text.encode())
+                send(b"\x1b")
+                send(b"q@")
+                expected_before = text + source
+                trigger, expected = b"a", text * 2 + source
+            elif scenario == "delete":
+                send(str(args.chars).encode())
+                trigger, expected = b"x", "z" * args.chars + newline + ordinary
+            elif scenario == "block":
+                send(b"\x16" + str(args.block_rows - 1).encode() + b"jI" + text.encode())
+                expected_before = text + source
+                trigger = b"\x1b"
+                lines = source.splitlines(keepends=True)
+                expected = "".join((text if i < args.block_rows else "") + line for i, line in enumerate(lines))
+            elif scenario == "paste":
+                send(b"i")
+                trigger, expected = b"\x1b[200~" + text.encode() + b"\x1b[201~", text + source
+            elif scenario == "substitute":
+                send(b":%s/value/item/g")
+                trigger, expected = b"\r", source.replace("value", "item")
+            else:
+                send(b"ggV" + str(args.block_rows - 1).encode() + b"j")
+                trigger = b">"
+                lines = source.splitlines(keepends=True)
+                expected = "".join(("    " if i < args.block_rows else "") + line for i, line in enumerate(lines))
+
+            before_lsp = synced(expected_before) if args.lsp != "off" else None
+            before_bytes = drained[0]
+            segment = send(trigger, events=1)
+            samples = defaultdict(list)
+            event_us = []
+            for line in segment.splitlines():
+                if match := EVENT.search(line):
+                    event_us.append(int(match.group(1)))
+                if match := TIMING.search(line):
+                    label, detail, micros = match.groups()
+                    if label in ("notify", "husk:notify") and detail:
+                        label += " " + detail
+                    samples[label].append(int(micros))
+            result = {
+                "scenario": scenario, "chars": args.chars, "lines": args.lines,
+                "plugins": args.plugins, "split": args.split,
+                "event_ms": round(sum(event_us) / 1000, 3),
+                "output_bytes": drained[0] - before_bytes,
+                "full_renders": len(samples["render:full"]),
+                "editor_window_renders": len(samples["render:editor_windows"]),
+                "highlight_misses": len(samples["highlight:miss"]),
+                "buffer_notifications": len(samples["notify buffer:changed"]),
+            }
+            if before_lsp is not None:
+                after_lsp = synced(expected)
+                result.update({"lsp": args.lsp, **{
+                    f"lsp_{key}": after_lsp[key] - before_lsp[key]
+                    for key in ("notifications", "full", "incremental", "text_bytes")
+                }})
+            if args.unicode or args.crlf:
+                result.update(unicode=args.unicode, crlf=args.crlf)
+            if scenario == "paste":
+                send(b"\x1b")
+            os.write(master, b":wq\r")
+            process.wait(timeout=args.timeout)
+            actual = fixture.read_bytes().decode()
+            if actual != expected:
+                raise AssertionError(f"{scenario}: saved text mismatch ({len(actual)} != {len(expected)} bytes)")
+            if process.returncode != 0:
+                raise RuntimeError(f"editor exited {process.returncode}")
+            return result
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=3)
+            os.close(master)
+            thread.join(timeout=1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, default=ROOT / "target/release/red")
+    parser.add_argument("--scenario", choices=SCENARIOS, action="append")
+    parser.add_argument("--chars", type=int, default=128)
+    parser.add_argument("--lines", type=int, default=2000)
+    parser.add_argument("--block-rows", type=int, default=16)
+    parser.add_argument("--rows", type=int, default=40)
+    parser.add_argument("--cols", type=int, default=120)
+    parser.add_argument("--timeout", type=float, default=45)
+    parser.add_argument("--lsp", choices=("off", "full", "incremental"), default="off")
+    parser.add_argument("--unicode", action="store_true", help="use emoji in the source")
+    parser.add_argument("--crlf", action="store_true", help="use CRLF source lines")
+    parser.add_argument("--plugins", action="store_true")
+    parser.add_argument("--split", action="store_true")
+    args = parser.parse_args()
+    args.binary = args.binary.resolve()
+    if not args.binary.is_file() or not 1 <= args.chars <= 10000 or not 2 <= args.block_rows <= args.lines or args.rows < 5 or args.cols < 20:
+        parser.error("require an existing binary, 1..10000 chars, 2 <= block-rows <= lines, rows >= 5, cols >= 20")
+    for scenario in args.scenario or SCENARIOS:
+        print(json.dumps(run(args, scenario), sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edit_replay_lsp.py
+++ b/scripts/edit_replay_lsp.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Minimal local LSP server for edit_replay_bench.py; validates ordered edits."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+
+def digest(text):
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def offset(text, position):
+    lines = text.split("\n")
+    line, units = position["line"], position["character"]
+    prefix = lines[line].encode("utf-16-le")[:units * 2].decode("utf-16-le")
+    assert len(prefix.encode("utf-16-le")) == units * 2
+    return sum(len(value) + 1 for value in lines[:line]) + len(prefix)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("full", "incremental"), required=True)
+    parser.add_argument("--state", type=Path, required=True)
+    args = parser.parse_args()
+    state = dict(opened=False, notifications=0, full=0, incremental=0, text_bytes=0)
+    document = ""
+    version = 0
+
+    def save():
+        state["sha256"] = digest(document)
+        state["version"] = version
+        temporary = args.state.with_suffix(".tmp")
+        temporary.write_text(json.dumps(state))
+        temporary.replace(args.state)
+
+    def reply(request, result):
+        data = json.dumps(dict(jsonrpc="2.0", id=request["id"], result=result)).encode()
+        sys.stdout.buffer.write(f"Content-Length: {len(data)}\r\n\r\n".encode() + data)
+        sys.stdout.buffer.flush()
+
+    try:
+        while True:
+            headers = {}
+            while line := sys.stdin.buffer.readline():
+                if line in (b"\r\n", b"\n"):
+                    break
+                key, value = line.decode().split(":", 1)
+                headers[key.lower()] = value.strip()
+            if not line:
+                break
+            message = json.loads(sys.stdin.buffer.read(int(headers["content-length"])))
+            method = message.get("method")
+            params = message.get("params", {})
+            if method == "initialize":
+                reply(message, {"capabilities": {"textDocumentSync": 1 if args.mode == "full" else 2}})
+            elif method == "textDocument/didOpen":
+                document = params["textDocument"]["text"]
+                version = params["textDocument"]["version"]
+                state["opened"] = True
+                save()
+            elif method == "textDocument/didChange":
+                assert params["textDocument"]["version"] > version
+                version = params["textDocument"]["version"]
+                state["notifications"] += 1
+                for change in params["contentChanges"]:
+                    text = change["text"]
+                    state["text_bytes"] += len(text.encode())
+                    if change.get("range") is None:
+                        document = text
+                        state["full"] += 1
+                    else:
+                        assert args.mode == "incremental"
+                        start = offset(document, change["range"]["start"])
+                        end = offset(document, change["range"]["end"])
+                        assert start <= end
+                        document = document[:start] + text + document[end:]
+                        state["incremental"] += 1
+                save()
+            elif method == "exit":
+                break
+            elif "id" in message:
+                reply(message, None)
+    except Exception as error:
+        state["error"] = repr(error)
+        save()
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -652,6 +652,21 @@ impl Buffer {
         line_start + position.character.min(line_len)
     }
 
+    /// Converts a canonical position to an LSP UTF-16 position without flattening
+    /// the document. Canonical ranges cannot split a Unicode scalar or CRLF.
+    pub(crate) fn position_to_lsp(&self, position: TextPosition) -> crate::lsp::Position {
+        let index = self.position_to_char_idx(position);
+        let line = self.content.char_to_line(index);
+        let start = self.content.line_to_char(line);
+        let character = self
+            .content
+            .slice(start..index)
+            .chars()
+            .map(char::len_utf16)
+            .sum();
+        crate::lsp::Position { line, character }
+    }
+
     /// Converts a canonical line and scalar position to its UTF-8 byte offset.
     pub(crate) fn position_to_byte_idx(&self, position: TextPosition) -> usize {
         self.content

--- a/src/editing/textarea.rs
+++ b/src/editing/textarea.rs
@@ -1553,14 +1553,49 @@ impl TextArea {
     }
 
     fn replay_keys(&mut self, recipe: &[char], layout: LayoutOptions) {
-        for character in recipe.iter().take(MAX_MACRO_EVENTS) {
-            let code = if *character == '\u{1b}' {
-                KeyCode::Esc
-            } else {
-                KeyCode::Char(*character)
-            };
-            self.handle_key(KeyEvent::new(code, KeyModifiers::NONE), layout);
+        let recipe = &recipe[..recipe.len().min(MAX_MACRO_EVENTS)];
+        let mut index = 0;
+        while index < recipe.len() {
+            if self.state.mode == Mode::Insert && matches!(recipe[index], ' '..='~') {
+                let end = index
+                    + recipe[index..]
+                        .iter()
+                        .take_while(|ch| matches!(**ch, ' '..='~'))
+                        .count();
+                let contents = self.text();
+                let byte = grapheme_to_byte(&contents, self.state.cursor);
+                // Printable ASCII cannot join another ASCII grapheme. A
+                // non-ASCII suffix may begin with a combining mark, so keep
+                // the original per-key semantics at that boundary.
+                if contents
+                    .as_bytes()
+                    .get(byte)
+                    .is_none_or(|next| next.is_ascii())
+                {
+                    let text = recipe[index..end].iter().collect::<String>();
+                    for &ch in &recipe[index..end] {
+                        self.record_insert_character(ch);
+                    }
+                    let accepted = text
+                        .len()
+                        .min(self.max_bytes.saturating_sub(contents.len()));
+                    self.insert(&text[..accepted]);
+                    index = end;
+                    continue;
+                }
+            }
+            self.replay_key(recipe[index], layout);
+            index += 1;
         }
+    }
+
+    fn replay_key(&mut self, character: char, layout: LayoutOptions) {
+        let code = if character == '\u{1b}' {
+            KeyCode::Esc
+        } else {
+            KeyCode::Char(character)
+        };
+        self.handle_key(KeyEvent::new(code, KeyModifiers::NONE), layout);
     }
 
     fn repeat_motion(&mut self, count: u16, mut motion: impl FnMut(&mut Self)) {
@@ -1891,6 +1926,54 @@ mod tests {
         area.set_cursor(0);
         area.set_mode(Mode::Normal);
         area
+    }
+
+    #[test]
+    fn batched_insert_replay_matches_per_key_unicode_and_capacity_behavior() {
+        for text in [
+            "plain text",
+            "λ😀tail",
+            "\u{301}tail",
+            "a\u{301}b",
+            "\u{600}a",
+            "👩\u{200d}💻 tail",
+            "first\nlast",
+        ] {
+            for cursor in [0, 1, crate::unicode_utils::grapheme_len(text)] {
+                for capacity in [text.len() + 5, 4096] {
+                    for recipe in [
+                        "iHello world\u{1b}",
+                        "iλx\u{301}y\u{1b}",
+                        "ihello\nworld\u{1b}",
+                    ] {
+                        let mut fast = TextArea::with_max_bytes(text, capacity);
+                        let mut slow = TextArea::with_max_bytes(text, capacity);
+                        for area in [&mut fast, &mut slow] {
+                            area.set_cursor(cursor);
+                            area.set_mode(Mode::Normal);
+                            area.replaying = true;
+                        }
+                        let recipe = recipe.chars().collect::<Vec<_>>();
+                        let layout = crate::text_layout::LayoutOptions::grapheme(80);
+                        fast.replay_keys(&recipe, layout);
+                        for &ch in &recipe {
+                            slow.replay_key(ch, layout);
+                        }
+                        assert_eq!(
+                            (fast.text(), fast.cursor(), fast.mode()),
+                            (slow.text(), slow.cursor(), slow.mode()),
+                            "text={text:?}, cursor={cursor}, capacity={capacity}"
+                        );
+                        fast.undo();
+                        slow.undo();
+                        assert_eq!((fast.text(), fast.cursor()), (slow.text(), slow.cursor()));
+                        fast.redo();
+                        slow.redo();
+                        assert_eq!((fast.text(), fast.cursor()), (slow.text(), slow.cursor()));
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -20,6 +20,7 @@ mod buffer_manager;
 mod diagnostics;
 mod diagnostics_picker;
 mod display_layout;
+mod edit_batch;
 mod inline_actions;
 mod inline_agent_outcomes;
 mod inline_changes;
@@ -3118,6 +3119,9 @@ pub struct Editor {
     /// Suppresses per-step repainting while queued repeated motions are drained.
     defer_motion_render: bool,
 
+    /// Nested synthetic/local edit publication boundary.
+    edit_batch: edit_batch::EditBatch,
+
     /// Repaint scope accumulated by deferred navigation.
     deferred_motion_render: MotionRender,
 
@@ -4518,6 +4522,7 @@ impl Editor {
             last_rendered_bracket_rows: Vec::new(),
             last_rendered_cursor_surface: None,
             defer_motion_render: false,
+            edit_batch: edit_batch::EditBatch::default(),
             deferred_motion_render: MotionRender::None,
             deferred_plugin_event: None,
             block_replay_depth: 0,
@@ -4806,7 +4811,7 @@ impl Editor {
         self.sync_to_window();
         let viewport_changed = self.last_rendered_viewport != self.rendered_viewport();
 
-        if self.defer_motion_render {
+        if self.render_is_deferred() {
             self.request_motion_render(if viewport_changed {
                 MotionRender::Window
             } else {
@@ -7213,6 +7218,9 @@ impl Editor {
     }
 
     async fn flush_deferred_plugin_event(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
+        if self.edit_batch.is_active() || self.block_replay_depth > 0 {
+            return Ok(());
+        }
         let Some((before, cause)) = self.deferred_plugin_event.take() else {
             return Ok(());
         };
@@ -8603,6 +8611,7 @@ impl Editor {
         let mut last_terminal_size_reconciliation = Instant::now();
 
         'editor_loop: loop {
+            pending_events.extend(self.edit_batch.pending_input.drain(..));
             // Wait for input, but at most 10ms so LSP messages, timers, and
             // plugin requests are still serviced on a steady tick. Unlike an
             // unconditional sleep, this wakes the moment a key arrives.
@@ -8638,6 +8647,7 @@ impl Editor {
                         EventRenderMode::CoalescedNavigation,
                     )
                     .await?;
+                pending_events.extend(self.edit_batch.pending_input.drain(..));
                 if processed.quit {
                     break 'editor_loop;
                 }
@@ -11306,6 +11316,9 @@ impl Editor {
     }
 
     fn flush_deferred_motion_render(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        if self.edit_batch.is_active() || self.block_replay_depth > 0 {
+            return Ok(());
+        }
         self.defer_motion_render = false;
         match std::mem::take(&mut self.deferred_motion_render) {
             MotionRender::None => return Ok(()),
@@ -11697,7 +11710,7 @@ impl Editor {
     }
 
     #[async_recursion::async_recursion]
-    async fn handle_key_action(
+    async fn handle_key_action_inner(
         &mut self,
         ev: &event::Event,
         action: &KeyAction,
@@ -11712,6 +11725,9 @@ impl Editor {
                 for action in actions {
                     if self.execute(action, buffer, runtime).await? {
                         quit = true;
+                        break;
+                    }
+                    if self.replay_is_cancelled() {
                         break;
                     }
                 }
@@ -11739,6 +11755,9 @@ impl Editor {
                 for _ in 0..*times as usize {
                     if self.handle_key_action(ev, action, buffer, runtime).await? {
                         quit = true;
+                        break;
+                    }
+                    if self.replay_checkpoint(buffer, runtime).await? {
                         break;
                     }
                 }
@@ -11770,6 +11789,9 @@ impl Editor {
                     {
                         anyhow::bail!("repeated change attempted to quit the editor");
                     }
+                }
+                if self.replay_checkpoint(buffer, runtime).await? {
+                    break;
                 }
             }
             Ok(())
@@ -11843,6 +11865,9 @@ impl Editor {
                     {
                         anyhow::bail!("macro attempted to quit the editor");
                     }
+                }
+                if self.replay_checkpoint(buffer, runtime).await? {
+                    break;
                 }
             }
             Ok(())
@@ -16842,7 +16867,7 @@ impl Editor {
     }
 
     #[async_recursion::async_recursion]
-    async fn execute_with_tracking(
+    async fn execute_action_inner(
         &mut self,
         action: &Action,
         buffer: &mut RenderBuffer,
@@ -17311,6 +17336,7 @@ impl Editor {
                     }
                 }
 
+                self.flush_edit_batch_events(runtime).await?;
                 self.mode = *new_mode;
 
                 if matches!(
@@ -17325,6 +17351,7 @@ impl Editor {
                 }
 
                 if !matches!(old_mode, Mode::Normal) && matches!(new_mode, Mode::Normal) {
+                    self.flush_edit_batch_changes(runtime).await?;
                     self.request_diagnostics().await?;
                 }
 
@@ -20358,10 +20385,20 @@ impl Editor {
         // Navigation repaints its active window; other actions may affect shared
         // buffers, layout, focus, or chrome in any editor window.
         if self.window_manager.window_count() > 1 && !Self::action_is_navigation(action) {
-            self.render(buffer)?;
+            if self.current_buffer().id() == action_buffer_id
+                && self.current_buffer().revision() != action_buffer_revision
+                && Self::action_is_batch_local(action)
+            {
+                self.render_editor_windows_frame(buffer)?;
+            } else {
+                self.render(buffer)?;
+            }
         }
 
-        if self.defer_motion_render {
+        if self.edit_batch.is_active() && event_snapshot_before_action.mode != self.mode {
+            self.notify_editor_event_changes(event_snapshot_before_action, runtime, &action_cause)
+                .await?;
+        } else if self.render_is_deferred() {
             if let Some((_, cause)) = &mut self.deferred_plugin_event {
                 *cause = action_cause;
             } else {
@@ -20779,6 +20816,7 @@ impl Editor {
         };
 
         let primary_cursor = self.cursor_snapshot();
+        let committed_deferred_render = self.deferred_motion_render;
         let committed_terminal_frame = self.previous_render_buffer.clone();
         let committed_render_generation = self.render_generation;
         let committed_viewport = self.last_rendered_viewport;
@@ -20803,8 +20841,16 @@ impl Editor {
                     replay_result = Err(error);
                     break;
                 }
+                match self.replay_checkpoint(&mut scratch_buffer, runtime).await {
+                    Ok(false) => {}
+                    Ok(true) => break,
+                    Err(error) => {
+                        replay_result = Err(error);
+                        break;
+                    }
+                }
             }
-            if replay_result.is_err() {
+            if replay_result.is_err() || self.replay_is_cancelled() {
                 break;
             }
         }
@@ -20814,6 +20860,7 @@ impl Editor {
         // Replay renders into a scratch frame with terminal output suppressed. Keep
         // terminal-derived caches tied to the last frame that was actually written,
         // then return to the primary edit so Escape finishes at the block's first row.
+        self.deferred_motion_render = committed_deferred_render;
         self.previous_render_buffer = committed_terminal_frame;
         self.render_generation = committed_render_generation;
         self.last_rendered_viewport = committed_viewport;
@@ -20823,19 +20870,16 @@ impl Editor {
         self.force_full_redraw = committed_force_full_redraw;
         self.restore_cursor_snapshot(primary_cursor);
 
-        if let Err(error) = replay_result {
-            if self.block_replay_depth == 0 {
-                self.block_replay_change_deferred = false;
-            }
-            return Err(error);
-        }
-
-        if self.block_replay_depth == 0 && self.block_replay_change_deferred {
-            self.block_replay_change_deferred = false;
-            self.notify_change(runtime).await?;
-        }
-
-        Ok(())
+        // A failed replay may already have changed earlier rows. Publish those
+        // edits as well, while preserving the original replay error.
+        let notification_result = if self.block_replay_depth == 0
+            && std::mem::take(&mut self.block_replay_change_deferred)
+        {
+            self.notify_change(runtime).await
+        } else {
+            Ok(())
+        };
+        replay_result.and(notification_result)
     }
 
     fn yank(&mut self, register: char) -> bool {
@@ -21352,41 +21396,64 @@ impl Editor {
             self.block_replay_change_deferred = true;
             return Ok(());
         }
+        if self.edit_batch.is_active() {
+            let id = self.current_buffer().id();
+            self.edit_batch.record_change(id);
+            perf::increment("edit:notifications_deferred", 1);
+            return Ok(());
+        }
+        self.notify_buffer_change(self.buffer_manager.active_index(), runtime)
+            .await
+    }
+
+    /// Publish one buffer without changing the active window or cursor.
+    async fn notify_buffer_change(
+        &mut self,
+        index: usize,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let id = self.buffer_manager[index].id();
+        let revision = self.buffer_manager[index].revision();
         self.sync_inline_change_summaries();
-
-        self.schedule_inline_completion();
-        let file = self.current_buffer().file.clone();
-
-        // Notify LSP if enabled and the buffer has a file.
+        perf::increment("edit:change_notifications", 1);
+        #[cfg(test)]
+        {
+            self.edit_batch.published_changes += 1;
+        }
+        if index == self.buffer_manager.active_index() {
+            self.schedule_inline_completion();
+        }
+        let file = self.buffer_manager[index].file.clone();
         if self.config.lsp.enabled {
             if let Some(file) = &file {
-                self.ensure_current_buffer_lsp_opened().await?;
-                self.lsp
-                    .did_change(file, self.current_buffer().contents())
-                    .await?;
+                self.ensure_buffer_lsp_opened(index).await?;
+                let snapshot = self.buffer_manager[index].contents_snapshot();
+                if let Some(change) = self.lsp_coordinator.pending_change(id, revision, snapshot) {
+                    self.lsp.did_change_edits(file, change).await?;
+                } else {
+                    let contents = self.buffer_manager[index].contents();
+                    self.lsp.did_change(file, contents).await?;
+                }
             }
         }
-
-        // Notify plugins about buffer change
+        let source = &self.buffer_manager[index];
+        let (column, line) = if index == self.buffer_manager.active_index() {
+            (self.cx, self.cy + self.vtop)
+        } else {
+            (source.pos.0, source.pos.1 + source.vtop)
+        };
         let buffer_info = serde_json::json!({
-            "buffer_id": self.buffer_manager.active_index(),
-            "buffer_name": self.current_buffer().name(),
+            "buffer_id": index,
+            "buffer_name": source.name(),
             "file_path": file,
-            "revision": self.current_buffer().revision(),
-            "line_count": self.current_buffer().len(),
-            "cursor": {
-                "line": self.cy + self.vtop,
-                "column": self.cx
-            }
+            "revision": revision,
+            "line_count": source.len(),
+            "cursor": { "line": line, "column": column }
         });
-
         self.plugin_registry
             .notify(runtime, "buffer:changed", buffer_info)
             .await?;
-
-        self.lsp_coordinator
-            .record_notified_revision(self.current_buffer().id(), self.current_buffer().revision());
-
+        self.lsp_coordinator.record_notified_revision(id, revision);
         Ok(())
     }
 
@@ -22706,11 +22773,35 @@ impl Editor {
     }
 
     fn replace_range(&mut self, range: TextRange, new_text: &str) {
+        let pending =
+            (self.config.lsp.enabled && self.current_buffer().file.is_some()).then(|| {
+                let source = self.current_buffer();
+                (
+                    source.id(),
+                    source.revision(),
+                    source.contents_snapshot(),
+                    crate::lsp::Range {
+                        start: source.position_to_lsp(range.start),
+                        end: source.position_to_lsp(range.end),
+                    },
+                )
+            });
         let Some(edit) =
             apply_transactional_replacement(self.current_buffer_mut(), range, new_text)
         else {
             return;
         };
+        if let Some((id, revision, before, lsp_range)) = pending {
+            self.lsp_coordinator.record_edit(
+                id,
+                revision,
+                self.current_buffer().revision(),
+                before,
+                lsp_range,
+                new_text,
+            );
+        }
+        perf::increment("edit:replacements", 1);
         self.update_anchors_for_edit(edit);
         self.set_special_mark_at_char('.', edit.start_char, AnchorAffinity::Left);
     }

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -1,0 +1,762 @@
+//! Publication boundaries for local edits and synthetic key replay.
+//!
+//! Text and undo state always change synchronously. Only derived notifications
+//! and repainting are delayed. Unknown/external actions are barriers, so a new
+//! action defaults to observing an up-to-date document.
+
+use super::*;
+
+const REPLAY_STEPS_PER_SLICE: usize = 512;
+
+pub(super) struct EditBatch {
+    depth: usize,
+    suspended: usize,
+    changed: Vec<BufferId>,
+    started: Option<Instant>,
+    steps: usize,
+    budget: Duration,
+    cancelled: bool,
+    terminal_input: bool,
+    pub(super) pending_input: VecDeque<Event>,
+    #[cfg(test)]
+    pub(super) published_changes: usize,
+}
+
+impl Default for EditBatch {
+    fn default() -> Self {
+        Self {
+            depth: 0,
+            suspended: 0,
+            changed: Vec::new(),
+            started: None,
+            steps: 0,
+            budget: Duration::from_millis(16),
+            cancelled: false,
+            terminal_input: false,
+            pending_input: VecDeque::new(),
+            #[cfg(test)]
+            published_changes: 0,
+        }
+    }
+}
+
+impl EditBatch {
+    pub(super) fn is_active(&self) -> bool {
+        self.depth > 0 && self.suspended == 0
+    }
+
+    pub(super) fn record_change(&mut self, id: BufferId) {
+        if !self.changed.contains(&id) {
+            self.changed.push(id);
+        }
+    }
+}
+
+impl Editor {
+    pub(super) fn render_is_deferred(&self) -> bool {
+        self.defer_motion_render || self.edit_batch.is_active() || self.block_replay_depth > 0
+    }
+
+    /// Only source-local operations may run past an unpublished edit. In
+    /// particular, save, LSP, plugin, dialog and document-switch actions are
+    /// deliberately absent. This list is conservative for new action variants.
+    pub(super) fn action_is_batch_local(action: &Action) -> bool {
+        Self::action_is_navigation(action)
+            || matches!(
+                action,
+                Action::EnterMode(
+                    Mode::Normal
+                        | Mode::Insert
+                        | Mode::Visual
+                        | Mode::VisualLine
+                        | Mode::VisualBlock
+                ) | Action::RepeatLastChange
+                    | Action::PlayMacro(_)
+                    | Action::InsertBlock
+                    | Action::MoveToLineEnd
+                    | Action::MoveToLineStart
+                    | Action::MoveToFirstLineChar
+                    | Action::MoveToLastLineChar
+                    | Action::MoveToBottom
+                    | Action::MoveToTop
+                    | Action::MoveTo(_, _)
+                    | Action::SetCursor(_, _)
+                    | Action::GoToLine(_)
+                    | Action::MoveToFilePercent(_)
+                    | Action::SetMark(_)
+                    | Action::Undo
+                    | Action::Redo
+                    | Action::InsertCharAtCursorPos(_)
+                    | Action::InsertString(_)
+                    | Action::InsertPastedText(_)
+                    | Action::InsertNewLine
+                    | Action::InsertLineAt(_, _)
+                    | Action::InsertLineBelowCursor
+                    | Action::InsertLineAtCursor
+                    | Action::InsertTab
+                    | Action::InsertText { .. }
+                    | Action::DeletePreviousChar
+                    | Action::DeleteCharAtCursorPos
+                    | Action::DeleteCharAt(_, _)
+                    | Action::DeleteCurrentLine
+                    | Action::DeleteCurrentLines(_)
+                    | Action::DeleteLineAt(_)
+                    | Action::DeleteRange(_, _, _, _)
+                    | Action::DeleteTextRange(_)
+                    | Action::ChangeTextRange(_)
+                    | Action::DeleteLinewiseRange(_)
+                    | Action::ChangeLinewiseRange(_)
+                    | Action::ChangeCurrentLine
+                    | Action::ChangeCurrentLines(_)
+                    | Action::DeleteWord
+                    | Action::DeleteToLineEnd(_)
+                    | Action::ChangeToLineEnd(_)
+                    | Action::DeletePreviousChars(_)
+                    | Action::ChangeCharsAtCursor(_)
+                    | Action::Delete
+                    | Action::ChangeSelection
+                    | Action::Paste
+                    | Action::PasteBefore
+                    | Action::ReplaceCharsAtCursor { .. }
+                    | Action::ReplaceLineAt(_, _)
+                    | Action::ReplaceSelection(_)
+                    | Action::JoinLines(_)
+                    | Action::JoinLinesKeepSpaces(_)
+                    | Action::JoinLinesInRange { .. }
+                    | Action::ToggleCharCase(_)
+                    | Action::TransformTextRange { .. }
+                    | Action::TransformSelection(_)
+                    | Action::IndentLine
+                    | Action::UnindentLine
+                    | Action::IndentSelection(_)
+                    | Action::UnindentSelection(_)
+                    | Action::ToggleCommentLines(_)
+                    | Action::ToggleCommentRange(_)
+                    | Action::ToggleCommentSelection
+                    | Action::StartCommentOperator(_)
+                    | Action::StartLowercaseOperator(_)
+                    | Action::StartUppercaseOperator(_)
+                    | Action::StartToggleCaseOperator(_)
+                    | Action::SwapNextParameter
+                    | Action::SwapPreviousParameter
+                    | Action::SwapNextFunction
+                    | Action::SwapPreviousFunction
+            )
+    }
+
+    fn begin_edit_batch(&mut self) {
+        if self.edit_batch.depth == 0 {
+            self.edit_batch.started = Some(Instant::now());
+            self.edit_batch.steps = 0;
+            self.edit_batch.terminal_input = self.terminal_output_enabled;
+        }
+        self.edit_batch.depth += 1;
+    }
+
+    /// Keep failed deliveries queued; the next boundary can retry them.
+    pub(super) async fn flush_edit_batch_changes(
+        &mut self,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        while let Some(id) = self.edit_batch.changed.first().copied() {
+            if let Some(index) = self
+                .buffer_manager
+                .iter()
+                .position(|buffer| buffer.id() == id)
+            {
+                let revision = self.buffer_manager[index].revision();
+                if !self.lsp_coordinator.is_revision_notified(id, revision) {
+                    self.notify_buffer_change(index, runtime).await?;
+                }
+            }
+            self.edit_batch.changed.remove(0);
+        }
+        Ok(())
+    }
+
+    pub(super) async fn flush_edit_batch_events(
+        &mut self,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        self.edit_batch.suspended += 1;
+        let result = self.flush_deferred_plugin_event(runtime).await;
+        self.edit_batch.suspended -= 1;
+        result
+    }
+
+    async fn publish_edit_batch(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        self.edit_batch.suspended += 1;
+        let notification_result = self.flush_edit_batch_changes(runtime).await;
+        let event_result = self.flush_deferred_plugin_event(runtime).await;
+        let render_result = if self.defer_motion_render {
+            Ok(())
+        } else {
+            self.flush_deferred_motion_render(buffer)
+        };
+        self.edit_batch.suspended -= 1;
+        notification_result.and(event_result).and(render_result)
+    }
+
+    async fn finish_edit_batch(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        self.edit_batch.depth -= 1;
+        if self.edit_batch.depth == 0 && self.block_replay_depth == 0 {
+            if std::mem::take(&mut self.edit_batch.cancelled) {
+                // Keep completed edits undoable, but do not replicate an unfinished
+                // visual-block insert when the user interrupts it.
+                self.pending_select_action = None;
+                self.pending_semantic_change = None;
+                self.waiting_key_action = None;
+                self.waiting_command = None;
+                self.pending_macro_action = None;
+                self.pending_mark_action = None;
+                self.pending_replace = false;
+                self.repeater = None;
+                self.clear_keymap_hints();
+                self.edit_batch.depth = 1;
+                let cleanup = self
+                    .execute_with_tracking(&Action::EnterMode(Mode::Normal), buffer, runtime, false)
+                    .await;
+                self.edit_batch.depth = 0;
+                cleanup?;
+                self.set_legacy_message(Some("replay interrupted".into()));
+                self.request_motion_render(MotionRender::Full);
+            }
+            self.publish_edit_batch(buffer, runtime).await?;
+        }
+        Ok(())
+    }
+
+    fn retain_replay_input(&mut self, event: Event) -> bool {
+        if matches!(event, Event::Key(KeyEvent { code: KeyCode::Char('c'), modifiers, kind: KeyEventKind::Press | KeyEventKind::Repeat, .. }) if modifiers.contains(KeyModifiers::CONTROL))
+        {
+            self.edit_batch.cancelled = true;
+            true
+        } else {
+            self.edit_batch.pending_input.push_back(event);
+            false
+        }
+    }
+
+    pub(super) fn replay_is_cancelled(&self) -> bool {
+        self.edit_batch.cancelled
+    }
+
+    // Keep the large background-service future out of recursive action frames.
+    #[inline(never)]
+    fn service_replay_background<'a>(
+        &'a mut self,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async move { self.service_background(buffer, runtime).await })
+    }
+
+    /// Bound synthetic work without dropping ordinary queued terminal input.
+    #[inline(never)]
+    pub(super) fn replay_checkpoint<'a>(
+        &'a mut self,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<bool>> {
+        Box::pin(async move {
+            if self.edit_batch.cancelled {
+                return Ok(true);
+            }
+            if !self.edit_batch.is_active() {
+                return Ok(false);
+            }
+            self.edit_batch.steps += 1;
+            if self.edit_batch.steps < REPLAY_STEPS_PER_SLICE
+                && self
+                    .edit_batch
+                    .started
+                    .is_none_or(|start| start.elapsed() < self.edit_batch.budget)
+            {
+                return Ok(false);
+            }
+            self.edit_batch.steps = 0;
+            self.edit_batch.started = Some(Instant::now());
+            perf::increment("edit:replay_slices", 1);
+            if self.edit_batch.terminal_input {
+                for _ in 0..64 {
+                    if !event::poll(Duration::ZERO)? {
+                        break;
+                    }
+                    if self.retain_replay_input(event::read()?) {
+                        break;
+                    }
+                }
+            }
+            if self.block_replay_depth == 0 {
+                self.publish_edit_batch(buffer, runtime).await?;
+                // Do not let agent/plugin mutations interleave with the middle
+                // of an unfinished insertion transaction.
+                if self.is_normal()
+                    && !self.transaction_active()
+                    && !self.is_waiting_for_key_sequence()
+                    && !self.edit_batch.cancelled
+                {
+                    self.edit_batch.suspended += 1;
+                    let result = self.service_replay_background(buffer, runtime).await;
+                    self.edit_batch.suspended -= 1;
+                    result?;
+                }
+            }
+            tokio::task::yield_now().await;
+            Ok(self.edit_batch.cancelled)
+        })
+    }
+
+    #[async_recursion::async_recursion]
+    pub(super) async fn execute_with_tracking(
+        &mut self,
+        action: &Action,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+        tracking: bool,
+    ) -> anyhow::Result<bool> {
+        let local = Self::action_is_batch_local(action);
+        let barrier = self.edit_batch.is_active() && !local;
+        if barrier {
+            self.publish_edit_batch(buffer, runtime).await?;
+            self.edit_batch.suspended += 1;
+        }
+        // InsertBlock deliberately preserves the primary committed frame until
+        // its enclosing mode transition. Its hidden row replay has its own guard.
+        let owner = local
+            && !Self::action_is_navigation(action)
+            && !matches!(action, Action::InsertBlock)
+            && self.edit_batch.suspended == 0
+            && self.block_replay_depth == 0;
+        if owner {
+            self.begin_edit_batch();
+        }
+        let result = self
+            .execute_action_inner(action, buffer, runtime, tracking)
+            .await;
+        if barrier {
+            self.edit_batch.suspended -= 1;
+        }
+        if owner {
+            let published = self.finish_edit_batch(buffer, runtime).await;
+            return result.and_then(|quit| published.map(|()| quit));
+        }
+        result
+    }
+
+    #[async_recursion::async_recursion]
+    pub(super) async fn handle_key_action(
+        &mut self,
+        event: &Event,
+        action: &KeyAction,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        let owner = matches!(action, KeyAction::Multiple(_) | KeyAction::Repeating(_, _))
+            && !Self::key_action_is_navigation(action)
+            && self.edit_batch.suspended == 0;
+        if owner {
+            self.begin_edit_batch();
+        }
+        let result = self
+            .handle_key_action_inner(event, action, buffer, runtime)
+            .await;
+        if owner {
+            let published = self.finish_edit_batch(buffer, runtime).await;
+            return result.and_then(|quit| published.map(|()| quit));
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Harness {
+        editor: Editor,
+        frame: RenderBuffer,
+        runtime: Runtime,
+    }
+
+    impl Harness {
+        fn new(source: &str) -> Self {
+            let mut config =
+                Config::from_toml_with_overrides(crate::assets::DEFAULT_CONFIG, &[]).unwrap();
+            config.lsp.enabled = false;
+            let lsp = Box::new(crate::LspManager::new(config.lsp.clone()));
+            let mut editor = Editor::with_size(
+                lsp,
+                80,
+                24,
+                config,
+                Theme::default(),
+                vec![Buffer::new(Some("fixture.rs".into()), source.into())],
+            )
+            .unwrap();
+            editor.test_disable_terminal_output();
+            editor.edit_batch.budget = Duration::MAX;
+            editor.test_set_clipboard(Box::new(crate::clipboard::DisabledClipboardProvider));
+            let mut frame = RenderBuffer::new(80, 24, &Style::default());
+            editor.render(&mut frame).unwrap();
+            Self {
+                editor,
+                frame,
+                runtime: Runtime::new(),
+            }
+        }
+
+        async fn event(&mut self, code: KeyCode, modifiers: KeyModifiers) {
+            self.editor
+                .process_editor_event(
+                    Event::Key(KeyEvent::new(code, modifiers)),
+                    &mut self.frame,
+                    &mut self.runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+
+        async fn keys(&mut self, keys: &str) {
+            for ch in keys.chars() {
+                self.event(
+                    if ch == '\u{1b}' {
+                        KeyCode::Esc
+                    } else {
+                        KeyCode::Char(ch)
+                    },
+                    KeyModifiers::NONE,
+                )
+                .await;
+            }
+        }
+
+        fn counts(&self) -> (u64, usize) {
+            (
+                self.editor.render_generation,
+                self.editor.edit_batch.published_changes,
+            )
+        }
+
+        fn assert_one_publication(&mut self, before: (u64, usize)) {
+            assert_eq!(self.counts(), (before.0 + 1, before.1 + 1));
+            assert_eq!(self.editor.edit_batch.depth, 0);
+            assert_eq!(self.editor.edit_batch.suspended, 0);
+            assert!(self.editor.edit_batch.changed.is_empty());
+            let mut full = self.frame.clone();
+            self.editor.render(&mut full).unwrap();
+            assert_eq!(self.frame.cells, full.cells);
+        }
+    }
+
+    #[tokio::test]
+    async fn dot_macro_and_counted_delete_publish_once() {
+        let mut h = Harness::new("one\ntwo\nthree\n");
+        h.keys(&format!("i{}\u{1b}j", "x".repeat(64))).await;
+        let before = h.counts();
+        h.keys(".").await;
+        h.assert_one_publication(before);
+        assert!(h
+            .editor
+            .current_buffer()
+            .get(1)
+            .unwrap()
+            .contains(&"x".repeat(64)));
+
+        h.editor
+            .execute(
+                &Action::SetMacroRegister {
+                    register: 'a',
+                    keys: format!("i{}<Esc>", "y".repeat(64)),
+                },
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        let before = h.counts();
+        h.editor
+            .execute(&Action::PlayMacro('a'), &mut h.frame, &mut h.runtime)
+            .await
+            .unwrap();
+        h.assert_one_publication(before);
+
+        h.keys("64").await;
+        let before = h.counts();
+        h.keys("x").await;
+        h.assert_one_publication(before);
+    }
+
+    #[tokio::test]
+    async fn block_replay_only_publishes_the_completed_primary_frame() {
+        let source = "value\n".repeat(16);
+        let mut h = Harness::new(&source);
+        h.event(KeyCode::Char('v'), KeyModifiers::CONTROL).await;
+        h.keys("15jI").await;
+        h.keys(&"x".repeat(32)).await;
+        let before = h.counts();
+        h.keys("\u{1b}").await;
+        h.assert_one_publication(before);
+        assert_eq!(
+            h.editor.current_buffer().contents(),
+            format!("{}value\n", "x".repeat(32)).repeat(16)
+        );
+        h.keys("u").await;
+        assert_eq!(h.editor.current_buffer().contents(), source);
+    }
+
+    #[tokio::test]
+    async fn an_external_action_observes_the_latest_revision() {
+        let mut h = Harness::new("value\n");
+        h.editor.begin_edit_batch();
+        h.editor
+            .execute(
+                &Action::InsertString("x".into()),
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        assert_eq!(h.editor.edit_batch.changed.len(), 1);
+        let before = h.editor.edit_batch.published_changes;
+        h.editor
+            .execute(
+                &Action::NotifyPlugins("test:barrier".into(), Value::Null),
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        assert_eq!(h.editor.edit_batch.published_changes, before + 1);
+        assert!(h.editor.edit_batch.changed.is_empty());
+        assert!(h.editor.lsp_coordinator.is_revision_notified(
+            h.editor.current_buffer().id(),
+            h.editor.current_buffer().revision()
+        ));
+        h.editor
+            .finish_edit_batch(&mut h.frame, &mut h.runtime)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn queued_changes_use_stable_buffer_identity() {
+        let mut h = Harness::new("first\n");
+        h.editor
+            .buffer_manager
+            .push_buffer(Buffer::new(Some("second.rs".into()), "second\n".into()));
+        h.editor.begin_edit_batch();
+        for index in [0, 1] {
+            h.editor.buffer_manager.set_active_index(index);
+            h.editor.begin_transaction("fixture");
+            h.editor
+                .replace_range(TextRange::insertion(TextPosition::new(0, 0)), "x");
+            h.editor.commit_transaction(h.editor.cursor_snapshot());
+            h.editor.notify_change(&mut h.runtime).await.unwrap();
+        }
+        assert_eq!(h.editor.edit_batch.changed.len(), 2);
+        let before = h.editor.edit_batch.published_changes;
+        h.editor
+            .finish_edit_batch(&mut h.frame, &mut h.runtime)
+            .await
+            .unwrap();
+        assert_eq!(h.editor.edit_batch.published_changes, before + 2);
+        assert_eq!(h.editor.buffer_manager.active_index(), 1);
+        for source in h.editor.buffer_manager.iter() {
+            assert!(h
+                .editor
+                .lsp_coordinator
+                .is_revision_notified(source.id(), source.revision()));
+        }
+    }
+
+    #[tokio::test]
+    async fn mode_transitions_and_explicit_plugin_barriers_remain_observable() {
+        let mut h = Harness::new("value\n");
+        while ACTION_DISPATCHER.try_recv_request().is_some() {}
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("observer.hk");
+        std::fs::write(&path, r#"
+            pub fn activate() {
+                red::on("mode:changed", mode_changed);
+                red::on("buffer:changed", buffer_changed);
+                red::on("test:barrier", barrier);
+            }
+            fn mode_changed(event: Json) { red::execute("Print", "mode:" + red::string(event.to, "")); }
+            fn buffer_changed(event: Json) { red::execute("Print", "buffer"); }
+            fn barrier(event: Json) { red::execute("Print", "barrier"); }
+        "#).unwrap();
+        h.editor
+            .plugin_registry
+            .add("observer", path.to_str().unwrap());
+        h.editor
+            .plugin_registry
+            .initialize(&mut h.runtime)
+            .await
+            .unwrap();
+        while ACTION_DISPATCHER.try_recv_request().is_some() {}
+        h.editor
+            .execute(
+                &Action::SetMacroRegister {
+                    register: 'a',
+                    keys: "iabc<Esc>".into(),
+                },
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        h.editor
+            .execute(&Action::PlayMacro('a'), &mut h.frame, &mut h.runtime)
+            .await
+            .unwrap();
+        let mut messages = Vec::new();
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            if let PluginRequest::Action(Action::Print(message)) = request {
+                messages.push(message);
+            }
+        }
+        assert_eq!(messages, ["mode:Insert", "buffer", "mode:Normal"]);
+        h.editor.begin_edit_batch();
+        h.editor
+            .execute(
+                &Action::InsertString("x".into()),
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        h.editor
+            .execute(
+                &Action::NotifyPlugins("test:barrier".into(), Value::Null),
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        h.editor
+            .finish_edit_batch(&mut h.frame, &mut h.runtime)
+            .await
+            .unwrap();
+        let mut messages = Vec::new();
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            if let PluginRequest::Action(Action::Print(message)) = request {
+                messages.push(message);
+            }
+        }
+        assert_eq!(messages, ["buffer", "barrier"]);
+    }
+
+    #[tokio::test]
+    async fn interruption_keeps_ordinary_input_and_commits_partial_insert() {
+        let mut h = Harness::new("value\n");
+        h.editor.begin_edit_batch();
+        h.editor
+            .execute(
+                &Action::EnterMode(Mode::Insert),
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        h.editor
+            .execute(
+                &Action::InsertString("partial".into()),
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        h.editor.pending_macro_action = Some(PendingMacroAction::Play);
+        h.editor.pending_replace = true;
+        h.editor.repeater = Some(12);
+        let ordinary = Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert!(!h.editor.retain_replay_input(ordinary.clone()));
+        assert!(h.editor.retain_replay_input(Event::Key(KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL
+        ))));
+        assert!(h
+            .editor
+            .replay_checkpoint(&mut h.frame, &mut h.runtime)
+            .await
+            .unwrap());
+        h.editor
+            .finish_edit_batch(&mut h.frame, &mut h.runtime)
+            .await
+            .unwrap();
+        assert!(h.editor.is_normal());
+        assert!(!h.editor.is_waiting_for_key_sequence());
+        assert!(!h.editor.transaction_active());
+        assert_eq!(
+            h.editor.edit_batch.pending_input.pop_front(),
+            Some(ordinary)
+        );
+        assert!(!h.editor.replay_is_cancelled());
+        h.keys("u").await;
+        assert_eq!(h.editor.current_buffer().contents(), "value\n");
+    }
+
+    #[tokio::test]
+    async fn adjacent_insert_undo_records_are_compacted() {
+        let mut h = Harness::new("value\n");
+        h.keys("iλé").await;
+        h.event(KeyCode::Enter, KeyModifiers::NONE).await;
+        h.keys("hello\u{1b}").await;
+        let inserted = h.editor.current_buffer().contents();
+        let edits = &h
+            .editor
+            .current_buffer()
+            .undo_history
+            .latest_transaction()
+            .unwrap()
+            .edits;
+        assert!(
+            edits.len() < 8,
+            "adjacent insertion should not store every typed character"
+        );
+        h.keys("u").await;
+        assert_eq!(h.editor.current_buffer().contents(), "value\n");
+        h.editor
+            .execute(&Action::Redo, &mut h.frame, &mut h.runtime)
+            .await
+            .unwrap();
+        assert_eq!(h.editor.current_buffer().contents(), inserted);
+    }
+
+    #[tokio::test]
+    async fn failed_replay_restores_publication_state() {
+        let mut h = Harness::new("value\n");
+        h.editor
+            .execute(
+                &Action::SetMacroRegister {
+                    register: 'a',
+                    keys: "ix<Esc>:q!<CR>".into(),
+                },
+                &mut h.frame,
+                &mut h.runtime,
+            )
+            .await
+            .unwrap();
+        assert!(h
+            .editor
+            .execute(&Action::PlayMacro('a'), &mut h.frame, &mut h.runtime)
+            .await
+            .is_err());
+        assert_eq!(h.editor.edit_batch.depth, 0);
+        assert_eq!(h.editor.edit_batch.suspended, 0);
+        assert_eq!(h.editor.macro_replay_depth, 0);
+        assert!(h.editor.edit_batch.changed.is_empty());
+        h.keys("iY\u{1b}").await;
+        assert!(h.editor.current_buffer().contents().starts_with("Yx"));
+    }
+}

--- a/src/editor/inline_changes.rs
+++ b/src/editor/inline_changes.rs
@@ -111,6 +111,7 @@ impl Editor {
 
     /// A summary is editor-owned and survives the ephemeral provider session.
     pub(super) fn sync_inline_change_summaries(&mut self) {
+        perf::increment("edit:inline_summary_refreshes", 1);
         self.sync_inline_agent_markers();
         if !self
             .inline_history

--- a/src/editor/lsp_coordinator.rs
+++ b/src/editor/lsp_coordinator.rs
@@ -1,6 +1,17 @@
 //! LSP client coordination and document synchronization tracking for the Red editor.
 
 use crate::buffer::{Buffer, BufferId};
+use crate::lsp::{DocumentChange, Range, TextDocumentContentChangeEvent};
+use ropey::Rope;
+
+#[derive(Debug)]
+struct PendingChanges {
+    before: Rope,
+    before_revision: u64,
+    after_revision: u64,
+    changes: Vec<TextDocumentContentChangeEvent>,
+    insert_end: Option<crate::lsp::Position>,
+}
 use std::collections::{HashMap, HashSet};
 
 /// Coordinates LSP client state, opened workspace document tracking, and buffer revision delivery.
@@ -10,6 +21,8 @@ pub struct LspCoordinator {
     opened_documents: HashSet<String>,
     /// Latest buffer revision delivered to LSP servers per buffer ID.
     notified_revisions: HashMap<BufferId, u64>,
+    pending_changes: HashMap<BufferId, PendingChanges>,
+    standard_line_revisions: HashMap<BufferId, (u64, bool)>,
 }
 
 impl LspCoordinator {
@@ -17,6 +30,8 @@ impl LspCoordinator {
     pub fn with_buffers(buffers: &[Buffer]) -> Self {
         Self {
             opened_documents: HashSet::new(),
+            pending_changes: HashMap::new(),
+            standard_line_revisions: HashMap::new(),
             notified_revisions: buffers
                 .iter()
                 .map(|buffer| (buffer.id(), buffer.revision()))
@@ -52,11 +67,97 @@ impl LspCoordinator {
     /// Updates the last notified revision for a buffer.
     pub fn record_notified_revision(&mut self, id: BufferId, revision: u64) {
         self.notified_revisions.insert(id, revision);
+        self.pending_changes.remove(&id);
     }
 
     /// Seeds a revision only when the buffer has not been tracked before.
     pub fn ensure_notified_revision(&mut self, id: BufferId, revision: u64) {
         self.notified_revisions.entry(id).or_insert(revision);
+    }
+
+    /// Records a canonical replacement before external publication. A revision
+    /// gap (for example undo or a raw workspace replacement) forces full sync.
+    pub fn record_edit(
+        &mut self,
+        id: BufferId,
+        before_revision: u64,
+        after_revision: u64,
+        before: Rope,
+        range: Range,
+        text: &str,
+    ) {
+        // Ropey recognizes more line separators than the existing LSP codec.
+        // Cache eligibility by revision, and retain the legacy full-text path
+        // for lone CR and Unicode separators. Canonical ranges cannot split CRLF.
+        let standard_before = self
+            .standard_line_revisions
+            .get(&id)
+            .filter(|(revision, _)| *revision == before_revision)
+            .map_or_else(
+                || standard_lsp_lines(before.chars()),
+                |(_, standard)| *standard,
+            );
+        let standard = standard_before && standard_lsp_lines(text.chars());
+        self.standard_line_revisions
+            .insert(id, (after_revision, standard));
+        if !standard {
+            self.pending_changes.remove(&id);
+            return;
+        }
+        if self
+            .pending_changes
+            .get(&id)
+            .is_some_and(|pending| pending.after_revision != before_revision)
+        {
+            self.pending_changes.remove(&id);
+        }
+        let pending = self
+            .pending_changes
+            .entry(id)
+            .or_insert_with(|| PendingChanges {
+                before,
+                before_revision,
+                after_revision: before_revision,
+                changes: Vec::new(),
+                insert_end: None,
+            });
+        pending.after_revision = after_revision;
+        // Cache the end coordinate instead of rescanning a growing insertion.
+        let insert_end = (range.start == range.end && !text.contains(['\r', '\n'])).then(|| {
+            crate::lsp::Position {
+                line: range.start.line,
+                character: range.start.character + text.encode_utf16().count(),
+            }
+        });
+        if insert_end.is_some() && pending.insert_end.as_ref() == Some(&range.start) {
+            if let Some(previous) = pending.changes.last_mut() {
+                previous.text.push_str(text);
+                pending.insert_end = insert_end;
+                return;
+            }
+        }
+        pending.insert_end = insert_end;
+        pending.changes.push(TextDocumentContentChangeEvent {
+            range: Some(range),
+            range_length: None,
+            text: text.to_string(),
+        });
+    }
+
+    pub fn pending_change(
+        &self,
+        id: BufferId,
+        revision: u64,
+        after: Rope,
+    ) -> Option<DocumentChange> {
+        let pending = self.pending_changes.get(&id)?;
+        (pending.after_revision == revision
+            && self.last_notified_revision(id) == Some(pending.before_revision))
+        .then(|| DocumentChange {
+            before: pending.before.clone(),
+            after,
+            changes: pending.changes.clone(),
+        })
     }
 
     /// Returns whether the exact revision has already been delivered.
@@ -66,14 +167,109 @@ impl LspCoordinator {
 
     /// Removes tracked revision for a closed buffer.
     pub fn forget_buffer(&mut self, id: BufferId) -> Option<u64> {
+        self.standard_line_revisions.remove(&id);
+        self.pending_changes.remove(&id);
         self.notified_revisions.remove(&id)
     }
+}
+
+fn standard_lsp_lines(chars: impl Iterator<Item = char>) -> bool {
+    let mut chars = chars;
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\r' if chars.next() != Some('\n') => return false,
+            '\u{000B}' | '\u{000C}' | '\u{0085}' | '\u{2028}' | '\u{2029}' => return false,
+            _ => {}
+        }
+    }
+    true
 }
 
 #[cfg(test)]
 mod tests {
     use super::LspCoordinator;
     use crate::buffer::Buffer;
+
+    #[test]
+    fn canonical_edits_merge_insertions_and_reject_revision_gaps() {
+        use crate::{
+            lsp::{Position, Range},
+            undo::{TextPosition, TextRange},
+        };
+        let mut buffer = Buffer::new(Some("fixture.rs".into()), "😀value\r\nnext".into());
+        let id = buffer.id();
+        let mut coordinator = LspCoordinator::with_buffers(std::slice::from_ref(&buffer));
+        for text in ["λ", "x"] {
+            let before = buffer.contents_snapshot();
+            let revision = buffer.revision();
+            let offset = if text == "λ" { 1 } else { 2 };
+            let position = TextPosition::new(0, offset);
+            let start = buffer.position_to_lsp(position);
+            buffer.replace_range_raw(TextRange::insertion(position), text);
+            coordinator.record_edit(
+                id,
+                revision,
+                buffer.revision(),
+                before,
+                Range { start, end: start },
+                text,
+            );
+        }
+        let change = coordinator
+            .pending_change(id, buffer.revision(), buffer.contents_snapshot())
+            .unwrap();
+        assert_eq!(change.changes.len(), 1);
+        assert_eq!(change.changes[0].text, "λx");
+        assert_eq!(
+            change.changes[0].range.as_ref().unwrap().start,
+            Position {
+                line: 0,
+                character: 2
+            }
+        );
+        assert_eq!(
+            buffer.position_to_lsp(TextPosition::new(1, 0)),
+            Position {
+                line: 1,
+                character: 0
+            }
+        );
+        buffer.insert_str(0, 0, "raw");
+        assert!(coordinator
+            .pending_change(id, buffer.revision(), buffer.contents_snapshot())
+            .is_none());
+        coordinator.record_notified_revision(id, buffer.revision());
+        assert!(coordinator.pending_changes.is_empty());
+    }
+
+    #[test]
+    fn unusual_line_separators_keep_the_full_text_fallback() {
+        use crate::{
+            lsp::Range,
+            undo::{TextPosition, TextRange},
+        };
+        for source in ["one\rtwo", "one\u{2028}two", "one\u{0085}two"] {
+            let mut buffer = Buffer::new(Some("fixture.rs".into()), source.into());
+            let id = buffer.id();
+            let mut coordinator = LspCoordinator::with_buffers(std::slice::from_ref(&buffer));
+            let before = buffer.contents_snapshot();
+            let revision = buffer.revision();
+            let position = TextPosition::new(1, 0);
+            let start = buffer.position_to_lsp(position);
+            buffer.replace_range_raw(TextRange::insertion(position), "x");
+            coordinator.record_edit(
+                id,
+                revision,
+                buffer.revision(),
+                before,
+                Range { start, end: start },
+                "x",
+            );
+            assert!(coordinator
+                .pending_change(id, buffer.revision(), buffer.contents_snapshot())
+                .is_none());
+        }
+    }
 
     #[test]
     fn tracks_documents_and_seeded_buffer_revisions() {

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1238,7 +1238,7 @@ impl Editor {
     /// Renders the entire editor state to the terminal
     /// This is the main entry point for all rendering operations
     pub fn render(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
-        if self.defer_motion_render {
+        if self.render_is_deferred() {
             self.request_motion_render(super::MotionRender::Full);
             return Ok(());
         }
@@ -1406,7 +1406,7 @@ impl Editor {
     }
 
     pub(crate) fn render_motion_frame(&mut self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
-        if self.defer_motion_render {
+        if self.render_is_deferred() {
             self.request_motion_render(super::MotionRender::Window);
             return Ok(());
         }
@@ -1422,7 +1422,7 @@ impl Editor {
         &mut self,
         buffer: &mut RenderBuffer,
     ) -> anyhow::Result<()> {
-        if self.defer_motion_render {
+        if self.render_is_deferred() {
             self.request_motion_render(super::MotionRender::EditorWindows);
             return Ok(());
         }
@@ -1515,6 +1515,10 @@ impl Editor {
         &mut self,
         buffer: &mut RenderBuffer,
     ) -> anyhow::Result<()> {
+        if self.render_is_deferred() {
+            self.request_motion_render(super::MotionRender::Cursor);
+            return Ok(());
+        }
         let _span = super::perf::PerfSpan::start("render:motion_delta");
         self.update_gutter_width();
         self.fix_cursor_pos();
@@ -1579,12 +1583,14 @@ impl Editor {
         Ok(())
     }
 
-    /// Flushes one complete, document-aware frame after an edit.
+    /// Repaint document-aware editor windows while reusing unchanged docked
+    /// surfaces. The shared frame path falls back to a full render when an
+    /// overlay, layout invalidation, or other surface makes reuse unsafe.
     pub(super) fn render_edited_window_rows(
         &mut self,
         buffer: &mut RenderBuffer,
     ) -> anyhow::Result<()> {
-        self.render(buffer)
+        self.render_editor_windows_frame(buffer)
     }
 
     fn render_window_rows(
@@ -3722,6 +3728,10 @@ impl Editor {
         self.fix_cursor_pos();
         self.sync_to_window();
 
+        if self.render_is_deferred() {
+            self.request_motion_render(super::MotionRender::Cursor);
+            return Ok(());
+        }
         if !self.terminal_output_enabled {
             return Ok(());
         }

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -621,7 +621,7 @@ pub struct RealLspClient {
     request_tx: mpsc::Sender<OutboundMessage>,
     response_rx: mpsc::Receiver<InboundMessage>,
     files_versions: HashMap<String, usize>,
-    files_content: HashMap<String, String>,
+    files_content: HashMap<String, ropey::Rope>,
     pending_responses: HashMap<i64, Request>,
     initialize_id: Option<i64>,
     initialized: bool,
@@ -866,7 +866,8 @@ impl RealLspClient {
         let params = did_open_params(file, contents, language_id)?;
 
         let uri = file_uri(file)?;
-        self.files_content.insert(uri.clone(), contents.to_string());
+        self.files_content
+            .insert(uri.clone(), ropey::Rope::from_str(contents));
         self.files_versions.insert(uri, 1);
         <Self as LspClient>::send_notification(self, "textDocument/didOpen", params, false).await?;
 
@@ -1291,6 +1292,7 @@ impl LspClient for RealLspClient {
     }
 
     async fn did_change(&mut self, file: &str, contents: String) -> Result<(), LspError> {
+        crate::editor::perf::increment("edit:lsp_full_text_bytes", contents.len() as u64);
         let uri = file_uri(file)?;
         // Diagnostics are debounced: typing produces a didChange per
         // keystroke, and requesting diagnostics for every one of them floods
@@ -1326,7 +1328,8 @@ impl LspClient for RealLspClient {
                     contents
                 } else {
                     let text = contents.clone();
-                    self.files_content.insert(uri.clone(), contents);
+                    self.files_content
+                        .insert(uri.clone(), ropey::Rope::from_str(&contents));
                     text
                 };
                 vec![TextDocumentContentChangeEvent {
@@ -1340,12 +1343,13 @@ impl LspClient for RealLspClient {
                 let old_content = self
                     .files_content
                     .get(&uri)
-                    .map(String::as_str)
-                    .unwrap_or("");
+                    .map(ToString::to_string)
+                    .unwrap_or_default();
 
-                // Calculate actual changes
-                let changes = Self::calculate_changes(old_content, &contents);
-                self.files_content.insert(uri.clone(), contents);
+                // Legacy callers do not supply canonical edit ranges.
+                let changes = Self::calculate_changes(&old_content, &contents);
+                self.files_content
+                    .insert(uri.clone(), ropey::Rope::from_str(&contents));
                 changes
             }
             _ => return Ok(()),
@@ -1365,6 +1369,47 @@ impl LspClient for RealLspClient {
             .await?;
 
         Ok(())
+    }
+
+    async fn did_change_edits(
+        &mut self,
+        file: &str,
+        change: super::DocumentChange,
+    ) -> Result<(), LspError> {
+        let uri = file_uri(file)?;
+        let incremental = matches!(
+            self.server_capabilities
+                .as_ref()
+                .and_then(|caps| caps.text_document_sync.as_ref())
+                .and_then(|sync| sync.change_kind()),
+            Some(TextDocumentSyncKind::Incremental)
+        );
+        let matches_before = self.files_content.get(&uri).is_some_and(|previous| {
+            previous.is_instance(&change.before) || previous == &change.before
+        });
+        if !incremental || !matches_before || change.changes.is_empty() {
+            return self.did_change(file, change.after.to_string()).await;
+        }
+        self.schedule_diagnostics(&uri);
+        let version = self.files_versions.entry(uri.clone()).or_insert(0);
+        *version += 1;
+        let version = *version;
+        crate::editor::perf::increment("edit:lsp_incremental_changes", change.changes.len() as u64);
+        crate::editor::perf::increment(
+            "edit:lsp_incremental_bytes",
+            change
+                .changes
+                .iter()
+                .map(|edit| edit.text.len() as u64)
+                .sum(),
+        );
+        self.files_content.insert(uri.clone(), change.after);
+        self.send_notification(
+            "textDocument/didChange",
+            did_change_params(&uri, version, change.changes),
+            false,
+        )
+        .await
     }
 
     async fn did_save(&mut self, file: &str, contents: &str) -> Result<(), LspError> {
@@ -3307,6 +3352,95 @@ mod test {
     }
 
     #[tokio::test]
+    async fn canonical_edits_use_incremental_sync_and_keep_shared_snapshots() {
+        let (request_tx, mut request_rx) = mpsc::channel(8);
+        let (_response_tx, response_rx) = mpsc::channel(1);
+        let config = default_language_servers().remove("rust").unwrap();
+        let mut client = RealLspClient::with_test_channels(
+            request_tx,
+            response_rx,
+            config,
+            std::env::current_dir().unwrap(),
+        );
+        client.server_capabilities =
+            Some(serde_json::from_value(json!({ "textDocumentSync": 2 })).unwrap());
+        let file = "/tmp/canonical-sync.rs";
+        let before = ropey::Rope::from_str("a😀b\r\nnext\n");
+        let mut after = before.clone();
+        after.remove(1..2);
+        after.insert(1, "λ");
+        client.did_open(file, &before.to_string()).await.unwrap();
+        request_rx.recv().await.unwrap();
+        client
+            .did_change_edits(
+                file,
+                crate::lsp::DocumentChange {
+                    before,
+                    after: after.clone(),
+                    changes: vec![TextDocumentContentChangeEvent {
+                        range: Some(Range {
+                            start: Position {
+                                line: 0,
+                                character: 1,
+                            },
+                            end: Position {
+                                line: 0,
+                                character: 3,
+                            },
+                        }),
+                        range_length: None,
+                        text: "λ".into(),
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+        let Some(OutboundMessage::Notification(notification)) = request_rx.recv().await else {
+            panic!("expected didChange");
+        };
+        assert_eq!(
+            notification.params["contentChanges"],
+            json!([{ "range": { "start": { "line": 0, "character": 1 }, "end": { "line": 0, "character": 3 } }, "text": "λ" }])
+        );
+        assert_eq!(notification.params["textDocument"]["version"], 2);
+        assert!(client.files_content[&file_uri(file).unwrap()].is_instance(&after));
+
+        // A stale or newly opened preimage must not receive obsolete ranges.
+        client
+            .did_change_edits(
+                file,
+                crate::lsp::DocumentChange {
+                    before: ropey::Rope::from_str("stale"),
+                    after: ropey::Rope::from_str("latest"),
+                    changes: vec![TextDocumentContentChangeEvent {
+                        range: Some(Range {
+                            start: Position {
+                                line: 0,
+                                character: 99,
+                            },
+                            end: Position {
+                                line: 0,
+                                character: 99,
+                            },
+                        }),
+                        range_length: None,
+                        text: "wrong".into(),
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+        let Some(OutboundMessage::Notification(notification)) = request_rx.recv().await else {
+            panic!("expected fallback didChange");
+        };
+        assert_eq!(notification.params["contentChanges"][0]["text"], "latest");
+        assert_eq!(
+            client.files_content[&file_uri(file).unwrap()].to_string(),
+            "latest"
+        );
+    }
+
+    #[tokio::test]
     async fn full_sync_moves_contents_into_notification_and_releases_cached_copy() {
         let (request_tx, mut request_rx) = mpsc::channel(4);
         let (_response_tx, response_rx) = mpsc::channel(1);
@@ -3324,7 +3458,7 @@ mod test {
         let file = "/tmp/full-sync.rs";
         let uri = file_uri(file).unwrap();
         client.did_open(file, "old").await.unwrap();
-        assert_eq!(client.files_content[&uri], "old");
+        assert_eq!(client.files_content[&uri].to_string(), "old");
 
         let contents = "updated 👋".repeat(64);
         let contents_ptr = contents.as_ptr();
@@ -3367,7 +3501,7 @@ mod test {
 
         client.did_change(file, "latest".to_string()).await.unwrap();
 
-        assert_eq!(client.files_content[&uri], "latest");
+        assert_eq!(client.files_content[&uri].to_string(), "latest");
         assert!(matches!(
             request_rx.recv().await,
             Some(OutboundMessage::Notification(notification))

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -407,6 +407,20 @@ impl LspClient for LspManager {
         result
     }
 
+    async fn did_change_edits(
+        &mut self,
+        file: &str,
+        change: super::DocumentChange,
+    ) -> Result<(), LspError> {
+        if let Some(key) = self.document_clients.get(file) {
+            if let Some(client) = self.clients.get_mut(key) {
+                return client.did_change_edits(file, change).await;
+            }
+        }
+        // Lazy routing may open the latest image. Do not apply older ranges to it.
+        self.did_change(file, change.after.to_string()).await
+    }
+
     async fn did_save(&mut self, file: &str, contents: &str) -> Result<(), LspError> {
         self.did_open(file, contents).await?;
         if let Some(key) = self.document_clients.get(file) {

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -42,6 +42,15 @@ pub mod manager;
 pub mod types;
 pub mod workspace_edit;
 
+/// Ordered incremental edits and their cheap, exact document snapshots.
+/// Ranges use UTF-16 coordinates in the document produced by the preceding edit.
+#[derive(Debug, Clone)]
+pub struct DocumentChange {
+    pub before: ropey::Rope,
+    pub after: ropey::Rope,
+    pub changes: Vec<TextDocumentContentChangeEvent>,
+}
+
 #[derive(Debug)]
 /// Failure returned by the LSP transport, protocol, or lifecycle boundary.
 pub enum LspError {
@@ -321,6 +330,15 @@ pub trait LspClient: std::any::Any + Send {
     async fn did_open(&mut self, file: &str, contents: &str) -> Result<(), LspError>;
     /// Publishes the current full document text as the next version.
     async fn did_change(&mut self, file: &str, contents: String) -> Result<(), LspError>;
+    /// Publishes known edits when supported, otherwise falls back to full text.
+    async fn did_change_edits(
+        &mut self,
+        file: &str,
+        change: DocumentChange,
+    ) -> Result<(), LspError> {
+        self.did_change(file, change.after.to_string()).await
+    }
+
     /// Notifies the server after the supplied document contents were saved successfully.
     async fn did_save(&mut self, _file: &str, _contents: &str) -> Result<(), LspError> {
         Ok(())

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -254,6 +254,8 @@ pub struct UndoHistory {
     current: Option<usize>,
     branch_selection: HashMap<usize, usize>,
     active_transaction: Option<EditTransaction>,
+    #[serde(skip)]
+    active_insert_end: Option<usize>,
     current_revision: u64,
     saved_revision: u64,
     next_revision: u64,
@@ -270,6 +272,7 @@ impl Default for UndoHistory {
             current: None,
             branch_selection: HashMap::new(),
             active_transaction: None,
+            active_insert_end: None,
             current_revision: 0,
             saved_revision: 0,
             next_revision: 1,
@@ -311,6 +314,7 @@ impl UndoHistory {
         origin: EditOrigin,
     ) {
         if self.active_transaction.is_none() {
+            self.active_insert_end = None;
             self.active_transaction = Some(EditTransaction::new(
                 label,
                 before_cursor,
@@ -365,6 +369,23 @@ impl UndoHistory {
         }
 
         if let Some(transaction) = &mut self.active_transaction {
+            let insertion = old_text.is_empty() && range.start == range.end;
+            let insertion_end = insertion.then(|| start_char + new_text.chars().count());
+            if insertion && self.active_insert_end == Some(start_char) {
+                if let Some(TextEdit::Replace {
+                    old_text: previous_old,
+                    new_text: previous_new,
+                    ..
+                }) = transaction.edits.last_mut()
+                {
+                    if previous_old.is_empty() {
+                        previous_new.push_str(&new_text);
+                        self.active_insert_end = insertion_end;
+                        return;
+                    }
+                }
+            }
+            self.active_insert_end = insertion_end;
             transaction.edits.push(TextEdit::Replace {
                 range,
                 start_char,
@@ -379,6 +400,7 @@ impl UndoHistory {
     /// Returns `true` only when history advanced. Empty transactions are discarded and
     /// sibling branches remain available.
     pub fn commit_transaction(&mut self, after_cursor: CursorSnapshot) -> bool {
+        self.active_insert_end = None;
         let Some(mut transaction) = self.active_transaction.take() else {
             return false;
         };
@@ -466,6 +488,7 @@ impl UndoHistory {
             .is_some_and(EditTransaction::is_empty)
         {
             self.active_transaction = None;
+            self.active_insert_end = None;
         }
     }
 


### PR DESCRIPTION
## Why

Dot-repeat, macros, counted edits, and visual-block replay were rebuilding frames and publishing document changes for individual replayed characters. A short repeat could therefore perform over a hundred full renders, while block insertion constructed thousands of hidden scratch frames.

## Changes

- Add nested edit batches that preserve synchronous text, marks, modes, and undo state while coalescing rendering and derived notifications. External actions flush first; plugin mode transitions remain ordered.
- Give long replays bounded checkpoints and Ctrl-C cancellation, preserving queued input and undoable partial edits.
- Send canonical UTF-16 edits to incremental LSP servers with exact-preimage checks and full-text fallbacks.
- Reuse document-aware editor-window rendering, compact adjacent insert undo records, and batch safe ASCII runs in embedded text areas.
- Add deterministic regressions, a real-PTY benchmark, a local LSP reconstruction fixture, and measurement/architecture documentation.

## Results

Local release samples on macOS arm64, with 2,000 Rust lines and trace instrumentation:

| Operation | Before | After |
| --- | ---: | ---: |
| 128-character dot-repeat | 68.5 ms | 7.2 ms |
| 128-character macro | 69.2 ms | 6.3 ms |
| 16-row block insertion | 1,593 ms | 91 ms |

Dot renders and LSP notifications fell from 130/128 to 1/1. Full-sync repeat payload fell from 4.75 MB to 37 KB. These are diagnostic samples, not CI timing thresholds. See `docs/performance-edit-replay-2026-08-17.md` for the complete comparison and retained scope decisions.

## How to Test

1. Build with `cargo build --locked --release -p red --bin red`, then run `python3 scripts/edit_replay_bench.py --binary target/release/red`. All eight scenarios should save the exact expected text; short dot/macro replay should publish one final frame.
2. Run the benchmark with `--plugins --split --scenario dot --scenario block`, then with `--lsp incremental --unicode --crlf`. Repeat with `--lsp full --scenario dot --scenario undo`. Shared views must agree, and the local LSP fixture must reconstruct the document exactly with increasing versions.
3. In a disposable file, run `:register a irepeat-me-repeat-me-repeat-me-<Esc>`, then `5000@a` and press Ctrl-C while it runs. Expect Normal mode and `replay interrupted`; `u` and Ctrl-r must undo and restore the partial insertion without damaging the original text.

Validated at `5050e50`: 2,784 tests passed, one ignored; strict all-target/all-feature Clippy and format checks passed. The retained smoke also passed 42 before/after PTY cases and six manual checks, including shared splits and cancellation undo/redo. Protocol coverage uses a deterministic local server, not every production language server.