### PR TITLE
perf(picker): accelerate large workspace file searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,6 +2344,7 @@ dependencies = [
  "once_cell",
  "path-absolutize",
  "pulldown-cmark",
+ "rayon",
  "regex",
  "reqwest",
  "ropey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ notify = "8.2.0"
 once_cell = "1.19.0"
 path-absolutize = "3.1.1"
 pulldown-cmark = "0.13"
+rayon = "1.12.0"
 regex = "1.11.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 ropey = "1.6.1"

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -85,6 +85,7 @@ impl FilePicker {
             .title("Find Files")
             .items(vec![])
             .filter_action(move |item, query| file_match_score(&score_matcher, item, query))
+            .incremental_filter()
             .filter_tie_breaker(|item| item.id.len())
             .filter_highlight_action(move |item, query| {
                 file_match_highlights(&highlight_matcher, item, query)
@@ -314,7 +315,10 @@ fn not_vcs_metadata(entry: &DirEntry) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, thread, time::Duration};
+    use std::{
+        fs, thread,
+        time::{Duration, Instant},
+    };
 
     use super::*;
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
@@ -439,6 +443,119 @@ mod tests {
             }
         }
         panic!("{needle:?} was not rendered");
+    }
+
+    #[test]
+    #[ignore = "manual performance benchmark for large workspaces"]
+    fn file_picker_large_workspace_performance() {
+        const SAMPLES: usize = 5;
+        const QUERIES: [&str; 5] = [
+            "thread",
+            "agent",
+            "config",
+            "workspace",
+            "codex-rs/core/src",
+        ];
+
+        let editor = test_editor();
+        let benchmark_root = std::env::var_os("RED_FILE_PICKER_BENCH_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let files = if std::env::var_os("RED_FILE_PICKER_BENCH_ROOT").is_some() {
+            let started = Instant::now();
+            let files = load_file_picker_items(&benchmark_root, FilePickerVisibility::default())
+                .expect("benchmark workspace should be readable");
+            eprintln!(
+                "file-picker benchmark discovery: files={} elapsed={:?} root={}",
+                files.len(),
+                started.elapsed(),
+                benchmark_root.display(),
+            );
+            files
+        } else {
+            const NAMES: [&str; 12] = [
+                "thread",
+                "agent",
+                "config",
+                "workspace",
+                "client",
+                "protocol",
+                "session",
+                "approval",
+                "terminal",
+                "message",
+                "history",
+                "review",
+            ];
+            (0..12_000)
+                .map(|index| {
+                    format!(
+                        "codex-rs/crate_{:02}/src/{}_{index:05}.rs",
+                        index % 96,
+                        NAMES[index % NAMES.len()],
+                    )
+                })
+                .collect()
+        };
+        assert!(files.len() >= 5_000, "benchmark requires a large workspace");
+
+        let mut installation_samples = Vec::with_capacity(SAMPLES);
+        let mut query_samples = vec![Vec::with_capacity(SAMPLES); QUERIES.len()];
+        let mut draw_samples = vec![Vec::with_capacity(SAMPLES); QUERIES.len()];
+        let mut slowest_keystrokes = Vec::with_capacity(SAMPLES);
+
+        for _ in 0..SAMPLES {
+            let (sender, receiver) = mpsc::channel();
+            let mut picker =
+                FilePicker::loading_with_root(&editor, benchmark_root.clone(), sender, receiver);
+            send_load(&picker, picker.load_generation, Ok(files.clone()));
+            let started = Instant::now();
+            assert!(picker.tick().expect("benchmark load should succeed"));
+            installation_samples.push(started.elapsed());
+            let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+            let mut slowest_keystroke = Duration::ZERO;
+
+            for (query_index, query) in QUERIES.iter().enumerate() {
+                while !picker.picker.query().is_empty() {
+                    picker.handle_event(&key(KeyCode::Backspace));
+                }
+                let mut query_elapsed = Duration::ZERO;
+                let mut draw_elapsed = Duration::ZERO;
+                for character in query.chars() {
+                    let started = Instant::now();
+                    picker.handle_event(&key(KeyCode::Char(character)));
+                    let elapsed = started.elapsed();
+                    query_elapsed += elapsed;
+                    slowest_keystroke = slowest_keystroke.max(elapsed);
+                    let started = Instant::now();
+                    picker
+                        .draw(&mut buffer)
+                        .expect("benchmark draw should succeed");
+                    draw_elapsed += started.elapsed();
+                }
+                query_samples[query_index].push(query_elapsed);
+                draw_samples[query_index].push(draw_elapsed);
+            }
+            slowest_keystrokes.push(slowest_keystroke);
+        }
+
+        let median = |samples: &mut [Duration]| {
+            samples.sort_unstable();
+            samples[samples.len() / 2]
+        };
+        eprintln!(
+            "file-picker benchmark: files={} samples={SAMPLES} install={:?} slowest_key={:?}",
+            files.len(),
+            median(&mut installation_samples),
+            median(&mut slowest_keystrokes),
+        );
+        for (index, query) in QUERIES.iter().enumerate() {
+            eprintln!(
+                "file-picker benchmark query={query:?}: filtering={:?} drawing={:?}",
+                median(&mut query_samples[index]),
+                median(&mut draw_samples[index]),
+            );
+        }
     }
 
     #[test]

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -10,6 +10,7 @@
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use fuzzy_matcher::skim::SkimMatcherV2;
+use rayon::prelude::*;
 use ropey::{Rope, RopeSlice};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -48,8 +49,8 @@ use super::{
 };
 
 type SelectAction = Box<dyn Fn(String) -> Action + Send>;
-type FilterAction = Box<dyn Fn(&PickerItem, &str) -> Option<i64> + Send>;
-type FilterTieBreaker = Box<dyn Fn(&PickerItem) -> usize + Send>;
+type FilterAction = Box<dyn Fn(&PickerItem, &str) -> Option<i64> + Send + Sync>;
+type FilterTieBreaker = Box<dyn Fn(&PickerItem) -> usize + Send + Sync>;
 type FilterHighlightAction = Box<dyn Fn(&PickerItem, &str) -> PickerFilterHighlights + Send>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -91,6 +92,7 @@ const LOCATION_PREVIEW_CACHE_CAPACITY: usize = 8;
 const COMMAND_COLUMN_GAP: usize = 2;
 const PICKER_ICON_WIDTH: usize = 2;
 const PICKER_ITEM_PREFIX_WIDTH: usize = 2 + PICKER_ICON_WIDTH;
+const PARALLEL_FILTER_MIN_ITEMS: usize = 1_024;
 const INTRINSIC_COLUMN_GAP: usize = 2;
 const INTRINSIC_FOOTER_GAP: usize = 4;
 
@@ -347,6 +349,8 @@ pub struct Picker {
     matcher: SkimMatcherV2,
     select_action: Option<SelectAction>,
     filter_action: Option<FilterAction>,
+    incremental_filter: bool,
+    filtered_query: Option<String>,
     filter_tie_breaker: Option<FilterTieBreaker>,
     filter_highlight_action: Option<FilterHighlightAction>,
     search: String,
@@ -524,6 +528,8 @@ impl Picker {
             matcher: SkimMatcherV2::default(),
             select_action: None,
             filter_action: None,
+            incremental_filter: false,
+            filtered_query: None,
             filter_tie_breaker: None,
             filter_highlight_action: None,
             search: String::new(),
@@ -775,36 +781,69 @@ impl Picker {
     pub fn filter(&mut self, term: &str) {
         if let Some(items) = &self.dynamic_items {
             if self.external_filter || term.is_empty() {
-                self.visible_dynamic_items = (0..items.len()).collect();
+                self.visible_dynamic_items.clear();
+                self.visible_dynamic_items.extend(0..items.len());
             } else {
-                let mut matches = items
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(index, item)| {
-                        self.filter_action
-                            .as_ref()
-                            .map_or_else(
-                                || default_filter_score(&self.matcher, &item.label, term),
-                                |filter| {
-                                    filter(item, term)
-                                        .map(|score| (PickerMatchKind::Fuzzy, Reverse(score)))
-                                },
-                            )
-                            .map(|score| {
-                                let tie_breaker = self
-                                    .filter_tie_breaker
-                                    .as_ref()
-                                    .map_or(0, |tie_breaker| tie_breaker(item));
-                                (index, score, tie_breaker)
-                            })
-                    })
-                    .collect::<Vec<_>>();
+                let filter_action = self.filter_action.as_ref();
+                let filter_tie_breaker = self.filter_tie_breaker.as_ref();
+                let matcher = &self.matcher;
+                let score_item = |index: usize| {
+                    let item = &items[index];
+                    filter_action
+                        .as_ref()
+                        .map_or_else(
+                            || default_filter_score(matcher, &item.label, term),
+                            |filter| {
+                                filter(item, term)
+                                    .map(|score| (PickerMatchKind::Fuzzy, Reverse(score)))
+                            },
+                        )
+                        .map(|score| {
+                            let tie_breaker = filter_tie_breaker
+                                .as_ref()
+                                .map_or(0, |tie_breaker| tie_breaker(item));
+                            (index, score, tie_breaker)
+                        })
+                };
+                let can_reuse_matches = self.incremental_filter
+                    && self
+                        .filtered_query
+                        .as_deref()
+                        .is_some_and(|previous| term.starts_with(previous));
+                let mut matches = if self.incremental_filter
+                    && (if can_reuse_matches {
+                        self.visible_dynamic_items.len()
+                    } else {
+                        items.len()
+                    }) >= PARALLEL_FILTER_MIN_ITEMS
+                {
+                    if can_reuse_matches {
+                        self.visible_dynamic_items
+                            .par_iter()
+                            .filter_map(|index| score_item(*index))
+                            .collect::<Vec<_>>()
+                    } else {
+                        (0..items.len())
+                            .into_par_iter()
+                            .filter_map(score_item)
+                            .collect()
+                    }
+                } else if can_reuse_matches {
+                    self.visible_dynamic_items
+                        .iter()
+                        .copied()
+                        .filter_map(score_item)
+                        .collect()
+                } else {
+                    (0..items.len()).filter_map(score_item).collect()
+                };
                 matches.sort_unstable_by_key(|(index, score, tie_breaker)| {
                     (*score, *tie_breaker, *index)
                 });
                 self.visible_dynamic_items =
                     matches.into_iter().map(|(index, _, _)| index).collect();
             }
+            self.filtered_query = Some(term.to_string());
             self.list.set_item_count(self.visible_dynamic_items.len());
             self.command_column_widths.set(None);
             return;
@@ -835,6 +874,7 @@ impl Picker {
         let previous = self.selected_item();
         self.item_preview_root = None;
         self.dynamic_items = None;
+        self.filtered_query = None;
         self.visible_dynamic_items.clear();
         self.items = items;
         let search = self.search.clone();
@@ -846,6 +886,7 @@ impl Picker {
         let previous = self.selected_item();
         self.item_preview_root = Some(root);
         self.dynamic_items = None;
+        self.filtered_query = None;
         self.visible_dynamic_items.clear();
         self.items = items;
         let search = self.search.clone();
@@ -858,6 +899,7 @@ impl Picker {
         self.item_preview_root = None;
         self.items.clear();
         self.dynamic_items = Some(items);
+        self.filtered_query = None;
         let search = self.search.clone();
         self.filter(&search);
         self.resize_to_viewport(self.viewport_width, self.viewport_height);
@@ -873,6 +915,7 @@ impl Picker {
                 let previous = self.selected_item();
                 let selected_id = self.selected_dynamic_item().map(|item| item.id.clone());
                 self.dynamic_items = Some(items);
+                self.filtered_query = None;
                 let query = self.search.clone();
                 self.filter(&query);
                 self.resize_to_viewport(self.viewport_width, self.viewport_height);
@@ -3596,6 +3639,7 @@ pub struct PickerBuilder {
     id: Option<i32>,
     select_action: Option<SelectAction>,
     filter_action: Option<FilterAction>,
+    incremental_filter: bool,
     filter_tie_breaker: Option<FilterTieBreaker>,
     filter_highlight_action: Option<FilterHighlightAction>,
     placeholder: Option<String>,
@@ -3622,6 +3666,7 @@ impl PickerBuilder {
             id: None,
             select_action: None,
             filter_action: None,
+            incremental_filter: false,
             filter_tie_breaker: None,
             filter_highlight_action: None,
             placeholder: None,
@@ -3664,16 +3709,24 @@ impl PickerBuilder {
     /// Sets the scorer used to filter structured picker rows for the current query.
     pub fn filter_action(
         mut self,
-        filter: impl Fn(&PickerItem, &str) -> Option<i64> + Send + 'static,
+        filter: impl Fn(&PickerItem, &str) -> Option<i64> + Send + Sync + 'static,
     ) -> Self {
         self.filter_action = Some(Box::new(filter));
+        self
+    }
+
+    /// Reuses prior matches when an extended query cannot match previously rejected rows.
+    ///
+    /// Custom scorers may opt in only when their matching predicate is prefix-monotonic.
+    pub(crate) fn incremental_filter(mut self) -> Self {
+        self.incremental_filter = true;
         self
     }
 
     /// Sets an ascending secondary sort key for structured rows with equal filter scores.
     pub fn filter_tie_breaker(
         mut self,
-        tie_breaker: impl Fn(&PickerItem) -> usize + Send + 'static,
+        tie_breaker: impl Fn(&PickerItem) -> usize + Send + Sync + 'static,
     ) -> Self {
         self.filter_tie_breaker = Some(Box::new(tie_breaker));
         self
@@ -3752,6 +3805,7 @@ impl PickerBuilder {
         let id = self.id;
         let select_action = self.select_action;
         let filter_action = self.filter_action;
+        let incremental_filter = self.incremental_filter;
         let filter_tie_breaker = self.filter_tie_breaker;
         let filter_highlight_action = self.filter_highlight_action;
         let placeholder = self.placeholder;
@@ -3772,6 +3826,7 @@ impl PickerBuilder {
             picker.select_action = Some(select_action);
         }
         picker.filter_action = filter_action;
+        picker.incremental_filter = incremental_filter;
         picker.filter_tie_breaker = filter_tie_breaker;
         picker.filter_highlight_action = filter_highlight_action;
         picker.placeholder = placeholder;
@@ -6642,6 +6697,141 @@ mod tests {
                 assert_eq!(visible_picker_labels(picker), labels);
             }
         }
+    }
+
+    #[test]
+    fn incremental_picker_filter_only_scores_previous_matches() {
+        let editor = test_editor();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let filter_calls = Arc::clone(&calls);
+        let mut picker = Picker::builder()
+            .structured_items(vec![
+                dynamic_item("alpha", "alpha"),
+                dynamic_item("alpine", "alpine"),
+                dynamic_item("beta", "beta"),
+                dynamic_item("alphabet", "alphabet"),
+            ])
+            .filter_action(move |item, query| {
+                filter_calls.fetch_add(1, Ordering::Relaxed);
+                item.label.contains(query).then_some(1)
+            })
+            .incremental_filter()
+            .build(&editor);
+
+        picker.filter("al");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), 4);
+        assert_eq!(
+            visible_picker_labels(&picker),
+            ["alpha", "alpine", "alphabet"]
+        );
+
+        picker.filter("alp");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), 3);
+        assert_eq!(
+            visible_picker_labels(&picker),
+            ["alpha", "alpine", "alphabet"]
+        );
+
+        picker.filter("alph");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), 3);
+        assert_eq!(visible_picker_labels(&picker), ["alpha", "alphabet"]);
+
+        picker.filter("alpha");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), 2);
+        assert_eq!(visible_picker_labels(&picker), ["alpha", "alphabet"]);
+    }
+
+    #[test]
+    fn incremental_picker_parallel_filter_preserves_stable_order_and_narrowing() {
+        let editor = test_editor();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let filter_calls = Arc::clone(&calls);
+        let item_count = super::PARALLEL_FILTER_MIN_ITEMS * 3;
+        let items = (0..item_count)
+            .map(|index| {
+                let label = if index % 2 == 0 { "alpha" } else { "beta" };
+                dynamic_item(&format!("item-{index:04}"), label)
+            })
+            .collect();
+        let mut picker = Picker::builder()
+            .structured_items(items)
+            .filter_action(move |item, query| {
+                filter_calls.fetch_add(1, Ordering::Relaxed);
+                item.label.contains(query).then_some(1)
+            })
+            .incremental_filter()
+            .build(&editor);
+
+        picker.filter("a");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), item_count);
+
+        picker.filter("al");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), item_count);
+        assert_eq!(
+            picker.visible_dynamic_items,
+            (0..item_count).step_by(2).collect::<Vec<_>>(),
+        );
+
+        picker.filter("alp");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), item_count / 2);
+    }
+
+    #[test]
+    fn incremental_picker_filter_rescores_all_rows_when_the_query_broadens() {
+        let editor = test_editor();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let filter_calls = Arc::clone(&calls);
+        let mut picker = Picker::builder()
+            .structured_items(vec![
+                dynamic_item("alpha", "alpha"),
+                dynamic_item("alpine", "alpine"),
+                dynamic_item("beta", "beta"),
+            ])
+            .filter_action(move |item, query| {
+                filter_calls.fetch_add(1, Ordering::Relaxed);
+                item.label.contains(query).then_some(1)
+            })
+            .incremental_filter()
+            .build(&editor);
+
+        picker.filter("alp");
+        calls.store(0, Ordering::Relaxed);
+
+        picker.filter("a");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), 3);
+        assert_eq!(visible_picker_labels(&picker), ["alpha", "alpine", "beta"]);
+
+        picker.filter("be");
+        assert_eq!(calls.swap(0, Ordering::Relaxed), 3);
+        assert_eq!(visible_picker_labels(&picker), ["beta"]);
+    }
+
+    #[test]
+    fn incremental_picker_filter_includes_new_rows_after_items_are_replaced() {
+        let editor = test_editor();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let filter_calls = Arc::clone(&calls);
+        let mut picker = Picker::builder()
+            .structured_items(vec![
+                dynamic_item("alpha", "alpha"),
+                dynamic_item("beta", "beta"),
+            ])
+            .filter_action(move |item, query| {
+                filter_calls.fetch_add(1, Ordering::Relaxed);
+                item.label.contains(query).then_some(1)
+            })
+            .incremental_filter()
+            .build(&editor);
+        picker.set_search("al".to_string());
+        calls.store(0, Ordering::Relaxed);
+
+        picker.replace_structured_items(vec![
+            dynamic_item("alpine", "alpine"),
+            dynamic_item("beta", "beta"),
+        ]);
+
+        assert_eq!(calls.swap(0, Ordering::Relaxed), 2);
+        assert_eq!(visible_picker_labels(&picker), ["alpine"]);
     }
 
     #[test]

--- a/src/ui/picker_matching.rs
+++ b/src/ui/picker_matching.rs
@@ -47,6 +47,9 @@ pub(super) fn match_path(
     query: &str,
 ) -> Option<PathMatch> {
     if !fuzzy_subsequence_matches(candidate.filename, query) {
+        if !fuzzy_subsequence_matches(candidate.path, query) {
+            return None;
+        }
         return Some(PathMatch {
             score: matcher.fuzzy_match(candidate.path, query)?,
             filename_score: None,


### PR DESCRIPTION
## Why

The file picker rescored every workspace file after every keystroke. In large repositories, broad path prefixes keep thousands of candidates alive and make typing noticeably sluggish.

## What changed

- Reuse the previous result set when a file-picker query narrows, and invalidate that cache when the query broadens or the available files change.
- Score candidate sets of at least 1,024 files in parallel with Rayon while preserving existing fuzzy scores, tie-breakers, and stable result ordering.
- Reject paths that cannot contain the requested fuzzy subsequence before invoking the more expensive matcher.
- Add an opt-in, five-sample performance benchmark that supports both a real workspace and a portable 12,000-file fixture.
- Add focused regressions for incremental narrowing, backspacing, replaced file lists, and stable ordering on large parallel-filtered sets.

Median filtering time for the `codex-rs/core/src` query in an optimized build:

| Workspace | Files | Before | After | Improvement |
| --- | ---: | ---: | ---: | ---: |
| Real Codex checkout | 6,415 | 106.7 ms | 22.8 ms | 4.7x |
| Synthetic fixture | 12,000 | 100.3 ms | 19.5 ms | 5.1x |

## How to Test

1. Run `cargo test -p red --lib ui:: -- --test-threads=1`; all 345 UI tests should pass, including the large-list ordering and query-broadening regressions. The manual benchmark remains ignored during normal runs.
2. Run `RED_FILE_PICKER_BENCH_ROOT=/path/to/large/workspace cargo test --release -p red --lib file_picker_large_workspace_performance -- --ignored --nocapture`; the benchmark should report five-sample medians for discovery, installation, keystrokes, filtering, and drawing. Omit the environment variable to exercise the portable 12,000-file fixture.
3. Open the file picker in a large repository, type a multi-character filename or path query, then backspace and change the query; results should remain responsive, correctly ranked, and include files that become eligible again.

Also verified with `cargo clippy --all-targets --all-features -- -D warnings`.
