### PR TITLE
feat(agent): add model selection to the agent pane

### DIFF
--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -384,8 +384,24 @@ protocol is unavailable; it does not fall back to `codex exec` or native edits.
 | `Space i` | Edit the current line or visual selection in a bounded popup. |
 | `:Agent` / `:AgentPrompt` | Open the prompt composer. |
 | `:AgentOpen` | Show and focus the conversation pane without opening a prompt. |
+| `:AgentModel` / `Alt+m` in the Agent pane | Choose this conversation’s model and reasoning effort. |
 | `:AgentCancel` | Interrupt the active Codex turn. |
 | `:AgentClear` | Clear visible conversation while retaining current context. |
 | `:AgentNew` | Close the current thread and start a new one. |
 | `:AgentClose` | Hide the conversation panel without discarding state. |
 | `:AgentHistory` | Inspect attributed agent transactions. |
+
+### Choosing a model
+
+Opening the Agent pane reads the workspace's configured Codex model without
+starting a conversation. Once a thread starts or resumes, its confirmed model
+and reasoning effort replace that preview. Click the model, press `Alt+m` from the pane's composer or transcript, or run
+`:AgentModel` from anywhere. Model names take priority over descriptions when
+space is limited, and a checkmark identifies the current choice. Search the
+model list, select with Enter, then choose a supported reasoning effort. Red
+preloads the catalog when the pane opens; if it is still loading, the picker
+shows a spinner and preserves anything you type while waiting. Escape leaves the previous settings and
+draft intact. Changes affect only this conversation; a running turn finishes
+with its existing model, and the header shows the accepted next-message choice.
+New conversations use Codex's default unless a model was explicitly selected
+before their first message. Red never changes global Codex configuration.

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.13.0` is defined by
+Red host API version `0.14.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -24,9 +24,9 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 annotations use `HUSK-A0004`. `--no-typecheck` is an unsupported development
 escape hatch; compatibility guarantees do not apply while it is enabled.
 
-Red `0.13.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
-`0.10.0`, `0.11.0`, and `0.12.0` contracts, so existing packages that declare those
-minors continue to load. New packages should target `"red_api_version": "^0.13.0"`.
+Red `0.14.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
+`0.10.0`, `0.11.0`, `0.12.0`, and `0.13.0` contracts, so existing packages that declare those
+minors continue to load. New packages should target `"red_api_version": "^0.14.0"`.
 
 ## Document-symbol breadcrumbs
 
@@ -305,7 +305,7 @@ process-specific and filesystem-watch-specific event names.
 New pickers should use
 `OpenPicker(title: String, items: [PickerItem], options: PickerOptions, handlers: PickerHandlers)`.
 The host returns an opaque integer handle that may be passed to `UpdatePickerItems`,
-`UpdatePickerQuery`, `UpdatePickerStatus`, and `ClosePicker`. Plugins
+`UpdatePickerQuery`, `UpdatePickerSelection`, `UpdatePickerStatus`, and `ClosePicker`. Plugins
 must not assign or interpret this handle.
 
 ```husk
@@ -476,3 +476,34 @@ in the complete reference but not in the compact action strip. Disabled actions
 are omitted. The strip and its clickable `F1 shortcuts` affordance use the same
 records, including the current mode and enabled state. `F1` opens help above the
 active surface; closing help does not replace that surface or its draft.
+
+## Agent model selection
+
+Host API `0.14.0` adds `AgentReadDefaultModel(callback)`, which returns
+`{ model_info, error }` for the current workspace without creating a thread.
+It reads Codex's effective configuration, falling back to the catalog default
+when no model is configured. This is a preview; thread settings remain authoritative.
+
+`AgentListModels(callback)` and
+`AgentSetModel(callback, session_id, selection)`. The catalog callback returns
+`{ models, error }`; model entries use Codex's `model/list` shape. Selection is
+`{ model: String, effort?: String }`. An empty session ID stores the choice for
+the next conversation; an existing ID updates only that conversation's next-turn
+settings. The callback reports `{ accepted, error }`. No global configuration is
+written. `agent:model_changed` carries `{ session_id, model_info }`, where
+`model_info` contains the effective `model`, optional `provider`, and optional
+`effort`. Treat that event as authoritative, and ignore foreign session IDs.
+`agent:model_rerouted` reports `{ session_id, model }` for the running turn only.
+
+For name-oriented lists, `PickerOptions.item_layout: "label_first"` reserves the
+longest filtered label, then aligns annotations and descriptions in shared columns.
+Secondary fields disappear before labels are shortened; the default layout is unchanged.
+`UpdatePickerSelection(handle, item_id)` selects a currently visible item without
+resetting the query. This is useful after populating a loading picker in place.
+
+`SetTextPanelHeaderDetail(id, detail?)` updates header metadata in place. Detail
+is `{ text: String, secondary?: String, compact_text?: String, action?: String, shortcut?: String }`.
+The header compacts its buttons before dropping secondary text. An optional
+`compact_text` preserves essential state in the shortened label. Clicking the visible
+detail emits the configured panel action; the shortcut works while the panel is focused and is included in contextual
+help. Omitting detail clears it. Draft, focus, scroll, and panel layout survive.

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.13.0",
+  "api_version": "0.14.0",
   "changes": [
+    {
+      "version": "0.14.0",
+      "kind": "introduced",
+      "symbols": ["UpdatePickerSelection", "PickerOptions.item_layout", "AgentReadDefaultModel", "AgentListModels", "AgentSetModel", "SetTextPanelHeaderDetail", "agent:model_changed", "agent:model_rerouted"],
+      "migration_note": "docs/PLUGIN_API.md#agent-model-selection"
+    },
     {
       "version": "0.13.0",
       "kind": "introduced",

--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -59,6 +59,7 @@ struct AgentConversationItem {
 struct AgentConversationEvent {
     thread_id: String,
     cwd: String,
+    model_info: Json,
     items: [AgentConversationItem],
 }
 
@@ -196,6 +197,20 @@ struct AgentPermissionEvent {
 }
 
 struct AgentState {
+    default_model_info: Json,
+    default_model_loading: bool,
+    model_info: Json,
+    turn_model_info: Json,
+    accepted_model: Json,
+    model_catalog: [Json],
+    model_catalog_loaded: bool,
+    model_catalog_request: i32,
+    model_picker: Option<i32>,
+    model_picker_session: String,
+    model_picker_loading: bool,
+    model_selection: Json,
+    model_header_text: String,
+    model_header_secondary: String,
     session_id: String,
     panel_created: bool,
     panel_open: bool,
@@ -231,6 +246,20 @@ struct AgentState {
 #[red::state]
 fn initial_state() -> AgentState {
     return AgentState {
+        default_model_info: Json {},
+        default_model_loading: false,
+        model_info: Json {},
+        turn_model_info: Json {},
+        accepted_model: Json {},
+        model_catalog: [],
+        model_catalog_loaded: false,
+        model_catalog_request: -1,
+        model_picker: None,
+        model_picker_session: "",
+        model_picker_loading: false,
+        model_selection: Json {},
+        model_header_text: "",
+        model_header_secondary: "",
         session_id: "",
         panel_created: false,
         panel_open: false,
@@ -267,6 +296,286 @@ fn initial_state() -> AgentState {
     };
 }
 
+struct AgentModelChangedEvent {
+    session_id: String,
+    model_info: Json,
+}
+
+struct AgentModelReroutedEvent {
+    session_id: String,
+    model: String,
+}
+
+#[red::on("agent:model_rerouted")]
+fn model_rerouted(event: AgentModelReroutedEvent) {
+    if event.session_id == "" || event.session_id != state().session_id { return; }
+    red::state_patch(AgentState { turn_model_info: Json { model: event.model } });
+    refresh_model_header();
+}
+
+struct AgentModelsResult {
+    models: [Json],
+    error: String,
+}
+
+struct AgentDefaultModelResult {
+    model_info: Json,
+    error: String,
+}
+
+// Preview only: opening a pane must not create a conversation or change settings.
+fn load_default_model() {
+    if state().session_id != "" || state().default_model_loading
+        || state().pending_prompt != "" || state().restoring { return; }
+    red::state_patch(AgentState { default_model_loading: true });
+    red::request("AgentReadDefaultModel", default_model_loaded);
+}
+
+fn default_model_loaded(result: AgentDefaultModelResult) {
+    red::state_patch(AgentState { default_model_loading: false });
+    if red::string(result.error, "") != "" { return; }
+    red::state_patch(AgentState { default_model_info: result.model_info });
+    refresh_model_header();
+}
+
+fn next_model_info() -> Json {
+    if model_name(state().accepted_model) != "" { return state().accepted_model; }
+    if model_name(state().model_info) != "" { return state().model_info; }
+    if state().session_id == "" { return state().default_model_info; }
+    return Json {};
+}
+
+struct AgentModelSetResult {
+    accepted: bool,
+    model_info: Json,
+    error: String,
+}
+
+fn model_name(info: Json) -> String {
+    if info == red::null() { return ""; }
+    return red::string(info.model, "");
+}
+
+fn model_effort(info: Json) -> String {
+    if info == red::null() { return ""; }
+    return red::string(info.effort, "");
+}
+
+fn model_description(info: Json) -> String {
+    let name = model_name(info);
+    let effort = model_effort(info);
+    if name != "" && effort != "" { return name + " · " + effort; }
+    return name;
+}
+
+fn same_model(left: Json, right: Json) -> bool {
+    return model_name(left) == model_name(right) && model_effort(left) == model_effort(right);
+}
+
+fn reset_model_state() {
+    red::state_patch(AgentState { model_info: Json {}, turn_model_info: Json {}, accepted_model: Json {} });
+    refresh_model_header();
+}
+
+fn refresh_model_header() {
+    if !state().panel_created { return; }
+    let current = state().model_info;
+    if model_name(current) == "" { current = next_model_info(); }
+    let running = state().turn_model_info;
+    let accepted = state().accepted_model;
+    let text = model_name(current);
+    let secondary = model_effort(current);
+    let next = Json {};
+    if model_name(running) != "" {
+        text = model_name(running);
+        secondary = model_effort(running);
+        if model_name(current) != "" && !same_model(running, current) {
+            next = current;
+        }
+    }
+    if model_name(accepted) != "" && !same_model(accepted, current) {
+        next = accepted;
+    }
+    if text == "" { text = "Codex"; }
+    let compact = "";
+    if model_name(next) != "" {
+        secondary = "Next: " + model_description(next);
+        compact = text + " → " + model_name(next);
+    }
+    if state().restoring { secondary = "restoring…"; compact = ""; }
+    if text == state().model_header_text && secondary == state().model_header_secondary { return; }
+    red::state_patch(AgentState { model_header_text: text, model_header_secondary: secondary });
+    red::execute("SetTextPanelHeaderDetail", "agent-conversation", Json {
+        text: text, secondary: secondary, compact_text: compact, action: "model", shortcut: "Alt-m",
+    });
+}
+
+#[red::on("agent:model_changed")]
+fn model_changed(event: AgentModelChangedEvent) {
+    if event.session_id == "" || event.session_id != state().session_id { return; }
+    if state().turn_active && model_name(state().turn_model_info) == "" {
+        red::state_patch(AgentState { turn_model_info: event.model_info });
+    }
+    red::state_patch(AgentState { model_info: event.model_info, accepted_model: Json {} });
+    refresh_model_header();
+}
+
+#[red::command(
+    name = "AgentModel",
+    title = "Change agent model",
+    category = "Agent",
+    description = "Choose the model and reasoning effort for this conversation",
+    aliases = ["change model", "reasoning effort"],
+    scope = "global",
+)]
+fn choose_model() {
+    if state().restoring {
+        red::execute("Print", "Wait for the agent session to finish restoring");
+        return;
+    }
+    if state().model_picker_loading { return; }
+    red::state_patch(AgentState { model_picker_session: state().session_id });
+    let loading = !state().model_catalog_loaded;
+    let status = "This conversation only";
+    if loading { status = "Loading models…"; }
+    let handle = red::execute("OpenPicker", "Agent model", model_items(), PickerOptions {
+        placeholder: "Search models…", initial_selection: current_catalog_model(),
+        status: status, busy: loading, presentation: "compact", item_layout: "label_first",
+    }, PickerHandlers { selected: model_selected, cancelled: model_picker_cancelled });
+    red::state_patch(AgentState { model_picker: Some(handle) });
+    prefetch_models();
+}
+
+fn prefetch_models() {
+    if state().model_catalog_loaded || state().model_catalog_request != -1 { return; }
+    let request = red::request("AgentListModels", models_loaded);
+    red::state_patch(AgentState { model_catalog_request: request });
+}
+
+fn invalidate_model_catalog() {
+    red::state_patch(AgentState {
+        model_catalog: [], model_catalog_loaded: false, model_catalog_request: -1,
+    });
+}
+
+fn current_catalog_model() -> String {
+    let current = model_name(next_model_info());
+    if current != "" { return current; }
+    for model in state().model_catalog {
+        if red::bool(model.isDefault, false) { return red::string(model.model, ""); }
+    }
+    return "";
+}
+
+fn model_picker_is_current() -> bool {
+    if state().model_picker_session != state().session_id {
+        red::execute("Print", "The agent conversation changed; choose its model again");
+        return false;
+    }
+    return true;
+}
+
+fn models_loaded(result: AgentModelsResult, request_id: i32) {
+    if request_id != state().model_catalog_request { return; }
+    red::state_patch(AgentState { model_catalog_request: -1 });
+    let error = red::string(result.error, "");
+    if error == "" && red::len(result.models) == 0 {
+        error = "Codex did not return any available models";
+    }
+    if error == "" {
+        red::state_patch(AgentState { model_catalog: result.models, model_catalog_loaded: true });
+    }
+    let Some(handle) = state().model_picker else { return; };
+    if state().model_picker_session != state().session_id {
+        red::state_patch(AgentState { model_picker: None });
+        red::execute("ClosePicker", handle);
+        return;
+    }
+    red::execute("UpdatePickerBusy", handle, false);
+    if error != "" {
+        red::execute("UpdatePickerStatus", handle, "Could not load models: " + error);
+        return;
+    }
+    red::execute("UpdatePickerItems", handle, model_items());
+    red::execute("UpdatePickerSelection", handle, current_catalog_model());
+    red::execute("UpdatePickerStatus", handle, "This conversation only");
+}
+
+fn model_items() -> [PickerItem] {
+    let current = current_catalog_model();
+    let items = [];
+    for model in state().model_catalog {
+        let id = red::string(model.model, "");
+        let icon = "";
+        if id == current { icon = "✓"; }
+        items = red::push(items, PickerItem {
+            id: id, icon: icon,
+            label: red::string(model.displayName, id),
+            detail: red::string(model.description, ""), data: model,
+        });
+    }
+    return items;
+}
+
+fn model_selected(item: PickerItem) {
+    red::state_patch(AgentState { model_picker: None });
+    if !model_picker_is_current() { return; }
+    let model = item.data;
+    let effort = model_effort(next_model_info());
+    let selected_effort = red::string(model.defaultReasoningEffort, "");
+    let items = [];
+    for option in model.supportedReasoningEfforts {
+        let id = red::string(option.reasoningEffort, "");
+        if id == effort { selected_effort = id; }
+        items = red::push(items, PickerItem {
+            id: id, label: id, detail: red::string(option.description, ""),
+            data: Json { model: model.model, effort: id },
+        });
+    }
+    red::state_patch(AgentState { model_selection: Json { model: model.model } });
+    if red::len(items) == 0 {
+        apply_model_selection();
+        return;
+    }
+    red::execute("OpenPicker", "Reasoning effort", items, PickerOptions {
+        placeholder: "Choose reasoning effort…", initial_selection: selected_effort,
+        status: red::string(model.displayName, model.model), presentation: "compact", item_layout: "label_first",
+    }, PickerHandlers { selected: model_effort_selected, cancelled: model_picker_cancelled });
+}
+
+fn model_effort_selected(item: PickerItem) {
+    red::state_patch(AgentState { model_selection: item.data });
+    apply_model_selection();
+}
+
+fn apply_model_selection() {
+    if !model_picker_is_current() { return; }
+    red::state_patch(AgentState { model_picker_loading: true });
+    red::request("AgentSetModel", model_set, state().model_picker_session, state().model_selection);
+}
+
+fn model_set(result: AgentModelSetResult) {
+    red::state_patch(AgentState { model_picker_loading: false });
+    if !model_picker_is_current() { return; }
+    let error = red::string(result.error, "");
+    if error != "" {
+        invalidate_model_catalog();
+        red::execute("Print", "Could not change Codex model: " + error);
+        return;
+    }
+    if model_name(result.model_info) != "" {
+        red::state_patch(AgentState { model_info: result.model_info, accepted_model: Json {} });
+    } else if !same_model(state().model_selection, state().model_info) {
+        red::state_patch(AgentState { accepted_model: state().model_selection });
+    }
+    refresh_model_header();
+    red::execute("Print", "Agent model selected: " + model_description(state().model_selection));
+}
+
+fn model_picker_cancelled(event: PickerCancelled) {
+    red::state_patch(AgentState { model_picker: None });
+}
+
 fn state() -> AgentState {
     return red::state();
 }
@@ -299,13 +608,14 @@ fn session_created(event: AgentSessionEvent) {
         red::state_patch(AgentState { turn_active: false });
     }
     if previous_session_id != event.session_id {
-        red::state_patch(AgentState { cancelled_session_id: "" });
+        red::state_patch(AgentState { cancelled_session_id: "", model_info: Json {}, turn_model_info: Json {} });
     }
     if previous_session_id != "" && previous_session_id != event.session_id {
         red::execute("AgentCloseSession", previous_session_id);
     }
     ensure_conversation_panel();
     render_conversation();
+    refresh_model_header();
     red::execute("Print", "Agent session started");
     if pending != "" {
         red::state_patch(AgentState { pending_prompt: "" });
@@ -398,6 +708,7 @@ fn open_conversation() {
         ensure_conversation_panel();
         render_conversation();
     }
+    if was_created && !state().panel_open { load_default_model(); prefetch_models(); }
     // An explicit open wins over a recovered hidden-pane preference.
     red::execute("SetPanelVisible", "agent-conversation", true);
     red::state_patch(AgentState { panel_open: true });
@@ -418,6 +729,10 @@ fn ensure_conversation_panel() {
             ],
         });
         red::state_patch(AgentState { panel_created: true });
+        red::state_patch(AgentState { model_header_text: "", model_header_secondary: "" });
+        prefetch_models();
+        refresh_model_header();
+        load_default_model();
         red::state_patch(AgentState { panel_open: true });
         red::state_patch(AgentState { focus_panel_on_first_prompt: true });
         return;
@@ -425,6 +740,8 @@ fn ensure_conversation_panel() {
     if !state().panel_open {
         red::execute("SetPanelVisible", "agent-conversation", true);
         red::state_patch(AgentState { panel_open: true });
+        load_default_model();
+        prefetch_models();
     }
 }
 
@@ -609,6 +926,10 @@ fn remove_queued_prompt_block(block_id: String) {
 
 #[red::on("agent:turn_started")]
 fn turn_started(event: AgentSessionEvent) {
+    if is_current_session(event.session_id) {
+        red::state_patch(AgentState { turn_model_info: state().model_info });
+        refresh_model_header();
+    }
     if !is_current_session(event.session_id) {
         return;
     }
@@ -619,6 +940,10 @@ fn turn_started(event: AgentSessionEvent) {
 fn set_phase(phase: String, label: String) {
     red::state_patch(AgentState { ui_phase: phase });
     red::state_patch(AgentState { ui_label: label });
+    if phase == "idle" && !state().turn_active {
+        red::state_patch(AgentState { turn_model_info: Json {} });
+        refresh_model_header();
+    }
     render_status();
 }
 
@@ -876,6 +1201,8 @@ fn panel_event(event: AgentPanelEvent) {
         red::execute("FocusTextPanelComposer", "agent-conversation");
     } else if event.action == "interrupt" {
         cancel();
+    } else if event.action == "model" {
+        choose_model();
     } else if event.action == "clear" {
         clear_conversation();
     } else if event.action == "new" {
@@ -948,9 +1275,10 @@ fn new_conversation() {
         if !state().restoring {
             red::execute("AgentCloseSession", session_id);
         }
-        red::execute("AgentForgetSession", session_id);
     }
+    red::execute("AgentForgetSession", session_id);
     red::state_patch(AgentState { session_id: "" });
+    reset_model_state();
     red::state_patch(AgentState { restoring: false });
     red::state_patch(AgentState { cancelled_session_id: "" });
     red::state_patch(AgentState { turn_active: false });
@@ -964,6 +1292,7 @@ fn new_conversation() {
     red::state_patch(AgentState { transcript: "" });
     red::execute("SetStorage", "transcript", "");
     red::execute("ClearTextPanelComposer", "agent-conversation");
+    if state().panel_created { load_default_model(); }
     prompt();
 }
 
@@ -1105,6 +1434,7 @@ fn completed(event: AgentCompletedEvent) {
     if session_id != "" && (stop_reason == "cancelled" || session_id == red::string(state().cancelled_session_id, "")) {
         red::execute("AgentCloseSession", session_id);
         red::state_patch(AgentState { session_id: "" });
+        reset_model_state();
         red::state_patch(AgentState { cancelled_session_id: "" });
         red::state_patch(AgentState { recap_pending: true });
     }
@@ -1156,6 +1486,7 @@ fn cancelled(event: AgentSessionEvent) {
     if !state().turn_active && session_id != "" {
         red::execute("AgentCloseSession", session_id);
         red::state_patch(AgentState { session_id: "" });
+        reset_model_state();
         red::state_patch(AgentState { cancelled_session_id: "" });
         red::state_patch(AgentState { recap_pending: true });
     }
@@ -1181,6 +1512,7 @@ fn failed(event: AgentErrorEvent) {
     if session_id != "" && session_id == red::string(state().cancelled_session_id, "") {
         red::execute("AgentCloseSession", session_id);
         red::state_patch(AgentState { session_id: "" });
+        reset_model_state();
         red::state_patch(AgentState { cancelled_session_id: "" });
         red::state_patch(AgentState { recap_pending: true });
     }
@@ -1238,6 +1570,7 @@ fn session_lost(event: AgentSessionLostEvent) {
     if !is_current_session(red::string(event.session_id, "")) && (session_id != "" || attempted == "") {
         return;
     }
+    invalidate_model_catalog();
     red::state_patch(AgentState { turn_active: false });
     collapse_activity(red::null());
     set_phase("idle", "");
@@ -1246,6 +1579,7 @@ fn session_lost(event: AgentSessionLostEvent) {
         red::state_patch(AgentState { recap_pending: true });
     }
     red::state_patch(AgentState { session_id: "" });
+    reset_model_state();
     red::state_patch(AgentState { cancelled_session_id: "" });
     if attempted != "" {
         red::state_patch(AgentState { pending_prompt: attempted });
@@ -1273,12 +1607,16 @@ fn setup_cancelled(event: PickerCancelled) {
 #[red::on("agent:credential_ready")]
 #[red::on("agent:backend_ready")]
 fn setup_ready(event: EmptyEvent) {
+    invalidate_model_catalog();
+    if state().panel_created { prefetch_models(); }
     if red::string(state().pending_prompt, "") != "" {
         start();
     }
 }
 
 fn finish_agent_turn() {
+    red::state_patch(AgentState { turn_model_info: Json {} });
+    refresh_model_header();
     if !state().streaming {
         return;
     }
@@ -1385,6 +1723,7 @@ fn transcript_restored(event: AgentTranscriptEvent) {
 
 #[red::on("agent:conversation_restore_pending")]
 fn conversation_restore_pending(event: AgentConversationEvent) {
+    red::state_patch(AgentState { model_info: event.model_info, accepted_model: Json {}, turn_model_info: Json {} });
     load_conversation(event);
     red::state_patch(AgentState { session_id: event.thread_id });
     red::state_patch(AgentState { restoring: true });
@@ -1393,6 +1732,7 @@ fn conversation_restore_pending(event: AgentConversationEvent) {
     red::state_patch(AgentState { activity_rows: [] });
     red::state_patch(AgentState { thought: "" });
     ensure_conversation_panel();
+    refresh_model_header();
     set_phase("restoring", "Restoring session…");
     red::execute("SetTextPanelComposerState", "agent-conversation", false, "Restoring agent session…");
     red::execute("AgentResumeSession", event.cwd, event.thread_id);
@@ -1400,12 +1740,14 @@ fn conversation_restore_pending(event: AgentConversationEvent) {
 
 #[red::on("agent:session_restored")]
 fn session_restored(event: AgentConversationEvent) {
+    red::state_patch(AgentState { model_info: event.model_info, accepted_model: Json {}, turn_model_info: Json {} });
     load_conversation(event);
     red::state_patch(AgentState { session_id: event.thread_id });
     red::state_patch(AgentState { restoring: false });
     red::state_patch(AgentState { recap_pending: false });
     set_phase("idle", "");
     red::execute("SetTextPanelComposerState", "agent-conversation", true, "");
+    refresh_model_header();
     red::execute("Print", "Agent session restored");
 }
 
@@ -1417,6 +1759,7 @@ struct AgentSessionRestoreFailedEvent {
 #[red::on("agent:session_restore_failed")]
 fn session_restore_failed(event: AgentSessionRestoreFailedEvent) {
     red::state_patch(AgentState { session_id: "" });
+    reset_model_state();
     red::state_patch(AgentState { restoring: false });
     red::state_patch(AgentState { recap_pending: red::trim(red::string(state().transcript, "")) != "" });
     red::execute("AgentForgetSession", event.session_id);
@@ -1757,6 +2100,7 @@ fn deactivate() {
     }
     red::execute("SetTextPanelStatus", "agent-conversation");
     red::state_patch(AgentState { session_id: "" });
+    reset_model_state();
     red::state_patch(AgentState { cancelled_session_id: "" });
     red::state_patch(AgentState { permission_request_id: "" });
     let timer = red::string(state().stream_timer, "");

--- a/src/agent_conversation.rs
+++ b/src/agent_conversation.rs
@@ -27,6 +27,8 @@ pub struct AgentTranscriptItem {
 pub struct AgentConversationSnapshot {
     pub thread_id: String,
     pub cwd: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_info: Option<crate::codex::AgentModelInfo>,
     #[serde(default)]
     pub items: Vec<AgentTranscriptItem>,
 }
@@ -72,6 +74,7 @@ impl AgentConversationSnapshot {
         Self {
             thread_id: thread_id.into(),
             cwd: cwd.into(),
+            model_info: None,
             items: Vec::new(),
         }
     }

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -34,6 +34,9 @@ use tokio::{
     time::timeout,
 };
 
+mod models;
+pub use models::{AgentModelInfo, AgentModelSelection, ModelRequest};
+
 use crate::agent_tools::{editor_tool_schemas, EditorToolCall, EditorToolRequest};
 use crate::inline_assist::InlineAssistResult;
 use crate::inline_context::InlineContextCall;
@@ -93,6 +96,16 @@ impl CodexProcessSpec {
 /// Commands sent from the editor owner to the Codex worker.
 #[derive(Debug, Clone)]
 pub enum CodexCommand {
+    /// Queries the model catalog or updates one conversation's next-turn settings.
+    ModelRequest {
+        request_id: i64,
+        request: ModelRequest,
+    },
+    /// Starts a conversation with an explicitly selected model.
+    NewSessionWithModel {
+        cwd: PathBuf,
+        selection: AgentModelSelection,
+    },
     /// Starts an isolated, ephemeral inline-edit thread and immediately submits a request.
     InlineAssist {
         /// Editor-generated identifier used to reject stale responses.
@@ -176,6 +189,18 @@ pub enum CodexCommand {
 /// Events delivered from the Codex worker to the editor owner.
 #[derive(Debug, Clone)]
 pub enum CodexEvent {
+    /// Result for a private plugin model request.
+    ModelRequestCompleted {
+        request_id: i64,
+        result: std::result::Result<Value, String>,
+    },
+    /// A running turn was routed to a different model without changing its next-turn settings.
+    SessionModelRerouted { session_id: String, model: String },
+    /// Authoritative next-turn settings for a user-visible conversation.
+    SessionModelChanged {
+        session_id: String,
+        model_info: AgentModelInfo,
+    },
     /// User-visible prose from an inline turn, retained separately from its result.
     InlineAnswerDelta { request_id: String, text: String },
     /// Provenance of a successful read-only inline context request.
@@ -375,6 +400,7 @@ pub trait CodexToolHost: Send + 'static {
 
 #[derive(Debug)]
 struct Session {
+    model_info: Option<AgentModelInfo>,
     cwd: PathBuf,
     active_turn: Option<String>,
     cancelled: Arc<AtomicBool>,
@@ -400,6 +426,7 @@ enum SessionKind {
 #[derive(Debug)]
 enum ThreadRequest {
     Agent {
+        selection: Option<AgentModelSelection>,
         cwd: PathBuf,
         launch: SessionLaunch,
     },
@@ -439,6 +466,7 @@ enum SessionLaunch {
 }
 
 enum Pending {
+    Model(models::PendingModelRequest),
     Config {
         request: ThreadRequest,
     },
@@ -759,6 +787,28 @@ async fn handle_command(
     next_id: &mut u64,
 ) -> Result<()> {
     match command {
+        CodexCommand::ModelRequest {
+            request_id,
+            request,
+        } => {
+            models::handle_command(
+                request_id, request, input, events, pending, sessions, next_id,
+            )
+            .await?;
+        }
+        CodexCommand::NewSessionWithModel { cwd, selection } => {
+            start_thread_request(
+                ThreadRequest::Agent {
+                    cwd,
+                    selection: Some(selection),
+                    launch: SessionLaunch::New,
+                },
+                input,
+                pending,
+                next_id,
+            )
+            .await?;
+        }
         CodexCommand::InlineAssist {
             request_id,
             cwd,
@@ -768,6 +818,7 @@ async fn handle_command(
             start_thread_request(
                 ThreadRequest::Agent {
                     cwd,
+                    selection: None,
                     launch: SessionLaunch::Inline {
                         request_id,
                         prompt,
@@ -832,6 +883,7 @@ async fn handle_command(
             start_thread_request(
                 ThreadRequest::Agent {
                     cwd,
+                    selection: None,
                     launch: SessionLaunch::New,
                 },
                 input,
@@ -861,6 +913,7 @@ async fn handle_command(
             start_thread_request(
                 ThreadRequest::Agent {
                     cwd,
+                    selection: None,
                     launch: SessionLaunch::Resume { session_id },
                 },
                 input,
@@ -1103,6 +1156,12 @@ async fn handle_message<H: CodexToolHost>(
         .and_then(Value::as_str)
         .unwrap_or_default();
     match method {
+        "thread/settings/updated" => {
+            models::settings_updated(&message["params"], events, sessions).await;
+        }
+        "model/rerouted" => {
+            models::model_rerouted(&message["params"], events, sessions).await;
+        }
         "item/agentMessage/delta" => {
             let params = &message["params"];
             let session_id = params["threadId"].as_str().unwrap_or_default();
@@ -1272,6 +1331,12 @@ async fn handle_response(
     let Some(request) = pending.remove(&key) else {
         return Ok(());
     };
+    if let Pending::Model(request) = request {
+        return models::handle_response(
+            request, message, input, events, pending, sessions, next_id,
+        )
+        .await;
+    }
     if let Some(error) = message.get("error") {
         let message = error["message"]
             .as_str()
@@ -1324,7 +1389,7 @@ async fn handle_response(
             config["features"]["hooks"] = json!(hooks_enabled);
             let id = rpc_id(next_id);
             let cwd = request.cwd().to_path_buf();
-            let rpc_request = match &request {
+            let mut rpc_request = match &request {
                 ThreadRequest::Agent {
                     launch: SessionLaunch::New,
                     ..
@@ -1392,6 +1457,16 @@ async fn handle_response(
                     }
                 }),
             };
+            if let ThreadRequest::Agent {
+                selection: Some(selection),
+                ..
+            } = &request
+            {
+                rpc_request["params"]["model"] = json!(selection.model);
+                if let Some(effort) = &selection.effort {
+                    rpc_request["params"]["config"]["model_reasoning_effort"] = json!(effort);
+                }
+            }
             pending.insert(id, Pending::Start { request });
             write_message(input, &rpc_request).await?;
         }
@@ -1457,6 +1532,7 @@ async fn handle_response(
                 sessions.insert(
                     session_id.clone(),
                     Session {
+                        model_info: AgentModelInfo::from_response(&message["result"]),
                         cwd,
                         active_turn: None,
                         cancelled: Arc::new(AtomicBool::new(false)),
@@ -1464,6 +1540,14 @@ async fn handle_response(
                         kind,
                     },
                 );
+                let model_event = sessions
+                    .get(&session_id)
+                    .filter(|session| matches!(session.kind, SessionKind::Agent))
+                    .and_then(|session| session.model_info.clone())
+                    .map(|model_info| CodexEvent::SessionModelChanged {
+                        session_id: session_id.clone(),
+                        model_info,
+                    });
                 match launch {
                     Some(SessionLaunch::New) => {
                         events
@@ -1515,8 +1599,12 @@ async fn handle_response(
                         .await?;
                     }
                 }
+                if let Some(event) = model_event {
+                    events.send(event).await.ok();
+                }
             }
         }
+        Pending::Model(_) => unreachable!("model responses are handled separately"),
         Pending::Turn { session_id } => {
             let turn_id = message
                 .pointer("/result/turn/id")
@@ -1585,7 +1673,7 @@ async fn send_pending_failure(
         Pending::Config { request }
         | Pending::Requirements { request, .. }
         | Pending::Start { request } => Some(request),
-        Pending::Turn { .. } | Pending::Interrupt { .. } => None,
+        Pending::Model(_) | Pending::Turn { .. } | Pending::Interrupt { .. } => None,
     };
     if let Some(request) = early_request {
         send_thread_failure(request, message, events).await;
@@ -1593,7 +1681,10 @@ async fn send_pending_failure(
     }
     let session_id = match request {
         Pending::Turn { session_id } | Pending::Interrupt { session_id, .. } => session_id,
-        Pending::Config { .. } | Pending::Requirements { .. } | Pending::Start { .. } => {
+        Pending::Model(_)
+        | Pending::Config { .. }
+        | Pending::Requirements { .. }
+        | Pending::Start { .. } => {
             unreachable!("early requests returned above")
         }
     };
@@ -2325,6 +2416,7 @@ mod tests {
         let mut sessions = HashMap::from([(
             "inline".into(),
             Session {
+                model_info: None,
                 cwd: PathBuf::from("/workspace"),
                 active_turn: Some("turn".into()),
                 cancelled: Arc::new(AtomicBool::new(false)),
@@ -2579,6 +2671,7 @@ mod tests {
         let mut sessions = HashMap::from([(
             "hidden-thread".to_string(),
             Session {
+                model_info: None,
                 cwd: PathBuf::from("/workspace"),
                 active_turn: None,
                 cancelled: Arc::new(AtomicBool::new(false)),

--- a/src/codex/models.rs
+++ b/src/codex/models.rs
@@ -1,0 +1,569 @@
+//! Model discovery and conversation-scoped settings. These requests never alter
+//! the user's on-disk configuration or Red's tool and permission restrictions.
+
+use super::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentModelSelection {
+    pub model: String,
+    #[serde(default)]
+    pub effort: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentModelInfo {
+    pub model: String,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub effort: Option<String>,
+}
+
+impl AgentModelInfo {
+    pub(super) fn from_response(value: &Value) -> Option<Self> {
+        let model = value.get("model")?.as_str()?.trim();
+        if model.is_empty() {
+            return None;
+        }
+        Some(Self {
+            model: model.to_string(),
+            provider: value
+                .get("modelProvider")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            effort: value
+                .get("reasoningEffort")
+                .or_else(|| value.get("effort"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ModelRequest {
+    /// Resolve a workspace's new-conversation defaults without creating a thread.
+    ReadDefault {
+        cwd: PathBuf,
+    },
+    List,
+    Set {
+        session_id: String,
+        selection: AgentModelSelection,
+    },
+}
+
+pub(super) enum ModelListPurpose {
+    Catalog,
+    Default {
+        provider: Option<String>,
+        effort: Option<String>,
+    },
+}
+
+pub(super) enum PendingModelRequest {
+    ReadDefault {
+        request_id: i64,
+    },
+    List {
+        request_id: i64,
+        purpose: ModelListPurpose,
+        models: Vec<Value>,
+        cursors: HashSet<String>,
+    },
+    Set {
+        request_id: i64,
+        session_id: String,
+        selection: AgentModelSelection,
+        previous: Option<AgentModelInfo>,
+    },
+}
+
+impl PendingModelRequest {
+    fn request_id(&self) -> i64 {
+        match self {
+            Self::ReadDefault { request_id }
+            | Self::List { request_id, .. }
+            | Self::Set { request_id, .. } => *request_id,
+        }
+    }
+}
+
+fn nonempty_string(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+async fn complete(
+    events: &mpsc::Sender<CodexEvent>,
+    request_id: i64,
+    result: std::result::Result<Value, String>,
+) {
+    events
+        .send(CodexEvent::ModelRequestCompleted { request_id, result })
+        .await
+        .ok();
+}
+
+async fn list_page(
+    state: PendingModelRequest,
+    cursor: Option<String>,
+    input: &mut (impl AsyncWrite + Unpin),
+    pending: &mut HashMap<String, Pending>,
+    next_id: &mut u64,
+) -> Result<()> {
+    let id = rpc_id(next_id);
+    pending.insert(id.clone(), Pending::Model(state));
+    write_message(input, &json!({"id": id, "method": "model/list", "params": {"limit": 100, "cursor": cursor, "includeHidden": false}})).await
+}
+
+pub(super) async fn handle_command(
+    request_id: i64,
+    request: ModelRequest,
+    input: &mut (impl AsyncWrite + Unpin),
+    events: &mpsc::Sender<CodexEvent>,
+    pending: &mut HashMap<String, Pending>,
+    sessions: &HashMap<String, Session>,
+    next_id: &mut u64,
+) -> Result<()> {
+    match request {
+        ModelRequest::ReadDefault { cwd } => {
+            let id = rpc_id(next_id);
+            pending.insert(
+                id.clone(),
+                Pending::Model(PendingModelRequest::ReadDefault { request_id }),
+            );
+            write_message(input, &json!({"id": id, "method": "config/read", "params": {"includeLayers": false, "cwd": cwd}})).await?;
+        }
+        ModelRequest::List => {
+            list_page(
+                PendingModelRequest::List {
+                    request_id,
+                    purpose: ModelListPurpose::Catalog,
+                    models: Vec::new(),
+                    cursors: HashSet::new(),
+                },
+                None,
+                input,
+                pending,
+                next_id,
+            )
+            .await?
+        }
+        ModelRequest::Set {
+            session_id,
+            selection,
+        } => {
+            if selection.model.trim().is_empty()
+                || !sessions
+                    .get(&session_id)
+                    .is_some_and(|session| matches!(session.kind, SessionKind::Agent))
+            {
+                complete(
+                    events,
+                    request_id,
+                    Err("Agent conversation is no longer available".into()),
+                )
+                .await;
+                return Ok(());
+            }
+            let id = rpc_id(next_id);
+            let mut params = json!({"threadId": session_id, "model": selection.model});
+            if let Some(effort) = &selection.effort {
+                params["effort"] = json!(effort);
+            }
+            pending.insert(
+                id.clone(),
+                Pending::Model(PendingModelRequest::Set {
+                    request_id,
+                    previous: sessions
+                        .get(&session_id)
+                        .and_then(|session| session.model_info.clone()),
+                    session_id,
+                    selection,
+                }),
+            );
+            write_message(
+                input,
+                &json!({"id": id, "method": "thread/settings/update", "params": params}),
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn handle_response(
+    request: PendingModelRequest,
+    message: Value,
+    input: &mut (impl AsyncWrite + Unpin),
+    events: &mpsc::Sender<CodexEvent>,
+    pending: &mut HashMap<String, Pending>,
+    sessions: &mut HashMap<String, Session>,
+    next_id: &mut u64,
+) -> Result<()> {
+    let request_id = request.request_id();
+    if let Some(error) = message.get("error") {
+        complete(
+            events,
+            request_id,
+            Err(error["message"]
+                .as_str()
+                .unwrap_or("Codex model request failed")
+                .to_string()),
+        )
+        .await;
+        return Ok(());
+    }
+    match request {
+        PendingModelRequest::ReadDefault { .. } => {
+            let Some(config) = message
+                .pointer("/result/config")
+                .filter(|value| value.is_object())
+            else {
+                complete(
+                    events,
+                    request_id,
+                    Err("Codex returned invalid model configuration".into()),
+                )
+                .await;
+                return Ok(());
+            };
+            let provider = nonempty_string(&config["model_provider"]);
+            let effort = nonempty_string(&config["model_reasoning_effort"]);
+            if let Some(model) = nonempty_string(&config["model"]) {
+                let info = AgentModelInfo {
+                    model,
+                    provider,
+                    effort,
+                };
+                complete(events, request_id, Ok(json!({"model_info": info}))).await;
+            } else {
+                list_page(
+                    PendingModelRequest::List {
+                        request_id,
+                        purpose: ModelListPurpose::Default { provider, effort },
+                        models: Vec::new(),
+                        cursors: HashSet::new(),
+                    },
+                    None,
+                    input,
+                    pending,
+                    next_id,
+                )
+                .await?;
+            }
+        }
+        PendingModelRequest::Set {
+            session_id,
+            selection,
+            previous,
+            ..
+        } => {
+            let confirmed = sessions
+                .get(&session_id)
+                .and_then(|session| session.model_info.as_ref())
+                .filter(|info| {
+                    Some(*info) != previous.as_ref()
+                        || (info.model == selection.model
+                            && (selection.effort.is_none() || info.effort == selection.effort))
+                });
+            complete(
+                events,
+                request_id,
+                Ok(json!({"accepted": true, "model_info": confirmed})),
+            )
+            .await
+        }
+        PendingModelRequest::List {
+            purpose,
+            mut models,
+            mut cursors,
+            ..
+        } => {
+            let Some(page) = message.pointer("/result/data").and_then(Value::as_array) else {
+                complete(
+                    events,
+                    request_id,
+                    Err("Codex returned an invalid model catalog".into()),
+                )
+                .await;
+                return Ok(());
+            };
+            for model in page {
+                if model["hidden"].as_bool() == Some(true) {
+                    continue;
+                }
+                if let Some(id) = model["model"].as_str().filter(|id| !id.is_empty()) {
+                    if !models
+                        .iter()
+                        .any(|entry| entry["model"].as_str() == Some(id))
+                    {
+                        models.push(model.clone());
+                    }
+                }
+            }
+            if let Some(cursor) = message
+                .pointer("/result/nextCursor")
+                .and_then(Value::as_str)
+                .filter(|cursor| !cursor.is_empty())
+            {
+                if models.len() > 4096
+                    || cursors.len() >= 100
+                    || !cursors.insert(cursor.to_string())
+                {
+                    complete(
+                        events,
+                        request_id,
+                        Err("Codex model catalog pagination did not finish".into()),
+                    )
+                    .await;
+                } else {
+                    list_page(
+                        PendingModelRequest::List {
+                            request_id,
+                            purpose,
+                            models,
+                            cursors,
+                        },
+                        Some(cursor.to_string()),
+                        input,
+                        pending,
+                        next_id,
+                    )
+                    .await?;
+                }
+            } else {
+                let result = match purpose {
+                    ModelListPurpose::Catalog => Ok(json!({"models": models})),
+                    ModelListPurpose::Default { provider, effort } => models
+                        .iter()
+                        .find(|model| model["isDefault"].as_bool() == Some(true))
+                        .map(|model| json!({"model_info": AgentModelInfo {
+                            model: model["model"].as_str().unwrap_or_default().to_string(),
+                            provider,
+                            effort: effort.or_else(|| nonempty_string(&model["defaultReasoningEffort"])),
+                        }}))
+                        .ok_or_else(|| "Codex did not return a default model".to_string()),
+                };
+                complete(events, request_id, result).await;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn settings_updated(
+    params: &Value,
+    events: &mpsc::Sender<CodexEvent>,
+    sessions: &mut HashMap<String, Session>,
+) {
+    let Some(session_id) = params["threadId"].as_str() else {
+        return;
+    };
+    let Some(session) = sessions
+        .get_mut(session_id)
+        .filter(|session| matches!(session.kind, SessionKind::Agent))
+    else {
+        return;
+    };
+    let Some(model_info) = AgentModelInfo::from_response(&params["threadSettings"]) else {
+        return;
+    };
+    if session.model_info.as_ref() == Some(&model_info) {
+        return;
+    }
+    session.model_info = Some(model_info.clone());
+    events
+        .send(CodexEvent::SessionModelChanged {
+            session_id: session_id.to_string(),
+            model_info,
+        })
+        .await
+        .ok();
+}
+
+pub(super) async fn model_rerouted(
+    params: &Value,
+    events: &mpsc::Sender<CodexEvent>,
+    sessions: &HashMap<String, Session>,
+) {
+    let (Some(session_id), Some(turn_id), Some(model)) = (
+        params["threadId"].as_str(),
+        params["turnId"].as_str(),
+        params["toModel"].as_str(),
+    ) else {
+        return;
+    };
+    if model.is_empty()
+        || !sessions.get(session_id).is_some_and(|session| {
+            matches!(session.kind, SessionKind::Agent)
+                && session.active_turn.as_deref() == Some(turn_id)
+        })
+    {
+        return;
+    }
+    events
+        .send(CodexEvent::SessionModelRerouted {
+            session_id: session_id.to_string(),
+            model: model.to_string(),
+        })
+        .await
+        .ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(model: &str, effort: &str, kind: SessionKind) -> Session {
+        Session {
+            model_info: Some(AgentModelInfo {
+                model: model.into(),
+                provider: None,
+                effort: Some(effort.into()),
+            }),
+            cwd: PathBuf::from("/workspace"),
+            active_turn: Some("turn-1".into()),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            tool_calls: 0,
+            kind,
+        }
+    }
+
+    #[test]
+    fn model_metadata_tolerates_missing_and_optional_fields() {
+        assert_eq!(AgentModelInfo::from_response(&json!({})), None);
+        assert_eq!(AgentModelInfo::from_response(&json!({"model":""})), None);
+        let info =
+            AgentModelInfo::from_response(&json!({"model":"custom", "reasoningEffort":null}))
+                .unwrap();
+        assert_eq!(
+            info,
+            AgentModelInfo {
+                model: "custom".into(),
+                provider: None,
+                effort: None
+            }
+        );
+        assert_eq!(
+            AgentModelInfo::from_response(&json!({"model":"custom", "effort":"high"}))
+                .unwrap()
+                .effort
+                .as_deref(),
+            Some("high")
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_catalog_cursor_fails_without_another_request() {
+        let (events, mut received) = mpsc::channel(2);
+        let mut output = Vec::new();
+        handle_response(
+            PendingModelRequest::List {
+                request_id: 7,
+                purpose: ModelListPurpose::Catalog,
+                models: Vec::new(),
+                cursors: HashSet::from(["again".into()]),
+            },
+            json!({"result":{"data":[],"nextCursor":"again"}}),
+            &mut output,
+            &events,
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+            &mut 1,
+        )
+        .await
+        .unwrap();
+        assert!(output.is_empty());
+        assert!(matches!(
+            received.recv().await,
+            Some(CodexEvent::ModelRequestCompleted {
+                request_id: 7,
+                result: Err(_)
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn settings_ack_uses_normalized_server_values() {
+        let (events, mut received) = mpsc::channel(2);
+        let previous = session("first", "high", SessionKind::Agent).model_info;
+        let mut sessions = HashMap::from([(
+            "thread-1".into(),
+            session("second", "low", SessionKind::Agent),
+        )]);
+        handle_response(
+            PendingModelRequest::Set {
+                request_id: 8,
+                session_id: "thread-1".into(),
+                selection: AgentModelSelection {
+                    model: "second".into(),
+                    effort: Some("high".into()),
+                },
+                previous,
+            },
+            json!({"result":{}}),
+            &mut Vec::new(),
+            &events,
+            &mut HashMap::new(),
+            &mut sessions,
+            &mut 1,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(received.recv().await, Some(CodexEvent::ModelRequestCompleted { result: Ok(value), .. }) if value["model_info"]["effort"] == "low")
+        );
+    }
+
+    #[tokio::test]
+    async fn hidden_and_stale_turns_cannot_change_the_visible_model() {
+        let (events, mut received) = mpsc::channel(4);
+        let mut sessions = HashMap::from([
+            ("agent".into(), session("first", "high", SessionKind::Agent)),
+            (
+                "inline".into(),
+                session(
+                    "hidden",
+                    "low",
+                    SessionKind::Inline {
+                        request_id: "inline-request".into(),
+                        result: None,
+                    },
+                ),
+            ),
+        ]);
+        settings_updated(
+            &json!({"threadId":"inline","threadSettings":{"model":"wrong"}}),
+            &events,
+            &mut sessions,
+        )
+        .await;
+        model_rerouted(
+            &json!({"threadId":"agent","turnId":"old-turn","toModel":"wrong"}),
+            &events,
+            &sessions,
+        )
+        .await;
+        assert!(received.try_recv().is_err());
+        model_rerouted(
+            &json!({"threadId":"agent","turnId":"turn-1","toModel":"routed"}),
+            &events,
+            &sessions,
+        )
+        .await;
+        assert!(
+            matches!(received.recv().await, Some(CodexEvent::SessionModelRerouted { session_id, model }) if session_id == "agent" && model == "routed")
+        );
+        assert_eq!(
+            sessions["agent"].model_info.as_ref().unwrap().model,
+            "first"
+        );
+    }
+}

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -16,6 +16,7 @@
 //! model.
 
 mod agent_manager;
+mod agent_models;
 mod buffer_manager;
 mod diagnostics;
 mod diagnostics_picker;
@@ -1265,6 +1266,20 @@ fn agent_event_payload(event: CodexEvent) -> (&'static str, Value) {
             "inline_assist:error",
             json!({ "request_id": request_id, "session_id": session_id, "message": message }),
         ),
+        CodexEvent::ModelRequestCompleted { .. } => {
+            unreachable!("model results use private callbacks")
+        }
+        CodexEvent::SessionModelRerouted { session_id, model } => (
+            "agent:model_rerouted",
+            json!({"session_id": session_id, "model": model}),
+        ),
+        CodexEvent::SessionModelChanged {
+            session_id,
+            model_info,
+        } => (
+            "agent:model_changed",
+            json!({ "session_id": session_id, "model_info": model_info }),
+        ),
         CodexEvent::SessionCreated { session_id } => (
             "agent:session_created",
             json!({ "session_id": session_id.to_string() }),
@@ -1529,6 +1544,14 @@ fn snake_case_key(key: &str) -> String {
 /// windows, UI resources, agent state, LSP state, or the filesystem.
 pub enum PluginRequest {
     Action(Action),
+    AgentModelRequest {
+        request_id: RequestId,
+        request: crate::codex::ModelRequest,
+    },
+    SetTextPanelHeaderDetail {
+        id: String,
+        detail: Option<plugin::TextPanelHeaderDetail>,
+    },
     AgentNewSession {
         cwd: PathBuf,
     },
@@ -1626,6 +1649,10 @@ pub enum PluginRequest {
     UpdatePickerQuery {
         id: i32,
         query: String,
+    },
+    UpdatePickerSelection {
+        id: i32,
+        selection: String,
     },
     UpdatePickerStatus {
         id: i32,
@@ -1925,6 +1952,8 @@ impl PluginRequest {
     fn label(&self) -> &'static str {
         match self {
             Self::Action(_) => "Action",
+            Self::AgentModelRequest { .. } => "AgentModelRequest",
+            Self::SetTextPanelHeaderDetail { .. } => "SetTextPanelHeaderDetail",
             Self::AgentNewSession { .. } => "AgentNewSession",
             Self::AgentResumeSession { .. } => "AgentResumeSession",
             Self::AgentPrompt { .. } => "AgentPrompt",
@@ -1948,6 +1977,7 @@ impl PluginRequest {
             Self::OpenCallbackConfirmation { .. } => "OpenCallbackConfirmation",
             Self::UpdatePickerItems { .. } => "UpdatePickerItems",
             Self::UpdatePickerQuery { .. } => "UpdatePickerQuery",
+            Self::UpdatePickerSelection { .. } => "UpdatePickerSelection",
             Self::UpdatePickerStatus { .. } => "UpdatePickerStatus",
             Self::UpdatePickerBusy { .. } => "UpdatePickerBusy",
             Self::UpdatePickerPreview { .. } => "UpdatePickerPreview",
@@ -8531,8 +8561,11 @@ impl Editor {
     ) -> anyhow::Result<bool> {
         if self.agent_manager.is_task_finished() {
             let message = self
-                .finish_agent_bridge("Codex app-server stopped before the prompt was sent")
-                .await;
+                .finish_agent_bridge(
+                    runtime,
+                    "Codex app-server stopped before the prompt was sent",
+                )
+                .await?;
             self.plugin_registry
                 .notify(
                     runtime,
@@ -8599,8 +8632,8 @@ impl Editor {
         );
         if bridge.send(command).await.is_err() {
             let message = self
-                .finish_agent_bridge("Codex app-server stopped while sending the prompt")
-                .await;
+                .finish_agent_bridge(runtime, "Codex app-server stopped while sending the prompt")
+                .await?;
             self.plugin_registry
                 .notify(
                     runtime,
@@ -8912,7 +8945,11 @@ impl Editor {
             .await
     }
 
-    async fn finish_agent_bridge(&mut self, fallback: &str) -> String {
+    async fn finish_agent_bridge(
+        &mut self,
+        runtime: &mut Runtime,
+        fallback: &str,
+    ) -> anyhow::Result<String> {
         let result = match self.agent_manager.take_task() {
             Some(task) => Some(task.await),
             None => None,
@@ -8938,7 +8975,18 @@ impl Editor {
         };
         let message = bounded_agent_failure_message(&message);
         self.fail_running_inline_jobs(&message);
-        message
+        // Every shutdown path must resolve metadata callbacks, including a
+        // request that replaces a failed bridge before the background tick.
+        for request_id in self.agent_manager.take_pending_model_requests() {
+            self.plugin_registry
+                .resolve_request(
+                    runtime,
+                    RequestId::from_raw(request_id),
+                    json!({"error": message.clone()}),
+                )
+                .await?;
+        }
+        Ok(message)
     }
 
     async fn service_background(
@@ -9028,6 +9076,17 @@ impl Editor {
             else {
                 break;
             };
+            if let CodexEvent::ModelRequestCompleted { request_id, result } = &event {
+                self.agent_manager.finish_model_request(*request_id);
+                self.plugin_registry
+                    .resolve_request(
+                        runtime,
+                        RequestId::from_raw(*request_id),
+                        agent_models::model_result_payload(result),
+                    )
+                    .await?;
+                continue;
+            }
             if let CodexEvent::CommitMessageGenerated { request_id, result } = &event {
                 self.agent_manager.finish_commit_message(*request_id);
                 let payload = match result {
@@ -9210,7 +9269,15 @@ impl Editor {
                     event => event,
                 };
             match &event {
+                CodexEvent::SessionModelChanged {
+                    session_id,
+                    model_info,
+                } => {
+                    self.agent_manager
+                        .set_conversation_model(session_id, model_info.clone());
+                }
                 CodexEvent::SessionCreated { session_id } => {
+                    self.agent_manager.take_next_model();
                     let root = self
                         .agent_manager
                         .root()
@@ -9339,6 +9406,7 @@ impl Editor {
                 .is_none_or(|bridge| !bridge.has_pending_events())
         {
             let pending_commit_messages = self.agent_manager.take_pending_commit_messages();
+            let model_only_bridge = self.agent_manager.is_model_only_bridge();
             let inline_scope = self
                 .current_dialog
                 .as_ref()
@@ -9349,8 +9417,8 @@ impl Editor {
                         .map(|assist| assist.scope.clone())
                 });
             let message = self
-                .finish_agent_bridge("Codex app-server stopped unexpectedly")
-                .await;
+                .finish_agent_bridge(runtime, "Codex app-server stopped unexpectedly")
+                .await?;
             for request_id in pending_commit_messages {
                 self.plugin_registry
                     .resolve_request(
@@ -9382,7 +9450,7 @@ impl Editor {
                 self.set_legacy_message(Some(format!(
                     "{message}; restoring the persisted agent session"
                 )));
-            } else {
+            } else if !model_only_bridge {
                 self.plugin_registry
                     .notify(runtime, "agent:session_lost", json!({ "message": message }))
                     .await?;
@@ -9521,15 +9589,33 @@ impl Editor {
                     needs_render = true;
                     // self.redraw(runtime, &current_buffer, buffer).await?;
                 }
+                PluginRequest::AgentModelRequest {
+                    request_id,
+                    request,
+                } => {
+                    self.handle_agent_model_request(runtime, request_id, request)
+                        .await?;
+                }
+                PluginRequest::SetTextPanelHeaderDetail { id, detail } => {
+                    needs_render |= self.panel_manager.set_text_panel_header_detail(&id, detail);
+                }
                 PluginRequest::AgentNewSession { cwd } => {
                     if self.agent_manager.is_task_finished() {
+                        let model_only_bridge = self.agent_manager.is_model_only_bridge();
                         let message = self
-                            .finish_agent_bridge("Codex app-server stopped unexpectedly")
-                            .await;
-                        self.plugin_registry
-                            .notify(runtime, "agent:session_lost", json!({ "message": message }))
+                            .finish_agent_bridge(runtime, "Codex app-server stopped unexpectedly")
                             .await?;
+                        if !model_only_bridge {
+                            self.plugin_registry
+                                .notify(
+                                    runtime,
+                                    "agent:session_lost",
+                                    json!({ "message": message }),
+                                )
+                                .await?;
+                        }
                     }
+                    self.agent_manager.mark_conversation_requested();
                     if let Err(error) = self.ensure_agent_bridge(&cwd) {
                         self.plugin_registry
                             .notify(
@@ -9543,22 +9629,34 @@ impl Editor {
                     let Some(bridge) = self.agent_manager.bridge() else {
                         continue;
                     };
-                    if bridge.send(CodexCommand::NewSession { cwd }).await.is_err() {
+                    let command = self.agent_manager.next_model().cloned().map_or_else(
+                        || CodexCommand::NewSession { cwd: cwd.clone() },
+                        |selection| CodexCommand::NewSessionWithModel {
+                            cwd: cwd.clone(),
+                            selection,
+                        },
+                    );
+                    if bridge.send(command).await.is_err() {
                         let message = self
                             .finish_agent_bridge(
+                                runtime,
                                 "Codex app-server stopped while starting the session",
                             )
-                            .await;
+                            .await?;
                         self.plugin_registry
                             .notify(runtime, "agent:session_lost", json!({ "message": message }))
                             .await?;
                     }
                 }
                 PluginRequest::AgentResumeSession { cwd, session_id } => {
+                    self.agent_manager.mark_conversation_requested();
                     if self.agent_manager.is_task_finished() {
                         let _ = self
-                            .finish_agent_bridge("Codex app-server stopped before restoration")
-                            .await;
+                            .finish_agent_bridge(
+                                runtime,
+                                "Codex app-server stopped before restoration",
+                            )
+                            .await?;
                     }
                     if let Err(error) = self.ensure_agent_bridge(&cwd) {
                         self.plugin_registry
@@ -9586,9 +9684,10 @@ impl Editor {
                     {
                         let message = self
                             .finish_agent_bridge(
+                                runtime,
                                 "Codex app-server stopped while restoring the session",
                             )
-                            .await;
+                            .await?;
                         self.plugin_registry
                             .notify(
                                 runtime,
@@ -9691,8 +9790,11 @@ impl Editor {
                         Ok(prompt) => {
                             if self.agent_manager.is_task_finished() {
                                 let _ = self
-                                    .finish_agent_bridge("Codex app-server stopped unexpectedly")
-                                    .await;
+                                    .finish_agent_bridge(
+                                        runtime,
+                                        "Codex app-server stopped unexpectedly",
+                                    )
+                                    .await?;
                             }
                             self.ensure_agent_bridge(&get_workspace_path())
                                 .and_then(|()| {
@@ -9924,6 +10026,12 @@ impl Editor {
                 PluginRequest::UpdatePickerQuery { id, query } => {
                     if let Some(dialog) = &mut self.current_dialog {
                         dialog.update_picker(id, PickerUpdate::Query(query));
+                    }
+                    needs_render = true;
+                }
+                PluginRequest::UpdatePickerSelection { id, selection } => {
+                    if let Some(dialog) = &mut self.current_dialog {
+                        dialog.update_picker(id, PickerUpdate::Selection(selection));
                     }
                     needs_render = true;
                 }
@@ -13522,6 +13630,11 @@ impl Editor {
         ev: &event::Event,
         runtime: Option<&Runtime>,
     ) -> Option<KeyAction> {
+        if let Some(event) = Self::key_string_for_event(ev)
+            .and_then(|key| self.panel_manager.header_shortcut_event(&key))
+        {
+            return Self::panel_event_key_action(event);
+        }
         if matches!(ev, Event::Key(key) if matches!(key.code, KeyCode::Tab | KeyCode::BackTab))
             && self
                 .panel_manager

--- a/src/editor/agent_manager.rs
+++ b/src/editor/agent_manager.rs
@@ -27,6 +27,9 @@ pub struct AgentManager {
     active_turn_ids: HashMap<String, String>,
     turn_started_at: HashMap<String, Instant>,
     pending_commit_messages: HashSet<i64>,
+    pending_model_requests: HashSet<i64>,
+    model_only_bridge: bool,
+    next_model: Option<crate::codex::AgentModelSelection>,
     conversation: Option<AgentConversationSnapshot>,
     forgotten_conversations: HashSet<String>,
 }
@@ -51,6 +54,7 @@ impl AgentManager {
     }
 
     pub fn set_bridge(&mut self, bridge: CodexBridge) {
+        self.model_only_bridge = false;
         self.bridge = Some(bridge);
     }
 
@@ -208,6 +212,56 @@ impl AgentManager {
         self.pending_commit_messages.drain().collect()
     }
 
+    pub fn mark_model_request_pending(&mut self, request_id: i64) {
+        self.pending_model_requests.insert(request_id);
+    }
+
+    pub fn finish_model_request(&mut self, request_id: i64) {
+        self.pending_model_requests.remove(&request_id);
+    }
+
+    pub fn take_pending_model_requests(&mut self) -> Vec<i64> {
+        self.pending_model_requests.drain().collect()
+    }
+
+    pub fn mark_model_only_bridge(&mut self) {
+        self.model_only_bridge = true;
+    }
+
+    pub fn mark_conversation_requested(&mut self) {
+        self.model_only_bridge = false;
+    }
+
+    pub fn is_model_only_bridge(&self) -> bool {
+        self.model_only_bridge
+    }
+
+    pub fn set_next_model(&mut self, selection: crate::codex::AgentModelSelection) {
+        self.next_model = Some(selection);
+    }
+
+    pub fn next_model(&self) -> Option<&crate::codex::AgentModelSelection> {
+        self.next_model.as_ref()
+    }
+
+    pub fn take_next_model(&mut self) -> Option<crate::codex::AgentModelSelection> {
+        self.next_model.take()
+    }
+
+    pub fn set_conversation_model(
+        &mut self,
+        session_id: &str,
+        model_info: crate::codex::AgentModelInfo,
+    ) {
+        if let Some(conversation) = self
+            .conversation
+            .as_mut()
+            .filter(|conversation| conversation.thread_id == session_id)
+        {
+            conversation.model_info = Some(model_info);
+        }
+    }
+
     pub fn begin_conversation(&mut self, thread_id: impl Into<String>, cwd: &Path) {
         let thread_id = thread_id.into();
         self.forgotten_conversations.remove(&thread_id);
@@ -242,6 +296,7 @@ impl AgentManager {
     }
 
     pub fn forget_conversation(&mut self, session_id: &str) {
+        self.next_model = None;
         self.forgotten_conversations.insert(session_id.to_string());
         if self
             .conversation

--- a/src/editor/agent_models.rs
+++ b/src/editor/agent_models.rs
@@ -1,0 +1,246 @@
+//! Editor ownership and callback routing for the Agent model picker.
+
+use super::*;
+use crate::codex::ModelRequest;
+
+/// The catalog intentionally keeps Codex's camelCase field names. Other agent
+/// notifications use `plugin_json`, which would change this public API shape.
+pub(super) fn model_result_payload(result: &Result<Value, String>) -> Value {
+    match result {
+        Ok(value) => {
+            let mut value = value.clone();
+            value["error"] = json!("");
+            value
+        }
+        Err(error) => json!({"error": error}),
+    }
+}
+
+impl Editor {
+    pub(super) async fn handle_agent_model_request(
+        &mut self,
+        runtime: &mut Runtime,
+        request_id: RequestId,
+        request: ModelRequest,
+    ) -> anyhow::Result<()> {
+        if let ModelRequest::Set {
+            session_id,
+            selection,
+        } = &request
+        {
+            if selection.model.trim().is_empty() {
+                self.plugin_registry
+                    .resolve_request(runtime, request_id, json!({"error": "Choose a model"}))
+                    .await?;
+                return Ok(());
+            }
+            let current = self.agent_manager.conversation_snapshot();
+            if session_id.is_empty() && current.is_none() {
+                self.agent_manager.set_next_model(selection.clone());
+                self.plugin_registry
+                    .resolve_request(runtime, request_id, json!({"accepted": true, "error": ""}))
+                    .await?;
+                return Ok(());
+            }
+            if current
+                .as_ref()
+                .is_none_or(|conversation| conversation.thread_id != *session_id)
+            {
+                self.plugin_registry
+                    .resolve_request(
+                        runtime,
+                        request_id,
+                        json!({"error": "The agent conversation changed; choose its model again"}),
+                    )
+                    .await?;
+                return Ok(());
+            }
+        }
+        if self.agent_manager.is_task_finished() {
+            let _ = self
+                .finish_agent_bridge(runtime, "Codex app-server stopped unexpectedly")
+                .await?;
+        }
+        let had_bridge = self.agent_manager.has_bridge();
+        let result = self
+            .ensure_agent_bridge(&get_workspace_path())
+            .and_then(|()| {
+                if !had_bridge {
+                    self.agent_manager.mark_model_only_bridge();
+                }
+                self.agent_manager
+                    .bridge()
+                    .ok_or_else(|| anyhow::anyhow!("Codex app-server did not start"))?
+                    .try_send(CodexCommand::ModelRequest {
+                        request_id: request_id.get(),
+                        request,
+                    })
+            });
+        if let Err(error) = result {
+            self.plugin_registry
+                .resolve_request(runtime, request_id, json!({"error": error.to_string()}))
+                .await?;
+        } else {
+            self.agent_manager
+                .mark_model_request_pending(request_id.get());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_catalog_callback_preserves_protocol_field_names() {
+        let payload = model_result_payload(&Ok(
+            json!({"models":[{"model":"test","displayName":"Test","supportedReasoningEfforts":[{"reasoningEffort":"high"}]}]}),
+        ));
+        assert_eq!(payload["models"][0]["displayName"], "Test");
+        assert_eq!(
+            payload["models"][0]["supportedReasoningEfforts"][0]["reasoningEffort"],
+            "high"
+        );
+        assert_eq!(payload["error"], "");
+    }
+
+    #[tokio::test]
+    async fn metadata_only_bridge_failure_resolves_callback_without_session_loss() {
+        while ACTION_DISPATCHER.try_recv_request().is_some() {}
+        let plugin_root = tempfile::tempdir().unwrap();
+        let plugin_path = plugin_root.path().join("model-preview.hk");
+        std::fs::write(&plugin_path, r#"
+            pub fn activate() {
+                red::add_command("PreviewModel", preview);
+                red::on("agent:session_lost", lost);
+            }
+            fn preview() { red::request("AgentReadDefaultModel", loaded); }
+            fn loaded(result: Json) { red::execute("Print", "preview:" + red::string(result.error, "")); }
+            fn lost(event: Json) { red::execute("Print", "unexpected conversation loss"); }
+        "#).unwrap();
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size(
+            lsp,
+            80,
+            24,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        let mut runtime = Runtime::new();
+        editor
+            .plugin_registry
+            .add("model_preview", plugin_path.to_string_lossy().as_ref());
+        editor
+            .plugin_registry
+            .initialize(&mut runtime)
+            .await
+            .unwrap();
+        runtime.execute_command("PreviewModel").await.unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::AgentModelRequest { request_id, .. } => request_id,
+            _ => panic!("expected model preview request"),
+        };
+        let (bridge, worker) = CodexBridge::channel(NonZeroUsize::new(1).unwrap());
+        drop(worker);
+        editor.agent_manager.set_bridge(bridge);
+        editor.agent_manager.mark_model_only_bridge();
+        editor
+            .agent_manager
+            .mark_model_request_pending(request_id.get());
+        editor
+            .agent_manager
+            .set_task(tokio::spawn(async { anyhow::bail!("preview unavailable") }));
+        while !editor.agent_manager.is_task_finished() {
+            tokio::task::yield_now().await;
+        }
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+        editor
+            .service_background(&mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert!(editor
+            .last_error
+            .as_deref()
+            .is_some_and(|message| message.starts_with("preview:")
+                && message.contains("preview unavailable")));
+        assert!(!editor.agent_manager.has_bridge());
+        assert!(editor
+            .agent_manager
+            .take_pending_model_requests()
+            .is_empty());
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+    }
+
+    #[test]
+    fn model_shortcut_precedes_composer_input_and_preserves_focus_and_draft() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size(
+            lsp,
+            100,
+            30,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor.panel_manager.create_text_panel(
+            "agent-conversation".into(),
+            plugin::PanelConfig {
+                title: Some("Agent".into()),
+                composer: Some(plugin::TextPanelComposerConfig {
+                    placeholder: "Ask".into(),
+                    rows: 3,
+                }),
+                ..Default::default()
+            },
+        );
+        editor.panel_manager.set_text_panel_header_detail(
+            "agent-conversation",
+            Some(plugin::TextPanelHeaderDetail {
+                text: "Codex".into(),
+                secondary: String::new(),
+                compact_text: String::new(),
+                action: Some("model".into()),
+                shortcut: Some("Alt-m".into()),
+            }),
+        );
+        editor
+            .panel_manager
+            .focus_text_panel_composer("agent-conversation");
+        editor
+            .panel_manager
+            .handle_focused_text_input(&Event::Paste("unfinished draft".into()), 100);
+        let key = Event::Key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT));
+        for composer in [true, false] {
+            if !composer {
+                editor.panel_manager.focus_focused_text_scrollback(100);
+            }
+            let before = editor.panel_manager.snapshot(100);
+            let action = editor.handle_panel_event(&key, None).unwrap();
+            assert!(
+                matches!(action, KeyAction::Multiple(actions) if actions.iter().any(|action| matches!(action, Action::NotifyPlugins(name, payload) if name == "panel:event:agent-conversation" && payload["action"] == "model")))
+            );
+            assert_eq!(editor.panel_manager.snapshot(100), before);
+            assert!(editor
+                .panel_manager
+                .surface_actions()
+                .iter()
+                .any(|action| action.key == "Alt-m"));
+        }
+        editor
+            .panel_manager
+            .create_text_panel("other".into(), plugin::PanelConfig::default());
+        editor.panel_manager.focus_panel("other");
+        assert!(editor
+            .panel_manager
+            .header_shortcut_event("Alt-m")
+            .is_none());
+    }
+}

--- a/src/editor/inline_comment_followup/tests.rs
+++ b/src/editor/inline_comment_followup/tests.rs
@@ -353,6 +353,9 @@ async fn changed_source_is_disclosed_and_detached_source_offers_agent() {
 #[tokio::test]
 async fn ask_agent_opens_the_composer_without_sending_or_creating_history() {
     let (mut editor, id) = fixture();
+    let (bridge, mut worker) =
+        crate::codex::CodexBridge::channel(std::num::NonZeroUsize::new(2).unwrap());
+    editor.agent_manager.set_bridge(bridge);
     let mut runtime = Runtime::new();
     runtime
         .load_plugin("agent", include_str!("../../../plugins/agent.hk"))
@@ -378,7 +381,27 @@ async fn ask_agent_opens_the_composer_without_sending_or_creating_history() {
     let staged = editor.staged_inline_agent_handoff.as_ref().unwrap();
     assert!(editor.inline_history.turn(&staged.request_id).is_none());
     assert_eq!(editor.inline_history.conversations.len(), 1);
-    assert!(!editor.agent_manager.has_bridge());
+    assert!(matches!(
+        worker.recv().await,
+        Some(crate::codex::CodexCommand::ModelRequest {
+            request: crate::codex::ModelRequest::List,
+            ..
+        })
+    ));
+    assert!(matches!(
+        worker.recv().await,
+        Some(crate::codex::CodexCommand::ModelRequest {
+            request: crate::codex::ModelRequest::ReadDefault { .. },
+            ..
+        })
+    ));
+    assert!(editor.agent_manager.conversation_snapshot().is_none());
+    assert!(!editor.agent_manager.has_active_sessions());
+    drop(editor.agent_manager.take_bridge());
+    assert!(
+        worker.recv().await.is_none(),
+        "opening the composer must not start a thread or turn"
+    );
 }
 
 #[tokio::test]

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.13.0",
+  "version": "0.14.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "FilePicker", "kind": "execute", "signature": "()", "introduced": "0.1.0" },
@@ -15,6 +15,10 @@
     { "name": "ListPlugins", "kind": "execute", "signature": "()", "introduced": "0.1.0" },
     { "name": "PreviewTheme", "kind": "execute", "signature": "(theme: String)", "introduced": "0.1.0" },
     { "name": "SetTheme", "kind": "execute", "signature": "(theme: String)", "introduced": "0.1.0" },
+    { "name": "AgentReadDefaultModel", "kind": "request", "signature": "(callback: fn(Json))", "introduced": "0.14.0" },
+    { "name": "AgentListModels", "kind": "request", "signature": "(callback: fn(Json))", "introduced": "0.14.0" },
+    { "name": "AgentSetModel", "kind": "request", "signature": "(callback: fn(Json), session_id: String, selection: Json)", "introduced": "0.14.0" },
+    { "name": "SetTextPanelHeaderDetail", "kind": "execute", "signature": "(id: String, detail?: Json)", "introduced": "0.14.0" },
     { "name": "AgentNewSession", "kind": "execute", "signature": "(cwd: String)", "introduced": "0.1.0" },
     { "name": "AgentResumeSession", "kind": "execute", "signature": "(cwd: String, session_id: String)", "introduced": "0.9.0" },
     { "name": "AgentPrompt", "kind": "execute", "signature": "(session_id: String, text: String)", "introduced": "0.1.0" },
@@ -40,6 +44,7 @@
     { "name": "OpenAgentComposer", "kind": "execute", "signature": "(title: String, id: i32, query: String, history: [String])", "introduced": "0.2.0" },
     { "name": "UpdatePickerItems", "kind": "execute", "signature": "(id: i32, items: [PickerItem])", "introduced": "0.1.0" },
     { "name": "UpdatePickerQuery", "kind": "execute", "signature": "(id: i32, query: String)", "introduced": "0.1.0" },
+    { "name": "UpdatePickerSelection", "kind": "execute", "signature": "(id: i32, selection: String)", "introduced": "0.14.0" },
     { "name": "UpdatePickerStatus", "kind": "execute", "signature": "(id: i32, status: String)", "introduced": "0.1.0" },
     { "name": "UpdatePickerBusy", "kind": "execute", "signature": "(id: i32, busy: bool)", "introduced": "0.6.0" },
     { "name": "ClosePicker", "kind": "execute", "signature": "(id: i32)", "introduced": "0.1.0" },

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -42,7 +42,7 @@ pub use panel::{
     PanelConfig, PanelManager, PanelManagerSnapshot, PanelRow, PanelRowKind, PanelSegment,
     PanelSessionSnapshot, PanelSide, PanelSnapshotKind, TextPanelBlock, TextPanelBlockFormat,
     TextPanelBlockKind, TextPanelComposerConfig, TextPanelComposerSnapshot, TextPanelHeaderAction,
-    TextPanelSessionSnapshot, TextPanelSnapshotFocus, TextPanelStatus,
+    TextPanelHeaderDetail, TextPanelSessionSnapshot, TextPanelSnapshotFocus, TextPanelStatus,
 };
 pub use registry::{PluginRegistry, PluginStatus, RED_HOST_API_VERSION};
 pub use runtime::{

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -198,6 +198,23 @@ pub struct TextPanelComposerConfig {
     pub rows: usize,
 }
 
+/// Optional metadata beside a stable text-panel title. Updating it does not
+/// replace the panel, its draft, or its focus and scroll state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TextPanelHeaderDetail {
+    pub text: String,
+    #[serde(default)]
+    pub secondary: String,
+    /// A shorter complete label for important state, such as a pending model switch.
+    #[serde(default)]
+    pub compact_text: String,
+    #[serde(default)]
+    pub action: Option<String>,
+    #[serde(default)]
+    pub shortcut: Option<String>,
+}
+
 /// One clickable action rendered in a text-panel header.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -380,6 +397,7 @@ pub struct TextPanel {
     viewport: FollowTailViewport,
     composer: Option<TextPanelComposer>,
     status: Option<TextPanelStatus>,
+    header_detail: Option<TextPanelHeaderDetail>,
     busy_since: Option<Instant>,
     selected_link: Option<u64>,
     scrollback: TextPanelScrollback,
@@ -872,6 +890,7 @@ impl TextPanel {
             viewport: FollowTailViewport::default(),
             composer,
             status: None,
+            header_detail: None,
             busy_since: None,
             selected_link: None,
             scrollback: TextPanelScrollback::default(),
@@ -2777,6 +2796,21 @@ impl PanelManager {
         }
     }
 
+    pub fn set_text_panel_header_detail(
+        &mut self,
+        id: &str,
+        detail: Option<TextPanelHeaderDetail>,
+    ) -> bool {
+        let Some(panel) = self.text_panels.get_mut(id) else {
+            return false;
+        };
+        if panel.header_detail == detail {
+            return false;
+        }
+        panel.header_detail = detail;
+        true
+    }
+
     pub fn update_text_panel(
         &mut self,
         id: &str,
@@ -3063,13 +3097,23 @@ impl PanelManager {
         else {
             return Vec::new();
         };
-        panel
+        let mut actions = panel
             .composer
             .as_ref()
             .map(|composer| {
                 text_panel_actions(composer, &panel.scrollback, TextPanelOverflow::None).1
             })
-            .unwrap_or_else(|| crate::ui::surface_reference_actions("SCROLLBACK NORMAL"))
+            .unwrap_or_else(|| crate::ui::surface_reference_actions("SCROLLBACK NORMAL"));
+        if let Some(detail) = &panel.header_detail {
+            if let (Some(action), Some(shortcut)) = (&detail.action, &detail.shortcut) {
+                actions.push(
+                    UiAction::new(action, shortcut, "model")
+                        .with_group("Conversation")
+                        .with_description("Change the agent model"),
+                );
+            }
+        }
+        actions
     }
 
     pub fn focused_row_panel(&self) -> bool {
@@ -3138,6 +3182,21 @@ impl PanelManager {
             .filter(|config| config.side == PanelSide::Bottom)
             .map(|config| config.width.saturating_add(1))
             .sum()
+    }
+
+    pub(crate) fn header_shortcut_event(&self, key: &str) -> Option<PanelEvent> {
+        let panel = self.text_panels.get(self.focused.as_deref()?)?;
+        let detail = panel.header_detail.as_ref()?;
+        if detail.shortcut.as_deref() != Some(key) {
+            return None;
+        }
+        Some(PanelEvent {
+            panel_id: panel.id.clone(),
+            action: detail.action.clone()?,
+            selected_index: panel.scroll,
+            row: None,
+            text: None,
+        })
     }
 
     pub fn handle_focused_key(
@@ -4017,8 +4076,26 @@ impl PanelManager {
         if let Some(panel) = self.text_panels.get_mut(&placement.id) {
             let metrics = TextPanelContentMetrics::new(placement.width);
             if y == placement.y && metrics.contains_x(placement.x, x) {
+                let column = metrics.column(placement.x, x);
+                if let Some((start, text)) = text_panel_header_detail_layout(panel, metrics.width) {
+                    if column >= start + 3 && column < start + display_width(&text) {
+                        if let Some(action) = panel
+                            .header_detail
+                            .as_ref()
+                            .and_then(|detail| detail.action.as_ref())
+                        {
+                            return Some(PanelEvent {
+                                panel_id: panel.id.clone(),
+                                action: action.clone(),
+                                selected_index: panel.scroll,
+                                row: None,
+                                text: None,
+                            });
+                        }
+                    }
+                }
                 if let Some(action) = text_panel_header_action_at(
-                    &panel.config,
+                    panel,
                     metrics.width,
                     metrics.column(placement.x, x),
                 ) {
@@ -4593,7 +4670,7 @@ fn render_text_panel(
         );
     }
 
-    let header_actions = text_panel_header_actions(&panel.config, metrics.width);
+    let header_actions = text_panel_header_actions_for_panel(panel, metrics.width);
     let title_rows = text_panel_header_rows(&panel.config);
     let title_width = header_actions
         .first()
@@ -4608,6 +4685,14 @@ fn render_text_panel(
             position.y,
             &fit_display_width(title, title_width),
             &title_style,
+        );
+    }
+    if let Some((start, text)) = text_panel_header_detail_layout(panel, metrics.width) {
+        buffer.set_text(
+            content_position.x + start,
+            position.y,
+            &text,
+            &palette.secondary,
         );
     }
     for (start, _, label) in header_actions {
@@ -5316,7 +5401,36 @@ fn render_text_panel_status(
 }
 
 fn text_panel_header_actions(config: &PanelConfig, width: usize) -> Vec<(usize, &str, &str)> {
-    let title_width = config.title.as_deref().map_or(0, display_width).min(5);
+    text_panel_header_actions_with_title_width(
+        config,
+        width,
+        config.title.as_deref().map_or(0, display_width).min(5),
+    )
+}
+
+fn text_panel_header_actions_for_panel(
+    panel: &TextPanel,
+    width: usize,
+) -> Vec<(usize, &str, &str)> {
+    let Some(detail) = &panel.header_detail else {
+        return text_panel_header_actions(&panel.config, width);
+    };
+    let title_width = panel.config.title.as_deref().map_or(0, display_width)
+        + 3
+        + display_width(&detail.text)
+        + if detail.secondary.is_empty() {
+            0
+        } else {
+            3 + display_width(&detail.secondary)
+        };
+    text_panel_header_actions_with_title_width(&panel.config, width, title_width)
+}
+
+fn text_panel_header_actions_with_title_width(
+    config: &PanelConfig,
+    width: usize,
+    title_width: usize,
+) -> Vec<(usize, &str, &str)> {
     let full_width = config
         .header_actions
         .iter()
@@ -5359,8 +5473,43 @@ fn text_panel_header_actions(config: &PanelConfig, width: usize) -> Vec<(usize, 
         .collect()
 }
 
-fn text_panel_header_action_at(config: &PanelConfig, width: usize, x: usize) -> Option<&str> {
-    text_panel_header_actions(config, width)
+/// Returns exactly the metadata cells painted in the header, also used for hit testing.
+fn text_panel_header_detail_layout(panel: &TextPanel, width: usize) -> Option<(usize, String)> {
+    let detail = panel.header_detail.as_ref()?;
+    let title = panel.config.title.as_deref().unwrap_or_default();
+    let end = text_panel_header_actions_for_panel(panel, width)
+        .first()
+        .map_or(width, |(start, _, _)| start.saturating_sub(1));
+    let start = display_width(title);
+    let available = end.saturating_sub(start);
+    if available < 5 || detail.text.is_empty() {
+        return None;
+    }
+    let text_width = available - 3;
+    let full = if detail.secondary.is_empty() {
+        detail.text.clone()
+    } else {
+        format!("{} · {}", detail.text, detail.secondary)
+    };
+    let text = if display_width(&full) <= text_width {
+        full
+    } else {
+        crate::unicode_utils::truncate_display_width_with_marker(
+            if detail.compact_text.is_empty() {
+                &detail.text
+            } else {
+                &detail.compact_text
+            },
+            text_width,
+            "…",
+            crate::unicode_utils::TruncationSide::Right,
+        )
+    };
+    Some((start, format!(" · {text}")))
+}
+
+fn text_panel_header_action_at(panel: &TextPanel, width: usize, x: usize) -> Option<&str> {
+    text_panel_header_actions_for_panel(panel, width)
         .into_iter()
         .find(|(start, _, label)| {
             x >= *start && x < start.saturating_add(display_width(label).saturating_add(2))
@@ -7316,6 +7465,130 @@ mod tests {
         manager.render(&mut buffer, &theme);
         assert!((1..6).any(|row| row_text(&buffer, row).contains("LATEST")));
         assert!((6..10).any(|row| row_text(&buffer, row).contains("Ask")));
+    }
+
+    #[test]
+    fn text_panel_model_header_preserves_state_and_uses_painted_hit_region() {
+        let mut manager = PanelManager::default();
+        manager.create_text_panel(
+            "agent-conversation".into(),
+            PanelConfig {
+                side: PanelSide::Right,
+                width: 62,
+                title: Some("Agent".into()),
+                composer: Some(TextPanelComposerConfig {
+                    placeholder: "Ask".into(),
+                    rows: 3,
+                }),
+                header_actions: vec![TextPanelHeaderAction {
+                    id: "close".into(),
+                    label: "×".into(),
+                    compact_label: None,
+                }],
+                ..PanelConfig::default()
+            },
+        );
+        manager.focus_text_panel_composer("agent-conversation");
+        let panel = manager.text_panels.get_mut("agent-conversation").unwrap();
+        panel
+            .composer
+            .as_mut()
+            .unwrap()
+            .prompt
+            .replace_draft("unfinished draft");
+        let detail = TextPanelHeaderDetail {
+            text: "model-with-a-long-name".into(),
+            secondary: "high".into(),
+            compact_text: String::new(),
+            action: Some("model".into()),
+            shortcut: Some("Alt-m".into()),
+        };
+        assert!(manager.set_text_panel_header_detail("agent-conversation", Some(detail.clone())));
+        assert!(!manager.set_text_panel_header_detail("agent-conversation", Some(detail)));
+        assert_eq!(
+            manager.text_panels["agent-conversation"]
+                .composer
+                .as_ref()
+                .unwrap()
+                .prompt
+                .text(),
+            "unfinished draft"
+        );
+        assert!(manager.focused_text_input_active());
+        let theme = Theme::default();
+        let mut wide = RenderBuffer::new(100, 20, &theme.style);
+        manager.render(&mut wide, &theme);
+        let header = row_text(&wide, 0);
+        assert!(header.contains("Agent · model-with-a-long-name · high"));
+        let x = display_width(&header[..header.find("model-with").unwrap()]);
+        assert_eq!(
+            manager
+                .focus_panel_at_position(x, 0, 100, 20)
+                .unwrap()
+                .action,
+            "model"
+        );
+        assert!(manager.focused_text_input_active());
+        let panel = &manager.text_panels["agent-conversation"];
+        for width in 0..70 {
+            if let Some((start, text)) = text_panel_header_detail_layout(panel, width) {
+                let action_start = text_panel_header_actions_for_panel(panel, width)
+                    .first()
+                    .map_or(width, |(start, _, _)| *start);
+                assert!(start + display_width(&text) < action_start);
+            }
+        }
+        let (_, narrow) = text_panel_header_detail_layout(panel, 24).unwrap();
+        assert!(narrow.ends_with('…'));
+        assert!(!narrow.contains("high"));
+    }
+
+    #[test]
+    fn pending_model_header_compacts_buttons_before_hiding_the_change() {
+        let mut panel = TextPanel::new(
+            "agent".into(),
+            PanelConfig {
+                title: Some("Agent".into()),
+                header_actions: [
+                    ("clear", "Clear", "C"),
+                    ("new", "New", "N"),
+                    ("close", "×", "×"),
+                ]
+                .into_iter()
+                .map(|(id, label, compact)| TextPanelHeaderAction {
+                    id: id.into(),
+                    label: label.into(),
+                    compact_label: Some(compact.into()),
+                })
+                .collect(),
+                ..Default::default()
+            },
+        );
+        panel.header_detail = Some(TextPanelHeaderDetail {
+            text: "smoke-deep".into(),
+            secondary: "Next: smoke-fast · medium".into(),
+            compact_text: "smoke-deep → smoke-fast".into(),
+            action: Some("model".into()),
+            shortcut: Some("Alt-m".into()),
+        });
+        assert!(text_panel_header_detail_layout(&panel, 60)
+            .unwrap()
+            .1
+            .contains("Next: smoke-fast"));
+        assert_eq!(
+            text_panel_header_actions_for_panel(&panel, 60)
+                .iter()
+                .map(|(_, _, label)| *label)
+                .collect::<Vec<_>>(),
+            ["C", "N", "×"]
+        );
+        assert!(text_panel_header_detail_layout(&panel, 42)
+            .unwrap()
+            .1
+            .contains('→'));
+        for (start, action, _) in text_panel_header_actions_for_panel(&panel, 60) {
+            assert_eq!(text_panel_header_action_at(&panel, 60, start), Some(action));
+        }
     }
 
     #[test]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -33,7 +33,7 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.13.0";
+pub const RED_HOST_API_VERSION: &str = "0.14.0";
 pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
     "0.4.0",
     "0.6.0",

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1498,6 +1498,12 @@ impl RedHost {
                 let query = args.get(1).map(value_to_string).unwrap_or_default();
                 self.send_request(PluginRequest::UpdatePickerQuery { id, query });
             }
+            "UpdatePickerSelection" => {
+                let id = args.first().and_then(value_to_i32).unwrap_or(1);
+                self.ensure_picker_owner(plugin, id, "UpdatePickerSelection")?;
+                let selection = args.get(1).map(value_to_string).unwrap_or_default();
+                self.send_request(PluginRequest::UpdatePickerSelection { id, selection });
+            }
             "UpdatePickerStatus" => {
                 let id = args.first().and_then(value_to_i32).unwrap_or(1);
                 self.ensure_picker_owner(plugin, id, "UpdatePickerStatus")?;
@@ -1782,6 +1788,18 @@ impl RedHost {
                     status,
                 });
             }
+            "SetTextPanelHeaderDetail" => {
+                let id = args
+                    .first()
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("SetTextPanelHeaderDetail requires a panel id"))?
+                    .to_string();
+                let detail = match args.get(1).map(value_to_json) {
+                    None | Some(serde_json::Value::Null) => None,
+                    Some(value) => Some(serde_json::from_value(value)?),
+                };
+                self.send_request(PluginRequest::SetTextPanelHeaderDetail { id, detail });
+            }
             "SetTextPanelStatus" => {
                 let id = args
                     .first()
@@ -1955,6 +1973,34 @@ impl RedHost {
             }
             "GetEditorInfo" => PluginRequest::EditorInfo(request_id),
             "EditHistory" => PluginRequest::EditHistory { request_id },
+            "AgentReadDefaultModel" => PluginRequest::AgentModelRequest {
+                request_id,
+                request: crate::codex::ModelRequest::ReadDefault {
+                    cwd: crate::utils::get_workspace_path(),
+                },
+            },
+            "AgentListModels" => PluginRequest::AgentModelRequest {
+                request_id,
+                request: crate::codex::ModelRequest::List,
+            },
+            "AgentSetModel" => {
+                let session_id = args
+                    .first()
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let selection = args
+                    .get(1)
+                    .map(value_to_json)
+                    .ok_or_else(|| anyhow::anyhow!("AgentSetModel requires a model selection"))?;
+                PluginRequest::AgentModelRequest {
+                    request_id,
+                    request: crate::codex::ModelRequest::Set {
+                        session_id,
+                        selection: serde_json::from_value(selection)?,
+                    },
+                }
+            }
             "GenerateCommitMessage" => {
                 let cwd = args
                     .first()
@@ -4338,6 +4384,24 @@ mod tests {
         }
     }
 
+    fn expect_agent_model_header() -> RequestId {
+        let catalog_request = expect_model_catalog_request();
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::SetTextPanelHeaderDetail {
+                id,
+                detail: Some(detail),
+            } => {
+                assert_eq!(id, "agent-conversation");
+                assert_eq!(detail.text, "Codex");
+                assert!(detail.secondary.is_empty());
+                assert_eq!(detail.action.as_deref(), Some("model"));
+                assert_eq!(detail.shortcut.as_deref(), Some("Alt-m"));
+            }
+            _ => panic!("expected initial Agent model header"),
+        }
+        catalog_request
+    }
+
     fn recv_optimistic_agent_start(
         prompt: &str,
         expected_history: serde_json::Value,
@@ -4356,6 +4420,19 @@ mod tests {
                     assert_eq!(id, "agent-conversation");
                     created = true;
                 }
+                PluginRequest::SetTextPanelHeaderDetail {
+                    id,
+                    detail: Some(detail),
+                } => {
+                    assert_eq!(id, "agent-conversation");
+                    assert_eq!(detail.text, "Codex");
+                }
+                PluginRequest::AgentModelRequest {
+                    request:
+                        crate::codex::ModelRequest::ReadDefault { .. }
+                        | crate::codex::ModelRequest::List,
+                    ..
+                } => {}
                 PluginRequest::UpdateTextPanel { id, blocks } => {
                     assert_eq!(id, "agent-conversation");
                     assert_eq!(
@@ -6704,6 +6781,7 @@ mod tests {
                     && config.title.as_deref() == Some("Agent")
                     && config.header_actions.iter().map(|action| action.id.as_str()).eq(["clear", "new", "close"])
         ));
+        expect_agent_model_header();
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::UpdateTextPanel { id, blocks }
@@ -7565,6 +7643,8 @@ mod tests {
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::CreateTextPanel { id, .. } if id == "agent-conversation"
         ));
+        expect_agent_model_header();
+        let _ = expect_default_model_request();
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::UpdateTextPanel { id, blocks }
@@ -7608,6 +7688,8 @@ mod tests {
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::CreateTextPanel { id, .. } if id == "agent-conversation"
         ));
+        expect_agent_model_header();
+        let _ = expect_default_model_request();
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::UpdateTextPanel { id, .. } if id == "agent-conversation"
@@ -8882,6 +8964,8 @@ mod tests {
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::CreateTextPanel { id, .. } if id == "agent-conversation"
         ));
+        expect_agent_model_header();
+        let _ = expect_default_model_request();
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::SetTextPanelStatus { id, status: None }
@@ -8990,6 +9074,8 @@ mod tests {
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::CreateTextPanel { id, .. } if id == "agent-conversation"
         ));
+        expect_agent_model_header();
+        let _ = expect_default_model_request();
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::UpdateTextPanel { id, .. } if id == "agent-conversation"
@@ -9089,6 +9175,8 @@ mod tests {
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::CreateTextPanel { id, .. } if id == "agent-conversation"
         ));
+        expect_agent_model_header();
+        let _ = expect_default_model_request();
         assert!(matches!(
             ACTION_DISPATCHER.recv_request(),
             PluginRequest::UpdateTextPanel { id, blocks }
@@ -9183,6 +9271,560 @@ mod tests {
             }
         }
         assert!(saw_enabled_composer);
+    }
+
+    fn expect_default_model_request() -> RequestId {
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::AgentModelRequest {
+                request_id,
+                request: crate::codex::ModelRequest::ReadDefault { cwd },
+            } => {
+                assert_eq!(cwd, crate::utils::get_workspace_path());
+                request_id
+            }
+            _ => panic!("expected read-only default model request"),
+        }
+    }
+
+    async fn open_for_default_model(runtime: &mut Runtime) -> RequestId {
+        runtime.execute_command("AgentOpen").await.unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::CreateTextPanel { .. }
+        ));
+        let catalog_request = expect_agent_model_header();
+        let request_id = expect_default_model_request();
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            assert!(matches!(
+                request,
+                PluginRequest::UpdateTextPanel { .. }
+                    | PluginRequest::SetPanelVisible { .. }
+                    | PluginRequest::FocusTextPanelComposer { .. }
+            ));
+        }
+        runtime
+            .resolve_request(catalog_request, test_model_catalog())
+            .await
+            .unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        request_id
+    }
+
+    #[tokio::test]
+    async fn bundled_agent_default_model_preview_is_read_only_and_thread_settings_win() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        let request_id = open_for_default_model(&mut runtime).await;
+        runtime
+            .resolve_request(
+                request_id,
+                serde_json::json!({"error":"","model_info":{"model":"configured","effort":"high"}}),
+            )
+            .await
+            .unwrap();
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::SetTextPanelHeaderDetail {
+                detail: Some(detail),
+                ..
+            } => {
+                assert_eq!(
+                    (detail.text.as_str(), detail.secondary.as_str()),
+                    ("configured", "high")
+                );
+            }
+            _ => panic!("preview must only update the header"),
+        }
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        runtime.execute_command("AgentClose").await.unwrap();
+        drain_requests();
+        runtime.execute_command("AgentOpen").await.unwrap();
+        let late = expect_default_model_request();
+        drain_requests();
+        runtime
+            .notify(
+                "agent:session_created",
+                serde_json::json!({"session_id":"thread"}),
+            )
+            .await
+            .unwrap();
+        runtime.notify("agent:model_changed", serde_json::json!({"session_id":"thread","model_info":{"model":"confirmed","effort":"low"}})).await.unwrap();
+        assert_eq!(take_model_header().unwrap().text, "confirmed");
+        runtime.resolve_request(late, serde_json::json!({"error":"","model_info":{"model":"stale-default","effort":"high"}})).await.unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+    }
+
+    #[tokio::test]
+    async fn bundled_agent_default_model_preview_does_not_replace_an_explicit_choice() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        let default_request = open_for_default_model(&mut runtime).await;
+        let (picker, items, _) = open_test_model_picker(&mut runtime).await;
+        runtime
+            .notify_picker(picker, PickerCallback::Selected(items[1].clone()))
+            .unwrap();
+        let (effort_picker, efforts, _) = recv_model_picker();
+        runtime
+            .notify_picker(effort_picker, PickerCallback::Selected(efforts[0].clone()))
+            .unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::AgentModelRequest {
+                request_id,
+                request: crate::codex::ModelRequest::Set { session_id, .. },
+            } => {
+                assert!(session_id.is_empty());
+                request_id
+            }
+            _ => panic!("expected pre-session selection"),
+        };
+        runtime
+            .resolve_request(request_id, serde_json::json!({"accepted":true,"error":""}))
+            .await
+            .unwrap();
+        let header = take_model_header().unwrap();
+        assert_eq!(
+            (header.text.as_str(), header.secondary.as_str()),
+            ("second", "low")
+        );
+        runtime
+            .resolve_request(
+                default_request,
+                serde_json::json!({"error":"","model_info":{"model":"first","effort":"high"}}),
+            )
+            .await
+            .unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+    }
+
+    #[tokio::test]
+    async fn bundled_agent_default_model_lookup_failure_is_quiet_and_retries_on_reopen() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        let request_id = open_for_default_model(&mut runtime).await;
+        runtime
+            .resolve_request(request_id, serde_json::json!({"error":"unavailable"}))
+            .await
+            .unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        runtime.execute_command("AgentClose").await.unwrap();
+        drain_requests();
+        runtime.execute_command("AgentOpen").await.unwrap();
+        let retry = expect_default_model_request();
+        drain_requests();
+        runtime
+            .resolve_request(
+                retry,
+                serde_json::json!({"error":"","model_info":{"model":"recovered"}}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(take_model_header().unwrap().text, "recovered");
+    }
+
+    fn recv_model_picker() -> (PickerHandle, Vec<PickerItem>, crate::ui::PickerOptions) {
+        loop {
+            match ACTION_DISPATCHER.recv_request() {
+                PluginRequest::OpenCallbackPicker {
+                    handle,
+                    items,
+                    options,
+                    ..
+                } => return (handle, items, options),
+                PluginRequest::Action(Action::Print(_)) => {}
+                _ => panic!("expected model picker"),
+            }
+        }
+    }
+
+    fn take_model_header() -> Option<crate::plugin::TextPanelHeaderDetail> {
+        let mut latest = None;
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            if let PluginRequest::SetTextPanelHeaderDetail { detail, .. } = request {
+                latest = detail;
+            }
+        }
+        latest
+    }
+
+    fn expect_model_catalog_request() -> RequestId {
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::AgentModelRequest {
+                request_id,
+                request: crate::codex::ModelRequest::List,
+            } => request_id,
+            _ => panic!("expected model catalog request"),
+        }
+    }
+
+    fn test_model_catalog() -> serde_json::Value {
+        serde_json::json!({"error":"", "models":[
+            {"model":"first","displayName":"First","isDefault":true,"defaultReasoningEffort":"high","supportedReasoningEfforts":[{"reasoningEffort":"high","description":"More reasoning"}]},
+            {"model":"second","displayName":"Second","defaultReasoningEffort":"low","supportedReasoningEfforts":[{"reasoningEffort":"low","description":"Less reasoning"}]}
+        ]})
+    }
+
+    fn recv_loaded_model_picker(handle: PickerHandle) -> (Vec<PickerItem>, String) {
+        assert!(matches!(ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerBusy { id, busy: false } if id == handle.get()));
+        let items = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::UpdatePickerItems { id, items } if id == handle.get() => items,
+            _ => panic!("expected in-place model catalog update"),
+        };
+        let selection = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::UpdatePickerSelection { id, selection } if id == handle.get() => {
+                selection
+            }
+            _ => panic!("expected current model selection"),
+        };
+        assert!(matches!(ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerStatus { id, status: Some(status) }
+                if id == handle.get() && status == "This conversation only"));
+        (items, selection)
+    }
+
+    async fn open_test_model_picker(
+        runtime: &mut Runtime,
+    ) -> (PickerHandle, Vec<PickerItem>, crate::ui::PickerOptions) {
+        runtime.execute_command("AgentModel").await.unwrap();
+        let (handle, items, mut options) = recv_model_picker();
+        if !options.busy {
+            return (handle, items, options);
+        }
+        assert!(items.is_empty());
+        let request_id = expect_model_catalog_request();
+        runtime
+            .resolve_request(request_id, test_model_catalog())
+            .await
+            .unwrap();
+        let (items, selection) = recv_loaded_model_picker(handle);
+        options.busy = false;
+        options.initial_selection = Some(selection);
+        (handle, items, options)
+    }
+
+    async fn open_unprimed_agent(runtime: &mut Runtime) -> RequestId {
+        runtime.execute_command("AgentOpen").await.unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::CreateTextPanel { .. }
+        ));
+        let catalog = expect_agent_model_header();
+        let _ = expect_default_model_request();
+        while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+            assert!(matches!(
+                request,
+                PluginRequest::UpdateTextPanel { .. }
+                    | PluginRequest::SetPanelVisible { .. }
+                    | PluginRequest::FocusTextPanelComposer { .. }
+            ));
+        }
+        catalog
+    }
+
+    #[tokio::test]
+    async fn bundled_agent_model_catalog_prefetch_populates_the_open_spinner_once() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        let catalog = open_unprimed_agent(&mut runtime).await;
+        runtime.execute_command("AgentModel").await.unwrap();
+        let (handle, items, options) = recv_model_picker();
+        assert!(items.is_empty());
+        assert!(options.busy);
+        assert_eq!(options.status.as_deref(), Some("Loading models…"));
+        assert!(
+            ACTION_DISPATCHER.try_recv_request().is_none(),
+            "reuse the in-flight preload"
+        );
+        runtime
+            .resolve_request(catalog, test_model_catalog())
+            .await
+            .unwrap();
+        let (items, selection) = recv_loaded_model_picker(handle);
+        assert_eq!(selection, "first");
+        assert_eq!(items.len(), 2);
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        runtime
+            .notify_picker(handle, PickerCallback::Cancelled)
+            .unwrap();
+        let (_, cached, options) = open_test_model_picker(&mut runtime).await;
+        assert!(!options.busy);
+        assert_eq!(cached, items);
+        assert!(
+            ACTION_DISPATCHER.try_recv_request().is_none(),
+            "cached opens must not fetch again"
+        );
+    }
+
+    #[tokio::test]
+    async fn bundled_agent_model_catalog_failure_retries_and_cancelled_load_stays_closed() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        let catalog = open_unprimed_agent(&mut runtime).await;
+        runtime
+            .resolve_request(catalog, serde_json::json!({"error":"offline"}))
+            .await
+            .unwrap();
+        assert!(
+            ACTION_DISPATCHER.try_recv_request().is_none(),
+            "preload errors are quiet"
+        );
+        runtime.execute_command("AgentModel").await.unwrap();
+        let (handle, _, options) = recv_model_picker();
+        assert!(options.busy);
+        let retry = expect_model_catalog_request();
+        runtime
+            .resolve_request(retry, serde_json::json!({"error":"still offline"}))
+            .await
+            .unwrap();
+        assert!(
+            matches!(ACTION_DISPATCHER.recv_request(), PluginRequest::UpdatePickerBusy { id, busy: false } if id == handle.get())
+        );
+        assert!(
+            matches!(ACTION_DISPATCHER.recv_request(), PluginRequest::UpdatePickerStatus { id, status: Some(status) } if id == handle.get() && status.contains("still offline"))
+        );
+        runtime
+            .notify_picker(handle, PickerCallback::Cancelled)
+            .unwrap();
+        runtime.execute_command("AgentModel").await.unwrap();
+        let (cancelled, _, options) = recv_model_picker();
+        assert!(options.busy);
+        let retry = expect_model_catalog_request();
+        runtime
+            .notify_picker(cancelled, PickerCallback::Cancelled)
+            .unwrap();
+        runtime
+            .resolve_request(retry, test_model_catalog())
+            .await
+            .unwrap();
+        assert!(
+            ACTION_DISPATCHER.try_recv_request().is_none(),
+            "late results must not reopen a cancelled picker"
+        );
+        let (_, items, options) = open_test_model_picker(&mut runtime).await;
+        assert_eq!(items.len(), 2);
+        assert!(!options.busy);
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+    }
+
+    #[tokio::test]
+    async fn bundled_agent_model_catalog_ignores_invalidated_and_foreign_session_results() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        let old = open_unprimed_agent(&mut runtime).await;
+        runtime
+            .notify("agent:backend_ready", serde_json::json!({}))
+            .await
+            .unwrap();
+        let fresh = expect_model_catalog_request();
+        runtime
+            .resolve_request(old, test_model_catalog())
+            .await
+            .unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        runtime.execute_command("AgentModel").await.unwrap();
+        let (handle, items, options) = recv_model_picker();
+        assert!(items.is_empty() && options.busy);
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        runtime
+            .notify(
+                "agent:session_created",
+                serde_json::json!({"session_id":"new-thread"}),
+            )
+            .await
+            .unwrap();
+        drain_requests();
+        runtime
+            .resolve_request(fresh, test_model_catalog())
+            .await
+            .unwrap();
+        assert!(
+            matches!(ACTION_DISPATCHER.recv_request(), PluginRequest::ClosePicker { id } if id == handle.get())
+        );
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        let (_, items, options) = open_test_model_picker(&mut runtime).await;
+        assert_eq!(items.len(), 2);
+        assert!(!options.busy);
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+    }
+
+    #[tokio::test]
+    async fn bundled_agent_model_picker_preserves_running_model_and_waits_for_acceptance() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        let _ = open_for_default_model(&mut runtime).await;
+        runtime
+            .notify(
+                "agent:session_created",
+                serde_json::json!({"session_id":"thread-1"}),
+            )
+            .await
+            .unwrap();
+        drain_requests();
+        runtime.notify("agent:model_changed", serde_json::json!({"session_id":"thread-1","model_info":{"model":"first","effort":"high"}})).await.unwrap();
+        assert_eq!(take_model_header().unwrap().text, "first");
+        runtime
+            .notify(
+                "agent:turn_started",
+                serde_json::json!({"session_id":"thread-1"}),
+            )
+            .await
+            .unwrap();
+        drain_requests();
+
+        let (picker, items, options) = open_test_model_picker(&mut runtime).await;
+        assert_eq!(options.initial_selection.as_deref(), Some("first"));
+        assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
+        assert_eq!(items[0].icon, Some(crate::ui::PickerIcon::Text("✓".into())));
+        assert_eq!(
+            items[1].icon,
+            Some(crate::ui::PickerIcon::Text(String::new()))
+        );
+        assert!(items.iter().all(|item| item.annotation.is_none()));
+        runtime
+            .notify_picker(picker, PickerCallback::Selected(items[1].clone()))
+            .unwrap();
+        let (effort_picker, efforts, options) = recv_model_picker();
+        assert_eq!(options.initial_selection.as_deref(), Some("low"));
+        assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
+        runtime
+            .notify_picker(effort_picker, PickerCallback::Cancelled)
+            .unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+
+        let (picker, items, _) = open_test_model_picker(&mut runtime).await;
+        runtime
+            .notify_picker(picker, PickerCallback::Selected(items[1].clone()))
+            .unwrap();
+        let (effort_picker, _, _) = recv_model_picker();
+        runtime
+            .notify_picker(effort_picker, PickerCallback::Selected(efforts[0].clone()))
+            .unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::AgentModelRequest {
+                request_id,
+                request:
+                    crate::codex::ModelRequest::Set {
+                        session_id,
+                        selection,
+                    },
+            } => {
+                assert_eq!(session_id, "thread-1");
+                assert_eq!(selection.model, "second");
+                assert_eq!(selection.effort.as_deref(), Some("low"));
+                request_id
+            }
+            _ => panic!("expected conversation-scoped model selection"),
+        };
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        runtime
+            .resolve_request(request_id, serde_json::json!({"accepted":true,"error":""}))
+            .await
+            .unwrap();
+        let pending = take_model_header().unwrap();
+        assert_eq!(pending.text, "first");
+        assert_eq!(pending.secondary, "Next: second · low");
+        runtime
+            .notify(
+                "agent:model_changed",
+                serde_json::json!({"session_id":"foreign","model_info":{"model":"wrong"}}),
+            )
+            .await
+            .unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+        runtime.notify("agent:model_changed", serde_json::json!({"session_id":"thread-1","model_info":{"model":"second","effort":"low"}})).await.unwrap();
+        assert!(
+            take_model_header().is_none(),
+            "running header already describes the same next model"
+        );
+        runtime
+            .notify(
+                "agent:completed",
+                serde_json::json!({"session_id":"thread-1","stop_reason":"completed"}),
+            )
+            .await
+            .unwrap();
+        let finished = take_model_header().unwrap();
+        assert_eq!(
+            (finished.text.as_str(), finished.secondary.as_str()),
+            ("second", "low")
+        );
+    }
+
+    #[tokio::test]
+    async fn bundled_agent_model_picker_rejects_stale_results_and_keeps_failed_selection() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin("agent", include_str!("../../plugins/agent.hk"))
+            .await
+            .unwrap();
+        let _ = open_for_default_model(&mut runtime).await;
+        let (picker, items, _) = open_test_model_picker(&mut runtime).await;
+        runtime
+            .notify_picker(picker, PickerCallback::Selected(items[0].clone()))
+            .unwrap();
+        let (effort_picker, efforts, _) = recv_model_picker();
+        runtime
+            .notify_picker(effort_picker, PickerCallback::Selected(efforts[0].clone()))
+            .unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::AgentModelRequest {
+                request_id,
+                request: crate::codex::ModelRequest::Set { session_id, .. },
+            } => {
+                assert!(session_id.is_empty());
+                request_id
+            }
+            _ => panic!("expected pre-session selection"),
+        };
+        runtime
+            .resolve_request(request_id, serde_json::json!({"error":"not allowed"}))
+            .await
+            .unwrap();
+        assert!(take_model_header().is_none());
+        let (picker, items, _) = open_test_model_picker(&mut runtime).await;
+        runtime
+            .notify(
+                "agent:session_created",
+                serde_json::json!({"session_id":"new-thread"}),
+            )
+            .await
+            .unwrap();
+        drain_requests();
+        runtime
+            .notify_picker(picker, PickerCallback::Selected(items[0].clone()))
+            .unwrap();
+        assert!(
+            matches!(ACTION_DISPATCHER.recv_request(), PluginRequest::Action(Action::Print(message)) if message.contains("conversation changed"))
+        );
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
     }
 
     #[tokio::test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -70,8 +70,8 @@ use list::List;
 pub(crate) use messages::{MessageRow, MessagesPanel, MessagesView};
 pub(crate) use picker::MAX_UNFOCUSED_PREVIEW_BYTES;
 pub use picker::{
-    LegacyPickerOptions, Picker, PickerIcon, PickerItem, PickerOptions, PickerPresentation,
-    PickerPreview, PickerUpdate,
+    LegacyPickerOptions, Picker, PickerIcon, PickerItem, PickerItemLayout, PickerOptions,
+    PickerPresentation, PickerPreview, PickerUpdate,
 };
 pub(crate) use prompt_buffer::{
     first_prompt_line, normalize_prompt_newlines, PromptBuffer, PromptInput, PromptKeyPolicy,

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -189,6 +189,9 @@ pub struct PickerOptions {
     pub actions: Vec<PickerKeyAction>,
     #[serde(default)]
     pub preview: Option<PickerPreview>,
+    /// Reserve full labels before allocating aligned secondary columns.
+    #[serde(default)]
+    pub item_layout: PickerItemLayout,
     #[serde(default)]
     pub presentation: PickerPresentation,
 }
@@ -200,6 +203,14 @@ pub struct LegacyPickerOptions {
     pub initial_selection: Option<String>,
     #[serde(default)]
     pub presentation: PickerPresentation,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PickerItemLayout {
+    #[default]
+    Default,
+    LabelFirst,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -353,6 +364,7 @@ pub struct Picker {
     history_navigation: Option<PickerHistoryNavigation>,
     input_position: PickerInputPosition,
     icons: PickerIconsConfig,
+    item_layout: PickerItemLayout,
     presentation: PickerPresentation,
     viewport_width: usize,
     viewport_height: usize,
@@ -402,6 +414,13 @@ struct CommandColumns {
     title: usize,
     shortcut: usize,
     colon: usize,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct LabelFirstColumns {
+    label: usize,
+    annotation: usize,
+    detail: usize,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -522,6 +541,7 @@ impl Picker {
             history_navigation: None,
             input_position: editor.picker_input_position(),
             icons: editor.picker_icons(),
+            item_layout: PickerItemLayout::Default,
             presentation,
             viewport_width: editor.vwidth(),
             viewport_height: editor.vheight(),
@@ -667,6 +687,7 @@ impl Picker {
         picker.set_busy(options.busy);
         picker.key_actions = options.actions;
         picker.preview = options.preview;
+        picker.item_layout = options.item_layout;
         picker.search = options.initial_query;
         picker.set_presentation_for_viewport(
             options.presentation,
@@ -1652,6 +1673,8 @@ impl Picker {
         };
         let content_width = rect.width.saturating_sub(PICKER_ITEM_PREFIX_WIDTH);
         let command_columns = self.command_columns(items, content_width);
+        let label_first_columns = (self.item_layout == PickerItemLayout::LabelFirst)
+            .then(|| self.label_first_columns(items, content_width));
         let selected = self.list.selected_index();
         let top = self.list.top_index();
         for (offset, index) in self
@@ -1744,6 +1767,60 @@ impl Picker {
                         command_columns.colon,
                         &content_style,
                         &detail_match_style,
+                        &item.detail_matches,
+                    );
+                }
+                continue;
+            }
+
+            if let Some(columns) = label_first_columns {
+                let label_style = self.result_label_style(&row_style);
+                let label_match_style = if derived_label_matches.is_some() {
+                    self.result_filter_match_style(&label_style)
+                } else {
+                    self.result_match_style(&label_style)
+                };
+                self.draw_text_with_matches(
+                    buffer,
+                    x,
+                    y,
+                    &item.label,
+                    columns.label,
+                    &label_style,
+                    &label_match_style,
+                    label_matches,
+                );
+                let mut column_x = x + columns.label;
+                if columns.annotation > 0 {
+                    column_x += INTRINSIC_COLUMN_GAP;
+                    let style = self.result_annotation_style(&row_style, is_selected);
+                    let matches = filter_highlights
+                        .as_ref()
+                        .map(|highlights| highlights.annotation.as_slice())
+                        .unwrap_or_default();
+                    self.draw_text_with_matches(
+                        buffer,
+                        column_x,
+                        y,
+                        item.annotation.as_deref().unwrap_or_default(),
+                        columns.annotation,
+                        &style,
+                        &self.result_filter_match_style(&style),
+                        matches,
+                    );
+                    column_x += columns.annotation;
+                }
+                if columns.detail > 0 {
+                    column_x += INTRINSIC_COLUMN_GAP;
+                    let style = self.result_content_style(&row_style, is_selected);
+                    self.draw_text_with_matches(
+                        buffer,
+                        column_x,
+                        y,
+                        item.detail.as_deref().unwrap_or_default(),
+                        columns.detail,
+                        &style,
+                        &self.result_match_style(&style),
                         &item.detail_matches,
                     );
                 }
@@ -1895,6 +1972,36 @@ impl Picker {
                 );
             }
         }
+    }
+
+    /// Use every filtered row, not just the current page, so scrolling does not
+    /// move the columns. Labels take priority over status and descriptions.
+    fn label_first_columns(&self, items: &[PickerItem], content_width: usize) -> LabelFirstColumns {
+        let mut columns = LabelFirstColumns::default();
+        for index in &self.visible_dynamic_items {
+            let item = &items[*index];
+            columns.label = columns.label.max(display_width(&item.label));
+            columns.annotation = columns
+                .annotation
+                .max(item.annotation.as_deref().map_or(0, display_width));
+            columns.detail = columns
+                .detail
+                .max(item.detail.as_deref().map_or(0, display_width));
+        }
+        columns.label = columns.label.min(content_width);
+        let mut remaining = content_width.saturating_sub(columns.label);
+        if columns.annotation > 0 && columns.annotation + INTRINSIC_COLUMN_GAP <= remaining {
+            remaining -= columns.annotation + INTRINSIC_COLUMN_GAP;
+        } else {
+            columns.annotation = 0;
+        }
+        let available_detail = remaining.saturating_sub(INTRINSIC_COLUMN_GAP);
+        if available_detail < columns.detail.min(8) {
+            columns.detail = 0;
+        } else {
+            columns.detail = columns.detail.min(available_detail);
+        }
+        columns
     }
 
     fn command_columns(&self, items: &[PickerItem], content_width: usize) -> CommandColumns {
@@ -4482,6 +4589,196 @@ mod tests {
         assert!(contrast_ratio(selected_bg, surface_bg) >= 3.0);
         assert_ne!(selected_bg, selection_color);
         assert_eq!(buffer.cells[detail_start + 4].style.bg, Some(match_color));
+    }
+
+    #[test]
+    fn label_first_picker_keeps_model_names_and_aligns_secondary_columns() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 120, 30);
+        let labels = ["GPT-5.6-Sol-OAI", "GPT-5.6-Sol", "漢字 model"];
+        let items = labels
+            .iter()
+            .enumerate()
+            .map(|(index, label)| {
+                let mut item = dynamic_item(&index.to_string(), label);
+                item.annotation = (index == 1).then(|| "Current".to_string());
+                item.detail = Some(format!(
+                    "Description {index} that should yield to the full model name"
+                ));
+                item
+            })
+            .collect();
+        let mut picker = Picker::new_dynamic(
+            Some("Agent model".into()),
+            &editor,
+            items,
+            24,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                presentation: PickerPresentation::Compact,
+                ..PickerOptions::default()
+            },
+        );
+        let mut buffer = RenderBuffer::new(120, 30, &Style::default());
+        picker.draw(&mut buffer).unwrap();
+        let rows = (0..labels.len())
+            .map(|index| render_row(&buffer, picker.layout().results.y + index))
+            .collect::<Vec<_>>();
+        let assert_label = |buffer: &RenderBuffer, x: usize, y: usize, label: &str| {
+            let mut column = x;
+            for character in label.chars() {
+                assert_eq!(buffer.cells[y * buffer.width + column].c, character);
+                column += display_width(&character.to_string());
+            }
+        };
+        // RenderBuffer stores a continuation cell for each wide character.
+        // Compare cell positions, not the display width of that debug string.
+        let description_column = |row: &str| {
+            row.find("Description")
+                .map(|index| row[..index].chars().count())
+        };
+        for (index, (row, label)) in rows.iter().zip(labels).enumerate() {
+            assert_label(
+                &buffer,
+                picker.layout().results.x + super::PICKER_ITEM_PREFIX_WIDTH,
+                picker.layout().results.y + index,
+                label,
+            );
+            assert_eq!(description_column(row), description_column(&rows[0]));
+        }
+        assert!(rows[1].contains("Current"));
+        assert!(picker.resize(40, 30));
+        let mut narrow = RenderBuffer::new(40, 30, &Style::default());
+        picker.draw(&mut narrow).unwrap();
+        for (index, label) in labels.into_iter().enumerate() {
+            let row = render_row(&narrow, picker.layout().results.y + index);
+            assert_label(
+                &narrow,
+                picker.layout().results.x + super::PICKER_ITEM_PREFIX_WIDTH,
+                picker.layout().results.y + index,
+                label,
+            );
+            assert!(!row.contains("Description"), "{row:?}");
+        }
+        assert!(picker.resize(22, 30));
+        let mut tiny = RenderBuffer::new(22, 30, &Style::default());
+        picker.draw(&mut tiny).unwrap();
+        let row = render_row(&tiny, picker.layout().results.y);
+        assert!(row.contains(labels[0]), "{row:?}");
+        assert!(!row.contains("Current"));
+        assert!(row.ends_with('│'), "{row:?}");
+    }
+
+    #[test]
+    fn loading_picker_updates_keep_the_query_and_visible_selection() {
+        let editor = test_editor();
+        let mut picker = Picker::new_dynamic(
+            Some("Agent model".into()),
+            &editor,
+            vec![],
+            27,
+            PickerOptions {
+                busy: true,
+                status: Some("Loading models…".into()),
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+        assert!(picker.apply_update(27, PickerUpdate::Query("second".into())));
+        assert!(picker.apply_update(
+            27,
+            PickerUpdate::Items(vec![
+                dynamic_item("first", "First"),
+                dynamic_item("second", "Second")
+            ])
+        ));
+        assert!(picker.apply_update(27, PickerUpdate::Selection("first".into())));
+        assert!(picker.apply_update(27, PickerUpdate::Busy(false)));
+        assert_eq!(picker.search, "second");
+        assert_eq!(picker.selected_dynamic_item().unwrap().id, "second");
+        assert!(picker.busy_since.is_none());
+    }
+
+    #[test]
+    fn label_first_picker_checkmark_uses_existing_prefix_space() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 120, 30);
+        let mut first = dynamic_item("first", "GPT-5.6-Sol-OAI");
+        first.detail = Some("Description one".into());
+        let mut current = dynamic_item("current", "GPT-5.6-Sol");
+        current.icon = Some(PickerIcon::Text("✓".into()));
+        current.detail = Some("Description two".into());
+        let picker = Picker::new_dynamic(
+            Some("Agent model".into()),
+            &editor,
+            vec![first, current],
+            26,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                presentation: PickerPresentation::Compact,
+                ..PickerOptions::default()
+            },
+        );
+        let mut buffer = RenderBuffer::new(120, 30, &Style::default());
+        picker.draw(&mut buffer).unwrap();
+        let rect = picker.layout().results;
+        let first = render_row(&buffer, rect.y);
+        let current = render_row(&buffer, rect.y + 1);
+        assert_eq!(buffer.cells[rect.y * buffer.width + rect.x].c, '›');
+        assert_eq!(
+            buffer.cells[(rect.y + 1) * buffer.width + rect.x + 2].c,
+            '✓'
+        );
+        let description_x = rect.x
+            + super::PICKER_ITEM_PREFIX_WIDTH
+            + display_width("GPT-5.6-Sol-OAI")
+            + super::INTRINSIC_COLUMN_GAP;
+        assert_eq!(display_column(&first, "Description"), Some(description_x));
+        assert_eq!(display_column(&current, "Description"), Some(description_x));
+        assert!(!current.contains("Current"));
+    }
+
+    #[test]
+    fn label_first_picker_columns_stay_aligned_across_pages() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 120, 18);
+        let mut items = (0..24)
+            .map(|index| {
+                let mut item = dynamic_item(&index.to_string(), &format!("Model {index}"));
+                item.detail = Some("Description".into());
+                item
+            })
+            .collect::<Vec<_>>();
+        items[20].label = "Longest model on the next page".into();
+        let mut picker = Picker::new_dynamic(
+            None,
+            &editor,
+            items,
+            25,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+        let width = picker
+            .layout()
+            .results
+            .width
+            .saturating_sub(super::PICKER_ITEM_PREFIX_WIDTH);
+        let columns = picker.label_first_columns(picker.dynamic_items.as_ref().unwrap(), width);
+        picker.list.set_selected_index(20);
+        assert_eq!(
+            columns,
+            picker.label_first_columns(picker.dynamic_items.as_ref().unwrap(), width)
+        );
+        assert_eq!(
+            columns.label,
+            display_width("Longest model on the next page")
+        );
+        picker.filter("Model 1");
+        assert!(
+            picker
+                .label_first_columns(picker.dynamic_items.as_ref().unwrap(), width)
+                .label
+                < columns.label
+        );
     }
 
     #[test]

--- a/tests/codex_app_server.rs
+++ b/tests/codex_app_server.rs
@@ -654,3 +654,280 @@ async fn direct_app_server_reports_live_startup_failure_and_stderr_availability(
         "{error}"
     );
 }
+
+fn mock_model_codex(directory: &std::path::Path) -> std::path::PathBuf {
+    let path = directory.join("codex-models");
+    std::fs::write(&path, r#"#!/usr/bin/env python3
+import json, sys
+def send(value):
+    print(json.dumps(value), flush=True)
+def info(model, effort):
+    return {"model": model, "modelProvider": "test-provider", "reasoningEffort": effort}
+for line in sys.stdin:
+    message = json.loads(line)
+    method, ident = message.get("method"), message.get("id")
+    params = message.get("params", {})
+    if method == "initialize":
+        send({"id": ident, "result": {"userAgent": "mock"}})
+    elif method == "account/read":
+        send({"id": ident, "result": {"account": {"type": "chatgpt"}}})
+    elif method == "config/read":
+        send({"id": ident, "result": {"config": {"mcp_servers": {}}}})
+    elif method == "configRequirements/read":
+        send({"id": ident, "result": {"requirements": None}})
+    elif method == "model/list":
+        assert params["includeHidden"] is False
+        if params.get("cursor") is None:
+            send({"id": ident, "result": {"data": [{"model":"first","displayName":"First"},{"model":"secret","hidden":True}],"nextCursor":"page-2"}})
+        else:
+            assert params["cursor"] == "page-2"
+            send({"id": ident, "result": {"data": [{"model":"first"},{"model":"second","displayName":"Second"}],"nextCursor":None}})
+    elif method == "thread/start":
+        assert params["model"] == "first"
+        assert params["config"]["model_reasoning_effort"] == "high"
+        assert params["sandbox"] == "read-only"
+        send({"id": ident, "result": dict(info("first", "high"), thread={"id":"model-thread"})})
+    elif method == "turn/start":
+        assert params["threadId"] == "model-thread"
+        assert "model" not in params
+        send({"id": ident, "result": {"turn":{"id":"running-turn"}}})
+    elif method == "thread/settings/update":
+        assert set(params) == {"threadId","model","effort"}
+        assert params["threadId"] == "model-thread"
+        if params["model"] == "rejected":
+            send({"id": ident, "error":{"code":-32602,"message":"model unavailable"}})
+            continue
+        assert params["model"] == "second" and params["effort"] == "low"
+        send({"method":"thread/settings/updated","params":{"threadId":"foreign-thread","threadSettings":{"model":"wrong","effort":"max"}}})
+        send({"method":"thread/settings/updated","params":{"threadId":"model-thread","threadSettings":{"model":"second","modelProvider":"test-provider","effort":"low"}}})
+        send({"id":ident,"result":{}})
+        send({"method":"turn/completed","params":{"threadId":"model-thread","turn":{"id":"running-turn","status":"completed"}}})
+    elif method == "thread/resume":
+        send({"id":ident,"result":dict(info("second","low"),thread={"id":"model-thread","turns":[]})})
+    elif method == "turn/interrupt":
+        raise AssertionError("changing the model must not interrupt the running turn")
+"#).unwrap();
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&path, permissions).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn direct_app_server_lists_and_changes_conversation_models() {
+    use red::codex::{AgentModelSelection, ModelRequest};
+    let _serial = MOCK_CODEX_TEST_LOCK.lock().await;
+    let directory = tempfile::tempdir().unwrap();
+    let host = RecordingHost {
+        writes: Arc::new(Mutex::new(Vec::new())),
+    };
+    let (mut bridge, mut task) = start_codex(
+        CodexProcessSpec::new(mock_model_codex(directory.path()), directory.path()),
+        host,
+        NonZeroUsize::new(32).unwrap(),
+    )
+    .unwrap();
+    bridge
+        .send(CodexCommand::ModelRequest {
+            request_id: 1,
+            request: ModelRequest::List,
+        })
+        .await
+        .unwrap();
+    match next_event(&mut bridge, &mut task).await {
+        CodexEvent::ModelRequestCompleted {
+            request_id: 1,
+            result: Ok(result),
+        } => {
+            assert_eq!(
+                result["models"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|model| model["model"].as_str().unwrap())
+                    .collect::<Vec<_>>(),
+                ["first", "second"]
+            );
+        }
+        event => panic!("unexpected catalog result: {event:?}"),
+    }
+    bridge
+        .send(CodexCommand::NewSessionWithModel {
+            cwd: directory.path().to_path_buf(),
+            selection: AgentModelSelection {
+                model: "first".into(),
+                effort: Some("high".into()),
+            },
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(next_event(&mut bridge, &mut task).await, CodexEvent::SessionCreated { session_id } if session_id == "model-thread")
+    );
+    assert!(
+        matches!(next_event(&mut bridge, &mut task).await, CodexEvent::SessionModelChanged { model_info, .. } if model_info.model == "first" && model_info.effort.as_deref() == Some("high"))
+    );
+    bridge
+        .send(CodexCommand::Prompt {
+            session_id: "model-thread".into(),
+            text: "keep working".into(),
+        })
+        .await
+        .unwrap();
+    bridge
+        .send(CodexCommand::ModelRequest {
+            request_id: 2,
+            request: ModelRequest::Set {
+                session_id: "model-thread".into(),
+                selection: AgentModelSelection {
+                    model: "second".into(),
+                    effort: Some("low".into()),
+                },
+            },
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(next_event(&mut bridge, &mut task).await, CodexEvent::SessionModelChanged { session_id, model_info } if session_id == "model-thread" && model_info.model == "second" && model_info.provider.as_deref() == Some("test-provider") && model_info.effort.as_deref() == Some("low"))
+    );
+    assert!(matches!(
+        next_event(&mut bridge, &mut task).await,
+        CodexEvent::ModelRequestCompleted {
+            request_id: 2,
+            result: Ok(_)
+        }
+    ));
+    assert!(
+        matches!(next_event(&mut bridge, &mut task).await, CodexEvent::Completed { session_id, .. } if session_id == "model-thread")
+    );
+    bridge
+        .send(CodexCommand::ModelRequest {
+            request_id: 3,
+            request: ModelRequest::Set {
+                session_id: "model-thread".into(),
+                selection: AgentModelSelection {
+                    model: "rejected".into(),
+                    effort: Some("low".into()),
+                },
+            },
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(next_event(&mut bridge, &mut task).await, CodexEvent::ModelRequestCompleted { request_id: 3, result: Err(error) } if error == "model unavailable")
+    );
+    bridge
+        .send(CodexCommand::ResumeSession {
+            cwd: directory.path().to_path_buf(),
+            session_id: "model-thread".into(),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_event(&mut bridge, &mut task).await,
+        CodexEvent::SessionRestored { .. }
+    ));
+    assert!(
+        matches!(next_event(&mut bridge, &mut task).await, CodexEvent::SessionModelChanged { model_info, .. } if model_info.model == "second")
+    );
+    drop(bridge);
+    task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn direct_app_server_previews_workspace_model_without_creating_a_thread() {
+    use red::codex::ModelRequest;
+    let _serial = MOCK_CODEX_TEST_LOCK.lock().await;
+    let directory = tempfile::tempdir().unwrap();
+    let executable = directory.path().join("codex-default-model");
+    std::fs::write(&executable, r#"#!/usr/bin/env python3
+import json, os, sys
+mode = None
+def send(ident, result):
+    print(json.dumps({"id":ident,"result":result}), flush=True)
+for line in sys.stdin:
+    msg=json.loads(line)
+    method, ident, params=msg.get("method"),msg.get("id"),msg.get("params",{})
+    if method == "initialize": send(ident,{"userAgent":"mock"})
+    elif method == "initialized": pass
+    elif method == "account/read": send(ident,{"account":{"type":"chatgpt"}})
+    elif method == "config/read":
+        assert params["includeLayers"] is False
+        mode=os.path.basename(params["cwd"])
+        config={"model_provider":"configured-provider"}
+        if mode == "configured": config.update(model="configured-model",model_reasoning_effort="high")
+        if mode == "effort": config["model_reasoning_effort"]="low"
+        if mode == "invalid": send(ident,{})
+        else: send(ident,{"config":config})
+    elif method == "model/list":
+        assert mode in ["fallback","effort","missing"], "explicit model must not need the catalog"
+        assert params["includeHidden"] is False
+        if params.get("cursor") is None:
+            send(ident,{"data":[{"model":"hidden","isDefault":True,"hidden":True},{"model":"other"}],"nextCursor":"page-2"})
+        else:
+            assert params["cursor"] == "page-2"
+            send(ident,{"data":[{"model":"catalog-default","isDefault":mode!="missing","defaultReasoningEffort":"medium"}],"nextCursor":None})
+    else: raise AssertionError("preview must be read-only: "+str(method))
+"#).unwrap();
+    std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let (mut bridge, mut task) = start_codex(
+        CodexProcessSpec::new(executable, directory.path()),
+        RecordingHost {
+            writes: Arc::new(Mutex::new(Vec::new())),
+        },
+        NonZeroUsize::new(8).unwrap(),
+    )
+    .unwrap();
+    for (index, (mode, model, effort)) in [
+        ("configured", "configured-model", "high"),
+        ("fallback", "catalog-default", "medium"),
+        ("effort", "catalog-default", "low"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let request_id = index as i64;
+        bridge
+            .send(CodexCommand::ModelRequest {
+                request_id,
+                request: ModelRequest::ReadDefault {
+                    cwd: directory.path().join(mode),
+                },
+            })
+            .await
+            .unwrap();
+        match next_event(&mut bridge, &mut task).await {
+            CodexEvent::ModelRequestCompleted {
+                request_id: actual,
+                result: Ok(result),
+            } => {
+                assert_eq!(actual, request_id);
+                assert_eq!(
+                    result["model_info"],
+                    json!({"model":model,"provider":"configured-provider","effort":effort})
+                );
+            }
+            event => panic!("unexpected preview result: {event:?}"),
+        }
+    }
+    for mode in ["invalid", "missing"] {
+        bridge
+            .send(CodexCommand::ModelRequest {
+                request_id: 4,
+                request: ModelRequest::ReadDefault {
+                    cwd: directory.path().join(mode),
+                },
+            })
+            .await
+            .unwrap();
+        assert!(matches!(
+            next_event(&mut bridge, &mut task).await,
+            CodexEvent::ModelRequestCompleted {
+                request_id: 4,
+                result: Err(_)
+            }
+        ));
+    }
+    drop(bridge);
+    task.await.unwrap().unwrap();
+}


### PR DESCRIPTION
The Agent pane does not show which Codex model will handle a request, and changing models requires leaving the conversation. This adds a visible, keyboard-accessible model selector without changing global Codex configuration.

## Changes

- Show the configured model before the first prompt, then use the settings confirmed by the active or restored thread.
- Open the model and reasoning-effort pickers by clicking the header, pressing `Alt+m` in the pane, or running `:AgentModel`. Keep full model names ahead of descriptions and mark the current choice with a checkmark.
- Preload and cache the model catalog. On a cold open, show a spinner and populate the existing picker without losing its search. Cancelled or stale requests do not reopen it.
- Apply model changes to this conversation's next turn. Keep a running turn's model visible, preserve drafts and focus, and leave existing tool and permission restrictions intact.
- Add the reusable header-detail, label-first picker, and picker-selection APIs in host API `0.14.0`, retaining the earlier plugin contracts.

## How to Test

1. With Codex configured, run `:AgentOpen`. Confirm the model appears beside `Agent` before sending a message.
2. Type an unfinished draft and press `Alt+m`. Confirm model names remain readable, the current model has a checkmark, and narrowing the window removes descriptions first. Select a model and supported reasoning effort; confirm the draft is preserved.
3. Start a turn, then choose another model while it is running. Confirm the active turn is not interrupted, the header indicates the next model, and the next turn uses it. `:AgentNew` should return to the configured default unless a new model is explicitly selected.
4. On a cold/slow catalog load, open the picker immediately and type a search. Confirm the spinner disappears when results arrive without clearing the search. Cancel while loading, then reopen after it finishes; the cancelled picker must stay closed and the next open should use the cache.
5. Cancel the reasoning-effort picker, or try a model rejected by the server. Confirm the prior model and draft remain intact.

Automated coverage includes `direct_app_server_previews_workspace_model_without_creating_a_thread`, `direct_app_server_lists_and_changes_conversation_models`, the `bundled_agent_model_catalog_*` tests, and `loading_picker_updates_keep_the_query_and_visible_selection`.

Validation on `f9a9801`: 2,830 tests passed, one ignored; strict all-target/all-feature Clippy, formatting, and build passed. Retained TUI smoke runs against deterministic app-server fixtures verified model switching, responsive layout, cache reuse, cancellation, and zero thread/turn creation for metadata-only operations. Production inference was not part of those smoke runs.
