### PR TITLE
fix(keymap): honor command-mode aliases across navigation contexts

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -348,6 +348,17 @@ of actions, define a nested chord, or invoke a plugin command:
 "Ctrl-j" = { PluginCommand = "BufferPicker" }
 ```
 
+Bindings to `EnterMode = "Command"` also work in panel navigation and modal
+workspaces. Normal-mode command bindings are inherited by visual modes; an
+explicit visual-mode binding takes precedence. Text input, searches, and
+unfinished Vim commands keep their characters. For example, this makes `;`
+an alternative to `:` without changing what it types in insert mode:
+
+```toml
+[keys.normal]
+";" = { EnterMode = "Command" }
+```
+
 The prefix guide can be configured independently:
 
 ```toml

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -17,6 +17,7 @@
 
 mod agent_manager;
 mod buffer_manager;
+mod command_mode;
 mod diagnostics;
 mod diagnostics_picker;
 mod display_layout;
@@ -11719,13 +11720,18 @@ impl Editor {
         )
     }
 
-    fn selection_motion_subset(action: &KeyAction) -> Option<KeyAction> {
+    fn action_is_visual_inherited(action: &Action) -> bool {
+        Self::action_is_selection_motion(action)
+            || matches!(action, Action::EnterMode(Mode::Command))
+    }
+
+    fn visual_inherited_subset(action: &KeyAction) -> Option<KeyAction> {
         match action {
-            KeyAction::Single(action) if Self::action_is_selection_motion(action) => {
+            KeyAction::Single(action) if Self::action_is_visual_inherited(action) => {
                 Some(KeyAction::Single(action.clone()))
             }
             KeyAction::Multiple(actions)
-                if !actions.is_empty() && actions.iter().all(Self::action_is_selection_motion) =>
+                if !actions.is_empty() && actions.iter().all(Self::action_is_visual_inherited) =>
             {
                 Some(KeyAction::Multiple(actions.clone()))
             }
@@ -11733,12 +11739,12 @@ impl Editor {
                 let mappings = mappings
                     .iter()
                     .filter_map(|(key, action)| {
-                        Self::selection_motion_subset(action).map(|action| (key.clone(), action))
+                        Self::visual_inherited_subset(action).map(|action| (key.clone(), action))
                     })
                     .collect::<HashMap<_, _>>();
                 (!mappings.is_empty()).then_some(KeyAction::Nested(mappings))
             }
-            KeyAction::Repeating(times, action) => Self::selection_motion_subset(action)
+            KeyAction::Repeating(times, action) => Self::visual_inherited_subset(action)
                 .map(|action| KeyAction::Repeating(*times, Box::new(action))),
             KeyAction::None | KeyAction::Single(_) | KeyAction::Multiple(_) => None,
         }
@@ -11760,18 +11766,22 @@ impl Editor {
     }
 
     fn visual_key_mappings(&self) -> HashMap<String, KeyAction> {
+        self.visual_key_mappings_for_mode(self.mode)
+    }
+
+    fn visual_key_mappings_for_mode(&self, mode: Mode) -> HashMap<String, KeyAction> {
         let mut mappings = self
             .config
             .keys
             .normal
             .iter()
             .filter_map(|(key, action)| {
-                Self::selection_motion_subset(action).map(|action| (key.clone(), action))
+                Self::visual_inherited_subset(action).map(|action| (key.clone(), action))
             })
             .collect::<HashMap<_, _>>();
 
         Self::merge_key_mappings(&mut mappings, &self.config.keys.visual);
-        match self.mode {
+        match mode {
             Mode::VisualLine => {
                 Self::merge_key_mappings(&mut mappings, &self.config.keys.visual_line)
             }
@@ -13289,12 +13299,17 @@ impl Editor {
             }
         }
 
-        if self.workspace_manager.is_active() {
-            return Ok(self.handle_workspace_event(ev));
-        }
-
         if self.is_command() {
             return Ok(self.handle_command_event(ev, runtime));
+        }
+
+        if self.workspace_manager.is_active() {
+            if self.workspace_manager.accepts_command_mode() {
+                if let Some(action) = self.command_mode_key_action(ev, Mode::Normal) {
+                    return Ok(Some(action));
+                }
+            }
+            return Ok(self.handle_workspace_event(ev));
         }
 
         if self.is_search() {
@@ -13308,6 +13323,9 @@ impl Editor {
         }
 
         if self.panel_manager.focused_panel_id().is_some() {
+            if let Some(action) = self.panel_command_mode_key_action(ev) {
+                return Ok(Some(action));
+            }
             if !self.panel_manager.focused_text_input_active() && self.handle_repeater(ev) {
                 return Ok(None);
             }
@@ -13711,7 +13729,7 @@ impl Editor {
                 | KeyModifiers::SUPER
                 | KeyModifiers::HYPER
                 | KeyModifiers::META,
-        ) && matches!(event.code, KeyCode::Char(c) if !matches!(c, ':' | ';'))
+        ) && matches!(event.code, KeyCode::Char(_))
     }
 
     fn handle_divider_mouse_event(&mut self, event: &MouseEvent) -> Option<KeyAction> {
@@ -13873,6 +13891,11 @@ impl Editor {
                 _ => None,
             })?;
 
+        // Direct command entries were resolved before the panel consumed input.
+        // Do not resurrect a normal-mode binding that a local mode overrode.
+        if Self::is_command_mode_entry(action) {
+            return None;
+        }
         self.key_action_for_panel(action, runtime)
     }
 

--- a/src/editor/command_mode.rs
+++ b/src/editor/command_mode.rs
@@ -1,0 +1,463 @@
+//! Resolve configured command-entry aliases before surface-local navigation.
+
+use super::*;
+
+impl Editor {
+    pub(super) fn is_command_mode_entry(action: &KeyAction) -> bool {
+        match action {
+            KeyAction::Single(Action::EnterMode(Mode::Command)) => true,
+            KeyAction::Multiple(actions) => {
+                !actions.is_empty()
+                    && actions
+                        .iter()
+                        .all(|action| matches!(action, Action::EnterMode(Mode::Command)))
+            }
+            KeyAction::Repeating(count, action) => {
+                *count > 0 && Self::is_command_mode_entry(action)
+            }
+            _ => false,
+        }
+    }
+
+    pub(super) fn command_mode_key_action(&self, event: &Event, mode: Mode) -> Option<KeyAction> {
+        let key = Self::key_string_for_event(event)?;
+        let visual;
+        let mappings = match mode {
+            Mode::Normal => &self.config.keys.normal,
+            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                visual = self.visual_key_mappings_for_mode(mode);
+                &visual
+            }
+            Mode::Insert | Mode::Command | Mode::Search => return None,
+        };
+        let action = mappings
+            .get(&key)
+            .or_else(|| (key == "Space").then(|| mappings.get(" ")).flatten())?;
+        Self::is_command_mode_entry(action).then(|| action.clone())
+    }
+
+    pub(super) fn panel_command_mode_key_action(&self, event: &Event) -> Option<KeyAction> {
+        self.command_mode_key_action(event, self.panel_manager.command_mode_keymap()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command_entry() -> KeyAction {
+        KeyAction::Single(Action::EnterMode(Mode::Command))
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn editor() -> Editor {
+        let mut config: Config = toml::from_str(include_str!("../../default_config.toml")).unwrap();
+        config.keys.normal.insert(";".into(), command_entry());
+        config.keys.normal.insert("!".into(), command_entry());
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size_and_preferences(
+            lsp,
+            80,
+            24,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, "one; two; three\n".into())],
+            PreferencesStore::in_memory(),
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor
+    }
+
+    fn text_panel(editor: &mut Editor) {
+        editor.test_create_text_panel(
+            "test",
+            plugin::PanelConfig {
+                side: plugin::PanelSide::Right,
+                width: 32,
+                composer: Some(plugin::TextPanelComposerConfig {
+                    placeholder: "Ask".into(),
+                    rows: 3,
+                }),
+                ..plugin::PanelConfig::default()
+            },
+        );
+        editor.test_update_text_panel(
+            "test",
+            vec![plugin::TextPanelBlock {
+                id: "answer".into(),
+                kind: plugin::TextPanelBlockKind::Text,
+                format: plugin::TextPanelBlockFormat::Plain,
+                text: "one; two; three".into(),
+            }],
+        );
+        assert!(editor.test_focus_panel("test"));
+    }
+
+    fn dispatch(editor: &mut Editor, code: KeyCode) -> Option<KeyAction> {
+        editor.handle_event(&key(code)).unwrap()
+    }
+
+    fn draft(editor: &Editor) -> String {
+        editor
+            .panel_manager
+            .snapshot(80)
+            .panels
+            .into_iter()
+            .find(|panel| panel.id == "test")
+            .unwrap()
+            .text
+            .unwrap()
+            .composer
+            .unwrap()
+            .text
+    }
+
+    #[test]
+    fn command_aliases_are_inherited_by_all_visual_modes() {
+        let mut editor = editor();
+        for mode in [
+            Mode::Normal,
+            Mode::Visual,
+            Mode::VisualLine,
+            Mode::VisualBlock,
+        ] {
+            editor.mode = mode;
+            for character in [':', ';', '!'] {
+                assert_eq!(
+                    dispatch(&mut editor, KeyCode::Char(character)),
+                    Some(command_entry()),
+                    "{mode:?} {character}"
+                );
+            }
+        }
+        editor
+            .config
+            .keys
+            .visual
+            .insert(";".into(), KeyAction::None);
+        for mode in [Mode::Visual, Mode::VisualLine, Mode::VisualBlock] {
+            editor.mode = mode;
+            assert_eq!(
+                dispatch(&mut editor, KeyCode::Char(';')),
+                Some(KeyAction::None)
+            );
+        }
+        editor
+            .config
+            .keys
+            .visual_line
+            .insert(";".into(), command_entry());
+        editor.mode = Mode::VisualLine;
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+    }
+
+    #[test]
+    fn command_aliases_do_not_steal_editor_text_or_find_targets() {
+        let mut editor = editor();
+        editor.mode = Mode::Insert;
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(KeyAction::Single(Action::InsertCharAtCursorPos(';')))
+        );
+        editor.mode = Mode::Normal;
+        dispatch(&mut editor, KeyCode::Char('f'));
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(KeyAction::Single(Action::FindCharForward {
+                target: ';',
+                count: 1
+            }))
+        );
+        editor.mode = Mode::Command;
+        assert_eq!(dispatch(&mut editor, KeyCode::Char(';')), None);
+        assert_eq!(editor.command, ";");
+        editor.begin_search(SearchDirection::Forward);
+        assert_eq!(dispatch(&mut editor, KeyCode::Char(';')), None);
+        assert_eq!(editor.active_search_text(), Some(";"));
+    }
+
+    #[test]
+    fn command_aliases_precede_row_panel_navigation_without_hardcoded_keys() {
+        let mut editor = editor();
+        editor
+            .config
+            .keys
+            .normal
+            .insert("j".into(), command_entry());
+        editor.test_create_panel("tree", plugin::PanelConfig::default());
+        assert!(editor.test_focus_panel("tree"));
+        for character in [':', ';', '!', 'j'] {
+            assert_eq!(
+                dispatch(&mut editor, KeyCode::Char(character)),
+                Some(command_entry())
+            );
+        }
+        editor
+            .config
+            .keys
+            .normal
+            .insert(":".into(), KeyAction::None);
+        assert_ne!(
+            dispatch(&mut editor, KeyCode::Char(':')),
+            Some(command_entry())
+        );
+    }
+
+    #[test]
+    fn command_aliases_preserve_composer_input_and_pending_commands() {
+        let mut editor = editor();
+        text_panel(&mut editor);
+        assert!(editor.test_focus_text_panel_composer("test"));
+        editor
+            .handle_event(&Event::Paste("one; two; three".into()))
+            .unwrap();
+        dispatch(&mut editor, KeyCode::Char(';'));
+        assert_eq!(draft(&editor), "one; two; three;");
+        dispatch(&mut editor, KeyCode::Esc);
+        assert_eq!(
+            editor.panel_manager.focused_text_panel_cursor_mode(),
+            Some(Mode::Normal)
+        );
+        for character in [':', ';', '!'] {
+            assert_eq!(
+                dispatch(&mut editor, KeyCode::Char(character)),
+                Some(command_entry())
+            );
+        }
+        for prefix in ['f', 'r', 'd'] {
+            dispatch(&mut editor, KeyCode::Char(prefix));
+            assert_ne!(
+                dispatch(&mut editor, KeyCode::Char(';')),
+                Some(command_entry()),
+                "{prefix};"
+            );
+            dispatch(&mut editor, KeyCode::Esc);
+            // Escape from idle Normal blurs the composer; focus it for the next case.
+            assert!(editor.test_focus_text_panel_composer("test"));
+        }
+        dispatch(&mut editor, KeyCode::Char('/'));
+        assert_eq!(
+            editor.panel_manager.focused_text_panel_cursor_mode(),
+            Some(Mode::Search)
+        );
+        assert_ne!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        dispatch(&mut editor, KeyCode::Esc);
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+    }
+
+    #[test]
+    fn command_aliases_preserve_transcript_search_and_find_targets() {
+        let mut editor = editor();
+        text_panel(&mut editor);
+        for character in [':', ';', '!'] {
+            assert_eq!(
+                dispatch(&mut editor, KeyCode::Char(character)),
+                Some(command_entry())
+            );
+        }
+        dispatch(&mut editor, KeyCode::Char('f'));
+        assert_ne!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        dispatch(&mut editor, KeyCode::Char('/'));
+        assert_eq!(
+            editor.panel_manager.focused_text_panel_cursor_mode(),
+            Some(Mode::Search)
+        );
+        assert_ne!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        dispatch(&mut editor, KeyCode::Esc);
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        dispatch(&mut editor, KeyCode::Char('v'));
+        assert_eq!(
+            editor.panel_manager.focused_text_panel_cursor_mode(),
+            Some(Mode::Visual)
+        );
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        editor
+            .config
+            .keys
+            .visual
+            .insert(";".into(), KeyAction::None);
+        editor
+            .config
+            .keys
+            .visual
+            .insert(":".into(), KeyAction::None);
+        for character in [':', ';'] {
+            assert_ne!(
+                dispatch(&mut editor, KeyCode::Char(character)),
+                Some(command_entry())
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn command_alias_round_trip_keeps_composer_draft_and_focus() {
+        let mut editor = editor();
+        text_panel(&mut editor);
+        assert!(editor.test_focus_text_panel_composer("test"));
+        editor
+            .handle_event(&Event::Paste("keep this draft".into()))
+            .unwrap();
+        dispatch(&mut editor, KeyCode::Esc);
+        let before = editor.panel_manager.snapshot(80);
+        let mut frame = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+        for code in [KeyCode::Char(';'), KeyCode::Char(';'), KeyCode::Esc] {
+            editor
+                .process_editor_event(
+                    key(code),
+                    &mut frame,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+            if code == KeyCode::Char(';') {
+                assert!(editor.is_command());
+            }
+        }
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!(editor.panel_manager.focused_panel_id(), Some("test"));
+        assert_eq!(editor.panel_manager.snapshot(80), before);
+    }
+
+    #[tokio::test]
+    async fn command_aliases_work_in_workspaces_without_stealing_filters() {
+        let mut editor = editor();
+        editor
+            .workspace_manager
+            .open("test".into(), plugin::WorkspaceConfig::default());
+        let mut frame = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+        editor
+            .process_editor_event(
+                key(KeyCode::Char(';')),
+                &mut frame,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert!(editor.is_command());
+        dispatch(&mut editor, KeyCode::Char('x'));
+        assert_eq!(editor.command, "x");
+        editor
+            .process_editor_event(
+                key(KeyCode::Esc),
+                &mut frame,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert!(editor.workspace_manager.is_active());
+        assert_eq!(editor.mode, Mode::Normal);
+        dispatch(&mut editor, KeyCode::Char('/'));
+        assert!(editor.workspace_manager.is_filtering());
+        assert_ne!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        assert!(editor.workspace_manager.is_filtering());
+        dispatch(&mut editor, KeyCode::Esc);
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        dispatch(&mut editor, KeyCode::Char('g'));
+        assert_ne!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+    }
+
+    #[test]
+    fn default_semicolon_keeps_local_character_search() {
+        let mut editor = editor();
+        editor
+            .config
+            .keys
+            .normal
+            .insert(";".into(), KeyAction::Single(Action::RepeatCharSearch(1)));
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(KeyAction::Single(Action::RepeatCharSearch(1)))
+        );
+        text_panel(&mut editor);
+        assert_ne!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        assert!(editor.test_focus_text_panel_composer("test"));
+        dispatch(&mut editor, KeyCode::Esc);
+        assert_ne!(
+            dispatch(&mut editor, KeyCode::Char(';')),
+            Some(command_entry())
+        );
+        assert_eq!(
+            dispatch(&mut editor, KeyCode::Char(':')),
+            Some(command_entry())
+        );
+    }
+
+    #[tokio::test]
+    async fn visual_command_alias_preserves_the_selected_command_range() {
+        let mut editor = editor();
+        let mut frame = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+        for mode in [Mode::Visual, Mode::VisualLine, Mode::VisualBlock] {
+            editor
+                .execute(&Action::EnterMode(mode), &mut frame, &mut runtime)
+                .await
+                .unwrap();
+            editor
+                .process_editor_event(
+                    key(KeyCode::Char(';')),
+                    &mut frame,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+            assert_eq!(editor.mode, Mode::Command);
+            assert_eq!(editor.command, "'<,'>");
+            editor
+                .process_editor_event(
+                    key(KeyCode::Esc),
+                    &mut frame,
+                    &mut runtime,
+                    EventRenderMode::Immediate,
+                )
+                .await
+                .unwrap();
+        }
+    }
+}

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -3029,6 +3029,41 @@ impl PanelManager {
             .is_some_and(|composer| composer.focused && composer.enabled)
     }
 
+    /// The navigation keymap eligible to open the editor command line.
+    /// Local text entry and incomplete Vim commands retain their next key.
+    pub(crate) fn command_mode_keymap(&self) -> Option<crate::editor::Mode> {
+        use crate::editor::Mode;
+
+        let id = self.focused.as_deref()?;
+        let Some(panel) = self.text_panels.get(id) else {
+            return Some(Mode::Normal);
+        };
+        if panel.scrollback.focused {
+            if panel.search.active.is_some()
+                || panel.scrollback.pending_find.is_some()
+                || panel.scrollback.pending_jump.is_some()
+            {
+                return None;
+            }
+        } else if let Some(composer) = panel
+            .composer
+            .as_ref()
+            .filter(|composer| composer.focused && composer.enabled)
+        {
+            if composer.prompt.has_pending_input() {
+                return None;
+            }
+        }
+        let mode = self
+            .focused_text_panel_cursor_mode()
+            .unwrap_or(Mode::Normal);
+        matches!(
+            mode,
+            Mode::Normal | Mode::Visual | Mode::VisualLine | Mode::VisualBlock
+        )
+        .then_some(mode)
+    }
+
     pub fn focused_text_panel_has_composer(&self) -> bool {
         self.focused
             .as_deref()

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -1434,6 +1434,14 @@ impl WorkspaceManager {
         }
     }
 
+    pub(crate) fn accepts_command_mode(&self) -> bool {
+        self.active.as_ref().is_some_and(|workspace| {
+            !workspace.filtering
+                && workspace.key_prefix.is_none()
+                && !workspace.action_menu.is_open()
+        })
+    }
+
     pub fn is_filtering(&self) -> bool {
         self.active
             .as_ref()

--- a/src/ui/prompt_buffer.rs
+++ b/src/ui/prompt_buffer.rs
@@ -104,6 +104,11 @@ impl PromptBuffer {
         self.area.mode()
     }
 
+    /// Whether a local Vim count or command still owns the next key.
+    pub(crate) fn has_pending_input(&self) -> bool {
+        self.area.state().has_pending_input()
+    }
+
     /// Changes the local prompt mode without mutating the global editor.
     pub(crate) fn set_mode(&mut self, mode: Mode) {
         self.area.set_mode(mode);


### PR DESCRIPTION
## Summary

Mapping `;` to `EnterMode = "Command"` worked in normal editor mode, but embedded composers and transcripts consumed it as a character-search repeat. Visual modes also failed to inherit the command-entry binding.

Resolve configured command-entry actions before panel and workspace navigation, and inherit them in visual modes while respecting explicit visual-mode overrides. Insert-mode text, search queries, workspace filters, and unfinished Vim commands retain their input. The default `;` character-search behavior is unchanged when no alias is configured.

Adds nine regression tests in `src/editor/command_mode.rs` and documents the existing keymap configuration; no new setting is required.

## How to Test

1. Add this binding to the user config and run `cargo run`:

   ```toml
   [keys.normal]
   ";" = { EnterMode = "Command" }
   ```

2. Press `;` in normal mode, then in each visual mode (`v`, `V`, and `Ctrl-v`). The command prompt should open; visual selections should retain the `'<,'>` command range.
3. Open the agent pane, enter a draft, press Escape to enter composer normal mode, then press `;`. Escape should return without changing the draft or focus. Repeat from transcript navigation and from `:GitDashboard`.
4. Check that `;` still types normally in insert mode and search/filter fields. In normal mode, `f;` must search for a semicolon rather than open the command prompt. An explicit `[keys.visual]` override should take precedence.
5. Run `cargo test -p red --lib command_mode::tests -- --test-threads=1` to exercise the focused regressions.

## Validation

- Focused regressions: 9 passed.
- Full all-targets/all-features suite: 2,816 passed, 1 ignored.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- Formatting and diff checks passed.
