### PR TITLE
fix(copilot): persist enablement across restarts

### DIFF
--- a/almanac/guides/agent/copilot-completion.md
+++ b/almanac/guides/agent/copilot-completion.md
@@ -41,7 +41,12 @@ max_file_bytes = 262144
 excluded_patterns = [".env", ".env.*", "*.pem", "*.key", "**/.git/**"]
 ```
 
-Alternatively, use `:Copilot enable` to opt in for the current editor session.
+Alternatively, use `:Copilot enable` to opt in. Red saves `enabled = true` in
+your user configuration so the choice survives restarts. Confirming “Enable
+and sign in” through `:Copilot signin` saves the same choice before starting
+authentication. `:Copilot disable` saves `enabled = false`; `:Copilot signout`
+signs out without changing the enablement setting. If the configuration cannot
+be saved, Red applies the choice only to the current session and shows a warning.
 Type `:Copilot ` and press `Tab` to cycle through subcommands, or complete a
 prefix such as `:Copilot en`. `Shift-Tab` cycles backward. Completion does not
 enable Copilot or start authentication.
@@ -71,10 +76,10 @@ configured `copilot-language-server` can be found [@editor] [@preferences].
 Displaying the hint records `copilot_setup_hint_seen` in preferences before the
 bridge starts. Running `:Copilot signin`, `:Copilot enable`, or
 `:Copilot disable` also records the hint as seen [@editor] [@preferences].
-This means the hint is onboarding state, not Copilot enablement state. A user
-can acknowledge the setup flow, reopen Red, and still have Copilot disabled if
-they only used session-level enablement rather than changing `[copilot].enabled`
-in configuration [@defaults] [@editor].
+The hint is onboarding state, not consent or authentication state. Detecting
+an installed server never enables it. Explicit enablement is remembered in
+`[copilot].enabled`, independently of whether authentication succeeds. Red
+leaves credential management to the language server [@defaults] [@editor].
 
 The sign-in flow keeps the device-code dialog open after Red sends
 `github.copilot.finishDeviceFlow` to the language server. Red copies the code to

--- a/default_config.toml
+++ b/default_config.toml
@@ -105,6 +105,7 @@ show_documentation = true
 [copilot]
 # Opt in before any source code is sent to GitHub Copilot. Install the official
 # @github/copilot-language-server separately, then use :Copilot signin.
+# :Copilot enable, disable, and confirmed sign-in save this setting.
 enabled = false
 command = "copilot-language-server"
 args = ["--stdio"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1743,6 +1743,40 @@ impl Config {
         Ok(())
     }
 
+    /// Saves Copilot consent without replacing unrelated settings or a config symlink.
+    pub(crate) fn persist_copilot_enabled(path: &Path, enabled: bool) -> anyhow::Result<()> {
+        use std::io::Write;
+
+        let target = match fs::symlink_metadata(path) {
+            Ok(_) => fs::canonicalize(path)?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => path.to_path_buf(),
+            Err(error) => return Err(error.into()),
+        };
+        let contents = match fs::read_to_string(&target) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
+            Err(error) => return Err(error.into()),
+        };
+        let updated = update_copilot_config_contents(&contents, enabled)?;
+        if updated == contents {
+            return Ok(());
+        }
+        let parent = target
+            .parent()
+            .filter(|path| !path.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        fs::create_dir_all(parent)?;
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        if let Ok(metadata) = fs::metadata(&target) {
+            temporary
+                .as_file()
+                .set_permissions(metadata.permissions())?;
+        }
+        temporary.write_all(updated.as_bytes())?;
+        temporary.persist(&target)?;
+        Ok(())
+    }
+
     /// Resolves a plugin path or bundled-plugin specifier for runtime loading.
     pub fn resolve_plugin_path(configured_path: &str) -> String {
         let configured = PathBuf::from(configured_path);
@@ -2696,6 +2730,32 @@ fn update_statusline_config_contents(
     Ok(document.to_string())
 }
 
+fn update_copilot_config_contents(contents: &str, enabled: bool) -> anyhow::Result<String> {
+    use anyhow::Context;
+    use toml_edit::{DocumentMut, Item, Table, Value};
+
+    let mut document = contents
+        .parse::<DocumentMut>()
+        .context("could not update config.toml")?;
+    if !document.contains_key("copilot") {
+        document["copilot"] = Item::Table(Table::new());
+    }
+    let table = document["copilot"]
+        .as_table_like_mut()
+        .context("could not update config.toml: copilot is not a table")?;
+    if let Some(item) = table.get_mut("enabled") {
+        let value = item
+            .as_value_mut()
+            .context("could not update config.toml: copilot.enabled is not a value")?;
+        let mut replacement = Value::from(enabled);
+        *replacement.decor_mut() = value.decor().clone();
+        *value = replacement;
+    } else {
+        table.insert("enabled", toml_edit::value(enabled));
+    }
+    Ok(document.to_string())
+}
+
 fn is_theme_assignment(line: &str) -> bool {
     let line = line.trim_start();
     if line.starts_with('#') {
@@ -3176,6 +3236,103 @@ color = false
                 .unwrap_err();
 
         assert!(error.to_string().contains("could not update config.toml"));
+    }
+
+    #[test]
+    fn update_copilot_config_preserves_other_settings_and_comments() {
+        let contents = "# user settings\ntheme = 'mocha.json'\n\n[copilot] # provider\n# consent\nenabled = false # remembered\ncommand = 'custom-copilot'\nargs = ['--stdio']\n\n[keys.normal]\n'x' = 'DeleteChar'\n";
+        let updated = update_copilot_config_contents(contents, true).unwrap();
+        assert_eq!(
+            updated,
+            contents.replacen("enabled = false", "enabled = true", 1)
+        );
+        assert_eq!(
+            update_copilot_config_contents(&updated, false).unwrap(),
+            contents
+        );
+    }
+
+    #[test]
+    fn update_copilot_config_supports_missing_inline_and_dotted_tables() {
+        for contents in [
+            "",
+            "theme = 'mocha.json'\n",
+            "[copilot]\ncommand = 'custom-copilot'\n",
+            "copilot = { enabled = false, command = 'custom-copilot' }\n",
+            "copilot.enabled = false\ncopilot.command = 'custom-copilot'\n",
+        ] {
+            let updated = update_copilot_config_contents(contents, true).unwrap();
+            let config = Config::from_user_toml_with_overrides(&updated, &[]).unwrap();
+            assert!(config.copilot.enabled, "{updated}");
+            if contents.contains("custom-copilot") {
+                assert_eq!(config.copilot.command, "custom-copilot");
+            }
+            assert_eq!(
+                update_copilot_config_contents(&updated, true).unwrap(),
+                updated
+            );
+        }
+    }
+
+    #[test]
+    fn persist_copilot_config_creates_and_reloads_user_setting() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("red/config.toml");
+        for enabled in [true, false] {
+            Config::persist_copilot_enabled(&path, enabled).unwrap();
+            assert_eq!(
+                Config::load_user_file(&path, &[])
+                    .unwrap()
+                    .config
+                    .copilot
+                    .enabled,
+                enabled
+            );
+        }
+    }
+
+    #[test]
+    fn persist_copilot_config_leaves_invalid_files_untouched() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("config.toml");
+        for contents in [
+            "[copilot\n",
+            "copilot = 42\n",
+            "[copilot.enabled]\nvalue = true\n",
+        ] {
+            fs::write(&path, contents).unwrap();
+            assert!(Config::persist_copilot_enabled(&path, true).is_err());
+            assert_eq!(fs::read_to_string(&path).unwrap(), contents);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persist_copilot_config_preserves_symlinks_and_permissions() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("dotfiles.toml");
+        let path = directory.path().join("config.toml");
+        fs::write(&target, "[copilot]\nenabled = false\n").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o640)).unwrap();
+        symlink(&target, &path).unwrap();
+        Config::persist_copilot_enabled(&path, true).unwrap();
+        assert!(fs::symlink_metadata(&path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(
+            Config::load_user_file(&target, &[])
+                .unwrap()
+                .config
+                .copilot
+                .enabled
+        );
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
     }
 
     #[test]

--- a/src/editor/inline_completion.rs
+++ b/src/editor/inline_completion.rs
@@ -265,7 +265,7 @@ impl Editor {
         self.current_dialog = Some(Box::new(Confirmation::new_actions(
             self,
             "Enable GitHub Copilot?",
-            "Eligible source files may be sent to GitHub for inline suggestions. Copilot will be enabled for this session.",
+            "Eligible source files may be sent to GitHub for inline suggestions. Red will remember that Copilot is enabled.",
             "Enable and sign in",
             "Cancel",
             Action::CopilotEnableAndSignIn,
@@ -274,11 +274,40 @@ impl Editor {
     }
 
     pub(super) fn enable_and_sign_in_copilot(&mut self) {
-        self.inline_completion.enabled_override = Some(true);
+        if self.config.disable_ai {
+            self.set_legacy_message(Some("Copilot is disabled by disable_ai = true".into()));
+            return;
+        }
+        let saved = self.set_copilot_enabled(true);
         self.inline_completion.failed = false;
         if self.ensure_copilot() {
             self.set_legacy_message(Some("Contacting GitHub Copilot...".into()));
             self.copilot_control(Control::SignIn);
+        }
+        self.report_copilot_save_error(true, saved);
+    }
+
+    fn set_copilot_enabled(&mut self, enabled: bool) -> anyhow::Result<()> {
+        self.mark_copilot_setup_hint_seen();
+        self.inline_completion.enabled_override = Some(enabled);
+        anyhow::ensure!(
+            self.preferences.is_persistent(),
+            "no persistent user configuration"
+        );
+        Config::persist_copilot_enabled(&self.language_config_path, enabled)?;
+        self.config.copilot.enabled = enabled;
+        Ok(())
+    }
+
+    fn report_copilot_save_error(&mut self, enabled: bool, saved: anyhow::Result<()>) {
+        if let Err(error) = saved {
+            let state = if enabled { "enabled" } else { "disabled" };
+            self.set_notification_message(
+                Severity::Warning,
+                Some(format!(
+                    "Copilot {state} for this session only; couldn't save configuration: {error:#}"
+                )),
+            );
         }
     }
 
@@ -306,33 +335,30 @@ impl Editor {
                     ));
                     return;
                 }
-                self.mark_copilot_setup_hint_seen();
-                self.inline_completion.enabled_override = Some(true);
+                let saved = self.set_copilot_enabled(true);
                 self.inline_completion.failed = false;
                 self.ensure_copilot();
                 self.set_legacy_message(Some(
-                    "Copilot enabled for this session; eligible source files may be sent to GitHub"
-                        .into(),
+                    "Copilot enabled; eligible source files may be sent to GitHub".into(),
                 ));
+                self.report_copilot_save_error(true, saved);
             }
             Some(CopilotCommand::Disable) => {
-                self.mark_copilot_setup_hint_seen();
+                let saved = self.set_copilot_enabled(false);
                 self.dismiss_inline_completion();
                 if self.inline_completion.sign_in.take().is_some() {
                     self.current_dialog = None;
                 }
-                self.inline_completion.enabled_override = Some(false);
                 self.inline_completion.bridge = None;
                 self.inline_completion.prompts.clear();
                 self.inline_completion.status = "Disabled".into();
                 self.set_legacy_message(Some("Copilot disabled".into()));
+                self.report_copilot_save_error(false, saved);
             }
             Some(CopilotCommand::SignIn) => {
                 self.inline_completion.failed = false;
                 if self.copilot_enabled() {
-                    if self.ensure_copilot() {
-                        self.copilot_control(Control::SignIn);
-                    }
+                    self.enable_and_sign_in_copilot();
                 } else {
                     self.confirm_copilot_sign_in();
                 }
@@ -736,8 +762,12 @@ mod tests {
 
     fn editor(text: &str) -> Editor {
         let mut config = Config::from_user_toml_with_overrides("", &[]).unwrap();
-        config.lsp.enabled = false;
         config.copilot.enabled = true;
+        editor_with_config(text, config)
+    }
+
+    fn editor_with_config(text: &str, mut config: Config) -> Editor {
+        config.lsp.enabled = false;
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
         let file = get_workspace_path()
             .join("src/main.rs")
@@ -755,6 +785,18 @@ mod tests {
         editor.test_disable_terminal_output();
         editor.inline_completion.failed = true;
         editor
+    }
+
+    fn use_temporary_config(editor: &mut Editor, directory: &Path, contents: &str) -> PathBuf {
+        let path = directory.join("config.toml");
+        std::fs::write(&path, contents).unwrap();
+        editor.preferences = PreferencesStore::load(directory.join("preferences.json"));
+        editor.set_language_reload_source(path.clone(), Vec::new());
+        path
+    }
+
+    fn reopen_with_config(path: &Path) -> Editor {
+        editor_with_config("foo", Config::load_user_file(path, &[]).unwrap().config)
     }
 
     async fn show(editor: &mut Editor, text: &str, cursor: usize) {
@@ -927,6 +969,12 @@ mod tests {
     #[tokio::test]
     async fn signin_confirms_consent_then_enables_and_starts_authentication() {
         let mut editor = editor("foo");
+        let directory = tempfile::tempdir().unwrap();
+        let path = use_temporary_config(
+            &mut editor,
+            directory.path(),
+            "[copilot]\nenabled = false\n",
+        );
         editor.config.copilot.enabled = false;
         editor.config.copilot.command = std::env::current_exe()
             .unwrap()
@@ -937,6 +985,7 @@ mod tests {
         editor.handle_copilot_command("signin");
 
         assert!(!editor.copilot_enabled());
+        assert!(!reopen_with_config(&path).copilot_enabled());
         assert!(editor.inline_completion.bridge.is_none());
         assert!(editor.preferences.copilot_setup_hint_seen());
         let dialog = editor.current_dialog.as_mut().unwrap();
@@ -955,7 +1004,7 @@ mod tests {
             ]))
         );
 
-        let (bridge, _requests, mut controls, _events) = Bridge::test_channels();
+        let (bridge, _requests, mut controls, events) = Bridge::test_channels();
         editor.inline_completion.bridge = Some(bridge);
         editor
             .test_execute_action(Action::CopilotEnableAndSignIn)
@@ -968,6 +1017,118 @@ mod tests {
             Some("Contacting GitHub Copilot...")
         );
         assert!(matches!(controls.recv().await, Some(Control::SignIn)));
+        assert!(reopen_with_config(&path).copilot_enabled());
+
+        events
+            .send(CopilotEvent::SignInFinished {
+                error: Some("not authorized".into()),
+            })
+            .await
+            .unwrap();
+        editor.service_inline_completion();
+        assert!(reopen_with_config(&path).copilot_enabled());
+    }
+
+    #[tokio::test]
+    async fn copilot_enable_and_disable_survive_restart() {
+        let mut editor = editor("foo");
+        let directory = tempfile::tempdir().unwrap();
+        let path = use_temporary_config(&mut editor, directory.path(), "# keep me\n");
+        editor.config.copilot.enabled = false;
+        let (bridge, _requests, _controls, _events) = Bridge::test_channels();
+        editor.inline_completion.bridge = Some(bridge);
+
+        editor.handle_copilot_command("enable");
+        assert!(editor.copilot_enabled());
+        assert!(reopen_with_config(&path).copilot_enabled());
+        assert!(std::fs::read_to_string(&path)
+            .unwrap()
+            .contains("# keep me"));
+
+        editor.handle_copilot_command("disable");
+        assert!(!editor.copilot_enabled());
+        assert!(editor.inline_completion.bridge.is_none());
+        assert!(!reopen_with_config(&path).copilot_enabled());
+    }
+
+    #[tokio::test]
+    async fn signin_persists_existing_session_enablement_and_signout_keeps_it() {
+        let mut editor = editor("foo");
+        let directory = tempfile::tempdir().unwrap();
+        let path = use_temporary_config(
+            &mut editor,
+            directory.path(),
+            "[copilot]\nenabled = false\n",
+        );
+        let (bridge, _requests, mut controls, _events) = Bridge::test_channels();
+        editor.inline_completion.bridge = Some(bridge);
+
+        editor.handle_copilot_command("signin");
+        assert!(matches!(controls.recv().await, Some(Control::SignIn)));
+        assert!(reopen_with_config(&path).copilot_enabled());
+        let contents = std::fs::read_to_string(&path).unwrap();
+
+        editor.handle_copilot_command("signout");
+        assert!(matches!(controls.recv().await, Some(Control::SignOut)));
+        assert!(editor.copilot_enabled());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), contents);
+    }
+
+    #[tokio::test]
+    async fn failed_copilot_saves_keep_session_choice_and_warn() {
+        let mut editor = editor("foo");
+        let directory = tempfile::tempdir().unwrap();
+        let contents = "[copilot\n";
+        let path = use_temporary_config(&mut editor, directory.path(), contents);
+        editor.config.copilot.enabled = false;
+        let (bridge, _requests, mut controls, _events) = Bridge::test_channels();
+        editor.inline_completion.bridge = Some(bridge);
+
+        editor.enable_and_sign_in_copilot();
+        assert!(editor.copilot_enabled());
+        assert!(matches!(controls.recv().await, Some(Control::SignIn)));
+        assert!(editor
+            .last_error
+            .as_deref()
+            .unwrap()
+            .starts_with("Copilot enabled for this session only; couldn't save configuration:"));
+        assert!(editor
+            .notifications
+            .records()
+            .any(|notice| notice.severity == Severity::Warning
+                && notice
+                    .content
+                    .summary
+                    .contains("couldn't save configuration")));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), contents);
+
+        editor.handle_copilot_command("disable");
+        assert!(!editor.copilot_enabled());
+        assert!(editor.inline_completion.bridge.is_none());
+        assert!(editor
+            .last_error
+            .as_deref()
+            .unwrap()
+            .starts_with("Copilot disabled for this session only; couldn't save configuration:"));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), contents);
+    }
+
+    #[test]
+    fn global_ai_disable_prevents_persisting_copilot_consent() {
+        let mut editor = editor("foo");
+        let directory = tempfile::tempdir().unwrap();
+        let contents = "disable_ai = true\n[copilot]\nenabled = false\n";
+        let path = use_temporary_config(&mut editor, directory.path(), contents);
+        editor.config.disable_ai = true;
+        editor.config.copilot.enabled = false;
+        for command in ["enable", "signin"] {
+            editor.handle_copilot_command(command);
+            assert!(!editor.copilot_enabled());
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), contents);
+        }
+        editor.enable_and_sign_in_copilot();
+        assert!(!editor.copilot_enabled());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), contents);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Copilot enablement currently lasts only for the editor session. After completing setup, users can restart Red and find Copilot disabled again even though they already consented and signed in.

## What changed

- Save `[copilot].enabled` when the user enables or disables Copilot, or confirms “Enable and sign in.” Authentication failure does not undo consent, and sign-out does not change enablement.
- Update only the relevant TOML setting with an atomic write, preserving unrelated settings, comments, config symlinks, and existing permissions.
- Keep the requested choice active for the current session and show a warning if saving fails. Installed-server detection still does not enable Copilot, and `disable_ai = true` remains authoritative.
- Update the consent dialog and documentation, and add restart, failed-save, authentication, and configuration-preservation regression tests.

## How to Test

1. With the Copilot language server installed and Copilot disabled in user config, run `:Copilot signin` and confirm **Enable and sign in**. Verify that user config now contains `enabled = true` under `[copilot]`. Restart Red and check `:Copilot status`; it should no longer report **Disabled**.
2. Run `:Copilot disable`, restart, and verify that Copilot remains disabled. Re-enable it, then run `:Copilot signout`; the saved enablement setting should remain true.
3. Run `cargo test --lib failed_copilot_saves_keep_session_choice_and_warn`. The regression uses an isolated malformed config and a fake bridge: enable/sign-in must still work for the current session, a warning must be recorded, disable must stop the bridge, and the malformed file must remain untouched.
4. Run `cargo test --lib persist_copilot_config` to cover config creation/reload, invalid-file preservation, and Unix symlink/permission preservation.

### Validation completed

- `cargo test --lib -- --test-threads=1`: 1,946 passed, 1 ignored.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

The tests use temporary config files and fake Copilot channels. A live GitHub authentication smoke test was not run.