### PR TITLE
fix(matchit): handle rust lifetimes in percent motions

### DIFF
--- a/src/matchit.rs
+++ b/src/matchit.rs
@@ -146,10 +146,10 @@ impl BracketMatchCache {
                     }
                     if character == '\'' {
                         if is_rust
-                            && rope
-                                .get_char(index.saturating_add(1))
-                                .is_some_and(|next| next == '_' || next.is_alphabetic())
-                            && rope.get_char(index.saturating_add(2)) != Some('\'')
+                            && is_rust_lifetime_start(
+                                rope.get_char(index.saturating_add(1)),
+                                rope.get_char(index.saturating_add(2)),
+                            )
                         {
                             continue;
                         }
@@ -195,6 +195,14 @@ fn single_character(token: &str) -> Option<char> {
     let mut characters = token.chars();
     let character = characters.next()?;
     characters.next().is_none().then_some(character)
+}
+
+/// Distinguishes a Rust lifetime or loop label from a quoted character.
+/// The caller has already found the apostrophe; an immediate closing quote
+/// keeps character literals such as `'a'` and `'_'` in the quoted path.
+fn is_rust_lifetime_start(next: Option<char>, after_next: Option<char>) -> bool {
+    next.is_some_and(|character| character == '_' || character.is_alphabetic())
+        && after_next != Some('\'')
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -413,7 +421,7 @@ fn tokens_for_document(
     config: &MatchitConfig,
 ) -> Vec<Token> {
     let groups = groups_for_config(language_id, config);
-    let skip_ranges = skip_ranges(doc);
+    let skip_ranges = skip_ranges(doc, language_id);
     let mut tokens = Vec::new();
     for (group_idx, group) in groups.iter().enumerate() {
         collect_group_tokens(doc, group_idx, group, &skip_ranges, &mut tokens);
@@ -587,12 +595,20 @@ fn should_keep_token(
         .any(|(range_start, range_end)| start >= *range_start && end <= *range_end)
 }
 
-fn skip_ranges(doc: &Document) -> Vec<(usize, usize)> {
+fn skip_ranges(doc: &Document, language_id: Option<&str>) -> Vec<(usize, usize)> {
     let chars = doc.chars();
     let mut ranges = Vec::new();
     let mut idx = 0;
     while idx < chars.len() {
         match chars[idx] {
+            '\'' if language_id == Some("rust")
+                && is_rust_lifetime_start(
+                    chars.get(idx + 1).copied(),
+                    chars.get(idx + 2).copied(),
+                ) =>
+            {
+                idx += 1;
+            }
             '"' | '\'' => {
                 let quote = chars[idx];
                 let start = idx;
@@ -993,5 +1009,122 @@ mod bracket_match_tests {
             ),
             Some(position(contents, "}", 0))
         );
+    }
+
+    #[test]
+    fn rust_percent_motion_matches_methods_with_lifetimes() {
+        for signature in [
+            "fn update(&mut self, d: &mut DrawHandle<'_>)",
+            "fn borrow<'value>(text: &'value str) -> &'value str",
+            "fn permanent(text: &'static str)",
+            "fn unicode<'é>(text: &'é str) -> &'é str",
+        ] {
+            let contents = format!("{signature} {{\n    let values = [1, 2];\n}}");
+            let config = MatchitConfig::default();
+            for (open, close) in [("{", "}"), ("[", "]"), ("(", ")")] {
+                let opener = position(&contents, open, 0);
+                let closer = position(&contents, close, 0);
+                for direction in [MatchDirection::Forward, MatchDirection::Backward] {
+                    for (start, expected) in [(opener, closer), (closer, opener)] {
+                        assert_eq!(
+                            find_motion(&contents, start, Some("rust"), &config, direction)
+                                .map(|motion| motion.target),
+                            Some(expected),
+                            "{signature}: {open}{close} {direction:?} from {start:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rust_percent_motion_preserves_quoted_literals() {
+        for literal in [
+            "'a'",
+            "'_'",
+            "'é'",
+            "']'",
+            "b']'",
+            r"'\''",
+            r"'\u{5d}'",
+            r#""text ']""#,
+        ] {
+            let contents = format!("[{literal}]");
+            let config = MatchitConfig::default();
+            assert_eq!(
+                find_motion(
+                    &contents,
+                    position(&contents, "[", 0),
+                    Some("rust"),
+                    &config,
+                    MatchDirection::Forward,
+                )
+                .map(|motion| motion.target),
+                Some(TextPosition::new(0, contents.chars().count() - 1)),
+                "literal: {literal}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_rust_percent_motion_preserves_single_quoted_strings() {
+        let contents = "['word ] text']";
+        for language in [None, Some("python"), Some("javascript"), Some("bash")] {
+            assert_eq!(
+                find_motion(
+                    contents,
+                    position(contents, "[", 0),
+                    language,
+                    &MatchitConfig::default(),
+                    MatchDirection::Forward,
+                )
+                .map(|motion| motion.target),
+                Some(position(contents, "]", 1)),
+                "language: {language:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rust_lifetimes_preserve_unmatched_and_around_motions() {
+        let contents = "fn update(d: &mut DrawHandle<'_>) {\n    work();\n}";
+        let config = MatchitConfig::default();
+        let cursor = position(contents, "work", 0);
+        let opener = position(contents, "{", 0);
+        let closer = position(contents, "}", 0);
+        for (direction, expected) in [
+            (MatchDirection::Backward, opener),
+            (MatchDirection::Forward, closer),
+        ] {
+            assert_eq!(
+                find_unmatched_group(contents, cursor, Some("rust"), &config, direction)
+                    .map(|motion| motion.target),
+                Some(expected)
+            );
+        }
+        assert_eq!(
+            select_around(contents, cursor, Some("rust"), &config),
+            Some(TextRange::new(opener, advance_position(closer)))
+        );
+    }
+
+    #[test]
+    fn rust_loop_labels_do_not_hide_matching_braces() {
+        let contents = "fn run() { 'outer: loop { break 'outer; } }";
+        let config = MatchitConfig::default();
+        for (open_occurrence, close_occurrence) in [(0, 1), (1, 0)] {
+            assert_eq!(
+                find_motion(
+                    contents,
+                    position(contents, "{", open_occurrence),
+                    Some("rust"),
+                    &config,
+                    MatchDirection::Forward,
+                )
+                .map(|motion| motion.target),
+                Some(position(contents, "}", close_occurrence))
+            );
+        }
     }
 }

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -1972,6 +1972,34 @@ async fn test_percent_matches_nested_bracket_under_cursor() {
 }
 
 #[tokio::test]
+async fn test_percent_matches_rust_method_with_lifetime() {
+    let contents = "impl Game {\n    fn update(&mut self, d: &mut DrawHandle<'_>) {\n        let values = [1, 2];\n    }\n}";
+    let opening_column = contents.lines().nth(1).unwrap().len() - 1;
+
+    for file in ["game.rs", "game.txt"] {
+        let buffer = Buffer::new(Some(file.to_string()), contents.to_string());
+        let mut harness = EditorHarness::with_config(buffer, default_key_config());
+        if file.ends_with(".txt") {
+            harness
+                .execute_action(Action::Command("syntax rust".to_string()))
+                .await
+                .unwrap();
+        }
+
+        harness
+            .execute_action(Action::MoveTo(opening_column, 2))
+            .await
+            .unwrap();
+        type_normal_keys(&mut harness, "%").await;
+        harness.assert_cursor_at(4, 3);
+        type_normal_keys(&mut harness, "%").await;
+        harness.assert_cursor_at(opening_column, 1);
+        type_normal_keys(&mut harness, "g%").await;
+        harness.assert_cursor_at(4, 3);
+    }
+}
+
+#[tokio::test]
 async fn test_counted_percent_jumps_to_file_percentage() {
     let content = (1..=100)
         .map(|line| format!("Line {line:03}"))


### PR DESCRIPTION
## Why

`%` can report `match not found` inside Rust methods whose signatures contain lifetimes such as `Chars<'_>`. The motion tokenizer treats the apostrophe as an opening quote and skips the method body, even though bracket highlighting already recognizes Rust lifetimes. Loop labels can also make the motion select the wrong closing brace.

## What changed

- Share the existing Rust lifetime/loop-label check between bracket highlighting and the matching-motion tokenizer in `src/matchit.rs`.
- Keep character literals and non-Rust single-quoted strings on their existing parsing path.
- Cover forward/backward matching, unmatched and around motions, loop labels, quoted literals, and actual `%`/`g%` key dispatch, including `:syntax rust`.

## How to Test

1. Build with `cargo build --locked --bin red`, then open a `.rs` file containing:

   ```rust
   struct Game;
   impl Game {
       fn update(&mut self, input: &mut std::str::Chars<'_>) {
           let _values = [']', 'a', '_'];
           let _ = input.next();
       }
   }
   ```

2. Put the cursor on the method's opening `{` and press `%`. It should jump to the method's closing `}`. Press `%` again to return; `g%` should also find the matching brace.
3. Put the cursor on the array's `[` and press `%`. It should reach the actual closing `]`, ignoring the `']'` character literal.
4. In a Python file containing `values = ['word ] text']`, repeat the array check. The bracket inside the quoted string should still be ignored.

Targeted automated checks:

```sh
cargo test --locked --lib matchit::bracket_match_tests -- --test-threads=1
cargo test --locked --test movement -- --test-threads=1
```

## Validation

- 12 matcher tests and 123 movement tests passed.
- Strict Clippy (`cargo clippy --all-targets --all-features -- -D warnings`) and formatting checks passed.
- Eight interactive smoke checks passed, including the originally failing Rust method in both directions.
