### PR TITLE
fix(editor): restore the terminal promptly on quit

### DIFF
--- a/docs/performance-quit-latency-2026-08-18.md
+++ b/docs/performance-quit-latency-2026-08-18.md
@@ -1,0 +1,84 @@
+# Quit latency, 2026-08-18
+
+Baseline: `7a668a4cd812da88d53049f320e5c8dfcc04a09c`. Measurements use
+release builds on macOS, a 100-column PTY, disposable configuration and files,
+the bundled plugins, and disabled AI/LSP. The timer starts when the benchmark
+sends Enter to an already-rendered `:q` command. Screen restoration means the
+PTY received `LeaveAlternateScreen`, not that a physical display painted it.
+Process exit is measured separately. Filesystem and scheduling noise affect the
+results; these are local samples, not a latency guarantee.
+
+## Results
+
+| Build / workload | Runs | Screen median | Screen max | Process median |
+| --- | ---: | ---: | ---: | ---: |
+| Original, 100 lines | 7 | 39.322 ms | 210.427 ms | 40.858 ms |
+| Original plus phase instrumentation, 100 lines | 5 | 15.659 ms | 20.408 ms | 18.689 ms |
+| Cleanup optimizations only, 100 lines | 5 | 19.621 ms | 238.885 ms | 22.510 ms |
+| Early terminal restore, 100 lines | 10 | 1.006 ms | 1.110 ms | 21.687 ms |
+| Original, 100,000 lines | 3 | 25.715 ms | 47.445 ms | 28.766 ms |
+| Early terminal restore, 100,000 lines | 5 | 1.274 ms | 3.135 ms | 30.506 ms |
+| Early terminal restore, 200 exit-hook storage updates | 3 | 1.362 ms | 1.392 ms | 23.408 ms |
+| Final, including deferred quit history, 100 lines | 10 | 0.605 ms | 1.092 ms | 21.556 ms |
+| Final, 100,000 lines | 5 | 0.742 ms | 1.113 ms | 31.715 ms |
+| Final, forced quit after rejected dirty quit | 30 | 0.593 ms | 1.086 ms | 23.114 ms |
+| Final, 200 exit-hook storage updates | 3 | 0.638 ms | 0.730 ms | 19.727 ms |
+| Early restore with synchronous history, 8 MiB preferences | 3 | 6.097 ms | 10.921 ms | 50.735 ms |
+| Final, 8 MiB preferences | 3 | 0.612 ms | 0.696 ms | 29.880 ms |
+
+The instrumented original spent 10.8–16.7 ms persisting its final recovery
+snapshot and about 1.8 ms deactivating plugins. Those writes include the
+existing atomic replacement, file sync, and directory sync. Removing that
+durability would be the wrong tradeoff.
+
+The cleanup-only changes batch plugin preference updates into one write and
+start agent shutdown before doing independent cleanup. A controlled plugin
+issuing 200 storage updates reduced the storage phase from 22.5–47.1 ms to
+0.252–0.291 ms. Snapshot sync still produced a 235 ms outlier, so these
+optimizations alone do not reliably remove the visible pause.
+
+The interactive lifecycle now restores terminal modes before exit hooks,
+recovery persistence, plugin teardown, and external-process waits. It still
+waits for all cleanup before exiting. Repeated terminal cleanup is harmless;
+the detached core does not acquire or restore interactive terminal ownership.
+An event-loop error also reaches service cleanup, and a terminal-restoration
+error does not prevent the recovery snapshot.
+
+## Reproduce
+
+```sh
+cargo build --locked --release --bin red
+python3 scripts/quit_bench.py --binary target/release/red --runs 10
+python3 scripts/quit_bench.py --binary target/release/red --lines 100000
+python3 scripts/quit_bench.py --binary target/release/red --storage-updates 200
+python3 scripts/quit_bench.py --binary target/release/red --preference-kib 8192
+python3 scripts/quit_bench.py --binary target/release/red --dirty
+```
+
+The dirty-buffer scenario verifies that ordinary `:q` stays in the editor,
+`:q!` restores the terminal exactly once, the source file remains unchanged,
+and the final recovery snapshot contains the unsaved edit. `RED_PERF=trace`
+now also records `shutdown:*` phases. The benchmark retains slow spans after
+the final Enter so pre-shutdown delays can be distinguished from cleanup.
+The final harness waits for completed key-event traces rather than relying on
+fixed sleeps between Escape, command entry, and Enter.
+
+Early restoration alone exposed a second pre-shutdown cost. An initial
+dirty-buffer sample included a 405.887 ms outlier; a subsequent 40-run sample
+recorded 278 and 627 ms inside the Enter action. A narrower trace confirmed
+synchronous command-history persistence on that path. With a controlled 8 MiB
+preferences file, this write took 4.4–10.2 ms before restoration could start.
+Quit-bearing commands now update history in memory, then flush it with the
+exit-hook preferences after an accepted quit. Rejected or failed commands
+still save their history before returning. The original outliers remain in
+the evidence; host scheduling and filesystem behavior can still vary.
+
+The final 30-run dirty-buffer sample restored the screen in 0.593 ms median
+and 1.086 ms maximum. Its slowest process exit was 390.667 ms: recovery still
+finishes before exit, but no longer keeps the alternate screen visible.
+
+Validation: the all-targets/all-features Rust suite passed 2,844 tests, with
+one ignored. Strict Clippy, focused
+shutdown-order/error regressions, and a retained tmux walkthrough of clean,
+rejected, and forced quit. Active network-backed AI/LSP shutdown latency is
+not represented by these isolated PTY measurements.

--- a/scripts/quit_bench.py
+++ b/scripts/quit_bench.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Measure Enter-to-screen-restore and Enter-to-process-exit on Unix.
+
+Use --dirty to verify refused/forced quit and recovery, or --storage-updates 200
+to exercise a busy plugin exit hook. All runs use disposable editor state.
+"""
+
+import argparse
+import fcntl
+import json
+import os
+import pty
+import re
+import select
+import statistics
+import struct
+import subprocess
+import tempfile
+import termios
+import time
+from pathlib import Path
+
+LEAVE = b"\x1b[?1049l"
+TIMING = re.compile(r"\[PERF\] ((?:shutdown:|session:snapshot)[^:]*): (\d+)us")
+
+
+def run_once(binary, size, dirty=False, storage_updates=0, preference_kib=0):
+    with tempfile.TemporaryDirectory(prefix="red-quit-bench-") as directory:
+        root = Path(directory)
+        config = root / "red"
+        config.mkdir()
+        if preference_kib:
+            (config / "preferences.json").write_text(
+                json.dumps(
+                    {
+                        "plugin_storage": {
+                            "quit_bench:payload": "x" * (preference_kib * 1024)
+                        }
+                    }
+                )
+            )
+        log = root / "red.log"
+        extra_config = ""
+        if storage_updates:
+            plugin = root / "quit_bench.hk"
+            plugin.write_text(
+                '#[red::lifecycle("before_exit")]\nfn before_exit(snapshot: Json) {\n'
+                + "".join(
+                    f'    red::execute("SetStorage", "key-{i}", "quit-bench-value-{i}");\n'
+                    for i in range(storage_updates)
+                )
+                + "}\n"
+            )
+            extra_config = f"\n[plugins]\nquit_bench = {json.dumps(str(plugin))}\n"
+        (config / "config.toml").write_text(
+            f"log_file = {json.dumps(str(log))}\nshow_whats_new = false\n"
+            "disable_ai = true\n[lsp]\nenabled = false\n" + extra_config
+        )
+        source = root / "fixture.txt"
+        source.write_text("quit latency fixture\n" * size)
+        master, slave = pty.openpty()
+        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 32, 100, 0, 0))
+        process = subprocess.Popen(
+            [str(binary), "--root", str(root), str(source)],
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            close_fds=True,
+            env=dict(
+                os.environ,
+                TERM="xterm-256color",
+                RED_PERF="trace",
+                XDG_CONFIG_HOME=str(root),
+            ),
+        )
+        output = bytearray()
+
+        def drain(wait=0.02):
+            if select.select([master], [], [], wait)[0]:
+                try:
+                    output.extend(os.read(master, 1 << 20))
+                except OSError:
+                    pass
+
+        def wait_until(predicate, timeout=30):
+            deadline = time.monotonic() + timeout
+            while not predicate():
+                if time.monotonic() >= deadline:
+                    raise RuntimeError("timed out: " + repr(bytes(output[-300:])))
+                if process.poll() is not None:
+                    raise RuntimeError(
+                        f"editor exited early ({process.returncode}): {bytes(output[-300:])!r}"
+                    )
+                drain()
+
+        def settle(seconds=0.10):
+            deadline = time.monotonic() + seconds
+            while time.monotonic() < deadline:
+                drain(min(0.01, max(0, deadline - time.monotonic())))
+
+        def send_and_wait(keys, code):
+            marker = "[BENCH] input\n"
+            with log.open("a") as stream:
+                stream.write(marker)
+            os.write(master, keys)
+            wait_until(
+                lambda: (
+                    f"event Key(KeyEvent {{ code: {code},"
+                    in log.read_text(errors="replace").rsplit(marker, 1)[-1]
+                )
+            )
+
+        try:
+            wait_until(
+                lambda: (
+                    log.exists()
+                    and "[PERF] startup:interactive:" in log.read_text(errors="replace")
+                )
+            )
+            settle()
+            if dirty:
+                output.clear()
+                os.write(master, b"iUNSAVED-QUIT-MARKER")
+                output.clear()
+                send_and_wait(b"\x1b", "Esc")
+                send_and_wait(b":q", "Char('q')")
+                os.write(master, b"\r")
+                # Differential rendering may move the cursor between words.
+                wait_until(lambda: b"unwritten" in output and b"changes:" in output)
+                assert LEAVE not in output, "rejected quit left alternate screen"
+                assert process.poll() is None, "rejected quit exited"
+            output.clear()
+            send_and_wait(
+                b":q!" if dirty else b":q", "Char('!')" if dirty else "Char('q')"
+            )
+            output.clear()
+            with log.open("a") as stream:
+                stream.write("[BENCH] quit\n")
+            started = time.monotonic_ns()
+            os.write(master, b"\r")
+            restored = None
+            deadline = time.monotonic() + 30
+            while process.poll() is None:
+                drain(0.001)
+                if restored is None and LEAVE in output:
+                    restored = time.monotonic_ns()
+                if time.monotonic() > deadline:
+                    raise RuntimeError("quit timed out")
+            exited = time.monotonic_ns()
+            drain(0)
+            if restored is None and LEAVE in output:
+                restored = time.monotonic_ns()
+            assert process.returncode == 0, f"exit status {process.returncode}"
+            assert restored is not None, "missing alternate-screen restore"
+            assert output.count(LEAVE) == 1, "terminal restored more than once"
+            modes = termios.tcgetattr(slave)
+            assert modes[3] & termios.ICANON and modes[3] & termios.ECHO, (
+                "raw mode was not restored"
+            )
+            if dirty:
+                assert "UNSAVED-QUIT-MARKER" not in source.read_text(), (
+                    "forced quit overwrote source"
+                )
+                assert any(
+                    "UNSAVED-QUIT-MARKER" in p.read_text(errors="replace")
+                    for p in (config / "sessions").rglob("*.json")
+                ), "recovery snapshot lost edit"
+            preferences = json.loads((config / "preferences.json").read_text())
+            assert preferences["command_history"][-1] == ("q!" if dirty else "q"), (
+                "quit command history was not persisted"
+            )
+            if storage_updates:
+                assert (
+                    f"quit-bench-value-{storage_updates - 1}"
+                    in preferences["plugin_storage"].values()
+                ), "exit-hook storage was not persisted"
+            return {
+                "screen_ms": round((restored - started) / 1e6, 3),
+                "exit_ms": round((exited - started) / 1e6, 3),
+                "leave_count": output.count(LEAVE),
+                "dirty_guard": dirty,
+                "timings_us": {
+                    label: int(micros)
+                    for label, micros in TIMING.findall(log.read_text(errors="replace"))
+                },
+                "quit_timings_us": {
+                    label: int(micros)
+                    for label, micros in re.findall(
+                        r"\[PERF\] (.*): (\d+)us",
+                        log.read_text(errors="replace").rsplit("[BENCH] quit\n", 1)[-1],
+                    )
+                    if int(micros) >= 1000 and not label.startswith("timing ")
+                },
+            }
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+            os.close(master)
+            os.close(slave)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--runs", type=int, default=7)
+    parser.add_argument("--lines", type=int, default=100)
+    parser.add_argument("--dirty", action="store_true")
+    parser.add_argument("--storage-updates", type=int, default=0)
+    parser.add_argument("--preference-kib", type=int, default=0)
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+    if (
+        args.runs < 1
+        or args.lines < 1
+        or args.storage_updates < 0
+        or args.preference_kib < 0
+    ):
+        parser.error(
+            "runs and lines must be positive; storage-updates and preference-kib must be nonnegative"
+        )
+    results = []
+    for _ in range(args.runs):
+        results.append(
+            run_once(
+                args.binary.resolve(),
+                args.lines,
+                args.dirty,
+                args.storage_updates,
+                args.preference_kib,
+            )
+        )
+        if args.json:
+            args.json.write_text(json.dumps({"runs": results}, indent=2) + "\n")
+    report = {
+        "binary": str(args.binary.resolve()),
+        "lines": args.lines,
+        "dirty": args.dirty,
+        "storage_updates": args.storage_updates,
+        "preference_kib": args.preference_kib,
+        "runs": results,
+        "summary": {
+            key: {
+                "median": round(statistics.median(r[key] for r in results), 3),
+                "max": max(r[key] for r in results),
+            }
+            for key in ("screen_ms", "exit_ms")
+        },
+    }
+    if args.json:
+        args.json.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3085,6 +3085,9 @@ pub struct Editor {
     /// Keyboard mode owned by this interactive terminal, never by the detached core.
     keyboard_protocol: crate::keyboard::KeyboardProtocol,
 
+    /// Whether this editor still owns terminal modes that need restoring.
+    terminal_active: bool,
+
     /// Whether render operations should write terminal escape sequences
     terminal_output_enabled: bool,
 
@@ -4595,6 +4598,7 @@ impl Editor {
             window_manager,
             stdout,
             keyboard_protocol: crate::keyboard::KeyboardProtocol::default(),
+            terminal_active: false,
             terminal_output_enabled: true,
             #[cfg(test)]
             pending_terminal_cursor: None,
@@ -8662,8 +8666,18 @@ impl Editor {
     /// A Result indicating success or failure of the editor session
     pub async fn run(&mut self) -> anyhow::Result<()> {
         let _perf_session = perf::PerfSession::start();
+        let mut runtime =
+            Runtime::try_new_with_permissions(self.config.plugin_permissions.clone())?;
+        runtime.set_typecheck_enabled(!self.config.disable_plugin_typecheck);
+        let result = self.run_interactive(&mut runtime).await;
+        self.finish_interactive(&mut runtime).await?;
+        result
+    }
+
+    async fn run_interactive(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
         let interactive_startup = perf::PerfSpan::start("startup:interactive");
         terminal::enable_raw_mode()?;
+        self.terminal_active = true;
         self.stdout
             .execute(event::EnableMouseCapture)?
             .execute(event::EnableFocusChange)?
@@ -8681,22 +8695,19 @@ impl Editor {
         // initialization are not lost.
         event::poll(Duration::from_millis(0))?;
 
-        let mut runtime;
         {
             let plugin_startup = perf::PerfSpan::start("startup:plugins");
-            runtime = Runtime::try_new_with_permissions(self.config.plugin_permissions.clone())?;
-            runtime.set_typecheck_enabled(!self.config.disable_plugin_typecheck);
-            self.refresh_plugin_snapshots(&mut runtime, true, true, true)?;
+            self.refresh_plugin_snapshots(runtime, true, true, true)?;
             for (name, path) in &self.config.plugins {
                 let path = Config::resolve_plugin_path(path);
                 self.plugin_registry.add(name, path.as_str());
             }
-            self.plugin_registry.initialize(&mut runtime).await?;
+            self.plugin_registry.initialize(runtime).await?;
             self.plugin_registry
-                .notify(&mut runtime, "editor:ready", json!({}))
+                .notify(runtime, "editor:ready", json!({}))
                 .await?;
-            self.restore_agent_plugin_state(&mut runtime).await?;
-            self.notify_pane_restore_intents(&mut runtime).await?;
+            self.restore_agent_plugin_state(runtime).await?;
+            self.notify_pane_restore_intents(runtime).await?;
             drop(plugin_startup);
         }
 
@@ -8736,7 +8747,7 @@ impl Editor {
                 if self.can_batch_scroll(&ev) {
                     let events = Self::read_scroll_batch(ev, &mut pending_events)?;
                     if self
-                        .process_scroll_batch(events, &mut buffer, &mut runtime)
+                        .process_scroll_batch(events, &mut buffer, runtime)
                         .await?
                     {
                         break 'editor_loop;
@@ -8748,7 +8759,7 @@ impl Editor {
                     .process_editor_event(
                         ev,
                         &mut buffer,
-                        &mut runtime,
+                        runtime,
                         EventRenderMode::CoalescedNavigation,
                     )
                     .await?;
@@ -8768,15 +8779,14 @@ impl Editor {
                                 signature,
                                 &mut pending_events,
                                 &mut buffer,
-                                &mut runtime,
+                                runtime,
                             )
                             .await?
                         {
                             break 'editor_loop;
                         }
                     } else {
-                        self.finish_navigation_batch(&mut buffer, &mut runtime)
-                            .await?;
+                        self.finish_navigation_batch(&mut buffer, runtime).await?;
                     }
                     serviced_background = true;
                     break;
@@ -8790,44 +8800,49 @@ impl Editor {
             if last_terminal_size_reconciliation.elapsed() >= TERMINAL_SIZE_RECONCILE_INTERVAL {
                 last_terminal_size_reconciliation = Instant::now();
                 let observed_size = terminal::size()?;
-                self.reconcile_observed_terminal_size(observed_size, &mut buffer, &mut runtime)
+                self.reconcile_observed_terminal_size(observed_size, &mut buffer, runtime)
                     .await?;
             }
 
             if !serviced_background {
-                self.service_background(&mut buffer, &mut runtime).await?;
+                self.service_background(&mut buffer, runtime).await?;
             }
             if self.persist_session_snapshot(/*force*/ false) {
                 self.render(&mut buffer)?;
             }
         }
 
-        self.shutdown_services(&mut runtime).await;
-
         Ok(())
     }
 
-    async fn shutdown_services(&mut self, runtime: &mut Runtime) {
-        drop(self.agent_manager.take_bridge());
-        if let Some(task) = self.agent_manager.take_task() {
-            match task.await {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => log!("Codex app-server shutdown failed: {error}"),
-                Err(error) => log!("Codex app-server task failed: {error}"),
-            }
-        }
+    async fn finish_interactive(&mut self, runtime: &mut Runtime) -> anyhow::Result<()> {
+        // Quit has been accepted (or the event loop failed). Give the terminal
+        // back before durable writes and external-process shutdown can block.
+        // A restoration error must not skip the final recovery snapshot.
+        let cleanup_result = self.cleanup();
+        self.shutdown_services(runtime).await;
+        cleanup_result
+    }
 
+    async fn shutdown_services(&mut self, runtime: &mut Runtime) {
+        let _shutdown = perf::PerfSpan::start("shutdown:services");
+        // Closing the command channel starts agent shutdown immediately. Its
+        // process can exit while we persist state and deactivate plugins.
+        drop(self.agent_manager.take_bridge());
+        let agent_task = self.agent_manager.take_task();
+        let before_exit = perf::PerfSpan::start("shutdown:before_exit");
         let snapshot = self.editor_state_snapshot();
         if let Err(err) = self.plugin_registry.before_exit(runtime, snapshot).await {
             log!("Plugin beforeExit failed: {}", err);
         }
+        drop(before_exit);
+        let storage = perf::PerfSpan::start("shutdown:plugin_storage");
+        let mut storage_updates = Vec::new();
         while let Some(request) = runtime.try_recv_request() {
             match request {
                 PluginRequest::SetPluginStorage { plugin, key, value } => {
                     let key = scoped_plugin_storage_key(&plugin, &key);
-                    if let Err(err) = self.preferences.set_plugin_storage(&plugin, &key, value) {
-                        log!("Plugin storage flush failed: {}", err);
-                    }
+                    storage_updates.push((plugin, key, value));
                 }
                 request => {
                     log!(
@@ -8837,11 +8852,29 @@ impl Editor {
                 }
             }
         }
+        if let Err(err) = self.preferences.flush_plugin_storage(storage_updates) {
+            log!("Plugin storage flush failed: {}", err);
+        }
+        drop(storage);
+        let snapshot = perf::PerfSpan::start("shutdown:session_snapshot");
         self.persist_session_snapshot(/*force*/ true);
+        drop(snapshot);
+        let deactivate = perf::PerfSpan::start("shutdown:deactivate_plugins");
         if let Err(err) = self.plugin_registry.deactivate_all(runtime).await {
             log!("Plugin deactivate failed: {}", err);
         }
+        drop(deactivate);
+        let companions = perf::PerfSpan::start("shutdown:companions");
         self.companion_manager.lock().await.shutdown().await;
+        drop(companions);
+        let _agent = perf::PerfSpan::start("shutdown:agent_wait");
+        if let Some(task) = agent_task {
+            match task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => log!("Codex app-server shutdown failed: {error}"),
+                Err(error) => log!("Codex app-server task failed: {error}"),
+            }
+        }
     }
 
     fn abort_agent_bridge(&mut self) {
@@ -15150,7 +15183,15 @@ impl Editor {
     }
 
     fn record_command_history(&mut self, command: &str) {
+        let _history = perf::PerfSpan::start("command:history");
         if let Err(error) = self.preferences.record_command(command) {
+            log!("failed to save command history: {error}");
+        }
+    }
+
+    fn flush_command_history(&self) {
+        let _history = perf::PerfSpan::start("command:history_flush");
+        if let Err(error) = self.preferences.save() {
             log!("failed to save command history: {error}");
         }
     }
@@ -16820,12 +16861,17 @@ impl Editor {
     }
 
     pub fn cleanup(&mut self) -> anyhow::Result<()> {
+        if !self.terminal_active {
+            return Ok(());
+        }
+        let _restore = perf::PerfSpan::start("shutdown:restore_terminal");
         let keyboard_result = std::mem::take(&mut self.keyboard_protocol).stop(&mut self.stdout);
         let output_result = Self::restore_terminal_output(&mut self.stdout);
         let raw_mode_result = terminal::disable_raw_mode();
         keyboard_result?;
         output_result?;
         raw_mode_result?;
+        self.terminal_active = false;
         Ok(())
     }
 
@@ -18682,13 +18728,34 @@ impl Editor {
             }
             Action::Command(cmd) => {
                 log!("Handling command: {cmd}");
-                self.record_command_history(cmd);
-
-                for action in self.handle_command(cmd, runtime) {
-                    self.set_legacy_message(None);
-                    if self.execute(&action, buffer, runtime).await? {
-                        return Ok(true);
+                let actions = self.handle_command(cmd, runtime);
+                // Even a small preferences write can stall on the filesystem.
+                // An accepted quit flushes this history with exit-hook storage,
+                // after terminal restoration. Rejected/failed quits flush here.
+                let deferred_history = if actions
+                    .iter()
+                    .any(|action| matches!(action, Action::Quit(_)))
+                {
+                    self.preferences.record_command_deferred(cmd)
+                } else {
+                    self.record_command_history(cmd);
+                    false
+                };
+                let result: anyhow::Result<bool> = async {
+                    for action in actions {
+                        self.set_legacy_message(None);
+                        if self.execute(&action, buffer, runtime).await? {
+                            return Ok(true);
+                        }
                     }
+                    Ok(false)
+                }
+                .await;
+                if deferred_history && !matches!(result, Ok(true)) {
+                    self.flush_command_history();
+                }
+                if result? {
+                    return Ok(true);
                 }
                 self.render(buffer)?;
             }
@@ -19981,6 +20048,7 @@ impl Editor {
                     let pid = Pid::from_raw(/*raw*/ 0);
                     signal::kill(pid, Signal::SIGSTOP)?;
                     terminal::enable_raw_mode()?;
+                    self.terminal_active = true;
                     self.stdout
                         .execute(event::EnableMouseCapture)?
                         .execute(event::EnableFocusChange)?
@@ -31562,6 +31630,131 @@ builtin = "rust"
         assert!(output
             .windows(restore_sequence.len())
             .any(|window| window == restore_sequence));
+    }
+
+    #[cfg(unix)]
+    #[derive(Clone, Default)]
+    struct ShutdownOutput {
+        bytes: Arc<std::sync::Mutex<Vec<u8>>>,
+        fail: bool,
+    }
+
+    #[cfg(unix)]
+    impl std::io::Write for ShutdownOutput {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if self.fail {
+                return Err(std::io::Error::other("terminal unavailable"));
+            }
+            self.bytes.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn interactive_shutdown_restores_and_persists_before_waiting_for_agent() {
+        let mut editor = test_editor(80, 24);
+        let output = ShutdownOutput::default();
+        editor.stdout = std::io::BufWriter::new(Box::new(output.clone()));
+        editor.terminal_active = true;
+        let directory = tempfile::tempdir().unwrap();
+        let store = SessionStore::new(directory.path().join("session"));
+        let latest = store.latest_path();
+        editor.set_session_store(store);
+        let (release, wait) = tokio::sync::oneshot::channel();
+        editor.agent_manager.set_task(tokio::spawn(async move {
+            wait.await?;
+            Ok(())
+        }));
+        let mut runtime = Runtime::new();
+
+        let (result, ()) = tokio::join!(editor.finish_interactive(&mut runtime), async {
+            let bytes = output.bytes.lock().unwrap();
+            assert!(bytes.windows(8).any(|window| window == b"\x1b[?1049l"));
+            assert!(latest.is_file(), "recovery must not wait for the agent");
+            release.send(()).unwrap();
+        });
+        result.unwrap();
+        assert!(!editor.terminal_active);
+        let restored = output.bytes.lock().unwrap().clone();
+        editor.cleanup().unwrap();
+        assert_eq!(*output.bytes.lock().unwrap(), restored);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn interactive_shutdown_persists_even_when_terminal_restore_fails() {
+        let mut editor = test_editor(80, 24);
+        editor.stdout = std::io::BufWriter::new(Box::new(ShutdownOutput {
+            fail: true,
+            ..ShutdownOutput::default()
+        }));
+        editor.terminal_active = true;
+        let directory = tempfile::tempdir().unwrap();
+        let store = SessionStore::new(directory.path().join("session"));
+        let latest = store.latest_path();
+        editor.set_session_store(store);
+
+        let error = editor
+            .finish_interactive(&mut Runtime::new())
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("terminal unavailable"));
+        assert!(latest.is_file());
+        assert!(editor.terminal_active, "failed restoration can be retried");
+    }
+
+    #[tokio::test]
+    async fn accepted_quit_defers_history_until_shutdown() {
+        let mut editor = test_editor(80, 24);
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("preferences.json");
+        editor.preferences = PreferencesStore::load(&path);
+        let mut frame = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+
+        assert!(editor
+            .execute(&Action::Command("q".into()), &mut frame, &mut runtime)
+            .await
+            .unwrap());
+        assert_eq!(editor.preferences.command_history(), ["q"]);
+        assert!(
+            !path.exists(),
+            "accepted quit must not wait for preferences I/O"
+        );
+
+        editor.finish_interactive(&mut runtime).await.unwrap();
+        assert_eq!(PreferencesStore::load(&path).command_history(), ["q"]);
+    }
+
+    #[tokio::test]
+    async fn rejected_quit_flushes_history_before_returning_to_editor() {
+        let mut editor = test_editor(80, 24);
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("preferences.json");
+        editor.preferences = PreferencesStore::load(&path);
+        editor.current_buffer_mut().insert_str(0, 0, "changed");
+        let mut frame = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+
+        assert!(!editor
+            .execute(&Action::Command("q".into()), &mut frame, &mut runtime)
+            .await
+            .unwrap());
+        assert_eq!(PreferencesStore::load(&path).command_history(), ["q"]);
+        assert!(editor
+            .execute(&Action::Command("q!".into()), &mut frame, &mut runtime)
+            .await
+            .unwrap());
+        assert_eq!(PreferencesStore::load(&path).command_history(), ["q"]);
+
+        editor.finish_interactive(&mut runtime).await.unwrap();
+        assert_eq!(PreferencesStore::load(&path).command_history(), ["q", "q!"]);
     }
 
     #[test]

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -178,8 +178,17 @@ impl PreferencesStore {
     ///
     /// History is bounded and a filesystem-backed store saves immediately.
     pub fn record_command(&mut self, command: &str) -> anyhow::Result<()> {
+        if self.record_command_deferred(command) {
+            self.save()?;
+        }
+        Ok(())
+    }
+
+    /// Records a possible quit command without blocking terminal restoration.
+    /// The caller must flush preferences after the command is accepted or rejected.
+    pub(crate) fn record_command_deferred(&mut self, command: &str) -> bool {
         if command.trim().is_empty() {
-            return Ok(());
+            return false;
         }
 
         if self
@@ -188,7 +197,7 @@ impl PreferencesStore {
             .last()
             .is_some_and(|last| last == command)
         {
-            return Ok(());
+            return false;
         }
 
         self.preferences.command_history.push(command.to_string());
@@ -201,7 +210,7 @@ impl PreferencesStore {
             self.preferences.command_history.drain(0..overflow);
         }
 
-        self.save()
+        true
     }
 
     /// Appends a non-empty search pattern unless it duplicates the newest entry.
@@ -330,6 +339,19 @@ impl PreferencesStore {
         self.preferences
             .plugin_storage
             .insert(plugin_storage_key(plugin, key), value);
+        self.save()
+    }
+
+    /// Flushes deferred preferences and ordered exit-hook values in one write.
+    pub(crate) fn flush_plugin_storage(
+        &mut self,
+        updates: Vec<(String, String, serde_json::Value)>,
+    ) -> anyhow::Result<()> {
+        for (plugin, key, value) in updates {
+            self.preferences
+                .plugin_storage
+                .insert(plugin_storage_key(&plugin, &key), value);
+        }
         self.save()
     }
 
@@ -839,6 +861,43 @@ mod tests {
         assert_eq!(
             store.plugin_storage("other", "history"),
             Some(&serde_json::json!(["other"]))
+        );
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn plugin_storage_batch_preserves_order_and_unrelated_values() {
+        let dir = unique_temp_dir("plugin-storage-batch");
+        let path = dir.join("preferences.json");
+        let mut store = PreferencesStore::load(&path);
+        assert!(store.record_command_deferred("q"));
+        assert!(!store.record_command_deferred("q"));
+        assert!(!store.record_command_deferred("  "));
+        assert!(!path.exists());
+        store.flush_plugin_storage(Vec::new()).unwrap();
+        assert_eq!(PreferencesStore::load(&path).command_history(), ["q"]);
+        store
+            .set_plugin_storage("other", "keep", serde_json::json!(1))
+            .unwrap();
+        store
+            .flush_plugin_storage(vec![
+                ("test".into(), "key".into(), serde_json::json!(2)),
+                ("test".into(), "key".into(), serde_json::json!(3)),
+                ("test".into(), "second".into(), serde_json::json!(4)),
+            ])
+            .unwrap();
+        let reloaded = PreferencesStore::load(&path);
+        assert_eq!(
+            reloaded.plugin_storage("other", "keep"),
+            Some(&serde_json::json!(1))
+        );
+        assert_eq!(
+            reloaded.plugin_storage("test", "key"),
+            Some(&serde_json::json!(3))
+        );
+        assert_eq!(
+            reloaded.plugin_storage("test", "second"),
+            Some(&serde_json::json!(4))
         );
         fs::remove_dir_all(dir).ok();
     }


### PR DESCRIPTION
## Why

`:q` could leave the editor visibly frozen while command history, recovery snapshots, plugin hooks, and external services finished shutting down. Local macOS PTY measurements put the original clean-quit screen transition at 39.3 ms median, with a 210 ms outlier. Recovery writes must remain durable, but they do not need to keep the alternate screen visible.

## What changed

- Batch exit-hook preference updates, start agent shutdown alongside independent cleanup, and defer accepted quit commands' history writes. Rejected or failed quit commands still persist history immediately.
- Restore terminal modes as soon as the interactive loop stops, then finish recovery and service cleanup. Repeated restoration is safe, and restoration errors do not skip the final snapshot.
- Add shutdown timing spans, lifecycle/persistence regressions, and `scripts/quit_bench.py`.

The final local measurements were **0.605 ms median / 1.092 ms maximum** for clean quit, and **0.593 ms median / 1.086 ms maximum** across 30 forced quits. Full process exit still waits for cleanup. These measurements used isolated configuration with AI/LSP disabled; they are not a physical-display or network-service latency guarantee. Full methodology and results are in `docs/performance-quit-latency-2026-08-18.md`.

## How to Test

1. Build with `cargo build --locked --release --bin red`.
2. Run `python3 scripts/quit_bench.py --binary target/release/red --runs 10`. Expect one alternate-screen restore, normal terminal flags, persisted quit history, and separate screen/process timings.
3. Run `python3 scripts/quit_bench.py --binary target/release/red --dirty --runs 5`. Expect ordinary `:q` to refuse unsaved changes, `:q!` to restore the terminal, the source file to remain unchanged, and the recovery snapshot to contain the edit.
4. Exercise preference-heavy exits with `--storage-updates 200` and `--preference-kib 8192`. Expect plugin state and command history to survive without delaying the screen transition until the writes finish.

Validated at `68c769c`: **2,844 Rust tests passed, one ignored**, strict all-targets/all-features Clippy passed, and the retained tmux clean/rejected/forced-quit walkthrough passed. Focused regressions include `interactive_shutdown_restores_and_persists_before_waiting_for_agent`, `interactive_shutdown_persists_even_when_terminal_restore_fails`, and the accepted/rejected quit-history tests.
