### PR TITLE
feat(picker): modernize buffer navigation

### DIFF
--- a/plugins/buffer_picker.hk
+++ b/plugins/buffer_picker.hk
@@ -1,11 +1,19 @@
-// Fuzzy picker for the editor's current buffer list.
+// Recent-buffer picker with file-aware rows, previews, and split navigation.
 //
-// The editor snapshot is authoritative for buffer identity and active state. Selection
-// requests a normal buffer switch and never mutates buffer contents.
+// The editor snapshot owns ordering, buffer identity, active state, and saved cursor
+// coordinates. File previews resolve through the editor's live buffer snapshots, while
+// split actions use explicit UTF-8 byte locations and never reopen unnamed buffers.
 
 struct BufferSummary {
     id: i32,
     name: String,
+    path: Option<String>,
+    display_path: Option<String>,
+    dirty: bool,
+    active: bool,
+    alternate: bool,
+    line: i32,
+    column: i32,
 }
 
 struct EditorInfo {
@@ -14,17 +22,45 @@ struct EditorInfo {
 
 struct BufferPickerData {
     id: i32,
+    path: Option<String>,
+    search_path: String,
+    dirty: bool,
+    active: bool,
+    line: i32,
+    column: i32,
 }
 
 struct BufferPickerItem {
     id: String,
     label: String,
     kind: String,
+    annotation: String,
+    detail: String,
     data: BufferPickerData,
+    preview: Json,
 }
 
 struct BufferPickerHandlers {
     selected: fn(BufferPickerItem),
+    cancelled: fn(PickerCancelled),
+    action: fn(PickerActionEvent),
+}
+
+struct BufferPickerState {
+    picker: Option<i32>,
+    preview: bool,
+}
+
+#[red::state]
+fn initial_state() -> BufferPickerState {
+    return BufferPickerState {
+        picker: None,
+        preview: true,
+    };
+}
+
+fn state() -> BufferPickerState {
+    return red::state();
 }
 
 #[red::command(
@@ -36,41 +72,187 @@ struct BufferPickerHandlers {
     scope = "global",
 )]
 fn buffer_picker() {
+    if let Some(handle) = state().picker {
+        red::execute("ClosePicker", handle);
+        red::state_patch(BufferPickerState { picker: None });
+    }
     red::request("GetEditorInfo", editor_info_loaded);
 }
 
 fn editor_info_loaded(info: EditorInfo) {
     let items: [BufferPickerItem] = [];
     let index = 0;
+    let dirty = 0;
+    let selected = "";
     while index < red::len(info.buffers) && index < 500 {
         let buffer = info.buffers[index];
-        let label = buffer.name;
-        if buffer.name == "[No Name]" {
-            label = buffer.name + " #" + buffer.id;
+        let item = buffer_item(buffer);
+        if buffer.dirty {
+            dirty = dirty + 1;
         }
-        items = red::push(items, BufferPickerItem {
-            id: "buffer:" + buffer.id,
-            label: label,
-            kind: "Buffer",
-            data: BufferPickerData {
-                id: buffer.id,
-            },
-        });
+        if buffer.alternate || (selected == "" && buffer.active) {
+            selected = item.id;
+        }
+        items = red::push(items, item);
         index = index + 1;
     }
 
-    let status = red::len(items) + " buffers";
+    let status = red::len(items) + " buffer";
+    if red::len(items) != 1 {
+        status = status + "s";
+    }
+    if dirty > 0 {
+        status = status + " · " + dirty + " modified";
+    }
     if index < red::len(info.buffers) {
         status = status + " (results truncated)";
     }
-    red::execute("OpenPicker", "Buffers", items, PickerOptions {
-        placeholder: "Filter buffers",
+    red::state_set("buffer_picker_items", items);
+    let handle = red::execute("OpenPicker", "Buffers", items, PickerOptions {
+        placeholder: "Search open buffers…",
         status: status,
+        initial_selection: selected,
+        item_layout: "label_first",
+        actions: [
+            PickerAction { action: "open_horizontal", key: "Ctrl-s", label: "Open horizontal split" },
+            PickerAction { action: "open_vertical", key: "Ctrl-v", label: "Open vertical split" },
+            PickerAction { action: "toggle_preview", key: "Alt-p", label: "Toggle preview" },
+        ],
     }, BufferPickerHandlers {
         selected: buffer_selected,
+        cancelled: buffer_cancelled,
+        action: buffer_action,
     });
+    red::state_patch(BufferPickerState { picker: Some(handle) });
+}
+
+fn buffer_item(buffer: BufferSummary) -> BufferPickerItem {
+    let display_path = buffer.name;
+    if let Some(path) = buffer.display_path {
+        display_path = path;
+    }
+    display_path = red::replace_all(display_path, "\\", "/");
+
+    let parts = red::split(display_path, "/");
+    let label = red::string(parts[red::len(parts) - 1], display_path);
+    if buffer.name == "[No Name]" {
+        label = buffer.name + " #" + buffer.id;
+    }
+    let annotation = "";
+    if red::len(parts) > 1 {
+        let parents = [];
+        let index = 0;
+        while index < red::len(parts) - 1 {
+            parents = red::push(parents, parts[index]);
+            index = index + 1;
+        }
+        annotation = red::join(parents, "/");
+    }
+
+    let kind = "Buffer";
+    let preview = red::null();
+    if let Some(path) = buffer.path {
+        kind = "FilePath";
+        if state().preview {
+            preview = Json { path: path, line: buffer.line, column: buffer.column };
+        }
+    }
+
+    let detail = "";
+    if buffer.dirty {
+        detail = "● modified";
+    }
+    if buffer.active {
+        if detail != "" {
+            detail = detail + " · ";
+        }
+        detail = detail + "current";
+    }
+
+    return BufferPickerItem {
+        id: "buffer:" + buffer.id,
+        label: label,
+        kind: kind,
+        annotation: annotation,
+        detail: detail,
+        data: BufferPickerData {
+            id: buffer.id,
+            path: buffer.path,
+            search_path: display_path,
+            dirty: buffer.dirty,
+            active: buffer.active,
+            line: buffer.line,
+            column: buffer.column,
+        },
+        preview: preview,
+    };
 }
 
 fn buffer_selected(item: BufferPickerItem) {
+    clear_picker();
     red::execute("OpenBufferById", item.data.id);
+}
+
+fn buffer_cancelled(event: PickerCancelled) {
+    clear_picker();
+}
+
+fn buffer_action(event: PickerActionEvent) {
+    if event.action == "toggle_preview" {
+        toggle_preview();
+    } else if event.action == "open_horizontal" {
+        open_buffer_split(event.item, "horizontal");
+    } else if event.action == "open_vertical" {
+        open_buffer_split(event.item, "vertical");
+    }
+}
+
+fn toggle_preview() {
+    let Some(handle) = state().picker else {
+        return;
+    };
+    let enabled = !state().preview;
+    red::state_patch(BufferPickerState { preview: enabled });
+
+    let items: [BufferPickerItem] = red::state("buffer_picker_items");
+    let updated: [BufferPickerItem] = [];
+    for item in items {
+        item.preview = red::null();
+        if enabled {
+            if let Some(path) = item.data.path {
+                item.preview = Json {
+                    path: path,
+                    line: item.data.line,
+                    column: item.data.column,
+                };
+            }
+        }
+        updated = red::push(updated, item);
+    }
+    red::state_set("buffer_picker_items", updated);
+    red::execute("UpdatePickerItems", handle, updated);
+}
+
+fn open_buffer_split(item: PickerItem, target: String) {
+    let path = red::string(item.data.path, "");
+    if path == "" {
+        red::execute("Print", "Save an unnamed buffer before opening it in a split");
+        return;
+    }
+    let Some(handle) = state().picker else {
+        return;
+    };
+    clear_picker();
+    red::execute("ClosePicker", handle);
+    red::execute("OpenLocation", Json {
+        path: path,
+        line: red::int(item.data.line, 0),
+        column: red::int(item.data.column, 0),
+        column_encoding: "utf8-byte",
+    }, target);
+}
+
+fn clear_picker() {
+    red::state_patch(BufferPickerState { picker: None });
+    red::state_set("buffer_picker_items", []);
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10602,7 +10602,25 @@ impl Editor {
                         continue;
                     }
                     let history_key = Self::picker_history_key(&title, None);
+                    let preview_paths = items
+                        .iter()
+                        .filter_map(|item| match item.preview.as_ref() {
+                            Some(PickerPreview::Location { path, .. }) => Some(path.as_str()),
+                            _ => item.data.get("path").and_then(Value::as_str),
+                        })
+                        .collect::<HashSet<_>>();
+                    let preview_contents = self
+                        .buffer_manager
+                        .iter()
+                        .filter_map(|buffer| {
+                            let path = buffer.file.as_ref()?;
+                            preview_paths
+                                .contains(path.as_str())
+                                .then(|| (path.clone(), buffer.contents_snapshot()))
+                        })
+                        .collect();
                     let mut picker = Picker::new_callback(title, self, items, handle, options);
+                    picker.set_location_preview_contents(preview_contents);
                     if let Some(history_key) = history_key {
                         let history = self.picker_history(&history_key).to_vec();
                         picker.set_history(history_key, history);
@@ -28117,12 +28135,67 @@ pub struct BufferInfo {
     id: BufferId,
     name: String,
     path: Option<String>,
+    display_path: Option<String>,
     dirty: bool,
+    active: bool,
+    alternate: bool,
+    line: usize,
+    column: usize,
 }
 
 impl From<&Editor> for EditorInfo {
     fn from(editor: &Editor) -> Self {
-        let buffers = editor.buffer_manager.iter().map(|b| b.into()).collect();
+        let active_id = editor.buffer_manager.active_buffer().map(Buffer::id);
+        let alternate_id = editor
+            .buffer_manager
+            .alternate_index()
+            .and_then(|index| editor.buffer_manager.get(index))
+            .map(Buffer::id);
+        let recent_ranks = editor
+            .buffer_manager
+            .recent_buffer_ids()
+            .rev()
+            .enumerate()
+            .map(|(rank, id)| (id, rank))
+            .collect::<HashMap<_, _>>();
+        let cwd = std::env::current_dir().ok();
+        let mut buffers = editor
+            .buffer_manager
+            .iter()
+            .map(|buffer| {
+                let active = Some(buffer.id()) == active_id;
+                let line = if active {
+                    editor.buffer_line()
+                } else {
+                    buffer.vtop.saturating_add(buffer.pos.1)
+                };
+                let grapheme_column = if active { editor.cx } else { buffer.pos.0 };
+                let column = buffer
+                    .get(line)
+                    .map(|text| grapheme_to_byte(text.trim_end_matches('\n'), grapheme_column))
+                    .unwrap_or_default();
+                let display_path = buffer.file.as_deref().map(|path| {
+                    let path = Path::new(path);
+                    cwd.as_deref()
+                        .and_then(|root| path.strip_prefix(root).ok())
+                        .unwrap_or(path)
+                        .to_string_lossy()
+                        .into_owned()
+                });
+                BufferInfo {
+                    id: buffer.id(),
+                    name: buffer.name().to_string(),
+                    path: buffer.file.clone(),
+                    display_path,
+                    dirty: buffer.is_dirty(),
+                    active,
+                    alternate: Some(buffer.id()) == alternate_id,
+                    line,
+                    column,
+                }
+            })
+            .collect::<Vec<_>>();
+        buffers.sort_by_key(|buffer| recent_ranks.get(&buffer.id).copied().unwrap_or(usize::MAX));
         let theme = editor.theme.clone();
         Self {
             buffers,
@@ -28135,17 +28208,6 @@ impl From<&Editor> for EditorInfo {
             cx: editor.cx,
             cy: editor.cy,
             vx: editor.vx,
-        }
-    }
-}
-
-impl From<&Buffer> for BufferInfo {
-    fn from(buffer: &Buffer) -> Self {
-        Self {
-            id: buffer.id(),
-            name: buffer.name().to_string(),
-            path: buffer.file.clone(),
-            dirty: buffer.is_dirty(),
         }
     }
 }
@@ -29083,6 +29145,49 @@ mod test {
         editor.set_default_register(Content::charwise("o\nt\nt\nf\n".to_string()));
 
         assert_eq!(copied.lock().unwrap().as_deref(), Some("o\nt\nt\nf\n"));
+    }
+
+    #[test]
+    fn editor_info_orders_buffers_by_recency_and_exposes_navigation_metadata() {
+        let mut editor = test_editor(80, 24);
+        let cwd = std::env::current_dir().unwrap();
+        let first = cwd.join("src/first.rs");
+        let second = cwd.join("src/second.rs");
+        let unvisited = cwd.join("docs/guide.md");
+        editor.buffer_manager.replace_buffers(vec![
+            Buffer::new(
+                Some(first.to_string_lossy().into_owned()),
+                "a😀z\n".to_string(),
+            ),
+            Buffer::new(
+                Some(second.to_string_lossy().into_owned()),
+                "second\n".to_string(),
+            ),
+            Buffer::new(
+                Some(unvisited.to_string_lossy().into_owned()),
+                "guide\n".to_string(),
+            ),
+        ]);
+        editor.buffer_manager.set_active_index(1);
+        editor.buffer_manager.set_active_index(0);
+        editor.cx = 2;
+        editor.cy = 0;
+
+        let info = editor.info();
+
+        assert_eq!(
+            info.buffers
+                .iter()
+                .map(|buffer| buffer.display_path.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            ["src/first.rs", "src/second.rs", "docs/guide.md"]
+        );
+        assert!(info.buffers[0].active);
+        assert!(!info.buffers[0].alternate);
+        assert_eq!(info.buffers[0].column, 5);
+        assert!(info.buffers[1].alternate);
+        assert!(!info.buffers[1].active);
+        assert_ne!(info.buffers[0].id, info.buffers[1].id);
     }
 
     #[tokio::test]

--- a/src/editor/buffer_manager.rs
+++ b/src/editor/buffer_manager.rs
@@ -73,6 +73,11 @@ impl BufferManager {
         })
     }
 
+    /// Returns visited buffer identities from their oldest visit to their newest.
+    pub(crate) fn recent_buffer_ids(&self) -> impl DoubleEndedIterator<Item = BufferId> + '_ {
+        self.recent_buffers.iter().copied()
+    }
+
     fn record_active_buffer(&mut self) {
         let Some(id) = self.active_buffer().map(Buffer::id) else {
             return;
@@ -193,6 +198,30 @@ mod tests {
         manager.remove_buffer(1);
         assert_eq!(manager.active_buffer().unwrap().name(), "a");
         assert_eq!(manager.alternate_index(), None);
+    }
+
+    #[test]
+    fn recent_buffer_ids_keep_visit_order_without_duplicate_or_removed_entries() {
+        let mut manager = BufferManager::with_buffers(vec![buffer("a"), buffer("b"), buffer("c")]);
+        let first = manager[0].id();
+        let second = manager[1].id();
+        let third = manager[2].id();
+
+        manager.set_active_index(1);
+        manager.set_active_index(2);
+        manager.set_active_index(1);
+
+        assert_eq!(
+            manager.recent_buffer_ids().collect::<Vec<_>>(),
+            vec![first, third, second]
+        );
+
+        manager.remove_buffer(1);
+
+        assert_eq!(
+            manager.recent_buffer_ids().collect::<Vec<_>>(),
+            vec![first, third]
+        );
     }
 
     #[test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -11220,9 +11220,39 @@ mod tests {
                 request_id,
                 serde_json::json!({
                     "buffers": [
-                        { "id": 41, "name": "src/main.rs", "path": "src/main.rs", "dirty": false },
-                        { "id": 42, "name": "[No Name]", "path": null, "dirty": true },
-                        { "id": 43, "name": "[No Name]", "path": null, "dirty": false },
+                        {
+                            "id": 41,
+                            "name": "/workspace/src/main.rs",
+                            "path": "/workspace/src/main.rs",
+                            "display_path": "src/main.rs",
+                            "dirty": false,
+                            "active": true,
+                            "alternate": false,
+                            "line": 4,
+                            "column": 8
+                        },
+                        {
+                            "id": 42,
+                            "name": "[No Name]",
+                            "path": null,
+                            "display_path": null,
+                            "dirty": true,
+                            "active": false,
+                            "alternate": true,
+                            "line": 0,
+                            "column": 0
+                        },
+                        {
+                            "id": 43,
+                            "name": "[No Name]",
+                            "path": null,
+                            "display_path": null,
+                            "dirty": false,
+                            "active": false,
+                            "alternate": false,
+                            "line": 0,
+                            "column": 0
+                        }
                     ],
                 }),
             )
@@ -11235,18 +11265,106 @@ mod tests {
                 handle,
                 title,
                 items,
-                ..
+                options,
             } => {
                 assert_eq!(owner, "buffer_picker");
                 assert_eq!(title.as_deref(), Some("Buffers"));
-                assert_eq!(items[0].label, "src/main.rs");
+                assert_eq!(items[0].id, "buffer:41");
+                assert_eq!(items[0].label, "main.rs");
+                assert_eq!(items[0].kind.as_deref(), Some("FilePath"));
+                assert_eq!(items[0].annotation.as_deref(), Some("src"));
+                assert_eq!(items[0].detail.as_deref(), Some("current"));
+                assert_eq!(
+                    items[0].preview,
+                    Some(crate::ui::PickerPreview::Location {
+                        path: "/workspace/src/main.rs".to_string(),
+                        line: Some(4),
+                        column: Some(8),
+                        matches: Vec::new(),
+                    })
+                );
+                assert_eq!(items[1].id, "buffer:42");
                 assert_eq!(items[1].label, "[No Name] #42");
+                assert_eq!(items[1].kind.as_deref(), Some("Buffer"));
+                assert_eq!(items[1].detail.as_deref(), Some("● modified"));
+                assert!(items[1].preview.is_none());
+                assert_eq!(items[2].id, "buffer:43");
                 assert_eq!(items[2].label, "[No Name] #43");
+                assert!(items[2].preview.is_none());
                 assert_ne!(items[1].id, items[2].id);
+                assert_eq!(options.initial_selection.as_deref(), Some("buffer:42"));
+                assert_eq!(options.status.as_deref(), Some("3 buffers · 1 modified"));
+                assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
+                assert_eq!(
+                    options
+                        .actions
+                        .iter()
+                        .map(|action| action.action.as_str())
+                        .collect::<Vec<_>>(),
+                    ["open_horizontal", "open_vertical", "toggle_preview"]
+                );
                 (handle, items)
             }
             _ => panic!("unexpected plugin request"),
         };
+
+        runtime
+            .notify_picker(
+                handle,
+                PickerCallback::Action {
+                    action: "toggle_preview".to_string(),
+                    item: Some(items[0].clone()),
+                    query: "main".to_string(),
+                },
+            )
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::UpdatePickerItems { id, items } => {
+                assert_eq!(id, handle.get());
+                assert!(items.iter().all(|item| item.preview.is_none()));
+            }
+            _ => panic!("preview toggle should update the existing picker"),
+        }
+
+        runtime
+            .notify_picker(
+                handle,
+                PickerCallback::Action {
+                    action: "toggle_preview".to_string(),
+                    item: Some(items[0].clone()),
+                    query: "main".to_string(),
+                },
+            )
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::UpdatePickerItems { id, items } => {
+                assert_eq!(id, handle.get());
+                assert!(items[0].preview.is_some());
+                assert!(items[1].preview.is_none());
+                assert!(items[2].preview.is_none());
+            }
+            _ => panic!("enabling previews should restore file-backed buffer previews"),
+        }
+
+        runtime
+            .notify_picker(
+                handle,
+                PickerCallback::Action {
+                    action: "open_vertical".to_string(),
+                    item: Some(items[1].clone()),
+                    query: String::new(),
+                },
+            )
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::Action(Action::Print(message)) => {
+                assert!(message.contains("unnamed buffer"));
+            }
+            _ => panic!("unnamed buffers must remain in the existing picker"),
+        }
 
         runtime
             .notify_picker(handle, PickerCallback::Selected(items[2].clone()))
@@ -11255,6 +11373,83 @@ mod tests {
         match ACTION_DISPATCHER.recv_request() {
             PluginRequest::Action(Action::OpenBufferById(id)) => assert_eq!(id, 43),
             _ => panic!("unexpected plugin request"),
+        }
+    }
+
+    #[tokio::test]
+    async fn buffer_picker_opens_file_splits_at_the_saved_utf8_cursor() {
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin(
+                "buffer_picker",
+                include_str!("../../plugins/buffer_picker.hk"),
+            )
+            .await
+            .unwrap();
+        runtime.execute_command("BufferPicker").await.unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::EditorInfo(request_id) => request_id,
+            _ => panic!("expected the open-buffer snapshot"),
+        };
+        runtime
+            .resolve_request(
+                request_id,
+                serde_json::json!({
+                    "buffers": [{
+                        "id": 12,
+                        "name": "/workspace/src/other.rs",
+                        "path": "/workspace/src/other.rs",
+                        "display_path": "src/other.rs",
+                        "dirty": true,
+                        "active": true,
+                        "alternate": false,
+                        "line": 7,
+                        "column": 11
+                    }]
+                }),
+            )
+            .await
+            .unwrap();
+        let (handle, item) = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackPicker { handle, items, .. } => (handle, items[0].clone()),
+            _ => panic!("expected the modern buffer picker"),
+        };
+
+        runtime
+            .notify_picker(
+                handle,
+                PickerCallback::Action {
+                    action: "open_horizontal".to_string(),
+                    item: Some(item),
+                    query: String::new(),
+                },
+            )
+            .unwrap();
+
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::ClosePicker { id } => assert_eq!(id, handle.get()),
+            PluginRequest::Action(Action::Print(message)) => {
+                panic!("split selection should close its picker, printed {message:?}")
+            }
+            _ => panic!("split selection should close its picker"),
+        }
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenLocation { location, target } => {
+                assert_eq!(location.path, "/workspace/src/other.rs");
+                assert_eq!(location.line, 7);
+                assert_eq!(location.column, 11);
+                assert_eq!(
+                    location.column_encoding,
+                    crate::plugin::LocationColumnEncoding::Utf8Byte
+                );
+                assert_eq!(target, crate::plugin::OpenLocationTarget::Horizontal);
+            }
+            PluginRequest::Action(Action::Print(message)) => {
+                panic!("split selection should preserve the saved cursor, printed {message:?}")
+            }
+            _ => panic!("split selection should preserve the saved cursor"),
         }
     }
 

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -43,7 +43,7 @@ use crate::{
 use super::{
     dialog::BorderStyle,
     first_prompt_line,
-    picker_matching::{match_path, PathCandidate},
+    picker_matching::{match_path, path_match_highlights, PathCandidate},
     spinner_frame, ActionBar, ActionPriority, Component, Dialog, IconCatalog, List, ScreenRect,
     UiAction, SPINNER_FRAME_INTERVAL_MS,
 };
@@ -66,7 +66,37 @@ fn default_filter_score(
     label: &str,
     query: &str,
 ) -> Option<(PickerMatchKind, Reverse<i64>)> {
-    let candidate = PathCandidate::from_path(label);
+    default_path_filter_score(matcher, PathCandidate::from_path(label), label, query)
+}
+
+fn default_item_filter_score(
+    matcher: &SkimMatcherV2,
+    item: &PickerItem,
+    query: &str,
+) -> Option<(PickerMatchKind, Reverse<i64>)> {
+    if item.kind.as_deref() != Some("FilePath") {
+        return default_filter_score(matcher, &item.label, query);
+    }
+
+    let path = item
+        .data
+        .get("search_path")
+        .and_then(Value::as_str)
+        .unwrap_or(&item.id);
+    default_path_filter_score(
+        matcher,
+        PathCandidate::new(path, &item.label, item.annotation.as_deref()),
+        &item.label,
+        query,
+    )
+}
+
+fn default_path_filter_score(
+    matcher: &SkimMatcherV2,
+    candidate: PathCandidate<'_>,
+    label: &str,
+    query: &str,
+) -> Option<(PickerMatchKind, Reverse<i64>)> {
     let matched = match_path(matcher, candidate, query)?;
     let (kind, score) = if label == query {
         (PickerMatchKind::Exact, matched.score)
@@ -695,6 +725,28 @@ impl Picker {
         picker.live = true;
         picker.visible_dynamic_items = (0..items.len()).collect();
         picker.list.set_item_count(items.len());
+        if items
+            .iter()
+            .any(|item| item.kind.as_deref() == Some("FilePath"))
+        {
+            let matcher = SkimMatcherV2::default();
+            picker.filter_highlight_action = Some(Box::new(move |item, query| {
+                if item.kind.as_deref() == Some("FilePath") {
+                    let path = item
+                        .data
+                        .get("search_path")
+                        .and_then(Value::as_str)
+                        .unwrap_or(&item.id);
+                    path_match_highlights(
+                        &matcher,
+                        PathCandidate::new(path, &item.label, item.annotation.as_deref()),
+                        query,
+                    )
+                } else {
+                    path_match_highlights(&matcher, PathCandidate::from_path(&item.label), query)
+                }
+            }));
+        }
         picker.dynamic_items = Some(items);
         picker.external_filter = options.external_filter;
         picker.placeholder = options.placeholder;
@@ -792,7 +844,7 @@ impl Picker {
                     filter_action
                         .as_ref()
                         .map_or_else(
-                            || default_filter_score(matcher, &item.label, term),
+                            || default_item_filter_score(matcher, item, term),
                             |filter| {
                                 filter(item, term)
                                     .map(|score| (PickerMatchKind::Fuzzy, Reverse(score)))
@@ -966,6 +1018,12 @@ impl Picker {
 
     pub fn set_status(&mut self, status: Option<String>) {
         self.status = status;
+    }
+
+    /// Keeps file previews aligned with structurally shared open-buffer contents.
+    pub(crate) fn set_location_preview_contents(&mut self, contents: HashMap<String, Rope>) {
+        self.location_preview_overrides = contents;
+        self.preview_text_cache.borrow_mut().clear();
     }
 
     fn set_busy(&mut self, busy: bool) {
@@ -2580,7 +2638,12 @@ pub(crate) fn picker_kind_icon(kind: &str, style: PickerIconStyle) -> &'static s
 
 fn item_file_path(item: &PickerItem) -> Option<&str> {
     match item.kind.as_deref()? {
-        "FilePath" => Some(item.id.as_str()),
+        "FilePath" => Some(
+            item.data
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or(&item.id),
+        ),
         "FileMatch" => item
             .data
             .get("location")
@@ -5202,6 +5265,35 @@ mod tests {
     }
 
     #[test]
+    fn callback_picker_location_preview_uses_an_open_buffer_snapshot() {
+        let editor = test_editor();
+        let path = "/tmp/red-callback-unsaved-preview.rs".to_string();
+        let mut item = dynamic_item(&path, "unsaved.rs");
+        item.kind = Some("FilePath".to_string());
+        item.preview = Some(PickerPreview::Location {
+            path: path.clone(),
+            line: Some(0),
+            column: Some(0),
+            matches: Vec::new(),
+        });
+        let mut picker = Picker::new_callback(
+            Some("Buffers".to_string()),
+            &editor,
+            vec![item],
+            PickerHandle::from_raw(49),
+            PickerOptions::default(),
+        );
+        picker.set_location_preview_contents(HashMap::from([(
+            path.clone(),
+            Rope::from_str("let unsaved = true;\n"),
+        )]));
+
+        let preview = picker.location_preview(&path, Some(0), 0, 10);
+
+        assert_eq!(preview.text.as_ref(), "let unsaved = true;\n");
+    }
+
+    #[test]
     fn unsaved_buffer_snapshot_keeps_large_location_preview_bounded() {
         const FOCUS_LINE: usize = 4_000;
 
@@ -5429,6 +5521,29 @@ mod tests {
                 g: 165,
                 b: 132,
             })
+        );
+    }
+
+    #[test]
+    fn file_rows_with_stable_ids_use_the_path_for_their_icon() {
+        let editor = test_editor();
+        let mut item = dynamic_item("buffer:41", "main.rs");
+        item.kind = Some("FilePath".to_string());
+        item.data = json!({
+            "path": "/workspace/src/main.rs",
+            "search_path": "src/main.rs",
+        });
+        let picker = Picker::new_dynamic(
+            Some("Buffers".to_string()),
+            &editor,
+            vec![item.clone()],
+            41,
+            PickerOptions::default(),
+        );
+
+        assert_eq!(
+            picker.item_icon(&item),
+            picker_file_icon("/workspace/src/main.rs", editor.picker_icons().style)
         );
     }
 
@@ -6569,6 +6684,49 @@ mod tests {
                 .collect(),
             None => picker.list.items().iter().map(String::as_str).collect(),
         }
+    }
+
+    #[test]
+    fn dynamic_file_rows_search_and_highlight_their_workspace_relative_parent() {
+        let editor = test_editor();
+        let mut first = dynamic_item("buffer:41", "main.rs");
+        first.kind = Some("FilePath".to_string());
+        first.annotation = Some("src/editor".to_string());
+        first.data = json!({
+            "path": "/workspace/src/editor/main.rs",
+            "search_path": "src/editor/main.rs",
+        });
+        let mut second = dynamic_item("buffer:42", "main.rs");
+        second.kind = Some("FilePath".to_string());
+        second.annotation = Some("docs".to_string());
+        second.data = json!({
+            "path": "/workspace/docs/main.rs",
+            "search_path": "docs/main.rs",
+        });
+        let mut scratch = dynamic_item("buffer:9", "[No Name]");
+        scratch.kind = Some("Buffer".to_string());
+        let mut picker = Picker::new_dynamic(
+            Some("Buffers".to_string()),
+            &editor,
+            vec![first, second, scratch],
+            12,
+            PickerOptions::default(),
+        );
+
+        picker.filter("editor");
+
+        assert_eq!(visible_picker_labels(&picker), ["main.rs"]);
+        let selected = picker.selected_dynamic_item().unwrap();
+        let highlights = picker.filter_highlight_action.as_ref().unwrap()(selected, "editor");
+        assert!(highlights.label.is_empty());
+        assert!(!highlights.annotation.is_empty());
+
+        picker.filter("docs/main");
+        assert_eq!(visible_picker_labels(&picker), ["main.rs"]);
+        assert_eq!(picker.selected_dynamic_item().unwrap().id, "buffer:42");
+
+        picker.filter("no name");
+        assert_eq!(visible_picker_labels(&picker), ["[No Name]"]);
     }
 
     #[test]


### PR DESCRIPTION
## Why

The buffer picker lagged behind Red's other navigation surfaces: it showed raw paths with generic icons, ignored unsaved/current-buffer state, preserved list order instead of visit history, and offered neither previews nor split navigation. Simply shortening paths would also have broken directory-based fuzzy matching.

## What changed

- Rebuild `plugins/buffer_picker.hk` around filename-first rows, muted parent directories, file-type icons, current/modified indicators, modified counts, and previous-buffer preselection.
- Extend the read-only editor snapshot with stable buffer identity, workspace-relative paths, active/alternate state, MRU ordering, and UTF-8 cursor coordinates.
- Teach shared callback pickers to fuzzy-match and highlight complete workspace-relative paths while keeping filenames prominent, and preview structurally shared live buffer contents instead of stale disk contents.
- Add `Alt-p` preview toggling plus `Ctrl-s`/`Ctrl-v` split actions that restore the saved cursor; keep unnamed buffers in the picker and explain why they cannot open in a split.
- Add focused regressions for visit ordering, duplicate filenames in different directories, unsaved previews, preview toggling, Unicode cursor conversion, split navigation, and unnamed-buffer safety.

## How to Test

1. Open several files, including two files with the same basename in different directories; edit one without saving and switch among them to establish a recent-buffer order.
2. Press `Ctrl-j` or `Space b`. Verify filenames lead each row, directories and file icons distinguish duplicates, the current/modified markers are accurate, and the previous buffer is initially selected.
3. Search by both filename and parent directory. Verify matching and highlighting work across the complete workspace-relative path.
4. Select the modified buffer and toggle `Alt-p` off and on. Verify the preview shows the unsaved in-memory contents rather than the on-disk version.
5. Move the cursor after a Unicode character, reopen the picker, and use `Ctrl-s` or `Ctrl-v`. Verify the requested split opens at the same line and character.
6. Select `[No Name]` and attempt a split. Verify Red explains that the buffer must be saved and leaves the picker open.
7. Run targeted coverage:

   ```sh
   cargo test --lib buffer_picker
   cargo test --lib dynamic_file_rows_search_and_highlight_their_workspace_relative_parent
   cargo test --test self_check
   ```

Validated locally: 2,116 library tests passed (2 ignored), both bundled-plugin self-check tests passed, and `cargo clippy --all-targets --all-features -- -D warnings` completed cleanly.

