### PR TITLE
feat(neotree): virtualize unbounded file trees

### DIFF
--- a/almanac/concepts/plugins/bundled-husk-plugins.md
+++ b/almanac/concepts/plugins/bundled-husk-plugins.md
@@ -15,6 +15,9 @@ sources:
   - id: runtime
     type: file
     path: src/plugin/runtime.rs
+  - id: tree-model
+    type: file
+    path: src/plugin/tree.rs
 ---
 
 Bundled Husk plugins are the Husk feature layer that ships with Red itself. The repository embeds the `plugins/` tree into the binary as runtime assets, while `default_config.toml` selects the default configured plugin set by mapping plugin names to `.hk` files [@assets] [@default-config]. Most bundled behavior lives in single `.hk` compatibility shells, but Git and Neo-tree also call embedded pure Husk packages for typed parsing, path handling, row construction, and command argument construction [@plugins-dir] [@runtime]. This distinction matters when changing plugin behavior: the shell owns editor events and host calls, while the core package owns deterministic logic that can be compiled and tested as Husk code.
@@ -29,7 +32,7 @@ Default enablement is a separate configuration decision. The `[plugins]` table i
 
 Most bundled plugins are `.hk` shells that register commands, listen to events, request editor state, and update editor-owned UI resources through the Red host API [@plugins-dir]. Examples include buffer picking, theme browsing, search decoration, breadcrumbs, inlay hints, project search, LSP symbol pickers, agent UI, and Git or Neo-tree panels [@plugins-dir].
 
-Git and Neo-tree have an extra split. `plugins/git.hk` remains the editor-facing plugin, but `plugins/git_core/` contains a Husk package with separate modules for status parsing, patch modeling, and Git command arguments [@plugins-dir]. `plugins/neotree.hk` stays responsible for panel events and filesystem actions, while `plugins/neotree_core/` contains pure path, status, and tree-row modules [@plugins-dir]. The runtime embeds both package source sets with `ResolvedPackage::from_sources`, compiles them under the native semantic profile, caches their compiled programs, and exposes them only through internal `red::git_core` and `red::neotree_core` operations [@runtime].
+Git and Neo-tree have an extra split. `plugins/git.hk` remains the editor-facing plugin, but `plugins/git_core/` contains a Husk package with separate modules for status parsing, patch modeling, and Git command arguments [@plugins-dir]. `plugins/neotree.hk` stays responsible for panel events and filesystem actions, while `plugins/neotree_core/` contains pure path, status, and compatibility tree-row modules [@plugins-dir]. Large Neo-tree panels use a Rust-owned virtual model that shares Husk directory-entry arrays, indexes every expanded entry, and decorates only visible terminal rows [@tree-model]. The runtime embeds both package source sets with `ResolvedPackage::from_sources`, compiles them under the native semantic profile, caches their compiled programs, and exposes them only through internal `red::git_core` and `red::neotree_core` operations [@runtime].
 
 That split keeps public plugin compatibility small. A shell can continue to use Red events and UI calls, while pure package code can use typed data models without becoming a public host API. The user-facing host contract for plugin authors belongs in [Plugin host API](../../reference/plugins/host-api), not in the internal bridge operation names [@runtime].
 

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -204,11 +204,14 @@ The Git plugin keeps its event, picker, and permissioned-process shell in
 logic, and Git argument construction live in the native, multi-file
 `plugins/git_core` Husk package. Neo-tree follows the same split: filesystem
 actions, confirmations, and panel events stay in `plugins/neotree.hk`, while
-normalized path handling, typed Git-status presentation, and bounded tree-row
-construction live in `plugins/neotree_core`. Red embeds those pure sources and
-exposes small internal bridges to the compatibility shells, so installed
-builds do not depend on checkout-relative source paths. The bridges are
-bundled-plugin implementation detail, not public plugin APIs.
+normalized path handling, typed Git-status presentation, and compatible
+tree-row construction live in `plugins/neotree_core`. Large Neo-tree panels
+use an internal Rust-owned virtual model that shares the plugin's directory
+entry arrays and decorates only rows in the terminal viewport. Red embeds the
+pure sources and exposes small internal bridges to the compatibility shells,
+so installed builds do not depend on checkout-relative source paths. The
+bridges and virtual tree are bundled-plugin implementation details, not
+public plugin APIs.
 
 `buffer:changed`, cursor, mode, viewport, file, theme, window, LSP, timer, picker, composer, panel, process, filesystem, workspace, and agent events are emitted by the production runtime. Subscribe only to the events a plugin needs and debounce expensive work.
 

--- a/docs/performance-neotree-unbounded-2026-08-21.md
+++ b/docs/performance-neotree-unbounded-2026-08-21.md
@@ -1,0 +1,65 @@
+# Neo-tree unbounded directory performance — 2026-08-21
+
+## Benchmark
+
+`scripts/neotree_bench.py` creates real directories, starts the optimized editor
+in a PTY, opens Neo-tree, jumps to its final row, and measures opening latency,
+navigation latency, resident memory, and idle CPU. A run is complete only when
+the alphabetically final fixture file is reachable. Benchmark parsing and
+completeness aggregation are covered by `tests/test_neotree_bench.py`.
+
+Run the same three-sample matrix used below:
+
+```sh
+cargo build --locked --release --bin red
+python3 -B scripts/neotree_bench.py \
+  --sizes 128 512 2048 8192 \
+  --samples 3 \
+  --navigation-presses 50 \
+  --require-complete
+```
+
+Add `--active-target` to open the final file before the tree and exercise the
+active-file reveal path. Process CPU values come from `ps` and have 10 ms
+resolution; RSS deltas are whole-process observations, not allocator-level
+measurements.
+
+## Matched results
+
+Clean baseline: `7380cba`. Both runs use optimized release builds, a 120 × 45
+PTY, syntax and bundled plugins enabled, LSP disabled, 50 navigation presses,
+and three samples per directory size. Values are medians.
+
+| Directory entries | Baseline complete | Updated complete | Open, baseline → updated | Navigation p95, baseline → updated | RSS increase, baseline → updated |
+| ---: | :---: | :---: | ---: | ---: | ---: |
+| 128 | Yes | Yes | 59.47 → 21.55 ms | 2.796 → 0.555 ms | 7,152 → 2,368 KiB |
+| 512 | No | Yes | 36.59 → 23.94 ms | 1.115 → 0.566 ms | 8,288 → 3,616 KiB |
+| 2,048 | No | Yes | 35.55 → 24.32 ms | 0.565 → 0.662 ms | 8,352 → 11,264 KiB |
+| 8,192 | No | Yes | 37.30 → 47.17 ms | 0.704 → 0.566 ms | 8,240 → 41,104 KiB |
+
+Baseline timings and memory above 128 entries are not full-directory costs:
+the previous host discarded every entry after its first 160 filesystem results,
+and the Husk presentation layer separately stopped at 200 tree rows. The
+updated 8,192-entry run indexes the complete directory, keeps its final file
+reachable, and retains a 0 ms median idle-CPU sample during the 350 ms measured
+idle window.
+
+A separate single-sample stress run reached the final file in a directory with
+32,768 entries. It opened in 119.88 ms, used approximately 163.5 MiB of
+additional whole-process RSS, and maintained 0.694 ms p95 navigation.
+
+## Implementation
+
+- Directory enumeration is uncapped, sorts every entry, and runs on Tokio's
+  blocking pool instead of the editor thread.
+- Expanded directories retain the Husk entry arrays through shared `Arc`
+  ownership. The Rust tree indexes entries by compact directory/entry
+  coordinates instead of allocating a decorated `PanelRow` per file.
+- Rich icons, theme styles, Git badges, branch guides, and paths are
+  materialized only for visible rows and explicit selection events.
+- Small trees continue using ordinary row panels; large trees switch to the
+  virtual tree without changing keyboard navigation, mouse handling,
+  active-file reveal, or persisted panel selection.
+- Nonrecursive filesystem watchers retain only directory and ignore-file
+  metadata fingerprints. They construct a complete listing only after a
+  fingerprint changes.

--- a/plugins/neotree.hk
+++ b/plugins/neotree.hk
@@ -1,6 +1,6 @@
 // Watched project tree panel with Neo-tree-style filesystem actions.
 //
-// Directory listings are authoritative snapshots supplied by Rust and may be truncated.
+// Directory listings are complete authoritative snapshots supplied by Rust.
 // Reveal walks one path segment at a time, watchers follow the displayed root, and row
 // IDs are normalized project-relative paths. All mutations are performed by Red's
 // workspace-confined filesystem host API.
@@ -1033,7 +1033,17 @@ fn render() {
     if !state().created {
         return;
     }
-    red::execute("UpdatePanel", "neotree", build_rows());
+    red::neotree_core(
+        "update_panel",
+        "neotree",
+        red::string(state().cwd, "."),
+        state().children,
+        state().expanded,
+        state().selected,
+        state().clipboard,
+        optional_text(state().status.root, ""),
+        state().status_entries
+    );
 }
 
 fn loading_rows() -> [TreePanelRow] {
@@ -1050,19 +1060,6 @@ fn loading_rows() -> [TreePanelRow] {
             right_segments: [],
         }
     ];
-}
-
-fn build_rows() -> [TreePanelRow] {
-    return red::neotree_core(
-        "build_rows",
-        red::string(state().cwd, "."),
-        state().children,
-        state().expanded,
-        state().selected,
-        state().clipboard,
-        optional_text(state().status.root, ""),
-        state().status_entries
-    );
 }
 
 fn segment(text: String, foreground: [String], bold: bool) -> TreePanelSegment {

--- a/plugins/neotree_core/src/tree.hk
+++ b/plugins/neotree_core/src/tree.hk
@@ -1,5 +1,5 @@
-// Typed, bounded Neo-tree row construction. Host-provided strings are parsed
-// once at the boundary and all presentation work stays in this pure core.
+// Pure, typed compatibility row construction. Large production trees use the
+// Rust-owned virtual model so decoration is limited to the visible viewport.
 
 struct DirectoryEntry {
     name: String,
@@ -98,9 +98,6 @@ pub fn build_rows(
     if expanded.contains(root) {
         rows = append_rows(root, [], rows, children, expanded, selected, clipboard, status_root, statuses);
     }
-    if rows.len() >= 200 {
-        rows.push(truncation_row("tree-limit", "… tree limited to 200 rows"));
-    }
     rows
 }
 
@@ -127,7 +124,7 @@ fn append_rows(
 
     let mut rows = rows;
     let mut index = 0;
-    while index < visible.len() && rows.len() < 200 {
+    while index < visible.len() {
         let entry = visible[index];
         let directory = entry.kind == "directory";
         let open = directory && expanded.contains(entry.path);
@@ -157,7 +154,7 @@ fn append_rows(
         }
         index += 1;
     }
-    if children_truncated(path, children) && rows.len() < 200 {
+    if children_truncated(path, children) {
         rows.push(truncation_row("directory-limit:" + path, "… directory listing truncated"));
     }
     rows
@@ -382,14 +379,13 @@ fn renders_typed_rows_with_status_and_selection_markers() {
 }
 
 #[test]
-fn caps_pathological_visible_listings() {
+fn renders_visible_listings_without_a_global_row_cap() {
     let mut entries: [DirectoryEntry] = [];
-    for index in 0..1000 {
+    for index in 0..240 {
         entries.push(DirectoryEntry { name: "file-" + index + ".rs", path: "./file-" + index + ".rs", kind: "file" });
     }
-    let rows = build_rows("/repo", [Children { path: ".", entries: entries, truncated: true }], ["."], [], [], "", []);
+    let rows = build_rows("/repo", [Children { path: ".", entries: entries, truncated: false }], ["."], [], [], "", []);
 
-    assert(rows.len() == 201);
-    assert(rows[200].path == None);
-    assert(rows[200].segments[1].text == "… tree limited to 200 rows");
+    assert(rows.len() == 241);
+    assert(rows[240].id == "./file-239.rs");
 }

--- a/scripts/neotree_bench.py
+++ b/scripts/neotree_bench.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Measure complete Neo-tree browsing and scaling through a real editor PTY.
+
+Build with `cargo build --locked --release --bin red`, then run:
+
+    python3 scripts/neotree_bench.py --sizes 128 512 2048 8192 --samples 3
+
+Pass `--require-complete` to turn missing final entries into a regression.
+"""
+
+import argparse
+from collections import defaultdict
+import fcntl
+import json
+import os
+from pathlib import Path
+import pty
+import re
+import statistics
+import struct
+import subprocess
+import tempfile
+import termios
+import threading
+import time
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TIMING = re.compile(r"\[PERF\] (\S+)(?: (.*?))?: (\d+)us")
+TARGET = "zz-final-target.rs"
+
+
+def cpu_seconds(pid):
+    value = subprocess.check_output(
+        ["ps", "-o", "time=", "-p", str(pid)], text=True
+    ).strip()
+    total = 0.0
+    for component in value.replace("-", ":").split(":"):
+        total = total * 60 + float(component)
+    return total
+
+
+def rss_kib(pid):
+    value = subprocess.check_output(
+        ["ps", "-o", "rss=", "-p", str(pid)], text=True
+    ).strip()
+    return int(value)
+
+
+def timing_samples(contents):
+    samples = defaultdict(list)
+    for line in contents.splitlines():
+        match = TIMING.search(line)
+        if not match:
+            continue
+        label, detail, micros = match.group(1), match.group(2) or "", int(match.group(3))
+        if label in ("drain", "notify", "husk:notify") and detail:
+            label = f"{label} {detail.split()[0]}"
+        samples[label].append(micros)
+    return dict(samples)
+
+
+def percentile(values, percentile):
+    if not values:
+        return 0
+    ordered = sorted(values)
+    return ordered[(len(ordered) - 1) * percentile // 100]
+
+
+def summarize(samples):
+    grouped = defaultdict(list)
+    for sample in samples:
+        grouped[sample["entries"]].append(sample)
+
+    result = []
+    for entries, cases in sorted(grouped.items()):
+        result.append(
+            {
+                "entries": entries,
+                "samples": len(cases),
+                "complete": all(case["target_reachable"] for case in cases),
+                "open_ms_median": round(
+                    statistics.median(case["open_ms"] for case in cases), 2
+                ),
+                "directory_ms_median": round(
+                    statistics.median(case["directory_ms"] for case in cases), 2
+                ),
+                "navigation_p95_us_median": round(
+                    statistics.median(case["navigation_p95_us"] for case in cases)
+                ),
+                "rss_delta_kib_median": round(
+                    statistics.median(case["rss_delta_kib"] for case in cases)
+                ),
+                "idle_cpu_ms_median": round(
+                    statistics.median(case["idle_cpu_ms"] for case in cases), 2
+                ),
+                "truncation_marker": any(case["truncation_marker"] for case in cases),
+            }
+        )
+    return result
+
+
+class Driver:
+    def __init__(self, binary, root, config_home, rows, cols, timeout, active_target=False):
+        self.log = config_home / "red.log"
+        config_dir = config_home / "red"
+        config_dir.mkdir(parents=True)
+        config_dir.joinpath("config.toml").write_text(
+            f"log_file = {json.dumps(str(self.log))}\n"
+            "show_whats_new = false\nfetch_release_notes = false\n"
+            "[lsp]\nenabled = false\n",
+            encoding="utf-8",
+        )
+
+        self.master, slave = pty.openpty()
+        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+        self.capture = bytearray()
+        active_file = TARGET if active_target else "000-open.rs"
+        self.process = subprocess.Popen(
+            [str(binary), "--root", str(root), str(root / active_file)],
+            cwd=root,
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            close_fds=True,
+            env=dict(
+                os.environ,
+                RED_PERF="trace",
+                XDG_CONFIG_HOME=str(config_home),
+                TERM="xterm-256color",
+                COLORTERM="truecolor",
+            ),
+        )
+        os.close(slave)
+        threading.Thread(target=self.drain, daemon=True).start()
+        self.wait_for(
+            lambda: "[PERF] startup:interactive:" in self.read_log(),
+            timeout,
+            "first editor frame",
+        )
+        time.sleep(0.1)
+
+    def drain(self):
+        while True:
+            try:
+                data = os.read(self.master, 1 << 20)
+            except OSError:
+                return
+            if not data:
+                return
+            self.capture.extend(data)
+
+    def read_log(self):
+        if not self.log.exists():
+            return ""
+        return self.log.read_text(encoding="utf-8", errors="replace")
+
+    def wait_for(self, condition, timeout, description):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if condition():
+                return
+            if self.process.poll() is not None:
+                raise RuntimeError(
+                    f"editor exited during {description}: {self.process.returncode}"
+                )
+            time.sleep(0.01)
+        raise TimeoutError(description)
+
+    def send(self, payload):
+        while payload:
+            count = os.write(self.master, payload)
+            if count <= 0:
+                raise RuntimeError("PTY write made no progress")
+            payload = payload[count:]
+
+    def run(self, entries, navigation_presses, timeout):
+        before_rss = rss_kib(self.process.pid)
+        before_log = len(self.read_log())
+        before_capture = len(self.capture)
+        started = time.monotonic()
+        self.send(b":NeoTree\r")
+
+        def opened():
+            content = self.read_log()[before_log:]
+            directory_finished = (
+                "[PERF] drain ListDirectory:" in content
+                or "[PERF] drain DirectoryListed:" in content
+            )
+            updates = content.count("[PERF] drain UpdatePanel:")
+            updates += content.count("[PERF] drain UpdateTreePanel:")
+            populated = b"item-000000.rs" in self.capture[before_capture:]
+            return directory_finished and updates >= 2 and populated
+
+        self.wait_for(opened, timeout, "populated Neo-tree")
+        open_ms = (time.monotonic() - started) * 1000
+        time.sleep(0.08)
+        after_rss = rss_kib(self.process.pid)
+
+        idle_before = cpu_seconds(self.process.pid)
+        time.sleep(0.35)
+        idle_cpu_ms = max(0.0, cpu_seconds(self.process.pid) - idle_before) * 1000
+
+        navigation_log = len(self.read_log())
+        screen_start = len(self.capture)
+        self.send(b"G")
+        self.wait_for(
+            lambda: "panel:event:neotree" in self.read_log()[navigation_log:],
+            timeout,
+            "jump to final tree entry",
+        )
+        time.sleep(0.05)
+        final_screen = bytes(self.capture[screen_start:])
+        target_reachable = TARGET.encode() in final_screen
+        truncation_marker = (
+            b"tree limited" in final_screen or b"listing truncated" in final_screen
+        )
+
+        self.send(b"g")
+        time.sleep(0.03)
+        for _ in range(navigation_presses):
+            self.send(b"j")
+            time.sleep(0.003)
+        time.sleep(0.1)
+        navigation = timing_samples(self.read_log()[navigation_log:])
+        opened_log = timing_samples(self.read_log()[before_log:navigation_log])
+        directory_spans = opened_log.get("drain ListDirectory", [])
+        directory_spans.extend(opened_log.get("drain DirectoryListed", []))
+
+        return {
+            "entries": entries,
+            "target_reachable": target_reachable,
+            "truncation_marker": truncation_marker,
+            "open_ms": round(open_ms, 2),
+            "directory_ms": round(sum(directory_spans) / 1000, 2),
+            "navigation_p95_us": percentile(navigation.get("event", []), 95),
+            "rss_delta_kib": max(0, after_rss - before_rss),
+            "idle_cpu_ms": round(idle_cpu_ms, 2),
+        }
+
+    def close(self):
+        if self.process.poll() is None:
+            self.send(b"q:q!\r")
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.terminate()
+                self.process.wait(timeout=5)
+        os.close(self.master)
+
+
+def populate(root, entries):
+    root.mkdir(parents=True)
+    root.joinpath("000-open.rs").write_text("fn open() {}\n", encoding="utf-8")
+    for index in range(entries):
+        root.joinpath(f"item-{index:06}.rs").write_text("", encoding="utf-8")
+    root.joinpath(TARGET).write_text("fn final_target() {}\n", encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, default=ROOT / "target/release/red")
+    parser.add_argument("--sizes", type=int, nargs="+", default=[128, 512, 2048, 8192])
+    parser.add_argument("--samples", type=int, default=3)
+    parser.add_argument("--navigation-presses", type=int, default=50)
+    parser.add_argument("--rows", type=int, default=45)
+    parser.add_argument("--cols", type=int, default=120)
+    parser.add_argument("--timeout", type=float, default=30)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--require-complete", action="store_true")
+    parser.add_argument(
+        "--active-target",
+        action="store_true",
+        help="open the final file first to exercise large-directory reveal",
+    )
+    args = parser.parse_args()
+    binary = args.binary.resolve()
+    if not binary.is_file():
+        parser.error(f"release binary does not exist: {binary}")
+    if args.samples < 1 or any(size < 1 for size in args.sizes):
+        parser.error("samples and every size must be positive")
+
+    measurements = []
+    with tempfile.TemporaryDirectory(prefix="red-neotree-bench-") as temp_name:
+        temp = Path(temp_name)
+        for entries in args.sizes:
+            root = temp / f"workspace-{entries}"
+            populate(root, entries)
+            for sample in range(args.samples):
+                driver = Driver(
+                    binary,
+                    root,
+                    temp / f"config-{entries}-{sample}",
+                    args.rows,
+                    args.cols,
+                    args.timeout,
+                    args.active_target,
+                )
+                try:
+                    measurement = driver.run(
+                        entries, args.navigation_presses, args.timeout
+                    )
+                    measurements.append(measurement)
+                    print(json.dumps(measurement), flush=True)
+                finally:
+                    driver.close()
+
+    result = {
+        "binary": str(binary),
+        "sizes": args.sizes,
+        "samples_per_size": args.samples,
+        "measurements": measurements,
+        "summary": summarize(measurements),
+    }
+    print(json.dumps({"summary": result["summary"]}, indent=2))
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    if args.require_complete and any(not case["complete"] for case in result["summary"]):
+        raise SystemExit("Neo-tree did not expose every directory entry")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -27878,12 +27878,34 @@ fn directory_watch_snapshot(path: &str, recursive: bool) -> Value {
             (metadata.is_dir(), metadata.len(), modified)
         })
     };
+    #[cfg(windows)]
+    let directory = (signature(root), directory_entry_fingerprint(root));
+    #[cfg(not(windows))]
+    let directory = signature(root);
     json!({
         "path": path,
-        "directory": signature(root),
+        "directory": directory,
         "gitignore": signature(&root.join(".gitignore")),
         "ignore": signature(&root.join(".ignore")),
     })
+}
+
+#[cfg(any(test, windows))]
+fn directory_entry_fingerprint(path: &Path) -> Option<(usize, u64)> {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    let mut count = 0;
+    let mut fingerprint = 0;
+    for entry in fs::read_dir(path).ok()?.flatten() {
+        let mut hasher = DefaultHasher::new();
+        entry.file_name().hash(&mut hasher);
+        fingerprint ^= hasher.finish();
+        count += 1;
+    }
+    Some((count, fingerprint))
 }
 
 fn directory_snapshot(path: &str, recursive: bool) -> Value {
@@ -41271,6 +41293,22 @@ while True:
         std::fs::write(root.path().join("new-file.rs"), "").unwrap();
         let changed = directory_watch_snapshot(&root.path().to_string_lossy(), false);
         assert_ne!(initial, changed);
+    }
+
+    #[test]
+    fn directory_entry_fingerprint_detects_renames_without_retaining_entries() {
+        let root = tempfile::tempdir().unwrap();
+        let original = root.path().join("original.rs");
+        let renamed = root.path().join("renamed.rs");
+        std::fs::write(&original, "").unwrap();
+
+        let initial = directory_entry_fingerprint(root.path()).unwrap();
+        std::fs::rename(original, renamed).unwrap();
+        let changed = directory_entry_fingerprint(root.path()).unwrap();
+
+        assert_eq!(initial.0, 1);
+        assert_eq!(changed.0, 1);
+        assert_ne!(initial.1, changed.1);
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -235,7 +235,6 @@ const DIAGNOSTIC_GUTTER_NAMESPACE: &str = "diagnostics";
 const MAX_HIGHLIGHT_SLICE_BYTES: usize = 512 * 1024;
 const MAX_PLUGIN_VIEWPORT_LINE_CHARS: usize = 64 * 1024;
 const MAX_AGENT_FAILURE_MESSAGE_CHARS: usize = 2048;
-const MAX_DIRECTORY_LISTING_ENTRIES: usize = 160;
 const AGENT_BRIDGE_CAPACITY: usize = 64;
 const PLUGIN_MANAGER_PICKER_ID: i32 = 9_101;
 const PLUGIN_MANAGER_ACTION_PICKER_ID: i32 = 9_102;
@@ -1897,6 +1896,10 @@ pub enum PluginRequest {
         id: String,
         rows: Vec<plugin::PanelRow>,
     },
+    UpdateTreePanel {
+        id: String,
+        model: plugin::TreePanelModel,
+    },
     CreateTextPanel {
         id: String,
         config: plugin::PanelConfig,
@@ -1974,6 +1977,10 @@ pub enum PluginRequest {
     ListDirectory {
         path: String,
         request_id: RequestId,
+    },
+    DirectoryListed {
+        request_id: RequestId,
+        payload: Value,
     },
     GetGitStatus {
         path: String,
@@ -2098,6 +2105,7 @@ impl PluginRequest {
             Self::RemoveOverlay { .. } => "RemoveOverlay",
             Self::CreatePanel { .. } => "CreatePanel",
             Self::UpdatePanel { .. } => "UpdatePanel",
+            Self::UpdateTreePanel { .. } => "UpdateTreePanel",
             Self::CreateTextPanel { .. } => "CreateTextPanel",
             Self::UpdateTextPanel { .. } => "UpdateTextPanel",
             Self::AppendTextPanel { .. } => "AppendTextPanel",
@@ -2119,6 +2127,7 @@ impl PluginRequest {
             Self::UpdateWindowBar { .. } => "UpdateWindowBar",
             Self::CloseWindowBar { .. } => "CloseWindowBar",
             Self::ListDirectory { .. } => "ListDirectory",
+            Self::DirectoryListed { .. } => "DirectoryListed",
             Self::GetGitStatus { .. } => "GetGitStatus",
             Self::FileOperation { .. } => "FileOperation",
             Self::WatchDirectory { .. } => "WatchDirectory",
@@ -11289,6 +11298,15 @@ impl Editor {
                     );
                     needs_render = true;
                 }
+                PluginRequest::UpdateTreePanel { id, model } => {
+                    self.panel_manager.update_tree_panel(&id, model);
+                    self.panel_manager.apply_pending_content_restore(
+                        &id,
+                        usize::from(self.size.1.saturating_sub(2)),
+                        usize::from(self.size.0),
+                    );
+                    needs_render = true;
+                }
                 PluginRequest::CreateTextPanel { id, config } => {
                     self.clear_replaced_panel_zoom(&id);
                     self.panel_manager.create_text_panel(id.clone(), config);
@@ -11447,7 +11465,20 @@ impl Editor {
                     }
                 }
                 PluginRequest::ListDirectory { path, request_id } => {
-                    let payload = directory_listing(&path);
+                    let callback_runtime = runtime.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let _span = perf::PerfSpan::with_detail("neotree:directory_scan", &path);
+                        let payload = directory_listing(&path);
+                        callback_runtime.send_request(PluginRequest::DirectoryListed {
+                            request_id,
+                            payload,
+                        });
+                    });
+                }
+                PluginRequest::DirectoryListed {
+                    request_id,
+                    payload,
+                } => {
                     self.plugin_registry
                         .resolve_request(runtime, request_id, payload)
                         .await?;
@@ -11590,7 +11621,7 @@ impl Editor {
                     self.directory_watchers.insert(
                         watch_id,
                         DirectoryWatcher {
-                            snapshot: directory_snapshot(&path, recursive),
+                            snapshot: directory_watch_snapshot(&path, recursive),
                             path,
                             last_checked: Instant::now(),
                             recursive,
@@ -14789,10 +14820,15 @@ impl Editor {
             }
             watcher.last_checked = now;
 
-            let next_snapshot = directory_snapshot(&watcher.path, watcher.recursive);
+            let next_snapshot = directory_watch_snapshot(&watcher.path, watcher.recursive);
             if next_snapshot != watcher.snapshot {
                 watcher.snapshot = next_snapshot.clone();
-                changes.push((*watch_id, next_snapshot));
+                let payload = if watcher.recursive {
+                    next_snapshot
+                } else {
+                    directory_listing(&watcher.path)
+                };
+                changes.push((*watch_id, payload));
             }
         }
 
@@ -27736,6 +27772,14 @@ impl From<&Buffer> for BufferInfo {
     }
 }
 
+#[derive(Debug)]
+struct DirectoryListingEntry {
+    name: String,
+    path: String,
+    kind: &'static str,
+    sort_name: String,
+}
+
 fn directory_listing(path: &str) -> Value {
     match std::fs::metadata(path) {
         Ok(metadata) if metadata.is_dir() => {}
@@ -27771,7 +27815,6 @@ fn directory_listing(path: &str) -> Value {
         });
 
     let mut entries = Vec::new();
-    let mut truncated = false;
     for entry in builder.build().filter_map(Result::ok).skip(1) {
         let kind = match entry.file_type() {
             Some(file_type) if file_type.is_dir() => "directory",
@@ -27792,36 +27835,54 @@ fn directory_listing(path: &str) -> Value {
         if kind == "other" {
             continue;
         }
-        if entries.len() == MAX_DIRECTORY_LISTING_ENTRIES {
-            truncated = true;
-            break;
-        }
-        entries.push(json!({
-            "name": entry.file_name().to_string_lossy(),
-            "path": entry.path().to_string_lossy(),
-            "kind": kind,
-        }));
+        let name = entry.file_name().to_string_lossy().into_owned();
+        entries.push(DirectoryListingEntry {
+            sort_name: name.to_lowercase(),
+            name,
+            path: entry.path().to_string_lossy().into_owned(),
+            kind,
+        });
     }
 
     entries.sort_by(|a, b| {
-        let kind_rank = |value: &Value| match value.get("kind").and_then(Value::as_str) {
-            Some("directory") => 0,
-            Some("file") => 1,
-            _ => 2,
-        };
-        let a_name = a.get("name").and_then(Value::as_str).unwrap_or_default();
-        let b_name = b.get("name").and_then(Value::as_str).unwrap_or_default();
-
-        kind_rank(a)
-            .cmp(&kind_rank(b))
-            .then_with(|| a_name.to_lowercase().cmp(&b_name.to_lowercase()))
+        (a.kind != "directory")
+            .cmp(&(b.kind != "directory"))
+            .then_with(|| a.sort_name.cmp(&b.sort_name))
     });
 
     json!({
         "path": path,
-        "entries": entries,
-        "truncated": truncated,
+        "entries": entries.into_iter().map(|entry| json!({
+            "name": entry.name,
+            "path": entry.path,
+            "kind": entry.kind,
+        })).collect::<Vec<_>>(),
+        "truncated": false,
         "error": null,
+    })
+}
+
+fn directory_watch_snapshot(path: &str, recursive: bool) -> Value {
+    if recursive {
+        return directory_snapshot(path, true);
+    }
+
+    let root = Path::new(path);
+    let signature = |path: &Path| {
+        fs::metadata(path).ok().map(|metadata| {
+            let modified = metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| (duration.as_secs(), duration.subsec_nanos()));
+            (metadata.is_dir(), metadata.len(), modified)
+        })
+    };
+    json!({
+        "path": path,
+        "directory": signature(root),
+        "gitignore": signature(&root.join(".gitignore")),
+        "ignore": signature(&root.join(".ignore")),
     })
 }
 
@@ -41179,23 +41240,37 @@ while True:
     }
 
     #[test]
-    fn directory_listing_caps_pathological_directories() {
+    fn directory_listing_returns_every_entry_in_large_directories() {
         let root =
             std::env::temp_dir().join(format!("red-dir-listing-cap-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).unwrap();
-        for index in 0..MAX_DIRECTORY_LISTING_ENTRIES + 10 {
-            std::fs::write(root.join(format!("file-{index:03}.txt")), "fixture").unwrap();
+        for index in 0..1_024 {
+            std::fs::write(root.join(format!("file-{index:04}.txt")), "fixture").unwrap();
         }
 
         let listing = directory_listing(&root.to_string_lossy());
 
-        assert_eq!(
-            listing["entries"].as_array().unwrap().len(),
-            MAX_DIRECTORY_LISTING_ENTRIES
-        );
-        assert_eq!(listing["truncated"], true);
+        assert_eq!(listing["entries"].as_array().unwrap().len(), 1_024);
+        assert_eq!(listing["truncated"], false);
+        assert_eq!(listing["entries"][1_023]["name"], "file-1023.txt");
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn nonrecursive_directory_watch_snapshots_do_not_retain_directory_entries() {
+        let root = tempfile::tempdir().unwrap();
+        for index in 0..256 {
+            std::fs::write(root.path().join(format!("file-{index:03}.rs")), "").unwrap();
+        }
+
+        let initial = directory_watch_snapshot(&root.path().to_string_lossy(), false);
+        assert!(initial.get("entries").is_none());
+        assert!(initial.to_string().len() < 512);
+
+        std::fs::write(root.path().join("new-file.rs"), "").unwrap();
+        let changed = directory_watch_snapshot(&root.path().to_string_lossy(), false);
+        assert_ne!(initial, changed);
     }
 
     #[test]

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -29,6 +29,7 @@ mod registry;
 mod runtime;
 mod text_link;
 pub mod timer_stats;
+mod tree;
 pub mod window_bar;
 pub mod workspace;
 
@@ -49,6 +50,7 @@ pub use runtime::{
     CommandMetadata, CommandScope, ComposerHandle, PickerHandle, RegisteredPluginCommand,
     RequestId, Runtime,
 };
+pub use tree::TreePanelModel;
 
 pub(crate) fn husk_lsp_declarations() -> &'static str {
     runtime::RED_HOST_DECLARATIONS

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -26,6 +26,7 @@ use super::markdown::{
     RenderedTextSpan, TextPanelLineSelection, TextPanelSpanSelection, TextPanelSpanStyle,
 };
 use super::text_link::{TextPanelLink, TextPanelLinkTarget};
+use super::TreePanelModel;
 use crate::{
     buffer::BufferId,
     color::{blend_color, Color},
@@ -2272,6 +2273,7 @@ pub struct PluginPanel {
     pub id: String,
     pub config: PanelConfig,
     pub rows: Vec<PanelRow>,
+    tree: Option<TreePanelModel>,
     pub selected: usize,
     pub scroll: usize,
 }
@@ -2282,18 +2284,20 @@ impl PluginPanel {
             id,
             config,
             rows: Vec::new(),
+            tree: None,
             selected: 0,
             scroll: 0,
         }
     }
 
     pub fn update_rows(&mut self, rows: Vec<PanelRow>) {
+        self.tree = None;
         self.rows = rows;
-        if self.rows.is_empty() {
+        if self.row_count() == 0 {
             self.selected = 0;
             self.scroll = 0;
-        } else if self.selected >= self.rows.len() {
-            self.selected = self.rows.len() - 1;
+        } else if self.selected >= self.row_count() {
+            self.selected = self.row_count() - 1;
         }
 
         if self.scroll > self.selected {
@@ -2301,12 +2305,43 @@ impl PluginPanel {
         }
     }
 
+    fn update_tree(&mut self, model: TreePanelModel) {
+        let selected_id = self.selected_row().map(|row| row.id);
+        self.rows.clear();
+        self.tree = Some(model);
+        let count = self.row_count();
+        if count == 0 {
+            self.selected = 0;
+            self.scroll = 0;
+            return;
+        }
+        self.selected = selected_id
+            .as_deref()
+            .and_then(|id| self.tree.as_ref()?.position(id))
+            .unwrap_or_else(|| self.selected.min(count - 1));
+        if self.scroll > self.selected {
+            self.scroll = self.selected;
+        }
+    }
+
+    fn row_count(&self) -> usize {
+        self.tree
+            .as_ref()
+            .map_or(self.rows.len(), TreePanelModel::len)
+    }
+
+    fn row(&self, index: usize) -> Option<PanelRow> {
+        self.tree
+            .as_ref()
+            .map_or_else(|| self.rows.get(index).cloned(), |tree| tree.row(index))
+    }
+
     pub fn move_selection(&mut self, delta: isize, panel_height: usize) {
-        if self.rows.is_empty() {
+        if self.row_count() == 0 {
             return;
         }
 
-        let max_index = self.rows.len() - 1;
+        let max_index = self.row_count() - 1;
         self.selected = self.selected.saturating_add_signed(delta).min(max_index);
 
         if self.selected < self.scroll {
@@ -2320,14 +2355,14 @@ impl PluginPanel {
     }
 
     fn scroll_view(&mut self, delta: isize, panel_height: usize, scrolloff: usize) {
-        if self.rows.is_empty() {
+        if self.row_count() == 0 {
             self.selected = 0;
             self.scroll = 0;
             return;
         }
 
         let visible_rows = self.visible_rows(panel_height);
-        let max_scroll = self.rows.len().saturating_sub(visible_rows);
+        let max_scroll = self.row_count().saturating_sub(visible_rows);
         let previous_scroll = self.scroll;
         self.scroll = self.scroll.saturating_add_signed(delta).min(max_scroll);
         if self.scroll == previous_scroll {
@@ -2339,7 +2374,7 @@ impl PluginPanel {
         let last = self
             .scroll
             .saturating_add(visible_rows.saturating_sub(scrolloff).saturating_sub(1))
-            .min(self.rows.len() - 1);
+            .min(self.row_count() - 1);
         self.selected = self.selected.clamp(first, last);
     }
 
@@ -2355,20 +2390,23 @@ impl PluginPanel {
     }
 
     fn scroll_to_bottom(&mut self, panel_height: usize) {
-        if self.rows.is_empty() {
+        if self.row_count() == 0 {
             self.scroll_to_top();
             return;
         }
 
-        self.selected = self.rows.len() - 1;
+        self.selected = self.row_count() - 1;
         self.scroll = self
-            .rows
-            .len()
+            .row_count()
             .saturating_sub(self.visible_rows(panel_height));
     }
 
     pub fn select_row_by_id(&mut self, row_id: &str, panel_height: usize) -> bool {
-        let Some(index) = self.rows.iter().position(|row| row.id == row_id) else {
+        let index = self.tree.as_ref().map_or_else(
+            || self.rows.iter().position(|row| row.id == row_id),
+            |tree| tree.position(row_id),
+        );
+        let Some(index) = index else {
             return false;
         };
 
@@ -2386,7 +2424,7 @@ impl PluginPanel {
     }
 
     pub fn selected_row(&self) -> Option<PanelRow> {
-        self.rows.get(self.selected).cloned()
+        self.row(self.selected)
     }
 
     fn rows_start(&self) -> usize {
@@ -2399,12 +2437,12 @@ impl PluginPanel {
 
     fn select_screen_row(&mut self, screen_y: usize) {
         let rows_start = self.rows_start();
-        if screen_y < rows_start || self.rows.is_empty() {
+        if screen_y < rows_start || self.row_count() == 0 {
             return;
         }
 
         let row_index = self.scroll + screen_y - rows_start;
-        if row_index < self.rows.len() {
+        if row_index < self.row_count() {
             self.selected = row_index;
         }
     }
@@ -2890,6 +2928,13 @@ impl PanelManager {
     pub fn update_panel(&mut self, id: &str, rows: Vec<PanelRow>) {
         if let Some(panel) = self.panels.get_mut(id) {
             panel.update_rows(rows);
+        }
+    }
+
+    /// Replaces a row panel with a compact tree while preserving its stable selection.
+    pub fn update_tree_panel(&mut self, id: &str, model: TreePanelModel) {
+        if let Some(panel) = self.panels.get_mut(id) {
+            panel.update_tree(model);
         }
     }
 
@@ -4324,7 +4369,7 @@ impl PanelManager {
 
         let clicked_row = screen_row
             .checked_sub(panel.rows_start())
-            .and_then(|index| panel.rows.get(panel.scroll.saturating_add(index)));
+            .and_then(|index| panel.row(panel.scroll.saturating_add(index)));
         let action = if let Some(row) = clicked_row {
             let now = Instant::now();
             let is_double_click = previous_row_click.is_some_and(|click| {
@@ -4767,13 +4812,7 @@ fn render_panel_at(
 
     let rows_start = if panel.config.title.is_some() { 1 } else { 0 };
     let visible_rows = height.saturating_sub(rows_start);
-    for (screen_row, row) in panel
-        .rows
-        .iter()
-        .skip(panel.scroll)
-        .take(visible_rows)
-        .enumerate()
-    {
+    let mut paint_row = |screen_row: usize, row: &PanelRow| {
         let y = position.y.saturating_add(rows_start + screen_row);
         let index = panel.scroll + screen_row;
         let selected = index == panel.selected;
@@ -4790,6 +4829,23 @@ fn render_panel_at(
             &surface_style,
             selected,
         );
+    };
+    if let Some(tree) = panel.tree.as_ref() {
+        for (screen_row, index) in (panel.scroll..tree.len()).take(visible_rows).enumerate() {
+            if let Some(row) = tree.row(index) {
+                paint_row(screen_row, &row);
+            }
+        }
+    } else {
+        for (screen_row, row) in panel
+            .rows
+            .iter()
+            .skip(panel.scroll)
+            .take(visible_rows)
+            .enumerate()
+        {
+            paint_row(screen_row, row);
+        }
     }
 }
 
@@ -9395,6 +9451,52 @@ mod tests {
         let mut buffer = RenderBuffer::new(10, 5, &style);
         manager.render(&mut buffer, &theme);
         assert_eq!(row_text(&buffer, 2).trim(), "d");
+    }
+
+    #[test]
+    fn virtual_tree_rows_remain_selectable_and_render_only_the_viewport() {
+        let entries = (0..1_024)
+            .map(|index| {
+                serde_json::json!({
+                    "name": format!("file-{index:04}.rs"),
+                    "path": format!("./file-{index:04}.rs"),
+                    "kind": "file",
+                })
+            })
+            .collect::<Vec<_>>();
+        let model = TreePanelModel::from_husk_values(&[
+            husk_runtime::Value::String("/repo".to_string()),
+            husk_runtime::Value::from_json(serde_json::json!([{
+                "path": ".",
+                "entries": entries,
+            }])),
+            husk_runtime::Value::from_json(serde_json::json!(["."])),
+            husk_runtime::Value::from_json(serde_json::json!([])),
+            husk_runtime::Value::from_json(serde_json::json!([])),
+            husk_runtime::Value::String(String::new()),
+            husk_runtime::Value::from_json(serde_json::json!([])),
+        ])
+        .unwrap();
+        let mut manager = PanelManager::default();
+        manager.create_panel(
+            "tree".to_string(),
+            PanelConfig {
+                width: 24,
+                ..PanelConfig::default()
+            },
+        );
+        manager.update_tree_panel("tree", model);
+        assert!(manager.focus_panel("tree"));
+
+        let event = manager.handle_focused_key("bottom", 5, 40, 0).unwrap();
+        assert_eq!(event.selected_index, 1_024);
+        assert_eq!(event.row.unwrap().id, "./file-1023.rs");
+        assert!(manager.panels["tree"].rows.is_empty());
+
+        let theme = Theme::default();
+        let mut buffer = RenderBuffer::new(40, 7, &theme.style);
+        manager.render(&mut buffer, &theme);
+        assert!((0..5).any(|row| row_text(&buffer, row).contains("file-1023.rs")));
     }
 
     #[test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -47,7 +47,7 @@ use crate::{
 
 use super::{
     Decoration, GutterSign, OverlayConfig, PanelConfig, PanelRow, TextPanelBlock, TextPanelStatus,
-    WindowBarConfig, WindowBarSegment,
+    TreePanelModel, WindowBarConfig, WindowBarSegment,
 };
 use super::{WorkspaceConfig, WorkspaceModel};
 
@@ -2757,6 +2757,25 @@ impl RedHost {
     fn call_neotree_core(&mut self, operation: &str, args: &[Value]) -> anyhow::Result<Value> {
         if operation == "status_entries" {
             return neotree_status_entries(args.first());
+        }
+        if operation == "update_panel" {
+            const EAGER_TREE_ROWS: usize = 192;
+            let id = args
+                .first()
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("Neo-tree panel update requires an id"))?
+                .to_string();
+            let model = TreePanelModel::from_husk_values(&args[1..])?;
+            crate::editor::perf::gauge_max("neotree:total_rows", model.len() as u64);
+            if model.len() <= EAGER_TREE_ROWS {
+                let rows = (0..model.len())
+                    .filter_map(|index| model.row(index))
+                    .collect::<Vec<_>>();
+                self.send_request(PluginRequest::UpdatePanel { id, rows });
+            } else {
+                self.send_request(PluginRequest::UpdateTreePanel { id, model });
+            }
+            return Ok(Value::Unit);
         }
 
         let function = match operation {
@@ -15971,7 +15990,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn neotree_caps_a_pathological_visible_listing_within_the_instruction_budget() {
+    async fn neotree_virtualizes_large_visible_listings_within_the_instruction_budget() {
         drain_requests();
 
         let mut runtime = Runtime::new();
@@ -16006,7 +16025,7 @@ mod tests {
                 serde_json::json!({
                     "path": ".",
                     "entries": entries,
-                    "truncated": true,
+                    "truncated": false,
                     "error": null,
                 }),
             )
@@ -16017,19 +16036,15 @@ mod tests {
             PluginRequest::WatchDirectory { path, .. } => assert_eq!(path, "."),
             _ => panic!("expected neotree directory watch"),
         }
-        let rows = match ACTION_DISPATCHER.recv_request() {
-            PluginRequest::UpdatePanel { id, rows } => {
+        let model = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::UpdateTreePanel { id, model } => {
                 assert_eq!(id, "neotree");
-                rows
+                model
             }
-            _ => panic!("expected neotree panel update"),
+            _ => panic!("expected virtualized Neo-tree panel update"),
         };
-        assert_eq!(rows.len(), 201);
-        assert!(rows.last().unwrap().path.is_none());
-        assert_eq!(
-            rows.last().unwrap().segments[1].text,
-            "… tree limited to 200 rows"
-        );
+        assert_eq!(model.len(), 1_001);
+        assert_eq!(model.row(1_000).unwrap().id, "./file-0999.rlib");
     }
 
     #[tokio::test]

--- a/src/plugin/tree.rs
+++ b/src/plugin/tree.rs
@@ -1,0 +1,679 @@
+//! Compact, lazily decorated row models for large filesystem tree panels.
+//!
+//! Directory entries remain shared with the Husk plugin state. The flattened model
+//! retains only entry coordinates and ancestry, and creates rich [`PanelRow`] values
+//! only for the terminal viewport or a selected row.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use husk_runtime::Value;
+
+use crate::theme::ThemeStyleSpec;
+
+use super::{PanelRow, PanelRowKind, PanelSegment};
+
+const FOLDER_STYLE: &[&str] = &[
+    "symbolIcon.folderForeground",
+    "sideBarTitle.foreground",
+    "list.highlightForeground",
+    "scope:entity.name.type",
+    "editor.foreground",
+];
+const INDENT_STYLE: &[&str] = &[
+    "tree.indentGuidesStroke",
+    "editorIndentGuide.background",
+    "editorLineNumber.foreground",
+    "scope:comment",
+];
+const FILE_STYLE: &[&str] = &[
+    "symbolIcon.fileForeground",
+    "sideBar.foreground",
+    "editor.foreground",
+];
+const FILE_NAME_STYLE: &[&str] = &["sideBar.foreground", "editor.foreground"];
+
+#[derive(Debug, Clone)]
+struct TreeDirectory {
+    entries: Arc<Vec<Value>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TreeRowSource {
+    Root,
+    Entry { directory: u32, entry: u32 },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TreeRow {
+    source: TreeRowSource,
+    parent: Option<u32>,
+    last: bool,
+    expanded: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum GitStatus {
+    Added,
+    Deleted,
+    Modified,
+    Renamed,
+    Untracked,
+    Ignored,
+    Staged,
+    Conflict,
+    #[default]
+    Unknown,
+}
+
+impl GitStatus {
+    fn parse(value: &str) -> Self {
+        match value {
+            "added" => Self::Added,
+            "deleted" => Self::Deleted,
+            "modified" => Self::Modified,
+            "renamed" => Self::Renamed,
+            "untracked" => Self::Untracked,
+            "ignored" => Self::Ignored,
+            "staged" => Self::Staged,
+            "conflict" => Self::Conflict,
+            _ => Self::Unknown,
+        }
+    }
+
+    fn symbol(self) -> &'static str {
+        match self {
+            Self::Added => "✚",
+            Self::Deleted => "✖",
+            Self::Modified => "",
+            Self::Renamed => "",
+            Self::Untracked => "",
+            Self::Ignored => "",
+            Self::Staged => "",
+            Self::Conflict => "",
+            Self::Unknown => "",
+        }
+    }
+
+    fn style(self) -> &'static [&'static str] {
+        match self {
+            Self::Added => &[
+                "gitDecoration.addedResourceForeground",
+                "gitDecoration.untrackedResourceForeground",
+                "editorGutter.addedBackground",
+                "scope:string",
+            ],
+            Self::Deleted => &[
+                "gitDecoration.deletedResourceForeground",
+                "gitDecoration.stageDeletedResourceForeground",
+                "editorGutter.deletedBackground",
+                "editorError.foreground",
+                "scope:markup.deleted",
+                "scope:invalid.illegal",
+                "scope:keyword",
+            ],
+            Self::Modified => &[
+                "gitDecoration.modifiedResourceForeground",
+                "gitDecoration.stageModifiedResourceForeground",
+                "editorGutter.modifiedBackground",
+                "scope:constant.numeric",
+            ],
+            Self::Renamed => &[
+                "gitDecoration.renamedResourceForeground",
+                "gitDecoration.modifiedResourceForeground",
+                "editorGutter.modifiedBackground",
+                "scope:constant.numeric",
+            ],
+            Self::Untracked => &[
+                "gitDecoration.untrackedResourceForeground",
+                "gitDecoration.addedResourceForeground",
+                "editorGutter.addedBackground",
+                "scope:string",
+            ],
+            Self::Ignored => &[
+                "gitDecoration.ignoredResourceForeground",
+                "editorLineNumber.foreground",
+                "scope:comment",
+            ],
+            Self::Staged => &[
+                "gitDecoration.stageModifiedResourceForeground",
+                "gitDecoration.addedResourceForeground",
+                "gitDecoration.untrackedResourceForeground",
+                "editorGutter.addedBackground",
+                "scope:string",
+            ],
+            Self::Conflict => &[
+                "gitDecoration.conflictingResourceForeground",
+                "editorError.foreground",
+                "scope:invalid.illegal",
+                "scope:markup.deleted",
+                "scope:keyword",
+            ],
+            Self::Unknown => &[],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ClipboardAction {
+    Copy,
+    Move,
+}
+
+/// A complete flattened filesystem tree with viewport-only row decoration.
+#[derive(Debug, Clone)]
+pub struct TreePanelModel {
+    cwd: String,
+    status_root: String,
+    directories: Vec<TreeDirectory>,
+    rows: Vec<TreeRow>,
+    statuses: HashMap<String, GitStatus>,
+    selected: HashSet<String>,
+    clipboard: HashMap<String, ClipboardAction>,
+}
+
+impl TreePanelModel {
+    /// Builds a complete index while borrowing shared directory-entry arrays from Husk.
+    pub(crate) fn from_husk_values(args: &[Value]) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            args.len() == 7,
+            "a tree panel model requires seven arguments"
+        );
+        let cwd = args[0]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("tree panel cwd must be a string"))?
+            .to_string();
+        let children = value_array(&args[1], "children")?;
+        let expanded = value_array(&args[2], "expanded")?
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<HashSet<_>>();
+        let selected = value_array(&args[3], "selected")?
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect::<HashSet<_>>();
+        let clipboard = value_array(&args[4], "clipboard")?
+            .iter()
+            .filter_map(|entry| {
+                let path = value_field_string(entry, "path")?;
+                let action = match value_field_string(entry, "action")? {
+                    "copy" => ClipboardAction::Copy,
+                    "move" => ClipboardAction::Move,
+                    _ => return None,
+                };
+                Some((path.to_string(), action))
+            })
+            .collect::<HashMap<_, _>>();
+        let status_root = normalize_path(args[5].as_str().unwrap_or_default());
+        let statuses = value_array(&args[6], "statuses")?
+            .iter()
+            .filter_map(|entry| {
+                Some((
+                    value_field_string(entry, "path")?.to_string(),
+                    GitStatus::parse(value_field_string(entry, "status")?),
+                ))
+            })
+            .collect::<HashMap<_, _>>();
+
+        let mut directories = Vec::with_capacity(children.len());
+        let mut directory_indices = HashMap::with_capacity(children.len());
+        for child in children {
+            let Some(path) = value_field_string(child, "path") else {
+                continue;
+            };
+            let Some(entries) = value_field_array(child, "entries") else {
+                continue;
+            };
+            directory_indices.insert(path.to_string(), directories.len());
+            directories.push(TreeDirectory {
+                entries: Arc::clone(entries),
+            });
+        }
+
+        let root_expanded = expanded.contains(".");
+        let mut model = Self {
+            cwd,
+            status_root,
+            directories,
+            rows: vec![TreeRow {
+                source: TreeRowSource::Root,
+                parent: None,
+                last: true,
+                expanded: root_expanded,
+            }],
+            statuses,
+            selected,
+            clipboard,
+        };
+        if root_expanded {
+            if let Some(&root) = directory_indices.get(".") {
+                model.append_directory(root, 0, &directory_indices, &expanded)?;
+            }
+        }
+        Ok(model)
+    }
+
+    fn append_directory(
+        &mut self,
+        directory: usize,
+        parent: usize,
+        directory_indices: &HashMap<String, usize>,
+        expanded: &HashSet<&str>,
+    ) -> anyhow::Result<()> {
+        let entries = Arc::clone(&self.directories[directory].entries);
+        let last = entries.iter().rposition(|entry| {
+            matches!(
+                value_field_string(entry, "kind"),
+                Some("file" | "directory")
+            )
+        });
+        for (index, entry) in entries.iter().enumerate() {
+            let Some(kind @ ("file" | "directory")) = value_field_string(entry, "kind") else {
+                continue;
+            };
+            let Some(path) = value_field_string(entry, "path") else {
+                continue;
+            };
+            let open = kind == "directory" && expanded.contains(path);
+            let row_index = self.rows.len();
+            self.rows.push(TreeRow {
+                source: TreeRowSource::Entry {
+                    directory: u32::try_from(directory)
+                        .map_err(|_| anyhow::anyhow!("tree directory index exceeds u32"))?,
+                    entry: u32::try_from(index)
+                        .map_err(|_| anyhow::anyhow!("tree directory entry index exceeds u32"))?,
+                },
+                parent: Some(
+                    u32::try_from(parent)
+                        .map_err(|_| anyhow::anyhow!("tree parent index exceeds u32"))?,
+                ),
+                last: Some(index) == last,
+                expanded: open,
+            });
+            if open {
+                if let Some(&child) = directory_indices.get(path) {
+                    self.append_directory(child, row_index, directory_indices, expanded)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub(crate) fn position(&self, id: &str) -> Option<usize> {
+        self.rows.iter().position(|row| match row.source {
+            TreeRowSource::Root => id == ".",
+            TreeRowSource::Entry { directory, entry } => {
+                self.directories[directory as usize]
+                    .entries
+                    .get(entry as usize)
+                    .and_then(|value| value_field_string(value, "path"))
+                    == Some(id)
+            }
+        })
+    }
+
+    pub(crate) fn row(&self, index: usize) -> Option<PanelRow> {
+        let row = self.rows.get(index)?;
+        match row.source {
+            TreeRowSource::Root => Some(self.root_row(row.expanded)),
+            TreeRowSource::Entry { directory, entry } => {
+                let entry = self
+                    .directories
+                    .get(directory as usize)?
+                    .entries
+                    .get(entry as usize)?;
+                self.entry_row(index, row, entry)
+            }
+        }
+    }
+
+    fn root_row(&self, expanded: bool) -> PanelRow {
+        let name = self.cwd.rsplit('/').next().unwrap_or(&self.cwd);
+        let status = self.status_for_path(".");
+        PanelRow {
+            id: ".".to_string(),
+            path: Some(".".to_string()),
+            expanded: Some(expanded),
+            kind: PanelRowKind::Directory,
+            segments: vec![
+                segment(" ", &[], false),
+                segment(" ", FOLDER_STYLE, false),
+                segment(
+                    name,
+                    &[
+                        "sideBarTitle.foreground",
+                        "symbolIcon.folderForeground",
+                        "list.highlightForeground",
+                        "scope:entity.name.type",
+                        "editor.foreground",
+                    ],
+                    true,
+                ),
+            ],
+            right_segments: visible_status_segments(status, true, expanded),
+        }
+    }
+
+    fn entry_row(&self, index: usize, row: &TreeRow, entry: &Value) -> Option<PanelRow> {
+        let name = value_field_string(entry, "name")?;
+        let path = value_field_string(entry, "path")?;
+        let directory = value_field_string(entry, "kind")? == "directory";
+        let status = self.status_for_path(path);
+        let mut segments = vec![segment(
+            self.selection_marker(path),
+            &["list.highlightForeground"],
+            true,
+        )];
+        self.append_branch_segments(index, &mut segments);
+        segments.push(segment(
+            format!("{} ", entry_icon(name, directory, row.expanded)),
+            entry_icon_style(name, status, directory),
+            false,
+        ));
+        segments.push(segment(name, entry_name_style(status, directory), false));
+        Some(PanelRow {
+            id: path.to_string(),
+            path: Some(path.to_string()),
+            expanded: Some(row.expanded),
+            kind: if directory {
+                PanelRowKind::Directory
+            } else {
+                PanelRowKind::File
+            },
+            segments,
+            right_segments: visible_status_segments(status, directory, row.expanded),
+        })
+    }
+
+    fn append_branch_segments(&self, index: usize, segments: &mut Vec<PanelSegment>) {
+        let Some(row) = self.rows.get(index) else {
+            return;
+        };
+        let mut ancestors = Vec::new();
+        let mut parent = row.parent;
+        while let Some(parent_index) = parent {
+            let Some(ancestor) = self.rows.get(parent_index as usize) else {
+                break;
+            };
+            if matches!(ancestor.source, TreeRowSource::Root) {
+                break;
+            }
+            ancestors.push(ancestor.last);
+            parent = ancestor.parent;
+        }
+        ancestors.reverse();
+
+        if ancestors.is_empty() {
+            segments.push(segment("  ", INDENT_STYLE, false));
+            return;
+        }
+        for (depth, last) in ancestors.into_iter().enumerate() {
+            segments.push(segment(
+                if depth > 0 && !last { "│ " } else { "  " },
+                INDENT_STYLE,
+                false,
+            ));
+        }
+        segments.push(segment(
+            if row.last { "└ " } else { "├ " },
+            INDENT_STYLE,
+            false,
+        ));
+    }
+
+    fn selection_marker(&self, path: &str) -> &'static str {
+        if self.selected.contains(path) {
+            return "✓ ";
+        }
+        match self.clipboard.get(path) {
+            Some(ClipboardAction::Move) => "✂ ",
+            Some(ClipboardAction::Copy) => "⧉ ",
+            None => "  ",
+        }
+    }
+
+    fn status_for_path(&self, path: &str) -> GitStatus {
+        if self.status_root.is_empty() {
+            return GitStatus::Unknown;
+        }
+        let relative = path.strip_prefix("./").unwrap_or(path);
+        let absolute = if relative.is_empty() || relative == "." {
+            self.status_root.clone()
+        } else if self.status_root == "/" {
+            format!("/{relative}")
+        } else {
+            format!("{}/{relative}", self.status_root)
+        };
+        self.statuses.get(&absolute).copied().unwrap_or_default()
+    }
+}
+
+fn value_array<'a>(value: &'a Value, name: &str) -> anyhow::Result<&'a [Value]> {
+    match value {
+        Value::Array(values) => Ok(values.as_slice()),
+        _ => anyhow::bail!("tree panel {name} must be an array"),
+    }
+}
+
+fn value_field_string<'a>(value: &'a Value, name: &str) -> Option<&'a str> {
+    match value {
+        Value::Object(fields) | Value::Struct { fields, .. } => fields.get(name)?.as_str(),
+        Value::Json(value) => value.get(name)?.as_str(),
+        _ => None,
+    }
+}
+
+fn value_field_array<'a>(value: &'a Value, name: &str) -> Option<&'a Arc<Vec<Value>>> {
+    match value {
+        Value::Object(fields) | Value::Struct { fields, .. } => match fields.get(name)? {
+            Value::Array(values) => Some(values),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn normalize_path(path: &str) -> String {
+    let mut path = path.replace('\\', "/");
+    while path.len() > 1 && path.ends_with('/') {
+        path.pop();
+    }
+    path
+}
+
+fn entry_icon(name: &str, directory: bool, expanded: bool) -> &'static str {
+    if directory {
+        return if expanded { "" } else { "" };
+    }
+    match extension(name).as_str() {
+        "js" | "mjs" | "cjs" => "",
+        "ts" => "",
+        "tsx" | "jsx" => "",
+        "json" => "",
+        "toml" => "",
+        "rs" => "",
+        "lua" => "",
+        "md" | "markdown" => "",
+        "lock" => "",
+        "sh" | "zsh" | "fish" => "",
+        _ => "󰈙",
+    }
+}
+
+fn extension(name: &str) -> String {
+    name.rsplit_once('.')
+        .map_or(name, |(_, suffix)| suffix)
+        .to_ascii_lowercase()
+}
+
+fn entry_icon_style(name: &str, status: GitStatus, directory: bool) -> &'static [&'static str] {
+    if status == GitStatus::Ignored {
+        return status.style();
+    }
+    if directory {
+        return FOLDER_STYLE;
+    }
+    match extension(name).as_str() {
+        "rs" | "toml" => &[
+            "terminal.ansiBrightYellow",
+            "terminal.ansiYellow",
+            "scope:constant.numeric",
+            "sideBar.foreground",
+            "editor.foreground",
+        ],
+        "js" | "mjs" | "cjs" | "json" => &[
+            "terminal.ansiYellow",
+            "terminal.ansiBrightYellow",
+            "scope:constant.numeric",
+            "sideBar.foreground",
+            "editor.foreground",
+        ],
+        "ts" | "lua" => &[
+            "terminal.ansiBlue",
+            "terminal.ansiCyan",
+            "scope:entity.name.function",
+            "sideBar.foreground",
+            "editor.foreground",
+        ],
+        "tsx" | "jsx" => &[
+            "terminal.ansiCyan",
+            "terminal.ansiBlue",
+            "scope:entity.name.tag",
+            "scope:entity.name.function",
+            "sideBar.foreground",
+            "editor.foreground",
+        ],
+        "sh" | "zsh" | "fish" => &[
+            "terminal.ansiGreen",
+            "scope:string",
+            "sideBar.foreground",
+            "editor.foreground",
+        ],
+        "md" | "markdown" => &[
+            "scope:markup.heading",
+            "terminal.ansiBlue",
+            "scope:entity.name.function",
+            "sideBar.foreground",
+            "editor.foreground",
+        ],
+        "lock" => &[
+            "descriptionForeground",
+            "editorLineNumber.foreground",
+            "scope:comment",
+            "sideBar.foreground",
+            "editor.foreground",
+        ],
+        _ => FILE_STYLE,
+    }
+}
+
+fn entry_name_style(status: GitStatus, directory: bool) -> &'static [&'static str] {
+    let style = status.style();
+    if !style.is_empty() {
+        style
+    } else if directory {
+        FOLDER_STYLE
+    } else {
+        FILE_NAME_STYLE
+    }
+}
+
+fn visible_status_segments(
+    status: GitStatus,
+    directory: bool,
+    expanded: bool,
+) -> Vec<PanelSegment> {
+    if status == GitStatus::Unknown || directory && expanded {
+        return Vec::new();
+    }
+    vec![segment(
+        status.symbol(),
+        status.style(),
+        status == GitStatus::Conflict,
+    )]
+}
+
+fn segment(text: impl Into<String>, foreground: &[&str], bold: bool) -> PanelSegment {
+    PanelSegment {
+        text: text.into(),
+        style: None,
+        semantic: Some(ThemeStyleSpec {
+            foreground: foreground
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+            bold: Some(bold),
+            ..ThemeStyleSpec::default()
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(children: serde_json::Value, expanded: serde_json::Value) -> TreePanelModel {
+        TreePanelModel::from_husk_values(&[
+            Value::String("/repo".to_string()),
+            Value::from_json(children),
+            Value::from_json(expanded),
+            Value::from_json(serde_json::json!([])),
+            Value::from_json(serde_json::json!([])),
+            Value::String(String::new()),
+            Value::from_json(serde_json::json!([])),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn indexes_every_entry_without_allocating_decorated_rows() {
+        let entries = (0..8_192)
+            .map(|index| {
+                serde_json::json!({
+                    "name": format!("file-{index:04}.rs"),
+                    "path": format!("./file-{index:04}.rs"),
+                    "kind": "file",
+                })
+            })
+            .collect::<Vec<_>>();
+        let model = model(
+            serde_json::json!([{ "path": ".", "entries": entries }]),
+            serde_json::json!(["."]),
+        );
+
+        assert_eq!(model.len(), 8_193);
+        assert_eq!(model.row(8_192).unwrap().id, "./file-8191.rs");
+        assert!(std::mem::size_of::<TreeRow>() <= 24);
+    }
+
+    #[test]
+    fn preserves_nested_tree_guides() {
+        let model = model(
+            serde_json::json!([
+                {
+                    "path": ".",
+                    "entries": [{ "name": "src", "path": "./src", "kind": "directory" }]
+                },
+                {
+                    "path": "./src",
+                    "entries": [{ "name": "main.rs", "path": "./src/main.rs", "kind": "file" }]
+                }
+            ]),
+            serde_json::json!([".", "./src"]),
+        );
+
+        let directory = model.row(1).unwrap();
+        let file = model.row(2).unwrap();
+        assert_eq!(directory.segments[1].text, "  ");
+        assert_eq!(file.segments[1].text, "  ");
+        assert_eq!(file.segments[2].text, "└ ");
+        assert_eq!(file.segments[3].text, " ");
+    }
+}

--- a/tests/test_neotree_bench.py
+++ b/tests/test_neotree_bench.py
@@ -1,0 +1,44 @@
+import unittest
+
+from scripts.neotree_bench import percentile, summarize, timing_samples
+
+
+class NeoTreeBenchmarkTest(unittest.TestCase):
+    def test_timing_samples_preserve_request_names(self) -> None:
+        samples = timing_samples(
+            "[PERF] drain ListDirectory: 42us\n"
+            "[PERF] drain UpdateTreePanel: 7us\n"
+            "[PERF] event Key: 11us\n"
+        )
+
+        self.assertEqual(samples["drain ListDirectory"], [42])
+        self.assertEqual(samples["drain UpdateTreePanel"], [7])
+        self.assertEqual(samples["event"], [11])
+
+    def test_percentile_handles_empty_and_orders_samples(self) -> None:
+        self.assertEqual(percentile([], 95), 0)
+        self.assertEqual(percentile([9, 1, 3], 50), 3)
+
+    def test_summary_requires_every_sample_to_reach_the_last_entry(self) -> None:
+        base = {
+            "entries": 512,
+            "open_ms": 20,
+            "directory_ms": 5,
+            "navigation_p95_us": 100,
+            "rss_delta_kib": 1024,
+            "idle_cpu_ms": 0,
+        }
+        result = summarize(
+            [
+                {**base, "target_reachable": True, "truncation_marker": False},
+                {**base, "target_reachable": False, "truncation_marker": True},
+            ]
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertFalse(result[0]["complete"])
+        self.assertTrue(result[0]["truncation_marker"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Neo-tree silently loses files in large directories: the host stops enumerating after 160 filesystem entries, and the Husk presentation layer separately stops after 200 visible rows. Entries are discarded before sorting, so valid files can disappear entirely and existing timings understate the real cost of browsing a complete directory.

## What changed

- Add `scripts/neotree_bench.py`, a real-editor PTY benchmark that creates fixture directories, verifies the alphabetically final file is reachable, and measures opening latency, navigation latency, resident memory, and idle CPU.
- Remove both directory and tree-row limits, sort every discovered entry, and move filesystem enumeration onto Tokio's blocking pool.
- Introduce `src/plugin/tree.rs`, a compact virtual tree model that shares Husk directory-entry arrays and materializes icons, paths, Git decorations, branch guides, and theme styles only for visible or selected rows.
- Preserve existing small-tree behavior, keyboard and mouse navigation, active-file reveal, selection, clipboard markers, and Git status rendering.
- Replace full nonrecursive watcher snapshots with compact directory/ignore-file metadata fingerprints; build a fresh listing only when that fingerprint changes.
- Document the benchmark methodology and matched baseline/results in `docs/performance-neotree-unbounded-2026-08-21.md`.

### Performance

Three-sample medians from optimized builds:

| Files | Baseline complete | Updated complete | Opening, baseline → updated | Updated navigation p95 |
| ---: | :---: | :---: | ---: | ---: |
| 128 | Yes | Yes | 59.47 → 21.55 ms | 0.555 ms |
| 512 | No | Yes | 36.59 → 23.94 ms | 0.566 ms |
| 2,048 | No | Yes | 35.55 → 24.32 ms | 0.662 ms |
| 8,192 | No | Yes | 37.30 → 47.17 ms | 0.566 ms |

Baseline numbers above 128 files cover only the first 160 entries, not the complete directory. A separate 32,768-file stress run reached the final file in 119.88 ms with 0.694 ms p95 navigation.

## How to Test

1. Build the optimized editor:

   ```sh
   cargo build --locked --release --bin red
   ```

2. Run the complete-directory benchmark:

   ```sh
   python3 -B scripts/neotree_bench.py \
     --sizes 128 512 2048 8192 \
     --samples 3 \
     --navigation-presses 50 \
     --require-complete
   ```

   Expect every size to report `complete: true`, no truncation marker, and the final alphabetically sorted file to remain reachable.

3. Exercise the active-file reveal regression case:

   ```sh
   python3 -B scripts/neotree_bench.py \
     --sizes 8192 \
     --samples 1 \
     --active-target \
     --require-complete
   ```

   Expect Neo-tree to reveal the already-open final file and keep that entry reachable in the large directory.

4. Run the focused directory, virtual-panel, Husk-core, and benchmark tests:

   ```sh
   cargo test --locked directory_listing_returns_every_entry_in_large_directories
   cargo test --locked virtual_tree_rows_remain_selectable_and_render_only_the_viewport
   cargo run --locked --release -p husk-cli -- test --locked plugins/neotree_core
   python3 -B -m unittest discover -s tests -p 'test_neotree_bench.py'
   ```

Validated locally with 2,958 passing Rust tests, six Neo-tree Husk tests, 19 Python tests, the bundled-plugin startup self-check, and all-target/all-feature Clippy with warnings denied.
