### PR TITLE
fix(completion): preserve snippet navigation with empty popups

### DIFF
--- a/docs/performance-edit-replay-2026-08-17.md
+++ b/docs/performance-edit-replay-2026-08-17.md
@@ -1,0 +1,135 @@
+# Red repeated-edit performance plan
+
+## Evidence
+
+Inspected on 2026-08-17 at `20f4cc2c36012a1399749737922b1faa65fc3506`.
+The primary checkout stayed clean. Local `origin/main` was `311a72e`, eight
+commits ahead; its syntax-indentation and signature-help changes were inspected.
+They do not replace the replay/render paths below. No running editor was touched.
+
+A one-off audit harness linked the inspected debug library and exercised the
+production dispatcher with default keymaps, `RED_PERF=trace`, disabled
+LSP/terminal output, and assertions on resulting text.
+It does not measure a live terminal, real language server, or loaded plugins.
+These are diagnostic samples, not release benchmarks or promised speedups.
+
+| Operation | Fixture | Time | Full renders | Highlight misses |
+| --- | --- | ---: | ---: | ---: |
+| Dot-repeat, 32 characters | 1,487,538-byte Rust source | 143.4 ms | 34 | 32 |
+| Bulk insert, 32 characters | Same source | 4.2 ms | 1 | 1 |
+| Dot-repeat, 128 characters | Same source | 638.6 ms | 130 | 128 |
+| Bulk insert, 128 characters | Same source | 5.5 ms | 1 | 1 |
+| Macro inserting 128 characters | Same source | 637.8 ms | 131 | 129 |
+| Undo that insertion | Same source | 9.6 ms | 1 | 1 |
+| `128x` | 256-character line | 339.6 ms | 131 | 129 |
+| Replicate 32 characters onto 15 more block rows | 16 short Rust lines | 3,441.1 ms | 481 | 480 |
+
+An earlier dot/bulk run measured 654.0 ms versus 5.8 ms for 128 characters.
+The second run spent 476.9 ms inside full-render spans and 9.6 ms inside
+character-replacement spans. Nested spans must not be added together.
+
+## Audit inventory
+
+- **Dot, macros, counts, and chained actions:** the [replay drivers](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L11692)
+  dispatch individual actions. Some operators already accept semantic counts,
+  but the generic fallback still repeats the whole action. Highest priority.
+- **Visual-block insert/change:** [execute_on_block](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L20699)
+  defers notifications and suppresses terminal output, but still constructs
+  scratch frames for each action on each row. Highest priority.
+- **Ordinary typing/deletion and split windows:** [render_edited_window_rows](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor/rendering.rs#L1582)
+  calls the full renderer. The [dispatcher tail](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L20265)
+  can render again for bounds changes or multiple windows.
+  [Highlight caches](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L6237) invalidate
+  on every content revision.
+- **LSP, plugins, inline summaries, and completion:** [notify_change](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L21294)
+  materializes full document text for LSP, awaits `buffer:changed`, refreshes
+  summaries, and schedules inline completion. Incremental LSP sync still
+  [compares old/new full strings](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/lsp/client.rs#L750).
+  Diagnostics are already debounced; document synchronization is not.
+- **Substitute-all, indentation, comments, completion edits, and plugin document
+  transactions:** [substitution](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L14558),
+  [indentation](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L16732),
+  [comments](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L22774), and
+  [plugin transactions](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editor.rs#L21599) are
+  already partly batched. Profile their remaining per-replacement anchor,
+  history, annotation, and dirty-state work before changing them.
+- **Undo/redo and whole-document replacements:** [undo history](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/undo.rs#L356)
+  retains individual replacements. Undo already renders once in this sample.
+  Visual paste, agent whole-file edits, and prepared LSP workspace edits can
+  replace a whole document; smaller edits may reduce copies and undo memory.
+- **Embedded text areas:** [TextArea replay](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editing/textarea.rs#L1530)
+  has a separate key-replay implementation and
+  [whole-text coordinate calculations](https://github.com/codersauce/red/blob/20f4cc2c36012a1399749737922b1faa65fc3506/src/editing/textarea.rs#L1724).
+  Benchmark large composer text separately; this component has no internal LSP
+  or terminal work.
+- **Newer main:** include syntax indentation and signature help in the baseline.
+  Keep indentation decisions that affect later edits synchronous; defer only
+  speculative UI work when safe.
+
+## Implementation order
+
+### 1. Permanent baselines
+
+Refresh main and use branch `fcoury/edit-replay-performance` in durable sibling
+worktree `red.fcoury-edit-replay-performance`. Extend
+`scripts/interaction_bench.py` or add a focused replay benchmark. Add counters
+for renders, highlight misses, replacements, LSP calls/bytes, plugin events,
+and inline-summary refreshes. Measure short/long inserts, large files, LSP and
+plugins off/on, shared-buffer splits, wrapping, and retained inline history.
+
+### 2. Batch replay rendering
+
+Add a small nested execution-batch boundary outside the large recursive
+dispatcher. Keep mutations, marks, revisions, selections, modes, and undo
+transactions exact. Accumulate render invalidation and commit one correct final
+frame for short commands. Apply it to dot, macros, generic counted/chained
+actions, and visual-block replay. Reuse existing navigation/block deferral where
+their semantics agree. Long macros need bounded work slices, cancellation, and
+background-service points. Preserve recursion limits and restore batch state on
+errors. Do not blindly convert arbitrary recorded keys into a paste.
+
+### 3. Batch notifications safely
+
+Track dirty buffers by stable `BufferId` and latest revision. Flush before LSP
+requests requiring current text, saves, document switches/closure, and other
+observable barriers. Define plugin event semantics before coalescing events:
+macros/plugins that depend on intermediate state must still see it. Preserve
+notification retry behavior. A plain single-buffer insertion replay should need
+one final change notification and one completion scheduling pass.
+
+### 4. Make individual edits cheaper
+
+Feed canonical replacements to incremental LSP synchronization, retaining
+full-sync support and correct UTF-16/CRLF conversion. Add safe changed-region
+rendering for interactive edits, with full-redraw fallbacks for syntax context,
+wrapping/layout changes, overlays, and shared-buffer windows. Preserve the
+existing committed-frame and document-aware highlighting invariants.
+
+### 5. Profile and optimize the remaining bulk paths
+
+Candidates: compact provably adjacent undo edits; defer derived history and
+annotation refreshes while transforming live anchors in order; implement more
+direct counted operations; retain smaller edit ranges for whole-document plans;
+cache or use rope-based coordinates in embedded text areas. Make these separate,
+measured changes rather than one editor rewrite.
+
+## Acceptance and validation
+
+- Compare final text, cursor, mode, registers, marks, selection, dirty state,
+  undo/redo, and rendered cells against the existing behavior.
+- Preserve location-relative dot semantics, literal periods, Unicode/emoji,
+  CRLF, tabs, EOF/final-newline edits, autoindent, snippets, visual-block padding,
+  nested macros, error recovery, and multi-buffer save/LSP/plugin barriers.
+- Assert work counts instead of machine-dependent timing thresholds. A short
+  plain-text repeat must not do one full render/highlight per character.
+- Keep the explicit 2 MiB-stack visual-block/dot regression. Avoid increasing
+  the recursive dispatcher frame.
+- Run focused tests, the full suite serially (`--test-threads=1`), formatting,
+  and `cargo clippy --all-targets --all-features -- -D warnings` before pushing.
+- Capture release-build PTY before/after evidence for dot, macros, block change,
+  cancellation, undo, and shared-buffer splits before claiming completion.
+
+Audit validation: `cargo build --locked --lib -p red` passed; all harness
+assertions passed; `cargo test --locked --test editing dot_ -- --test-threads=1`
+passed 12 tests at the inspected commit. The audit changed no production source
+and did not push or open a PR.

--- a/src/editor/snippet.rs
+++ b/src/editor/snippet.rs
@@ -314,7 +314,6 @@ impl Editor {
 
     pub(super) fn handle_snippet_event(&mut self, event: &Event) -> Option<KeyAction> {
         if !self.is_insert()
-            || self.current_dialog.is_some()
             || self.panel_manager.focused_panel_id().is_some()
             || self
                 .snippet_session
@@ -345,6 +344,17 @@ impl Editor {
             }
             _ => return None,
         };
+
+        if let Some(dialog) = &self.current_dialog {
+            // An invisible, zero-match completion must not swallow snippet Tab.
+            // Keep ordinary completion acceptance and other dialog keys intact.
+            return (dialog.is_empty_completion()
+                && matches!(
+                    action,
+                    Action::NextSnippetPlaceholder | Action::PreviousSnippetPlaceholder
+                ))
+            .then(|| KeyAction::Multiple(vec![Action::CloseDialog, action]));
+        }
         Some(KeyAction::Single(action))
     }
 

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -582,6 +582,10 @@ impl CompletionUI {
 }
 
 impl Component for CompletionUI {
+    fn is_empty_completion(&self) -> bool {
+        self.selected_item().is_none()
+    }
+
     fn completion_popup_bounds(&self) -> Option<(usize, usize, usize, usize)> {
         self.has_shortcut_context()
             .then_some((self.x, self.y, self.width, self.visible_rows + 2))
@@ -1175,8 +1179,10 @@ mod tests {
     fn enter_inserts_a_newline_when_no_completion_is_selected() {
         let mut ui = CompletionUI::new();
         ui.show(vec![item("alpha", Some(CompletionItemKind::Text))], 0, 0);
+        assert!(!ui.is_empty_completion());
         ui.set_filter("no_match");
 
+        assert!(ui.is_empty_completion());
         assert!(ui.selected_item().is_none());
         assert_eq!(
             ui.handle_event(&key(KeyCode::Tab, KeyModifiers::NONE)),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -214,6 +214,12 @@ pub trait Component: Send {
         false
     }
 
+    /// Whether this is a completion popup with no selectable item.
+    /// Filtering can leave such a popup installed even when it draws nothing.
+    fn is_empty_completion(&self) -> bool {
+        false
+    }
+
     /// Absolute bounds of an interactive completion popup, including its border.
     fn completion_popup_bounds(&self) -> Option<(usize, usize, usize, usize)> {
         None

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -646,6 +646,109 @@ async fn an_open_completion_menu_accepts_before_snippet_navigation() {
     assert_eq!(editor.test_cursor_position(), (12, 1));
 }
 
+async fn editor_with_argument_snippet() -> Editor {
+    let (mut editor, _) = recording_editor(Buffer::new(None, "alpha\nseed".to_string()));
+    let mut completion = item("call");
+    completion.text_edit = Some(text_edit(
+        range(1, 0, 1, 4),
+        "call(${1:value}, ${2:next}, ${3:last})$0",
+    ));
+    completion.insert_text_format = Some(InsertTextFormat::Snippet);
+    editor
+        .test_execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    editor
+        .test_execute_action(Action::ApplyCompletion {
+            item: Box::new(completion),
+            commit_character: None,
+        })
+        .await
+        .unwrap();
+    editor
+}
+
+async fn filter_argument_completion_to_zero(editor: &mut Editor) {
+    editor.test_type_text("a").await.unwrap();
+    editor
+        .test_execute_action(Action::RequestCompletion)
+        .await
+        .unwrap();
+    // Use real key events so the open popup's filter changes with the buffer.
+    for character in "zzz".chars() {
+        editor
+            .test_execute_event(Event::Key(KeyEvent::new(
+                KeyCode::Char(character),
+                KeyModifiers::NONE,
+            )))
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn empty_completion_menu_does_not_block_next_snippet_placeholder() {
+    let mut editor = editor_with_argument_snippet().await;
+    filter_argument_completion_to_zero(&mut editor).await;
+    assert_eq!(
+        editor.test_buffer_contents(),
+        "alpha\ncall(azzz, next, last)"
+    );
+
+    editor
+        .test_execute_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+    assert_eq!(
+        editor.test_buffer_contents(),
+        "alpha\ncall(azzz, next, last)"
+    );
+    assert_eq!(editor.test_cursor_position(), (11, 1));
+
+    editor.test_type_text("42").await.unwrap();
+    editor
+        .test_execute_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+    assert_eq!(editor.test_buffer_contents(), "alpha\ncall(azzz, 42, last)");
+    assert_eq!(editor.test_cursor_position(), (15, 1));
+}
+
+#[tokio::test]
+async fn empty_completion_menu_does_not_block_previous_snippet_placeholder() {
+    let mut editor = editor_with_argument_snippet().await;
+    editor
+        .test_execute_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+    filter_argument_completion_to_zero(&mut editor).await;
+    assert_eq!(
+        editor.test_buffer_contents(),
+        "alpha\ncall(value, azzz, last)"
+    );
+
+    editor
+        .test_execute_event(Event::Key(KeyEvent::new(
+            KeyCode::BackTab,
+            KeyModifiers::SHIFT,
+        )))
+        .await
+        .unwrap();
+    assert_eq!(
+        editor.test_buffer_contents(),
+        "alpha\ncall(value, azzz, last)"
+    );
+    assert_eq!(editor.test_cursor_position(), (5, 1));
+
+    editor.test_type_text("7").await.unwrap();
+    editor
+        .test_execute_event(Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)))
+        .await
+        .unwrap();
+    assert_eq!(editor.test_buffer_contents(), "alpha\ncall(7, azzz, last)");
+    assert_eq!(editor.test_cursor_position(), (8, 1));
+}
+
 #[tokio::test]
 async fn moving_outside_snippet_cancels_selected_argument_replacement() {
     let (mut editor, _) = recording_editor(Buffer::new(None, "prefix seed".to_string()));


### PR DESCRIPTION
## Why

Follow-up to #262. While editing a function argument, an automatic completion popup can filter down to zero matches and disappear without closing. The invisible popup still blocks snippet navigation, so `Tab` inserts whitespace and `Shift-Tab` does not move to the previous argument.

## What changed

- Expose whether a completion popup has no selectable item.
- Close an empty popup before moving to the next or previous active snippet placeholder.
- Preserve normal completion acceptance when a suggestion is selected, and add forward/backward regression tests using real key events.

## How to Test

1. Open a Rust file with rust-analyzer running. Define a function with several arguments and a local variable such as `alternate_value`. Accept the function's callable completion. Its first argument should be selected.
2. Type `alt`, wait for the completion popup, then continue with text that matches no suggestion. When the popup disappears, press `Tab`. The next argument should become selected without inserting whitespace. Repeat in the second argument with `Shift-Tab`; the first argument should become selected.
3. Repeat with a matching suggestion. The first `Tab` should accept that suggestion, and the next should advance to the next argument. Fill the remaining arguments and confirm the final `Tab` reaches the end of the call.
4. Run `cargo test --test completion empty_completion_menu_does_not_block -- --test-threads=1` for the two focused regressions.

### Validation

- Both new regressions failed before the fix and passed afterward.
- Completion integration suite: 46 passed, including a rerun after syncing current `main`.
- Completion UI unit tests: 26 passed.
- Real rust-analyzer smoke in tmux: all nine checkpoints passed, covering both zero-match navigation directions, normal completion acceptance, and the final snippet stop.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- Formatting and diff whitespace checks: passed.
