### PR TITLE
fix(editor): reveal wrapped final lines

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -25705,6 +25705,40 @@ impl Editor {
         self.cx = self.cx.min(max_cursor_x);
     }
 
+    /// Reveal wrapped EOF continuations without scrolling the cursor offscreen.
+    ///
+    /// Earlier logical lines may leave only one screen row for the final line.
+    /// Scroll those rows away until its last segment appears or the cursor's
+    /// segment reaches the top of the viewport.
+    fn reveal_last_wrapped_line(&mut self, line_index: usize, display_col: usize, height: usize) {
+        if line_index != self.last_navigable_line() {
+            return;
+        }
+
+        for _ in 0..height {
+            let Some(window) = self.active_window_with_editor_view() else {
+                break;
+            };
+            let layout = self.layout_for_window(&window);
+            let Some(cursor_segment) = layout.rows.iter().find(|segment| {
+                segment.line == line_index && segment.contains_cursor_col(display_col)
+            }) else {
+                break;
+            };
+            let last_segment_visible = layout
+                .rows
+                .iter()
+                .any(|segment| segment.line == line_index && segment.last_segment);
+            if last_segment_visible || cursor_segment.row == 0 {
+                break;
+            }
+            if !self.scroll_wrapped_viewport_down_one_screen_line() {
+                break;
+            }
+            self.cy = line_index.saturating_sub(self.vtop);
+        }
+    }
+
     fn ensure_cursor_visible(&mut self) {
         let width = self.active_content_width();
         if width == 0 {
@@ -25771,6 +25805,7 @@ impl Editor {
         }
 
         self.cy = buffer_line.saturating_sub(self.vtop);
+        self.reveal_last_wrapped_line(buffer_line, display_col, height);
     }
 
     fn start_selection(&mut self) {

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -352,6 +352,98 @@ async fn test_wrap_renders_long_line_across_screen_rows() {
 }
 
 #[tokio::test]
+async fn test_wrap_renders_final_line_at_viewport_bottom_when_enabled_by_default() {
+    for trailing_newline in [false, true] {
+        let ending = if trailing_newline { "\n" } else { "" };
+        let contents = format!("one\ntwo\nthree\nabcdefghijklmnop{ending}");
+        let buffer = Buffer::new(None, contents);
+        let mut harness = EditorHarness::with_config_and_size(buffer, Config::default(), 10, 6);
+        assert!(harness.wrap());
+
+        harness.execute_action(Action::MoveToBottom).await.unwrap();
+
+        let screen = (0..4)
+            .map(|row| harness.render_row(row).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            screen.contains("ghijkl"),
+            "final line should wrap below its first segment \
+             (trailing newline: {trailing_newline}): {screen:?}"
+        );
+        assert!(
+            screen.contains("mnop"),
+            "final line should remain visible through its last segment \
+             (trailing newline: {trailing_newline}): {screen:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_wrap_renders_final_line_at_viewport_bottom_when_toggled_on() {
+    for trailing_newline in [false, true] {
+        let ending = if trailing_newline { "\n" } else { "" };
+        let contents = format!("one\ntwo\nthree\nabcdefghijklmnop{ending}");
+        let buffer = Buffer::new(None, contents);
+        let config = Config {
+            wrap: Some(false),
+            ..Default::default()
+        };
+        let mut harness = EditorHarness::with_config_and_size(buffer, config, 10, 6);
+
+        harness.execute_action(Action::MoveToBottom).await.unwrap();
+        harness.execute_action(Action::ToggleWrap).await.unwrap();
+
+        let screen = (0..4)
+            .map(|row| harness.render_row(row).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            screen.contains("ghijkl"),
+            "final line should wrap below its first segment after toggling \
+             (trailing newline: {trailing_newline}): {screen:?}"
+        );
+        assert!(
+            screen.contains("mnop"),
+            "final line should remain visible through its last segment after toggling \
+             (trailing newline: {trailing_newline}): {screen:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_wrap_keeps_cursor_visible_when_final_line_exceeds_viewport_height() {
+    let contents = "one\ntwo\nthree\nabcdefghijklmnopqrstuvwxyz0123456789\n";
+    let buffer = Buffer::new(None, contents.to_string());
+    let mut harness = EditorHarness::with_config_and_size(buffer, Config::default(), 10, 6);
+
+    harness.execute_action(Action::MoveToBottom).await.unwrap();
+
+    let screen = (0..4)
+        .map(|row| harness.render_row(row).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert_eq!(
+        harness.render_cursor_position(),
+        Some((4, 0)),
+        "the first segment should remain visible: {screen:?}"
+    );
+    for (row, expected) in [(0, "abcdef"), (1, "ghijkl"), (2, "mnopqr"), (3, "stuvwx")] {
+        assert_eq!(
+            harness
+                .render_row(row)
+                .unwrap()
+                .chars()
+                .skip(4)
+                .take(6)
+                .collect::<String>(),
+            expected,
+            "final line should fill the viewport without hiding its cursor"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_nowrap_scrolls_horizontally_as_cursor_moves() {
     let buffer = Buffer::new(None, "abcdefghijklmnopqrstuvwxyz".to_string());
     let config = Config {
@@ -466,7 +558,7 @@ async fn test_screen_line_down_updates_rendered_cursor_without_lag() {
 
 #[tokio::test]
 async fn test_screen_line_down_reveals_hidden_wrapped_segment() {
-    let content = format!("one\ntwo\nthree\n{}", "abcdefghijklmnop");
+    let content = format!("one\ntwo\nthree\n{}\nlast", "abcdefghijklmnop");
     let buffer = Buffer::new(None, content);
     let config = Config {
         wrap: Some(true),
@@ -490,7 +582,7 @@ async fn test_screen_line_down_reveals_hidden_wrapped_segment() {
 
 #[tokio::test]
 async fn test_screen_line_up_returns_from_hidden_wrapped_segment() {
-    let content = format!("one\ntwo\nthree\n{}", "abcdefghijklmnop");
+    let content = format!("one\ntwo\nthree\n{}\nlast", "abcdefghijklmnop");
     let buffer = Buffer::new(None, content);
     let config = Config {
         wrap: Some(true),


### PR DESCRIPTION
## Why

When a file's final line starts on the bottom screen row, wrapping renders only its first segment and leaves the rest below the viewport. This happens whether wrapping is enabled by default or toggled on later, and whether or not the file ends with a newline.

## What Changed

- Scroll earlier rows out of view until the final wrapped segment becomes visible, without scrolling the cursor's segment offscreen.
- Keep the cursor visible when the final line is taller than the entire viewport.
- Cover default and toggled wrapping with and without a trailing newline, and preserve hidden-segment navigation coverage for non-final lines.

## How to Test

1. Open a file in a narrow editor with several short lines followed by a final line wider than the text area. Move to the final line with wrapping enabled by default and verify its continuation rows appear instead of stopping at the bottom screen row.
2. Start with wrapping disabled, move to the same final line, and run `:wrap`. Verify the final line reflows and its continuation rows become visible.
3. Repeat both cases with and without a trailing newline. Use a final line taller than the viewport and verify the cursor remains visible while the available rows fill with wrapped text.
4. Run `cargo test --test movement --test editing`; all 126 movement tests and 353 editing tests should pass.
