### PR TITLE
fix(lsp): tolerate language server failures

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -13652,6 +13652,9 @@ impl Editor {
             InboundMessage::ProcessingError(error_msg) => {
                 Some(Action::Print(error_msg.to_string()))
             }
+            InboundMessage::ServerStderr(message) => {
+                Some(Action::Print(format!("LSP server error: {message}")))
+            }
         }
     }
 
@@ -22456,10 +22459,32 @@ impl Editor {
 
     async fn request_diagnostics(&mut self) -> anyhow::Result<()> {
         if let Some(uri) = self.current_buffer().uri()? {
-            self.ensure_current_buffer_lsp_opened().await?;
-            self.lsp.request_diagnostics(&uri).await?;
+            if let Err(error) = self.ensure_current_buffer_lsp_opened().await {
+                self.report_diagnostics_lsp_failure("open document", &error);
+                return Ok(());
+            }
+            if let Err(error) = self.lsp.request_diagnostics(&uri).await {
+                self.report_diagnostics_lsp_failure("request diagnostics", &error);
+            }
         }
         Ok(())
+    }
+
+    fn report_diagnostics_lsp_failure(&mut self, operation: &str, error: &dyn std::fmt::Display) {
+        log!(
+            "{}",
+            json!({
+                "event": "lsp_diagnostics_unavailable",
+                "level": "warn",
+                "service": "red",
+                "operation": operation,
+                "error": error.to_string(),
+            })
+        );
+        self.set_notification_message(
+            Severity::Warning,
+            Some(format!("Language server unavailable: {error}")),
+        );
     }
 
     async fn ensure_current_buffer_lsp_opened(&mut self) -> anyhow::Result<()> {
@@ -35936,6 +35961,21 @@ builtin = "rust"
         assert!(matches!(
             action,
             Some(Action::Print(message)) if message.contains("husk lsp exited")
+        ));
+    }
+
+    #[test]
+    fn lsp_server_stderr_is_visible_without_becoming_a_processing_error() {
+        let mut editor = test_editor(40, 10);
+        let message =
+            InboundMessage::ServerStderr("thread 'main' panicked in a cargo child".to_string());
+
+        let action = editor.handle_lsp_message(&message, None);
+
+        assert!(matches!(
+            action,
+            Some(Action::Print(message))
+                if message.contains("LSP server error") && message.contains("cargo child")
         ));
     }
 

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -357,12 +357,7 @@ impl RealLspClient {
                 }
 
                 if should_surface_server_stderr(&message) {
-                    match rtx
-                        .send(InboundMessage::ProcessingError(LspError::ServerError(
-                            message,
-                        )))
-                        .await
-                    {
+                    match rtx.send(InboundMessage::ServerStderr(message)).await {
                         Ok(_) => (),
                         Err(err) => {
                             log!("[lsp] error sending stderr to editor: {}", err);
@@ -1060,7 +1055,10 @@ impl LspClient for RealLspClient {
 
         match self.response_rx.try_recv() {
             Ok(mut msg) => {
-                if matches!(msg, InboundMessage::ProcessingError(_)) {
+                if matches!(
+                    msg,
+                    InboundMessage::ProcessingError(_) | InboundMessage::ServerStderr(_)
+                ) {
                     if let Some(error) = self.poll_process_failure() {
                         msg = InboundMessage::ProcessingError(error);
                     }
@@ -2092,6 +2090,54 @@ mod test {
 
         client.did_close("/tmp/unavailable.hk").await.unwrap();
         client.shutdown().await.unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn panic_shaped_stderr_does_not_fail_a_running_server() {
+        let config = LanguageServerConfig {
+            command: "/bin/sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "printf \"thread 'main' panicked in a cargo child\\n\" >&2; exec sleep 10"
+                    .to_string(),
+            ],
+            language_id: "rust".to_string(),
+            file_extensions: vec!["rs".to_string()],
+            filenames: Vec::new(),
+            documents: Vec::new(),
+            root_markers: Vec::new(),
+            env: HashMap::new(),
+            initialization_options: None,
+            settings: None,
+            workspace_name: None,
+        };
+        let mut client = RealLspClient::start(config, std::env::current_dir().unwrap())
+            .await
+            .unwrap();
+
+        let (message, method) = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(message) = client.recv_response().await.unwrap() {
+                    break message;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("panic-shaped stderr should be surfaced while the server is running");
+
+        assert!(matches!(
+            message,
+            InboundMessage::ServerStderr(ref message)
+                if message.contains("panicked in a cargo child")
+        ));
+        assert!(method.is_none());
+        assert!(!client.initialize_failed);
+        assert!(client.child.as_mut().unwrap().try_wait().unwrap().is_none());
+
+        client.child.as_mut().unwrap().start_kill().unwrap();
+        client.child.as_mut().unwrap().wait().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -275,6 +275,8 @@ pub enum InboundMessage {
     Error(ResponseError),
     /// Error paired with a known Red request ID.
     RequestError { id: i64, error: LspError },
+    /// Important server stderr that should be visible without failing the transport.
+    ServerStderr(String),
     /// Transport or parsing failure not tied to one request.
     ProcessingError(LspError),
 }

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1256,6 +1256,38 @@ async fn global_mark_reopens_a_closed_file_buffer() {
 }
 
 #[tokio::test]
+async fn opening_file_survives_an_lsp_did_open_failure() {
+    let path = temp_file_path("open-with-failed-lsp");
+    fs::write(&path, "fn main() {}\n").unwrap();
+    let lsp = RecordingLsp::failing_next_did_open();
+    let mut editor = Editor::test_with_size(
+        Box::new(lsp),
+        80,
+        24,
+        Config::default(),
+        Theme::default(),
+        vec![Buffer::new(None, String::new())],
+    )
+    .unwrap();
+    editor.test_disable_terminal_output();
+
+    editor
+        .test_execute_production_action(Action::OpenFile(path.clone()))
+        .await
+        .expect("an unavailable language server should not abort file navigation");
+
+    assert_eq!(
+        editor.test_current_buffer().file.as_deref(),
+        Some(path.as_str())
+    );
+    assert!(editor.test_last_error().is_some_and(|error| {
+        error.contains("Language server unavailable") && error.contains("injected didOpen failure")
+    }));
+
+    fs::remove_file(path).unwrap();
+}
+
+#[tokio::test]
 async fn jumplist_switches_buffers_but_forgets_a_deleted_buffer() {
     let first_path = temp_file_path("jumplist-first");
     let second_path = temp_file_path("jumplist-second");


### PR DESCRIPTION
Language servers and their child processes can emit important stderr while the server remains healthy, and a failed document-open or diagnostics request should not prevent the editor from opening the requested file. These failures currently enter the processing-error path or bubble out of diagnostics, which can interrupt normal editing.

This change:

- adds a dedicated `ServerStderr` message so important stderr remains visible without being treated as a transport failure, while still upgrading it when the server process has actually exited
- makes document-open and diagnostics failures non-fatal to editor actions, with a structured warning log and an in-editor notification
- adds regression coverage for panic-shaped child stderr from a running server and a failed `didOpen` during file navigation

## How to Test

1. Run `cargo test -p red panic_shaped_stderr_does_not_fail_a_running_server -- --test-threads=1`.
   Expected: panic-shaped stderr is surfaced while the server process stays alive and the client is not marked initialization-failed.
2. Run `cargo test -p red lsp_server_stderr_is_visible_without_becoming_a_processing_error -- --test-threads=1`.
   Expected: the editor prints stderr as an LSP server error without mapping it to `ProcessingError`.
3. Run `cargo test -p red --test editing opening_file_survives_an_lsp_did_open_failure -- --test-threads=1`.
   Expected: the file opens and the editor shows a `Language server unavailable` warning when `didOpen` fails.