### PR TITLE
fix(agent): make transcript links navigable

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -14227,6 +14227,12 @@ impl Editor {
                         return Some(self.follow_text_panel_link(target));
                     }
                 }
+                if let Some(target) = self
+                    .panel_manager
+                    .double_clicked_text_link_at_position(x, y, width, height)
+                {
+                    return Some(self.follow_text_panel_link(target));
+                }
                 self.panel_manager
                     .focus_panel_at_position(x, y, width, height)
                     .and_then(Self::panel_event_key_action)
@@ -14274,10 +14280,13 @@ impl Editor {
     fn follow_text_panel_link(&mut self, target: plugin::TextPanelLinkTarget) -> KeyAction {
         match target {
             plugin::TextPanelLinkTarget::File { path, location } => {
-                if let Err(error) = validate_text_panel_file(&path) {
-                    self.set_legacy_message(Some(format!("Unable to open link: {error}")));
-                    return KeyAction::Single(Action::Refresh);
-                }
+                let path = match self.resolve_text_panel_file_path(&path) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        self.set_legacy_message(Some(format!("Unable to open link: {error}")));
+                        return KeyAction::Single(Action::Refresh);
+                    }
+                };
                 self.panel_manager.focus_editor();
                 if let Some(location) = location {
                     KeyAction::Single(Action::OpenLocation(
@@ -14290,7 +14299,6 @@ impl Editor {
                         plugin::OpenLocationTarget::Current,
                     ))
                 } else {
-                    let path = self.open_buffer_name_for_path(&path).unwrap_or(path);
                     KeyAction::Single(Action::OpenFile(path))
                 }
             }
@@ -14307,6 +14315,48 @@ impl Editor {
                 ])
             }
         }
+    }
+
+    fn resolve_text_panel_file_path(&self, path: &str) -> anyhow::Result<String> {
+        let direct_error = match validate_text_panel_file(path) {
+            Ok(()) => {
+                return Ok(self
+                    .open_buffer_name_for_path(path)
+                    .unwrap_or_else(|| path.to_string()));
+            }
+            Err(error) => error,
+        };
+
+        let relative = Path::new(path);
+        if relative.is_absolute() || path.starts_with('~') {
+            return Err(direct_error);
+        }
+
+        let matches = |buffer_path: &str| {
+            Path::new(buffer_path).ends_with(relative)
+                && validate_text_panel_file(buffer_path).is_ok()
+        };
+        if let Some(current) = self
+            .current_buffer()
+            .file
+            .as_deref()
+            .filter(|path| matches(path))
+        {
+            return Ok(current.to_string());
+        }
+
+        let mut open_matches = self
+            .buffer_manager
+            .iter()
+            .filter_map(|buffer| buffer.file.as_deref())
+            .filter(|buffer_path| matches(buffer_path));
+        let Some(first) = open_matches.next() else {
+            return Err(direct_error);
+        };
+        if open_matches.next().is_some() {
+            anyhow::bail!("Link target matches multiple open files: {path}");
+        }
+        Ok(first.to_string())
     }
 
     fn open_buffer_name_for_path(&self, path: &str) -> Option<String> {
@@ -39008,6 +39058,59 @@ while True:
         );
     }
 
+    #[test]
+    fn relative_text_panel_links_resolve_unique_open_buffer_suffixes() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory
+            .path()
+            .join("codex-worktree/codex-rs/tui/src/app_server_session.rs");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, "fn start_thread() {}\n").unwrap();
+
+        let mut editor = test_editor(40, 10);
+        editor.buffer_manager.push_buffer(Buffer::new(
+            Some(file.to_string_lossy().into_owned()),
+            "fn start_thread() {}\n".to_string(),
+        ));
+
+        let expected = file.to_string_lossy().into_owned();
+        assert_eq!(
+            editor
+                .resolve_text_panel_file_path("codex-rs/tui/src/app_server_session.rs")
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            editor
+                .resolve_text_panel_file_path("app_server_session.rs")
+                .unwrap(),
+            expected
+        );
+
+        let duplicate = directory
+            .path()
+            .join("other-worktree/app_server_session.rs");
+        std::fs::create_dir_all(duplicate.parent().unwrap()).unwrap();
+        std::fs::write(&duplicate, "fn other() {}\n").unwrap();
+        editor.buffer_manager.push_buffer(Buffer::new(
+            Some(duplicate.to_string_lossy().into_owned()),
+            "fn other() {}\n".to_string(),
+        ));
+        assert!(editor
+            .resolve_text_panel_file_path("app_server_session.rs")
+            .unwrap_err()
+            .to_string()
+            .contains("multiple open files"));
+
+        editor.buffer_manager.set_active_index(1);
+        assert_eq!(
+            editor
+                .resolve_text_panel_file_path("app_server_session.rs")
+                .unwrap(),
+            expected
+        );
+    }
+
     #[tokio::test]
     async fn locationless_text_panel_links_preserve_existing_buffer_positions() {
         let directory = tempfile::tempdir().unwrap();
@@ -39368,6 +39471,74 @@ while True:
             editor.panel_manager.focused_text_panel_cursor_mode(),
             Some(Mode::Insert)
         );
+    }
+
+    #[test]
+    fn text_panel_links_open_on_enter_and_double_click() {
+        let setup = || {
+            let mut editor = test_editor(80, 24);
+            editor.test_create_text_panel(
+                "agent-conversation",
+                plugin::PanelConfig {
+                    side: plugin::PanelSide::Right,
+                    width: 40,
+                    ..plugin::PanelConfig::default()
+                },
+            );
+            editor.test_update_text_panel(
+                "agent-conversation",
+                vec![plugin::TextPanelBlock {
+                    id: "answer".into(),
+                    kind: plugin::TextPanelBlockKind::Agent,
+                    format: plugin::TextPanelBlockFormat::Markdown,
+                    text: "[docs](https://example.com)".into(),
+                }],
+            );
+            editor
+        };
+        let click = |editor: &mut Editor| {
+            for row in 0..24 {
+                for column in 0..80 {
+                    if editor
+                        .panel_manager
+                        .text_link_at_position(column, row, 80, 24)
+                        .is_some()
+                    {
+                        return MouseEvent {
+                            kind: MouseEventKind::Down(MouseButton::Left),
+                            column: u16::try_from(column).unwrap(),
+                            row: u16::try_from(row).unwrap(),
+                            modifiers: KeyModifiers::NONE,
+                        };
+                    }
+                }
+            }
+            panic!("rendered text link should have a hit target");
+        };
+        let is_docs_link = |action| {
+            matches!(
+                action,
+                Some(KeyAction::Single(Action::OpenExternalUrl(url)))
+                    if url == "https://example.com"
+            )
+        };
+
+        let mut double_click_editor = setup();
+        let mouse = click(&mut double_click_editor);
+        assert!(!is_docs_link(
+            double_click_editor.handle_panel_mouse_event(&mouse)
+        ));
+        assert!(is_docs_link(
+            double_click_editor.handle_panel_mouse_event(&mouse)
+        ));
+
+        let mut enter_editor = setup();
+        let mouse = click(&mut enter_editor);
+        assert!(!is_docs_link(enter_editor.handle_panel_mouse_event(&mouse)));
+        assert!(is_docs_link(enter_editor.handle_panel_event(
+            &Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            None,
+        )));
     }
 
     #[test]

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -2484,6 +2484,12 @@ struct RowClick {
     at: Instant,
 }
 
+struct TextLinkClick {
+    panel_id: String,
+    link_id: u64,
+    at: Instant,
+}
+
 #[derive(Default)]
 pub struct PanelManager {
     presentation: PanelPresentation,
@@ -2497,6 +2503,7 @@ pub struct PanelManager {
     pending_restore: HashMap<String, PendingPanelRestore>,
     pending_focused: Option<String>,
     last_row_click: Option<RowClick>,
+    last_text_link_click: Option<TextLinkClick>,
 }
 
 impl PanelManager {
@@ -3696,6 +3703,38 @@ impl PanelManager {
         terminal_height: usize,
     ) -> Option<TextPanelLinkTarget> {
         self.text_link_at_position_impl(x, y, terminal_width, terminal_height, false)
+            .map(|(_, link)| link.target)
+    }
+
+    pub(crate) fn double_clicked_text_link_at_position(
+        &mut self,
+        x: usize,
+        y: usize,
+        terminal_width: usize,
+        terminal_height: usize,
+    ) -> Option<TextPanelLinkTarget> {
+        let clicked = self.text_link_at_position_impl(x, y, terminal_width, terminal_height, false);
+        let Some((panel_id, link)) = clicked else {
+            self.last_text_link_click = None;
+            return None;
+        };
+
+        let now = Instant::now();
+        let is_double_click = self.last_text_link_click.take().is_some_and(|click| {
+            click.panel_id == panel_id
+                && click.link_id == link.id
+                && now.duration_since(click.at) <= ROW_DOUBLE_CLICK_INTERVAL
+        });
+        if is_double_click {
+            Some(link.target)
+        } else {
+            self.last_text_link_click = Some(TextLinkClick {
+                panel_id,
+                link_id: link.id,
+                at: now,
+            });
+            None
+        }
     }
 
     pub(crate) fn text_action_at_position(
@@ -3706,6 +3745,7 @@ impl PanelManager {
         terminal_height: usize,
     ) -> Option<TextPanelLinkTarget> {
         self.text_link_at_position_impl(x, y, terminal_width, terminal_height, true)
+            .map(|(_, link)| link.target)
     }
 
     fn text_link_at_position_impl(
@@ -3715,7 +3755,7 @@ impl PanelManager {
         terminal_width: usize,
         terminal_height: usize,
         action_only: bool,
-    ) -> Option<TextPanelLinkTarget> {
+    ) -> Option<(String, TextPanelLink)> {
         let placement = self.panel_at_position(x, y, terminal_width, terminal_height)?;
         let panel = self.text_panels.get_mut(&placement.id)?;
         let title_rows = text_panel_header_rows(&panel.config);
@@ -3751,12 +3791,12 @@ impl PanelManager {
                 if action_only && !matches!(link.target, TextPanelLinkTarget::PanelAction { .. }) {
                     return None;
                 }
-                self.focused = Some(placement.id);
+                self.focused = Some(placement.id.clone());
                 panel.selected_link = Some(link.id);
                 if let Some(composer) = panel.composer.as_mut() {
                     composer.focused = false;
                 }
-                return Some(link.target.clone());
+                return Some((placement.id, link.clone()));
             }
             used = end;
         }
@@ -7821,6 +7861,36 @@ mod tests {
                 path: "src/main.rs".to_string(),
                 location: None,
             })
+        );
+
+        assert_eq!(
+            manager.double_clicked_text_link_at_position(placement.x + 1, 2, 80, 20),
+            None
+        );
+        assert_eq!(
+            manager.double_clicked_text_link_at_position(placement.x + 11, 2, 80, 20),
+            None
+        );
+        assert_eq!(
+            manager.double_clicked_text_link_at_position(placement.x + 1, 2, 80, 20),
+            None
+        );
+        assert_eq!(
+            manager.double_clicked_text_link_at_position(placement.x + 1, 2, 80, 20),
+            Some(TextPanelLinkTarget::ExternalUrl(
+                "https://example.com".to_string()
+            ))
+        );
+
+        assert_eq!(
+            manager.double_clicked_text_link_at_position(placement.x + 1, 2, 80, 20),
+            None
+        );
+        manager.last_text_link_click.as_mut().unwrap().at -=
+            ROW_DOUBLE_CLICK_INTERVAL + Duration::from_millis(1);
+        assert_eq!(
+            manager.double_clicked_text_link_at_position(placement.x + 1, 2, 80, 20),
+            None
         );
     }
 

--- a/src/plugin/text_link.rs
+++ b/src/plugin/text_link.rs
@@ -60,14 +60,19 @@ pub(crate) fn linkify_source_locations(text: &str) -> Vec<(&str, Option<TextPane
     let mut cursor = 0;
 
     for (token_start, token) in whitespace_tokens(text) {
-        let leading = token
-            .char_indices()
-            .take_while(|(_, character)| {
-                matches!(character, '(' | '[' | '{' | '<' | '\'' | '"' | '`')
-            })
-            .map(|(index, character)| index + character.len_utf8())
-            .last()
-            .unwrap_or(0);
+        // Inline code can quote Markdown source verbatim, for example
+        // `[label](src/main.rs:12)`. Start after the label/destination boundary
+        // so the label is not accidentally folded into the file path.
+        let destination_start = token.rfind("](").map_or(0, |index| index + 2);
+        let leading = destination_start
+            + token[destination_start..]
+                .char_indices()
+                .take_while(|(_, character)| {
+                    matches!(character, '(' | '[' | '{' | '<' | '\'' | '"' | '`')
+                })
+                .map(|(index, character)| index + character.len_utf8())
+                .last()
+                .unwrap_or(0);
         let candidate = &token[leading..];
         let candidate_len = candidate
             .trim_end_matches(|character: char| {
@@ -320,6 +325,27 @@ mod tests {
                     },
                 ),
             ]
+        );
+    }
+
+    #[test]
+    fn linkifies_source_locations_inside_literal_markdown_links() {
+        let fragments = linkify_source_locations("`[startup](app_server_session.rs:1661-1697)`");
+
+        assert_eq!(
+            fragments
+                .iter()
+                .find_map(|(fragment, target)| target.as_ref().map(|target| (*fragment, target))),
+            Some((
+                "app_server_session.rs:1661-1697",
+                &TextPanelLinkTarget::File {
+                    path: "app_server_session.rs".to_string(),
+                    location: Some(TextPanelFileLocation {
+                        line: 1661,
+                        column: 1,
+                    }),
+                }
+            ))
         );
     }
 


### PR DESCRIPTION
Agent transcript links can look actionable but fail when a source target is relative to the conversation workspace rather than the current Red workspace. An ordinary double-click also only selected the link, and source locations shown inside literal Markdown could produce a malformed keyboard-navigation target.

This change:

- activates rendered transcript links with an unmodified double-click while preserving modifier-click behavior
- resolves missing relative file targets against the current or uniquely matching open buffer and fails closed when matches are ambiguous
- recognizes the destination inside literal Markdown link examples without folding the label into the file path

## How to Test

1. Open a source file whose basename is not resolvable from the Red process working directory.
2. Render a transcript link such as [startup](app_server_session.rs:1661-1697).
3. Single-click the link and press Enter; expect Red to reuse the open buffer and move to line 1661.
4. Return to another line and double-click the same link without modifiers; expect the same navigation.
5. Open two files with the same matching suffix and follow a relative link while neither is current; expect Red to refuse the ambiguous target rather than choosing one.

Automated coverage includes the focused link parsing, path-resolution, Enter, and double-click tests, plus:

- cargo test -- --test-threads=1
- cargo clippy --all-targets --all-features -- -D warnings