### PR TITLE
fix(picker): prioritize filename matches

### DIFF
--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -12,7 +12,7 @@ use std::{
 
 use anyhow::Context;
 use crossterm::event::{self};
-use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use fuzzy_matcher::skim::SkimMatcherV2;
 use ignore::{DirEntry, WalkBuilder};
 
 use crate::{
@@ -22,9 +22,11 @@ use crate::{
     theme::Theme,
 };
 
-use super::{picker::PickerFilterHighlights, Component, Picker, PickerItem, PickerPreview};
-
-const FILENAME_MATCH_BONUS: i64 = 1;
+use super::{
+    picker::PickerFilterHighlights,
+    picker_matching::{match_path, path_match_highlights, PathCandidate},
+    Component, Picker, PickerItem, PickerPreview,
+};
 
 pub struct FilePicker {
     picker: Picker,
@@ -248,25 +250,12 @@ impl Component for FilePicker {
 }
 
 fn file_match_score(matcher: &SkimMatcherV2, item: &PickerItem, query: &str) -> Option<i64> {
-    if !fuzzy_subsequence_matches(&item.label, query) {
-        return matcher.fuzzy_match(&item.id, query);
-    }
-
-    let filename_score = matcher
-        .fuzzy_match(&item.label, query)
-        .map(|score| score.saturating_add(FILENAME_MATCH_BONUS))?;
-    let query_matches_parent = item
-        .annotation
-        .as_deref()
-        .is_some_and(|parent| fuzzy_subsequence_matches(parent, query));
-
-    if query_matches_parent {
-        matcher
-            .fuzzy_match(&item.id, query)
-            .map(|path_score| path_score.max(filename_score))
-    } else {
-        Some(filename_score)
-    }
+    match_path(
+        matcher,
+        PathCandidate::new(&item.id, &item.label, item.annotation.as_deref()),
+        query,
+    )
+    .map(|matched| matched.score)
 }
 
 fn file_match_highlights(
@@ -274,99 +263,11 @@ fn file_match_highlights(
     item: &PickerItem,
     query: &str,
 ) -> PickerFilterHighlights {
-    let Some((filename_score, filename_indices)) = matcher.fuzzy_indices(&item.label, query) else {
-        return matcher
-            .fuzzy_indices(&item.id, query)
-            .map(|(_, indices)| path_match_highlights(item, indices))
-            .unwrap_or_default();
-    };
-    let filename_score = filename_score.saturating_add(FILENAME_MATCH_BONUS);
-    let query_matches_parent = item
-        .annotation
-        .as_deref()
-        .is_some_and(|parent| fuzzy_subsequence_matches(parent, query));
-
-    if query_matches_parent {
-        if let Some((path_score, path_indices)) = matcher.fuzzy_indices(&item.id, query) {
-            if path_score > filename_score {
-                return path_match_highlights(item, path_indices);
-            }
-        }
-    }
-
-    PickerFilterHighlights {
-        label: indices_to_ranges(filename_indices),
-        annotation: Vec::new(),
-    }
-}
-
-fn path_match_highlights(item: &PickerItem, indices: Vec<usize>) -> PickerFilterHighlights {
-    let label_start = item
-        .id
-        .chars()
-        .count()
-        .saturating_sub(item.label.chars().count());
-    let annotation_len = item
-        .annotation
-        .as_deref()
-        .map(|annotation| annotation.chars().count())
-        .unwrap_or_default();
-    let mut label_indices = Vec::new();
-    let mut annotation_indices = Vec::new();
-
-    for index in indices {
-        if index >= label_start {
-            label_indices.push(index - label_start);
-        } else if index < annotation_len {
-            annotation_indices.push(index);
-        }
-    }
-
-    PickerFilterHighlights {
-        label: indices_to_ranges(label_indices),
-        annotation: indices_to_ranges(annotation_indices),
-    }
-}
-
-fn indices_to_ranges(indices: Vec<usize>) -> Vec<[usize; 2]> {
-    let mut ranges: Vec<[usize; 2]> = Vec::new();
-    for index in indices {
-        if let Some(last) = ranges.last_mut() {
-            if last[1] == index {
-                last[1] += 1;
-                continue;
-            }
-        }
-        ranges.push([index, index + 1]);
-    }
-    ranges
-}
-
-fn fuzzy_subsequence_matches(candidate: &str, query: &str) -> bool {
-    let case_sensitive = query
-        .chars()
-        .any(|character| character.is_ascii_uppercase());
-    let mut query = query.chars();
-    let Some(mut expected) = query.next() else {
-        return true;
-    };
-
-    for character in candidate.chars() {
-        let matches = if case_sensitive {
-            character == expected
-        } else {
-            character.eq_ignore_ascii_case(&expected)
-        };
-        if !matches {
-            continue;
-        }
-        let Some(next) = query.next() else {
-            return true;
-        };
-        expected = next;
-    }
-
-    false
+    path_match_highlights(
+        matcher,
+        PathCandidate::new(&item.id, &item.label, item.annotation.as_deref()),
+        query,
+    )
 }
 
 fn load_file_picker_items(
@@ -665,6 +566,37 @@ mod tests {
 
         assert!(picker.tick().unwrap());
         assert_eq!(selected_file(&mut picker), "deep/src/main.rs");
+    }
+
+    #[test]
+    fn file_picker_prefers_filename_matches_over_shared_parent_matches() {
+        let editor = test_editor();
+        let mut picker = FilePicker::loading(&editor);
+        for character in "recap".chars() {
+            picker.handle_event(&key(KeyCode::Char(character)));
+        }
+        send_load(
+            &picker,
+            picker.load_generation,
+            Ok(vec![
+                "codex.fcoury-recap/src/lib.rs".to_string(),
+                "codex.fcoury-recap/src/thread_recap.rs".to_string(),
+                "codex.fcoury-recap/src/recap.rs".to_string(),
+            ]),
+        );
+
+        assert!(picker.tick().unwrap());
+        assert_eq!(
+            selected_file(&mut picker),
+            "codex.fcoury-recap/src/recap.rs"
+        );
+        picker.handle_event(&key(KeyCode::Down));
+        assert_eq!(
+            selected_file(&mut picker),
+            "codex.fcoury-recap/src/thread_recap.rs"
+        );
+        picker.handle_event(&key(KeyCode::Down));
+        assert_eq!(selected_file(&mut picker), "codex.fcoury-recap/src/lib.rs");
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -27,6 +27,7 @@ mod learn;
 mod list;
 mod messages;
 mod picker;
+mod picker_matching;
 mod prompt_buffer;
 mod rich_text;
 mod selection;

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -10,7 +10,6 @@
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use fuzzy_matcher::skim::SkimMatcherV2;
-use fuzzy_matcher::FuzzyMatcher;
 use ropey::{Rope, RopeSlice};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -41,8 +40,11 @@ use crate::{
 };
 
 use super::{
-    dialog::BorderStyle, first_prompt_line, spinner_frame, ActionBar, ActionPriority, Component,
-    Dialog, IconCatalog, List, ScreenRect, UiAction, SPINNER_FRAME_INTERVAL_MS,
+    dialog::BorderStyle,
+    first_prompt_line,
+    picker_matching::{match_path, PathCandidate},
+    spinner_frame, ActionBar, ActionPriority, Component, Dialog, IconCatalog, List, ScreenRect,
+    UiAction, SPINNER_FRAME_INTERVAL_MS,
 };
 
 type SelectAction = Box<dyn Fn(String) -> Action + Send>;
@@ -54,6 +56,7 @@ type FilterHighlightAction = Box<dyn Fn(&PickerItem, &str) -> PickerFilterHighli
 enum PickerMatchKind {
     Exact,
     ExactIgnoreCase,
+    Filename,
     Fuzzy,
 }
 
@@ -62,14 +65,20 @@ fn default_filter_score(
     label: &str,
     query: &str,
 ) -> Option<(PickerMatchKind, Reverse<i64>)> {
-    // Keep smart-case eligibility, but rank whole labels ahead of fuzzy prefixes.
-    let score = matcher.fuzzy_match(label, query)?;
-    let kind = if label == query {
-        PickerMatchKind::Exact
+    let candidate = PathCandidate::from_path(label);
+    let matched = match_path(matcher, candidate, query)?;
+    let (kind, score) = if label == query {
+        (PickerMatchKind::Exact, matched.score)
     } else if label.eq_ignore_ascii_case(query) {
-        PickerMatchKind::ExactIgnoreCase
+        (PickerMatchKind::ExactIgnoreCase, matched.score)
+    } else if candidate.has_parent() {
+        matched
+            .filename_score
+            .map_or((PickerMatchKind::Fuzzy, matched.score), |filename_score| {
+                (PickerMatchKind::Filename, filename_score)
+            })
     } else {
-        PickerMatchKind::Fuzzy
+        (PickerMatchKind::Fuzzy, matched.score)
     };
     Some((kind, Reverse(score)))
 }
@@ -6557,6 +6566,55 @@ mod tests {
                 "",
                 &["DrawTail", "Draw", "draw"],
                 &["DrawTail", "Draw", "draw"],
+            ),
+            (
+                "recap",
+                &[
+                    "/workspace/codex.fcoury-recap/src/lib.rs",
+                    "/workspace/codex.fcoury-recap/src/thread_recap.rs",
+                    "/workspace/codex.fcoury-recap/src/recap.rs",
+                    "/workspace/codex.fcoury-recap/src/app.rs",
+                ],
+                &[
+                    "/workspace/codex.fcoury-recap/src/recap.rs",
+                    "/workspace/codex.fcoury-recap/src/thread_recap.rs",
+                    "/workspace/codex.fcoury-recap/src/lib.rs",
+                    "/workspace/codex.fcoury-recap/src/app.rs",
+                ],
+            ),
+            (
+                "recap",
+                &[
+                    r"C:\workspace\codex.fcoury-recap\src\lib.rs",
+                    r"C:\workspace\codex.fcoury-recap\src\thread_recap.rs",
+                    r"C:\workspace\codex.fcoury-recap\src\recap.rs",
+                ],
+                &[
+                    r"C:\workspace\codex.fcoury-recap\src\recap.rs",
+                    r"C:\workspace\codex.fcoury-recap\src\thread_recap.rs",
+                    r"C:\workspace\codex.fcoury-recap\src\lib.rs",
+                ],
+            ),
+            (
+                "routing",
+                &[
+                    "/workspace/routing/src/lib.rs",
+                    "/workspace/other/src/app.rs",
+                ],
+                &["/workspace/routing/src/lib.rs"],
+            ),
+            (
+                "src/recap",
+                &["/workspace/lib/recap.rs", "/workspace/src/recap.rs"],
+                &["/workspace/src/recap.rs"],
+            ),
+            (
+                "Recap",
+                &[
+                    "/workspace/recap/src/recap.rs",
+                    "/workspace/recap/src/Recap.rs",
+                ],
+                &["/workspace/recap/src/Recap.rs"],
             ),
         ];
 

--- a/src/ui/picker_matching.rs
+++ b/src/ui/picker_matching.rs
@@ -1,0 +1,176 @@
+//! Shared fuzzy matching for picker rows that represent filesystem paths.
+
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+
+use super::picker::PickerFilterHighlights;
+
+const FILENAME_MATCH_BONUS: i64 = 1;
+
+#[derive(Clone, Copy)]
+pub(super) struct PathCandidate<'a> {
+    path: &'a str,
+    filename: &'a str,
+    parent: Option<&'a str>,
+}
+
+impl<'a> PathCandidate<'a> {
+    pub(super) fn new(path: &'a str, filename: &'a str, parent: Option<&'a str>) -> Self {
+        Self {
+            path,
+            filename,
+            parent,
+        }
+    }
+
+    pub(super) fn from_path(path: &'a str) -> Self {
+        let Some(separator) = path.rfind(['/', '\\']) else {
+            return Self::new(path, path, None);
+        };
+        let (parent, filename) = path.split_at(separator);
+
+        Self::new(path, &filename[1..], (!parent.is_empty()).then_some(parent))
+    }
+
+    pub(super) fn has_parent(self) -> bool {
+        self.parent.is_some()
+    }
+}
+
+pub(super) struct PathMatch {
+    pub(super) score: i64,
+    pub(super) filename_score: Option<i64>,
+}
+
+pub(super) fn match_path(
+    matcher: &SkimMatcherV2,
+    candidate: PathCandidate<'_>,
+    query: &str,
+) -> Option<PathMatch> {
+    if !fuzzy_subsequence_matches(candidate.filename, query) {
+        return Some(PathMatch {
+            score: matcher.fuzzy_match(candidate.path, query)?,
+            filename_score: None,
+        });
+    }
+
+    let filename_score = matcher
+        .fuzzy_match(candidate.filename, query)?
+        .saturating_add(FILENAME_MATCH_BONUS);
+    let query_matches_parent = candidate
+        .parent
+        .is_some_and(|parent| fuzzy_subsequence_matches(parent, query));
+    let score = if query_matches_parent {
+        matcher
+            .fuzzy_match(candidate.path, query)?
+            .max(filename_score)
+    } else {
+        filename_score
+    };
+
+    Some(PathMatch {
+        score,
+        filename_score: Some(filename_score),
+    })
+}
+
+pub(super) fn path_match_highlights(
+    matcher: &SkimMatcherV2,
+    candidate: PathCandidate<'_>,
+    query: &str,
+) -> PickerFilterHighlights {
+    let Some((filename_score, filename_indices)) = matcher.fuzzy_indices(candidate.filename, query)
+    else {
+        return matcher
+            .fuzzy_indices(candidate.path, query)
+            .map(|(_, indices)| split_path_highlights(candidate, indices))
+            .unwrap_or_default();
+    };
+    let filename_score = filename_score.saturating_add(FILENAME_MATCH_BONUS);
+    let query_matches_parent = candidate
+        .parent
+        .is_some_and(|parent| fuzzy_subsequence_matches(parent, query));
+
+    if query_matches_parent {
+        if let Some((path_score, path_indices)) = matcher.fuzzy_indices(candidate.path, query) {
+            if path_score > filename_score {
+                return split_path_highlights(candidate, path_indices);
+            }
+        }
+    }
+
+    PickerFilterHighlights {
+        label: indices_to_ranges(filename_indices),
+        annotation: Vec::new(),
+    }
+}
+
+fn split_path_highlights(
+    candidate: PathCandidate<'_>,
+    indices: Vec<usize>,
+) -> PickerFilterHighlights {
+    let filename_start = candidate
+        .path
+        .chars()
+        .count()
+        .saturating_sub(candidate.filename.chars().count());
+    let parent_len = candidate
+        .parent
+        .map(|parent| parent.chars().count())
+        .unwrap_or_default();
+    let mut filename_indices = Vec::new();
+    let mut parent_indices = Vec::new();
+
+    for index in indices {
+        if index >= filename_start {
+            filename_indices.push(index - filename_start);
+        } else if index < parent_len {
+            parent_indices.push(index);
+        }
+    }
+
+    PickerFilterHighlights {
+        label: indices_to_ranges(filename_indices),
+        annotation: indices_to_ranges(parent_indices),
+    }
+}
+
+fn indices_to_ranges(indices: Vec<usize>) -> Vec<[usize; 2]> {
+    let mut ranges: Vec<[usize; 2]> = Vec::new();
+    for index in indices {
+        if let Some(last) = ranges.last_mut() {
+            if last[1] == index {
+                last[1] += 1;
+                continue;
+            }
+        }
+        ranges.push([index, index + 1]);
+    }
+    ranges
+}
+
+fn fuzzy_subsequence_matches(candidate: &str, query: &str) -> bool {
+    let case_sensitive = query
+        .chars()
+        .any(|character| character.is_ascii_uppercase());
+    let mut query = query.chars();
+    let Some(mut expected) = query.next() else {
+        return true;
+    };
+
+    for character in candidate.chars() {
+        let matches = if case_sensitive {
+            character == expected
+        } else {
+            character.eq_ignore_ascii_case(&expected)
+        };
+        if !matches {
+            continue;
+        }
+        let Some(next) = query.next() else {
+            return true;
+        };
+        expected = next;
+    }
+
+    false
+}


### PR DESCRIPTION
## Why

The buffer picker searches complete paths, so a query like `recap` matches the shared `codex.fcoury-recap` directory in every open buffer. That can rank unrelated files such as `lib.rs` ahead of relevant filenames such as `thread_recap.rs`.

## What changed

- Extract filename/path scoring, smart-case matching, and Unicode-aware highlights into `src/ui/picker_matching.rs`.
- Rank filename matches ahead of directory-only matches in plain and plugin-backed pickers while preserving exact matches, full-path queries, custom ordering, and existing file-picker behavior.
- Add regressions for shared parent directories, Windows paths, directory-only queries, cross-directory searches, and smart-case queries.

## How to Test

1. Open `recap.rs`, `thread_recap.rs`, and `lib.rs` beneath a shared `codex.fcoury-recap` directory, run `BufferPicker`, and search for `recap`. Expect `recap.rs` and `thread_recap.rs` to appear before `lib.rs`.
2. Search for a parent-directory name or `src/recap`; expect directory and full-path matches to remain discoverable. Search for `Recap`; expect smart-case filtering.
3. Run `cargo test -p red --lib picker`; expect all 153 picker tests to pass, including the buffer-picker integration and shared-parent regressions.
4. Run `cargo test -p red --lib` and `cargo clippy --all-targets --all-features -- -D warnings`; expect 2,074 passing library tests, one ignored test, and no Clippy warnings.
