### PR TITLE
fix(lsp): improve workspace symbol filtering

### DIFF
--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -1,11 +1,11 @@
 // Document-symbol, workspace-symbol, and reference pickers backed by LSP requests.
 //
 // Picker rows retain serialized source locations and open them through the plugin
-// location contract, including explicit column encoding. Live workspace queries replace
-// results for the active picker instead of creating competing dialogs, and request IDs
-// keep late LSP responses from replacing newer flows. Large symbol and reference responses
-// are converted in cancellable timer batches so no callback monopolizes the Husk instruction
-// budget; a final safety ceiling bounds pathological server responses.
+// location contract, including explicit column encoding. Live workspace queries filter and
+// rank the current rows locally while debounced LSP results replace the picker candidates;
+// request IDs keep late responses from replacing newer flows. Large symbol and reference
+// responses are converted in cancellable timer batches so no callback monopolizes the Husk
+// instruction budget; a final safety ceiling bounds pathological server responses.
 
 struct SymbolIconOptions {
     enabled: bool,
@@ -81,6 +81,8 @@ struct LspSymbolsState {
     batch_workspace_only: bool,
     reference_file: String,
     reference_position: Option<Position>,
+    workspace_query: String,
+    workspace_query_timer: String,
     picker: Option<i32>,
     request: i32,
     waiting_for_references: bool,
@@ -99,6 +101,8 @@ fn initial_state() -> LspSymbolsState {
         batch_workspace_only: false,
         reference_file: "",
         reference_position: None,
+        workspace_query: "",
+        workspace_query_timer: "",
         picker: None,
         request: -1,
         waiting_for_references: false,
@@ -224,9 +228,10 @@ fn document_symbols() {
 fn workspace_symbols() {
     begin_symbol_flow();
     let handle = red::execute("OpenPicker", "Workspace Symbols", [], PickerOptions {
-        external_filter: true,
         placeholder: "Type to search workspace symbols",
         status: "Loading workspace symbols",
+        busy: true,
+        item_layout: "label_first",
     }, PickerHandlers {
         query: workspace_query,
         selected: open_symbol_selection,
@@ -243,7 +248,30 @@ fn workspace_query(query: String) {
         return;
     }
     cancel_symbol_batch();
-    request_workspace_symbols(query);
+    schedule_workspace_query(query);
+}
+
+fn schedule_workspace_query(query: String) {
+    let current = state();
+    if current.workspace_query_timer != "" {
+        red::execute("CancelTimeout", current.workspace_query_timer);
+    }
+    current.workspace_query = query;
+    current.workspace_query_timer = red::execute("SetTimeout", 100);
+    // Invalidate any request that predates the current picker query. Its eventual
+    // callback will be ignored even if it arrives before the debounce expires.
+    current.request = -1;
+    save_state(current);
+}
+
+fn cancel_workspace_query() {
+    let current = state();
+    if current.workspace_query_timer != "" {
+        red::execute("CancelTimeout", current.workspace_query_timer);
+    }
+    current.workspace_query = "";
+    current.workspace_query_timer = "";
+    save_state(current);
 }
 
 fn request_workspace_symbols(query: String) {
@@ -373,13 +401,13 @@ fn update_workspace_symbols(result: SymbolsResult, request_id: i32) {
         cancel_symbol_batch();
         red::execute("UpdatePickerItems", handle, []);
         red::execute("UpdatePickerStatus", handle, "Workspace symbols unavailable: " + result.error);
+        red::execute("UpdatePickerBusy", handle, false);
         return;
     }
 
     let total = red::len(result.symbols);
     if total > 64 {
         start_symbol_batch(result.symbols, true, handle);
-        red::execute("UpdatePickerItems", handle, []);
         red::execute("UpdatePickerStatus", handle, "Loading 0/" + total + " symbols");
         return;
     }
@@ -389,6 +417,7 @@ fn update_workspace_symbols(result: SymbolsResult, request_id: i32) {
     let count = red::len(items);
     red::execute("UpdatePickerItems", handle, items);
     red::execute("UpdatePickerStatus", handle, count + " symbols");
+    red::execute("UpdatePickerBusy", handle, false);
 }
 
 fn start_symbol_batch(symbols: [LspSymbol], workspace_only: bool, handle: i32) {
@@ -428,6 +457,19 @@ fn schedule_symbol_batch() {
 #[red::on("timeout:callback")]
 fn symbol_batch_timeout(event: TimerEvent) {
     let current = state();
+    if event.timer_id == current.workspace_query_timer {
+        let query = current.workspace_query;
+        let Some(handle) = current.picker else {
+            cancel_workspace_query();
+            return;
+        };
+        current.workspace_query_timer = "";
+        save_state(current);
+        red::execute("UpdatePickerBusy", handle, true);
+        red::execute("UpdatePickerStatus", handle, "Searching workspace symbols");
+        request_workspace_symbols(query);
+        return;
+    }
     if event.timer_id != current.batch_timer {
         return;
     }
@@ -489,7 +531,7 @@ fn symbol_batch_timeout(event: TimerEvent) {
     } else {
         red::execute("UpdatePickerStatus", handle, red::len(items) + " " + noun);
     }
-    if kind == "references" {
+    if kind == "references" || (kind == "symbols" && workspace_only) {
         red::execute("UpdatePickerBusy", handle, false);
     }
     clear_symbol_batch();
@@ -649,6 +691,7 @@ fn finish_symbol_flow() {
     current.picker = None;
     current.waiting_for_references = false;
     save_state(current);
+    cancel_workspace_query();
     cancel_symbol_batch();
     let current = state();
     current.request = -1;

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -17371,6 +17371,7 @@ mod tests {
 
         let mut runtime = Runtime::new();
         load_lsp_symbols(&mut runtime).await;
+        let timeout_count = runtime.pending_timeout_count();
 
         runtime
             .execute_command("LspWorkspaceSymbols")
@@ -17378,8 +17379,16 @@ mod tests {
             .unwrap();
 
         let handle = match ACTION_DISPATCHER.recv_request() {
-            PluginRequest::OpenCallbackPicker { handle, title, .. } => {
+            PluginRequest::OpenCallbackPicker {
+                handle,
+                title,
+                options,
+                ..
+            } => {
                 assert_eq!(title.as_deref(), Some("Workspace Symbols"));
+                assert!(!options.external_filter);
+                assert!(options.busy);
+                assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
                 handle
             }
             _ => panic!("unexpected plugin request"),
@@ -17393,8 +17402,43 @@ mod tests {
         };
 
         runtime
+            .notify_picker(handle, PickerCallback::Query("mai".to_string()))
+            .unwrap();
+        runtime
             .notify_picker(handle, PickerCallback::Query("main".to_string()))
             .unwrap();
+        assert_eq!(runtime.pending_timeout_count(), timeout_count + 1);
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+
+        runtime
+            .resolve_request(initial_request_id, sample_symbol_payload_with_count(2))
+            .await
+            .unwrap();
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        let callbacks = runtime.poll_timer_callbacks();
+        assert_eq!(callbacks.len(), 1);
+        let PluginRequest::TimeoutCallback { timer_id } = &callbacks[0] else {
+            panic!("expected workspace-symbol debounce timeout");
+        };
+        runtime
+            .notify(
+                "timeout:callback",
+                serde_json::json!({ "timer_id": timer_id }),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerBusy { id, busy: true } if id == handle.get()
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerStatus { id, status }
+                if id == handle.get() && status.as_deref() == Some("Searching workspace symbols")
+        ));
 
         let query_request_id = match ACTION_DISPATCHER.recv_request() {
             PluginRequest::WorkspaceSymbols { request_id, query } => {
@@ -17403,12 +17447,6 @@ mod tests {
             }
             _ => panic!("unexpected plugin request"),
         };
-
-        runtime
-            .resolve_request(initial_request_id, sample_symbol_payload_with_count(2))
-            .await
-            .unwrap();
-        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
 
         runtime
             .resolve_request(query_request_id, sample_symbol_payload())
@@ -17430,10 +17468,36 @@ mod tests {
             }
             _ => panic!("unexpected plugin request"),
         }
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerBusy { id, busy: false } if id == handle.get()
+        ));
 
         runtime
             .notify_picker(handle, PickerCallback::Query("later".to_string()))
             .unwrap();
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        let callbacks = runtime.poll_timer_callbacks();
+        assert_eq!(callbacks.len(), 1);
+        let PluginRequest::TimeoutCallback { timer_id } = &callbacks[0] else {
+            panic!("expected workspace-symbol debounce timeout");
+        };
+        runtime
+            .notify(
+                "timeout:callback",
+                serde_json::json!({ "timer_id": timer_id }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerBusy { id, busy: true } if id == handle.get()
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerStatus { id, status }
+                if id == handle.get() && status.as_deref() == Some("Searching workspace symbols")
+        ));
         let late_request_id = match ACTION_DISPATCHER.recv_request() {
             PluginRequest::WorkspaceSymbols { request_id, query } => {
                 assert_eq!(query, "later");
@@ -17449,6 +17513,116 @@ mod tests {
             .await
             .unwrap();
         assert!(runtime.picker_plugin(handle).is_none());
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+    }
+
+    #[tokio::test]
+    async fn lsp_symbols_workspace_batch_keeps_previous_items_until_replacement_arrives() {
+        drain_requests();
+
+        let mut runtime = Runtime::new();
+        load_lsp_symbols(&mut runtime).await;
+        runtime
+            .execute_command("LspWorkspaceSymbols")
+            .await
+            .unwrap();
+
+        let handle = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackPicker { handle, .. } => handle,
+            _ => panic!("expected workspace-symbol picker"),
+        };
+        let initial_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::WorkspaceSymbols { request_id, .. } => request_id,
+            _ => panic!("expected initial workspace-symbol request"),
+        };
+        runtime
+            .resolve_request(initial_request_id, sample_symbol_payload())
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerItems { id, ref items }
+                if id == handle.get() && items.len() == 1
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerStatus { id, .. } if id == handle.get()
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerBusy { id, busy: false } if id == handle.get()
+        ));
+
+        runtime
+            .notify_picker(handle, PickerCallback::Query("symbol".to_string()))
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        let callbacks = runtime.poll_timer_callbacks();
+        assert_eq!(callbacks.len(), 1);
+        let PluginRequest::TimeoutCallback { timer_id } = &callbacks[0] else {
+            panic!("expected workspace-symbol debounce timeout");
+        };
+        runtime
+            .notify(
+                "timeout:callback",
+                serde_json::json!({ "timer_id": timer_id }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerBusy { id, busy: true } if id == handle.get()
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerStatus { id, .. } if id == handle.get()
+        ));
+        let query_request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::WorkspaceSymbols { request_id, query } => {
+                assert_eq!(query, "symbol");
+                request_id
+            }
+            _ => panic!("expected debounced workspace-symbol request"),
+        };
+
+        runtime
+            .resolve_request(query_request_id, sample_symbol_payload_with_count(65))
+            .await
+            .unwrap();
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerStatus { id, ref status }
+                if id == handle.get() && status.as_deref() == Some("Loading 0/65 symbols")
+        ));
+        assert!(ACTION_DISPATCHER.try_recv_request().is_none());
+
+        for expected_count in [64, 65] {
+            let callbacks = runtime.poll_timer_callbacks();
+            assert_eq!(callbacks.len(), 1);
+            let PluginRequest::TimeoutCallback { timer_id } = &callbacks[0] else {
+                panic!("expected workspace-symbol batch timeout");
+            };
+            runtime
+                .notify(
+                    "timeout:callback",
+                    serde_json::json!({ "timer_id": timer_id }),
+                )
+                .await
+                .unwrap();
+            assert!(matches!(
+                ACTION_DISPATCHER.recv_request(),
+                PluginRequest::UpdatePickerItems { id, ref items }
+                    if id == handle.get() && items.len() == expected_count
+            ));
+            assert!(matches!(
+                ACTION_DISPATCHER.recv_request(),
+                PluginRequest::UpdatePickerStatus { id, .. } if id == handle.get()
+            ));
+        }
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::UpdatePickerBusy { id, busy: false } if id == handle.get()
+        ));
         assert!(ACTION_DISPATCHER.try_recv_request().is_none());
     }
 

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -6506,6 +6506,43 @@ mod tests {
     }
 
     #[test]
+    fn callback_picker_filters_and_ranks_locally_while_emitting_queries() {
+        let editor = test_editor();
+        let handle = PickerHandle::from_raw(12);
+        let items = vec![
+            dynamic_item("scattered", "EventProcessorWithHumanOutput"),
+            dynamic_item("embedded", "ApprovalPromptContext"),
+            dynamic_item("unrelated", "WorkspaceSymbol"),
+            dynamic_item("exact", "Prompt"),
+        ];
+        let mut picker = Picker::new_callback(
+            /*title*/ Some("Workspace Symbols".to_string()),
+            &editor,
+            items,
+            handle,
+            PickerOptions::default(),
+        );
+
+        let mut action = None;
+        for character in "Prompt".chars() {
+            action = picker.handle_event(&key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+
+        assert_eq!(
+            action,
+            Some(KeyAction::Single(Action::NotifyPicker(
+                handle,
+                Box::new(PickerCallback::Query("Prompt".to_string())),
+            )))
+        );
+        let labels = visible_picker_labels(&picker);
+        assert_eq!(labels.first(), Some(&"Prompt"));
+        assert!(labels.contains(&"ApprovalPromptContext"));
+        assert!(labels.contains(&"EventProcessorWithHumanOutput"));
+        assert!(!labels.contains(&"WorkspaceSymbol"));
+    }
+
+    #[test]
     fn replacing_dynamic_items_preserves_selection_by_id() {
         let editor = test_editor();
         let items = vec![dynamic_item("a", "alpha"), dynamic_item("b", "bravo")];


### PR DESCRIPTION
Workspace symbol search currently delegates filtering entirely to the LSP callback. As a result, typing can briefly flash the query without narrowing or reranking the current rows, and fast queries can wait on or be overtaken by asynchronous responses.

This change keeps local picker filtering and label-first ranking active while continuing to refresh candidates from the language server. It debounces workspace requests, invalidates stale responses as soon as the query changes, reports loading state consistently, and preserves existing rows until large batched replacements begin arriving.

## How to Test

1. Open a Rust workspace with LSP symbols, invoke Workspace Symbols with Space w, and wait for the initial results.
2. Type Prompt. The visible list should filter immediately, with an exact Prompt symbol ranked ahead of fuzzy matches, then refresh after the debounced server response.
3. Edit the query rapidly. Results from an older request must not replace the latest query, and existing rows should remain visible while a large replacement is batched.

Automated coverage:
- cargo test -p red lsp_symbols_
- cargo test -p red callback_picker_filters_and_ranks_locally_while_emitting_queries