### PR TITLE
fix(breadcrumbs): restore symbol context and abbreviate home paths

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -501,6 +501,7 @@ theme_browser = "theme_browser.hk"
 
 # Breadcrumb text uses theme colors; file icons use nvim-web-devicons' light/dark palette.
 # Set nerd_font to false for a plain Unicode presentation.
+# Paths are relative to cwd when possible, otherwise the home prefix becomes ~.
 [plugin_config.barbecue]
 enabled = true
 separator = ""

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.12.0` is defined by
+Red host API version `0.13.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -24,9 +24,27 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 annotations use `HUSK-A0004`. `--no-typecheck` is an unsupported development
 escape hatch; compatibility guarantees do not apply while it is enabled.
 
-Red `0.12.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
-`0.10.0`, and `0.11.0` contracts, so existing packages that declare those minors continue to
-load. New packages should target `"red_api_version": "^0.12.0"`.
+Red `0.13.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
+`0.10.0`, `0.11.0`, and `0.12.0` contracts, so existing packages that declare those
+minors continue to load. New packages should target `"red_api_version": "^0.13.0"`.
+
+## Document-symbol breadcrumbs
+
+Host API `0.13.0` adds `document_id` to `GetWindows` entries and successful
+`DocumentSymbols` results, and to `file:saved` events. This identifies one live
+buffer and survives buffer-index changes. Cache symbols by this ID and `revision`, not by the display or navigation
+path. The optional argument to `DocumentSymbols` remains a buffer index. Responses
+for closed, renamed, or changed documents return an error.
+
+`GetWindows.breadcrumb_components` contains display-only path labels: relative to
+the working directory when possible, otherwise home-abbreviated with `~`, otherwise
+absolute. Native roots, drive letters, and UNC shares are preserved. Never use these
+labels for file access or LSP requests.
+
+`red::document_symbol_chain(symbols, position, file)` returns the containing symbol
+ancestry from normalized document symbols. `position` uses zero-based UTF-16 LSP
+coordinates; `file` is the response's navigation path. The native lookup preserves
+the original records and works beyond the bundled plugin's former 512-symbol limit.
 
 ## Language-pack indentation
 

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.12.0",
+  "api_version": "0.13.0",
   "changes": [
+    {
+      "version": "0.13.0",
+      "kind": "introduced",
+      "symbols": ["GetWindows.document_id", "GetWindows.breadcrumb_components", "DocumentSymbols.document_id", "file:saved.document_id", "red::document_symbol_chain"],
+      "migration_note": "docs/PLUGIN_API.md#document-symbol-breadcrumbs"
+    },
     {
       "version": "0.12.0",
       "kind": "introduced",

--- a/plugins/barbecue.hk
+++ b/plugins/barbecue.hk
@@ -27,7 +27,6 @@ struct BarbecuePluginConfig {
 }
 
 struct BarbecueConfigValue {
-    cwd: String,
     plugin_config: BarbecuePluginConfig,
 }
 
@@ -43,7 +42,9 @@ struct BarbecueCursor {
 struct BarbecueWindow {
     window_id: i32,
     buffer_index: i32,
+    document_id: i32,
     buffer_path: String,
+    breadcrumb_components: [String],
     revision: i32,
     cursor: BarbecueCursor,
     lsp_position: Position,
@@ -73,21 +74,20 @@ struct BarbecueSymbol {
 struct BarbecueSymbolsResult {
     ok: bool,
     file: String,
-    buffer_index: i32,
+    document_id: i32,
     revision: i32,
     symbols: [BarbecueSymbol],
 }
 
 struct SymbolRecord {
     file: String,
-    buffer_index: i32,
+    document_id: i32,
     revision: i32,
     symbols: [BarbecueSymbol],
 }
 
 struct FileSavedEvent {
-    file: String,
-    buffer_index: i32,
+    document_id: i32,
 }
 
 struct CursorMovedEvent {
@@ -99,7 +99,7 @@ struct CursorMovedEvent {
 
 struct RenderedWindow {
     window_id: i32,
-    buffer_path: String,
+    document_id: i32,
 }
 
 struct BarbecueThemeStyle {
@@ -137,7 +137,6 @@ struct WindowBarActionEvent {
 }
 
 struct BarbecueState {
-    cwd: String,
     windows: [BarbecueWindow],
     symbols: [SymbolRecord],
     fallback_symbols: [SymbolRecord],
@@ -163,7 +162,6 @@ struct BarbecueState {
 #[red::state]
 fn initial_state() -> BarbecueState {
     return BarbecueState {
-        cwd: "",
         windows: [],
         symbols: [],
         fallback_symbols: [],
@@ -251,7 +249,6 @@ fn timeout_callback(event: TimerEvent) {
 
 fn config_loaded(event: BarbecueConfigEvent) {
     let config = event.value;
-    red::state_patch(BarbecueState { cwd: red::string(config.cwd, "") });
     red::state_patch(BarbecueState { context_loaded: true });
     let options = config.plugin_config.barbecue;
     if options != red::null() {
@@ -285,10 +282,11 @@ fn windows_loaded(result: BarbecueWindowsResult) {
     let buffers: [i32] = [];
     for window in result.windows {
         let buffer_index = red::int(window.buffer_index, -1);
-        if buffer_index < 0 || red::contains(buffers, buffer_index) {
+        if buffer_index < 0 || red::string(window.buffer_path, "") == ""
+            || has_symbols_for(window) || red::contains(buffers, window.document_id) {
             continue;
         }
-        buffers = red::push(buffers, buffer_index);
+        buffers = red::push(buffers, window.document_id);
         red::request("DocumentSymbols", symbols_loaded, buffer_index);
     }
 }
@@ -303,10 +301,19 @@ fn symbols_loaded(result: BarbecueSymbolsResult) {
     if !red::bool(result.ok, false) {
         return;
     }
+    let current = false;
+    for window in state().windows {
+        if window.document_id == result.document_id && window.revision == result.revision {
+            current = true;
+        }
+    }
+    if !current {
+        return;
+    }
     let records: [SymbolRecord] = [];
     let should_add = true;
     for record in state().symbols {
-        if record.file != result.file {
+        if record.document_id != result.document_id {
             records = red::push(records, record);
         } else if red::int(record.revision, -1) > red::int(result.revision, -1) {
             records = red::push(records, record);
@@ -323,7 +330,7 @@ fn symbols_loaded(result: BarbecueSymbolsResult) {
 fn symbol_record(result: BarbecueSymbolsResult) -> SymbolRecord {
     return SymbolRecord {
         file: result.file,
-        buffer_index: red::int(result.buffer_index, -1),
+        document_id: result.document_id,
         revision: result.revision,
         symbols: result.symbols,
     };
@@ -333,16 +340,14 @@ fn symbol_record(result: BarbecueSymbolsResult) -> SymbolRecord {
 fn file_saved(event: FileSavedEvent) {
     let records: [SymbolRecord] = [];
     for record in state().symbols {
-        if record.file != event.file
-            && red::int(record.buffer_index, -1) != red::int(event.buffer_index, -2) {
+        if record.document_id != event.document_id {
             records = red::push(records, record);
         }
     }
     red::state_patch(BarbecueState { symbols: records });
     let fallback_records: [SymbolRecord] = [];
     for record in state().fallback_symbols {
-        if record.file != event.file
-            && red::int(record.buffer_index, -1) != red::int(event.buffer_index, -2) {
+        if record.document_id != event.document_id {
             fallback_records = red::push(fallback_records, record);
         }
     }
@@ -398,7 +403,7 @@ fn should_defer_symbol_render(window: BarbecueWindow) -> bool {
     }
     for rendered in state().rendered_windows {
         if red::int(rendered.window_id, -1) == red::int(window.window_id, -2)
-            && rendered.buffer_path == window.buffer_path {
+            && rendered.document_id == window.document_id {
             return true;
         }
     }
@@ -407,7 +412,7 @@ fn should_defer_symbol_render(window: BarbecueWindow) -> bool {
 
 fn has_symbols_for(window: BarbecueWindow) -> bool {
     for record in state().symbols {
-        if record.file == window.buffer_path && red::int(record.revision, -1) == red::int(window.revision, -1) {
+        if record.document_id == window.document_id && record.revision == window.revision {
             return true;
         }
     }
@@ -423,7 +428,7 @@ fn remember_rendered_window(window: BarbecueWindow) {
     }
     rendered_windows = red::push(rendered_windows, RenderedWindow {
         window_id: window.window_id,
-        buffer_path: window.buffer_path,
+        document_id: window.document_id,
     });
     red::state_patch(BarbecueState { rendered_windows: rendered_windows });
 }
@@ -442,12 +447,7 @@ fn retain_rendered_windows(windows: [BarbecueWindow]) {
 
 fn segments_for(window: BarbecueWindow) -> [BarSegment] {
     let segments: [BarSegment] = [];
-    let path = normalize_path(red::string(window.buffer_path, ""));
-    let cwd = normalize_path(red::string(state().cwd, ""));
-    if cwd != "" && red::starts_with(path, cwd + "/") {
-        path = red::slice(path, red::len(cwd) + 1);
-    }
-    let parts = red::split(path, "/");
+    let parts = window.breadcrumb_components;
     let file = "[No Name]";
     if red::len(parts) > 0 {
         file = red::string(parts[red::len(parts) - 1], "[No Name]");
@@ -495,7 +495,7 @@ fn segments_for(window: BarbecueWindow) -> [BarSegment] {
                 id: "symbol:" + symbol.id,
                 text: symbol_icon(symbol.kind_name) + " " + symbol.name,
                 style: symbol_style(symbol.kind_name, index == red::len(chain) - 1),
-                action: "jump:" + window.buffer_index + ":" + symbol.id,
+                action: "jump:" + window.document_id + ":" + symbol.id,
             });
             index = index + 1;
         }
@@ -514,102 +514,45 @@ fn add_separator(segments: [BarSegment]) -> [BarSegment] {
     return segments;
 }
 
-fn symbols_for(window: BarbecueWindow) -> [BarbecueSymbol] {
-    for record in state().symbols {
-        if record.file == window.buffer_path && red::int(record.revision, -1) == red::int(window.revision, -1) {
-            return record.symbols;
-        }
-    }
-    return [];
-}
-
 fn symbol_chain(window: BarbecueWindow) -> [BarbecueSymbol] {
     let position = window_position(window);
-    let symbols = symbols_for(window);
-    let chain = symbol_chain_for(symbols, position);
-    if red::len(chain) > 0 {
-        remember_fallback_symbols(window, symbols);
-        return chain;
+    for record in state().symbols {
+        if record.document_id == window.document_id && record.revision == window.revision {
+            let chain: [BarbecueSymbol] = red::document_symbol_chain(record.symbols, position, record.file);
+            if red::len(chain) > 0 {
+                remember_fallback_symbols(record);
+                return chain;
+            }
+            // A nonempty current outline is authoritative outside its scopes.
+            if red::len(record.symbols) > 0 {
+                return [];
+            }
+        }
     }
 
     for record in state().fallback_symbols {
-        if record.file == window.buffer_path {
-            return symbol_chain_for(record.symbols, position);
+        if record.document_id == window.document_id {
+            return red::document_symbol_chain(record.symbols, position, record.file);
         }
     }
     return [];
 }
 
-fn remember_fallback_symbols(window: BarbecueWindow, symbols: [BarbecueSymbol]) {
+fn remember_fallback_symbols(snapshot: SymbolRecord) {
     let records: [SymbolRecord] = [];
     let should_add = true;
     for record in state().fallback_symbols {
-        if record.file != window.buffer_path {
+        if record.document_id != snapshot.document_id {
             records = red::push(records, record);
-        } else if red::int(record.revision, -1) > red::int(window.revision, -1) {
+        } else if record.revision > snapshot.revision {
             records = red::push(records, record);
             should_add = false;
         }
     }
     if should_add {
-        records = red::push(records, SymbolRecord {
-            file: window.buffer_path,
-            buffer_index: red::int(window.buffer_index, -1),
-            revision: window.revision,
-            symbols: symbols,
-        });
+        records = red::push(records, snapshot);
     }
     red::state_patch(BarbecueState { fallback_symbols: records });
-}
-
-fn symbol_chain_for(symbols: [BarbecueSymbol], position: Position) -> [BarbecueSymbol] {
-    // Breadcrumb rendering runs once per window, so keep each callback's scan bounded.
-    let leaf = red::null();
-    let leaf_depth = -1;
-    let containing: [BarbecueSymbol] = [];
-    let index = 0;
-    while index < red::len(symbols) && index < 512 {
-        let symbol = symbols[index];
-        if contains_position(symbol.range, position) {
-            containing = red::push(containing, symbol);
-            if red::int(symbol.depth, 0) >= leaf_depth {
-                leaf = symbol;
-                leaf_depth = red::int(symbol.depth, 0);
-            }
-        }
-        index = index + 1;
-    }
-    if leaf == red::null() {
-        return [];
-    }
-    let chain: [BarbecueSymbol] = [];
-    let current = leaf;
-    let steps = 0;
-    while current != red::null() && steps <= red::len(containing) {
-        if contains_position(current.range, position) {
-            chain = red::unshift(chain, current);
-        }
-        if let Some(parent_id) = symbol_parent_id(current) {
-            current = symbol_by_id(containing, parent_id);
-        } else {
-            current = red::null();
-        }
-        steps = steps + 1;
-    }
-    return chain;
-}
-
-fn symbol_parent_id(symbol: BarbecueSymbol) -> Option<String> {
-    return symbol.parent_id;
-}
-
-fn symbol_by_id(symbols: [BarbecueSymbol], id: String) -> Json {
-    for symbol in symbols {
-        if red::string(symbol.id, "") == id {
-            return symbol;
-        }
-    }
-    return red::null();
 }
 
 fn window_position(window: BarbecueWindow) -> Position {
@@ -620,23 +563,6 @@ fn window_position(window: BarbecueWindow) -> Position {
         line: red::int(window.cursor.y, 0),
         character: red::int(window.cursor.x, 0),
     };
-}
-
-fn contains_position(range: BarbecueRange, position: Position) -> bool {
-    if range.start == red::null() || range.end == red::null() {
-        return false;
-    }
-    let after_start = position.line > range.start.line || (position.line == range.start.line && position.character >= range.start.character);
-    let before_end = position.line < range.end.line || (position.line == range.end.line && position.character < range.end.character);
-    return after_start && before_end;
-}
-
-fn normalize_path(path: String) -> String {
-    path = red::replace_all(path, "\\", "/");
-    if red::ends_with(path, "/") {
-        path = red::slice(path, 0, red::len(path) - 1);
-    }
-    return path;
 }
 
 fn file_icon(file: String) -> String {
@@ -813,10 +739,12 @@ fn bar_action(event: WindowBarActionEvent) {
         return;
     }
     let parts = red::split(action, ":");
-    let buffer_index = red::int(parts[1], 0);
-    let symbol_id = red::string(parts[2], "");
+    let document_id = red::int(parts[1], -1);
+    // Symbol IDs themselves contain colons; preserve the complete suffix.
+    let prefix = "jump:" + document_id + ":";
+    let symbol_id = red::slice(action, red::len(prefix));
     for record in state().symbols {
-        if red::int(record.buffer_index, buffer_index) != buffer_index {
+        if record.document_id != document_id {
             continue;
         }
         for symbol in record.symbols {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3853,7 +3853,8 @@ struct EditorEventSnapshot {
 #[derive(Debug, Clone)]
 struct PendingDocumentSymbols {
     plugin_request_id: RequestId,
-    buffer_index: usize,
+    buffer_id: BufferId,
+    uri: String,
     revision: u64,
 }
 
@@ -6062,6 +6063,8 @@ impl Editor {
 
     fn plugin_windows_payload(&self) -> Value {
         let active_id = self.window_manager.active_stable_window_id();
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let home = std::env::home_dir();
         let windows = self
             .window_manager
             .windows()
@@ -6079,7 +6082,11 @@ impl Editor {
                     "window_id": window.id.0,
                     "active": Some(window.id) == active_id,
                     "buffer_index": window.buffer_index,
+                    "document_id": buffer.id(),
                     "buffer_path": buffer.file,
+                    "breadcrumb_components": buffer.file.as_deref().map(|file| {
+                        crate::utils::breadcrumb_path_components(Path::new(file), &cwd, home.as_deref())
+                    }).unwrap_or_default(),
                     "file": buffer.file,
                     "name": buffer.name(),
                     "revision": buffer.revision(),
@@ -8148,6 +8155,7 @@ impl Editor {
                             json!({
                                 "file": file,
                                 "buffer_index": self.buffer_manager.active_index(),
+                                "document_id": self.current_buffer().id(),
                             }),
                         )
                         .await;
@@ -10315,6 +10323,8 @@ impl Editor {
                             .await?;
                         continue;
                     };
+                    let buffer_id = target_buffer.id();
+                    let uri = target_buffer.uri()?.expect("file-backed buffer has a URI");
                     let revision = target_buffer.revision();
 
                     let request_result: anyhow::Result<i64> = async {
@@ -10329,7 +10339,8 @@ impl Editor {
                                 lsp_request_id,
                                 PendingDocumentSymbols {
                                     plugin_request_id: request_id,
-                                    buffer_index,
+                                    buffer_id,
+                                    uri,
                                     revision,
                                 },
                             );
@@ -22005,16 +22016,27 @@ impl Editor {
         response: &ResponseMessage,
         pending: &PendingDocumentSymbols,
     ) -> anyhow::Result<Value> {
-        let file = response_text_document_uri(response)
-            .map(|uri| self.uri_to_file(uri))
-            .or_else(|| self.current_file_name())
-            .ok_or_else(|| anyhow::anyhow!("document symbol response did not include a file"))?;
+        let buffer_index = self
+            .buffer_manager
+            .iter()
+            .position(|buffer| {
+                buffer.id() == pending.buffer_id
+                    && buffer.revision() == pending.revision
+                    && buffer.uri().ok().flatten().as_deref() == Some(pending.uri.as_str())
+            })
+            .ok_or_else(|| anyhow::anyhow!("document symbol response is no longer current"))?;
+        anyhow::ensure!(
+            response_text_document_uri(response).is_none_or(|uri| uri == pending.uri),
+            "document symbol response belongs to another document"
+        );
+        let file = self.uri_to_file(&pending.uri);
         let symbols = self.normalize_document_symbols(&response.result, &file)?;
 
         Ok(json!({
             "ok": true,
             "file": file,
-            "buffer_index": pending.buffer_index,
+            "buffer_index": buffer_index,
+            "document_id": pending.buffer_id,
             "revision": pending.revision,
             "symbols": symbols,
         }))
@@ -25543,7 +25565,7 @@ impl Editor {
                     .notify(
                         runtime,
                         "file:saved",
-                        json!({ "file": file, "buffer_index": index }),
+                        json!({ "file": file, "buffer_index": index, "document_id": self.current_buffer().id() }),
                     )
                     .await?;
             }
@@ -25706,7 +25728,8 @@ impl Editor {
                 if let Some(file) = &self.current_buffer().file {
                     let save_info = serde_json::json!({
                         "file": file,
-                        "buffer_index": self.buffer_manager.active_index()
+                        "buffer_index": self.buffer_manager.active_index(),
+                        "document_id": self.current_buffer().id(),
                     });
                     self.plugin_registry
                         .notify(runtime, "file:saved", save_info)
@@ -25859,7 +25882,8 @@ impl Editor {
                 // Notify plugins about file save
                 let save_info = serde_json::json!({
                     "file": saved_file,
-                    "buffer_index": self.buffer_manager.active_index()
+                    "buffer_index": self.buffer_manager.active_index(),
+                    "document_id": self.current_buffer().id(),
                 });
                 self.plugin_registry
                     .notify(runtime, "file:saved", save_info)
@@ -33961,9 +33985,177 @@ builtin = "rust"
         assert_eq!(overlay_buffer.cells[cursor_index].style, cursor_style);
     }
 
+    fn pending_document_symbols(editor: &Editor, index: usize) -> PendingDocumentSymbols {
+        let buffer = &editor.buffer_manager[index];
+        PendingDocumentSymbols {
+            plugin_request_id: RequestId::from_raw(1),
+            buffer_id: buffer.id(),
+            uri: buffer.uri().unwrap().unwrap(),
+            revision: buffer.revision(),
+        }
+    }
+
+    #[test]
+    fn document_symbols_follow_stable_identity_and_reject_stale_responses() {
+        let mut editor = test_editor(80, 10);
+        let file = std::env::current_dir()
+            .unwrap()
+            .join("src/breadcrumb-fixture.rs");
+        editor.buffer_manager.push_buffer(Buffer::new(
+            Some(file.to_string_lossy().into_owned()),
+            "fn main() {}".into(),
+        ));
+        let pending = pending_document_symbols(&editor, 1);
+        let response = ResponseMessage {
+            id: 1,
+            result: json!([]),
+            request: Some(crate::lsp::Request::new(
+                "textDocument/documentSymbol",
+                json!({
+                    "textDocument": { "uri": pending.uri }
+                }),
+            )),
+        };
+        editor.buffer_manager.remove_buffer(0);
+        let payload = editor
+            .plugin_document_symbols_payload(&response, &pending)
+            .unwrap();
+        assert_eq!(payload["buffer_index"], 0);
+        assert_eq!(payload["document_id"], json!(pending.buffer_id));
+        assert_eq!(
+            editor.plugin_windows_payload()["windows"][0]["document_id"],
+            payload["document_id"]
+        );
+
+        editor
+            .current_buffer_mut()
+            .replace_range_raw(TextRange::insertion(TextPosition::new(0, 0)), "// edit\n");
+        assert!(editor
+            .plugin_document_symbols_payload(&response, &pending)
+            .is_err());
+        let renamed = pending_document_symbols(&editor, 0);
+        editor.current_buffer_mut().file =
+            Some(file.with_extension("ts").to_string_lossy().into_owned());
+        assert!(editor
+            .plugin_document_symbols_payload(&response, &renamed)
+            .is_err());
+        editor.buffer_manager.replace_buffers(vec![Buffer::new(
+            Some(file.to_string_lossy().into_owned()),
+            "fn main() {}".into(),
+        )]);
+        assert!(editor
+            .plugin_document_symbols_payload(&response, &pending)
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn barbecue_renders_real_workspace_document_symbol_payload() {
+        drain_plugin_requests();
+        let mut editor = test_editor(100, 10);
+        let file = std::env::current_dir()
+            .unwrap()
+            .join("src/breadcrumb-fixture.rs");
+        editor.buffer_manager.replace_buffers(vec![Buffer::new(
+            Some(file.to_string_lossy().into_owned()),
+            "impl App {\n    fn render() {\n        work();\n    }\n}\n".into(),
+        )]);
+        editor.cy = 2;
+        editor.sync_to_window();
+        let windows = editor.plugin_windows_payload();
+        let pending = pending_document_symbols(&editor, 0);
+        let response = ResponseMessage {
+            id: 1,
+            result: json!([{
+                "name": "App", "kind": 23,
+                "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 5, "character": 0 } },
+                "children": [{
+                    "name": "render", "kind": 6,
+                    "range": { "start": { "line": 1, "character": 0 }, "end": { "line": 4, "character": 0 } }
+                }]
+            }]),
+            request: Some(crate::lsp::Request::new(
+                "textDocument/documentSymbol",
+                json!({
+                    "textDocument": { "uri": pending.uri }
+                }),
+            )),
+        };
+        let payload = editor
+            .plugin_document_symbols_payload(&response, &pending)
+            .unwrap();
+        assert_ne!(payload["file"], windows["windows"][0]["buffer_path"]);
+        assert_eq!(
+            windows["windows"][0]["breadcrumb_components"],
+            json!(["src", "breadcrumb-fixture.rs"])
+        );
+
+        let mut runtime = Runtime::new();
+        runtime.set_snapshot("windows", windows.clone());
+        runtime.set_snapshot(
+            "editor_info",
+            json!({ "theme": { "style": { "bg": "#111111" } } }),
+        );
+        runtime
+            .load_plugin("barbecue", include_str!("../plugins/barbecue.hk"))
+            .await
+            .unwrap();
+        let mut symbols_request = None;
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            match request {
+                PluginRequest::GetConfig { request_id, .. } => {
+                    runtime
+                        .resolve_request(
+                            request_id,
+                            json!({ "value": {
+                        "plugin_config": { "barbecue": { "nerd_font": false, "separator": ">" } }
+                    } }),
+                        )
+                        .await
+                        .unwrap();
+                }
+                PluginRequest::GetWindows { request_id } => {
+                    runtime
+                        .resolve_request(request_id, windows.clone())
+                        .await
+                        .unwrap();
+                }
+                PluginRequest::DocumentSymbols { request_id, .. } => {
+                    symbols_request = Some(request_id)
+                }
+                PluginRequest::CreateWindowBar { .. } | PluginRequest::UpdateWindowBar { .. } => {}
+                _ => panic!("unexpected breadcrumb startup request"),
+            }
+        }
+        runtime
+            .resolve_request(symbols_request.unwrap(), payload)
+            .await
+            .unwrap();
+        let mut rendered = String::new();
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            if let PluginRequest::UpdateWindowBar { segments, .. } = request {
+                rendered = segments.into_iter().map(|segment| segment.text).collect();
+            }
+        }
+        assert!(
+            rendered.contains("src > breadcrumb-fixture.rs"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("App") && rendered.contains("render"),
+            "{rendered}"
+        );
+    }
+
     #[test]
     fn document_symbols_payload_flattens_hierarchical_symbols() {
-        let editor = test_editor(40, 10);
+        let mut editor = test_editor(40, 10);
+        editor.current_buffer_mut().file = Some(
+            std::env::temp_dir()
+                .join("red-symbol-payload/src/app.ts")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let uri = editor.current_buffer().uri().unwrap().unwrap();
         let response = ResponseMessage {
             id: 1,
             result: serde_json::json!([
@@ -33999,7 +34191,7 @@ builtin = "rust"
                 "textDocument/documentSymbol",
                 serde_json::json!({
                     "textDocument": {
-                        "uri": "file:///tmp/project/src/app.ts"
+                        "uri": uri
                     }
                 }),
             )),
@@ -34010,7 +34202,8 @@ builtin = "rust"
                 &response,
                 &PendingDocumentSymbols {
                     plugin_request_id: RequestId::from_raw(1),
-                    buffer_index: 0,
+                    buffer_id: editor.current_buffer().id(),
+                    uri: editor.current_buffer().uri().unwrap().unwrap(),
                     revision: 0,
                 },
             )
@@ -34018,7 +34211,7 @@ builtin = "rust"
         let symbols = payload["symbols"].as_array().unwrap();
 
         assert_eq!(payload["ok"], true);
-        assert_eq!(payload["file"], "/tmp/project/src/app.ts");
+        assert_eq!(payload["file"], editor.uri_to_file(&uri));
         assert_eq!(symbols.len(), 2);
         assert_eq!(symbols[0]["id"], "root:0:App");
         assert_eq!(symbols[0]["parent_id"], serde_json::Value::Null);
@@ -34035,7 +34228,17 @@ builtin = "rust"
 
     #[test]
     fn document_symbols_payload_accepts_flat_symbol_information() {
-        let editor = test_editor(40, 10);
+        let mut editor = test_editor(40, 10);
+        editor.current_buffer_mut().file = Some(
+            std::env::temp_dir()
+                .join("red-symbol-payload/src/index.ts")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let uri = editor.current_buffer().uri().unwrap().unwrap();
+        let other_uri =
+            crate::lsp::file_uri(std::env::temp_dir().join("red-symbol-payload/src/build.ts"))
+                .unwrap();
         let response = ResponseMessage {
             id: 1,
             result: serde_json::json!([
@@ -34044,7 +34247,7 @@ builtin = "rust"
                     "kind": 12,
                     "containerName": "tools",
                     "location": {
-                        "uri": "file:///tmp/project/src/build.ts",
+                        "uri": other_uri,
                         "range": {
                             "start": { "line": 4, "character": 2 },
                             "end": { "line": 9, "character": 3 }
@@ -34056,7 +34259,7 @@ builtin = "rust"
                 "textDocument/documentSymbol",
                 serde_json::json!({
                     "textDocument": {
-                        "uri": "file:///tmp/project/src/index.ts"
+                        "uri": uri
                     }
                 }),
             )),
@@ -34067,19 +34270,20 @@ builtin = "rust"
                 &response,
                 &PendingDocumentSymbols {
                     plugin_request_id: RequestId::from_raw(1),
-                    buffer_index: 0,
+                    buffer_id: editor.current_buffer().id(),
+                    uri: editor.current_buffer().uri().unwrap().unwrap(),
                     revision: 0,
                 },
             )
             .unwrap();
         let symbols = payload["symbols"].as_array().unwrap();
 
-        assert_eq!(payload["file"], "/tmp/project/src/index.ts");
+        assert_eq!(payload["file"], editor.uri_to_file(&uri));
         assert_eq!(symbols.len(), 1);
         assert_eq!(symbols[0]["name"], "build");
         assert_eq!(symbols[0]["detail"], "tools");
         assert_eq!(symbols[0]["kind_name"], "Function");
-        assert_eq!(symbols[0]["file"], "/tmp/project/src/build.ts");
+        assert_eq!(symbols[0]["file"], editor.uri_to_file(&other_uri));
         assert_eq!(symbols[0]["selection_range"]["start"]["line"], 4);
     }
 

--- a/src/plugin/api.rs
+++ b/src/plugin/api.rs
@@ -1704,7 +1704,10 @@ mod tests {
                 "GetBufferText",
                 "(callback: fn(Json), start_line?: i32, end_line?: i32)",
             ),
-            ("DocumentSymbols", "(callback: fn(Json), buffer_id?: i32)"),
+            (
+                "DocumentSymbols",
+                "(callback: fn(Json), buffer_index?: i32)",
+            ),
             (
                 "References",
                 "(callback: fn(Json), include_declaration?: bool)",

--- a/src/plugin/document_symbols.rs
+++ b/src/plugin/document_symbols.rs
@@ -1,0 +1,172 @@
+//! Native containment lookup for plugin-owned document-symbol breadcrumbs.
+//!
+//! The VM receives only the containing ancestry, so large files do not require
+//! a truncated scan or a larger per-callback instruction budget. Original Husk
+//! records are retained, including their nominal types and navigation ranges.
+
+use std::collections::{HashMap, HashSet};
+
+use husk_runtime::Value;
+
+type Position = (i64, i64);
+
+struct Candidate<'a> {
+    index: usize,
+    id: &'a str,
+    parent: Option<&'a str>,
+    depth: i64,
+    start: Position,
+    end: Position,
+}
+
+fn field<'a>(value: &'a Value, name: &str) -> Option<&'a Value> {
+    match value {
+        Value::Object(fields) | Value::Struct { fields, .. } => fields.get(name),
+        _ => None,
+    }
+}
+
+fn integer(value: &Value) -> Option<i64> {
+    match value {
+        Value::Int(value) => Some(*value),
+        _ => None,
+    }
+}
+
+fn position(value: &Value) -> Option<Position> {
+    Some((
+        integer(field(value, "line")?)?,
+        integer(field(value, "character")?)?,
+    ))
+}
+
+fn optional_string(value: &Value) -> Option<&str> {
+    match value {
+        Value::Variant { case, fields, .. } if case == "Some" => {
+            fields.first().and_then(Value::as_str)
+        }
+        value => value.as_str(),
+    }
+}
+
+pub(super) fn chain(symbols: &[Value], cursor: &Value, file: &str) -> Vec<Value> {
+    let Some(cursor) = position(cursor) else {
+        return Vec::new();
+    };
+    let containing: Vec<_> = symbols
+        .iter()
+        .enumerate()
+        .filter_map(|(index, symbol)| {
+            if field(symbol, "file")?.as_str()? != file {
+                return None;
+            }
+            let range = field(symbol, "range")?;
+            let start = position(field(range, "start")?)?;
+            let end = position(field(range, "end")?)?;
+            (start <= cursor && cursor < end).then(|| Candidate {
+                index,
+                id: field(symbol, "id").and_then(Value::as_str).unwrap_or(""),
+                parent: field(symbol, "parent_id").and_then(optional_string),
+                depth: field(symbol, "depth").and_then(integer).unwrap_or(0),
+                start,
+                end,
+            })
+        })
+        .collect();
+    let Some(mut current) = containing.iter().max_by(|left, right| {
+        left.depth
+            .cmp(&right.depth)
+            .then_with(|| left.start.cmp(&right.start))
+            .then_with(|| right.end.cmp(&left.end))
+    }) else {
+        return Vec::new();
+    };
+    let by_id: HashMap<_, _> = containing
+        .iter()
+        .map(|symbol| (symbol.id, symbol))
+        .collect();
+    let mut visited = HashSet::new();
+    let mut chain = Vec::new();
+    while visited.insert(current.index) {
+        chain.push(symbols[current.index].clone());
+        let Some(parent) = current.parent.and_then(|id| by_id.get(id)) else {
+            break;
+        };
+        current = parent;
+    }
+    chain.reverse();
+    chain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn symbol(
+        id: &str,
+        parent: Option<&str>,
+        depth: usize,
+        start: Position,
+        end: Position,
+    ) -> Value {
+        Value::from_json(json!({
+            "id": id, "parent_id": parent, "depth": depth, "file": "main.rs",
+            "range": {
+                "start": { "line": start.0, "character": start.1 },
+                "end": { "line": end.0, "character": end.1 }
+            }
+        }))
+    }
+
+    fn ids(symbols: &[Value], cursor: Position) -> Vec<String> {
+        chain(
+            symbols,
+            &Value::from_json(json!({
+                "line": cursor.0, "character": cursor.1
+            })),
+            "main.rs",
+        )
+        .iter()
+        .map(|symbol| field(symbol, "id").unwrap().as_str().unwrap().to_string())
+        .collect()
+    }
+
+    #[test]
+    fn uses_half_open_utf16_ranges_and_preserves_ancestry() {
+        let symbols = [
+            symbol("outer", None, 0, (0, 0), (9, 0)),
+            symbol("inner", Some("outer"), 1, (2, 2), (2, 7)),
+        ];
+        assert_eq!(ids(&symbols, (2, 2)), ["outer", "inner"]);
+        assert_eq!(ids(&symbols, (2, 6)), ["outer", "inner"]);
+        assert_eq!(ids(&symbols, (2, 7)), ["outer"]);
+        assert!(ids(&symbols, (9, 0)).is_empty());
+    }
+
+    #[test]
+    fn flat_symbols_choose_the_smallest_containing_range() {
+        let symbols = [
+            symbol("inner", None, 0, (2, 0), (3, 0)),
+            symbol("outer", None, 0, (0, 0), (9, 0)),
+        ];
+        assert_eq!(ids(&symbols, (2, 1)), ["inner"]);
+        assert!(chain(
+            &symbols,
+            &Value::from_json(json!({
+                "line": 2, "character": 1
+            })),
+            "other.rs"
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn malformed_parent_cycles_terminate() {
+        let symbols = [
+            symbol("a", Some("b"), 0, (0, 0), (9, 0)),
+            symbol("b", Some("a"), 1, (1, 0), (8, 0)),
+        ];
+        assert_eq!(ids(&symbols, (2, 0)), ["a", "b"]);
+    }
+}

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.0",
+  "version": "0.13.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },
@@ -96,7 +96,7 @@
     { "name": "GetEditorState", "kind": "request", "signature": "(callback: fn(Json))", "introduced": "0.1.0" },
     { "name": "RestoreEditorState", "kind": "request", "signature": "(callback: fn(Json), snapshot: Json)", "introduced": "0.1.0" },
     { "name": "GetWindows", "kind": "request", "signature": "(callback: fn(Json))", "introduced": "0.1.0" },
-    { "name": "DocumentSymbols", "kind": "request", "signature": "(callback: fn(Json), buffer_id?: i32)", "introduced": "0.1.0" },
+    { "name": "DocumentSymbols", "kind": "request", "signature": "(callback: fn(Json), buffer_index?: i32)", "introduced": "0.1.0" },
     { "name": "WorkspaceSymbols", "kind": "request", "signature": "(callback: fn(Json), query: String)", "introduced": "0.1.0" },
     { "name": "References", "kind": "request", "signature": "(callback: fn(Json), include_declaration?: bool)", "introduced": "0.1.0" },
     { "name": "ResolveThemeStyle", "kind": "request", "signature": "(callback: fn(Json), style: Json)", "introduced": "0.1.0" },

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -15,6 +15,7 @@ pub mod catalog;
 pub mod companion;
 pub mod decoration;
 pub mod document;
+mod document_symbols;
 pub(crate) mod filesystem;
 pub mod gutter;
 pub mod location;

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -33,7 +33,7 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.12.0";
+pub const RED_HOST_API_VERSION: &str = "0.13.0";
 pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
     "0.4.0",
     "0.6.0",
@@ -42,6 +42,7 @@ pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
     "0.9.0",
     "0.10.0",
     "0.11.0",
+    "0.12.0",
     RED_HOST_API_VERSION,
 ];
 

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -287,6 +287,7 @@ extern "red" {
         fn char() -> String;
         fn null() -> JsValue;
         fn parse_json() -> JsValue;
+        fn document_symbol_chain() -> JsValue;
         fn git_core() -> JsValue;
         fn neotree_core() -> JsValue;
     }
@@ -2610,6 +2611,16 @@ impl RedHost {
                     return schema.named_record(record, &value_to_json(&value));
                 }
                 Ok(value)
+            }
+            "red::document_symbol_chain" => {
+                let symbols = red_required_value_array(args, 0, path)?;
+                let cursor = args
+                    .get(1)
+                    .ok_or_else(|| anyhow::anyhow!("`{path}` requires a position"))?;
+                let file = red_required_string(args, 2, path)?;
+                Ok(Value::Array(Arc::new(super::document_symbols::chain(
+                    &symbols, cursor, file,
+                ))))
             }
             "red::neotree_core" => {
                 let operation = red_required_string(args, 0, path)?;
@@ -10663,18 +10674,22 @@ mod tests {
                     {
                         "window_id": 7,
                         "buffer_index": 2,
+                        "document_id": 42,
                         "buffer_path": "/repo/plugins/example.rs",
+                        "breadcrumb_components": ["plugins", "example.rs"],
                         "revision": 4,
-                        "cursor": { "x": 1, "y": 6 },
-                        "lsp_position": { "line": 6, "character": 1 },
+                        "cursor": { "x": 1, "y": 906 },
+                        "lsp_position": { "line": 906, "character": 1 },
                     },
                     {
                         "window_id": 8,
                         "buffer_index": 2,
+                        "document_id": 42,
                         "buffer_path": "/repo/plugins/example.rs",
+                        "breadcrumb_components": ["plugins", "example.rs"],
                         "revision": 4,
-                        "cursor": { "x": 1, "y": 6 },
-                        "lsp_position": { "line": 6, "character": 1 },
+                        "cursor": { "x": 1, "y": 905 },
+                        "lsp_position": { "line": 905, "character": 1 },
                     }
                 ]
             }),
@@ -10731,18 +10746,22 @@ mod tests {
                         {
                             "window_id": 7,
                             "buffer_index": 2,
+                            "document_id": 42,
                             "buffer_path": "/repo/plugins/example.rs",
+                            "breadcrumb_components": ["plugins", "example.rs"],
                             "revision": 4,
-                            "cursor": { "x": 1, "y": 6 },
-                            "lsp_position": { "line": 6, "character": 1 },
+                            "cursor": { "x": 1, "y": 906 },
+                            "lsp_position": { "line": 906, "character": 1 },
                         },
                         {
                             "window_id": 8,
                             "buffer_index": 2,
+                            "document_id": 42,
                             "buffer_path": "/repo/plugins/example.rs",
+                            "breadcrumb_components": ["plugins", "example.rs"],
                             "revision": 4,
-                            "cursor": { "x": 1, "y": 6 },
-                            "lsp_position": { "line": 6, "character": 1 },
+                            "cursor": { "x": 1, "y": 905 },
+                            "lsp_position": { "line": 905, "character": 1 },
                         }
                     ]
                 }),
@@ -10767,23 +10786,23 @@ mod tests {
 
         let symbols = (0..1_000)
             .map(|index| {
-                let (id, name, parent_id, depth, start_line, end_line) = if index == 5 {
+                let (id, name, parent_id, depth, start_line, end_line) = if index == 905 {
                     (
-                        "outer".to_string(),
+                        "root:905:outer".to_string(),
                         "outer".to_string(),
                         serde_json::Value::Null,
                         0,
-                        5,
-                        8,
+                        905,
+                        908,
                     )
-                } else if index == 6 {
+                } else if index == 906 {
                     (
+                        "root:905:outer:0:inner".to_string(),
                         "inner".to_string(),
-                        "inner".to_string(),
-                        serde_json::json!("outer"),
+                        serde_json::json!("root:905:outer"),
                         1,
-                        6,
-                        7,
+                        906,
+                        907,
                     )
                 } else {
                     (
@@ -10800,7 +10819,7 @@ mod tests {
                     "parent_id": parent_id,
                     "name": name,
                     "kind_name": "Function",
-                    "file": "/repo/plugins/example.rs",
+                    "file": "plugins/example.rs",
                     "depth": depth,
                     "range": {
                         "start": { "line": start_line, "character": 0 },
@@ -10818,8 +10837,9 @@ mod tests {
                 symbol_request_id,
                 serde_json::json!({
                     "ok": true,
-                    "file": "/repo/plugins/example.rs",
+                    "file": "plugins/example.rs",
                     "buffer_index": 2,
+                    "document_id": 42,
                     "revision": 4,
                     "symbols": symbols,
                 }),
@@ -10830,9 +10850,21 @@ mod tests {
         let mut saw_outer = false;
         let mut saw_inner = false;
         while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
-            if let PluginRequest::UpdateWindowBar { segments, .. } = request {
-                saw_outer |= segments.iter().any(|segment| segment.text == "󰊕 outer");
-                saw_inner |= segments.iter().any(|segment| segment.text == "󰊕 inner");
+            if let PluginRequest::UpdateWindowBar {
+                window_id,
+                segments,
+                ..
+            } = request
+            {
+                let outer = segments.iter().any(|segment| segment.text == "󰊕 outer");
+                let inner = segments.iter().any(|segment| segment.text == "󰊕 inner");
+                if window_id == 7 {
+                    assert!(outer && inner);
+                    saw_inner = true;
+                } else if window_id == 8 {
+                    assert!(outer && !inner);
+                    saw_outer = true;
+                }
             }
         }
         assert!(saw_outer && saw_inner);
@@ -10840,14 +10872,14 @@ mod tests {
         runtime
             .notify(
                 "window_bar:action:barbecue",
-                serde_json::json!({ "action": "jump:2:inner" }),
+                serde_json::json!({ "action": "jump:42:root:905:outer:0:inner" }),
             )
             .await
             .unwrap();
         match ACTION_DISPATCHER.recv_request() {
             PluginRequest::OpenLocation { location, .. } => {
-                assert_eq!(location.path, "/repo/plugins/example.rs");
-                assert_eq!(location.line, 6);
+                assert_eq!(location.path, "plugins/example.rs");
+                assert_eq!(location.line, 906);
                 assert_eq!(location.column, 0);
                 assert_eq!(
                     location.column_encoding,
@@ -10866,7 +10898,9 @@ mod tests {
             "windows": [{
                 "window_id": 7,
                 "buffer_index": 2,
+                "document_id": 42,
                 "buffer_path": "/repo/src/main.rs",
+                "breadcrumb_components": ["src", "main.rs"],
                 "revision": 4,
                 "cursor": { "x": 1, "y": 48 },
                 "lsp_position": { "line": 48, "character": 1 },
@@ -10968,6 +11002,7 @@ mod tests {
                     "ok": true,
                     "file": "/repo/src/main.rs",
                     "buffer_index": 2,
+                    "document_id": 42,
                     "revision": 4,
                     "symbols": symbols.clone(),
                 }),
@@ -11041,7 +11076,9 @@ mod tests {
                     "windows": [{
                         "window_id": 7,
                         "buffer_index": 2,
+                        "document_id": 42,
                         "buffer_path": "/repo/src/main.rs",
+                        "breadcrumb_components": ["src", "main.rs"],
                         "revision": 5,
                         "cursor": { "x": 8, "y": 97 },
                         "lsp_position": { "line": 97, "character": 8 },
@@ -11078,6 +11115,7 @@ mod tests {
                     "ok": true,
                     "file": "/repo/src/main.rs",
                     "buffer_index": 2,
+                    "document_id": 42,
                     "revision": 5,
                     "symbols": [],
                 }),
@@ -11092,6 +11130,7 @@ mod tests {
                 serde_json::json!({
                     "file": "/repo/src/main.rs",
                     "buffer_index": 2,
+                    "document_id": 42,
                 }),
             )
             .await
@@ -11107,7 +11146,9 @@ mod tests {
                     "windows": [{
                         "window_id": 7,
                         "buffer_index": 2,
+                        "document_id": 42,
                         "buffer_path": "/repo/src/main.rs",
+                        "breadcrumb_components": ["src", "main.rs"],
                         "revision": 5,
                         "cursor": { "x": 8, "y": 98 },
                         "lsp_position": { "line": 98, "character": 8 },
@@ -11127,6 +11168,7 @@ mod tests {
                     "ok": true,
                     "file": "/repo/src/main.rs",
                     "buffer_index": 2,
+                    "document_id": 42,
                     "revision": 5,
                     "symbols": [],
                 }),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@
 
 use std::{
     env,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use path_absolutize::Absolutize;
@@ -68,6 +68,72 @@ fn home_dir() -> Option<PathBuf> {
         .or_else(|| env::var_os("USERPROFILE").map(PathBuf::from))
 }
 
+/// Formats a file path as breadcrumb labels without changing its identity.
+/// Working-directory-relative paths take precedence over home abbreviation.
+/// This is lexical: missing files and symlink spellings are preserved.
+pub(crate) fn breadcrumb_path_components(
+    path: &Path,
+    cwd: &Path,
+    home: Option<&Path>,
+) -> Vec<String> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    if cwd.is_absolute() {
+        if let Some(relative) = strip_display_prefix(&absolute, cwd) {
+            return display_components(relative);
+        }
+    }
+    if let Some(relative) = home
+        .filter(|home| home.is_absolute())
+        .and_then(|home| strip_display_prefix(&absolute, home))
+    {
+        let mut parts = vec!["~".to_string()];
+        parts.extend(display_components(relative));
+        return parts;
+    }
+    display_components(&absolute)
+}
+
+fn strip_display_prefix<'a>(path: &'a Path, base: &Path) -> Option<&'a Path> {
+    let mut components = path.components();
+    for expected in base.components() {
+        let actual = components.next()?;
+        #[cfg(windows)]
+        let matches = actual
+            .as_os_str()
+            .as_encoded_bytes()
+            .eq_ignore_ascii_case(expected.as_os_str().as_encoded_bytes());
+        #[cfg(not(windows))]
+        let matches = actual == expected;
+        if !matches {
+            return None;
+        }
+    }
+    Some(components.as_path())
+}
+
+fn display_components(path: &Path) -> Vec<String> {
+    let mut parts: Vec<String> = Vec::new();
+    let mut has_prefix = false;
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Prefix(prefix) => {
+                parts.push(prefix.as_os_str().to_string_lossy().into_owned());
+                has_prefix = true;
+            }
+            Component::RootDir if has_prefix => {
+                parts.last_mut().unwrap().push(std::path::MAIN_SEPARATOR);
+            }
+            component => parts.push(component.as_os_str().to_string_lossy().into_owned()),
+        }
+    }
+    parts
+}
+
 /// Get the current working directory
 pub fn get_workspace_path() -> PathBuf {
     env::current_dir()
@@ -84,6 +150,58 @@ pub fn get_workspace_uri() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn breadcrumbs_prefer_cwd_then_home_and_match_whole_components() {
+        let root = std::env::temp_dir();
+        let home = root.join("breadcrumb-home");
+        let cwd = home.join("project");
+        let format = |path: &Path| breadcrumb_path_components(path, &cwd, Some(&home));
+        assert_eq!(format(&cwd.join("src/main.rs")), ["src", "main.rs"]);
+        assert_eq!(format(Path::new("src/main.rs")), ["src", "main.rs"]);
+        assert_eq!(
+            format(&home.join("other/main.rs")),
+            ["~", "other", "main.rs"]
+        );
+        assert_eq!(format(&home), ["~"]);
+        assert_ne!(format(&root.join("breadcrumb-home-other/main.rs"))[0], "~");
+        assert_eq!(
+            breadcrumb_path_components(&home.join("main.rs"), &cwd, None),
+            display_components(&home.join("main.rs"))
+        );
+        assert_eq!(
+            format(&home.join("missing/日本語.rs")),
+            ["~", "missing", "日本語.rs"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn breadcrumbs_preserve_unix_roots_and_backslashes_in_names() {
+        assert_eq!(
+            breadcrumb_path_components(Path::new("/var/data/a\\b.rs"), Path::new("/work"), None),
+            ["/", "var", "data", "a\\b.rs"]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn breadcrumbs_handle_windows_drives_unc_and_home_case() {
+        let cwd = Path::new(r"C:\Users\Alice\project");
+        let home = Some(Path::new(r"C:\Users\Alice"));
+        assert_eq!(
+            breadcrumb_path_components(Path::new(r"c:\users\ALICE\other\main.rs"), cwd, home),
+            ["~", "other", "main.rs"]
+        );
+        assert_eq!(
+            breadcrumb_path_components(Path::new(r"D:\src\main.rs"), cwd, home),
+            ["D:\\", "src", "main.rs"]
+        );
+        assert_eq!(
+            breadcrumb_path_components(Path::new(r"\\server\share\src\main.rs"), cwd, home),
+            ["\\\\server\\share\\", "src", "main.rs"]
+        );
+    }
 
     #[test]
     fn expands_bare_tilde_to_home() {


### PR DESCRIPTION
## Why

The bundled barbecue plugin could omit the current method because window snapshots used absolute file paths while document-symbol responses could use workspace-relative paths. Its symbol scan also stopped after 512 entries, and paths outside the working directory displayed the full home directory.

## What changed

- Match symbol caches and responses by stable document ID and revision, and reject responses for changed, renamed, or closed buffers.
- Build display-only path components with native path handling. Prefer working-directory-relative paths, then abbreviate the home prefix with `~`; preserve drive roots and UNC shares.
- Resolve containing symbol ancestry in Rust without the old 512-symbol limit. Preserve complete symbol IDs when clicking a breadcrumb, and keep split-window cursor context independent.
- Add the backward-compatible host API 0.13.0 fields and helper, with documentation and regression coverage.

## How to Test

1. Build with `cargo build --all-features --bin red`, then run `target/debug/red src/editor/rendering.rs` with rust-analyzer available. Search for `pub fn render(` and move into its body. The breadcrumb should include `src > editor > rendering.rs > impl Editor > render`.
2. Open a second split on the same file and move its cursor into another method. Each split should show its own context. Click a symbol breadcrumb and confirm it jumps to that declaration.
3. From outside the project, run the built binary with `-c 'lsp.enabled = false' <absolute-path-to-a-text-file-under-your-home>`. The breadcrumb should begin with `~`, end with the filename, and omit symbol context. Narrow the window and confirm the current method remains visible when LSP is enabled.
4. Run `cargo test --all-features -p red --lib -- barbecue_ document_symbols breadcrumbs_ --test-threads=1`. This covers real workspace-relative LSP payloads, stale responses, split cursors, symbol IDs containing colons, symbols after entry 900, and native path boundaries.

## Validation

- Full Red suite: 2,800 tests passed across 21 suites.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- Build and bundled runtime self-check: passed.
- Manual macOS smoke: Rust and TypeScript method context, home abbreviation without LSP, and 28-column clipping passed.
- The exact path helper and Windows tests cross-compile for `x86_64-pc-windows-msvc`; Windows execution remains unverified.
