### PR TITLE
feat(onboarding): add interactive first-run tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ Open a file:
 red path/to/file
 ```
 
-Red offers to create a starter config on the first interactive run. Declining
-is fine: the embedded defaults, plugins, and themes are enough to start editing.
+The first interactive launch offers a guided tour, release highlights, and an
+immediate exit into the editor. The tour uses a disposable practice buffer and
+safe Git/agent demonstrations; reopen it with `:welcome` or `:tutorial`.
+Starter configuration remains optional: embedded defaults, plugins, and themes
+are enough to begin editing.
 
 | Key | Action |
 | --- | --- |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -18,9 +18,28 @@ Set an explicit workspace root with `-r`:
 red -r path/to/project src/main.rs
 ```
 
-On the first interactive run, Red offers to create a starter configuration at
-`~/.config/red/config.toml`. The file is optional; Red starts with its embedded
-configuration, themes, and plugins when it is absent.
+The first interactive launch opens a keyboard-first welcome screen inside the
+editor. Start its guided tour, press `i` for a shorter tour, view release
+highlights, or press `Esc` to begin editing immediately. Use `:welcome` to
+reopen it later.
+
+The guided tour uses an unnamed practice buffer and simulated Git and agent
+previews; it never saves the practice buffer, changes your repository, or
+starts Codex. The full tour covers modal editing, command discovery, fuzzy
+navigation, completion, Git, reviewable agent proposals, and themes. Start or
+control it at any time:
+
+```text
+:tutorial          # start the full guided tour
+:tutorial quick    # start the shorter experienced-user tour
+:tutorial resume   # continue an unfinished tour
+:tutorial next     # skip the current lesson
+:tutorial quit     # exit and restore your original editor layout
+```
+
+A starter configuration at `~/.config/red/config.toml` remains optional. Press
+`c` on the welcome screen to create one without overwriting existing settings.
+Embedded configuration, themes, and plugins work when the file is absent.
 
 ## Editor model
 

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -474,6 +474,24 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Action::CommandPalette,
         ),
         builtin(
+            "editor.welcome",
+            "Welcome to Red",
+            "Editor",
+            "Open the first-run welcome, guided tour, and release highlights",
+            Some(":welcome"),
+            &["first launch", "onboarding", "what's new"],
+            Action::OpenWelcome,
+        ),
+        builtin(
+            "editor.tutorial",
+            "Take the guided Red tour",
+            "Editor",
+            "Practice editing, navigation, Git, and reviewable agent changes",
+            Some(":tutorial"),
+            &["tour", "walkthrough", "learn red", "onboarding"],
+            Action::StartTutorial(crate::tutorial::TutorialTrack::Guided),
+        ),
+        builtin(
             "editor.config_diagnostics",
             "Configuration diagnostics",
             "Editor",
@@ -1357,6 +1375,8 @@ fn action_label(action: &Action) -> String {
         Action::OpenInlineActivity | Action::OpenInlineHistory => {
             "Inline assist history".to_string()
         }
+        Action::OpenWelcome => "Welcome to Red".to_string(),
+        Action::StartTutorial(_) => "Take the guided Red tour".to_string(),
         Action::ConfigDiagnostics => "Configuration diagnostics".to_string(),
         Action::OpenWhatsNew => "What’s new in Red".to_string(),
         Action::OpenDiagnosticsPicker => "Diagnostics".to_string(),
@@ -1573,6 +1593,18 @@ mod tests {
             .unwrap();
         assert_eq!(zoom.action, Action::TogglePaneZoom);
         assert!(zoom.shortcuts.iter().any(|shortcut| shortcut == "Ctrl-w z"));
+
+        let welcome = entries
+            .iter()
+            .find(|entry| entry.id == "editor.welcome")
+            .unwrap();
+        assert_eq!(welcome.colon.as_deref(), Some(":welcome"));
+
+        let tutorial = entries
+            .iter()
+            .find(|entry| entry.id == "editor.tutorial")
+            .unwrap();
+        assert_eq!(tutorial.colon.as_deref(), Some(":tutorial"));
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -147,12 +147,17 @@ use crate::{
     },
     textobjects::{ResolvedTextObject, SyntaxObjectKind, SyntaxTextObjectService},
     theme::{parse_vscode_theme, parse_vscode_theme_contents, Style, Theme},
+    tutorial::{
+        TutorialController, TutorialLesson, TutorialObservation, TutorialProgress, TutorialTrack,
+        PRACTICE_CONTENTS,
+    },
     ui::{
         AgentComposer, CompletionUI, Component, Confirmation, CopilotSignInDialog,
         CopilotSignInModel, CopilotSignInPhase, DiagnosticInfo, FilePicker, HoverInfo,
         HoverInfoFormat, InlineAssistPopup, InlineAssistPopupState, InputPrompt,
         LegacyPickerOptions, OverlayLayout, Picker, PickerItem, PickerOptions, PickerPreview,
-        PickerUpdate, ScreenRect, StatuslineLayoutPanel, WhatsNewPanel,
+        PickerUpdate, ScreenRect, StatuslineLayoutPanel, TutorialDemoKind, TutorialDemoPanel,
+        WelcomePanel, WhatsNewPanel,
     },
     undo::{AppliedTextEdit, CursorSnapshot, EditOrigin, RevertEdit, TextPosition, TextRange},
     utils::{expand_user_path, get_workspace_path, normalized_file_path, same_file_path},
@@ -2492,6 +2497,16 @@ pub enum Action {
     ExitLearnLesson,
     RestartLearnLesson,
     FinishLearnLesson,
+    OpenWelcome,
+    DismissWelcome,
+    StartTutorial(TutorialTrack),
+    ResumeTutorial,
+    AdvanceTutorial,
+    ExitTutorial,
+    DismissTutorialDemo,
+    AcceptTutorialProposal,
+    RejectTutorialProposal,
+    CreateStarterConfig,
     OpenStatuslineManager,
     OpenDiagnosticsPicker,
     OpenErrorDiagnosticsPicker,
@@ -3293,6 +3308,12 @@ pub struct Editor {
     /// The announcement was prepared and still needs a successful rendered-frame claim.
     whats_new_needs_persistence: bool,
 
+    /// First launch is presented only after a visible, usable editor is ready.
+    welcome_startup_pending: bool,
+
+    /// Owns the unnamed practice buffer while a nonmodal guided tour is active.
+    tutorial_controller: Option<TutorialController>,
+
     /// Active command-history navigation state.
     command_history_navigation: Option<PromptHistoryNavigation>,
 
@@ -3608,6 +3629,16 @@ impl DetachedEditorCore {
     /// Prepares a pending release modal only after a client authenticates.
     pub fn prepare_startup_whats_new(&mut self) -> anyhow::Result<bool> {
         if !self.editor.prepare_startup_whats_new() {
+            return Ok(false);
+        }
+        self.editor.render(&mut self.render_buffer)?;
+        self.finish_render()?;
+        Ok(true)
+    }
+
+    /// Opens fresh-install onboarding only after a detached client authenticates.
+    pub fn prepare_startup_welcome(&mut self) -> anyhow::Result<bool> {
+        if !self.editor.prepare_startup_welcome() {
             return Ok(false);
         }
         self.editor.render(&mut self.render_buffer)?;
@@ -4670,6 +4701,8 @@ impl Editor {
             learn_session: None,
             whats_new_auto_presentation_enabled: false,
             whats_new_needs_persistence: false,
+            welcome_startup_pending: false,
+            tutorial_controller: None,
             command_history_navigation: None,
             command_completion: None,
             search_term: String::new(),
@@ -4812,6 +4845,232 @@ impl Editor {
         {
             log!("could not persist the displayed release version: {error}");
         }
+    }
+
+    /// Requests the editor-native welcome for a genuinely fresh installation.
+    ///
+    /// Detached owners retain the request until an authenticated client attaches.
+    pub fn enable_first_launch_welcome(&mut self, first_launch: bool) {
+        self.welcome_startup_pending = first_launch && !self.preferences.welcome_completed();
+        if self.welcome_startup_pending {
+            self.whats_new_startup_pending = false;
+        }
+    }
+
+    fn open_welcome_panel(&mut self) -> bool {
+        if !WelcomePanel::fits(self.vwidth(), self.vheight()) {
+            return false;
+        }
+        let can_resume = self
+            .preferences
+            .tutorial_progress()
+            .is_some_and(|progress| !progress.completed);
+        self.current_dialog = Some(Box::new(WelcomePanel::new(self, can_resume)));
+        self.welcome_startup_pending = false;
+        true
+    }
+
+    fn prepare_startup_welcome(&mut self) -> bool {
+        self.welcome_startup_pending && self.current_dialog.is_none() && self.open_welcome_panel()
+    }
+
+    fn finish_welcome(&mut self) {
+        self.welcome_startup_pending = false;
+        if let Err(error) = self.preferences.complete_welcome() {
+            log!("could not persist first-run welcome decision: {error}");
+        }
+    }
+
+    async fn start_tutorial(
+        &mut self,
+        progress: TutorialProgress,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        if self.tutorial_controller.is_some() {
+            self.finish_tutorial(/*completed*/ false, buffer, runtime)
+                .await?;
+        }
+
+        self.finish_welcome();
+        self.release_current_dialog_callbacks(runtime);
+        self.current_dialog = None;
+        self.sync_to_window();
+        let original_window_layout = self.window_manager.snapshot();
+        let original_buffer_index = self.buffer_manager.active_index();
+        let practice = Buffer::new(/*file*/ None, PRACTICE_CONTENTS.to_string());
+        let practice_buffer_id = practice.id();
+        self.buffer_manager.push_buffer(practice);
+        let practice_index = self.buffer_manager.len() - 1;
+        self.tutorial_controller = Some(TutorialController::new(
+            progress,
+            practice_buffer_id,
+            original_buffer_index,
+            original_window_layout,
+        ));
+        self.mode = Mode::Normal;
+        self.splash_dismissed = true;
+        if let Some(window) = self.window_manager.active_window_mut() {
+            window.buffer_index = practice_index;
+        }
+        self.set_current_buffer(buffer, practice_index).await?;
+        self.persist_tutorial_progress();
+        self.render(buffer)
+    }
+
+    async fn finish_tutorial(
+        &mut self,
+        completed: bool,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let Some(mut tutorial) = self.tutorial_controller.take() else {
+            return Ok(());
+        };
+        if completed {
+            while !tutorial.progress().completed {
+                tutorial.advance();
+            }
+        }
+        if let Err(error) = self
+            .preferences
+            .set_tutorial_progress(tutorial.progress().clone())
+        {
+            log!("could not persist guided-tour progress: {error}");
+        }
+
+        self.release_current_dialog_callbacks(runtime);
+        self.current_dialog = None;
+        if let Some(index) = self
+            .buffer_manager
+            .iter()
+            .position(|candidate| candidate.id() == tutorial.practice_buffer_id)
+        {
+            self.buffer_manager.remove_buffer(index);
+        }
+
+        let buffer_map = (0..self.buffer_manager.len())
+            .map(|index| (index, index))
+            .collect::<HashMap<_, _>>();
+        if let Some(restored) = WindowManager::from_snapshot(
+            &tutorial.original_window_layout,
+            (self.size.0 as usize, self.size.1 as usize),
+            &buffer_map,
+        ) {
+            self.window_manager = restored;
+        }
+        self.buffer_manager
+            .set_active_index(tutorial.original_buffer_index);
+        self.sync_with_window();
+        self.mode = Mode::Normal;
+        self.highlight_cache.clear();
+        self.layout_cache.borrow_mut().clear();
+        self.force_full_redraw = true;
+        if completed {
+            self.last_error = Some("Red tour complete — your project was never modified".into());
+        }
+        self.render(buffer)
+    }
+
+    fn persist_tutorial_progress(&mut self) {
+        let Some(progress) = self
+            .tutorial_controller
+            .as_ref()
+            .map(|tutorial| tutorial.progress().clone())
+        else {
+            return;
+        };
+        if let Err(error) = self.preferences.set_tutorial_progress(progress) {
+            log!("could not persist guided-tour progress: {error}");
+        }
+    }
+
+    fn tutorial_shortcut(&self) -> Option<String> {
+        let tutorial = self.tutorial_controller.as_ref()?;
+        let action = tutorial
+            .lesson()?
+            .suggested_action(tutorial.progress().phase)?;
+        command_palette::shortcuts_for_action(&self.config.keys, &action)
+            .into_iter()
+            .next()
+    }
+
+    async fn observe_tutorial_action(
+        &mut self,
+        action: &Action,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        if matches!(
+            action,
+            Action::StartTutorial(_)
+                | Action::ResumeTutorial
+                | Action::AdvanceTutorial
+                | Action::ExitTutorial
+        ) {
+            return Ok(());
+        }
+        let Some(tutorial) = &mut self.tutorial_controller else {
+            return Ok(());
+        };
+        let observation = tutorial.observe(action);
+        if observation == TutorialObservation::Unchanged {
+            return Ok(());
+        }
+        self.persist_tutorial_progress();
+        if observation == TutorialObservation::Completed {
+            self.finish_tutorial(/*completed*/ true, buffer, runtime)
+                .await?;
+        } else {
+            self.render(buffer)?;
+        }
+        Ok(())
+    }
+
+    async fn accept_tutorial_proposal(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let Some(practice_id) = self
+            .tutorial_controller
+            .as_ref()
+            .map(|tutorial| tutorial.practice_buffer_id)
+        else {
+            return Ok(());
+        };
+        let Some(index) = self
+            .buffer_manager
+            .iter()
+            .position(|candidate| candidate.id() == practice_id)
+        else {
+            return Ok(());
+        };
+        if index != self.buffer_manager.active_index() {
+            if let Some(window) = self.window_manager.active_window_mut() {
+                window.buffer_index = index;
+            }
+            self.set_current_buffer(buffer, index).await?;
+        }
+        let contents = self.current_buffer().contents();
+        let old = "prices.iter().sum()";
+        if let Some((line, text)) = contents
+            .lines()
+            .enumerate()
+            .find(|(_, line)| line.contains(old))
+        {
+            let character = text
+                .find(old)
+                .map(|byte| text[..byte].chars().count())
+                .unwrap_or_default();
+            let start = TextPosition::new(line, character);
+            let end = TextPosition::new(line, character + old.chars().count());
+            self.begin_transaction("accept tutorial practice proposal");
+            self.replace_range(TextRange::new(start, end), "prices.iter().copied().sum()");
+            self.commit_transaction(self.cursor_snapshot());
+            self.notify_change(runtime).await?;
+        }
+        Ok(())
     }
 
     /// Synchronizes the editor's state with the active window
@@ -8708,6 +8967,7 @@ impl Editor {
         self.ensure_current_buffer_lsp_opened().await?;
         let (columns, rows) = terminal::size()?;
         self.resize_terminal_surface(columns, rows, &mut buffer);
+        self.prepare_startup_welcome();
         self.prepare_startup_whats_new();
         self.render(&mut buffer)?;
         self.mark_whats_new_presented();
@@ -14450,15 +14710,34 @@ impl Editor {
         if matches!(cmd, "whats-new" | "changelog") {
             return vec![Action::OpenWhatsNew];
         }
-        if matches!(cmd, "learn" | "tutorial" | "welcome") {
+        if cmd == "learn" {
             return vec![Action::OpenLearn];
         }
-        match cmd {
-            "tutorial essentials" => return vec![Action::StartLearnLesson],
-            "tutorial quit" => return vec![Action::ExitLearnLesson],
-            "tutorial restart" => return vec![Action::RestartLearnLesson],
-            "tutorial next" => return vec![Action::FinishLearnLesson],
-            _ => {}
+        if cmd == "welcome" {
+            return vec![Action::OpenWelcome];
+        }
+        if let Some(arguments) = cmd.strip_prefix("tutorial") {
+            if arguments.is_empty() || arguments.starts_with(' ') {
+                return match arguments.trim() {
+                    "" => vec![Action::StartTutorial(TutorialTrack::Guided)],
+                    "essentials" => vec![Action::StartLearnLesson],
+                    "restart" if self.learn_session.is_some() => vec![Action::RestartLearnLesson],
+                    "restart" => vec![Action::StartTutorial(TutorialTrack::Guided)],
+                    "quick" => vec![Action::StartTutorial(TutorialTrack::Quick)],
+                    "resume" => vec![Action::ResumeTutorial],
+                    "next" if self.learn_session.is_some() => vec![Action::FinishLearnLesson],
+                    "next" | "skip" => vec![Action::AdvanceTutorial],
+                    "quit" if self.learn_session.is_some() => vec![Action::ExitLearnLesson],
+                    "quit" | "exit" => vec![Action::ExitTutorial],
+                    _ => {
+                        self.last_error = Some(
+                            "usage: tutorial [quick|resume|restart|essentials|next|quit]"
+                                .to_string(),
+                        );
+                        Vec::new()
+                    }
+                };
+            }
         }
         if cmd == "config-diagnostics" {
             return vec![Action::ConfigDiagnostics];
@@ -17089,6 +17368,16 @@ impl Editor {
         if self.intercept_learn_action(action, buffer, runtime)? {
             return Ok(false);
         }
+        if matches!(action, Action::Save | Action::SaveAs(_))
+            && self
+                .tutorial_controller
+                .as_ref()
+                .is_some_and(|tutorial| tutorial.practice_buffer_id == self.current_buffer().id())
+        {
+            self.last_error = Some("the Red tutorial practice buffer cannot be saved".to_string());
+            self.render(buffer)?;
+            return Ok(false);
+        }
         let sensitive_action = matches!(action, Action::NotifyPlugin(_, _, _))
             || matches!(
                 action,
@@ -18693,7 +18982,25 @@ impl Editor {
                 self.render(buffer)?;
             }
             Action::PluginCommand(cmd) => {
-                self.plugin_registry.execute(runtime, cmd).await?;
+                let demo = match (
+                    self.tutorial_controller
+                        .as_ref()
+                        .and_then(TutorialController::lesson),
+                    cmd.as_str(),
+                ) {
+                    (Some(TutorialLesson::Git), "GitDashboard") => Some(TutorialDemoKind::Git),
+                    (Some(TutorialLesson::Agent), "Agent" | "AgentOpen") => {
+                        Some(TutorialDemoKind::Agent)
+                    }
+                    _ => None,
+                };
+                if let Some(kind) = demo {
+                    self.release_current_dialog_callbacks(runtime);
+                    self.current_dialog = Some(Box::new(TutorialDemoPanel::new(self, kind)));
+                    self.render(buffer)?;
+                } else {
+                    self.plugin_registry.execute(runtime, cmd).await?;
+                }
             }
             Action::GoToLine(line) => {
                 self.go_to_line(*line, buffer, runtime, GoToLinePosition::Center)
@@ -19586,6 +19893,13 @@ impl Editor {
                 self.render(buffer)?;
             }
             Action::OpenWhatsNew => {
+                if self
+                    .current_dialog
+                    .as_ref()
+                    .is_some_and(|dialog| dialog.shortcut_context() == "Welcome to Red")
+                {
+                    self.finish_welcome();
+                }
                 self.release_current_dialog_callbacks(runtime);
                 if self.open_whats_new_panel() {
                     self.render(buffer)?;
@@ -19598,11 +19912,19 @@ impl Editor {
                 }
             }
             Action::OpenLearn | Action::FinishLearnLesson => {
+                if self.tutorial_controller.is_some() {
+                    self.finish_tutorial(/*completed*/ false, buffer, runtime)
+                        .await?;
+                }
                 self.finish_learn_lesson(buffer, runtime)?;
                 self.open_learn_hub(runtime);
                 self.render(buffer)?;
             }
             Action::StartLearnLesson | Action::RestartLearnLesson => {
+                if self.tutorial_controller.is_some() {
+                    self.finish_tutorial(/*completed*/ false, buffer, runtime)
+                        .await?;
+                }
                 self.start_learn_lesson(buffer, runtime).await?;
             }
             Action::ExitLearnLesson => {
@@ -19611,6 +19933,72 @@ impl Editor {
             Action::OpenStatuslineManager => {
                 self.release_current_dialog_callbacks(runtime);
                 self.current_dialog = Some(Box::new(StatuslineLayoutPanel::new(self)));
+                self.render(buffer)?;
+            }
+            Action::OpenWelcome => {
+                self.release_current_dialog_callbacks(runtime);
+                if !self.open_welcome_panel() {
+                    self.last_error = Some("terminal is too small for the welcome screen".into());
+                }
+                self.render(buffer)?;
+            }
+            Action::DismissWelcome => {
+                self.finish_welcome();
+                self.release_current_dialog_callbacks(runtime);
+                self.current_dialog = None;
+                self.render(buffer)?;
+            }
+            Action::StartTutorial(track) => {
+                self.start_tutorial(TutorialProgress::new(*track), buffer, runtime)
+                    .await?;
+            }
+            Action::ResumeTutorial => {
+                let progress = self
+                    .preferences
+                    .tutorial_progress()
+                    .cloned()
+                    .filter(|progress| !progress.completed)
+                    .unwrap_or_else(|| TutorialProgress::new(TutorialTrack::Guided));
+                self.start_tutorial(progress, buffer, runtime).await?;
+            }
+            Action::AdvanceTutorial => {
+                if let Some(tutorial) = &mut self.tutorial_controller {
+                    let completed = tutorial.advance() == TutorialObservation::Completed;
+                    self.persist_tutorial_progress();
+                    if completed {
+                        self.finish_tutorial(/*completed*/ true, buffer, runtime)
+                            .await?;
+                    } else {
+                        self.current_dialog = None;
+                        self.mode = Mode::Normal;
+                        self.render(buffer)?;
+                    }
+                }
+            }
+            Action::ExitTutorial => {
+                self.finish_tutorial(/*completed*/ false, buffer, runtime)
+                    .await?;
+            }
+            Action::DismissTutorialDemo | Action::RejectTutorialProposal => {
+                self.release_current_dialog_callbacks(runtime);
+                self.current_dialog = None;
+                self.render(buffer)?;
+            }
+            Action::AcceptTutorialProposal => {
+                self.release_current_dialog_callbacks(runtime);
+                self.current_dialog = None;
+                self.accept_tutorial_proposal(buffer, runtime).await?;
+                self.render(buffer)?;
+            }
+            Action::CreateStarterConfig => {
+                match crate::onboarding::create_starter_config(&Config::config_dir()) {
+                    Ok(path) => {
+                        self.last_error = Some(format!("starter config: {}", path.display()))
+                    }
+                    Err(error) => {
+                        self.last_error = Some(format!("could not create config: {error}"))
+                    }
+                }
                 self.render(buffer)?;
             }
             Action::OpenDiagnosticsPicker => {
@@ -20621,6 +21009,9 @@ impl Editor {
         }
 
         self.observe_learn_action(action, buffer)?;
+        self.observe_tutorial_action(action, buffer, runtime)
+            .await?;
+
         Ok(false)
     }
 
@@ -27889,16 +28280,43 @@ mod test {
     fn learn_red_commands_are_explicit_and_discoverable() {
         let mut editor = test_editor(80, 24);
         let runtime = Runtime::new();
-        for command in ["learn", "tutorial", "welcome"] {
-            assert_eq!(
-                editor.handle_command(command, &runtime),
-                vec![Action::OpenLearn]
-            );
-        }
+        assert_eq!(
+            editor.handle_command("learn", &runtime),
+            vec![Action::OpenLearn]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial", &runtime),
+            vec![Action::StartTutorial(TutorialTrack::Guided)]
+        );
+        assert_eq!(
+            editor.handle_command("welcome", &runtime),
+            vec![Action::OpenWelcome]
+        );
         assert_eq!(
             editor.handle_command("tutorial essentials", &runtime),
             vec![Action::StartLearnLesson]
         );
+        assert_eq!(
+            editor.handle_command("tutorial quit", &runtime),
+            vec![Action::ExitTutorial]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial restart", &runtime),
+            vec![Action::StartTutorial(TutorialTrack::Guided)]
+        );
+    }
+
+    #[tokio::test]
+    async fn active_learn_lesson_retains_contextual_tutorial_controls() {
+        let mut editor = test_editor(100, 24);
+        let mut buffer = RenderBuffer::new(100, 24, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .execute(&Action::StartLearnLesson, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
         assert_eq!(
             editor.handle_command("tutorial quit", &runtime),
             vec![Action::ExitLearnLesson]
@@ -27906,6 +28324,10 @@ mod test {
         assert_eq!(
             editor.handle_command("tutorial restart", &runtime),
             vec![Action::RestartLearnLesson]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial next", &runtime),
+            vec![Action::FinishLearnLesson]
         );
     }
 
@@ -28204,6 +28626,296 @@ mod test {
 
         assert!(error.to_string().contains("buffer changed"));
         assert_eq!(editor.current_buffer().contents(), "newer\n");
+    }
+
+    #[tokio::test]
+    async fn fresh_install_welcome_waits_for_an_explicit_user_decision() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("preferences.json");
+        let preferences = PreferencesStore::load(&path);
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size_and_preferences(
+            lsp,
+            /*width*/ 100,
+            /*height*/ 28,
+            config,
+            Theme::default(),
+            vec![Buffer::new(/*file*/ None, String::new())],
+            preferences,
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 28, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor.enable_first_launch_welcome(/*first_launch*/ true);
+        assert!(editor.prepare_startup_welcome());
+        assert!(editor.current_dialog.is_some());
+        assert!(!editor.whats_new_startup_pending);
+        assert!(!path.exists(), "showing the screen is not a user decision");
+
+        editor
+            .execute(&Action::DismissWelcome, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(editor.current_dialog.is_none());
+        assert!(PreferencesStore::load(&path).welcome_completed());
+    }
+
+    #[tokio::test]
+    async fn first_run_release_preview_opens_the_existing_whats_new_panel() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("preferences.json");
+        let preferences = PreferencesStore::load(&path);
+        let config = Config {
+            fetch_release_notes: Some(false),
+            ..Config::default()
+        };
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let mut editor = Editor::with_size_and_preferences(
+            lsp,
+            /*width*/ 100,
+            /*height*/ 28,
+            config,
+            Theme::default(),
+            vec![Buffer::new(/*file*/ None, String::new())],
+            preferences,
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 28, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor.enable_first_launch_welcome(/*first_launch*/ true);
+        assert!(editor.prepare_startup_welcome());
+        editor
+            .execute(&Action::OpenWhatsNew, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(render_text_rows(&buffer)
+            .join("\n")
+            .contains("RELEASE NOTES"));
+        let preferences = PreferencesStore::load(&path);
+        assert!(preferences.welcome_completed());
+        assert_eq!(
+            preferences.last_seen_version(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    #[tokio::test]
+    async fn tutorial_practice_buffer_cannot_write_and_exit_restores_original_buffer() {
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 24);
+        let original_id = editor.current_buffer().id();
+        let original_contents = editor.current_buffer().contents();
+        let directory = tempfile::tempdir().unwrap();
+        let forbidden = directory.path().join("tutorial-should-not-exist.rs");
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 24, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .execute(
+                &Action::StartTutorial(TutorialTrack::Guided),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(editor.buffer_manager.len(), 2);
+        assert_ne!(editor.current_buffer().id(), original_id);
+        assert!(editor.current_buffer().file.is_none());
+
+        editor
+            .execute(
+                &Action::SaveAs(forbidden.to_string_lossy().into_owned()),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+
+        assert!(!forbidden.exists());
+        assert!(editor
+            .last_error
+            .as_deref()
+            .unwrap()
+            .contains("cannot be saved"));
+
+        editor
+            .execute(&Action::ExitTutorial, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert_eq!(editor.buffer_manager.len(), 1);
+        assert_eq!(editor.current_buffer().id(), original_id);
+        assert_eq!(editor.current_buffer().contents(), original_contents);
+        assert!(editor.tutorial_controller.is_none());
+    }
+
+    #[tokio::test]
+    async fn editing_lesson_advances_only_after_real_mode_edit_and_undo_actions() {
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 24);
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 24, &Style::default());
+        let mut runtime = Runtime::new();
+        editor
+            .execute(
+                &Action::StartTutorial(TutorialTrack::Guided),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+
+        for action in [
+            Action::EnterMode(Mode::Insert),
+            Action::InsertCharAtCursorPos('x'),
+            Action::EnterMode(Mode::Normal),
+            Action::Undo,
+        ] {
+            editor
+                .execute(&action, &mut buffer, &mut runtime)
+                .await
+                .unwrap();
+        }
+
+        let tutorial = editor.tutorial_controller.as_ref().unwrap();
+        assert_eq!(tutorial.lesson(), Some(TutorialLesson::Discovery));
+        assert_eq!(tutorial.progress().lesson_index, 1);
+    }
+
+    #[tokio::test]
+    async fn git_lesson_opens_a_simulated_workspace_without_a_git_plugin() {
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 24);
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 24, &Style::default());
+        let mut runtime = Runtime::new();
+        editor
+            .execute(
+                &Action::StartTutorial(TutorialTrack::Guided),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        for _ in 0..4 {
+            editor
+                .execute(&Action::AdvanceTutorial, &mut buffer, &mut runtime)
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            editor.tutorial_controller.as_ref().unwrap().lesson(),
+            Some(TutorialLesson::Git)
+        );
+
+        editor
+            .execute(
+                &Action::PluginCommand("GitDashboard".to_string()),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+
+        assert!(editor.current_dialog.is_some());
+        assert!(render_text_rows(&buffer)
+            .join("\n")
+            .contains("SAFE PRACTICE DIFF"));
+
+        editor
+            .execute(&Action::DismissTutorialDemo, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(
+            editor.tutorial_controller.as_ref().unwrap().lesson(),
+            Some(TutorialLesson::Agent)
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_lesson_accepts_only_a_local_simulated_proposal() {
+        let mut editor = test_editor(/*width*/ 100, /*height*/ 24);
+        let original_contents = editor.current_buffer().contents();
+        let mut buffer =
+            RenderBuffer::new(/*width*/ 100, /*height*/ 24, &Style::default());
+        let mut runtime = Runtime::new();
+        editor
+            .execute(
+                &Action::StartTutorial(TutorialTrack::Quick),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        editor
+            .execute(&Action::AdvanceTutorial, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        editor
+            .execute(&Action::AdvanceTutorial, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        editor
+            .execute(
+                &Action::PluginCommand("Agent".to_string()),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        assert!(render_text_rows(&buffer).join("\n").contains("NOT APPLIED"));
+
+        editor
+            .execute(&Action::AcceptTutorialProposal, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert!(editor.tutorial_controller.is_none());
+        assert_eq!(editor.current_buffer().contents(), original_contents);
+        assert!(editor
+            .preferences
+            .tutorial_progress()
+            .is_some_and(|progress| progress.completed));
+    }
+
+    #[test]
+    fn tutorial_colon_commands_cover_start_resume_skip_and_exit() {
+        let mut editor = test_editor(/*width*/ 80, /*height*/ 16);
+        let runtime = Runtime::new();
+
+        assert_eq!(
+            editor.handle_command("welcome", &runtime),
+            vec![Action::OpenWelcome]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial", &runtime),
+            vec![Action::StartTutorial(TutorialTrack::Guided)]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial quick", &runtime),
+            vec![Action::StartTutorial(TutorialTrack::Quick)]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial resume", &runtime),
+            vec![Action::ResumeTutorial]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial next", &runtime),
+            vec![Action::AdvanceTutorial]
+        );
+        assert_eq!(
+            editor.handle_command("tutorial quit", &runtime),
+            vec![Action::ExitTutorial]
+        );
     }
 
     fn catalog_test_package() -> plugin::catalog::CatalogPackage {

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1330,6 +1330,10 @@ impl Editor {
                 help.context.clone_from(&context);
             }
         }
+        if let Some(tutorial) = &self.tutorial_controller {
+            let shortcut = self.tutorial_shortcut();
+            crate::ui::draw_tutorial_coach(buffer, &self.theme, tutorial, shortcut.as_deref());
+        }
         // Render all plugins
         self.render_from_plugins(buffer)?;
         drop(chrome_span);

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -829,6 +829,7 @@ async fn serve_editor_connection(
         core.clear_pending_paste();
         core.resize(columns, rows).await?;
         core.focus(focused).await?;
+        core.prepare_startup_welcome()?;
         core.prepare_startup_whats_new()?
     };
     let render = core.lock().await.snapshot(last_revision);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub mod terminal_output;
 pub mod text_layout;
 mod textobjects;
 pub mod theme;
+pub mod tutorial;
 pub mod ui;
 pub mod undo;
 pub mod unicode_utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,6 @@ use red::headless::{
 use red::language::GrammarTrustStore;
 use red::logger::Logger;
 use red::lsp::{LspClient, LspManager};
-use red::onboarding;
 use red::preferences::PreferencesStore;
 use red::session::SessionStore;
 use red::theme::{parse_vscode_theme, parse_vscode_theme_contents, Theme};
@@ -190,12 +189,8 @@ async fn run() -> anyhow::Result<()> {
     }
 
     let config_file = Config::path("config.toml");
-    if !config_file.exists() {
-        let config_dir = config_file
-            .parent()
-            .expect("config path always has a parent directory");
-        onboarding::run(config_dir)?;
-    }
+    let preferences_file = Config::path("preferences.json");
+    let first_launch = !config_file.exists() && !preferences_file.exists();
 
     let (mut loaded, theme, logger) = finalize_runtime_config(Config::load_user_file(
         &config_file,
@@ -203,7 +198,7 @@ async fn run() -> anyhow::Result<()> {
     )?)?;
     loaded.config.disable_plugin_typecheck = args.no_typecheck;
     LOGGER.get_or_init(|| logger);
-    let preferences = PreferencesStore::load(Config::path("preferences.json"));
+    let preferences = PreferencesStore::load(preferences_file);
 
     loaded.config.startup_file_count = args.files.len();
     loaded.config.startup_session_resumed = args.resume;
@@ -249,6 +244,7 @@ async fn run() -> anyhow::Result<()> {
     let diagnostics = std::mem::take(&mut loaded.diagnostics);
     let recovery = loaded.recovery;
     let mut editor = Editor::new_with_preferences(lsp, loaded.config, theme, buffers, preferences)?;
+    editor.enable_first_launch_welcome(first_launch && resumed_session.is_none());
     editor.set_language_reload_source(config_file, args.config_overrides.clone());
     editor.set_config_diagnostics(diagnostics, recovery);
     if let Some(snapshot) = &resumed_session {

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -7,7 +7,7 @@
 
 use std::fs;
 use std::io::{self, IsTerminal, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::assets;
 
@@ -67,6 +67,17 @@ fn write_default_assets(config_dir: &Path) -> anyhow::Result<()> {
     fs::create_dir_all(config_dir)?;
     fs::write(config_dir.join("config.toml"), assets::starter_config())?;
     Ok(())
+}
+
+/// Writes an optional starter config without overwriting an existing user file.
+///
+/// The editor-native welcome invokes this only after an explicit user request.
+pub fn create_starter_config(config_dir: &Path) -> anyhow::Result<PathBuf> {
+    let config_path = config_dir.join("config.toml");
+    if !config_path.exists() {
+        write_default_assets(config_dir)?;
+    }
+    Ok(config_path)
 }
 
 /// Print the prompt caret and read a `[Y/n]` answer from stdin.
@@ -215,6 +226,21 @@ mod tests {
         let parsed = crate::config::Config::from_user_toml_with_overrides(&contents, &[]);
         assert!(parsed.is_ok(), "starter config should parse: {parsed:?}");
 
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn explicit_starter_config_creation_never_overwrites_existing_settings() {
+        let dir = unique_temp_dir("onboarding-explicit");
+        fs::create_dir_all(&dir).unwrap();
+        let config_path = dir.join("config.toml");
+        fs::write(&config_path, "theme = \"mine.json\"\n").unwrap();
+
+        assert_eq!(create_starter_config(&dir).unwrap(), config_path);
+        assert_eq!(
+            fs::read_to_string(dir.join("config.toml")).unwrap(),
+            "theme = \"mine.json\"\n"
+        );
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -14,7 +14,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::{plugin::PanelSide, LOGGER};
+use crate::{plugin::PanelSide, tutorial::TutorialProgress, LOGGER};
 
 const COMMAND_HISTORY_LIMIT: usize = 100;
 const SEARCH_HISTORY_LIMIT: usize = 100;
@@ -39,6 +39,10 @@ pub struct Preferences {
     copilot_setup_hint_seen: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     learn_completed_lessons: Vec<String>,
+    #[serde(default)]
+    welcome_completed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tutorial_progress: Option<TutorialProgress>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -171,6 +175,36 @@ impl PreferencesStore {
             return Ok(());
         }
         self.preferences.copilot_setup_hint_seen = true;
+        self.save()
+    }
+
+    /// Whether the first-run welcome has already received an explicit decision.
+    #[must_use]
+    pub const fn welcome_completed(&self) -> bool {
+        self.preferences.welcome_completed
+    }
+
+    /// Persists dismissal or acceptance without requiring a starter config file.
+    pub fn complete_welcome(&mut self) -> anyhow::Result<()> {
+        if self.preferences.welcome_completed {
+            return Ok(());
+        }
+        self.preferences.welcome_completed = true;
+        self.save()
+    }
+
+    /// Returns the last explicitly persisted guided-tour position.
+    #[must_use]
+    pub fn tutorial_progress(&self) -> Option<&TutorialProgress> {
+        self.preferences.tutorial_progress.as_ref()
+    }
+
+    /// Saves a resumable lesson or completed track without touching editor files.
+    pub fn set_tutorial_progress(&mut self, progress: TutorialProgress) -> anyhow::Result<()> {
+        if self.preferences.tutorial_progress.as_ref() == Some(&progress) {
+            return Ok(());
+        }
+        self.preferences.tutorial_progress = Some(progress);
         self.save()
     }
 
@@ -552,6 +586,8 @@ mod tests {
         assert!(store.command_history().is_empty());
         assert!(store.search_history().is_empty());
         assert_eq!(store.last_seen_version(), None);
+        assert!(!store.welcome_completed());
+        assert!(store.tutorial_progress().is_none());
     }
 
     #[test]
@@ -564,6 +600,24 @@ mod tests {
 
         let reloaded = PreferencesStore::load(&path);
         assert_eq!(reloaded.last_seen_version(), Some("0.5.0"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn welcome_decision_and_tutorial_progress_survive_reload() {
+        let dir = unique_temp_dir("welcome-progress");
+        let path = dir.join("preferences.json");
+        let mut store = PreferencesStore::load(&path);
+        let mut progress = TutorialProgress::new(crate::tutorial::TutorialTrack::Quick);
+        progress.lesson_index = 1;
+        progress.phase = 1;
+
+        store.complete_welcome().unwrap();
+        store.set_tutorial_progress(progress.clone()).unwrap();
+
+        let reloaded = PreferencesStore::load(&path);
+        assert!(reloaded.welcome_completed());
+        assert_eq!(reloaded.tutorial_progress(), Some(&progress));
         fs::remove_dir_all(dir).ok();
     }
 
@@ -593,6 +647,8 @@ mod tests {
         assert_eq!(store.command_history(), ["write"]);
         assert!(store.search_history().is_empty());
         assert_eq!(store.last_seen_version(), None);
+        assert!(!store.welcome_completed());
+        assert!(store.tutorial_progress().is_none());
         fs::remove_dir_all(dir).ok();
     }
 

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -1,0 +1,423 @@
+//! Action-driven lessons for Red's optional, side-effect-free first-run tour.
+//!
+//! Lessons observe semantic editor actions rather than raw key presses. This keeps
+//! custom keymaps working and lets real pickers remain interactive while the coach is
+//! visible. Git and agent lessons explicitly use simulated, editor-owned previews.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{buffer::BufferId, editor::Action, editor::Mode, window::WindowManagerSnapshot};
+
+/// Increment this when persisted lesson identifiers or progression rules change.
+pub const CURRICULUM_VERSION: u16 = 1;
+
+/// Initial contents of the unnamed, never-saved practice buffer.
+pub const PRACTICE_CONTENTS: &str = r#"// Welcome to Red. This practice buffer never touches your project.
+
+fn total_price(prices: &[u32]) -> u32 {
+    prices.iter().sum()
+}
+
+fn main() {
+    let prices = [12, 8, 4];
+    println!(\"Total: {}\", total_price(&prices));
+}
+"#;
+
+/// Length and audience of a guided editor tour.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TutorialTrack {
+    /// The complete tour, including modal editing, Git, and theme customization.
+    #[default]
+    Guided,
+    /// A short tour for people already comfortable with Vim.
+    Quick,
+}
+
+impl TutorialTrack {
+    /// User-facing duration for the selected curriculum.
+    #[must_use]
+    pub const fn duration(self) -> &'static str {
+        match self {
+            Self::Guided => "about 5 min",
+            Self::Quick => "about 90 sec",
+        }
+    }
+
+    /// Ordered lessons included in the selected curriculum.
+    #[must_use]
+    pub const fn lessons(self) -> &'static [TutorialLesson] {
+        match self {
+            Self::Guided => &GUIDED_LESSONS,
+            Self::Quick => &QUICK_LESSONS,
+        }
+    }
+}
+
+/// Stable identifier for a hands-on lesson.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TutorialLesson {
+    /// Enter Insert mode, change text, return to Normal mode, and undo.
+    Editing,
+    /// Discover effective commands and their configured shortcuts.
+    Discovery,
+    /// Open the file picker and project-search picker.
+    Navigation,
+    /// Trigger offline-safe, buffer-word completion.
+    Completion,
+    /// Inspect a simulated Git diff without touching the real repository.
+    Git,
+    /// Inspect and accept or reject a simulated agent proposal.
+    Agent,
+    /// Preview an installed theme and explicitly decide whether to keep it.
+    Themes,
+}
+
+const GUIDED_LESSONS: [TutorialLesson; 7] = [
+    TutorialLesson::Editing,
+    TutorialLesson::Discovery,
+    TutorialLesson::Navigation,
+    TutorialLesson::Completion,
+    TutorialLesson::Git,
+    TutorialLesson::Agent,
+    TutorialLesson::Themes,
+];
+
+const QUICK_LESSONS: [TutorialLesson; 3] = [
+    TutorialLesson::Discovery,
+    TutorialLesson::Navigation,
+    TutorialLesson::Agent,
+];
+
+impl TutorialLesson {
+    /// Short, readable title shown in the coach and progress indicator.
+    #[must_use]
+    pub const fn title(self) -> &'static str {
+        match self {
+            Self::Editing => "Editing that feels familiar",
+            Self::Discovery => "Discover every command",
+            Self::Navigation => "Find files and search projects",
+            Self::Completion => "Code intelligence, immediately",
+            Self::Git => "Git without leaving Red",
+            Self::Agent => "The agent asks permission",
+            Self::Themes => "Make Red yours",
+        }
+    }
+
+    /// The semantic action whose effective shortcut should be displayed.
+    #[must_use]
+    pub fn suggested_action(self, phase: u8) -> Option<Action> {
+        match (self, phase) {
+            (Self::Editing, 0) => Some(Action::EnterMode(Mode::Insert)),
+            (Self::Editing, 2) => Some(Action::EnterMode(Mode::Normal)),
+            (Self::Editing, 3) => Some(Action::Undo),
+            (Self::Discovery, _) => Some(Action::CommandPalette),
+            (Self::Navigation, 0) => Some(Action::FilePicker),
+            (Self::Navigation, _) => Some(Action::PluginCommand("ProjectSearch".to_string())),
+            (Self::Completion, 0) => Some(Action::EnterMode(Mode::Insert)),
+            (Self::Completion, _) => Some(Action::RequestCompletion),
+            (Self::Git, 0) => Some(Action::PluginCommand("GitDashboard".to_string())),
+            (Self::Agent, 0) => Some(Action::PluginCommand("Agent".to_string())),
+            (Self::Themes, 0) => Some(Action::PluginCommand("ThemeBrowser".to_string())),
+            _ => None,
+        }
+    }
+
+    /// Contextual instruction for the next real action in this lesson.
+    #[must_use]
+    pub fn instruction(self, phase: u8, shortcut: Option<&str>) -> String {
+        let key = |fallback| shortcut.unwrap_or(fallback);
+        match (self, phase) {
+            (Self::Editing, 0) => format!("Press {} to enter Insert mode.", key("i")),
+            (Self::Editing, 1) => "Type a few characters in the practice buffer.".to_string(),
+            (Self::Editing, 2) => format!("Press {} to return to Normal mode.", key("Esc")),
+            (Self::Editing, _) => format!("Press {} to undo your practice edit.", key("u")),
+            (Self::Discovery, _) => {
+                format!("Press {} to open the command palette.", key("Space ?"))
+            }
+            (Self::Navigation, 0) => {
+                format!("Press {} to open the fuzzy file picker.", key("Ctrl-p"))
+            }
+            (Self::Navigation, _) => format!(
+                "Close the picker, then press {} to search the project.",
+                key("Space g")
+            ),
+            (Self::Completion, 0) => {
+                format!("Press {} to enter Insert mode first.", key("i"))
+            }
+            (Self::Completion, _) => format!(
+                "Press {} for offline-safe buffer completion.",
+                key("Ctrl-Space")
+            ),
+            (Self::Git, 0) => format!("Press {} to inspect a safe sample diff.", key("Space G")),
+            (Self::Git, _) => "Inspect the sample diff, then press Esc to continue.".to_string(),
+            (Self::Agent, 0) => {
+                format!("Press {} to inspect a simulated proposal.", key("Space A"))
+            }
+            (Self::Agent, _) => {
+                "Press a to accept or r to reject the practice-only proposal.".to_string()
+            }
+            (Self::Themes, 0) => format!("Press {} to browse installed themes.", key("Space t")),
+            (Self::Themes, _) => {
+                "Preview a theme, then select one or close the browser.".to_string()
+            }
+        }
+    }
+
+    /// Short product explanation shown below the active instruction.
+    #[must_use]
+    pub const fn explanation(self) -> &'static str {
+        match self {
+            Self::Editing => "Your normal Vim muscle memory works here.",
+            Self::Discovery => "Search commands, descriptions, and your actual keymaps.",
+            Self::Navigation => "Fuzzy previews and project search keep your hands on the keys.",
+            Self::Completion => "Open buffers supply suggestions even without a language server.",
+            Self::Git => "Real Git changes always remain under your control.",
+            Self::Agent => "Nothing changes on disk until you review and accept it.",
+            Self::Themes => "Bundled themes and plugins work without a config file.",
+        }
+    }
+}
+
+/// Persisted progress that can resume after Red restarts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TutorialProgress {
+    /// Schema version of the lesson identifiers and action phases.
+    #[serde(default = "curriculum_version")]
+    pub curriculum_version: u16,
+    /// Curriculum selected by the user.
+    #[serde(default)]
+    pub track: TutorialTrack,
+    /// Zero-based index into the selected track.
+    #[serde(default)]
+    pub lesson_index: usize,
+    /// Zero-based phase within the current lesson.
+    #[serde(default)]
+    pub phase: u8,
+    /// Whether every lesson in the selected track has completed.
+    #[serde(default)]
+    pub completed: bool,
+}
+
+const fn curriculum_version() -> u16 {
+    CURRICULUM_VERSION
+}
+
+impl TutorialProgress {
+    /// Creates a new, unstarted track.
+    #[must_use]
+    pub const fn new(track: TutorialTrack) -> Self {
+        Self {
+            curriculum_version: CURRICULUM_VERSION,
+            track,
+            lesson_index: 0,
+            phase: 0,
+            completed: false,
+        }
+    }
+
+    /// Returns the current lesson unless the selected track is complete.
+    #[must_use]
+    pub fn current_lesson(&self) -> Option<TutorialLesson> {
+        (!self.completed)
+            .then(|| self.track.lessons().get(self.lesson_index).copied())
+            .flatten()
+    }
+
+    /// Older curricula restart safely instead of pointing at an unrelated lesson.
+    #[must_use]
+    pub fn normalized(self) -> Self {
+        if self.curriculum_version != CURRICULUM_VERSION
+            || self.lesson_index >= self.track.lessons().len() && !self.completed
+        {
+            Self::new(self.track)
+        } else {
+            self
+        }
+    }
+}
+
+/// Result of observing one semantic editor action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TutorialObservation {
+    /// The current lesson did not consume this action.
+    Unchanged,
+    /// Another action is needed inside the same lesson.
+    Progressed,
+    /// The next lesson is now active.
+    Advanced,
+    /// The selected track has finished.
+    Completed,
+}
+
+/// Runtime-only ownership of the practice buffer and pre-tutorial window layout.
+#[derive(Debug)]
+pub struct TutorialController {
+    progress: TutorialProgress,
+    /// Stable identity of the unnamed practice buffer.
+    pub practice_buffer_id: BufferId,
+    /// Buffer selected before the tutorial opened.
+    pub original_buffer_index: usize,
+    /// Full pre-tutorial split tree and cursor/window state.
+    pub original_window_layout: WindowManagerSnapshot,
+}
+
+impl TutorialController {
+    /// Starts or resumes a curriculum inside an isolated practice buffer.
+    #[must_use]
+    pub fn new(
+        progress: TutorialProgress,
+        practice_buffer_id: BufferId,
+        original_buffer_index: usize,
+        original_window_layout: WindowManagerSnapshot,
+    ) -> Self {
+        Self {
+            progress: progress.normalized(),
+            practice_buffer_id,
+            original_buffer_index,
+            original_window_layout,
+        }
+    }
+
+    /// Current progress for display and persistence.
+    #[must_use]
+    pub const fn progress(&self) -> &TutorialProgress {
+        &self.progress
+    }
+
+    /// Current product lesson, if the track has not completed.
+    #[must_use]
+    pub fn lesson(&self) -> Option<TutorialLesson> {
+        self.progress.current_lesson()
+    }
+
+    /// Advances explicitly, for the always-available skip command.
+    pub fn advance(&mut self) -> TutorialObservation {
+        if self.progress.completed {
+            return TutorialObservation::Unchanged;
+        }
+        self.progress.lesson_index = self.progress.lesson_index.saturating_add(1);
+        self.progress.phase = 0;
+        if self.progress.lesson_index >= self.progress.track.lessons().len() {
+            self.progress.completed = true;
+            TutorialObservation::Completed
+        } else {
+            TutorialObservation::Advanced
+        }
+    }
+
+    /// Observes editor actions without capturing keys or bypassing normal dispatch.
+    pub fn observe(&mut self, action: &Action) -> TutorialObservation {
+        let Some(lesson) = self.lesson() else {
+            return TutorialObservation::Unchanged;
+        };
+
+        let accepted = match (lesson, self.progress.phase, action) {
+            (TutorialLesson::Editing, 0, Action::EnterMode(Mode::Insert))
+            | (TutorialLesson::Editing, 2, Action::EnterMode(Mode::Normal)) => true,
+            (
+                TutorialLesson::Editing,
+                1,
+                Action::InsertCharAtCursorPos(_)
+                | Action::InsertString(_)
+                | Action::InsertPastedText(_),
+            ) => true,
+            (TutorialLesson::Editing, 3, Action::Undo) => return self.advance(),
+            (TutorialLesson::Discovery, _, Action::CommandPalette) => return self.advance(),
+            (TutorialLesson::Navigation, 0, Action::FilePicker) => true,
+            (TutorialLesson::Navigation, 1, Action::PluginCommand(name))
+                if name == "ProjectSearch" =>
+            {
+                return self.advance();
+            }
+            (TutorialLesson::Completion, 0, Action::EnterMode(Mode::Insert)) => true,
+            (
+                TutorialLesson::Completion,
+                _,
+                Action::RequestCompletion | Action::RequestCompletionWithTrigger(_),
+            ) => return self.advance(),
+            (TutorialLesson::Git, 0, Action::PluginCommand(name)) if name == "GitDashboard" => true,
+            (TutorialLesson::Git, 1, Action::DismissTutorialDemo) => return self.advance(),
+            (TutorialLesson::Agent, 0, Action::PluginCommand(name))
+                if matches!(name.as_str(), "Agent" | "AgentOpen") =>
+            {
+                true
+            }
+            (
+                TutorialLesson::Agent,
+                1,
+                Action::AcceptTutorialProposal | Action::RejectTutorialProposal,
+            ) => return self.advance(),
+            (TutorialLesson::Themes, 0, Action::PluginCommand(name)) if name == "ThemeBrowser" => {
+                true
+            }
+            (TutorialLesson::Themes, 1, Action::SetTheme(_) | Action::CloseDialog) => {
+                return self.advance();
+            }
+            _ => false,
+        };
+
+        if accepted {
+            self.progress.phase = self.progress.phase.saturating_add(1);
+            TutorialObservation::Progressed
+        } else {
+            TutorialObservation::Unchanged
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guided_track_teaches_reds_seven_highlights() {
+        assert_eq!(TutorialTrack::Guided.lessons().len(), 7);
+        assert!(TutorialTrack::Guided
+            .lessons()
+            .contains(&TutorialLesson::Git));
+        assert!(TutorialTrack::Guided
+            .lessons()
+            .contains(&TutorialLesson::Agent));
+    }
+
+    #[test]
+    fn quick_track_prioritizes_discovery_navigation_and_safe_agents() {
+        assert_eq!(
+            TutorialTrack::Quick.lessons(),
+            &[
+                TutorialLesson::Discovery,
+                TutorialLesson::Navigation,
+                TutorialLesson::Agent,
+            ]
+        );
+    }
+
+    #[test]
+    fn stale_or_invalid_progress_restarts_the_same_track() {
+        let stale = TutorialProgress {
+            curriculum_version: 0,
+            track: TutorialTrack::Quick,
+            lesson_index: 100,
+            phase: 3,
+            completed: false,
+        };
+
+        assert_eq!(
+            stale.normalized(),
+            TutorialProgress::new(TutorialTrack::Quick)
+        );
+    }
+
+    #[test]
+    fn lessons_keep_real_fallback_shortcuts_readable() {
+        assert!(TutorialLesson::Agent
+            .instruction(/*phase*/ 0, /*shortcut*/ None)
+            .contains("Space A"));
+        assert!(TutorialLesson::Discovery
+            .instruction(/*phase*/ 0, Some("F1"))
+            .contains("F1"));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -34,6 +34,7 @@ mod shortcut_catalog;
 pub(crate) mod signature_help;
 mod spinner;
 mod statusline_layout;
+mod welcome;
 mod whats_new;
 
 pub(crate) use action_bar::ActionMenu;
@@ -85,6 +86,8 @@ pub(crate) use shortcut_catalog::{
 };
 pub(crate) use spinner::{spinner_frame, SPINNER_FRAME_INTERVAL_MS};
 pub use statusline_layout::StatuslineLayoutPanel;
+pub(crate) use welcome::draw_tutorial_coach;
+pub use welcome::{TutorialDemoKind, TutorialDemoPanel, WelcomePanel};
 pub use whats_new::WhatsNewPanel;
 
 use crate::{

--- a/src/ui/welcome.rs
+++ b/src/ui/welcome.rs
@@ -1,0 +1,796 @@
+//! Branded first-run choices and safe, editor-owned tutorial previews.
+
+use crossterm::event::{Event, KeyCode, KeyModifiers, MouseEventKind};
+
+use crate::{
+    config::KeyAction,
+    editor::{Action, Editor, RenderBuffer},
+    plugin::markdown::{render_markdown_lines, RenderedTextLine, TextPanelSpanStyle},
+    splash::{self, Role},
+    theme::{SelectionForegroundPriority, Style, Theme},
+    tutorial::{TutorialController, TutorialTrack},
+    unicode_utils::{display_width, truncate_display_width},
+};
+
+use super::{
+    dialog::{BorderStyle, Dialog, SurfaceRole},
+    paint_rich_text, ActionPriority, Component, UiAction,
+};
+
+const MAX_WELCOME_WIDTH: usize = 98;
+const MAX_WELCOME_HEIGHT: usize = 25;
+const MIN_WELCOME_WIDTH: usize = 36;
+const MIN_WELCOME_HEIGHT: usize = 12;
+const WIDE_CARDS_WIDTH: usize = 72;
+const COACH_HEIGHT: usize = 7;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WelcomePage {
+    Home,
+    ReleaseHighlights,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WelcomeCard {
+    GuidedTour,
+    ReleaseHighlights,
+}
+
+/// Keyboard-first welcome that enters the editor before requesting any setup.
+pub struct WelcomePanel {
+    dialog: Dialog,
+    page: WelcomePage,
+    selected: WelcomeCard,
+    release_lines: Vec<RenderedTextLine>,
+    release_scroll: usize,
+    can_resume: bool,
+    theme: Theme,
+}
+
+impl WelcomePanel {
+    /// Compact welcome screens still require a readable body and close action.
+    #[must_use]
+    pub const fn fits(width: usize, height: usize) -> bool {
+        width >= MIN_WELCOME_WIDTH && height >= MIN_WELCOME_HEIGHT
+    }
+
+    /// Builds a responsive welcome over the current theme and viewport.
+    #[must_use]
+    pub fn new(editor: &Editor, can_resume: bool) -> Self {
+        let (x, y, width, height) = geometry(editor.vwidth(), editor.vheight());
+        let theme = editor.theme.clone();
+        let style = theme.ui_style.dialog.clone();
+        let dialog = Dialog::new(
+            Some(format!("WELCOME TO RED · v{}", env!("CARGO_PKG_VERSION"))),
+            x,
+            y,
+            width,
+            height,
+            &style,
+            BorderStyle::Rounded,
+            &theme,
+        )
+        .with_surface_theme(&theme, SurfaceRole::Dialog);
+
+        let mut panel = Self {
+            dialog,
+            page: WelcomePage::Home,
+            selected: WelcomeCard::GuidedTour,
+            release_lines: Vec::new(),
+            release_scroll: 0,
+            can_resume,
+            theme,
+        };
+        panel.reflow();
+        panel
+    }
+
+    fn release_body_height(&self) -> usize {
+        self.dialog.height.saturating_sub(6)
+    }
+
+    fn reflow(&mut self) {
+        let markdown = embedded_release_notes(env!("CARGO_PKG_VERSION"));
+        self.release_lines = render_markdown_lines(&markdown, self.dialog.width.saturating_sub(6));
+        self.release_scroll = self.release_scroll.min(
+            self.release_lines
+                .len()
+                .saturating_sub(self.release_body_height()),
+        );
+        self.update_actions();
+    }
+
+    fn update_actions(&mut self) {
+        let actions = match self.page {
+            WelcomePage::Home => {
+                let mut actions = vec![
+                    UiAction::new("select", "Enter", "Choose")
+                        .with_priority(ActionPriority::Essential),
+                    UiAction::new("dismiss", "Esc", "Start editing")
+                        .with_priority(ActionPriority::Essential),
+                    UiAction::new("quick", "i", "Quick tour"),
+                    UiAction::new("notes", "v", "What’s new"),
+                    UiAction::new("config", "c", "Create config")
+                        .with_priority(ActionPriority::Secondary),
+                ];
+                if self.can_resume {
+                    actions.push(UiAction::new("resume", "r", "Resume tour"));
+                }
+                actions
+            }
+            WelcomePage::ReleaseHighlights => vec![
+                UiAction::new("back", "Esc", "Back").with_priority(ActionPriority::Essential),
+                UiAction::new("tour", "t", "Guided tour").with_priority(ActionPriority::Essential),
+                UiAction::new("scroll", "j/k", "Scroll"),
+                UiAction::new("release", "o", "Full release notes"),
+            ],
+        };
+        self.dialog.set_actions(actions);
+    }
+
+    fn center(&self, buffer: &mut RenderBuffer, row: usize, text: &str, style: &Style) {
+        if row >= self.dialog.height.saturating_sub(1) {
+            return;
+        }
+        let width = self.dialog.width.saturating_sub(4);
+        let text = truncate_display_width(text, width);
+        let x = self.dialog.x + 1 + self.dialog.width.saturating_sub(display_width(&text)) / 2;
+        buffer.set_text(x, self.dialog.y + 1 + row, &text, style);
+    }
+
+    fn draw_brand(&self, buffer: &mut RenderBuffer, row: usize) {
+        let palette = splash::palette(&self.theme);
+        let mark = "red";
+        let width = display_width(mark) + 2;
+        let x = self.dialog.x + 1 + self.dialog.width.saturating_sub(width) / 2;
+        let y = self.dialog.y + 1 + row;
+        buffer.set_text(x, y, mark, palette.style(Role::Mark));
+        buffer.set_text(
+            x + display_width(mark) + 1,
+            y,
+            "●",
+            palette.style(Role::Dot),
+        );
+    }
+
+    fn draw_card(
+        &self,
+        buffer: &mut RenderBuffer,
+        x: usize,
+        y: usize,
+        width: usize,
+        card: WelcomeCard,
+    ) {
+        if width < 14 || y + 4 >= self.dialog.y + self.dialog.height {
+            return;
+        }
+        let selected = self.selected == card;
+        let selected_style = self.theme.selected_style(
+            &self.theme.ui_style.dialog,
+            &self.theme.ui_style.picker_selected_item,
+            SelectionForegroundPriority::Selection,
+        );
+        let surface = if selected {
+            selected_style
+        } else {
+            self.theme.ui_style.dialog.clone()
+        };
+        let palette = splash::palette(&self.theme);
+        let border = if selected {
+            palette.style(Role::Key).with_bg(surface.bg)
+        } else {
+            self.theme.ui_style.dialog_border.clone()
+        };
+        let title = match card {
+            WelcomeCard::GuidedTour => "Take the guided tour",
+            WelcomeCard::ReleaseHighlights => "What’s new",
+        };
+        let lines: [&str; 2] = match card {
+            WelcomeCard::GuidedTour => ["Learn Red by using it.", "Editing · Git · safe agents"],
+            WelcomeCard::ReleaseHighlights => [
+                "Discover release highlights.",
+                "Immediate and offline-ready",
+            ],
+        };
+
+        buffer.fill_rect(x, y, width, 5, ' ', &surface, &self.theme);
+        buffer.set_text(x, y, &format!("╭{}╮", "─".repeat(width - 2)), &border);
+        buffer.set_text(x, y + 4, &format!("╰{}╯", "─".repeat(width - 2)), &border);
+        for row in 1..4 {
+            buffer.set_text(x, y + row, "│", &border);
+            buffer.set_text(x + width - 1, y + row, "│", &border);
+        }
+        let title_style = Style {
+            bold: true,
+            ..surface.clone()
+        };
+        buffer.set_text(
+            x + 2,
+            y + 1,
+            &truncate_display_width(title, width.saturating_sub(4)),
+            &title_style,
+        );
+        for (offset, line) in lines.iter().enumerate() {
+            let style = if selected {
+                surface.clone()
+            } else {
+                self.theme.ui_style.muted.clone().with_bg(surface.bg)
+            };
+            buffer.set_text(
+                x + 2,
+                y + offset + 2,
+                &truncate_display_width(line, width.saturating_sub(4)),
+                &style,
+            );
+        }
+    }
+
+    fn draw_home(&self, buffer: &mut RenderBuffer) {
+        let palette = splash::palette(&self.theme);
+        let tall = self.dialog.height >= 17;
+        let brand_row = if tall { 1 } else { 0 };
+        self.draw_brand(buffer, brand_row);
+        let title = Style {
+            bold: true,
+            ..self.theme.ui_style.dialog_title.clone()
+        };
+        self.center(
+            buffer,
+            brand_row + 2,
+            "Your editor. Your muscle memory.",
+            &title,
+        );
+        self.center(
+            buffer,
+            brand_row + 3,
+            "An agent that asks permission.",
+            palette.style(Role::Muted),
+        );
+
+        let cards_y = self.dialog.y + 1 + brand_row + 5;
+        if self.dialog.width >= WIDE_CARDS_WIDTH && self.dialog.height >= 14 {
+            let inner_width = self.dialog.width.saturating_sub(6);
+            let first_width = inner_width / 2;
+            let second_width = inner_width.saturating_sub(first_width + 2);
+            let first_x = self.dialog.x + 3;
+            self.draw_card(
+                buffer,
+                first_x,
+                cards_y,
+                first_width,
+                WelcomeCard::GuidedTour,
+            );
+            self.draw_card(
+                buffer,
+                first_x + first_width + 2,
+                cards_y,
+                second_width,
+                WelcomeCard::ReleaseHighlights,
+            );
+            self.center(
+                buffer,
+                brand_row + 11,
+                "Already know Vim? Press i for the 90-second highlights tour.",
+                palette.style(Role::Muted),
+            );
+        } else {
+            for (offset, (card, label)) in [
+                (
+                    WelcomeCard::GuidedTour,
+                    "Take the guided tour · about 5 min",
+                ),
+                (
+                    WelcomeCard::ReleaseHighlights,
+                    "See what’s new in this release",
+                ),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                let prefix = if self.selected == card { "› " } else { "  " };
+                let style = if self.selected == card {
+                    palette.style(Role::Key)
+                } else {
+                    palette.style(Role::Text)
+                };
+                self.center(
+                    buffer,
+                    brand_row + 5 + offset,
+                    &format!("{prefix}{label}"),
+                    style,
+                );
+            }
+        }
+    }
+
+    fn draw_release(&self, buffer: &mut RenderBuffer) {
+        let palette = splash::palette(&self.theme);
+        let title = Style {
+            bold: true,
+            ..self.theme.ui_style.dialog_title.clone()
+        };
+        self.center(buffer, 0, "What’s new in Red", &title);
+        self.center(
+            buffer,
+            1,
+            &format!("Release {}", env!("CARGO_PKG_VERSION")),
+            palette.style(Role::Muted),
+        );
+
+        let rule_width = self.dialog.width.saturating_sub(6);
+        buffer.set_text(
+            self.dialog.x + 3,
+            self.dialog.y + 4,
+            &"─".repeat(rule_width),
+            palette.style(Role::Rule),
+        );
+        let x = self.dialog.x + 3;
+        let y = self.dialog.y + 5;
+        for (offset, line) in self
+            .release_lines
+            .iter()
+            .skip(self.release_scroll)
+            .take(self.release_body_height())
+            .enumerate()
+        {
+            paint_rich_text(buffer, x, y + offset, rule_width, line, |span| {
+                let base = match span.style {
+                    TextPanelSpanStyle::Heading | TextPanelSpanStyle::Strong => Style {
+                        bold: true,
+                        ..self.theme.ui_style.dialog_title.clone()
+                    },
+                    TextPanelSpanStyle::Muted | TextPanelSpanStyle::Quote => {
+                        self.theme.ui_style.muted.clone()
+                    }
+                    TextPanelSpanStyle::InlineCode
+                    | TextPanelSpanStyle::Code
+                    | TextPanelSpanStyle::Link => palette.style(Role::Key).clone(),
+                    _ => self.theme.ui_style.dialog.clone(),
+                };
+                base.with_bg(self.theme.ui_style.dialog.bg)
+            });
+        }
+    }
+
+    fn toggle_selection(&mut self) {
+        self.selected = match self.selected {
+            WelcomeCard::GuidedTour => WelcomeCard::ReleaseHighlights,
+            WelcomeCard::ReleaseHighlights => WelcomeCard::GuidedTour,
+        };
+    }
+
+    fn open_highlights(&mut self) -> Option<KeyAction> {
+        self.page = WelcomePage::ReleaseHighlights;
+        self.release_scroll = 0;
+        self.update_actions();
+        Some(KeyAction::Single(Action::Refresh))
+    }
+}
+
+impl Component for WelcomePanel {
+    fn shortcut_context(&self) -> &str {
+        "Welcome to Red"
+    }
+
+    fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.dialog.draw(buffer)?;
+        match self.page {
+            WelcomePage::Home => self.draw_home(buffer),
+            WelcomePage::ReleaseHighlights => self.draw_release(buffer),
+        }
+        Ok(())
+    }
+
+    fn set_theme(&mut self, theme: &Theme) {
+        self.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
+    }
+
+    fn resize(&mut self, viewport_width: usize, viewport_height: usize) -> bool {
+        if !Self::fits(viewport_width, viewport_height) {
+            return false;
+        }
+        let (x, y, width, height) = geometry(viewport_width, viewport_height);
+        self.dialog.x = x;
+        self.dialog.y = y;
+        self.dialog.width = width;
+        self.dialog.height = height;
+        self.reflow();
+        true
+    }
+
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        let Event::Key(key) = event else {
+            return match event {
+                Event::Mouse(mouse) if matches!(mouse.kind, MouseEventKind::ScrollDown) => {
+                    self.release_scroll = self.release_scroll.saturating_add(3).min(
+                        self.release_lines
+                            .len()
+                            .saturating_sub(self.release_body_height()),
+                    );
+                    Some(KeyAction::Single(Action::Refresh))
+                }
+                Event::Mouse(mouse) if matches!(mouse.kind, MouseEventKind::ScrollUp) => {
+                    self.release_scroll = self.release_scroll.saturating_sub(3);
+                    Some(KeyAction::Single(Action::Refresh))
+                }
+                _ => None,
+            };
+        };
+
+        match self.page {
+            WelcomePage::Home => match (key.code, key.modifiers) {
+                (KeyCode::Esc | KeyCode::Char('q'), _) => {
+                    Some(KeyAction::Single(Action::DismissWelcome))
+                }
+                (KeyCode::Enter, _) => match self.selected {
+                    WelcomeCard::GuidedTour => Some(KeyAction::Single(Action::StartTutorial(
+                        TutorialTrack::Guided,
+                    ))),
+                    WelcomeCard::ReleaseHighlights => self.open_highlights(),
+                },
+                (KeyCode::Char('t'), _) => Some(KeyAction::Single(Action::StartTutorial(
+                    TutorialTrack::Guided,
+                ))),
+                (KeyCode::Char('i'), _) => Some(KeyAction::Single(Action::StartTutorial(
+                    TutorialTrack::Quick,
+                ))),
+                (KeyCode::Char('r'), _) if self.can_resume => {
+                    Some(KeyAction::Single(Action::ResumeTutorial))
+                }
+                (KeyCode::Char('c'), _) => Some(KeyAction::Single(Action::CreateStarterConfig)),
+                (KeyCode::Char('v'), _) => self.open_highlights(),
+                (KeyCode::Left | KeyCode::Right | KeyCode::Tab | KeyCode::BackTab, _) => {
+                    self.toggle_selection();
+                    Some(KeyAction::Single(Action::Refresh))
+                }
+                _ => None,
+            },
+            WelcomePage::ReleaseHighlights => match (key.code, key.modifiers) {
+                (KeyCode::Esc | KeyCode::Char('q'), _) => {
+                    self.page = WelcomePage::Home;
+                    self.update_actions();
+                    Some(KeyAction::Single(Action::Refresh))
+                }
+                (KeyCode::Char('t'), _) => Some(KeyAction::Single(Action::StartTutorial(
+                    TutorialTrack::Guided,
+                ))),
+                (KeyCode::Char('o'), _) => Some(KeyAction::Single(Action::OpenWhatsNew)),
+                (KeyCode::Down | KeyCode::Char('j'), _) => {
+                    self.release_scroll = self.release_scroll.saturating_add(1).min(
+                        self.release_lines
+                            .len()
+                            .saturating_sub(self.release_body_height()),
+                    );
+                    Some(KeyAction::Single(Action::Refresh))
+                }
+                (KeyCode::Up | KeyCode::Char('k'), _) => {
+                    self.release_scroll = self.release_scroll.saturating_sub(1);
+                    Some(KeyAction::Single(Action::Refresh))
+                }
+                (KeyCode::Char('d'), KeyModifiers::CONTROL) | (KeyCode::PageDown, _) => {
+                    self.release_scroll = self
+                        .release_scroll
+                        .saturating_add(self.release_body_height())
+                        .min(
+                            self.release_lines
+                                .len()
+                                .saturating_sub(self.release_body_height()),
+                        );
+                    Some(KeyAction::Single(Action::Refresh))
+                }
+                (KeyCode::Char('u'), KeyModifiers::CONTROL) | (KeyCode::PageUp, _) => {
+                    self.release_scroll = self
+                        .release_scroll
+                        .saturating_sub(self.release_body_height());
+                    Some(KeyAction::Single(Action::Refresh))
+                }
+                _ => None,
+            },
+        }
+    }
+}
+
+/// Which real-world workflow is being demonstrated without side effects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TutorialDemoKind {
+    /// An entirely synthetic, read-only Git workspace diff.
+    Git,
+    /// A local proposal that changes only the unnamed practice buffer.
+    Agent,
+}
+
+/// Clearly labeled Git or agent demonstration inside the guided tour.
+pub struct TutorialDemoPanel {
+    dialog: Dialog,
+    kind: TutorialDemoKind,
+    theme: Theme,
+}
+
+impl TutorialDemoPanel {
+    /// Creates a safe demonstration without launching Git, Codex, or a shell.
+    #[must_use]
+    pub fn new(editor: &Editor, kind: TutorialDemoKind) -> Self {
+        let viewport_width = editor.vwidth();
+        let viewport_height = editor.vheight();
+        let width = viewport_width.saturating_sub(6).clamp(1, 76);
+        let height = viewport_height.saturating_sub(4).clamp(1, 12);
+        let x = viewport_width.saturating_sub(width + 2) / 2;
+        let y = viewport_height.saturating_sub(height + 2) / 2;
+        let theme = editor.theme.clone();
+        let title = match kind {
+            TutorialDemoKind::Git => "GIT · SAFE PRACTICE DIFF",
+            TutorialDemoKind::Agent => "AGENT · REVIEW REQUIRED",
+        };
+        let mut dialog = Dialog::new(
+            Some(title.to_string()),
+            x,
+            y,
+            width,
+            height,
+            &theme.ui_style.dialog,
+            BorderStyle::Rounded,
+            &theme,
+        )
+        .with_surface_theme(&theme, SurfaceRole::Dialog);
+        let actions = match kind {
+            TutorialDemoKind::Git => vec![UiAction::new("continue", "Esc", "Continue")
+                .with_priority(ActionPriority::Essential)],
+            TutorialDemoKind::Agent => vec![
+                UiAction::new("accept", "a", "Accept practice change")
+                    .with_priority(ActionPriority::Essential),
+                UiAction::new("reject", "r", "Reject").with_priority(ActionPriority::Essential),
+            ],
+        };
+        dialog.set_actions(actions);
+        Self {
+            dialog,
+            kind,
+            theme,
+        }
+    }
+}
+
+impl Component for TutorialDemoPanel {
+    fn draw(&self, buffer: &mut RenderBuffer) -> anyhow::Result<()> {
+        self.dialog.draw(buffer)?;
+        let palette = splash::palette(&self.theme);
+        let lines = match self.kind {
+            TutorialDemoKind::Git => [
+                "  practice/src/prices.rs                         modified",
+                "",
+                "  @@ fn total_price(prices: &[u32]) -> u32 @@",
+                "  -    prices.iter().sum()",
+                "  +    prices.iter().copied().sum()",
+                "",
+                "  Sample only — your repository is unchanged.",
+            ],
+            TutorialDemoKind::Agent => [
+                "  Agent request: Explain and improve total_price.",
+                "",
+                "  PROPOSED CHANGE · NOT APPLIED",
+                "  -    prices.iter().sum()",
+                "  +    prices.iter().copied().sum()",
+                "",
+                "  Accept changes only the unnamed practice buffer.",
+            ],
+        };
+        let width = self.dialog.width.saturating_sub(4);
+        for (offset, line) in lines.iter().enumerate() {
+            if offset >= self.dialog.height.saturating_sub(1) {
+                break;
+            }
+            let role = if line.trim_start().starts_with("+") {
+                Role::Key
+            } else if line.trim_start().starts_with("-") {
+                Role::Dot
+            } else if line.contains("Sample only") || line.contains("Accept changes") {
+                Role::Muted
+            } else {
+                Role::Text
+            };
+            buffer.set_text(
+                self.dialog.x + 2,
+                self.dialog.y + 2 + offset,
+                &truncate_display_width(line, width),
+                palette.style(role),
+            );
+        }
+        Ok(())
+    }
+
+    fn set_theme(&mut self, theme: &Theme) {
+        self.theme = theme.clone();
+        self.dialog.apply_surface_theme(theme, SurfaceRole::Dialog);
+    }
+
+    fn resize(&mut self, viewport_width: usize, viewport_height: usize) -> bool {
+        if viewport_width < 24 || viewport_height < 8 {
+            return false;
+        }
+        self.dialog.width = viewport_width.saturating_sub(6).clamp(1, 76);
+        self.dialog.height = viewport_height.saturating_sub(4).clamp(1, 12);
+        self.dialog.x = viewport_width.saturating_sub(self.dialog.width + 2) / 2;
+        self.dialog.y = viewport_height.saturating_sub(self.dialog.height + 2) / 2;
+        true
+    }
+
+    fn handle_event(&mut self, event: &Event) -> Option<KeyAction> {
+        let Event::Key(key) = event else {
+            return None;
+        };
+        match (self.kind, key.code) {
+            (TutorialDemoKind::Git, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) => {
+                Some(KeyAction::Single(Action::DismissTutorialDemo))
+            }
+            (TutorialDemoKind::Agent, KeyCode::Char('a') | KeyCode::Enter) => {
+                Some(KeyAction::Single(Action::AcceptTutorialProposal))
+            }
+            (TutorialDemoKind::Agent, KeyCode::Esc | KeyCode::Char('r') | KeyCode::Char('q')) => {
+                Some(KeyAction::Single(Action::RejectTutorialProposal))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Paints a nonmodal coach so pickers and real editor actions keep working.
+pub(crate) fn draw_tutorial_coach(
+    buffer: &mut RenderBuffer,
+    theme: &Theme,
+    tutorial: &TutorialController,
+    shortcut: Option<&str>,
+) {
+    let Some(lesson) = tutorial.lesson() else {
+        return;
+    };
+    if buffer.width < 28 || buffer.height < COACH_HEIGHT + 3 {
+        return;
+    }
+    let width = buffer.width.saturating_sub(4).min(96);
+    let x = buffer.width.saturating_sub(width) / 2;
+    let y = buffer.height.saturating_sub(COACH_HEIGHT + 2);
+    let palette = splash::palette(theme);
+    let surface = &theme.ui_style.dialog;
+    let border = &theme.ui_style.dialog_border;
+    buffer.fill_rect(x, y, width, COACH_HEIGHT, ' ', surface, theme);
+    buffer.set_text(x, y, &format!("╭{}╮", "─".repeat(width - 2)), border);
+    buffer.set_text(
+        x,
+        y + COACH_HEIGHT - 1,
+        &format!("╰{}╯", "─".repeat(width - 2)),
+        border,
+    );
+    for row in 1..COACH_HEIGHT - 1 {
+        buffer.set_text(x, y + row, "│", border);
+        buffer.set_text(x + width - 1, y + row, "│", border);
+    }
+
+    let progress = tutorial.progress();
+    let heading = format!(
+        " {}   ·   {}/{} ",
+        lesson.title(),
+        progress.lesson_index + 1,
+        progress.track.lessons().len()
+    );
+    buffer.set_text(
+        x + 2,
+        y,
+        &truncate_display_width(&heading, width.saturating_sub(4)),
+        &theme.ui_style.dialog_title,
+    );
+    let instruction = lesson.instruction(progress.phase, shortcut);
+    buffer.set_text(
+        x + 3,
+        y + 2,
+        &truncate_display_width(&instruction, width.saturating_sub(6)),
+        palette.style(Role::Key),
+    );
+    buffer.set_text(
+        x + 3,
+        y + 3,
+        &truncate_display_width(lesson.explanation(), width.saturating_sub(6)),
+        &theme.ui_style.muted,
+    );
+    buffer.set_text(
+        x + 3,
+        y + 4,
+        &truncate_display_width(":tutorial next  ·  :tutorial quit", width.saturating_sub(6)),
+        &theme.ui_style.muted,
+    );
+}
+
+fn geometry(viewport_width: usize, viewport_height: usize) -> (usize, usize, usize, usize) {
+    let width = viewport_width.saturating_sub(6).clamp(1, MAX_WELCOME_WIDTH);
+    let height = viewport_height
+        .saturating_sub(4)
+        .clamp(1, MAX_WELCOME_HEIGHT);
+    (
+        viewport_width.saturating_sub(width + 2) / 2,
+        viewport_height.saturating_sub(height + 2) / 2,
+        width,
+        height,
+    )
+}
+
+fn embedded_release_notes(version: &str) -> String {
+    let changelog = include_str!("../../CHANGELOG.md");
+    let heading = format!("## [{version}]");
+    let mut lines = changelog.lines();
+    for line in lines.by_ref() {
+        if line.starts_with(&heading) {
+            return lines
+                .take_while(|line| !line.starts_with("## ["))
+                .collect::<Vec<_>>()
+                .join("\n");
+        }
+    }
+    format!(
+        "## Included with Red {version}\n\n- Familiar modal editing\n- Fast file and project search\n- Reviewable agent proposals\n- Built-in Git and language tools"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{buffer::Buffer, config::Config, editor::Editor, lsp::LspManager};
+
+    use super::*;
+
+    fn editor(width: usize, height: usize) -> Editor {
+        let config = Config::default();
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        Editor::with_size(
+            lsp,
+            width,
+            height,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn welcome_renders_brand_choices_and_safe_agent_promise() {
+        let editor = editor(/*width*/ 100, /*height*/ 28);
+        let panel = WelcomePanel::new(&editor, /*can_resume*/ false);
+        let mut buffer = RenderBuffer::new(100, 28, &Style::default());
+
+        panel.draw(&mut buffer).unwrap();
+        let rendered = buffer.dump(false).replace('·', " ");
+        assert!(rendered.contains("WELCOME TO RED"));
+        assert!(rendered.contains("guided tour"));
+        assert!(rendered.contains("What’s new"));
+        assert!(rendered.contains("agent that asks permission"));
+    }
+
+    #[test]
+    fn embedded_notes_are_for_the_installed_version_only() {
+        let notes = embedded_release_notes(env!("CARGO_PKG_VERSION"));
+
+        assert!(notes.contains("### Features") || notes.contains("Included with Red"));
+        assert!(!notes.contains("## [0.4.0]"));
+    }
+
+    #[test]
+    fn agent_preview_clearly_labels_its_side_effect_free_contract() {
+        let editor = editor(/*width*/ 90, /*height*/ 20);
+        let panel = TutorialDemoPanel::new(&editor, TutorialDemoKind::Agent);
+        let mut buffer = RenderBuffer::new(90, 20, &Style::default());
+
+        panel.draw(&mut buffer).unwrap();
+        let rendered = buffer.dump(false).replace('·', " ");
+        assert!(rendered.contains("NOT APPLIED"));
+        assert!(rendered.contains("unnamed practice buffer"));
+    }
+
+    #[test]
+    fn compact_welcome_never_draws_outside_its_viewport() {
+        let editor = editor(/*width*/ 40, /*height*/ 13);
+        let panel = WelcomePanel::new(&editor, /*can_resume*/ true);
+        let mut buffer = RenderBuffer::new(40, 13, &Style::default());
+
+        panel.draw(&mut buffer).unwrap();
+        assert_eq!(buffer.cells.len(), 40 * 13);
+    }
+}


### PR DESCRIPTION
## Why

First-time users should understand Red's editing, navigation, Git, and reviewable-agent workflows before being asked to configure the editor or trust changes to their project. The existing release announcement and Learn Red hub also need to coexist with that first-run experience.

## What changed

- Replace the blocking first-run configuration prompt with a responsive, keyboard-first welcome offering a guided tour, quick tour, release highlights, or immediate editing.
- Add a seven-lesson guided curriculum covering modal editing, command discovery, file/project navigation, completion, Git, agent proposals, and themes, plus a focused three-lesson quick tour.
- Keep practice inside an unnamed, unsavable buffer; simulate Git and agent actions locally, require explicit proposal acceptance or rejection, and restore the original editor layout when the tour ends.
- Persist first-run decisions and resumable tutorial progress, expose `:welcome`, `:tutorial`, and command-palette entries, and retain the existing `:learn` / `:tutorial essentials` workflow.
- Connect release previews to the existing What’s New panel from #201, preserve authenticated detached-session startup, and keep starter configuration explicitly optional and non-destructive.

## How to Test

1. Run `XDG_CONFIG_HOME="$(mktemp -d)" cargo run --` and confirm the first interactive frame presents the welcome screen without creating a config file or forcing a release modal.
2. Start the guided tour and complete editing, command discovery, navigation, completion, Git, agent-review, and theme lessons; verify Git and agent previews are clearly simulated and do not change the repository.
3. From the welcome screen, press `v` for release highlights and then `o`; confirm the existing full What’s New panel opens and the welcome decision is persisted.
4. Run `:tutorial quick`, then attempt to save the practice buffer; verify saving is rejected, `:tutorial quit` restores the original buffer/layout, and `:tutorial resume` restores unfinished progress.
5. Run `:learn` followed by `:tutorial essentials`; verify the existing Learn Red lesson still starts and its contextual `:tutorial restart`, `:tutorial next`, and `:tutorial quit` controls remain intact.
6. Automated validation: `cargo test -p red --lib -- --test-threads=1` (1,955 passed; one intentionally ignored) and `cargo clippy --all-targets --all-features -- -D warnings`.
