### PR TITLE
fix(editor): preserve navigation jump history

### DIFF
--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -3908,7 +3908,7 @@ fn navigate_patch(patch: String, cursor_line: i32, forward: bool) {
         print_hunk_boundary(forward);
         return;
     }
-    red::execute("SetCursorPosition", 0, target);
+    red::execute("SetCursorPosition", 0, target, true);
 }
 
 fn print_hunk_boundary(forward: bool) {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -40123,8 +40123,8 @@ while True:
             .await
             .expect("failed formatter initialization should fall back to an unformatted save");
 
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "value   \n");
-        assert_eq!(editor.buffer_manager[0].contents(), "value   \n");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "value\n");
+        assert_eq!(editor.buffer_manager[0].contents(), "value\n");
         assert!(!editor.buffer_manager[0].is_dirty());
         assert!(editor.pending_lsp_edit_requests.is_empty());
         assert!(editor.pending_lsp_format_saves.is_empty());
@@ -40195,8 +40195,8 @@ while True:
                 .await
                 .expect("failed formatter initialization should not abort a new-document save");
 
-            assert_eq!(std::fs::read_to_string(&target).unwrap(), "value   \n");
-            assert_eq!(editor.current_buffer().contents(), "value   \n");
+            assert_eq!(std::fs::read_to_string(&target).unwrap(), "value\n");
+            assert_eq!(editor.current_buffer().contents(), "value\n");
             assert!(!editor.current_buffer().is_dirty());
             assert!(editor.pending_lsp_edit_requests.is_empty());
             assert!(editor.pending_lsp_format_saves.is_empty());

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -12690,37 +12690,40 @@ impl Editor {
         Ok(quit)
     }
 
-    async fn replay_last_semantic_change(
-        &mut self,
-        buffer: &mut RenderBuffer,
-        runtime: &mut Runtime,
-    ) -> anyhow::Result<()> {
-        let Some(change) = self.last_semantic_change.clone() else {
-            self.set_legacy_message(Some("no change to repeat".to_string()));
-            return Ok(());
-        };
+    #[inline(never)]
+    fn replay_last_semantic_change<'a>(
+        &'a mut self,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async move {
+            let Some(change) = self.last_semantic_change.clone() else {
+                self.set_legacy_message(Some("no change to repeat".to_string()));
+                return Ok(());
+            };
 
-        self.pending_semantic_change = None;
-        self.replaying_semantic_change = true;
-        let result = async {
-            for event in &change.events {
-                if let Some(action) = self.handle_event_with_runtime(event, Some(runtime))? {
-                    if self
-                        .handle_resolved_key_action(event, &action, buffer, runtime)
-                        .await?
-                    {
-                        anyhow::bail!("repeated change attempted to quit the editor");
+            self.pending_semantic_change = None;
+            self.replaying_semantic_change = true;
+            let result = async {
+                for event in &change.events {
+                    if let Some(action) = self.handle_event_with_runtime(event, Some(runtime))? {
+                        if self
+                            .handle_resolved_key_action(event, &action, buffer, runtime)
+                            .await?
+                        {
+                            anyhow::bail!("repeated change attempted to quit the editor");
+                        }
+                    }
+                    if self.replay_checkpoint(buffer, runtime).await? {
+                        break;
                     }
                 }
-                if self.replay_checkpoint(buffer, runtime).await? {
-                    break;
-                }
+                Ok(())
             }
-            Ok(())
-        }
-        .await;
-        self.replaying_semantic_change = false;
-        result
+            .await;
+            self.replaying_semantic_change = false;
+            result
+        })
     }
 
     async fn play_macro(

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1772,6 +1772,7 @@ pub enum PluginRequest {
     SetCursorPosition {
         x: usize,
         y: usize,
+        jump: bool,
     },
     GetCursorDisplayColumn {
         request_id: RequestId,
@@ -3254,6 +3255,9 @@ pub struct Editor {
     /// Incremented after full renders so event handling can avoid duplicate frames.
     render_generation: u64,
 
+    /// Picker callbacks may enqueue navigation that must commit before the next input event.
+    service_background_before_next_input: bool,
+
     /// Active window represented by the last committed frame.
     last_rendered_window: Option<WindowId>,
 
@@ -3538,6 +3542,10 @@ pub struct Editor {
     pending_lsp_format_saves: HashMap<i64, PendingLspFormatSave>,
     pending_lsp_revision_snapshots: HashMap<i64, Vec<(String, u64)>>,
     pending_completions: HashMap<i64, PendingCompletion>,
+    /// Definition requests whose eventual destination must precede queued CTRL-O/CTRL-I actions.
+    pending_definition_requests: HashSet<i64>,
+    /// Jumplist traversal typed while a definition request is still in flight.
+    deferred_jump_navigation: VecDeque<Action>,
     pending_completion_resolutions: HashMap<i64, completion_resolve::PendingCompletionResolution>,
     scheduled_completion: Option<ScheduledCompletion>,
     // Keep optional AI state out of Editor values and the startup futures that own them.
@@ -4772,6 +4780,7 @@ impl Editor {
             is_focused: true,
             suppress_reactivation_click: false,
             render_generation: 0,
+            service_background_before_next_input: false,
             last_rendered_window: None,
             last_rendered_viewport: None,
             splash_shown: false,
@@ -4887,6 +4896,8 @@ impl Editor {
             pending_lsp_format_saves: HashMap::new(),
             pending_lsp_revision_snapshots: HashMap::new(),
             pending_completions: HashMap::new(),
+            pending_definition_requests: HashSet::new(),
+            deferred_jump_navigation: VecDeque::new(),
             pending_completion_resolutions: HashMap::new(),
             scheduled_completion: None,
             inline_completion: Box::default(),
@@ -9328,6 +9339,11 @@ impl Editor {
                 if processed.quit {
                     break 'editor_loop;
                 }
+                if std::mem::take(&mut self.service_background_before_next_input) {
+                    self.service_background(&mut buffer, runtime).await?;
+                    serviced_background = true;
+                    break;
+                }
                 if processed.navigation_deferred {
                     if let Some(signature) = processed
                         .drain_repeated_motion
@@ -10189,12 +10205,29 @@ impl Editor {
                         &msg,
                         InboundMessage::Notification(ParsedNotification::Progress(_))
                     );
+                    let completed_definition =
+                        if method.as_deref() == Some("textDocument/definition") {
+                            match &msg {
+                                InboundMessage::Message(response) => Some(response.id),
+                                InboundMessage::RequestError { id, .. } => Some(*id),
+                                _ => None,
+                            }
+                        } else {
+                            None
+                        };
                     if let Some(action) = self.handle_lsp_message(&msg, method) {
                         // TODO: handle quit
                         let generation_before = self.render_generation;
                         self.execute(&action, buffer, runtime).await?;
                         if !progress_only && self.render_generation == generation_before {
                             needs_render = true;
+                        }
+                    }
+                    if let Some(request_id) = completed_definition {
+                        self.pending_definition_requests.remove(&request_id);
+                        if self.pending_definition_requests.is_empty() {
+                            self.execute_deferred_jump_navigation(buffer, runtime)
+                                .await?;
                         }
                     }
                 }
@@ -10769,7 +10802,13 @@ impl Editor {
                         .resolve_request(runtime, request_id, pos)
                         .await?;
                 }
-                PluginRequest::SetCursorPosition { x, y } => {
+                PluginRequest::SetCursorPosition { x, y, jump } => {
+                    if jump {
+                        self.execute(&Action::MoveTo(x, y.saturating_add(1)), buffer, runtime)
+                            .await?;
+                        needs_motion_render = true;
+                        continue;
+                    }
                     self.cx = x;
                     let viewport_height = self.vheight().max(1);
                     // Adjust viewport if needed
@@ -18172,7 +18211,7 @@ impl Editor {
             .ensure_notified_revision(action_buffer_id, action_buffer_revision);
         let event_snapshot_before_action = self.event_snapshot();
         let action_cause = Self::action_cause(action);
-        let jump_entry_before_action = self.current_jump_entry();
+        let jump_entry_before_action = self.jump_origin_for_action(action);
         let picker_handle_before_action = self
             .current_dialog
             .as_ref()
@@ -18489,7 +18528,7 @@ impl Editor {
             | Action::ViewInlineAssistAnswer
             | Action::EscalateInlineAssist
             | Action::StageInlineAssistHandoff { .. } => {
-                add_to_history = false;
+                add_to_history = tracking && Self::records_jump(action);
                 if let std::ops::ControlFlow::Break(quit) =
                     self.execute_inline_action(action, buffer, runtime).await?
                 {
@@ -19213,7 +19252,8 @@ impl Editor {
             Action::JumpToMark { mark, linewise } => {
                 if *mark == '\'' {
                     add_to_history = false;
-                    if let Some(entry) = self.jump_back_entry() {
+                    if let Some(entry) = self.active_jump_list().previous_context.clone() {
+                        self.remember_previous_context(self.current_jump_entry());
                         self.jump_to_entry(&entry, buffer, runtime).await?;
                     } else {
                         self.set_legacy_message(Some("previous jump is not set".to_string()));
@@ -19764,9 +19804,11 @@ impl Editor {
                 if let Some(file) = self.current_buffer().file.clone() {
                     let position = self.cursor_lsp_position();
                     self.ensure_current_buffer_lsp_opened().await?;
-                    self.lsp
+                    let request_id = self
+                        .lsp
                         .goto_definition(&file, position.character, position.line)
                         .await?;
+                    self.pending_definition_requests.insert(request_id);
                 }
             }
             Action::Hover => {
@@ -20925,7 +20967,13 @@ impl Editor {
                 self.open_inline_history(buffer, runtime).await?;
             }
             Action::InlineHistoryAction(action) => {
-                add_to_history = false;
+                add_to_history = tracking
+                    && matches!(
+                        action,
+                        crate::inline_history::HistoryAction::FollowFile { .. }
+                            | crate::inline_history::HistoryAction::Jump
+                            | crate::inline_history::HistoryAction::ShowAnnotations
+                    );
                 self.handle_inline_history_action(action, buffer, runtime)
                     .await?;
             }
@@ -21492,8 +21540,13 @@ impl Editor {
             }
             Action::JumpBack => {
                 add_to_history = false;
+                if !self.pending_definition_requests.is_empty() {
+                    self.deferred_jump_navigation.push_back(Action::JumpBack);
+                    return Ok(false);
+                }
                 if let Some(entry) = self.jump_back_entry() {
                     log!("jumping back to {entry:?}");
+                    self.remember_previous_context(self.current_jump_entry());
                     self.jump_to_entry(&entry, buffer, runtime).await?;
                 } else {
                     self.set_legacy_message(Some("at start of jump list".to_string()));
@@ -21502,8 +21555,13 @@ impl Editor {
             }
             Action::JumpForward => {
                 add_to_history = false;
+                if !self.pending_definition_requests.is_empty() {
+                    self.deferred_jump_navigation.push_back(Action::JumpForward);
+                    return Ok(false);
+                }
                 if let Some(entry) = self.jump_forward_entry() {
                     log!("jumping forward to {entry:?}");
+                    self.remember_previous_context(self.current_jump_entry());
                     self.jump_to_entry(&entry, buffer, runtime).await?;
                 } else {
                     self.set_legacy_message(Some("at end of jump list".to_string()));
@@ -21529,6 +21587,10 @@ impl Editor {
                 self.plugin_registry
                     .notify_picker(runtime, *handle, event.as_ref().clone())
                     .await?;
+                // A picker selection may enqueue its OpenLocation request from the
+                // callback. Commit that navigation before accepting the next key,
+                // so an immediately typed CTRL-O sees the new jump.
+                self.service_background_before_next_input = true;
             }
             Action::NotifyComposer(handle, event) => {
                 self.plugin_registry
@@ -21804,7 +21866,7 @@ impl Editor {
         self.finish_snippet_after_action(action);
 
         if add_to_history && Self::records_jump(action) {
-            self.save_to_history(jump_entry_before_action);
+            self.save_jump_after_action(jump_entry_before_action, action);
         }
 
         if self.current_buffer().id() == action_buffer_id
@@ -21940,9 +22002,26 @@ impl Editor {
                 | Action::SwapPreviousFunction
                 | Action::NextDiagnostic
                 | Action::PreviousDiagnostic
+                | Action::NextInlineComment
+                | Action::PreviousInlineComment
+                | Action::OpenInlineComment(_)
+                | Action::FocusInlineComment(_)
+                | Action::NavigateInlineCommentCard { .. }
+                | Action::NavigateOverlappingInlineComment { open: true, .. }
+                | Action::OpenInlineJob(_)
+                | Action::OpenLatestInlineCompletion
+                | Action::OpenInlineCompletion(_)
+                | Action::ViewInlineChanges { .. }
+                | Action::ViewInlineAgentChanges { .. }
                 | Action::MoveTo(_, _)
                 | Action::MoveToFilePos(_, _, _)
+                | Action::GoToLine(_)
                 | Action::JumpToMark { .. }
+                | Action::InlineHistoryAction(
+                    crate::inline_history::HistoryAction::FollowFile { .. }
+                        | crate::inline_history::HistoryAction::Jump
+                        | crate::inline_history::HistoryAction::ShowAnnotations,
+                )
                 | Action::OpenLocation(_, _)
                 | Action::OpenFile(_)
                 | Action::OpenBuffer(_)
@@ -21981,6 +22060,26 @@ impl Editor {
         }
     }
 
+    fn jump_origin_for_action(&self, action: &Action) -> JumpEntry {
+        if matches!(
+            action,
+            Action::InlineHistoryAction(
+                crate::inline_history::HistoryAction::FollowFile { .. }
+                    | crate::inline_history::HistoryAction::Jump
+                    | crate::inline_history::HistoryAction::ShowAnnotations,
+            ) | Action::OpenInlineJob(_)
+                | Action::OpenLatestInlineCompletion
+                | Action::OpenInlineCompletion(_)
+                | Action::ViewInlineChanges { .. }
+                | Action::ViewInlineAgentChanges { .. }
+        ) {
+            if let Some(browser) = &self.inline_history_browser {
+                return browser.origin.clone();
+            }
+        }
+        self.current_jump_entry()
+    }
+
     fn clean_jump_list(&mut self) {
         let valid_buffers = self
             .buffer_manager
@@ -21990,6 +22089,13 @@ impl Editor {
         let current_buffer_id = self.current_buffer().id();
         let current_line = self.buffer_line();
         let list = self.active_jump_list_mut();
+        if list
+            .previous_context
+            .as_ref()
+            .is_some_and(|entry| !valid_buffers.contains(&entry.buffer_id))
+        {
+            list.previous_context = None;
+        }
         let old_index = list.index.min(list.entries.len());
         let mut keep = vec![false; list.entries.len()];
 
@@ -22038,6 +22144,14 @@ impl Editor {
                 .entries
                 .retain(|entry| entry.buffer_id != buffer_id);
             window.jump_list.index = retained_before_index.min(window.jump_list.entries.len());
+            if window
+                .jump_list
+                .previous_context
+                .as_ref()
+                .is_some_and(|entry| entry.buffer_id == buffer_id)
+            {
+                window.jump_list.previous_context = None;
+            }
         }
     }
 
@@ -22046,7 +22160,38 @@ impl Editor {
         if entry.buffer_id == current.buffer_id && entry.char_index == current.char_index {
             return;
         }
+        self.remember_previous_context(entry.clone());
         self.push_history_entry(entry);
+    }
+
+    fn save_jump_after_action(&mut self, entry: JumpEntry, action: &Action) {
+        let current = self.current_jump_entry();
+        let moved = entry.buffer_id != current.buffer_id || entry.char_index != current.char_index;
+        if !moved && !Self::records_stationary_jump(action) {
+            return;
+        }
+        self.remember_previous_context(entry.clone());
+        self.push_history_entry(entry);
+    }
+
+    fn records_stationary_jump(action: &Action) -> bool {
+        matches!(
+            action,
+            Action::FindNext
+                | Action::FindPrevious
+                | Action::RepeatSearch
+                | Action::RepeatSearchOpposite
+                | Action::SearchWordUnderCursor
+                | Action::MoveToBottom
+                | Action::MoveToTop
+                | Action::MoveTo(_, _)
+                | Action::GoToLine(_)
+                | Action::JumpToMark { .. }
+        )
+    }
+
+    fn remember_previous_context(&mut self, entry: JumpEntry) {
+        self.active_jump_list_mut().previous_context = Some(entry);
     }
 
     fn push_current_history_entry(&mut self) {
@@ -22124,6 +22269,17 @@ impl Editor {
             false,
         )
         .await?;
+        Ok(())
+    }
+
+    async fn execute_deferred_jump_navigation(
+        &mut self,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        while let Some(action) = self.deferred_jump_navigation.pop_front() {
+            self.execute(&action, buffer, runtime).await?;
+        }
         Ok(())
     }
 
@@ -23877,6 +24033,9 @@ impl Editor {
                     KeyAction::Single(Action::MoveToViewportBottom(_)) => {
                         KeyAction::Single(Action::MoveToViewportBottom(count))
                     }
+                    KeyAction::Single(Action::MoveToBottom) => {
+                        KeyAction::Single(Action::GoToLine(usize::from(count)))
+                    }
                     KeyAction::Single(Action::HalfPageDown(_)) => {
                         KeyAction::Single(Action::HalfPageDown(count))
                     }
@@ -25071,6 +25230,7 @@ impl Editor {
                 window_index: self.window_manager.active_window_id(),
                 jumps: snapshot.jumps.clone(),
                 jump_index: snapshot.jump_index,
+                previous_context: None,
             }]
         } else {
             snapshot.window_jumps.clone()
@@ -25088,6 +25248,10 @@ impl Editor {
                     JumpList {
                         index: saved.jump_index.min(entries.len()),
                         entries,
+                        previous_context: saved
+                            .previous_context
+                            .as_ref()
+                            .and_then(|jump| self.restore_session_jump(jump, &buffer_map)),
                     },
                 )
             })
@@ -25417,6 +25581,11 @@ impl Editor {
                     window_index,
                     jump_index: window.jump_list.index.min(jumps.len()),
                     jumps,
+                    previous_context: window
+                        .jump_list
+                        .previous_context
+                        .as_ref()
+                        .and_then(|jump| self.snapshot_jump(jump, &buffer_indices)),
                 }
             })
             .collect::<Vec<_>>();
@@ -32771,9 +32940,24 @@ builtin = "rust"
         editor.test_disable_terminal_output();
         let mut core = DetachedEditorCore::new(editor).await.unwrap();
 
-        ACTION_DISPATCHER.send_request(PluginRequest::SetCursorPosition { x: 0, y: 2 });
+        ACTION_DISPATCHER.send_request(PluginRequest::SetCursorPosition {
+            x: 0,
+            y: 2,
+            jump: false,
+        });
         let position = core.tick().await.unwrap().expect("cursor-position render");
         assert_eq!(position.cursor.1, 2);
+
+        ACTION_DISPATCHER.send_request(PluginRequest::SetCursorPosition {
+            x: 0,
+            y: 3,
+            jump: true,
+        });
+        let jump = core.tick().await.unwrap().expect("jump-position render");
+        assert_eq!(jump.cursor.1, 3);
+        ACTION_DISPATCHER.send_request(PluginRequest::Action(Action::JumpBack));
+        let returned = core.tick().await.unwrap().expect("jump-back render");
+        assert_eq!(returned.cursor.1, 2);
 
         ACTION_DISPATCHER.send_request(PluginRequest::SetCursorDisplayColumn { column: 1, y: 3 });
         let column = core.tick().await.unwrap().expect("cursor-column render");
@@ -32781,7 +32965,9 @@ builtin = "rust"
         drain_plugin_requests();
     }
 
-    fn lsp_progress_test_editor() -> (
+    fn lsp_channel_test_editor(
+        buffer: Buffer,
+    ) -> (
         Editor,
         tokio::sync::mpsc::Sender<InboundMessage>,
         tokio::sync::mpsc::Receiver<crate::lsp::OutboundMessage>,
@@ -32804,11 +32990,19 @@ builtin = "rust"
             /*height*/ 24,
             config,
             Theme::default(),
-            vec![Buffer::new(None, "hello".to_string())],
+            vec![buffer],
         )
         .unwrap();
         editor.test_disable_terminal_output();
         (editor, responses, requests)
+    }
+
+    fn lsp_progress_test_editor() -> (
+        Editor,
+        tokio::sync::mpsc::Sender<InboundMessage>,
+        tokio::sync::mpsc::Receiver<crate::lsp::OutboundMessage>,
+    ) {
+        lsp_channel_test_editor(Buffer::new(None, "hello".to_string()))
     }
 
     fn lsp_progress_notification(token: Value, index: usize) -> InboundMessage {
@@ -32823,6 +33017,60 @@ builtin = "rust"
         }))
         .unwrap();
         InboundMessage::Notification(ParsedNotification::Progress(progress))
+    }
+
+    #[tokio::test]
+    async fn jump_back_waits_for_an_in_flight_definition_destination() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory.path().join("definition.rs");
+        std::fs::write(&file, "zero\none\ntwo\n").unwrap();
+        let (mut editor, responses, _requests) = lsp_channel_test_editor(Buffer::new(
+            Some(file.to_string_lossy().into_owned()),
+            "zero\none\ntwo\n".to_string(),
+        ));
+        let mut frame = RenderBuffer::new(/*width*/ 80, /*height*/ 24, &Style::default());
+        let mut runtime = Runtime::new();
+        let uri = editor.current_buffer().uri().unwrap().unwrap();
+        let request_id = editor
+            .lsp
+            .send_request("textDocument/definition", json!({}), /*force*/ true)
+            .await
+            .unwrap();
+        editor.pending_definition_requests.insert(request_id);
+
+        editor
+            .execute(&Action::JumpBack, &mut frame, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.buffer_line(), 0);
+        assert_eq!(editor.deferred_jump_navigation.len(), 1);
+
+        responses
+            .send(InboundMessage::Message(ResponseMessage {
+                id: request_id,
+                result: json!({
+                    "uri": uri,
+                    "range": {
+                        "start": { "line": 2, "character": 0 },
+                        "end": { "line": 2, "character": 0 }
+                    }
+                }),
+                request: None,
+            }))
+            .await
+            .unwrap();
+        editor
+            .service_background(&mut frame, &mut runtime)
+            .await
+            .unwrap();
+
+        assert_eq!(editor.buffer_line(), 0);
+        assert!(editor.deferred_jump_navigation.is_empty());
+        editor
+            .execute(&Action::JumpForward, &mut frame, &mut runtime)
+            .await
+            .unwrap();
+        assert_eq!(editor.buffer_line(), 2);
     }
 
     #[tokio::test]

--- a/src/editor/inline_agent_outcomes/tests.rs
+++ b/src/editor/inline_agent_outcomes/tests.rs
@@ -169,14 +169,24 @@ async fn inline_agent_outcome_groups_real_writes_and_survives_completion_and_rec
             .count(),
         2
     );
+    let return_file = editor.current_buffer().file.clone();
     editor
-        .view_inline_agent_changes("inline-request", 0, 1, &mut frame, &mut runtime)
+        .test_execute_production_action(Action::ViewInlineAgentChanges {
+            request_id: "inline-request".into(),
+            outcome: 0,
+            change: 1,
+        })
         .await
         .unwrap();
     assert_eq!(
         editor.current_buffer().file.as_deref(),
         root.path().join("second.rs").to_str()
     );
+    editor
+        .test_execute_production_action(Action::JumpBack)
+        .await
+        .unwrap();
+    assert_eq!(editor.current_buffer().file, return_file);
     let mut recovered: InlineHistory =
         serde_json::from_slice(&serde_json::to_vec(&editor.inline_history).unwrap()).unwrap();
     recovered.recover();

--- a/src/editor/inline_comments/tests.rs
+++ b/src/editor/inline_comments/tests.rs
@@ -14,7 +14,7 @@ use crate::{
     lsp::LspManager,
     plugin::Runtime,
     theme::{Style, Theme},
-    undo::TextRange,
+    undo::{TextPosition, TextRange},
     unicode_utils::display_width,
 };
 use crossterm::event::{
@@ -715,6 +715,28 @@ fn clearing_inline_comments_preserves_cursor_near_eof() {
     editor.clear_inline_comments();
     editor.check_bounds();
     assert_eq!(editor.buffer_line(), 4);
+}
+
+#[tokio::test]
+async fn inline_comment_navigation_participates_in_the_jumplist() {
+    let mut editor = editor("zero\none\ntwo\nthree\nfour\nfive\n", 40, 10, false);
+    editor.move_to_text_position(TextPosition::new(2, 0));
+    editor.set_inline_comment("first comment");
+    editor.move_to_text_position(TextPosition::new(5, 0));
+    editor.set_inline_comment("second comment");
+    editor.move_to_text_position(TextPosition::new(0, 0));
+
+    editor
+        .test_execute_production_action(Action::NextInlineComment)
+        .await
+        .unwrap();
+    assert_eq!(editor.buffer_line(), 2);
+
+    editor
+        .test_execute_production_action(Action::JumpBack)
+        .await
+        .unwrap();
+    assert_eq!(editor.buffer_line(), 0);
 }
 
 #[test]

--- a/src/editor/inline_history.rs
+++ b/src/editor/inline_history.rs
@@ -40,7 +40,7 @@ pub(super) struct HistoryRow {
 
 #[derive(Debug)]
 pub(super) struct HistoryBrowser {
-    origin: JumpEntry,
+    pub(super) origin: JumpEntry,
     viewport: (usize, usize, usize),
     active_comments: HashMap<(WindowId, BufferId), uuid::Uuid>,
     file: Option<String>,
@@ -577,9 +577,7 @@ impl Editor {
         self.clear_history_preview();
         self.current_dialog = None;
         self.inline_comment_selections = browser.active_comments;
-        if jump {
-            self.save_to_history(browser.origin);
-        } else {
+        if !jump {
             self.jump_to_entry(&browser.origin, buffer, runtime).await?;
             let line = self.buffer_line();
             self.vtop = browser.viewport.0.min(line);

--- a/src/editor/inline_history/tests.rs
+++ b/src/editor/inline_history/tests.rs
@@ -968,6 +968,7 @@ async fn inline_history_file_link_navigates_without_applying_or_saving() {
     let mut editor = editor("original\n");
     begin(&mut editor, "group", "one", line_range(0, 1), "Explain");
     complete(&mut editor, "one", None, "See another file").await;
+    let origin_file = editor.current_buffer().file.clone();
     editor
         .open_inline_history(
             &mut RenderBuffer::new(100, 30, &Style::default()),
@@ -975,15 +976,14 @@ async fn inline_history_file_link_navigates_without_applying_or_saving() {
         )
         .await
         .unwrap();
-    run_history_action(
-        &mut editor,
-        HistoryAction::FollowFile {
+    editor
+        .test_execute_production_action(Action::InlineHistoryAction(HistoryAction::FollowFile {
             path: destination.to_string_lossy().into_owned(),
             line: Some(2),
             column: Some(2),
-        },
-    )
-    .await;
+        }))
+        .await
+        .unwrap();
     assert!(editor.inline_history_browser.is_none());
     assert_eq!(
         editor.current_buffer().file.as_deref(),
@@ -999,6 +999,12 @@ async fn inline_history_file_link_navigates_without_applying_or_saving() {
         editor.inline_history.turn("one").unwrap().state,
         InlineTurnState::Completed
     );
+
+    editor
+        .test_execute_production_action(Action::JumpBack)
+        .await
+        .unwrap();
+    assert_eq!(editor.current_buffer().file, origin_file);
 }
 
 #[tokio::test]

--- a/src/editor/inline_notifications.rs
+++ b/src/editor/inline_notifications.rs
@@ -329,9 +329,7 @@ impl Editor {
         {
             self.view_inline_changes(request, 0, frame, runtime).await
         } else if latest {
-            let origin = self.current_jump_entry();
             self.open_inline_job(&group, frame, runtime).await?;
-            self.save_to_history(origin);
             Ok(())
         } else {
             self.open_inline_history_request(&group, request, frame, runtime)

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -29,7 +29,7 @@
     { "name": "AgentForgetSession", "kind": "execute", "signature": "(session_id: String)", "introduced": "0.9.0" },
     { "name": "AgentPermissionResponse", "kind": "execute", "signature": "(request_id: String, option_id: String?)", "introduced": "0.1.0" },
     { "name": "RevertTransaction", "kind": "execute", "signature": "(transaction_id: String)", "introduced": "0.1.0" },
-    { "name": "SetCursorPosition", "kind": "execute", "signature": "(x: i32, y: i32)", "introduced": "0.1.0" },
+    { "name": "SetCursorPosition", "kind": "execute", "signature": "(x: i32, y: i32, jump?: bool)", "introduced": "0.1.0" },
     { "name": "CloseScratchBuffer", "kind": "execute", "signature": "(id: i32)", "introduced": "0.1.0" },
     { "name": "SetStorage", "kind": "execute", "signature": "(key: String, value: Json)", "introduced": "0.1.0" },
     { "name": "SetDecorations", "kind": "execute", "signature": "(namespace: String, decorations: [Decoration])", "introduced": "0.1.0" },

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1252,7 +1252,8 @@ impl RedHost {
             "SetCursorPosition" => {
                 let x = args.first().and_then(value_to_u64).unwrap_or(0) as usize;
                 let y = args.get(1).and_then(value_to_u64).unwrap_or(0) as usize;
-                self.send_request(PluginRequest::SetCursorPosition { x, y });
+                let jump = args.get(2).and_then(Value::as_bool).unwrap_or(false);
+                self.send_request(PluginRequest::SetCursorPosition { x, y, jump });
             }
             "CloseScratchBuffer" => {
                 let buffer_index = args
@@ -15223,7 +15224,8 @@ mod tests {
                                 .await
                                 .unwrap();
                         }
-                        PluginRequest::SetCursorPosition { x, y } => {
+                        PluginRequest::SetCursorPosition { x, y, jump } => {
+                            assert!(jump);
                             result = Some(Ok((x, y)));
                         }
                         PluginRequest::Action(Action::Print(message)) => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -200,6 +200,9 @@ pub struct SessionWindowJumps {
     pub jumps: Vec<SessionJump>,
     /// Current position in [`Self::jumps`].
     pub jump_index: usize,
+    /// Destination used by the previous-context mark in this window.
+    #[serde(default)]
+    pub previous_context: Option<SessionJump>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/window.rs
+++ b/src/window.rs
@@ -180,6 +180,8 @@ pub(crate) struct JumpEntry {
 pub(crate) struct JumpList {
     pub(crate) entries: Vec<JumpEntry>,
     pub(crate) index: usize,
+    /// Destination used by Vim's previous-context mark (`''` and `` `` ``).
+    pub(crate) previous_context: Option<JumpEntry>,
 }
 
 impl Window {

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1140,6 +1140,9 @@ async fn mark_jumps_participate_in_the_jumplist_and_support_linewise_motion() {
 
     type_normal_keys(&mut harness, "''").await;
     harness.assert_cursor_at(0, 2);
+
+    type_normal_keys(&mut harness, "''").await;
+    harness.assert_cursor_at(2, 0);
 }
 
 #[tokio::test]

--- a/tests/lsp_lazy.rs
+++ b/tests/lsp_lazy.rs
@@ -387,6 +387,7 @@ async fn default_format_on_save_requests_once_before_writing_and_ignores_a_dupli
         recorded(&events),
         vec![
             LspEvent::DidOpen(path.to_string_lossy().into_owned()),
+            LspEvent::DidChange(path.to_string_lossy().into_owned()),
             LspEvent::FormatDocument(path.to_string_lossy().into_owned()),
         ]
     );

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -1254,6 +1254,30 @@ async fn test_file_movement() {
 }
 
 #[tokio::test]
+async fn counted_g_targets_an_absolute_line_and_records_the_jump() {
+    let buffer = Buffer::new(None, "one\ntwo\nthree\nfour\nfive".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    type_normal_keys(&mut harness, "3G").await;
+    harness.assert_cursor_at(0, 2);
+
+    harness.execute_action(Action::JumpBack).await.unwrap();
+    harness.assert_cursor_at(0, 0);
+}
+
+#[tokio::test]
+async fn stationary_jump_still_leaves_a_return_destination() {
+    let mut harness = EditorHarness::with_content("one\ntwo\nthree\nfour\nfive");
+
+    harness.execute_action(Action::MoveToBottom).await.unwrap();
+    harness.execute_action(Action::MoveToBottom).await.unwrap();
+    harness.execute_action(Action::MoveUp).await.unwrap();
+    harness.execute_action(Action::JumpBack).await.unwrap();
+
+    harness.assert_cursor_at(0, 4);
+}
+
+#[tokio::test]
 async fn jump_back_records_current_position_for_jump_forward() {
     let mut harness = EditorHarness::with_content("one\ntwo\nthree\nfour\nfive");
 
@@ -1450,6 +1474,27 @@ async fn per_window_jumplists_round_trip_through_session_recovery() {
     restored.assert_cursor_at(0, 3);
     restored.execute_action(Action::JumpBack).await.unwrap();
     restored.assert_cursor_at(0, 1);
+}
+
+#[tokio::test]
+async fn previous_context_mark_round_trips_through_session_recovery() {
+    let contents = "one\ntwo\nthree\nfour\nfive";
+    let mut source = EditorHarness::with_content(contents);
+    source.execute_action(Action::MoveTo(0, 5)).await.unwrap();
+    let snapshot = source.editor.test_session_snapshot();
+
+    let mut buffers = Editor::buffers_from_session_snapshot(&snapshot);
+    let mut restored = EditorHarness::with_buffer(buffers.remove(0));
+    restored.editor.restore_session_snapshot(&snapshot).unwrap();
+    restored
+        .execute_action(Action::JumpToMark {
+            mark: '\'',
+            linewise: true,
+        })
+        .await
+        .unwrap();
+
+    restored.assert_cursor_at(0, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Ctrl-O and Ctrl-I currently miss several editor-owned navigation paths. Queued input can also race Project Search selections and LSP definition responses, leaving the new destination absent from the jump list when traversal runs. Counted and stationary jumps, plus the previous-context mark, have additional Vim parity gaps.

## What Changed

- Record source locations for inline comment, Inline History, Agent change, file, location, and Git hunk navigation through the central jump-history path.
- Defer jump traversal until in-flight definition and picker destinations have committed, preserving immediate Ctrl-O/Ctrl-I ordering.
- Persist the per-window previous-context location and make repeated previous-context jumps toggle between the last two positions.
- Treat counted `G` as an absolute line jump and preserve a return location for successful stationary jumps.
- Add an optional jump flag to plugin `SetCursorPosition` requests and use it for bundled Git hunk navigation.
- Add regression coverage for same-file, cross-file, session-restored, plugin-owned, and asynchronous navigation.

## How to Test

1. Place the cursor in one file, open Project Search, select a result in another file, and press Ctrl-O immediately after Enter. Expect the first Ctrl-O to return to the exact original file and position; Ctrl-I should reopen the result.
2. Invoke `gd` on a symbol and press Ctrl-O before the definition response arrives. Expect Red to return after the destination commits, with Ctrl-I reopening the definition.
3. Navigate with `]h` or to the next inline comment, then press Ctrl-O. Expect a return to the source position.
4. Run `3G`, then Ctrl-O; repeat the previous-context command twice; and run `G`, move one line, then Ctrl-O. Expect absolute-line navigation, two-position toggling, and a usable stationary-jump return point.
5. Run the focused regressions:

   ```sh
   cargo test --test movement
   cargo test inline_comment_navigation_participates_in_the_jumplist
   cargo test jump_back_waits_for_an_in_flight_definition_destination
   ```

The exact committed build also passed retained manual smoke coverage for Project Search, Git hunks, inline comments, real rust-analyzer definition navigation, and Vim parity cases.
