### PR TITLE
feat(lsp): cache diagnostics across editor restarts

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -21,6 +21,7 @@ mod agent_models;
 mod buffer_manager;
 mod command_mode;
 mod completion_resolve;
+mod diagnostic_cache;
 mod diagnostics;
 mod diagnostics_picker;
 mod display_layout;
@@ -3467,6 +3468,7 @@ pub struct Editor {
     /// Map of diagnostics per file uri
     diagnostics: HashMap<String, Vec<Diagnostic>>,
     diagnostic_reports: diagnostics::DiagnosticReports,
+    diagnostic_cache: Option<diagnostic_cache::DiagnosticCache>,
 
     /// Indentation rules per file type
     indentation: HashMap<String, Indentation>,
@@ -4416,6 +4418,7 @@ impl Editor {
         let count = loaded.config.languages.len();
         self.config.languages = loaded.config.languages;
         self.config.lsp = loaded.config.lsp;
+        self.mark_diagnostic_cache_dirty();
         self.config.formatting = loaded.config.formatting;
         self.config.commenting = loaded.config.commenting;
         self.config_diagnostics = loaded.diagnostics;
@@ -4830,6 +4833,7 @@ impl Editor {
             clipboard,
             diagnostics: HashMap::new(),
             diagnostic_reports: diagnostics::DiagnosticReports::default(),
+            diagnostic_cache: None,
             indentation,
             render_commands: VecDeque::new(),
             overlay_manager: plugin::OverlayManager::new(),
@@ -12803,6 +12807,7 @@ impl Editor {
             return;
         }
         self.diagnostic_reports.remove(&uri);
+        self.mark_diagnostic_cache_dirty();
         self.sync_diagnostic_gutter_signs();
     }
 
@@ -12824,6 +12829,7 @@ impl Editor {
         log!("Adding diagnostics for {uri}: {diagnostics:#?}");
         let merged = self.diagnostic_reports.update(&uri, kind, diagnostics);
         self.diagnostics.insert(uri, merged);
+        self.mark_diagnostic_cache_dirty();
         self.sync_diagnostic_gutter_signs();
 
         Some(Action::Refresh)
@@ -13533,9 +13539,8 @@ impl Editor {
         match msg {
             InboundMessage::Message(msg) => {
                 if let Some(ref method) = method {
-                    if method == "initialize" {
-                        // self.server_capabilities = self.lsp.get_server_capabilities().cloned();
-                        // log!("server capabilities: {:#?}", self.server_capabilities);
+                    if method == "initialize" && self.diagnostic_reports.has_provisional() {
+                        return Some(Action::RefreshDiagnostics);
                     }
 
                     if method == "textDocument/diagnostic" && self.config.show_diagnostics {
@@ -22677,6 +22682,7 @@ impl Editor {
                 }
                 self.diagnostics.remove(uri);
                 self.diagnostic_reports.remove(uri);
+                self.mark_diagnostic_cache_dirty();
             }
         }
         self.lsp_coordinator.forget_buffer(removed_id);
@@ -22788,6 +22794,7 @@ impl Editor {
     }
 
     async fn ensure_buffer_lsp_opened(&mut self, buffer_index: usize) -> anyhow::Result<()> {
+        self.restore_cached_diagnostics();
         let Some(buffer) = self.buffer_manager.get(buffer_index) else {
             return Ok(());
         };
@@ -22832,6 +22839,7 @@ impl Editor {
                     self.diagnostics.insert(current_uri.clone(), diagnostics);
                 }
             }
+            self.mark_diagnostic_cache_dirty();
         }
         self.sync_diagnostic_gutter_signs();
         self.ensure_buffer_lsp_opened(buffer_index).await
@@ -23987,6 +23995,7 @@ impl Editor {
         if let Some((uri, edit)) = diagnostic_edit {
             if let Some(diagnostics) = self.diagnostic_reports.rebase(&uri, &edit, new_text) {
                 self.diagnostics.insert(uri, diagnostics);
+                self.mark_diagnostic_cache_dirty();
                 self.sync_diagnostic_gutter_signs();
             }
         }
@@ -24606,6 +24615,56 @@ impl Editor {
         self.session_manager.set_store(store);
     }
 
+    /// Enables provisional, workspace-scoped diagnostics recovery across editor launches.
+    pub fn enable_diagnostic_cache(&mut self, directory: PathBuf) {
+        self.diagnostic_cache = Some(diagnostic_cache::DiagnosticCache::new(directory));
+        self.restore_cached_diagnostics();
+    }
+
+    fn restore_cached_diagnostics(&mut self) {
+        if !self.config.show_diagnostics {
+            return;
+        }
+        let Some(cache) = &mut self.diagnostic_cache else {
+            return;
+        };
+        let restored = cache.load(&self.config.lsp, &self.buffer_manager);
+        let mut changed = false;
+        for reports in restored {
+            if self.diagnostics.contains_key(&reports.uri) {
+                continue;
+            }
+            let diagnostics =
+                self.diagnostic_reports
+                    .restore(reports.uri.clone(), reports.push, reports.pull);
+            self.diagnostics.insert(reports.uri, diagnostics);
+            changed = true;
+        }
+        if changed {
+            self.sync_diagnostic_gutter_signs();
+        }
+    }
+
+    fn mark_diagnostic_cache_dirty(&mut self) {
+        if let Some(cache) = &mut self.diagnostic_cache {
+            cache.mark_dirty();
+        }
+    }
+
+    fn persist_diagnostic_cache(&mut self, force: bool) {
+        let Some(cache) = &mut self.diagnostic_cache else {
+            return;
+        };
+        if let Err(error) = cache.flush(
+            &self.config.lsp,
+            &self.buffer_manager,
+            &self.diagnostic_reports,
+            force,
+        ) {
+            log!("failed to persist diagnostic cache: {error}");
+        }
+    }
+
     #[doc(hidden)]
     pub fn test_persist_session_snapshot(&mut self, force: bool, due: bool) {
         if due {
@@ -25192,6 +25251,7 @@ impl Editor {
     }
 
     fn persist_session_snapshot(&mut self, force: bool) -> bool {
+        self.persist_diagnostic_cache(force);
         // Learn Red checkpoints the real workspace before opening its scratch
         // window. Keep that recovery snapshot intact until the lesson exits.
         if self.learn_session.is_some() {
@@ -26531,6 +26591,7 @@ impl Editor {
                 if let Some(diagnostics) = self.diagnostics.remove(uri) {
                     self.diagnostics.insert(new_uri.clone(), diagnostics);
                 }
+                self.mark_diagnostic_cache_dirty();
             }
             if let Err(error) = self
                 .lsp

--- a/src/editor/diagnostic_cache.rs
+++ b/src/editor/diagnostic_cache.rs
@@ -1,0 +1,567 @@
+//! Best-effort, workspace-scoped recovery of provisional language-server findings.
+//!
+//! Cached diagnostics are never authoritative. Their document text, language-server
+//! configuration, and workspace manifests must still match before they are displayed,
+//! and the first fresh report replaces both restored producer channels.
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    fs::{self, File},
+    io::{self, Read as _, Write as _},
+    path::{Component, Path, PathBuf},
+    thread::JoinHandle,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use ropey::Rope;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest as _, Sha256};
+
+use crate::{
+    buffer::Buffer,
+    config::{LanguageServerConfig, LspConfig},
+    lsp::{file_path, Diagnostic, LspManager},
+};
+
+use super::diagnostics::DiagnosticReports;
+
+const CACHE_SCHEMA_VERSION: u32 = 1;
+const MAX_CACHE_FILE_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_CACHED_DOCUMENT_BYTES: u64 = 16 * 1024 * 1024;
+const CACHE_WRITE_DEBOUNCE: Duration = Duration::from_secs(2);
+const MAX_CACHE_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const WORKSPACE_MANIFESTS: &[&str] = &[
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain",
+    "rust-toolchain.toml",
+    "Husk.toml",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "bun.lock",
+    "bun.lockb",
+    "pyproject.toml",
+    "poetry.lock",
+    "uv.lock",
+    "requirements.txt",
+    "go.mod",
+    "go.sum",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedDocument {
+    uri: String,
+    server_name: String,
+    content_sha256: [u8; 32],
+    server_config_sha256: [u8; 32],
+    #[serde(default)]
+    push: Vec<Diagnostic>,
+    #[serde(default)]
+    pull: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedWorkspace {
+    version: u32,
+    workspace_root: PathBuf,
+    workspace_sha256: [u8; 32],
+    captured_at_ms: u64,
+    documents: Vec<CachedDocument>,
+}
+
+#[derive(Clone)]
+struct OpenDocument {
+    file: String,
+    uri: String,
+    contents: Rope,
+}
+
+#[derive(Clone)]
+struct ReportSnapshot {
+    uri: String,
+    push: Vec<Diagnostic>,
+    pull: Vec<Diagnostic>,
+}
+
+pub(super) struct RestoredDiagnosticReports {
+    pub(super) uri: String,
+    pub(super) push: Vec<Diagnostic>,
+    pub(super) pull: Vec<Diagnostic>,
+}
+
+/// Debounces owner-private cache writes and tracks workspaces already hydrated.
+pub(super) struct DiagnosticCache {
+    directory: PathBuf,
+    loaded_workspaces: HashSet<PathBuf>,
+    dirty_since: Option<Instant>,
+    writer: Option<JoinHandle<anyhow::Result<()>>>,
+}
+
+impl DiagnosticCache {
+    pub(super) fn new(directory: PathBuf) -> Self {
+        Self {
+            directory,
+            loaded_workspaces: HashSet::new(),
+            dirty_since: None,
+            writer: None,
+        }
+    }
+
+    pub(super) fn mark_dirty(&mut self) {
+        self.dirty_since.get_or_insert_with(Instant::now);
+    }
+
+    /// Opens each workspace at most once, including when a file is opened later.
+    pub(super) fn load(
+        &mut self,
+        config: &LspConfig,
+        buffers: &[Buffer],
+    ) -> Vec<RestoredDiagnosticReports> {
+        if !config.enabled {
+            return Vec::new();
+        }
+
+        let routing = LspManager::new(config.clone());
+        let open_documents = open_documents(buffers);
+        let open_by_uri = open_documents
+            .iter()
+            .map(|document| (document.uri.as_str(), &document.contents))
+            .collect::<HashMap<_, _>>();
+        let mut restored = Vec::new();
+
+        for document in &open_documents {
+            let Some(route) = routing.resolve_document(&document.file) else {
+                continue;
+            };
+            let workspace_root = canonical_workspace_root(&route.workspace_root);
+            if !self.loaded_workspaces.insert(workspace_root.clone()) {
+                continue;
+            }
+
+            let cache_path = workspace_cache_path(&self.directory, &workspace_root);
+            let workspace = match read_workspace(&cache_path) {
+                Ok(Some(workspace)) => workspace,
+                Ok(None) => continue,
+                Err(error) => {
+                    crate::log!(
+                        "ignoring unreadable diagnostic cache {}: {error}",
+                        cache_path.display()
+                    );
+                    continue;
+                }
+            };
+            if workspace.version != CACHE_SCHEMA_VERSION
+                || workspace.workspace_root != workspace_root
+                || cache_expired(workspace.captured_at_ms)
+            {
+                continue;
+            }
+            let Ok(fingerprint) = workspace_fingerprint(&workspace_root, config) else {
+                continue;
+            };
+            if workspace.workspace_sha256 != fingerprint {
+                continue;
+            }
+
+            for cached in workspace.documents {
+                if cached.push.is_empty() && cached.pull.is_empty() {
+                    continue;
+                }
+                let Ok(path) = file_path(&cached.uri) else {
+                    continue;
+                };
+                let Some(route) = routing.resolve_document(&path) else {
+                    continue;
+                };
+                if route.uri != cached.uri
+                    || route.server_name != cached.server_name
+                    || canonical_workspace_root(&route.workspace_root) != workspace_root
+                {
+                    continue;
+                }
+                let Some(server) = config.servers.get(&route.server_name) else {
+                    continue;
+                };
+                if server_fingerprint(server).ok() != Some(cached.server_config_sha256) {
+                    continue;
+                }
+                let current_hash = open_by_uri
+                    .get(cached.uri.as_str())
+                    .map(|contents| hash_rope(contents))
+                    .or_else(|| hash_file(Path::new(&path)).ok());
+                if current_hash != Some(cached.content_sha256) {
+                    continue;
+                }
+                restored.push(RestoredDiagnosticReports {
+                    uri: cached.uri,
+                    push: cached.push,
+                    pull: cached.pull,
+                });
+            }
+        }
+
+        restored
+    }
+
+    /// Captures cheap rope snapshots and moves hashing and disk writes off-thread.
+    pub(super) fn flush(
+        &mut self,
+        config: &LspConfig,
+        buffers: &[Buffer],
+        reports: &DiagnosticReports,
+        force: bool,
+    ) -> anyhow::Result<()> {
+        self.finish_writer(force)?;
+        if self.writer.is_some() {
+            return Ok(());
+        }
+        let Some(dirty_since) = self.dirty_since else {
+            return Ok(());
+        };
+        if !force && dirty_since.elapsed() < CACHE_WRITE_DEBOUNCE {
+            return Ok(());
+        }
+
+        let directory = self.directory.clone();
+        let config = config.clone();
+        let documents = open_documents(buffers);
+        let reports = reports
+            .entries()
+            .map(|(uri, push, pull)| ReportSnapshot {
+                uri: uri.to_string(),
+                push: push.to_vec(),
+                pull: pull.to_vec(),
+            })
+            .collect::<Vec<_>>();
+        self.dirty_since = None;
+        match std::thread::Builder::new()
+            .name("red-diagnostic-cache".to_string())
+            .spawn(move || persist_workspaces(&directory, &config, &documents, &reports))
+        {
+            Ok(writer) => self.writer = Some(writer),
+            Err(error) => {
+                self.mark_dirty();
+                return Err(error.into());
+            }
+        }
+
+        if force {
+            self.finish_writer(true)?;
+        }
+        Ok(())
+    }
+
+    fn finish_writer(&mut self, force: bool) -> anyhow::Result<()> {
+        if !self
+            .writer
+            .as_ref()
+            .is_some_and(|writer| force || writer.is_finished())
+        {
+            return Ok(());
+        }
+        let writer = self.writer.take().expect("finished cache writer exists");
+        match writer.join() {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => {
+                self.mark_dirty();
+                Err(error)
+            }
+            Err(_) => {
+                self.mark_dirty();
+                anyhow::bail!("diagnostic cache writer panicked")
+            }
+        }
+    }
+}
+
+fn open_documents(buffers: &[Buffer]) -> Vec<OpenDocument> {
+    buffers
+        .iter()
+        .filter_map(|buffer| {
+            Some(OpenDocument {
+                file: buffer.file.clone()?,
+                uri: buffer.uri().ok().flatten()?,
+                contents: buffer.contents_snapshot(),
+            })
+        })
+        .collect()
+}
+
+fn persist_workspaces(
+    directory: &Path,
+    config: &LspConfig,
+    open_documents: &[OpenDocument],
+    reports: &[ReportSnapshot],
+) -> anyhow::Result<()> {
+    if !config.enabled {
+        return Ok(());
+    }
+    let routing = LspManager::new(config.clone());
+    let open_by_uri = open_documents
+        .iter()
+        .map(|document| (document.uri.as_str(), &document.contents))
+        .collect::<HashMap<_, _>>();
+    let mut workspaces = HashMap::<PathBuf, CachedWorkspace>::new();
+
+    for document in open_documents {
+        let Some(route) = routing.resolve_document(&document.file) else {
+            continue;
+        };
+        let workspace_root = canonical_workspace_root(&route.workspace_root);
+        if workspaces.contains_key(&workspace_root) {
+            continue;
+        }
+        let workspace_sha256 = workspace_fingerprint(&workspace_root, config)?;
+        workspaces.insert(
+            workspace_root.clone(),
+            CachedWorkspace {
+                version: CACHE_SCHEMA_VERSION,
+                workspace_root,
+                workspace_sha256,
+                captured_at_ms: current_time_ms(),
+                documents: Vec::new(),
+            },
+        );
+    }
+
+    for report in reports {
+        if report.push.is_empty() && report.pull.is_empty() {
+            continue;
+        }
+        let Ok(path) = file_path(&report.uri) else {
+            continue;
+        };
+        let Some(route) = routing.resolve_document(&path) else {
+            continue;
+        };
+        if route.uri != report.uri {
+            continue;
+        }
+        let workspace_root = canonical_workspace_root(&route.workspace_root);
+        let Some(workspace) = workspaces.get_mut(&workspace_root) else {
+            continue;
+        };
+        let Some(server) = config.servers.get(&route.server_name) else {
+            continue;
+        };
+        let content_sha256 = match open_by_uri.get(report.uri.as_str()) {
+            Some(contents) => hash_rope(contents),
+            None => match hash_file(Path::new(&path)) {
+                Ok(hash) => hash,
+                Err(_) => continue,
+            },
+        };
+        workspace.documents.push(CachedDocument {
+            uri: report.uri.clone(),
+            server_name: route.server_name,
+            content_sha256,
+            server_config_sha256: server_fingerprint(server)?,
+            push: report.push.clone(),
+            pull: report.pull.clone(),
+        });
+    }
+
+    for workspace in workspaces.values_mut() {
+        workspace
+            .documents
+            .sort_unstable_by(|left, right| left.uri.cmp(&right.uri));
+        write_workspace(directory, workspace)?;
+    }
+    Ok(())
+}
+
+fn canonical_workspace_root(root: &Path) -> PathBuf {
+    fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf())
+}
+
+fn workspace_cache_path(directory: &Path, workspace_root: &Path) -> PathBuf {
+    let digest = Sha256::digest(workspace_root.to_string_lossy().as_bytes());
+    directory.join(format!("{digest:x}.json"))
+}
+
+fn cache_expired(captured_at_ms: u64) -> bool {
+    current_time_ms().saturating_sub(captured_at_ms)
+        > u64::try_from(MAX_CACHE_AGE.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| u64::try_from(duration.as_millis()).ok())
+        .unwrap_or_default()
+}
+
+fn hash_rope(contents: &Rope) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    for chunk in contents.chunks() {
+        digest.update(chunk.as_bytes());
+    }
+    digest.finalize().into()
+}
+
+fn hash_file(path: &Path) -> io::Result<[u8; 32]> {
+    let mut file = File::open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > MAX_CACHED_DOCUMENT_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "diagnostic cache document is not a bounded regular file",
+        ));
+    }
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        digest.update(&buffer[..count]);
+    }
+    Ok(digest.finalize().into())
+}
+
+fn server_fingerprint(server: &LanguageServerConfig) -> anyhow::Result<[u8; 32]> {
+    let mut value = serde_json::to_value(server)?;
+    canonicalize_json(&mut value);
+    Ok(Sha256::digest(serde_json::to_vec(&value)?).into())
+}
+
+fn canonicalize_json(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            let mut entries = std::mem::take(object).into_iter().collect::<Vec<_>>();
+            entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+            for (key, mut value) in entries {
+                canonicalize_json(&mut value);
+                object.insert(key, value);
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(canonicalize_json),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn workspace_fingerprint(root: &Path, config: &LspConfig) -> io::Result<[u8; 32]> {
+    let mut markers = WORKSPACE_MANIFESTS
+        .iter()
+        .copied()
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    for marker in config
+        .servers
+        .values()
+        .flat_map(|server| server.root_markers.iter())
+    {
+        let mut components = Path::new(marker).components();
+        if matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none() {
+            markers.insert(marker.clone());
+        }
+    }
+
+    let mut digest = Sha256::new();
+    for marker in markers {
+        digest.update(marker.as_bytes());
+        digest.update([0]);
+        match fs::metadata(root.join(&marker)) {
+            Ok(metadata) if metadata.is_file() => {
+                digest.update([1]);
+                digest.update(hash_file(&root.join(&marker))?);
+            }
+            Ok(metadata) if metadata.is_dir() => digest.update([2]),
+            Ok(_) => digest.update([3]),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => digest.update([0]),
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(digest.finalize().into())
+}
+
+fn read_workspace(path: &Path) -> anyhow::Result<Option<CachedWorkspace>> {
+    let mut file = match open_cache_file(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let metadata = file.metadata()?;
+    anyhow::ensure!(
+        metadata.is_file() && metadata.len() <= MAX_CACHE_FILE_BYTES,
+        "diagnostic cache must be a bounded regular file"
+    );
+    let mut contents = Vec::new();
+    (&mut file)
+        .take(MAX_CACHE_FILE_BYTES + 1)
+        .read_to_end(&mut contents)?;
+    anyhow::ensure!(
+        contents.len() as u64 <= MAX_CACHE_FILE_BYTES,
+        "diagnostic cache exceeds its read limit"
+    );
+    Ok(Some(serde_json::from_slice(&contents)?))
+}
+
+#[cfg(unix)]
+fn open_cache_file(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_cache_file(path: &Path) -> io::Result<File> {
+    if fs::symlink_metadata(path)?.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "diagnostic cache must not be a symlink",
+        ));
+    }
+    File::open(path)
+}
+
+fn write_workspace(directory: &Path, workspace: &CachedWorkspace) -> anyhow::Result<()> {
+    fs::create_dir_all(directory)?;
+    let metadata = fs::symlink_metadata(directory)?;
+    anyhow::ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "diagnostic cache directory must not be a symlink"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        fs::set_permissions(directory, fs::Permissions::from_mode(0o700))?;
+    }
+
+    let contents = serde_json::to_vec(workspace)?;
+    anyhow::ensure!(
+        contents.len() as u64 <= MAX_CACHE_FILE_BYTES,
+        "diagnostic cache exceeds its write limit"
+    );
+    let destination = workspace_cache_path(directory, &workspace.workspace_root);
+    if let Ok(metadata) = fs::symlink_metadata(&destination) {
+        anyhow::ensure!(
+            metadata.is_file() && !metadata.file_type().is_symlink(),
+            "diagnostic cache destination must be a regular file"
+        );
+    }
+    let mut temporary = tempfile::NamedTempFile::new_in(directory)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        temporary
+            .as_file()
+            .set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    temporary.write_all(&contents)?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .persist(&destination)
+        .map_err(|error| error.error)?;
+    Ok(())
+}

--- a/src/editor/diagnostics.rs
+++ b/src/editor/diagnostics.rs
@@ -17,6 +17,7 @@ pub(super) enum DiagnosticReportKind {
 struct DocumentReports {
     push: Vec<Diagnostic>,
     pull: Vec<Diagnostic>,
+    provisional: bool,
 }
 
 #[derive(Default)]
@@ -32,11 +33,49 @@ impl DiagnosticReports {
         diagnostics: &[Diagnostic],
     ) -> Vec<Diagnostic> {
         let reports = self.documents.entry(uri.to_string()).or_default();
+        if reports.provisional {
+            reports.push.clear();
+            reports.pull.clear();
+            reports.provisional = false;
+        }
         match kind {
             DiagnosticReportKind::Push => reports.push = diagnostics.to_vec(),
             DiagnosticReportKind::Pull => reports.pull = diagnostics.to_vec(),
         }
         merged_reports(reports)
+    }
+
+    /// Restores both channels optimistically until the restarted server responds.
+    pub(super) fn restore(
+        &mut self,
+        uri: String,
+        push: Vec<Diagnostic>,
+        pull: Vec<Diagnostic>,
+    ) -> Vec<Diagnostic> {
+        let reports = DocumentReports {
+            push,
+            pull,
+            provisional: true,
+        };
+        let merged = merged_reports(&reports);
+        self.documents.insert(uri, reports);
+        merged
+    }
+
+    pub(super) fn entries(
+        &self,
+    ) -> impl Iterator<Item = (&str, &[Diagnostic], &[Diagnostic])> + '_ {
+        self.documents.iter().map(|(uri, reports)| {
+            (
+                uri.as_str(),
+                reports.push.as_slice(),
+                reports.pull.as_slice(),
+            )
+        })
+    }
+
+    pub(super) fn has_provisional(&self) -> bool {
+        self.documents.values().any(|reports| reports.provisional)
     }
 
     /// Move untouched diagnostic ranges with their text and discard edited ranges.
@@ -232,6 +271,25 @@ mod tests {
         );
     }
 
+    fn diagnostic_workspace(contents: &str) -> (tempfile::TempDir, std::path::PathBuf, String) {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("Cargo.toml"),
+            "[package]\nname = \"diagnostic-cache\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let file = root.path().join("main.rs");
+        std::fs::write(&file, contents).unwrap();
+        let uri = crate::lsp::file_uri(&file).unwrap();
+        (root, file, uri)
+    }
+
+    fn cached_editor(file: &std::path::Path, contents: &str, cache: &std::path::Path) -> Editor {
+        let mut editor = editor(file.to_string_lossy().into_owned(), contents, true);
+        editor.enable_diagnostic_cache(cache.to_path_buf());
+        editor
+    }
+
     #[test]
     fn pushed_and_pulled_diagnostics_replace_only_their_own_reports() {
         let root = tempfile::tempdir().unwrap();
@@ -262,6 +320,276 @@ mod tests {
         assert_eq!(editor.diagnostics[&uri], vec![compiler, native]);
         pull(&mut editor, &uri, json!({ "kind": "full", "items": [] }));
         assert!(editor.diagnostics[&uri].is_empty());
+    }
+
+    #[test]
+    fn cached_diagnostics_restore_both_reports_and_gutter_signs_after_restart() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let compiler = diagnostic("cached compiler error");
+        let native = diagnostic("cached native error");
+
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![compiler.clone()]);
+        pull(
+            &mut first,
+            &uri,
+            json!({ "kind": "full", "items": [native.clone()] }),
+        );
+        first.persist_diagnostic_cache(true);
+
+        let mut restarted = cached_editor(&file, "x\n", &cache);
+        assert_eq!(restarted.diagnostics[&uri], vec![compiler, native]);
+        assert!(restarted.diagnostic_reports.has_provisional());
+        assert!(restarted.gutter_sign_manager.visible_sign(0, 0).is_some());
+
+        let refresh = restarted.handle_lsp_message(
+            &InboundMessage::Message(ResponseMessage {
+                id: 1,
+                result: json!({}),
+                request: Some(Request::new("initialize", json!({}))),
+            }),
+            Some("initialize".to_string()),
+        );
+        assert!(matches!(refresh, Some(Action::RefreshDiagnostics)));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            assert_eq!(
+                std::fs::metadata(&cache).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            let cached_file = std::fs::read_dir(&cache)
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+                .path();
+            assert_eq!(
+                std::fs::metadata(cached_file).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn cached_diagnostics_reject_changed_document_contents() {
+        let (root, file, uri) = diagnostic_workspace("before\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "before\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("outdated error")]);
+        first.persist_diagnostic_cache(true);
+
+        std::fs::write(&file, "after\n").unwrap();
+        let restarted = cached_editor(&file, "after\n", &cache);
+
+        assert!(!restarted.diagnostics.contains_key(&uri));
+        assert!(!restarted.diagnostic_reports.has_provisional());
+    }
+
+    #[test]
+    fn cached_diagnostics_validate_unsaved_buffer_contents_instead_of_disk() {
+        let (root, file, uri) = diagnostic_workspace("saved on disk\n");
+        let cache = root.path().join("cache");
+        let unsaved = "restored unsaved contents\n";
+        let mut first = cached_editor(&file, unsaved, &cache);
+        push(&mut first, &uri, vec![diagnostic("unsaved buffer error")]);
+        first.persist_diagnostic_cache(true);
+
+        let resumed = cached_editor(&file, unsaved, &cache);
+        assert_eq!(resumed.diagnostics[&uri][0].message, "unsaved buffer error");
+
+        let clean_restart = cached_editor(&file, "saved on disk\n", &cache);
+        assert!(!clean_restart.diagnostics.contains_key(&uri));
+    }
+
+    #[test]
+    fn cached_diagnostics_reject_changed_language_server_configuration() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("old server error")]);
+        first.persist_diagnostic_cache(true);
+
+        let mut restarted = editor(file.to_string_lossy().into_owned(), "x\n", true);
+        restarted
+            .config
+            .lsp
+            .servers
+            .get_mut("rust")
+            .unwrap()
+            .args
+            .push("--different-configuration".to_string());
+        restarted.enable_diagnostic_cache(cache);
+
+        assert!(!restarted.diagnostics.contains_key(&uri));
+    }
+
+    #[test]
+    fn cached_diagnostics_reject_changed_workspace_manifests() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("old dependency error")]);
+        first.persist_diagnostic_cache(true);
+
+        std::fs::write(
+            root.path().join("Cargo.toml"),
+            "[package]\nname = \"changed-dependencies\"\nversion = \"0.2.0\"\n",
+        )
+        .unwrap();
+        let restarted = cached_editor(&file, "x\n", &cache);
+
+        assert!(!restarted.diagnostics.contains_key(&uri));
+    }
+
+    #[test]
+    fn first_fresh_report_replaces_both_provisional_diagnostic_channels() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("outdated compiler")]);
+        pull(
+            &mut first,
+            &uri,
+            json!({ "kind": "full", "items": [diagnostic("outdated native")] }),
+        );
+        first.persist_diagnostic_cache(true);
+
+        let mut restarted = cached_editor(&file, "x\n", &cache);
+        let current = diagnostic("fresh compiler");
+        push(&mut restarted, &uri, vec![current.clone()]);
+
+        assert_eq!(restarted.diagnostics[&uri], vec![current]);
+        assert!(!restarted.diagnostic_reports.has_provisional());
+
+        let native = diagnostic("fresh native");
+        pull(
+            &mut restarted,
+            &uri,
+            json!({ "kind": "full", "items": [native.clone()] }),
+        );
+        assert_eq!(restarted.diagnostics[&uri][1], native);
+    }
+
+    #[test]
+    fn fresh_empty_report_removes_cached_findings_for_the_next_restart() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("resolved error")]);
+        first.persist_diagnostic_cache(true);
+
+        let mut refreshed = cached_editor(&file, "x\n", &cache);
+        push(&mut refreshed, &uri, vec![]);
+        assert!(refreshed.diagnostics[&uri].is_empty());
+        refreshed.persist_diagnostic_cache(true);
+
+        let restarted = cached_editor(&file, "x\n", &cache);
+        assert!(!restarted.diagnostics.contains_key(&uri));
+    }
+
+    #[test]
+    fn cached_diagnostics_restore_unopened_workspace_documents() {
+        let (root, file, _) = diagnostic_workspace("fn main() {}\n");
+        let other = root.path().join("other.rs");
+        std::fs::write(&other, "broken();\n").unwrap();
+        let other_uri = crate::lsp::file_uri(&other).unwrap();
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "fn main() {}\n", &cache);
+        push(
+            &mut first,
+            &other_uri,
+            vec![diagnostic("unopened document error")],
+        );
+        first.persist_diagnostic_cache(true);
+
+        let restarted = cached_editor(&file, "fn main() {}\n", &cache);
+        assert_eq!(
+            restarted.diagnostics[&other_uri][0].message,
+            "unopened document error"
+        );
+
+        std::fs::write(&other, "fixed();\n").unwrap();
+        let changed = cached_editor(&file, "fn main() {}\n", &cache);
+        assert!(!changed.diagnostics.contains_key(&other_uri));
+    }
+
+    #[test]
+    fn cached_diagnostics_load_when_a_workspace_is_opened_after_startup() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("lazy workspace error")]);
+        first.persist_diagnostic_cache(true);
+
+        let config = Config {
+            show_diagnostics: true,
+            ..Config::default()
+        };
+        let mut restarted = Editor::with_size(
+            Box::new(LspManager::new(config.lsp.clone())),
+            60,
+            12,
+            config,
+            Theme::default(),
+            vec![Buffer::new(None, String::new())],
+        )
+        .unwrap();
+        restarted.test_disable_terminal_output();
+        restarted.enable_diagnostic_cache(cache);
+        assert!(restarted.diagnostics.is_empty());
+
+        restarted.buffer_manager.add_buffer(Buffer::new(
+            Some(file.to_string_lossy().into_owned()),
+            "x\n".to_string(),
+        ));
+        restarted.restore_cached_diagnostics();
+
+        assert_eq!(
+            restarted.diagnostics[&uri][0].message,
+            "lazy workspace error"
+        );
+    }
+
+    #[test]
+    fn cached_diagnostics_expire_instead_of_restoring_old_findings() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("old cached error")]);
+        first.persist_diagnostic_cache(true);
+
+        let cached_file = std::fs::read_dir(&cache)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let mut saved: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&cached_file).unwrap()).unwrap();
+        saved["captured_at_ms"] = json!(0);
+        std::fs::write(&cached_file, serde_json::to_vec(&saved).unwrap()).unwrap();
+
+        let restarted = cached_editor(&file, "x\n", &cache);
+        assert!(!restarted.diagnostics.contains_key(&uri));
+    }
+
+    #[test]
+    fn cached_diagnostics_do_not_cross_workspace_roots() {
+        let (first_root, first_file, first_uri) = diagnostic_workspace("x\n");
+        let (second_root, second_file, second_uri) = diagnostic_workspace("x\n");
+        let cache = tempfile::tempdir().unwrap();
+        let mut first = cached_editor(&first_file, "x\n", cache.path());
+        push(&mut first, &first_uri, vec![diagnostic("first workspace")]);
+        first.persist_diagnostic_cache(true);
+
+        let second = cached_editor(&second_file, "x\n", cache.path());
+        assert!(!second.diagnostics.contains_key(&first_uri));
+        assert!(!second.diagnostics.contains_key(&second_uri));
+        assert_ne!(first_root.path(), second_root.path());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,7 @@ async fn run_editor_inner(args: Args) -> anyhow::Result<()> {
             );
         }
     }
+    editor.enable_diagnostic_cache(Config::path("cache/lsp-diagnostics"));
     editor.set_session_store(session_store);
 
     if let Some(session) = &args.core_session {


### PR DESCRIPTION
## Why

Restarting Red clears all LSP findings until language servers initialize and republish them. Larger workspaces can therefore reopen without gutter markers or diagnostics even when their source files and project configuration have not changed.

## What Changed

- Persist push and pull diagnostics in owner-private, workspace-scoped caches with debounced background writes and 24-hour expiration.
- Restore matching findings before the first render, including unsaved recovered buffers, unopened workspace files, and workspaces opened after startup.
- Reuse cached findings only when document SHA-256, language-server configuration, workspace identity, and relevant manifests or lockfiles still match.
- Treat restored findings as provisional, refresh after server initialization, and replace both cached channels when the first authoritative report arrives.

## How to Test

1. Open a Rust workspace containing a compiler error and confirm its diagnostic appears in the gutter or diagnostics picker.
2. Close and reopen Red in the same workspace. The previous finding should appear immediately, then refresh once rust-analyzer initializes.
3. Change the source file, `Cargo.toml`, `Cargo.lock`, or rust-analyzer configuration while Red is closed. Reopen the workspace and confirm stale findings are not restored.
4. Recover an unsaved session with `red --resume` and confirm restored findings match the recovered in-memory text rather than older on-disk contents.
5. Run the focused regressions:

   ```bash
   cargo test -p red --lib editor::diagnostics::tests::
   cargo test -p red --test lsp_lazy
   ```

   Coverage includes matching and changed content, dirty buffers, server and manifest invalidation, unopened files, lazy hydration, workspace isolation, expiration, cleared findings, and push/pull replacement.

Validated with 2,084 passing library tests, 48 passing lazy-LSP integration tests, and clean all-target/all-feature Clippy and formatting checks.
