### PR TITLE
fix(buffers): toggle between recently used buffers

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -410,7 +410,7 @@ Esc = { EnterMode = "Normal" }
 "X" = "ClearInlineComments"
 "v" = "ShowInlineComment"
 "x" = "DismissInlineComment"
-" " = "NextBuffer"
+" " = "AlternateBuffer"
 "a" = [ "MoveToTop", { EnterMode = "VisualLine" }, "MoveToBottom" ]
 "A" = { PluginCommand = "Agent" }
 "i" = "InlineAssist"

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -223,7 +223,8 @@ The command palette includes descriptions, effective keymaps, and accepted
 - `Ctrl-w z` maximizes the focused window or docked pane; press it again to
   restore the layout. Moving focus or changing the layout restores it first.
   The same chord zooms the focused file-list or diff pane in Git workspaces.
-- `Space Space`, `Space n`, and `Space p` move through buffers.
+- `Space Space` toggles between your two most recently used buffers.
+- `Space n` and `Space p` move through the buffer list in order.
 
 ## Command mode
 

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -573,6 +573,15 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Action::FilePicker,
         ),
         builtin(
+            "buffer.alternate",
+            "Alternate buffer",
+            "Buffer",
+            "Switch to the most recently used buffer",
+            None,
+            &["recent buffer", "last buffer", "toggle buffer"],
+            Action::AlternateBuffer,
+        ),
+        builtin(
             "buffer.next",
             "Next buffer",
             "Buffer",
@@ -1382,6 +1391,7 @@ fn action_label(action: &Action) -> String {
         Action::SwapPreviousParameter => "Swap with previous parameter".to_string(),
         Action::SwapNextFunction => "Swap with next function".to_string(),
         Action::SwapPreviousFunction => "Swap with previous function".to_string(),
+        Action::AlternateBuffer => "Alternate buffer".to_string(),
         Action::NextBuffer => "Next buffer".to_string(),
         Action::PreviousBuffer => "Previous buffer".to_string(),
         Action::FilePicker => "Find file".to_string(),
@@ -1504,6 +1514,20 @@ mod tests {
         let config: crate::config::Config =
             toml::from_str(include_str!("../default_config.toml")).unwrap();
         config.keys
+    }
+
+    #[test]
+    fn palette_distinguishes_alternate_and_sequential_buffer_shortcuts() {
+        let entries = entries(&default_keys(), &[]);
+        for (id, action, shortcut) in [
+            ("buffer.alternate", Action::AlternateBuffer, "Space Space"),
+            ("buffer.next", Action::NextBuffer, "Space n"),
+            ("buffer.previous", Action::PreviousBuffer, "Space p"),
+        ] {
+            let entry = entries.iter().find(|entry| entry.id == id).unwrap();
+            assert_eq!(entry.action, action);
+            assert_eq!(entry.shortcuts, vec![shortcut]);
+        }
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2479,6 +2479,8 @@ pub enum Action {
 
     NextBuffer,
     PreviousBuffer,
+    /// Switches to the most recently used other buffer.
+    AlternateBuffer,
     DeleteBuffer(bool),
     FilePicker,
     CommandPalette,
@@ -19442,6 +19444,11 @@ impl Editor {
                 };
                 self.set_current_buffer(buffer, new_index).await?;
             }
+            Action::AlternateBuffer => {
+                if let Some(index) = self.buffer_manager.alternate_index() {
+                    self.set_current_buffer(buffer, index).await?;
+                }
+            }
             Action::OpenBuffer(name) => {
                 if let Some(index) = self.buffer_manager.iter().position(|b| b.name() == *name) {
                     self.set_current_buffer(buffer, index).await?;
@@ -20713,6 +20720,7 @@ impl Editor {
                 | Action::SplitVerticalWithFile(_)
                 | Action::NextBuffer
                 | Action::PreviousBuffer
+                | Action::AlternateBuffer
         )
     }
 
@@ -21757,8 +21765,8 @@ impl Editor {
         self.lsp_coordinator.forget_buffer(removed_id);
 
         if self.buffer_manager.len() == 1 {
-            self.buffer_manager[0] = Buffer::new(None, String::new());
-            self.buffer_manager.set_active_index(0);
+            self.buffer_manager
+                .replace_buffers(vec![Buffer::new(None, String::new())]);
             self.cx = 0;
             self.cy = 0;
             self.vtop = 0;
@@ -25644,7 +25652,7 @@ impl Editor {
         let previous = self.buffer_manager.active_index();
         self.buffer_manager[previous].pos = (self.cx, self.cy);
         self.buffer_manager[previous].vtop = self.vtop;
-        self.buffer_manager.set_active_index(index);
+        self.buffer_manager.set_active_index_without_history(index);
         (self.cx, self.cy) = self.buffer_manager[index].pos;
         self.vtop = self.buffer_manager[index].vtop;
         self.vleft = 0;
@@ -27814,6 +27822,119 @@ mod test {
         editor.set_default_register(Content::charwise("o\nt\nt\nf\n".to_string()));
 
         assert_eq!(copied.lock().unwrap().as_deref(), Some("o\nt\nt\nf\n"));
+    }
+
+    #[tokio::test]
+    async fn space_space_toggles_recent_buffers_without_changing_sequential_navigation() {
+        let mut editor = test_editor(80, 24);
+        editor.config.keys = toml::from_str::<Config>(include_str!("../default_config.toml"))
+            .unwrap()
+            .keys;
+        editor.buffer_manager.push_buffer(Buffer::new(
+            Some("second".to_string()),
+            "second".to_string(),
+        ));
+        editor
+            .buffer_manager
+            .push_buffer(Buffer::new(Some("third".to_string()), "third".to_string()));
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+
+        for (chord, expected) in [
+            ("  ", 0), // No previous visit yet.
+            (" n", 1),
+            (" n", 2),
+            ("  ", 1),
+            ("  ", 2),
+            ("  ", 1),
+            (" p", 0),
+            ("  ", 1),
+            ("  ", 0),
+        ] {
+            for key in chord.chars() {
+                editor
+                    .process_editor_event(
+                        Event::Key(KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)),
+                        &mut buffer,
+                        &mut runtime,
+                        EventRenderMode::Immediate,
+                    )
+                    .await
+                    .unwrap();
+            }
+            assert_eq!(
+                editor.buffer_manager.active_index(),
+                expected,
+                "chord {chord:?}"
+            );
+        }
+
+        editor
+            .execute(
+                &Action::OpenBuffer("third".to_string()),
+                &mut buffer,
+                &mut runtime,
+            )
+            .await
+            .unwrap();
+        editor
+            .execute(&Action::AlternateBuffer, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.buffer_manager.active_index(), 0);
+
+        editor.select_buffer_for_lsp_edit(1);
+        editor.select_buffer_for_lsp_edit(0);
+        editor
+            .execute(&Action::AlternateBuffer, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.buffer_manager.active_index(), 2);
+
+        editor
+            .execute(&Action::DeleteBuffer(false), &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.buffer_manager.active_index(), 1);
+        editor
+            .execute(&Action::AlternateBuffer, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.buffer_manager.active_index(), 0);
+    }
+
+    #[tokio::test]
+    async fn alternate_buffer_tracks_window_focus() {
+        let mut editor = test_editor(80, 24);
+        editor.buffer_manager.push_buffer(Buffer::new(
+            Some("second".to_string()),
+            "second".to_string(),
+        ));
+        editor
+            .buffer_manager
+            .push_buffer(Buffer::new(Some("third".to_string()), "third".to_string()));
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+        let first_window = editor.window_manager.active_window_id();
+        editor
+            .execute(&Action::SplitVertical, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        editor.set_current_buffer(&mut buffer, 1).await.unwrap();
+        editor.set_current_buffer(&mut buffer, 2).await.unwrap();
+
+        assert!(editor.set_active_window(first_window));
+        assert_eq!(editor.buffer_manager.active_index(), 0);
+        editor
+            .execute(&Action::AlternateBuffer, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.buffer_manager.active_index(), 2);
+        editor
+            .execute(&Action::AlternateBuffer, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.buffer_manager.active_index(), 0);
     }
 
     #[tokio::test]

--- a/src/editor/buffer_manager.rs
+++ b/src/editor/buffer_manager.rs
@@ -1,6 +1,6 @@
 //! Buffer state and active tab management for the Red editor.
 
-use crate::buffer::Buffer;
+use crate::buffer::{Buffer, BufferId};
 use std::ops::{Deref, DerefMut};
 
 /// Encapsulates the open buffer list and active buffer selection.
@@ -8,6 +8,8 @@ use std::ops::{Deref, DerefMut};
 pub struct BufferManager {
     buffers: Vec<Buffer>,
     current_index: usize,
+    /// Visited buffers, oldest first. IDs survive buffer-list compaction.
+    recent_buffers: Vec<BufferId>,
 }
 
 impl Default for BufferManager {
@@ -19,17 +21,16 @@ impl Default for BufferManager {
 impl BufferManager {
     /// Creates a new, empty BufferManager.
     pub fn new() -> Self {
-        Self {
-            buffers: Vec::new(),
-            current_index: 0,
-        }
+        Self::with_buffers(Vec::new())
     }
 
     /// Creates a BufferManager with an initial set of buffers.
     pub fn with_buffers(buffers: Vec<Buffer>) -> Self {
+        let recent_buffers = buffers.first().map(Buffer::id).into_iter().collect();
         Self {
             buffers,
             current_index: 0,
+            recent_buffers,
         }
     }
 
@@ -48,14 +49,38 @@ impl BufferManager {
         self.current_index
     }
 
-    /// Sets the active buffer index, clamping to valid bounds.
+    /// Selects a buffer and records it as most recently used.
     pub fn set_active_index(&mut self, index: usize) -> usize {
-        if self.buffers.is_empty() {
-            self.current_index = 0;
-        } else {
-            self.current_index = index.min(self.buffers.len() - 1);
-        }
+        self.set_active_index_without_history(index);
+        self.record_active_buffer();
         self.current_index
+    }
+
+    /// Temporarily selects a buffer for background edits, without recording a visit.
+    pub fn set_active_index_without_history(&mut self, index: usize) -> usize {
+        self.current_index = index;
+        self.clamp_active_index();
+        self.current_index
+    }
+
+    /// Finds the most recently visited open buffer other than the active buffer.
+    pub fn alternate_index(&self) -> Option<usize> {
+        let active_id = self.active_buffer()?.id();
+        self.recent_buffers.iter().rev().find_map(|id| {
+            (*id != active_id)
+                .then(|| self.buffers.iter().position(|buffer| buffer.id() == *id))
+                .flatten()
+        })
+    }
+
+    fn record_active_buffer(&mut self) {
+        let Some(id) = self.active_buffer().map(Buffer::id) else {
+            return;
+        };
+        if self.recent_buffers.last() != Some(&id) {
+            self.recent_buffers.retain(|recent| *recent != id);
+            self.recent_buffers.push(id);
+        }
     }
 
     /// Returns the total number of open buffers.
@@ -66,9 +91,8 @@ impl BufferManager {
     /// Adds a buffer and makes it active in editor tests.
     #[cfg(test)]
     pub fn add_buffer(&mut self, buffer: Buffer) -> usize {
-        self.buffers.push(buffer);
-        self.current_index = self.buffers.len() - 1;
-        self.current_index
+        self.push_buffer(buffer);
+        self.set_active_index(self.buffers.len() - 1)
     }
 
     /// Appends a buffer without changing the active selection.
@@ -78,22 +102,25 @@ impl BufferManager {
 
     /// Removes and returns the last buffer while keeping selection in bounds.
     pub fn pop_buffer(&mut self) -> Option<Buffer> {
-        let removed = self.buffers.pop();
-        self.clamp_active_index();
-        removed
+        let index = self.buffers.len().checked_sub(1)?;
+        Some(self.remove_buffer(index))
     }
 
     /// Removes a buffer by index while keeping selection in bounds.
     pub fn remove_buffer(&mut self, index: usize) -> Buffer {
         let removed = self.buffers.remove(index);
+        self.recent_buffers.retain(|id| *id != removed.id());
+        if index < self.current_index {
+            self.current_index -= 1;
+        }
         self.clamp_active_index();
+        self.record_active_buffer();
         removed
     }
 
     /// Replaces every open buffer and resets selection to the first buffer.
     pub fn replace_buffers(&mut self, buffers: Vec<Buffer>) {
-        self.buffers = buffers;
-        self.current_index = 0;
+        *self = Self::with_buffers(buffers);
     }
 
     fn clamp_active_index(&mut self) {
@@ -126,6 +153,66 @@ mod tests {
 
     fn buffer(name: &str) -> Buffer {
         Buffer::new(Some(name.to_string()), String::new())
+    }
+
+    #[test]
+    fn alternate_buffer_toggles_only_the_two_latest_visits() {
+        let mut manager = BufferManager::with_buffers(vec![buffer("a"), buffer("b"), buffer("c")]);
+        assert_eq!(manager.alternate_index(), None);
+        manager.set_active_index(1);
+        manager.set_active_index(2);
+        manager.set_active_index(2);
+
+        for expected in [1, 2, 1, 2] {
+            assert_eq!(manager.alternate_index(), Some(expected));
+            manager.set_active_index(expected);
+        }
+
+        manager.set_active_index(0);
+        assert_eq!(manager.alternate_index(), Some(2));
+    }
+
+    #[test]
+    fn alternate_buffer_survives_removal_and_falls_back_to_older_visits() {
+        let mut manager =
+            BufferManager::with_buffers(vec![buffer("a"), buffer("b"), buffer("c"), buffer("d")]);
+        for index in [2, 1, 3] {
+            manager.set_active_index(index);
+        }
+
+        manager.remove_buffer(1);
+        assert_eq!(manager.active_buffer().unwrap().name(), "d");
+        assert_eq!(manager.alternate_index(), Some(1));
+        manager.set_active_index(1);
+        assert_eq!(manager.active_buffer().unwrap().name(), "c");
+        assert_eq!(manager.alternate_index(), Some(2));
+
+        manager.pop_buffer();
+        assert_eq!(manager.active_buffer().unwrap().name(), "c");
+        assert_eq!(manager.alternate_index(), Some(0));
+        manager.remove_buffer(1);
+        assert_eq!(manager.active_buffer().unwrap().name(), "a");
+        assert_eq!(manager.alternate_index(), None);
+    }
+
+    #[test]
+    fn alternate_buffer_ignores_temporary_edits_and_resets_with_buffers() {
+        let mut manager = BufferManager::new();
+        assert_eq!(manager.alternate_index(), None);
+        manager.add_buffer(buffer("a"));
+        assert_eq!(manager.alternate_index(), None);
+        manager.add_buffer(buffer("b"));
+        manager.push_buffer(buffer("c"));
+        manager.set_active_index_without_history(2);
+        manager.set_active_index_without_history(1);
+        assert_eq!(manager.alternate_index(), Some(0));
+
+        manager.replace_buffers(vec![buffer("d"), buffer("e")]);
+        assert_eq!(manager.alternate_index(), None);
+        manager.set_active_index(1);
+        assert_eq!(manager.alternate_index(), Some(0));
+        manager.replace_buffers(Vec::new());
+        assert_eq!(manager.alternate_index(), None);
     }
 
     #[test]

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -236,6 +236,7 @@ mod tests {
             Action::SaveAs("outside.rs".into()),
             Action::OpenFile("outside.rs".into()),
             Action::NextBuffer,
+            Action::AlternateBuffer,
             Action::PluginCommand("Agent".into()),
             Action::InlineAssist,
         ] {


### PR DESCRIPTION
`Space Space` currently shares the `NextBuffer` action with `Space n`, so it cycles through every open buffer instead of returning to the last one used.

This adds an `AlternateBuffer` action and maps `Space Space` to it. Buffer history uses stable IDs, follows explicit navigation and window focus, and skips closed buffers. Temporary selections made for LSP edits do not change that history. `Space n` and `Space p` keep their existing sequential behavior. The command palette and getting-started guide describe the new shortcut.

## How to Test

1. Open three buffers, then visit them in order with `Space n`. From the third buffer, press `Space Space` repeatedly. It should alternate between the second and third buffers without returning to the first.
2. Use `Space p` to visit another buffer, then press `Space Space`. It should return to the buffer you just left. Verify that `Space n` and `Space p` still traverse the buffer list in order.
3. Close one of the recently visited buffers with `:bd`, then use `Space Space`. It should switch only to a remaining, previously visited buffer. With no other visited buffer, the shortcut should do nothing.
4. Run `cargo test --lib buffer`. The regression tests cover the actual key chord, window focus, buffer removal, temporary LSP selections, and command-palette shortcuts.

Local validation at `2fcfc72`: all 138 buffer-related tests passed; the full library rerun passed with 1,943 tests passed and one ignored; formatting and `cargo clippy --all-targets --all-features -- -D warnings` passed. One format-on-save test failed on a missing temporary output file during the first full run, then passed both in isolation and in the full rerun.
