### PR TITLE
feat(completion): add opt-in coordinated suggestions

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -86,6 +86,11 @@ ignorecase = false
 smartcase = false
 
 [completion]
+# Disable ordinary completion entirely (including Ctrl-Space), independently of Copilot.
+enabled = true
+# "coordinated" lets compatible Copilot suggestions extend the selected menu item.
+# Tab/Enter accepts the menu item first; Ctrl-l accepts the whole AI suggestion.
+inline_mode = "popup_first"
 # Request completion after an identifier prefix is typed. Increase debounce_ms
 # if the language server should wait for a quiet period before each request.
 auto_trigger = true

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -129,6 +129,27 @@ Patterns use Rust regular-expression syntax. `incsearch`, `hlsearch`,
 | `Space .` | Show code actions and quick fixes |
 | `Space r` | Rename the current symbol |
 
+Ordinary completion and Copilot can be enabled independently. The default
+completion menu takes priority over Copilot ghost text. To try coordinated
+previews instead, add:
+
+```toml
+[completion]
+inline_mode = "coordinated"
+```
+
+When Copilot can extend the selected plain-text completion, both stay visible.
+Up/Down changes the selected item, Tab or Enter accepts that item first, and a
+second Tab accepts the remaining AI text. Ctrl-l accepts the whole AI suggestion
+at once. Snippets and completions with additional edits keep the default
+popup-first behavior. Ctrl-e closes the menu; Alt-\ requests Copilot on its own.
+Set `inline_mode = "popup_first"` to restore the default.
+
+For Copilot only, set `enabled = false` under `[completion]`. This also disables
+Ctrl-Space and language-server trigger characters. To stop only identifier-prefix
+popups, use `auto_trigger = false` instead; Ctrl-Space and language-server trigger
+characters remain available. Neither setting enables or disables Copilot.
+
 Supported documents are formatted on save by default. Red prefers an installed
 language-pack formatter and otherwise uses LSP. To disable automatic formatting,
 add this to `~/.config/red/config.toml`:

--- a/src/config.rs
+++ b/src/config.rs
@@ -751,10 +751,25 @@ impl Default for SearchConfig {
     }
 }
 
+/// How the completion menu shares the editor with inline AI suggestions.
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InlineCompletionMode {
+    #[default]
+    PopupFirst,
+    Coordinated,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Insert-mode completion behavior shared by buffer and language-server sources.
 pub struct CompletionConfig {
+    /// Enable ordinary completion, including explicit requests. Independent of Copilot.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Whether compatible inline suggestions may extend the selected menu item.
+    #[serde(default)]
+    pub inline_mode: InlineCompletionMode,
     /// Request completion after an identifier prefix is typed.
     #[serde(default = "default_true")]
     pub auto_trigger: bool,
@@ -775,6 +790,8 @@ pub struct CompletionConfig {
 impl Default for CompletionConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
+            inline_mode: InlineCompletionMode::default(),
             auto_trigger: true,
             min_prefix_length: default_completion_min_prefix_length(),
             debounce_ms: default_completion_debounce_ms(),
@@ -2057,7 +2074,9 @@ fn known_schema_path(path: &[String]) -> bool {
         ),
         ["completion", field] => matches!(
             *field,
-            "auto_trigger"
+            "enabled"
+                | "inline_mode"
+                | "auto_trigger"
                 | "min_prefix_length"
                 | "debounce_ms"
                 | "buffer_words"
@@ -2827,6 +2846,31 @@ mod test {
     use super::*;
 
     const LEGACY_CONFIG: &str = include_str!("../tests/fixtures/legacy_config.toml");
+
+    #[test]
+    fn completion_modes_preserve_defaults_and_allow_copilot_only() {
+        let defaults = Config::from_user_toml_with_overrides("", &[]).unwrap();
+        assert!(defaults.completion.enabled);
+        assert_eq!(
+            defaults.completion.inline_mode,
+            InlineCompletionMode::PopupFirst
+        );
+        let config = Config::from_user_toml_with_overrides(
+            "[completion]\nenabled = false\ninline_mode = 'coordinated'\n[copilot]\nenabled = true\n",
+            &[],
+        ).unwrap();
+        assert!(!config.completion.enabled);
+        assert!(config.completion.auto_trigger);
+        assert!(config.copilot.enabled);
+        assert_eq!(
+            config.completion.inline_mode,
+            InlineCompletionMode::Coordinated
+        );
+        assert!(toml::from_str::<CompletionConfig>("inline_mode = 'unknown'").is_err());
+        let legacy: CompletionConfig = toml::from_str("auto_trigger = false").unwrap();
+        assert!(legacy.enabled);
+        assert_eq!(legacy.inline_mode, InlineCompletionMode::PopupFirst);
+    }
 
     #[test]
     fn legacy_config_recovers_key_actions_and_reports_ignored_settings() {

--- a/src/copilot.rs
+++ b/src/copilot.rs
@@ -172,6 +172,13 @@ fn normalized_document_path(path: &Path) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+/// The real edit represented by the selected ordinary completion item.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SelectedCompletionInfo {
+    pub range: Range,
+    pub text: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Snapshot {
     pub generation: u64,
@@ -179,6 +186,7 @@ pub(crate) struct Snapshot {
     pub revision: u64,
     pub cursor: TextPosition,
     pub uri: String,
+    pub selected_completion_info: Option<SelectedCompletionInfo>,
 }
 
 #[derive(Debug, Clone)]
@@ -423,9 +431,13 @@ impl<W: AsyncWrite + Unpin> Protocol<W> {
             .as_ref()
             .expect("document was synchronized")
             .version;
+        let mut context = json!({"triggerKind":if request.automatic {2} else {1}});
+        if let Some(selected) = &request.snapshot.selected_completion_info {
+            context["selectedCompletionInfo"] = serde_json::to_value(selected)?;
+        }
         let id = self.request("textDocument/inlineCompletion", json!({
             "textDocument":{"uri":uri,"version":version},"position":request.position,
-            "context":{"triggerKind":if request.automatic {2} else {1}},
+            "context":context,
             "formattingOptions":{"tabSize":request.tab_size,"insertSpaces":request.insert_spaces}
         }), Pending::Completion(request.snapshot)).await?;
         self.completion = Some((id, tokio::time::Instant::now() + REQUEST_TIMEOUT));
@@ -827,6 +839,7 @@ mod tests {
                 revision: generation,
                 cursor: TextPosition::new(0, 0),
                 uri: uri.into(),
+                selected_completion_info: None,
             },
             language_id: "rust".into(),
             contents: text.into(),
@@ -868,6 +881,9 @@ mod tests {
         let first = read(&mut reader).await;
         assert_eq!(first["method"], "textDocument/inlineCompletion");
         assert_eq!(first["params"]["textDocument"]["version"], 1);
+        assert!(first["params"]["context"]
+            .get("selectedCompletionInfo")
+            .is_none());
         protocol
             .complete(request(2, "file:///workspace/a.rs", "😀x"))
             .await
@@ -899,6 +915,63 @@ mod tests {
             1
         );
         assert_eq!(protocol.pending.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn selected_completion_context_never_changes_the_synchronized_document() {
+        let (writer, reader) = tokio::io::duplex(8192);
+        let mut reader = BufReader::new(reader);
+        let mut protocol = Protocol {
+            writer,
+            next_id: 0,
+            pending: HashMap::new(),
+            completion: None,
+            document: None,
+        };
+        let mut request = request(1, "file:///workspace/a.rs", "foo");
+        request.snapshot.selected_completion_info = Some(SelectedCompletionInfo {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 3,
+                },
+            },
+            text: "foobar".into(),
+        });
+        protocol.complete(request.clone()).await.unwrap();
+        let open = read(&mut reader).await;
+        assert_eq!(open["params"]["textDocument"]["text"], "foo");
+        assert_eq!(read(&mut reader).await["method"], "textDocument/didFocus");
+        let first = read(&mut reader).await;
+        assert_eq!(
+            first["params"]["context"]["selectedCompletionInfo"]["text"],
+            "foobar"
+        );
+        assert_eq!(
+            first["params"]["context"]["selectedCompletionInfo"]["range"]["end"]["character"],
+            3
+        );
+        request.snapshot.generation += 1;
+        request
+            .snapshot
+            .selected_completion_info
+            .as_mut()
+            .unwrap()
+            .text = "foobaz".into();
+        protocol.complete(request).await.unwrap();
+        assert_eq!(read(&mut reader).await["method"], "$/cancelRequest");
+        assert_eq!(read(&mut reader).await["method"], "textDocument/didFocus");
+        let second = read(&mut reader).await;
+        assert_eq!(second["params"]["textDocument"]["version"], 1);
+        assert_eq!(
+            second["params"]["context"]["selectedCompletionInfo"]["text"],
+            "foobaz"
+        );
+        assert_eq!(protocol.document.as_ref().unwrap().contents, "foo");
     }
 
     #[tokio::test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3419,7 +3419,8 @@ pub struct Editor {
     pending_lsp_revision_snapshots: HashMap<i64, Vec<(String, u64)>>,
     pending_completions: HashMap<i64, PendingCompletion>,
     scheduled_completion: Option<ScheduledCompletion>,
-    inline_completion: inline_completion::InlineCompletionState,
+    // Keep optional AI state out of Editor values and the startup futures that own them.
+    inline_completion: Box<inline_completion::InlineCompletionState>,
     completion_snapshot: Option<CompletionSnapshot>,
     /// Insert-mode placeholder anchors belonging to the most recently expanded snippet.
     snippet_session: Option<snippet::SnippetSession>,
@@ -4762,7 +4763,7 @@ impl Editor {
             pending_lsp_revision_snapshots: HashMap::new(),
             pending_completions: HashMap::new(),
             scheduled_completion: None,
-            inline_completion: inline_completion::InlineCompletionState::default(),
+            inline_completion: Box::default(),
             completion_snapshot: None,
             snippet_session: None,
         })

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3936,7 +3936,7 @@ struct PendingLspEdit {
     uri: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct CompletionSnapshot {
     buffer_id: BufferId,
     initial_revision: u64,
@@ -12704,7 +12704,7 @@ impl Editor {
         &self,
         pending: &PendingCompletion,
     ) -> Option<CompletionSnapshot> {
-        if pending.superseded {
+        if !self.config.completion.enabled || pending.superseded {
             return None;
         }
         if pending.displayed_immediately {
@@ -25282,7 +25282,8 @@ impl Editor {
             self.scheduled_completion = None;
             return;
         };
-        if !self.config.completion.auto_trigger
+        if !self.config.completion.enabled
+            || !self.config.completion.auto_trigger
             || prefix.chars().count() < self.config.completion.min_prefix_length
         {
             self.scheduled_completion = None;
@@ -25297,6 +25298,9 @@ impl Editor {
     }
 
     fn is_completion_trigger_char(&self, c: char) -> bool {
+        if !self.config.completion.enabled {
+            return false;
+        }
         let Some(file) = self.current_buffer().file.as_deref() else {
             return false;
         };
@@ -25520,7 +25524,10 @@ impl Editor {
         items: Vec<CompletionResponseItem>,
         snapshot: CompletionSnapshot,
     ) -> bool {
-        if items.is_empty() || !self.is_insert() || !self.completion_snapshot_is_current(&snapshot)
+        if !self.config.completion.enabled
+            || items.is_empty()
+            || !self.is_insert()
+            || !self.completion_snapshot_is_current(&snapshot)
         {
             return false;
         }
@@ -25588,7 +25595,7 @@ impl Editor {
         &mut self,
         trigger_character: Option<char>,
     ) -> anyhow::Result<bool> {
-        if !self.is_insert() {
+        if !self.config.completion.enabled || !self.is_insert() {
             return Ok(false);
         }
 
@@ -25655,12 +25662,37 @@ impl Editor {
         Ok(displayed_immediately)
     }
 
+    /// Resolve the exact main edit used by both ordinary and coordinated completion.
+    fn completion_main_edit(
+        &self,
+        item: &CompletionResponseItem,
+        snapshot: Option<&CompletionSnapshot>,
+    ) -> Option<LspTextEdit> {
+        match &item.text_edit {
+            Some(edit) => rebase_completion_edit(edit, snapshot, true),
+            None => Some(LspTextEdit {
+                range: snapshot
+                    .and_then(|snapshot| snapshot.current_range.clone())
+                    .unwrap_or_else(|| self.completion_default_range()),
+                new_text: item
+                    .insert_text
+                    .as_deref()
+                    .unwrap_or(&item.label)
+                    .to_owned(),
+            }),
+        }
+    }
+
     async fn apply_completion(
         &mut self,
         item: &CompletionResponseItem,
         commit_character: Option<char>,
         runtime: &mut Runtime,
     ) -> anyhow::Result<()> {
+        if !self.config.completion.enabled {
+            return Ok(());
+        }
+        let continuation = self.coordinated_completion_continuation(item, commit_character);
         let snapshot = self.completion_snapshot.take();
         if snapshot
             .as_ref()
@@ -25671,40 +25703,15 @@ impl Editor {
         }
 
         let contents = self.current_buffer().contents();
-        let session_ranges = snapshot.as_ref().and_then(|snapshot| {
-            Some((
-                snapshot.original_range.as_ref()?,
-                snapshot.current_range.as_ref()?,
-            ))
-        });
-        let session_changed = snapshot
-            .as_ref()
-            .is_some_and(|snapshot| snapshot.initial_revision != snapshot.revision);
-        let rebase_edit = |edit: &LspTextEdit, is_main: bool| {
-            if !session_changed {
-                return Some(edit.clone());
-            }
-            let (original, current) = session_ranges?;
-            Some(LspTextEdit {
-                range: rebase_completion_range(&edit.range, original, current, is_main)?,
-                new_text: edit.new_text.clone(),
-            })
-        };
-        let main_text_edit = match item.text_edit.as_ref() {
-            Some(edit) => match rebase_edit(edit, true) {
-                Some(edit) => Some(edit),
-                None => {
-                    self.set_legacy_message(Some(
-                        "completion edit could not be rebased after typing".to_string(),
-                    ));
-                    return Ok(());
-                }
-            },
-            None => None,
+        let Some(main_text_edit) = self.completion_main_edit(item, snapshot.as_ref()) else {
+            self.set_legacy_message(Some(
+                "completion edit could not be rebased after typing".to_string(),
+            ));
+            return Ok(());
         };
         let mut additional_text_edits = Vec::new();
         for edit in item.additional_text_edits.iter().flatten() {
-            let Some(edit) = rebase_edit(edit, false) else {
+            let Some(edit) = rebase_completion_edit(edit, snapshot.as_ref(), false) else {
                 self.set_legacy_message(Some(
                     "additional completion edit could not be rebased after typing".to_string(),
                 ));
@@ -25712,8 +25719,7 @@ impl Editor {
             };
             additional_text_edits.push(edit);
         }
-        let validation_edits = main_text_edit
-            .iter()
+        let validation_edits = std::iter::once(&main_text_edit)
             .chain(additional_text_edits.iter())
             .cloned()
             .collect::<Vec<_>>();
@@ -25728,30 +25734,12 @@ impl Editor {
 
         self.begin_transaction("apply completion");
 
-        let mut edits = Vec::new();
-        if let Some(text_edit) = &main_text_edit {
-            edits.push(completion_edit_from_lsp(
-                &contents,
-                text_edit,
-                item.insert_text_format.as_ref(),
-                true,
-            )?);
-        } else {
-            let text = item.insert_text.as_deref().unwrap_or(&item.label);
-            let range = snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.current_range.clone())
-                .unwrap_or_else(|| self.completion_default_range());
-            edits.push(completion_edit_from_lsp(
-                &contents,
-                &LspTextEdit {
-                    range,
-                    new_text: text.to_string(),
-                },
-                item.insert_text_format.as_ref(),
-                true,
-            )?);
-        }
+        let mut edits = vec![completion_edit_from_lsp(
+            &contents,
+            &main_text_edit,
+            item.insert_text_format.as_ref(),
+            true,
+        )?];
         for text_edit in &additional_text_edits {
             edits.push(completion_edit_from_lsp(&contents, text_edit, None, false)?);
         }
@@ -25814,6 +25802,10 @@ impl Editor {
 
         if let Some(command) = &item.command {
             self.execute_lsp_command(command, None).await?;
+        }
+
+        if let Some(continuation) = continuation {
+            self.restore_coordinated_completion(continuation);
         }
 
         Ok(())
@@ -26960,6 +26952,25 @@ fn shift_lsp_position_after_prefix_change(
     Some(LspPosition {
         line: position.line,
         character,
+    })
+}
+
+fn rebase_completion_edit(
+    edit: &LspTextEdit,
+    snapshot: Option<&CompletionSnapshot>,
+    is_main: bool,
+) -> Option<LspTextEdit> {
+    let Some(snapshot) = snapshot.filter(|s| s.initial_revision != s.revision) else {
+        return Some(edit.clone());
+    };
+    Some(LspTextEdit {
+        range: rebase_completion_range(
+            &edit.range,
+            snapshot.original_range.as_ref()?,
+            snapshot.current_range.as_ref()?,
+            is_main,
+        )?,
+        new_text: edit.new_text.clone(),
     })
 }
 

--- a/src/editor/inline_completion.rs
+++ b/src/editor/inline_completion.rs
@@ -3,8 +3,10 @@
 use super::*;
 use crate::{
     agent_tools::EditorPosition,
+    config::InlineCompletionMode,
     copilot::{
-        Bridge, CompletionItem, CompletionRequest, Control, Event as CopilotEvent, Snapshot,
+        Bridge, CompletionItem, CompletionRequest, Control, Event as CopilotEvent,
+        SelectedCompletionInfo, Snapshot,
     },
 };
 use std::{
@@ -20,6 +22,8 @@ pub(super) struct InlineCompletionState {
     generation: u64,
     scheduled: Option<(Instant, Snapshot)>,
     requested: Option<Snapshot>,
+    observed_selection: Option<ObservedCompletion>,
+    selected_completion: Option<CoordinatedCompletion>,
     pub(super) suggestion: Option<Suggestion>,
     status: String,
     failed: bool,
@@ -31,6 +35,28 @@ pub(super) struct InlineCompletionState {
 pub(super) struct Suggestion {
     pub snapshot: Snapshot,
     pub insertion: String,
+    item: CompletionItem,
+    shown: bool,
+}
+
+#[derive(Clone, PartialEq)]
+struct ObservedCompletion {
+    item: CompletionResponseItem,
+    snapshot: CompletionSnapshot,
+}
+
+#[derive(Clone, PartialEq)]
+struct CoordinatedCompletion {
+    item: CompletionResponseItem,
+    info: SelectedCompletionInfo,
+    insertion: String,
+}
+
+pub(super) struct CoordinatedContinuation {
+    buffer_id: BufferId,
+    contents: String,
+    cursor: TextPosition,
+    insertion: String,
     item: CompletionItem,
     shown: bool,
 }
@@ -123,6 +149,18 @@ impl Editor {
             return None;
         }
         self.visible_inline_suggestion()?;
+        // The menu owns navigation, Tab, Enter, and dismissal. Only the explicit
+        // AI binding accepts the combined preview while the menu is open.
+        if self.visible_completion_menu() {
+            return matches!(
+                mapping,
+                Some(KeyAction::Single(
+                    Action::AcceptInlineCompletion | Action::DismissInlineCompletion
+                ))
+            )
+            .then_some(mapping)
+            .flatten();
+        }
         if matches!(
             mapping,
             Some(KeyAction::Single(
@@ -189,12 +227,18 @@ impl Editor {
             revision: self.current_buffer().revision(),
             cursor: self.cursor_text_position(),
             uri: self.current_buffer().uri().ok()??,
+            selected_completion_info: self
+                .inline_completion
+                .selected_completion
+                .as_ref()
+                .map(|selected| selected.info.clone()),
         })
     }
 
     fn inline_snapshot_current(&self, snapshot: &Snapshot) -> bool {
         self.is_insert()
             && self.copilot_enabled()
+            && self.completion_selection_is_observed()
             && self.inline_snapshot().as_ref() == Some(snapshot)
     }
 
@@ -204,11 +248,131 @@ impl Editor {
             && !self.panel_manager.has_focused_panel()
     }
 
+    fn visible_completion_menu(&self) -> bool {
+        self.current_dialog.as_ref().is_some_and(|dialog| {
+            dialog.allows_event_passthrough() && dialog.has_shortcut_context()
+        })
+    }
+
+    fn completion_selection(&self) -> Option<(&CompletionResponseItem, &CompletionSnapshot)> {
+        if !self.copilot_enabled()
+            || !self.config.completion.enabled
+            || self.config.completion.inline_mode != InlineCompletionMode::Coordinated
+            || !self.visible_completion_menu()
+        {
+            return None;
+        }
+        let item = self.current_dialog.as_ref()?.selected_completion()?;
+        let snapshot = self.completion_snapshot.as_ref()?;
+        self.completion_snapshot_is_current(snapshot)
+            .then_some((item, snapshot))
+    }
+
+    fn completion_selection_is_observed(&self) -> bool {
+        match (
+            self.completion_selection(),
+            &self.inline_completion.observed_selection,
+        ) {
+            (None, None) => true,
+            (Some((item, snapshot)), Some(observed)) => {
+                item == &observed.item && snapshot == &observed.snapshot
+            }
+            _ => false,
+        }
+    }
+
+    /// This cheap check also hides stale previews before the next service tick.
+    fn coordinated_completion(&self) -> Option<&CoordinatedCompletion> {
+        self.inline_completion
+            .selected_completion
+            .as_ref()
+            .filter(|_| self.completion_selection_is_observed())
+    }
+
+    /// Only insertion-equivalent, side-effect-free items can share a preview.
+    /// Resolve against source text once per selection/document change, not per frame.
+    fn prepare_coordinated_completion(
+        &self,
+        observed: &ObservedCompletion,
+    ) -> Option<CoordinatedCompletion> {
+        let item = &observed.item;
+        let snapshot = &observed.snapshot;
+        if !self.copilot_file_allowed()
+            || item.insert_text_format == Some(InsertTextFormat::Snippet)
+            || item.command.is_some()
+            || item
+                .additional_text_edits
+                .as_ref()
+                .is_some_and(|edits| !edits.is_empty())
+        {
+            return None;
+        }
+        let edit = self.completion_main_edit(item, Some(snapshot))?;
+        if edit.range.end != self.cursor_lsp_position() {
+            return None;
+        }
+        let contents = self.current_buffer().contents();
+        let candidate = CompletionItem {
+            insert_text: edit.new_text.clone(),
+            range: Some(edit.range.clone()),
+            command: None,
+            extra: Default::default(),
+        };
+        let insertion =
+            insertion_for_edit(&contents, self.cursor_lsp_position(), &candidate, true)?;
+        // Ordinary completion does not normalize newlines. Require the preview
+        // projection and the actual ordinary edit to produce identical bytes.
+        let actual = crate::lsp::apply_text_edits(&contents, std::slice::from_ref(&edit)).ok()?;
+        let insertion_edit = LspTextEdit {
+            range: Range {
+                start: edit.range.end,
+                end: edit.range.end,
+            },
+            new_text: insertion.clone(),
+        };
+        if actual != crate::lsp::apply_text_edits(&contents, &[insertion_edit]).ok()? {
+            return None;
+        }
+        Some(CoordinatedCompletion {
+            item: item.clone(),
+            info: SelectedCompletionInfo {
+                range: edit.range,
+                text: edit.new_text,
+            },
+            insertion,
+        })
+    }
+
+    /// Selection changes do not change the buffer revision, so they need their
+    /// own generation and cancellation boundary.
+    fn refresh_coordinated_completion(&mut self) -> bool {
+        if self.completion_selection_is_observed() {
+            return false;
+        }
+        let observed = self
+            .completion_selection()
+            .map(|(item, snapshot)| ObservedCompletion {
+                item: item.clone(),
+                snapshot: snapshot.clone(),
+            });
+        let selected = observed
+            .as_ref()
+            .and_then(|observed| self.prepare_coordinated_completion(observed));
+        let changed = selected.is_some() || self.inline_completion.selected_completion.is_some();
+        self.inline_completion.observed_selection = observed;
+        self.inline_completion.selected_completion = selected;
+        if changed {
+            self.schedule_inline_completion();
+        }
+        changed
+    }
+
     /// An installed completion component may have no visible matches.
     /// Only an interactive popup (or another dialog) takes priority over ghost text.
     fn inline_completion_obscured(&self) -> bool {
         self.current_dialog.as_ref().is_some_and(|dialog| {
-            !dialog.allows_event_passthrough() || dialog.has_shortcut_context()
+            !dialog.allows_event_passthrough()
+                || (dialog.has_shortcut_context() && self.coordinated_completion().is_none())
         })
     }
 
@@ -487,6 +651,8 @@ impl Editor {
                 self.current_dialog = None;
                 self.completion_snapshot = None;
             }
+            self.inline_completion.observed_selection = None;
+            self.inline_completion.selected_completion = None;
         }
         let Some(snapshot) = self.inline_snapshot() else {
             return;
@@ -523,6 +689,22 @@ impl Editor {
 
     pub(super) fn service_inline_completion(&mut self) -> bool {
         let mut changed = false;
+        if !self.config.completion.enabled {
+            self.scheduled_completion = None;
+            for pending in self.pending_completions.values_mut() {
+                pending.superseded = true;
+            }
+            if self
+                .current_dialog
+                .as_ref()
+                .is_some_and(|dialog| dialog.allows_event_passthrough())
+            {
+                self.current_dialog = None;
+                self.completion_snapshot = None;
+                changed = true;
+            }
+        }
+        changed |= self.refresh_coordinated_completion();
         if !self.inline_completion.setup_hint_checked
             && !self.config.disable_ai
             && !self.config.copilot.enabled
@@ -621,6 +803,16 @@ impl Editor {
                     let contents = self.current_buffer().contents();
                     let position = self.cursor_lsp_position();
                     if let Some((item, insertion)) = items.into_iter().find_map(|item| {
+                        if let Some(selected) = &snapshot.selected_completion_info {
+                            if item.range.as_ref() != Some(&selected.range)
+                                || item
+                                    .insert_text
+                                    .strip_prefix(&selected.text)
+                                    .is_none_or(|suffix| suffix.is_empty())
+                            {
+                                return None;
+                            }
+                        }
                         insertion_for_item(&contents, position, &item)
                             .map(|insertion| (item, insertion))
                     }) {
@@ -690,7 +882,7 @@ impl Editor {
         &mut self,
         runtime: &mut Runtime,
     ) -> anyhow::Result<()> {
-        if !self.inline_editor_focused() || self.inline_completion_obscured() {
+        if self.visible_inline_suggestion().is_none() {
             return Ok(());
         }
         let Some(suggestion) = self.inline_completion.suggestion.take() else {
@@ -705,6 +897,8 @@ impl Editor {
             self.current_dialog = None;
             self.completion_snapshot = None;
         }
+        self.inline_completion.observed_selection = None;
+        self.inline_completion.selected_completion = None;
         let resume_insert = self.transaction_active();
         if resume_insert {
             self.commit_transaction(self.cursor_snapshot());
@@ -725,12 +919,89 @@ impl Editor {
         self.copilot_control(Control::Accepted(suggestion.item));
         Ok(())
     }
+
+    /// Capture the suffix before ordinary completion invalidates the snapshot.
+    pub(super) fn coordinated_completion_continuation(
+        &self,
+        item: &CompletionResponseItem,
+        commit_character: Option<char>,
+    ) -> Option<CoordinatedContinuation> {
+        if commit_character.is_some() {
+            return None;
+        }
+        let suggestion = self.visible_inline_suggestion()?;
+        let selected = self.coordinated_completion()?;
+        if &selected.item != item {
+            return None;
+        }
+        let insertion = suggestion.insertion.strip_prefix(&selected.insertion)?;
+        if insertion.is_empty() {
+            return None;
+        }
+        let contents = self.current_buffer().contents();
+        let edit = LspTextEdit {
+            range: selected.info.range.clone(),
+            new_text: selected.info.text.clone(),
+        };
+        let prepared = completion_edit_from_lsp(&contents, &edit, None, true).ok()?;
+        Some(CoordinatedContinuation {
+            buffer_id: self.current_buffer().id(),
+            contents: crate::lsp::apply_text_edits(&contents, &[edit]).ok()?,
+            cursor: offset_text_position(
+                prepared.range.start,
+                &prepared.new_text,
+                prepared.new_text.chars().count(),
+            ),
+            insertion: insertion.to_owned(),
+            item: suggestion.item.clone(),
+            shown: suggestion.shown,
+        })
+    }
+
+    pub(super) fn restore_coordinated_completion(&mut self, continuation: CoordinatedContinuation) {
+        if self.current_buffer().id() != continuation.buffer_id
+            || self.current_buffer().contents() != continuation.contents
+            || self.cursor_text_position() != continuation.cursor
+            || !self.inline_editor_focused()
+            || !self.copilot_enabled()
+        {
+            return;
+        }
+        self.current_dialog = None;
+        self.completion_snapshot = None;
+        self.scheduled_completion = None;
+        for pending in self.pending_completions.values_mut() {
+            pending.superseded = true;
+        }
+        self.inline_completion.observed_selection = None;
+        self.inline_completion.selected_completion = None;
+        self.dismiss_inline_completion();
+        if let Some(snapshot) = self.inline_snapshot() {
+            self.inline_completion.suggestion = Some(Suggestion {
+                snapshot,
+                insertion: continuation.insertion,
+                item: continuation.item,
+                shown: continuation.shown,
+            });
+            self.layout_cache.borrow_mut().clear();
+            self.force_full_redraw = true;
+        }
+    }
 }
 
 fn insertion_for_item(
     contents: &str,
     cursor: LspPosition,
     item: &CompletionItem,
+) -> Option<String> {
+    insertion_for_edit(contents, cursor, item, false)
+}
+
+fn insertion_for_edit(
+    contents: &str,
+    cursor: LspPosition,
+    item: &CompletionItem,
+    allow_empty: bool,
 ) -> Option<String> {
     let offset = |position: LspPosition| {
         utf16_byte_offset(
@@ -754,7 +1025,7 @@ fn insertion_for_item(
     let before = contents.get(start..cursor)?;
     let after = contents.get(cursor..end)?;
     let inserted = item.insert_text.strip_prefix(before)?.strip_suffix(after)?;
-    if inserted.is_empty()
+    if (!allow_empty && inserted.is_empty())
         || inserted
             .chars()
             .any(|ch| ch.is_control() && !matches!(ch, '\n' | '\r' | '\t'))
@@ -878,6 +1149,436 @@ mod tests {
             command: None,
             extra: Default::default(),
         }
+    }
+
+    fn ordinary(label: &str) -> CompletionResponseItem {
+        serde_json::from_value(json!({"label": label})).unwrap()
+    }
+
+    async fn coordinated_editor(
+        text: &str,
+        cursor: usize,
+        items: Vec<CompletionResponseItem>,
+    ) -> (
+        Editor,
+        tokio::sync::watch::Receiver<Option<CompletionRequest>>,
+        tokio::sync::mpsc::Receiver<Control>,
+        tokio::sync::mpsc::Sender<CopilotEvent>,
+    ) {
+        let mut editor = editor(text);
+        editor.config.completion.inline_mode = InlineCompletionMode::Coordinated;
+        show(&mut editor, "", cursor).await;
+        editor.dismiss_inline_completion();
+        let (bridge, requests, controls, events) = Bridge::test_channels();
+        editor.inline_completion.bridge = Some(bridge);
+        editor.inline_completion.failed = false;
+        assert!(editor.show_completion_items(items, editor.completion_snapshot()));
+        editor.service_inline_completion();
+        if editor.coordinated_completion().is_some() {
+            expire_inline_schedule(&mut editor);
+            editor.service_inline_completion();
+        }
+        (editor, requests, controls, events)
+    }
+
+    async fn respond(
+        editor: &mut Editor,
+        events: &tokio::sync::mpsc::Sender<CopilotEvent>,
+        snapshot: Snapshot,
+        items: Vec<CompletionItem>,
+    ) {
+        events
+            .send(CopilotEvent::Completion { snapshot, items })
+            .await
+            .unwrap();
+        editor.service_inline_completion();
+    }
+
+    async fn execute_key(editor: &mut Editor, code: KeyCode, modifiers: KeyModifiers) {
+        match editor
+            .handle_event(&Event::Key(KeyEvent::new(code, modifiers)))
+            .unwrap()
+        {
+            Some(KeyAction::Single(action)) => editor.test_execute_action(action).await.unwrap(),
+            Some(KeyAction::Multiple(actions)) => {
+                for action in actions {
+                    editor.test_execute_action(action).await.unwrap();
+                }
+            }
+            Some(KeyAction::None) | None => {}
+            action => panic!("unexpected action: {action:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn coordinated_preview_extends_selected_item_and_accepts_in_two_steps() {
+        for accept in [KeyCode::Tab, KeyCode::Enter] {
+            let (mut editor, requests, mut controls, events) =
+                coordinated_editor("foo()", 3, vec![ordinary("foobar")]).await;
+            let request = requests.borrow().clone().unwrap();
+            assert_eq!(request.contents, "foo()");
+            assert_eq!(
+                request
+                    .snapshot
+                    .selected_completion_info
+                    .as_ref()
+                    .unwrap()
+                    .text,
+                "foobar"
+            );
+            let ai = item("foobar_extra", 0, 3);
+            respond(&mut editor, &events, request.snapshot, vec![ai.clone()]).await;
+            assert!(editor.visible_completion_menu());
+            assert_eq!(
+                editor.visible_inline_suggestion().unwrap().insertion,
+                "bar_extra"
+            );
+            assert!(rendered_rows(&mut editor)
+                .iter()
+                .any(|row| row.contains("foobar_extra()")));
+            assert_eq!(editor.current_buffer().contents(), "foo()");
+            assert!(matches!(controls.try_recv(), Ok(Control::Shown(_))));
+
+            execute_key(&mut editor, accept, KeyModifiers::NONE).await;
+            assert_eq!(editor.current_buffer().contents(), "foobar()");
+            assert!(editor.current_dialog.is_none());
+            assert_eq!(
+                editor.visible_inline_suggestion().unwrap().insertion,
+                "_extra"
+            );
+            assert!(controls.try_recv().is_err());
+            editor.service_inline_completion();
+            assert!(controls.try_recv().is_err());
+            execute_key(&mut editor, KeyCode::Tab, KeyModifiers::NONE).await;
+            assert_eq!(editor.current_buffer().contents(), "foobar_extra()");
+            assert!(
+                matches!(controls.try_recv(), Ok(Control::Accepted(accepted)) if accepted == ai)
+            );
+            editor
+                .test_execute_action(Action::EnterMode(Mode::Normal))
+                .await
+                .unwrap();
+            editor.test_execute_action(Action::Undo).await.unwrap();
+            assert_eq!(editor.current_buffer().contents(), "foobar()");
+            editor.test_execute_action(Action::Undo).await.unwrap();
+            assert_eq!(editor.current_buffer().contents(), "foo()");
+        }
+    }
+
+    #[tokio::test]
+    async fn coordinated_ctrl_l_accepts_the_whole_edit_in_one_undo_step() {
+        let (mut editor, requests, mut controls, events) =
+            coordinated_editor("foo()", 3, vec![ordinary("foobar")]).await;
+        let snapshot = requests.borrow().as_ref().unwrap().snapshot.clone();
+        let ai = item("foobar\nnext", 0, 3);
+        respond(&mut editor, &events, snapshot, vec![ai.clone()]).await;
+        assert!(matches!(controls.try_recv(), Ok(Control::Shown(_))));
+        execute_key(&mut editor, KeyCode::Char('l'), KeyModifiers::CONTROL).await;
+        assert_eq!(editor.current_buffer().contents(), "foobar\nnext()");
+        assert!(editor.current_dialog.is_none());
+        assert!(matches!(controls.try_recv(), Ok(Control::Accepted(accepted)) if accepted == ai));
+        editor
+            .test_execute_action(Action::EnterMode(Mode::Normal))
+            .await
+            .unwrap();
+        editor.test_execute_action(Action::Undo).await.unwrap();
+        assert_eq!(editor.current_buffer().contents(), "foo()");
+    }
+
+    #[tokio::test]
+    async fn coordinated_selection_change_rejects_old_results_without_a_text_edit() {
+        let (mut editor, requests, _controls, events) =
+            coordinated_editor("foo", 3, vec![ordinary("foobar"), ordinary("foobaz")]).await;
+        let first = requests.borrow().as_ref().unwrap().snapshot.clone();
+        let selected = first
+            .selected_completion_info
+            .as_ref()
+            .unwrap()
+            .text
+            .clone();
+        respond(
+            &mut editor,
+            &events,
+            first.clone(),
+            vec![item(&format!("{selected}_old"), 0, 3)],
+        )
+        .await;
+        assert!(editor.visible_inline_suggestion().is_some());
+        execute_key(&mut editor, KeyCode::Down, KeyModifiers::NONE).await;
+        assert!(editor.visible_inline_suggestion().is_none());
+        editor
+            .test_execute_action(Action::AcceptInlineCompletion)
+            .await
+            .unwrap();
+        assert_eq!(editor.current_buffer().contents(), "foo");
+        editor.service_inline_completion();
+        expire_inline_schedule(&mut editor);
+        editor.service_inline_completion();
+        let second = requests.borrow().as_ref().unwrap().snapshot.clone();
+        assert_eq!(first.revision, second.revision);
+        assert_ne!(first.generation, second.generation);
+        assert_ne!(
+            first.selected_completion_info,
+            second.selected_completion_info
+        );
+        respond(
+            &mut editor,
+            &events,
+            first,
+            vec![item(&format!("{selected}_late"), 0, 3)],
+        )
+        .await;
+        assert!(editor.visible_inline_suggestion().is_none());
+        let selected = second
+            .selected_completion_info
+            .as_ref()
+            .unwrap()
+            .text
+            .clone();
+        respond(
+            &mut editor,
+            &events,
+            second,
+            vec![item(&format!("{selected}_new"), 0, 3)],
+        )
+        .await;
+        assert!(editor
+            .visible_inline_suggestion()
+            .unwrap()
+            .insertion
+            .ends_with("_new"));
+    }
+
+    #[tokio::test]
+    async fn coordinated_rejects_incompatible_results_and_unsafe_ordinary_items() {
+        let (mut editor, requests, _controls, events) =
+            coordinated_editor("foo", 3, vec![ordinary("foobar")]).await;
+        let snapshot = requests.borrow().as_ref().unwrap().snapshot.clone();
+        respond(
+            &mut editor,
+            &events,
+            snapshot,
+            vec![
+                item("foobaz_extra", 0, 3),
+                item("foobar", 0, 3),
+                item("foobar_extra", 1, 3),
+            ],
+        )
+        .await;
+        assert!(editor.visible_inline_suggestion().is_none());
+        assert!(editor.visible_completion_menu());
+
+        for value in [
+            json!({"label":"foobar", "insertTextFormat":2}),
+            json!({"label":"foobar", "command":{"title":"run","command":"run"}}),
+            json!({"label":"foobar", "additionalTextEdits":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"newText":"import\n"}]}),
+            json!({"label":"foobar", "textEdit":{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":4}},"newText":"foobar"}}),
+            json!({"label":"foobar", "insertText":"different"}),
+        ] {
+            let ordinary = serde_json::from_value(value).unwrap();
+            let (editor, requests, _controls, _events) =
+                coordinated_editor("foo()", 3, vec![ordinary]).await;
+            assert!(editor.coordinated_completion().is_none());
+            assert!(editor.inline_completion_obscured());
+            assert!(requests.borrow().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn coordinated_identity_includes_payload_and_explicit_request_is_standalone() {
+        let (mut editor, requests, _controls, events) =
+            coordinated_editor("foo", 3, vec![ordinary("foobar")]).await;
+        let first = requests.borrow().as_ref().unwrap().snapshot.clone();
+        respond(
+            &mut editor,
+            &events,
+            first.clone(),
+            vec![item("foobar_extra", 0, 3)],
+        )
+        .await;
+        let mut changed = ordinary("foobar");
+        changed.data = Some(json!({"identity":2}));
+        assert!(editor.show_completion_items(vec![changed], editor.completion_snapshot()));
+        assert!(editor.visible_inline_suggestion().is_none());
+        editor.service_inline_completion();
+        expire_inline_schedule(&mut editor);
+        editor.service_inline_completion();
+        let second = requests.borrow().as_ref().unwrap().snapshot.clone();
+        assert_eq!(
+            first.selected_completion_info,
+            second.selected_completion_info
+        );
+        assert_ne!(first.generation, second.generation);
+        execute_key(&mut editor, KeyCode::Char('\\'), KeyModifiers::ALT).await;
+        assert!(editor.current_dialog.is_none());
+        let request = requests.borrow().clone().unwrap();
+        assert!(!request.automatic);
+        assert!(request.snapshot.selected_completion_info.is_none());
+        assert_eq!(request.contents, "foo");
+    }
+
+    #[tokio::test]
+    async fn coordinated_plain_text_edits_use_rebased_utf16_ranges() {
+        let ordinary = serde_json::from_value(json!({
+            "label":"foobar",
+            "textEdit":{"range":{"start":{"line":0,"character":2},"end":{"line":0,"character":5}},"newText":"foobar"}
+        })).unwrap();
+        let (mut editor, requests, _controls, events) =
+            coordinated_editor("😀foo", 4, vec![ordinary]).await;
+        execute_key(&mut editor, KeyCode::Char('b'), KeyModifiers::NONE).await;
+        editor.service_inline_completion();
+        expire_inline_schedule(&mut editor);
+        editor.service_inline_completion();
+        let request = requests.borrow().clone().unwrap();
+        let selected = request.snapshot.selected_completion_info.as_ref().unwrap();
+        assert_eq!(selected.range.start.character, 2);
+        assert_eq!(selected.range.end.character, 6);
+        respond(
+            &mut editor,
+            &events,
+            request.snapshot,
+            vec![item("foobar_extra", 2, 6)],
+        )
+        .await;
+        execute_key(&mut editor, KeyCode::Tab, KeyModifiers::NONE).await;
+        assert_eq!(editor.current_buffer().contents(), "😀foobar");
+        assert_eq!(
+            editor.visible_inline_suggestion().unwrap().insertion,
+            "_extra"
+        );
+    }
+
+    #[tokio::test]
+    async fn completion_can_be_disabled_without_disabling_copilot() {
+        let mut editor = editor("foo foobar");
+        show(&mut editor, "_ai", 3).await;
+        show_popup(&mut editor, "foobar");
+        editor.config.completion.enabled = false;
+        editor.service_inline_completion();
+        assert!(editor.current_dialog.is_none());
+        assert!(editor.copilot_enabled());
+        editor.schedule_automatic_completion();
+        assert!(editor.scheduled_completion.is_none());
+        assert!(!editor.request_completion(None).await.unwrap());
+        assert!(
+            !editor.show_completion_items(vec![ordinary("foobar")], editor.completion_snapshot())
+        );
+        assert_eq!(editor.visible_inline_suggestion().unwrap().insertion, "_ai");
+        execute_key(&mut editor, KeyCode::Tab, KeyModifiers::NONE).await;
+        assert_eq!(editor.current_buffer().contents(), "foo_ai foobar");
+
+        editor.config.completion.enabled = true;
+        editor.config.completion.auto_trigger = false;
+        editor.schedule_automatic_completion();
+        assert!(editor.scheduled_completion.is_none());
+        editor
+            .test_execute_action(Action::SetCursor(3, 0))
+            .await
+            .unwrap();
+        assert!(editor.request_completion(None).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn coordinated_dismissal_returns_to_standalone_and_commit_drops_suffix() {
+        let (mut editor, requests, _controls, events) =
+            coordinated_editor("foo", 3, vec![ordinary("foobar")]).await;
+        let old = requests.borrow().as_ref().unwrap().snapshot.clone();
+        respond(
+            &mut editor,
+            &events,
+            old.clone(),
+            vec![item("foobar_extra", 0, 3)],
+        )
+        .await;
+        execute_key(&mut editor, KeyCode::Char('e'), KeyModifiers::CONTROL).await;
+        assert!(editor.current_dialog.is_none());
+        assert!(editor.visible_inline_suggestion().is_none());
+        editor.service_inline_completion();
+        expire_inline_schedule(&mut editor);
+        editor.service_inline_completion();
+        let standalone = requests.borrow().as_ref().unwrap().snapshot.clone();
+        assert!(standalone.selected_completion_info.is_none());
+        respond(&mut editor, &events, old, vec![item("foobar_late", 0, 3)]).await;
+        assert!(editor.visible_inline_suggestion().is_none());
+        respond(
+            &mut editor,
+            &events,
+            standalone,
+            vec![item("foo_standalone", 0, 3)],
+        )
+        .await;
+        assert_eq!(
+            editor.visible_inline_suggestion().unwrap().insertion,
+            "_standalone"
+        );
+
+        let mut ordinary = ordinary("foobar");
+        ordinary.commit_characters = Some(vec![".".into()]);
+        let (mut editor, requests, _controls, events) =
+            coordinated_editor("foo", 3, vec![ordinary]).await;
+        let snapshot = requests.borrow().as_ref().unwrap().snapshot.clone();
+        respond(
+            &mut editor,
+            &events,
+            snapshot,
+            vec![item("foobar_extra", 0, 3)],
+        )
+        .await;
+        execute_key(&mut editor, KeyCode::Char('.'), KeyModifiers::NONE).await;
+        assert_eq!(editor.current_buffer().contents(), "foobar.");
+        assert!(editor.visible_inline_suggestion().is_none());
+    }
+
+    #[tokio::test]
+    async fn coordinated_already_typed_item_preserves_a_crlf_suffix() {
+        let (mut editor, requests, _controls, events) =
+            coordinated_editor("foo\r\n", 3, vec![ordinary("foo")]).await;
+        let snapshot = requests.borrow().as_ref().unwrap().snapshot.clone();
+        respond(
+            &mut editor,
+            &events,
+            snapshot,
+            vec![item("foo\nnext", 0, 3)],
+        )
+        .await;
+        assert_eq!(
+            editor.visible_inline_suggestion().unwrap().insertion,
+            "\r\nnext"
+        );
+        execute_key(&mut editor, KeyCode::Tab, KeyModifiers::NONE).await;
+        assert_eq!(editor.current_buffer().contents(), "foo\r\n");
+        assert_eq!(
+            editor.visible_inline_suggestion().unwrap().insertion,
+            "\r\nnext"
+        );
+        execute_key(&mut editor, KeyCode::Tab, KeyModifiers::NONE).await;
+        assert_eq!(editor.current_buffer().contents(), "foo\r\nnext\r\n");
+    }
+
+    #[tokio::test]
+    async fn disabled_completion_rejects_late_lsp_responses() {
+        let mut editor = editor("foo");
+        show(&mut editor, "_ai", 3).await;
+        editor.pending_completions.insert(
+            71,
+            PendingCompletion {
+                buffer_items: vec![ordinary("foobar")],
+                snapshot: editor.completion_snapshot(),
+                displayed_immediately: false,
+                superseded: false,
+            },
+        );
+        editor.config.completion.enabled = false;
+        let response = InboundMessage::Message(ResponseMessage {
+            id: 71,
+            result: json!([{"label":"foobar"}]),
+            request: None,
+        });
+        assert!(editor
+            .handle_lsp_message(&response, Some("textDocument/completion".into()))
+            .is_none());
+        assert!(editor.current_dialog.is_none());
+        assert_eq!(editor.visible_inline_suggestion().unwrap().insertion, "_ai");
     }
     #[test]
     fn only_insertion_equivalent_edits_are_accepted() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,17 @@ async fn run() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    run_editor(args).await
+}
+
+// Keep constructing the large interactive future out of utility-command stack
+// frames, including --self-check on Windows' smaller executable stack.
+#[inline(never)]
+fn run_editor(args: Args) -> impl std::future::Future<Output = anyhow::Result<()>> {
+    Box::pin(run_editor_inner(args))
+}
+
+async fn run_editor_inner(args: Args) -> anyhow::Result<()> {
     let config_file = Config::path("config.toml");
     let preferences_file = Config::path("preferences.json");
     let first_launch = !config_file.exists() && !preferences_file.exists();
@@ -1200,6 +1211,15 @@ async fn load_startup_buffers(files: &[String]) -> anyhow::Result<Vec<Buffer>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn startup_dispatch_future_stays_small() {
+        let bytes = std::mem::size_of_val(&run());
+        assert!(
+            bytes <= 32 * 1024,
+            "startup dispatch future is {bytes} bytes"
+        );
+    }
 
     #[test]
     fn plugin_default_keymaps_install_shared_leader_siblings() {

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -582,6 +582,10 @@ impl CompletionUI {
 }
 
 impl Component for CompletionUI {
+    fn selected_completion(&self) -> Option<&CompletionResponseItem> {
+        self.selected_item()
+    }
+
     fn is_empty_completion(&self) -> bool {
         self.selected_item().is_none()
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -174,6 +174,11 @@ pub trait Component: Send {
         false
     }
 
+    /// Selected ordinary completion, if this component owns a completion menu.
+    fn selected_completion(&self) -> Option<&CompletionResponseItem> {
+        None
+    }
+
     fn picker_id(&self) -> Option<i32> {
         None
     }

--- a/tests/self_check.rs
+++ b/tests/self_check.rs
@@ -1,16 +1,49 @@
-use std::process::Command;
+use std::{
+    path::Path,
+    process::{Command, Output},
+};
+
+fn self_check_command(config: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_red"));
+    configure_self_check(&mut command, config);
+    command
+}
+
+fn configure_self_check(command: &mut Command, config: &Path) {
+    command
+        .arg("--self-check")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("NO_COLOR", "1")
+        .env("XDG_CONFIG_HOME", config);
+}
 
 #[test]
 fn self_check_reports_every_bundled_plugin_and_finishes_with_success() {
     let config = tempfile::tempdir().unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_red"))
-        .arg("--self-check")
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .env("NO_COLOR", "1")
-        .env("XDG_CONFIG_HOME", config.path())
-        .output()
-        .unwrap();
+    assert_self_check_report(self_check_command(config.path()).output().unwrap());
+}
 
+#[cfg(unix)]
+#[test]
+fn self_check_succeeds_with_a_small_main_stack() {
+    let config = tempfile::tempdir().unwrap();
+    // Exercise the executable's main stack, not the larger Rust test-thread
+    // stack. Windows already runs the ordinary self-check with its native
+    // executable stack limit. Use a fresh shell's main thread: changing
+    // RLIMIT_STACK in a test worker's pre_exec hook can fail on macOS.
+    let mut command = Command::new("/bin/sh");
+    command
+        .args([
+            "-c",
+            "ulimit -s 1024 && exec \"$@\"",
+            "red-self-check-stack",
+        ])
+        .arg(env!("CARGO_BIN_EXE_red"));
+    configure_self_check(&mut command, config.path());
+    assert_self_check_report(command.output().unwrap());
+}
+
+fn assert_self_check_report(output: Output) {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(


### PR DESCRIPTION
## Why

#279 keeps ordinary autocomplete and Copilot available together, with the completion popup taking priority. Keep that behavior as the default while letting users opt into a coordinated preview—or turn ordinary completion off and use Copilot alone.

## What changed

- Add `completion.inline_mode = "coordinated"`; the default remains `"popup_first"`.
- Send the selected completion's real range and text to Copilot without synchronizing fictional document contents. Show an inline suggestion beside the menu only when it safely extends that selected item.
- Keep Up/Down, Tab, and Enter owned by the menu. Tab/Enter accepts the ordinary item first and preserves a valid AI suffix; Ctrl-L accepts the whole suggestion in one undo step. Alt + backslash (`\`) requests standalone Copilot.
- Fall back to popup-first for snippets, commands, additional edits, incompatible ranges, and incompatible AI results. Cancel stale previews when the selected item changes, even if the buffer revision does not.
- Add `completion.enabled = false` to disable automatic, trigger-character, and Ctrl-Space completion independently of Copilot. Preserve the existing narrower meaning of `completion.auto_trigger`.
- Document the settings and cover selection races, acceptance/undo, UTF-16, CRLF, late responses, and protocol synchronization.

## How to Test

1. Build with `cargo build --bin red`. With Copilot installed and authenticated, open a source file using `target/debug/red -c 'copilot.enabled=true'`. Without an inline-mode override, the ordinary menu should still hide ghost text and own Tab/Enter.
2. Restart with `target/debug/red -c 'copilot.enabled=true' -c 'completion.inline_mode="coordinated"'`. Type an identifier prefix with ordinary completions. If Copilot returns a compatible extension, both the menu and ghost text should remain visible. Up/Down must invalidate the previous item's preview.
3. Press Tab or Enter: only the selected ordinary item should be inserted. If an AI suffix remains, another Tab should accept it. Repeat with Ctrl-L: the whole suggestion should be inserted, and one undo should remove that combined edit.
4. With the menu open, press Alt + backslash (`\`). The menu should close and a standalone Copilot request should run. An older ordinary-completion response must not reopen the menu.
5. Restart with `target/debug/red -c 'copilot.enabled=true' -c 'completion.enabled=false'`. Identifier typing, language-server trigger characters, and Ctrl-Space must not open ordinary completion; Copilot should still work.
6. Run `cargo test --lib completion -- --test-threads=1`. In particular, `coordinated_rejects_incompatible_results_and_unsafe_ordinary_items` and `coordinated_selection_change_rejects_old_results_without_a_text_edit` verify safe fallback and stale-response rejection.

### Validation completed

- Full library run: 1,984 passed, 1 ignored.
- Final completion-focused run, including three additional regressions: 131 passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- Formatting, diff checks, and `cargo build --bin red`: passed.

Live Copilot and end-to-end testing remain intentionally deferred for the manual feel check.


