### PR TITLE
feat(lsp): accelerate rust workspace restores

### DIFF
--- a/plugins/barbecue.hk
+++ b/plugins/barbecue.hk
@@ -327,6 +327,11 @@ fn symbols_loaded(result: BarbecueSymbolsResult) {
     render_windows();
 }
 
+#[red::on("lsp:document_symbols_refreshed")]
+fn refreshed_symbols_loaded(result: BarbecueSymbolsResult) {
+    symbols_loaded(result);
+}
+
 fn symbol_record(result: BarbecueSymbolsResult) -> SymbolRecord {
     return SymbolRecord {
         file: result.file,

--- a/plugins/inlay_hints.hk
+++ b/plugins/inlay_hints.hk
@@ -41,6 +41,12 @@ struct InlayHintsResult {
     hints: [InlayHint],
 }
 
+struct RefreshedInlayHintsResult {
+    ok: bool,
+    hints: [InlayHint],
+    request_id: i32,
+}
+
 struct InlayHintGroup {
     line: i32,
     hints: [InlayHint],
@@ -190,6 +196,17 @@ fn hints_loaded(result: InlayHintsResult, request_id: i32) {
     red::state_patch(InlayHintsState { hints: Some(result) });
     red::state_patch(InlayHintsState { hints_loaded: true });
     render_if_ready();
+}
+
+#[red::on("lsp:inlay_hints_refreshed")]
+fn refreshed_hints_loaded(result: RefreshedInlayHintsResult) {
+    hints_loaded(
+        InlayHintsResult {
+            ok: result.ok,
+            hints: result.hints,
+        },
+        result.request_id
+    );
 }
 
 fn render_if_ready() {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3509,6 +3509,9 @@ pub struct Editor {
     diagnostics: HashMap<String, Vec<Diagnostic>>,
     diagnostic_reports: diagnostics::DiagnosticReports,
     diagnostic_cache: Option<diagnostic_cache::DiagnosticCache>,
+    diagnostic_refresh_after_progress: bool,
+    cached_document_symbols: HashMap<String, Value>,
+    cached_inlay_hints: HashMap<String, diagnostic_cache::InlayHintSnapshot>,
 
     /// Indentation rules per file type
     indentation: HashMap<String, Indentation>,
@@ -3538,7 +3541,7 @@ pub struct Editor {
     pending_plugin_document_symbols: HashMap<i64, PendingDocumentSymbols>,
     pending_plugin_workspace_symbols: HashMap<i64, RequestId>,
     pending_plugin_references: HashMap<i64, RequestId>,
-    pending_plugin_inlay_hints: HashMap<i64, RequestId>,
+    pending_plugin_inlay_hints: HashMap<i64, PendingInlayHints>,
     pending_lsp_edit_requests: HashMap<i64, PendingLspEdit>,
     /// LSP request currently owning the visible, cancellable code-action picker.
     pending_code_action_request: Option<i64>,
@@ -4060,6 +4063,17 @@ struct PendingDocumentSymbols {
     buffer_id: BufferId,
     uri: String,
     revision: u64,
+    resolved_from_cache: bool,
+}
+
+#[derive(Debug, Clone)]
+struct PendingInlayHints {
+    plugin_request_id: RequestId,
+    buffer_id: BufferId,
+    uri: String,
+    revision: u64,
+    range: Range,
+    resolved_from_cache: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -4457,6 +4471,7 @@ impl Editor {
                 self.lsp_coordinator.mark_document_closed(&uri);
                 self.diagnostics.remove(&uri);
                 self.diagnostic_reports.remove(&uri);
+                self.invalidate_cached_lsp_display_data(&uri);
             }
             self.lsp_coordinator.mark_document_opened(uri);
         }
@@ -4882,6 +4897,9 @@ impl Editor {
             diagnostics: HashMap::new(),
             diagnostic_reports: diagnostics::DiagnosticReports::default(),
             diagnostic_cache: None,
+            diagnostic_refresh_after_progress: false,
+            cached_document_symbols: HashMap::new(),
+            cached_inlay_hints: HashMap::new(),
             indentation,
             render_commands: VecDeque::new(),
             overlay_manager: plugin::OverlayManager::new(),
@@ -10246,6 +10264,12 @@ impl Editor {
             }
         }
 
+        if let Ok(Some(uri)) = self.current_buffer().uri() {
+            if self.diagnostic_reports.take_retry_due(&uri, Instant::now()) {
+                self.request_diagnostics().await?;
+            }
+        }
+
         // Startup refreshes form short request chains. Drain a bounded batch so each
         // operation does not wait for a separate 10 ms editor tick.
         for _ in 0..PLUGIN_REQUESTS_PER_TICK {
@@ -11132,6 +11156,30 @@ impl Editor {
                     let buffer_id = target_buffer.id();
                     let uri = target_buffer.uri()?.expect("file-backed buffer has a URI");
                     let revision = target_buffer.revision();
+                    let mut pending = PendingDocumentSymbols {
+                        plugin_request_id: request_id,
+                        buffer_id,
+                        uri: uri.clone(),
+                        revision,
+                        resolved_from_cache: false,
+                    };
+
+                    if let Some(result) = self.cached_document_symbols.get(&uri).cloned() {
+                        let response = ResponseMessage {
+                            id: 0,
+                            result,
+                            request: None,
+                        };
+                        if let Ok(mut payload) =
+                            self.plugin_document_symbols_payload(&response, &pending)
+                        {
+                            payload["provisional"] = json!(true);
+                            self.plugin_registry
+                                .resolve_request(runtime, request_id, payload)
+                                .await?;
+                            pending.resolved_from_cache = true;
+                        }
+                    }
 
                     let request_result: anyhow::Result<i64> = async {
                         self.ensure_buffer_lsp_opened(buffer_index).await?;
@@ -11141,17 +11189,10 @@ impl Editor {
 
                     match request_result {
                         Ok(lsp_request_id) if lsp_request_id > 0 => {
-                            self.pending_plugin_document_symbols.insert(
-                                lsp_request_id,
-                                PendingDocumentSymbols {
-                                    plugin_request_id: request_id,
-                                    buffer_id,
-                                    uri,
-                                    revision,
-                                },
-                            );
+                            self.pending_plugin_document_symbols
+                                .insert(lsp_request_id, pending);
                         }
-                        Ok(_) => {
+                        Ok(_) if !pending.resolved_from_cache => {
                             self.plugin_registry
                                 .resolve_request(
                                     runtime,
@@ -11162,7 +11203,7 @@ impl Editor {
                                 )
                                 .await?;
                         }
-                        Err(err) => {
+                        Err(err) if !pending.resolved_from_cache => {
                             self.plugin_registry
                                 .resolve_request(
                                     runtime,
@@ -11171,6 +11212,7 @@ impl Editor {
                                 )
                                 .await?;
                         }
+                        Ok(_) | Err(_) => {}
                     }
                 }
                 PluginRequest::ResolveThemeStyle { request_id, spec } => {
@@ -11322,6 +11364,12 @@ impl Editor {
                             .await?;
                         continue;
                     };
+                    let buffer_id = self.current_buffer().id();
+                    let uri = self
+                        .current_buffer()
+                        .uri()?
+                        .expect("file-backed buffer has a URI");
+                    let revision = self.current_buffer().revision();
 
                     let range = range.unwrap_or_else(|| {
                         let contents = self.current_buffer().contents();
@@ -11346,19 +11394,47 @@ impl Editor {
                             end: crate::lsp::Position { line, character },
                         }
                     });
+                    let mut pending = PendingInlayHints {
+                        plugin_request_id: request_id,
+                        buffer_id,
+                        uri: uri.clone(),
+                        revision,
+                        range: range.clone(),
+                        resolved_from_cache: false,
+                    };
+
+                    if let Some(result) = self
+                        .cached_inlay_hints
+                        .get(&uri)
+                        .and_then(|snapshot| cached_inlay_hint_result(snapshot, &range))
+                    {
+                        let response = ResponseMessage {
+                            id: 0,
+                            result,
+                            request: None,
+                        };
+                        if let Ok(mut payload) = self.plugin_inlay_hints_payload(&response) {
+                            payload["provisional"] = json!(true);
+                            payload["request_id"] = json!(request_id.get());
+                            self.plugin_registry
+                                .resolve_request(runtime, request_id, payload)
+                                .await?;
+                            pending.resolved_from_cache = true;
+                        }
+                    }
 
                     let request_result: anyhow::Result<i64> = async {
                         self.ensure_current_buffer_lsp_opened().await?;
-                        Ok(self.lsp.inlay_hint(&file, range).await?)
+                        Ok(self.lsp.inlay_hint(&file, range.clone()).await?)
                     }
                     .await;
 
                     match request_result {
                         Ok(lsp_request_id) if lsp_request_id > 0 => {
                             self.pending_plugin_inlay_hints
-                                .insert(lsp_request_id, request_id);
+                                .insert(lsp_request_id, pending);
                         }
-                        Ok(_) => {
+                        Ok(_) if !pending.resolved_from_cache => {
                             self.plugin_registry
                                 .resolve_request(
                                     runtime,
@@ -11369,7 +11445,7 @@ impl Editor {
                                 )
                                 .await?;
                         }
-                        Err(err) => {
+                        Err(err) if !pending.resolved_from_cache => {
                             self.plugin_registry
                                 .resolve_request(
                                     runtime,
@@ -11378,6 +11454,7 @@ impl Editor {
                                 )
                                 .await?;
                         }
+                        Ok(_) | Err(_) => {}
                     }
                 }
                 PluginRequest::GetTextDisplayWidth { request_id, text } => {
@@ -13052,6 +13129,23 @@ impl Editor {
     }
 
     fn process_progress(&mut self, progress_params: &ProgressParams) -> Option<Action> {
+        let ProgressToken::String(token) = &progress_params.token else {
+            return Some(Action::ShowProgress(progress_params.clone()));
+        };
+        if !token.to_ascii_lowercase().contains("primecaches") {
+            return Some(Action::ShowProgress(progress_params.clone()));
+        }
+        let Some(client) = &progress_params.lsp_client else {
+            return Some(Action::ShowProgress(progress_params.clone()));
+        };
+        let active = progress_params.kind.as_deref() != Some("end");
+        if self
+            .diagnostic_reports
+            .set_workspace_priming(Path::new(&client.workspace_root), active)
+            && !active
+        {
+            self.diagnostic_refresh_after_progress = true;
+        }
         Some(Action::ShowProgress(progress_params.clone()))
     }
 
@@ -13105,7 +13199,10 @@ impl Editor {
             }
             "workspace/symbol" => self.pending_plugin_workspace_symbols.remove(&id)?,
             "textDocument/references" => self.pending_plugin_references.remove(&id)?,
-            "textDocument/inlayHint" => self.pending_plugin_inlay_hints.remove(&id)?,
+            "textDocument/inlayHint" => {
+                let pending = self.pending_plugin_inlay_hints.remove(&id)?;
+                (!pending.resolved_from_cache).then_some(pending.plugin_request_id)?
+            }
             _ => return None,
         })
     }
@@ -13741,9 +13838,23 @@ impl Editor {
                         {
                             let payload = match self.plugin_document_symbols_payload(msg, &pending)
                             {
-                                Ok(payload) => payload,
+                                Ok(mut payload) => {
+                                    self.cached_document_symbols
+                                        .insert(pending.uri.clone(), msg.result.clone());
+                                    self.mark_diagnostic_cache_dirty();
+                                    payload["provisional"] = json!(false);
+                                    payload
+                                }
                                 Err(err) => plugin_lsp_error(&err.to_string()),
                             };
+                            if pending.resolved_from_cache {
+                                return payload["ok"].as_bool().unwrap_or(false).then(|| {
+                                    Action::NotifyPlugins(
+                                        "lsp:document_symbols_refreshed".to_string(),
+                                        payload,
+                                    )
+                                });
+                            }
                             return Some(Action::ResolvePluginRequest(
                                 pending.plugin_request_id.get(),
                                 payload,
@@ -13774,13 +13885,36 @@ impl Editor {
                     }
 
                     if method == "textDocument/inlayHint" {
-                        if let Some(request_id) = self.pending_plugin_inlay_hints.remove(&msg.id) {
-                            let mut payload = match self.plugin_inlay_hints_payload(msg) {
-                                Ok(payload) => payload,
-                                Err(err) => plugin_lsp_error(&err.to_string()),
-                            };
-                            payload["request_id"] = json!(request_id.get());
-                            return Some(Action::ResolvePluginRequest(request_id.get(), payload));
+                        if let Some(pending) = self.pending_plugin_inlay_hints.remove(&msg.id) {
+                            let mut payload =
+                                match self.plugin_inlay_hints_payload_for_pending(msg, &pending) {
+                                    Ok(payload) => {
+                                        self.cached_inlay_hints.insert(
+                                            pending.uri.clone(),
+                                            diagnostic_cache::InlayHintSnapshot {
+                                                range: pending.range.clone(),
+                                                result: msg.result.clone(),
+                                            },
+                                        );
+                                        self.mark_diagnostic_cache_dirty();
+                                        payload
+                                    }
+                                    Err(err) => plugin_lsp_error(&err.to_string()),
+                                };
+                            payload["request_id"] = json!(pending.plugin_request_id.get());
+                            payload["provisional"] = json!(false);
+                            if pending.resolved_from_cache {
+                                return payload["ok"].as_bool().unwrap_or(false).then(|| {
+                                    Action::NotifyPlugins(
+                                        "lsp:inlay_hints_refreshed".to_string(),
+                                        payload,
+                                    )
+                                });
+                            }
+                            return Some(Action::ResolvePluginRequest(
+                                pending.plugin_request_id.get(),
+                                payload,
+                            ));
                         }
                     }
 
@@ -13931,10 +14065,13 @@ impl Editor {
                     return self.completion_resolution_failed(id, &error_msg.message);
                 }
                 if method.as_deref() == Some("textDocument/inlayHint") {
-                    if let Some(request_id) = self.pending_plugin_inlay_hints.remove(&id) {
+                    if let Some(pending) = self.pending_plugin_inlay_hints.remove(&id) {
+                        if pending.resolved_from_cache {
+                            return None;
+                        }
                         return Some(Action::ResolvePluginRequest(
-                            request_id.get(),
-                            plugin_inlay_hints_error(request_id, &error_msg.message),
+                            pending.plugin_request_id.get(),
+                            plugin_inlay_hints_error(pending.plugin_request_id, &error_msg.message),
                         ));
                     }
                 }
@@ -14019,10 +14156,13 @@ impl Editor {
                     return self.completion_resolution_failed(*id, &error.to_string());
                 }
                 if method.as_deref() == Some("textDocument/inlayHint") {
-                    if let Some(request_id) = self.pending_plugin_inlay_hints.remove(id) {
+                    if let Some(pending) = self.pending_plugin_inlay_hints.remove(id) {
+                        if pending.resolved_from_cache {
+                            return None;
+                        }
                         return Some(Action::ResolvePluginRequest(
-                            request_id.get(),
-                            plugin_inlay_hints_error(request_id, &error.to_string()),
+                            pending.plugin_request_id.get(),
+                            plugin_inlay_hints_error(pending.plugin_request_id, &error.to_string()),
                         ));
                     }
                 }
@@ -21669,6 +21809,11 @@ impl Editor {
                 self.plugin_registry
                     .notify(runtime, method, params.clone())
                     .await?;
+                if method == "lsp:progress"
+                    && std::mem::take(&mut self.diagnostic_refresh_after_progress)
+                {
+                    self.request_diagnostics().await?;
+                }
             }
             Action::NotifyPlugin(plugin, method, params) => {
                 self.plugin_registry
@@ -23092,6 +23237,9 @@ impl Editor {
         index: usize,
         runtime: &mut Runtime,
     ) -> anyhow::Result<()> {
+        if let Ok(Some(uri)) = self.buffer_manager[index].uri() {
+            self.invalidate_cached_lsp_display_data(&uri);
+        }
         let id = self.buffer_manager[index].id();
         let revision = self.buffer_manager[index].revision();
         self.sync_inline_change_summaries();
@@ -23367,6 +23515,7 @@ impl Editor {
             return Ok(());
         }
         if let Some(previous_uri) = previous_uri {
+            self.invalidate_cached_lsp_display_data(previous_uri);
             if self.lsp_coordinator.mark_document_closed(previous_uri) {
                 if let Ok(file) = lsp_file_path(previous_uri) {
                     self.lsp.did_close(&file).await?;
@@ -23725,6 +23874,34 @@ impl Editor {
         Ok(json!({
             "ok": true,
             "file": file,
+            "hints": hints,
+        }))
+    }
+
+    fn plugin_inlay_hints_payload_for_pending(
+        &self,
+        response: &ResponseMessage,
+        pending: &PendingInlayHints,
+    ) -> anyhow::Result<Value> {
+        anyhow::ensure!(
+            self.buffer_manager.iter().any(|buffer| {
+                buffer.id() == pending.buffer_id
+                    && buffer.revision() == pending.revision
+                    && buffer.uri().ok().flatten().as_deref() == Some(pending.uri.as_str())
+            }),
+            "inlay hint response is no longer current"
+        );
+        anyhow::ensure!(
+            response_text_document_uri(response).is_none_or(|uri| uri == pending.uri),
+            "inlay hint response belongs to another document"
+        );
+        let hints = plugin_json(serde_json::to_value(
+            self.normalize_inlay_hints(&response.result)?,
+        )?);
+
+        Ok(json!({
+            "ok": true,
+            "file": self.uri_to_file(&pending.uri),
             "hints": hints,
         }))
     }
@@ -25302,30 +25479,42 @@ impl Editor {
         self.session_manager.set_store(store);
     }
 
-    /// Enables provisional, workspace-scoped diagnostics recovery across editor launches.
+    /// Enables provisional, workspace-scoped LSP display recovery across editor launches.
     pub fn enable_diagnostic_cache(&mut self, directory: PathBuf) {
         self.diagnostic_cache = Some(diagnostic_cache::DiagnosticCache::new(directory));
         self.restore_cached_diagnostics();
     }
 
     fn restore_cached_diagnostics(&mut self) {
-        if !self.config.show_diagnostics {
-            return;
-        }
         let Some(cache) = &mut self.diagnostic_cache else {
             return;
         };
         let restored = cache.load(&self.config.lsp, &self.buffer_manager);
         let mut changed = false;
-        for reports in restored {
-            if self.diagnostics.contains_key(&reports.uri) {
-                continue;
+        for state in restored {
+            if let Some(symbols) = state.document_symbols {
+                self.cached_document_symbols
+                    .entry(state.uri.clone())
+                    .or_insert(symbols);
             }
-            let diagnostics =
-                self.diagnostic_reports
-                    .restore(reports.uri.clone(), reports.push, reports.pull);
-            self.diagnostics.insert(reports.uri, diagnostics);
-            changed = true;
+            if let Some(hints) = state.inlay_hints {
+                self.cached_inlay_hints
+                    .entry(state.uri.clone())
+                    .or_insert(hints);
+            }
+            if self.config.show_diagnostics
+                && (!state.push.is_empty() || !state.pull.is_empty())
+                && !self.diagnostics.contains_key(&state.uri)
+            {
+                let diagnostics = self.diagnostic_reports.restore(
+                    state.uri.clone(),
+                    state.push,
+                    state.pull,
+                    state.defer_empty,
+                );
+                self.diagnostics.insert(state.uri, diagnostics);
+                changed = true;
+            }
         }
         if changed {
             self.sync_diagnostic_gutter_signs();
@@ -25338,6 +25527,14 @@ impl Editor {
         }
     }
 
+    fn invalidate_cached_lsp_display_data(&mut self, uri: &str) {
+        let removed_symbols = self.cached_document_symbols.remove(uri).is_some();
+        let removed_hints = self.cached_inlay_hints.remove(uri).is_some();
+        if removed_symbols || removed_hints {
+            self.mark_diagnostic_cache_dirty();
+        }
+    }
+
     fn persist_diagnostic_cache(&mut self, force: bool) {
         let Some(cache) = &mut self.diagnostic_cache else {
             return;
@@ -25346,6 +25543,8 @@ impl Editor {
             &self.config.lsp,
             &self.buffer_manager,
             &self.diagnostic_reports,
+            &self.cached_document_symbols,
+            &self.cached_inlay_hints,
             force,
         ) {
             log!("failed to persist diagnostic cache: {error}");
@@ -28476,6 +28675,41 @@ fn response_text_document_uri(response: &ResponseMessage) -> Option<&str> {
         .as_object()?
         .get("uri")?
         .as_str()
+}
+
+fn cached_inlay_hint_result(
+    snapshot: &diagnostic_cache::InlayHintSnapshot,
+    requested: &Range,
+) -> Option<Value> {
+    let position = |position: crate::lsp::Position| (position.line, position.character);
+    if position(snapshot.range.start) > position(requested.start)
+        || position(snapshot.range.end) < position(requested.end)
+    {
+        return None;
+    }
+    if snapshot.result.is_null() {
+        return Some(Value::Null);
+    }
+    let hints = snapshot.result.as_array()?;
+    let start = position(requested.start);
+    let end = position(requested.end);
+    Some(Value::Array(
+        hints
+            .iter()
+            .filter(|hint| {
+                hint.get("position")
+                    .cloned()
+                    .and_then(|position| {
+                        serde_json::from_value::<crate::lsp::Position>(position).ok()
+                    })
+                    .is_some_and(|hint| {
+                        let hint = position(hint);
+                        start <= hint && hint < end
+                    })
+            })
+            .cloned()
+            .collect(),
+    ))
 }
 
 fn normalized_document_symbol(
@@ -37319,6 +37553,7 @@ builtin = "rust"
             buffer_id: buffer.id(),
             uri: buffer.uri().unwrap().unwrap(),
             revision: buffer.revision(),
+            resolved_from_cache: false,
         }
     }
 
@@ -37532,6 +37767,7 @@ builtin = "rust"
                     buffer_id: editor.current_buffer().id(),
                     uri: editor.current_buffer().uri().unwrap().unwrap(),
                     revision: 0,
+                    resolved_from_cache: false,
                 },
             )
             .unwrap();
@@ -37600,6 +37836,7 @@ builtin = "rust"
                     buffer_id: editor.current_buffer().id(),
                     uri: editor.current_buffer().uri().unwrap().unwrap(),
                     revision: 0,
+                    resolved_from_cache: false,
                 },
             )
             .unwrap();
@@ -37612,6 +37849,53 @@ builtin = "rust"
         assert_eq!(symbols[0]["kind_name"], "Function");
         assert_eq!(symbols[0]["file"], editor.uri_to_file(&other_uri));
         assert_eq!(symbols[0]["selection_range"]["start"]["line"], 4);
+    }
+
+    #[test]
+    fn fresh_document_symbols_replace_cache_and_notify_breadcrumbs() {
+        let mut editor = test_editor(40, 10);
+        let file = "/tmp/project/src/symbol-cache.rs";
+        editor.buffer_manager.push_buffer(Buffer::new(
+            Some(file.to_string()),
+            "fn main() {}\n".to_string(),
+        ));
+        editor.buffer_manager.set_active_index(1);
+        let mut pending = pending_document_symbols(&editor, 1);
+        pending.resolved_from_cache = true;
+        let uri = pending.uri.clone();
+        editor.pending_plugin_document_symbols.insert(42, pending);
+        let result = json!([{
+            "name": "main",
+            "kind": 12,
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 12 }
+            },
+            "selectionRange": {
+                "start": { "line": 0, "character": 3 },
+                "end": { "line": 0, "character": 7 }
+            }
+        }]);
+        let message = InboundMessage::Message(ResponseMessage {
+            id: 42,
+            result: result.clone(),
+            request: Some(crate::lsp::Request::new(
+                "textDocument/documentSymbol",
+                json!({ "textDocument": { "uri": uri } }),
+            )),
+        });
+
+        let action =
+            editor.handle_lsp_message(&message, Some("textDocument/documentSymbol".to_string()));
+
+        assert!(matches!(
+            action,
+            Some(Action::NotifyPlugins(topic, payload))
+                if topic == "lsp:document_symbols_refreshed"
+                    && payload["provisional"] == false
+                    && payload["symbols"][0]["name"] == "main"
+        ));
+        assert_eq!(editor.cached_document_symbols[&uri], result);
     }
 
     #[test]
@@ -40919,12 +41203,31 @@ while True:
         assert!(!editor.pending_plugin_workspace_symbols.contains_key(&42));
     }
 
+    fn pending_inlay_hints(editor: &Editor, request_id: i64) -> PendingInlayHints {
+        PendingInlayHints {
+            plugin_request_id: RequestId::from_raw(request_id),
+            buffer_id: editor.current_buffer().id(),
+            uri: "file:///tmp/inlay-hints.rs".to_string(),
+            revision: editor.current_buffer().revision(),
+            range: Range {
+                start: crate::lsp::Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: crate::lsp::Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+            resolved_from_cache: false,
+        }
+    }
+
     #[test]
     fn content_modified_resolves_inlay_hints_without_a_visible_error() {
         let mut editor = test_editor(40, 10);
-        editor
-            .pending_plugin_inlay_hints
-            .insert(42, RequestId::from_raw(7));
+        let pending = pending_inlay_hints(&editor, 7);
+        editor.pending_plugin_inlay_hints.insert(42, pending);
         let message = InboundMessage::Error(crate::lsp::ResponseError {
             id: Some(42),
             code: -32801,
@@ -40952,9 +41255,8 @@ while True:
     #[test]
     fn timeout_resolves_inlay_hints_with_a_schema_safe_retry_payload() {
         let mut editor = test_editor(40, 10);
-        editor
-            .pending_plugin_inlay_hints
-            .insert(42, RequestId::from_raw(7));
+        let pending = pending_inlay_hints(&editor, 7);
+        editor.pending_plugin_inlay_hints.insert(42, pending);
         let message = InboundMessage::RequestError {
             id: 42,
             error: crate::lsp::LspError::RequestTimeout(std::time::Duration::from_secs(30)),
@@ -41009,6 +41311,96 @@ while True:
         assert_eq!(hints[0]["position"]["line"], 2);
         assert_eq!(hints[0]["label"][0]["value"], ": PathBuf");
         assert_eq!(hints[0]["kind"], 1);
+    }
+
+    #[test]
+    fn cached_inlay_hints_are_used_only_for_covered_ranges() {
+        let snapshot = diagnostic_cache::InlayHintSnapshot {
+            range: Range {
+                start: crate::lsp::Position {
+                    line: 10,
+                    character: 0,
+                },
+                end: crate::lsp::Position {
+                    line: 20,
+                    character: 0,
+                },
+            },
+            result: json!([
+                { "position": { "line": 11, "character": 2 }, "label": ": first" },
+                { "position": { "line": 18, "character": 2 }, "label": ": second" }
+            ]),
+        };
+        let covered = Range {
+            start: crate::lsp::Position {
+                line: 11,
+                character: 0,
+            },
+            end: crate::lsp::Position {
+                line: 15,
+                character: 0,
+            },
+        };
+        let outside = Range {
+            start: crate::lsp::Position {
+                line: 0,
+                character: 0,
+            },
+            end: crate::lsp::Position {
+                line: 12,
+                character: 0,
+            },
+        };
+
+        assert_eq!(
+            cached_inlay_hint_result(&snapshot, &covered),
+            Some(json!([
+                { "position": { "line": 11, "character": 2 }, "label": ": first" }
+            ]))
+        );
+        assert!(cached_inlay_hint_result(&snapshot, &outside).is_none());
+    }
+
+    #[test]
+    fn fresh_inlay_hints_replace_cache_and_notify_after_provisional_response() {
+        let mut editor = test_editor(40, 10);
+        let file = "/tmp/project/src/inlay-cache.rs";
+        editor.buffer_manager.push_buffer(Buffer::new(
+            Some(file.to_string()),
+            "fn main() {}\n".to_string(),
+        ));
+        editor.buffer_manager.set_active_index(1);
+        let uri = editor.current_buffer().uri().unwrap().unwrap();
+        let mut pending = pending_inlay_hints(&editor, 7);
+        pending.uri = uri.clone();
+        pending.resolved_from_cache = true;
+        editor.pending_plugin_inlay_hints.insert(42, pending);
+        let message = InboundMessage::Message(ResponseMessage {
+            id: 42,
+            result: json!([{
+                "position": { "line": 0, "character": 8 },
+                "label": ": ()"
+            }]),
+            request: Some(crate::lsp::Request::new(
+                "textDocument/inlayHint",
+                json!({ "textDocument": { "uri": uri } }),
+            )),
+        });
+
+        let action =
+            editor.handle_lsp_message(&message, Some("textDocument/inlayHint".to_string()));
+
+        assert!(matches!(
+            action,
+            Some(Action::NotifyPlugins(topic, payload))
+                if topic == "lsp:inlay_hints_refreshed"
+                    && payload["request_id"] == 7
+                    && payload["provisional"] == false
+        ));
+        assert_eq!(
+            editor.cached_inlay_hints[&uri].result[0]["label"],
+            json!(": ()")
+        );
     }
 
     #[tokio::test]

--- a/src/editor/diagnostic_cache.rs
+++ b/src/editor/diagnostic_cache.rs
@@ -1,8 +1,8 @@
-//! Best-effort, workspace-scoped recovery of provisional language-server findings.
+//! Best-effort, workspace-scoped recovery of provisional language-server display data.
 //!
-//! Cached diagnostics are never authoritative. Their document text, language-server
-//! configuration, and workspace manifests must still match before they are displayed,
-//! and the first fresh report replaces both restored producer channels.
+//! Cached diagnostics, symbols, and inlay hints are never authoritative. Their document
+//! text, language-server configuration, and workspace manifests must still match before
+//! they are displayed. Mutating requests always go to the live server.
 
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -21,12 +21,12 @@ use sha2::{Digest as _, Sha256};
 use crate::{
     buffer::Buffer,
     config::{LanguageServerConfig, LspConfig},
-    lsp::{file_path, Diagnostic, LspManager},
+    lsp::{file_path, Diagnostic, LspManager, Range},
 };
 
 use super::diagnostics::DiagnosticReports;
 
-const CACHE_SCHEMA_VERSION: u32 = 1;
+const CACHE_SCHEMA_VERSION: u32 = 2;
 const MAX_CACHE_FILE_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_CACHED_DOCUMENT_BYTES: u64 = 16 * 1024 * 1024;
 const CACHE_WRITE_DEBOUNCE: Duration = Duration::from_secs(2);
@@ -61,6 +61,16 @@ struct CachedDocument {
     push: Vec<Diagnostic>,
     #[serde(default)]
     pull: Vec<Diagnostic>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    document_symbols: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    inlay_hints: Option<InlayHintSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(super) struct InlayHintSnapshot {
+    pub(super) range: Range,
+    pub(super) result: Value,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -86,10 +96,13 @@ struct ReportSnapshot {
     pull: Vec<Diagnostic>,
 }
 
-pub(super) struct RestoredDiagnosticReports {
+pub(super) struct RestoredDocumentState {
     pub(super) uri: String,
     pub(super) push: Vec<Diagnostic>,
     pub(super) pull: Vec<Diagnostic>,
+    pub(super) defer_empty: bool,
+    pub(super) document_symbols: Option<Value>,
+    pub(super) inlay_hints: Option<InlayHintSnapshot>,
 }
 
 /// Debounces owner-private cache writes and tracks workspaces already hydrated.
@@ -119,7 +132,7 @@ impl DiagnosticCache {
         &mut self,
         config: &LspConfig,
         buffers: &[Buffer],
-    ) -> Vec<RestoredDiagnosticReports> {
+    ) -> Vec<RestoredDocumentState> {
         if !config.enabled {
             return Vec::new();
         }
@@ -167,7 +180,11 @@ impl DiagnosticCache {
             }
 
             for cached in workspace.documents {
-                if cached.push.is_empty() && cached.pull.is_empty() {
+                if cached.push.is_empty()
+                    && cached.pull.is_empty()
+                    && cached.document_symbols.is_none()
+                    && cached.inlay_hints.is_none()
+                {
                     continue;
                 }
                 let Ok(path) = file_path(&cached.uri) else {
@@ -195,10 +212,13 @@ impl DiagnosticCache {
                 if current_hash != Some(cached.content_sha256) {
                     continue;
                 }
-                restored.push(RestoredDiagnosticReports {
+                restored.push(RestoredDocumentState {
                     uri: cached.uri,
                     push: cached.push,
                     pull: cached.pull,
+                    defer_empty: route.language_id == "rust",
+                    document_symbols: cached.document_symbols,
+                    inlay_hints: cached.inlay_hints,
                 });
             }
         }
@@ -212,6 +232,8 @@ impl DiagnosticCache {
         config: &LspConfig,
         buffers: &[Buffer],
         reports: &DiagnosticReports,
+        document_symbols: &HashMap<String, Value>,
+        inlay_hints: &HashMap<String, InlayHintSnapshot>,
         force: bool,
     ) -> anyhow::Result<()> {
         self.finish_writer(force)?;
@@ -236,11 +258,21 @@ impl DiagnosticCache {
                 pull: pull.to_vec(),
             })
             .collect::<Vec<_>>();
+        let document_symbols = document_symbols.clone();
+        let inlay_hints = inlay_hints.clone();
         self.dirty_since = None;
         match std::thread::Builder::new()
             .name("red-diagnostic-cache".to_string())
-            .spawn(move || persist_workspaces(&directory, &config, &documents, &reports))
-        {
+            .spawn(move || {
+                persist_workspaces(
+                    &directory,
+                    &config,
+                    &documents,
+                    &reports,
+                    &document_symbols,
+                    &inlay_hints,
+                )
+            }) {
             Ok(writer) => self.writer = Some(writer),
             Err(error) => {
                 self.mark_dirty();
@@ -295,6 +327,8 @@ fn persist_workspaces(
     config: &LspConfig,
     open_documents: &[OpenDocument],
     reports: &[ReportSnapshot],
+    document_symbols: &HashMap<String, Value>,
+    inlay_hints: &HashMap<String, InlayHintSnapshot>,
 ) -> anyhow::Result<()> {
     if !config.enabled {
         return Ok(());
@@ -327,17 +361,34 @@ fn persist_workspaces(
         );
     }
 
-    for report in reports {
-        if report.push.is_empty() && report.pull.is_empty() {
+    let reports_by_uri = reports
+        .iter()
+        .map(|report| (report.uri.as_str(), report))
+        .collect::<HashMap<_, _>>();
+    let state_uris = reports_by_uri
+        .keys()
+        .copied()
+        .chain(document_symbols.keys().map(String::as_str))
+        .chain(inlay_hints.keys().map(String::as_str))
+        .collect::<BTreeSet<_>>();
+
+    for uri in &state_uris {
+        let report = reports_by_uri.get(uri).copied();
+        let symbols = document_symbols.get(*uri);
+        let hints = inlay_hints.get(*uri);
+        if report.is_none_or(|report| report.push.is_empty() && report.pull.is_empty())
+            && symbols.is_none()
+            && hints.is_none()
+        {
             continue;
         }
-        let Ok(path) = file_path(&report.uri) else {
+        let Ok(path) = file_path(uri) else {
             continue;
         };
         let Some(route) = routing.resolve_document(&path) else {
             continue;
         };
-        if route.uri != report.uri {
+        if route.uri != *uri {
             continue;
         }
         let workspace_root = canonical_workspace_root(&route.workspace_root);
@@ -347,7 +398,7 @@ fn persist_workspaces(
         let Some(server) = config.servers.get(&route.server_name) else {
             continue;
         };
-        let content_sha256 = match open_by_uri.get(report.uri.as_str()) {
+        let content_sha256 = match open_by_uri.get(*uri) {
             Some(contents) => hash_rope(contents),
             None => match hash_file(Path::new(&path)) {
                 Ok(hash) => hash,
@@ -355,22 +406,57 @@ fn persist_workspaces(
             },
         };
         workspace.documents.push(CachedDocument {
-            uri: report.uri.clone(),
+            uri: (*uri).to_string(),
             server_name: route.server_name,
             content_sha256,
             server_config_sha256: server_fingerprint(server)?,
-            push: report.push.clone(),
-            pull: report.pull.clone(),
+            push: report.map_or_else(Vec::new, |report| report.push.clone()),
+            pull: report.map_or_else(Vec::new, |report| report.pull.clone()),
+            document_symbols: symbols.cloned(),
+            inlay_hints: hints.cloned(),
         });
     }
 
     for workspace in workspaces.values_mut() {
+        merge_previous_documents(
+            directory,
+            workspace,
+            open_by_uri.keys().copied(),
+            &state_uris,
+        );
         workspace
             .documents
             .sort_unstable_by(|left, right| left.uri.cmp(&right.uri));
         write_workspace(directory, workspace)?;
     }
     Ok(())
+}
+
+fn merge_previous_documents<'a>(
+    directory: &Path,
+    workspace: &mut CachedWorkspace,
+    open_uris: impl Iterator<Item = &'a str>,
+    replaced_uris: &BTreeSet<&str>,
+) {
+    let open_uris = open_uris.collect::<HashSet<_>>();
+    let path = workspace_cache_path(directory, &workspace.workspace_root);
+    let Ok(Some(previous)) = read_workspace(&path) else {
+        return;
+    };
+    if previous.version != CACHE_SCHEMA_VERSION
+        || previous.workspace_root != workspace.workspace_root
+        || previous.workspace_sha256 != workspace.workspace_sha256
+        || cache_expired(previous.captured_at_ms)
+    {
+        return;
+    }
+
+    workspace
+        .documents
+        .extend(previous.documents.into_iter().filter(|document| {
+            !open_uris.contains(document.uri.as_str())
+                && !replaced_uris.contains(document.uri.as_str())
+        }));
 }
 
 fn canonical_workspace_root(root: &Path) -> PathBuf {
@@ -463,6 +549,10 @@ fn workspace_fingerprint(root: &Path, config: &LspConfig) -> io::Result<[u8; 32]
     }
 
     let mut digest = Sha256::new();
+    let mut config_value = serde_json::to_value(config).map_err(io::Error::other)?;
+    canonicalize_json(&mut config_value);
+    digest.update(b"lsp-config");
+    digest.update(serde_json::to_vec(&config_value).map_err(io::Error::other)?);
     for marker in markers {
         digest.update(marker.as_bytes());
         digest.update([0]);
@@ -477,7 +567,37 @@ fn workspace_fingerprint(root: &Path, config: &LspConfig) -> io::Result<[u8; 32]
             Err(error) => return Err(error),
         }
     }
+    digest.update(b"repository-local-lsp-settings");
+    match workspace_settings_file(root) {
+        Some(path) => {
+            digest.update([1]);
+            digest.update(hash_file(&path)?);
+        }
+        None => digest.update([0]),
+    }
     Ok(digest.finalize().into())
+}
+
+fn workspace_settings_file(workspace_root: &Path) -> Option<PathBuf> {
+    let repository_root = workspace_root
+        .ancestors()
+        .find(|ancestor| ancestor.join(".git").exists());
+    let settings_boundary = repository_root.unwrap_or(workspace_root);
+    for ancestor in workspace_root.ancestors() {
+        let candidate = ancestor.join(".vscode/settings.json");
+        if candidate.is_file() {
+            let canonical_boundary = fs::canonicalize(settings_boundary).ok()?;
+            let canonical_candidate = fs::canonicalize(&candidate).ok()?;
+            if !canonical_candidate.starts_with(canonical_boundary) {
+                return None;
+            }
+            return Some(candidate);
+        }
+        if repository_root.is_none() || repository_root == Some(ancestor) {
+            break;
+        }
+    }
+    None
 }
 
 fn read_workspace(path: &Path) -> anyhow::Result<Option<CachedWorkspace>> {

--- a/src/editor/diagnostics.rs
+++ b/src/editor/diagnostics.rs
@@ -3,9 +3,16 @@
 //! A server can publish compiler diagnostics and return its own native diagnostics
 //! from a pull request. An empty report clears only the channel that produced it.
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    path::Path,
+    time::{Duration, Instant},
+};
 
-use crate::lsp::{Diagnostic, Position, Range};
+use crate::lsp::{file_path, Diagnostic, Position, Range};
+
+const EMPTY_REPORT_RETRY_DELAY: Duration = Duration::from_secs(2);
+const MAX_PROVISIONAL_AGE: Duration = Duration::from_secs(10 * 60);
 
 #[derive(Clone, Copy)]
 pub(super) enum DiagnosticReportKind {
@@ -18,6 +25,12 @@ struct DocumentReports {
     push: Vec<Diagnostic>,
     pull: Vec<Diagnostic>,
     provisional: bool,
+    defer_empty: bool,
+    priming: bool,
+    ready: bool,
+    empty_report_deferred: bool,
+    retry_at: Option<Instant>,
+    expires_at: Option<Instant>,
 }
 
 #[derive(Default)]
@@ -34,9 +47,27 @@ impl DiagnosticReports {
     ) -> Vec<Diagnostic> {
         let reports = self.documents.entry(uri.to_string()).or_default();
         if reports.provisional {
+            let now = Instant::now();
+            let keep_provisional = diagnostics.is_empty()
+                && reports.defer_empty
+                && !reports.ready
+                && reports
+                    .expires_at
+                    .is_some_and(|expires_at| now < expires_at)
+                && (reports.priming
+                    || !reports.empty_report_deferred
+                    || reports.retry_at.is_some());
+            if keep_provisional {
+                if !reports.priming && !reports.empty_report_deferred {
+                    reports.empty_report_deferred = true;
+                    reports.retry_at = Some(now + EMPTY_REPORT_RETRY_DELAY);
+                }
+                return merged_reports(reports);
+            }
             reports.push.clear();
             reports.pull.clear();
             reports.provisional = false;
+            reports.retry_at = None;
         }
         match kind {
             DiagnosticReportKind::Push => reports.push = diagnostics.to_vec(),
@@ -51,11 +82,19 @@ impl DiagnosticReports {
         uri: String,
         push: Vec<Diagnostic>,
         pull: Vec<Diagnostic>,
+        defer_empty: bool,
     ) -> Vec<Diagnostic> {
+        let now = Instant::now();
         let reports = DocumentReports {
             push,
             pull,
             provisional: true,
+            defer_empty,
+            priming: false,
+            ready: false,
+            empty_report_deferred: false,
+            retry_at: None,
+            expires_at: Some(now + MAX_PROVISIONAL_AGE),
         };
         let merged = merged_reports(&reports);
         self.documents.insert(uri, reports);
@@ -76,6 +115,49 @@ impl DiagnosticReports {
 
     pub(super) fn has_provisional(&self) -> bool {
         self.documents.values().any(|reports| reports.provisional)
+    }
+
+    pub(super) fn take_retry_due(&mut self, uri: &str, now: Instant) -> bool {
+        let Some(reports) = self.documents.get_mut(uri) else {
+            return false;
+        };
+        if !reports.provisional || reports.priming {
+            return false;
+        }
+        let retry_due = reports.retry_at.is_some_and(|retry_at| retry_at <= now)
+            || reports
+                .expires_at
+                .is_some_and(|expires_at| expires_at <= now);
+        if retry_due {
+            reports.retry_at = None;
+            reports.ready |= reports
+                .expires_at
+                .is_some_and(|expires_at| expires_at <= now);
+        }
+        retry_due
+    }
+
+    /// Tracks rust-analyzer cache priming for restored documents in one workspace.
+    pub(super) fn set_workspace_priming(&mut self, workspace_root: &Path, active: bool) -> bool {
+        let mut affected = false;
+        for (uri, reports) in &mut self.documents {
+            if !reports.provisional || !reports.defer_empty {
+                continue;
+            }
+            let Ok(path) = file_path(uri) else {
+                continue;
+            };
+            if !Path::new(&path).starts_with(workspace_root) {
+                continue;
+            }
+            reports.priming = active;
+            if !active {
+                reports.ready = true;
+                reports.retry_at = None;
+            }
+            affected = true;
+        }
+        affected
     }
 
     /// Move untouched diagnostic ranges with their text and discard edited ranges.
@@ -446,6 +528,25 @@ mod tests {
     }
 
     #[test]
+    fn cached_state_rejects_changed_repository_lsp_settings() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("old configuration")]);
+        first.persist_diagnostic_cache(true);
+        std::fs::create_dir(root.path().join(".vscode")).unwrap();
+        std::fs::write(
+            root.path().join(".vscode/settings.json"),
+            r#"{"rust-analyzer.cachePriming.enable":true}"#,
+        )
+        .unwrap();
+
+        let restarted = cached_editor(&file, "x\n", &cache);
+
+        assert!(!restarted.diagnostics.contains_key(&uri));
+    }
+
+    #[test]
     fn first_fresh_report_replaces_both_provisional_diagnostic_channels() {
         let (root, file, uri) = diagnostic_workspace("x\n");
         let cache = root.path().join("cache");
@@ -475,7 +576,7 @@ mod tests {
     }
 
     #[test]
-    fn fresh_empty_report_removes_cached_findings_for_the_next_restart() {
+    fn empty_report_waits_for_priming_before_removing_cached_findings() {
         let (root, file, uri) = diagnostic_workspace("x\n");
         let cache = root.path().join("cache");
         let mut first = cached_editor(&file, "x\n", &cache);
@@ -484,11 +585,138 @@ mod tests {
 
         let mut refreshed = cached_editor(&file, "x\n", &cache);
         push(&mut refreshed, &uri, vec![]);
+        assert_eq!(refreshed.diagnostics[&uri][0].message, "resolved error");
+        assert!(refreshed
+            .diagnostic_reports
+            .set_workspace_priming(root.path(), true));
+        push(&mut refreshed, &uri, vec![]);
+        assert_eq!(refreshed.diagnostics[&uri][0].message, "resolved error");
+        assert!(refreshed
+            .diagnostic_reports
+            .set_workspace_priming(root.path(), false));
+        push(&mut refreshed, &uri, vec![]);
         assert!(refreshed.diagnostics[&uri].is_empty());
         refreshed.persist_diagnostic_cache(true);
 
         let restarted = cached_editor(&file, "x\n", &cache);
         assert!(!restarted.diagnostics.contains_key(&uri));
+    }
+
+    #[test]
+    fn empty_report_is_rechecked_when_no_priming_progress_arrives() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("resolved error")]);
+        first.persist_diagnostic_cache(true);
+
+        let mut restarted = cached_editor(&file, "x\n", &cache);
+        push(&mut restarted, &uri, vec![]);
+        assert_eq!(restarted.diagnostics[&uri][0].message, "resolved error");
+        assert!(restarted
+            .diagnostic_reports
+            .take_retry_due(&uri, Instant::now() + EMPTY_REPORT_RETRY_DELAY));
+        push(&mut restarted, &uri, vec![]);
+
+        assert!(restarted.diagnostics[&uri].is_empty());
+        assert!(!restarted.diagnostic_reports.has_provisional());
+    }
+
+    #[test]
+    fn prime_caches_end_queues_a_fresh_diagnostic_request() {
+        let (root, file, uri) = diagnostic_workspace("x\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "x\n", &cache);
+        push(&mut first, &uri, vec![diagnostic("resolved error")]);
+        first.persist_diagnostic_cache(true);
+        let mut restarted = cached_editor(&file, "x\n", &cache);
+        let mut progress: crate::lsp::ProgressParams = serde_json::from_value(json!({
+            "token": "rustAnalyzer/PrimeCaches",
+            "value": { "kind": "end" }
+        }))
+        .unwrap();
+        progress.enrich("rust", root.path().to_string_lossy());
+
+        restarted.process_progress(&progress);
+
+        assert!(restarted.diagnostic_refresh_after_progress);
+        push(&mut restarted, &uri, vec![]);
+        assert!(restarted.diagnostics[&uri].is_empty());
+    }
+
+    #[test]
+    fn cached_read_only_lsp_artifacts_restore_with_matching_contents() {
+        let (root, file, uri) = diagnostic_workspace("fn main() {}\n");
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&file, "fn main() {}\n", &cache);
+        let symbols = json!([{
+            "name": "main",
+            "kind": 12,
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 12 }
+            },
+            "selectionRange": {
+                "start": { "line": 0, "character": 3 },
+                "end": { "line": 0, "character": 7 }
+            }
+        }]);
+        let hints = crate::editor::diagnostic_cache::InlayHintSnapshot {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+            result: json!([{
+                "position": { "line": 0, "character": 9 },
+                "label": ": ()",
+                "kind": 1
+            }]),
+        };
+        first
+            .cached_document_symbols
+            .insert(uri.clone(), symbols.clone());
+        first.cached_inlay_hints.insert(uri.clone(), hints.clone());
+        first.mark_diagnostic_cache_dirty();
+        first.persist_diagnostic_cache(true);
+
+        let restarted = cached_editor(&file, "fn main() {}\n", &cache);
+
+        assert_eq!(restarted.cached_document_symbols[&uri], symbols);
+        assert_eq!(restarted.cached_inlay_hints[&uri], hints);
+
+        std::fs::write(&file, "fn changed() {}\n").unwrap();
+        let changed = cached_editor(&file, "fn changed() {}\n", &cache);
+        assert!(!changed.cached_document_symbols.contains_key(&uri));
+        assert!(!changed.cached_inlay_hints.contains_key(&uri));
+    }
+
+    #[test]
+    fn concurrent_workspace_sessions_merge_cached_documents() {
+        let (root, first_file, first_uri) = diagnostic_workspace("first();\n");
+        let second_file = root.path().join("second.rs");
+        std::fs::write(&second_file, "second();\n").unwrap();
+        let second_uri = crate::lsp::file_uri(&second_file).unwrap();
+        let cache = root.path().join("cache");
+        let mut first = cached_editor(&first_file, "first();\n", &cache);
+        let mut second = cached_editor(&second_file, "second();\n", &cache);
+
+        push(&mut first, &first_uri, vec![diagnostic("first error")]);
+        first.persist_diagnostic_cache(true);
+        push(&mut second, &second_uri, vec![diagnostic("second error")]);
+        second.persist_diagnostic_cache(true);
+
+        let restarted = cached_editor(&first_file, "first();\n", &cache);
+        assert_eq!(restarted.diagnostics[&first_uri][0].message, "first error");
+        assert_eq!(
+            restarted.diagnostics[&second_uri][0].message,
+            "second error"
+        );
     }
 
     #[test]

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -13,6 +13,8 @@ use std::{
     collections::{HashMap, HashSet},
     future::Future,
     path::{Path, PathBuf},
+    process::Command,
+    sync::Mutex,
 };
 
 use path_absolutize::Absolutize;
@@ -71,6 +73,7 @@ pub struct LspManager {
     failed_clients: HashSet<String>,
     opened_documents: HashSet<String>,
     document_clients: HashMap<String, String>,
+    cargo_workspace_roots: Mutex<HashMap<PathBuf, Option<PathBuf>>>,
     next_client_poll: usize,
 }
 
@@ -113,6 +116,7 @@ impl LspManager {
             failed_clients: HashSet::new(),
             opened_documents: HashSet::new(),
             document_clients: HashMap::new(),
+            cargo_workspace_roots: Mutex::new(HashMap::new()),
             next_client_poll: 0,
         }
     }
@@ -137,7 +141,12 @@ impl LspManager {
 
         let path = Path::new(file);
         let path = path.absolutize().ok()?.to_path_buf();
-        let workspace_root = find_workspace_root(&path, server);
+        let workspace_root = find_workspace_root(
+            &path,
+            server,
+            &selector.language_id,
+            &self.cargo_workspace_roots,
+        );
         let uri = file_uri(&path).ok()?;
 
         Some(DocumentInfo {
@@ -173,6 +182,10 @@ impl LspManager {
             super::workspace_settings::apply_workspace_settings(
                 &mut config,
                 &document.workspace_root,
+                &document.language_id,
+            );
+            super::workspace_settings::apply_fast_startup_defaults(
+                &mut config,
                 &document.language_id,
             );
 
@@ -260,9 +273,25 @@ fn document_key(document: &DocumentInfo) -> String {
     format!("{}:{}", client_key(document), document.uri)
 }
 
-fn find_workspace_root(path: &Path, server: &LanguageServerConfig) -> PathBuf {
+fn find_workspace_root(
+    path: &Path,
+    server: &LanguageServerConfig,
+    language_id: &str,
+    cargo_workspace_roots: &Mutex<HashMap<PathBuf, Option<PathBuf>>>,
+) -> PathBuf {
     let start = path.parent().unwrap_or(path);
+    let marker_root = marker_workspace_root(start, server);
 
+    if language_id == "rust" {
+        if let Some(workspace_root) = cargo_workspace_root(start, server, cargo_workspace_roots) {
+            return workspace_root;
+        }
+    }
+
+    marker_root
+}
+
+fn marker_workspace_root(start: &Path, server: &LanguageServerConfig) -> PathBuf {
     for ancestor in start.ancestors() {
         if server
             .root_markers
@@ -274,6 +303,107 @@ fn find_workspace_root(path: &Path, server: &LanguageServerConfig) -> PathBuf {
     }
 
     std::env::current_dir().unwrap_or_else(|_| start.to_path_buf())
+}
+
+fn cargo_workspace_root(
+    start: &Path,
+    server: &LanguageServerConfig,
+    cache: &Mutex<HashMap<PathBuf, Option<PathBuf>>>,
+) -> Option<PathBuf> {
+    let manifest = start
+        .ancestors()
+        .map(|ancestor| ancestor.join("Cargo.toml"))
+        .find(|candidate| candidate.is_file())?;
+    let manifest = std::fs::canonicalize(&manifest).unwrap_or(manifest);
+
+    if let Some(cached) = cache
+        .lock()
+        .ok()
+        .and_then(|roots| roots.get(&manifest).cloned())
+    {
+        return cached;
+    }
+
+    let resolved = locate_cargo_workspace(&manifest, start, server);
+    if let Ok(mut roots) = cache.lock() {
+        roots.insert(manifest, resolved.clone());
+    }
+    resolved
+}
+
+fn locate_cargo_workspace(
+    manifest: &Path,
+    document_directory: &Path,
+    server: &LanguageServerConfig,
+) -> Option<PathBuf> {
+    let mut command = cargo_command_for_server(server);
+    let output = command
+        .args([
+            "locate-project",
+            "--workspace",
+            "--message-format",
+            "plain",
+            "--manifest-path",
+        ])
+        .arg(manifest)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let workspace_manifest = std::str::from_utf8(&output.stdout).ok()?.trim();
+    if workspace_manifest.is_empty() {
+        return None;
+    }
+    let workspace_manifest = PathBuf::from(workspace_manifest);
+    if workspace_manifest
+        .file_name()
+        .and_then(|name| name.to_str())
+        != Some("Cargo.toml")
+        || !workspace_manifest.is_file()
+    {
+        return None;
+    }
+    let workspace_root = workspace_manifest.parent()?;
+    let workspace_root = std::fs::canonicalize(workspace_root).ok()?;
+    let document_directory = std::fs::canonicalize(document_directory)
+        .unwrap_or_else(|_| document_directory.to_path_buf());
+    if !document_directory.starts_with(&workspace_root) {
+        return None;
+    }
+
+    let repository_root = document_directory
+        .ancestors()
+        .find(|ancestor| ancestor.join(".git").exists())
+        .and_then(|root| std::fs::canonicalize(root).ok());
+    if repository_root
+        .as_ref()
+        .is_some_and(|repository_root| !workspace_root.starts_with(repository_root))
+    {
+        return None;
+    }
+
+    Some(workspace_root)
+}
+
+fn cargo_command_for_server(server: &LanguageServerConfig) -> Command {
+    let rustup = Path::new(&server.command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "rustup" || name == "rustup.exe");
+    if rustup
+        && server
+            .args
+            .first()
+            .is_some_and(|argument| argument == "run")
+    {
+        if let Some(toolchain) = server.args.get(1) {
+            let mut command = Command::new(&server.command);
+            command.args(["run", toolchain, "cargo"]);
+            return command;
+        }
+    }
+    Command::new("cargo")
 }
 
 #[async_trait::async_trait]
@@ -347,6 +477,7 @@ impl LspClient for LspManager {
         self.config = replacement.config;
         self.document_selectors = replacement.document_selectors;
         self.filename_selectors = replacement.filename_selectors;
+        self.cargo_workspace_roots = replacement.cargo_workspace_roots;
         self.client_poll_order
             .retain(|key| self.clients.contains_key(key));
         self.next_client_poll = 0;
@@ -851,6 +982,7 @@ impl LspClient for LspManager {
 mod tests {
     use std::{
         collections::HashMap,
+        fs,
         sync::{
             atomic::{AtomicBool, AtomicUsize, Ordering},
             Arc,
@@ -984,6 +1116,91 @@ mod tests {
         });
 
         assert!(manager.resolve_document("README.md").is_none());
+    }
+
+    #[test]
+    fn rust_members_share_the_cargo_workspace_root() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir(root.path().join(".git")).unwrap();
+        fs::write(
+            root.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"core\", \"tui\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        let mut files = Vec::new();
+        for member in ["core", "tui"] {
+            let directory = root.path().join(member).join("src");
+            fs::create_dir_all(&directory).unwrap();
+            fs::write(
+                root.path().join(member).join("Cargo.toml"),
+                format!(
+                    "[package]\nname = \"{member}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"
+                ),
+            )
+            .unwrap();
+            let file = directory.join("lib.rs");
+            fs::write(&file, "pub fn example() {}\n").unwrap();
+            files.push(file);
+        }
+        let mut rust = server("rust", &["rs"]);
+        rust.command = "rustup".to_string();
+        rust.args = vec![
+            "run".to_string(),
+            "stable".to_string(),
+            "rust-analyzer".to_string(),
+        ];
+        rust.root_markers = vec!["Cargo.toml".to_string(), ".git".to_string()];
+        let manager = LspManager::new(LspConfig {
+            enabled: true,
+            format_on_save: false,
+            servers: HashMap::from([("rust".to_string(), rust)]),
+        });
+
+        let core = manager
+            .resolve_document(files[0].to_string_lossy().as_ref())
+            .unwrap();
+        let tui = manager
+            .resolve_document(files[1].to_string_lossy().as_ref())
+            .unwrap();
+        let expected = fs::canonicalize(root.path()).unwrap();
+
+        assert_eq!(core.workspace_root, expected);
+        assert_eq!(tui.workspace_root, expected);
+        assert_eq!(client_key(&core), client_key(&tui));
+    }
+
+    #[test]
+    fn cargo_workspace_discovery_does_not_escape_a_nested_repository() {
+        let outer = tempfile::tempdir().unwrap();
+        fs::write(
+            outer.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"nested/member\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        let repository = outer.path().join("nested");
+        let member = repository.join("member");
+        fs::create_dir_all(repository.join(".git")).unwrap();
+        fs::create_dir_all(member.join("src")).unwrap();
+        fs::write(
+            member.join("Cargo.toml"),
+            "[package]\nname = \"member\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        let file = member.join("src/lib.rs");
+        fs::write(&file, "pub fn example() {}\n").unwrap();
+        let mut rust = server("rust", &["rs"]);
+        rust.root_markers = vec!["Cargo.toml".to_string(), ".git".to_string()];
+        let manager = LspManager::new(LspConfig {
+            enabled: true,
+            format_on_save: false,
+            servers: HashMap::from([("rust".to_string(), rust)]),
+        });
+
+        let document = manager
+            .resolve_document(file.to_string_lossy().as_ref())
+            .unwrap();
+
+        assert_eq!(document.workspace_root, member);
     }
 
     #[test]

--- a/src/lsp/workspace_settings.rs
+++ b/src/lsp/workspace_settings.rs
@@ -1,4 +1,4 @@
-//! Bounded, formatting-only imports from repository-local VS Code settings.
+//! Bounded imports of safe rust-analyzer options from repository-local VS Code settings.
 //!
 //! Workspace settings are applied to a cloned server configuration, so one
 //! repository cannot change another repository's language-server behavior.
@@ -10,6 +10,7 @@ use std::{
 };
 
 use json_comments::StripComments;
+use path_absolutize::Absolutize;
 use serde_json::{Map, Value};
 
 use crate::{config::LanguageServerConfig, log};
@@ -18,6 +19,11 @@ const MAX_SETTINGS_BYTES: u64 = 1024 * 1024;
 const MAX_RUSTFMT_ARGS: usize = 64;
 const MAX_RUSTFMT_ARG_BYTES: usize = 8 * 1024;
 const RUSTFMT_EXTRA_ARGS_KEY: &str = "rust-analyzer.rustfmt.extraArgs";
+const CARGO_TARGET_DIR_KEY: &str = "rust-analyzer.cargo.targetDir";
+const CACHE_PRIMING_ENABLE_KEY: &str = "rust-analyzer.cachePriming.enable";
+const CHECK_WORKSPACE_KEY: &str = "rust-analyzer.check.workspace";
+const CARGO_ALL_TARGETS_KEY: &str = "rust-analyzer.cargo.allTargets";
+const WORKSPACE_FOLDER_PLACEHOLDER: &str = "${workspaceFolder}";
 
 /// Merge safe project-local rustfmt settings without changing shared defaults.
 pub(super) fn apply_workspace_settings(
@@ -42,53 +48,98 @@ pub(super) fn apply_workspace_settings(
             return;
         }
     };
-    let Some(project_args) = rustfmt_extra_args(&settings) else {
+    if let Some(project_args) = rustfmt_extra_args(&settings) {
+        let existing_args = existing_rustfmt_args(config).cloned();
+        let args = existing_args.unwrap_or(project_args);
+        merge_setting(
+            config,
+            &["rustfmt", "extraArgs"],
+            &["rust-analyzer", "rustfmt", "extraArgs"],
+            &args,
+            &path,
+            "rustfmt extra arguments",
+        );
+    }
+
+    if let Some(target_dir) = cargo_target_dir(&settings, &path) {
+        merge_project_setting(
+            config,
+            &["cargo", "targetDir"],
+            &["rust-analyzer", "cargo", "targetDir"],
+            CARGO_TARGET_DIR_KEY,
+            target_dir,
+            &path,
+            "Cargo target directory",
+        );
+    }
+
+    merge_project_bool(
+        config,
+        &settings,
+        CACHE_PRIMING_ENABLE_KEY,
+        &["rust-analyzer", "cachePriming", "enable"],
+        &["cachePriming", "enable"],
+        &path,
+    );
+    merge_project_bool(
+        config,
+        &settings,
+        CHECK_WORKSPACE_KEY,
+        &["rust-analyzer", "check", "workspace"],
+        &["check", "workspace"],
+        &path,
+    );
+    merge_project_bool(
+        config,
+        &settings,
+        CARGO_ALL_TARGETS_KEY,
+        &["rust-analyzer", "cargo", "allTargets"],
+        &["cargo", "allTargets"],
+        &path,
+    );
+}
+
+/// Avoid eager whole-workspace priming unless the user or repository opted back in.
+pub(super) fn apply_fast_startup_defaults(config: &mut LanguageServerConfig, language_id: &str) {
+    if language_id != "rust" {
         return;
-    };
-
-    let existing_args = existing_rustfmt_args(config).cloned();
-    let args = existing_args.unwrap_or(project_args);
-
-    if !insert_missing(
-        &mut config.initialization_options,
-        &["rustfmt", "extraArgs"],
-        &args,
-    ) {
-        log!(
-            "[lsp] could not merge rustfmt workspace settings into initialization options for {}",
-            path.display()
-        );
     }
-    if !insert_missing(
-        &mut config.settings,
-        &["rust-analyzer", "rustfmt", "extraArgs"],
-        &args,
-    ) {
-        log!(
-            "[lsp] could not merge rustfmt workspace settings into dynamic settings for {}",
-            path.display()
-        );
-    }
+
+    let value = existing_setting(
+        config,
+        &["cachePriming", "enable"],
+        &["rust-analyzer", "cachePriming", "enable"],
+        CACHE_PRIMING_ENABLE_KEY,
+    )
+    .cloned()
+    .unwrap_or(Value::Bool(false));
+    merge_setting(
+        config,
+        &["cachePriming", "enable"],
+        &["rust-analyzer", "cachePriming", "enable"],
+        &value,
+        Path::new("built-in rust-analyzer defaults"),
+        "cache priming",
+    );
 }
 
 fn find_settings_file(workspace_root: &Path) -> Option<PathBuf> {
     let repository_root = workspace_root
         .ancestors()
         .find(|ancestor| ancestor.join(".git").exists());
+    let settings_boundary = repository_root.unwrap_or(workspace_root);
 
     for ancestor in workspace_root.ancestors() {
         let candidate = ancestor.join(".vscode").join("settings.json");
         if candidate.is_file() {
-            if let Some(repository_root) = repository_root {
-                let canonical_root = fs::canonicalize(repository_root).ok()?;
-                let canonical_candidate = fs::canonicalize(&candidate).ok()?;
-                if !canonical_candidate.starts_with(canonical_root) {
-                    log!(
-                        "[lsp] ignored workspace settings outside the repository: {}",
-                        candidate.display()
-                    );
-                    return None;
-                }
+            let canonical_boundary = fs::canonicalize(settings_boundary).ok()?;
+            let canonical_candidate = fs::canonicalize(&candidate).ok()?;
+            if !canonical_candidate.starts_with(canonical_boundary) {
+                log!(
+                    "[lsp] ignored workspace settings outside the workspace boundary: {}",
+                    candidate.display()
+                );
+                return None;
             }
             return Some(candidate);
         }
@@ -189,6 +240,146 @@ fn rustfmt_extra_args(settings: &Value) -> Option<Value> {
     }
 
     Some(Value::Array(args.clone()))
+}
+
+fn cargo_target_dir(settings: &Value, settings_path: &Path) -> Option<Value> {
+    let raw = project_setting(
+        settings,
+        CARGO_TARGET_DIR_KEY,
+        &["rust-analyzer", "cargo", "targetDir"],
+    )?
+    .as_str()?;
+    if raw.is_empty() || raw.contains('\0') {
+        return None;
+    }
+
+    let workspace_folder = settings_path.parent()?.parent()?;
+    let relative = if let Some(suffix) = raw.strip_prefix(WORKSPACE_FOLDER_PLACEHOLDER) {
+        suffix.strip_prefix('/')?
+    } else {
+        if raw.contains("${") {
+            return None;
+        }
+        raw
+    };
+    if relative.is_empty() {
+        return None;
+    }
+
+    let workspace_folder = workspace_folder.absolutize().ok()?.to_path_buf();
+    let target = Path::new(relative)
+        .absolutize_from(&workspace_folder)
+        .ok()?
+        .to_path_buf();
+    if !target.starts_with(&workspace_folder) || target == workspace_folder {
+        return None;
+    }
+
+    Some(Value::String(target.to_string_lossy().into_owned()))
+}
+
+fn project_setting<'a>(settings: &'a Value, flat: &str, nested: &[&str]) -> Option<&'a Value> {
+    settings
+        .get(flat)
+        .or_else(|| value_at_path(settings, nested))
+}
+
+fn merge_project_bool(
+    config: &mut LanguageServerConfig,
+    settings: &Value,
+    flat: &str,
+    dynamic_path: &[&str],
+    initialization_path: &[&str],
+    settings_path: &Path,
+) {
+    let Some(value) =
+        project_setting(settings, flat, dynamic_path).filter(|value| value.is_boolean())
+    else {
+        return;
+    };
+    merge_project_setting(
+        config,
+        initialization_path,
+        dynamic_path,
+        flat,
+        value.clone(),
+        settings_path,
+        flat,
+    );
+}
+
+fn merge_project_setting(
+    config: &mut LanguageServerConfig,
+    initialization_path: &[&str],
+    dynamic_path: &[&str],
+    flat: &str,
+    project_value: Value,
+    settings_path: &Path,
+    label: &str,
+) {
+    let value = existing_setting(config, initialization_path, dynamic_path, flat)
+        .cloned()
+        .unwrap_or(project_value);
+    merge_setting(
+        config,
+        initialization_path,
+        dynamic_path,
+        &value,
+        settings_path,
+        label,
+    );
+}
+
+fn merge_setting(
+    config: &mut LanguageServerConfig,
+    initialization_path: &[&str],
+    dynamic_path: &[&str],
+    value: &Value,
+    source: &Path,
+    label: &str,
+) {
+    if !insert_missing(
+        &mut config.initialization_options,
+        initialization_path,
+        value,
+    ) {
+        log!(
+            "[lsp] could not merge {label} into initialization options from {}",
+            source.display()
+        );
+    }
+    if !insert_missing(&mut config.settings, dynamic_path, value) {
+        log!(
+            "[lsp] could not merge {label} into dynamic settings from {}",
+            source.display()
+        );
+    }
+}
+
+fn existing_setting<'a>(
+    config: &'a LanguageServerConfig,
+    initialization_path: &[&str],
+    dynamic_path: &[&str],
+    flat: &str,
+) -> Option<&'a Value> {
+    config
+        .initialization_options
+        .as_ref()
+        .and_then(|value| value_at_path(value, initialization_path))
+        .or_else(|| {
+            config
+                .settings
+                .as_ref()
+                .and_then(|value| value_at_path(value, dynamic_path))
+        })
+        .or_else(|| config.settings.as_ref().and_then(|value| value.get(flat)))
+}
+
+fn value_at_path<'a>(mut value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    for part in path {
+        value = value.get(*part)?;
+    }
+    Some(value)
 }
 
 fn existing_rustfmt_args(config: &LanguageServerConfig) -> Option<&Value> {
@@ -472,6 +663,128 @@ mod tests {
     }
 
     #[test]
+    fn imports_repository_local_target_dir_and_workload_settings() {
+        let (repository, workspace) = repository();
+        write_settings(
+            repository.path(),
+            r#"{
+                "rust-analyzer.cargo.targetDir": "${workspaceFolder}/codex-rs/target/rust-analyzer",
+                "rust-analyzer.cachePriming.enable": true,
+                "rust-analyzer.check.workspace": false,
+                "rust-analyzer.cargo.allTargets": false
+            }"#,
+        );
+
+        let mut config = rust_server();
+        apply_workspace_settings(&mut config, &workspace, "rust");
+
+        let target = repository
+            .path()
+            .join("codex-rs/target/rust-analyzer")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            config.initialization_options,
+            Some(json!({
+                "cargo": { "targetDir": target, "allTargets": false },
+                "cachePriming": { "enable": true },
+                "check": { "workspace": false },
+            }))
+        );
+        assert_eq!(
+            config.settings,
+            Some(json!({
+                "rust-analyzer": {
+                    "cargo": { "targetDir": target, "allTargets": false },
+                    "cachePriming": { "enable": true },
+                    "check": { "workspace": false },
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn rejects_target_dirs_outside_the_settings_workspace() {
+        for target_dir in ["../outside", "/tmp/outside", "${workspaceFolder}"] {
+            let (repository, workspace) = repository();
+            write_settings(
+                repository.path(),
+                &json!({ CARGO_TARGET_DIR_KEY: target_dir }).to_string(),
+            );
+            let mut config = rust_server();
+
+            apply_workspace_settings(&mut config, &workspace, "rust");
+
+            assert!(config.initialization_options.is_none(), "{target_dir}");
+            assert!(config.settings.is_none(), "{target_dir}");
+        }
+    }
+
+    #[test]
+    fn explicit_target_dir_and_workload_settings_take_precedence() {
+        let (repository, workspace) = repository();
+        write_settings(
+            repository.path(),
+            r#"{
+                "rust-analyzer.cargo.targetDir": "target/project",
+                "rust-analyzer.cachePriming.enable": false
+            }"#,
+        );
+        let mut config = rust_server();
+        config.initialization_options = Some(json!({
+            "cargo": { "targetDir": "/trusted/user/target" },
+            "cachePriming": { "enable": true },
+        }));
+
+        apply_workspace_settings(&mut config, &workspace, "rust");
+
+        assert_eq!(
+            config.initialization_options.as_ref().unwrap()["cargo"]["targetDir"],
+            json!("/trusted/user/target")
+        );
+        assert_eq!(
+            config.initialization_options.as_ref().unwrap()["cachePriming"]["enable"],
+            json!(true)
+        );
+        assert_eq!(
+            config.settings.as_ref().unwrap()["rust-analyzer"]["cargo"]["targetDir"],
+            json!("/trusted/user/target")
+        );
+        assert_eq!(
+            config.settings.as_ref().unwrap()["rust-analyzer"]["cachePriming"]["enable"],
+            json!(true)
+        );
+    }
+
+    #[test]
+    fn fast_startup_disables_cache_priming_without_overriding_explicit_values() {
+        let mut config = rust_server();
+        apply_fast_startup_defaults(&mut config, "rust");
+        assert_eq!(
+            config.initialization_options.as_ref().unwrap()["cachePriming"]["enable"],
+            json!(false)
+        );
+        assert_eq!(
+            config.settings.as_ref().unwrap()["rust-analyzer"]["cachePriming"]["enable"],
+            json!(false)
+        );
+
+        let mut explicit = rust_server();
+        explicit.initialization_options = Some(json!({
+            "cachePriming": { "enable": true }
+        }));
+        apply_fast_startup_defaults(&mut explicit, "rust");
+        assert_eq!(
+            explicit.initialization_options.as_ref().unwrap()["cachePriming"]["enable"],
+            json!(true)
+        );
+        assert_eq!(
+            explicit.settings.as_ref().unwrap()["rust-analyzer"]["cachePriming"]["enable"],
+            json!(true)
+        );
+    }
+
+    #[test]
     fn ignores_non_rust_documents() {
         let (repository, workspace) = repository();
         write_settings(
@@ -573,6 +886,28 @@ mod tests {
 
         let mut config = rust_server();
         apply_workspace_settings(&mut config, &workspace, "rust");
+
+        assert!(config.initialization_options.is_none());
+        assert!(config.settings.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_settings_symlinked_outside_a_workspace_without_git() {
+        let workspace = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let external = outside.path().join("settings.json");
+        fs::write(
+            &external,
+            r#"{"rust-analyzer.cargo.targetDir":"target/rust-analyzer"}"#,
+        )
+        .unwrap();
+        let vscode = workspace.path().join(".vscode");
+        fs::create_dir(&vscode).unwrap();
+        std::os::unix::fs::symlink(external, vscode.join("settings.json")).unwrap();
+        let mut config = rust_server();
+
+        apply_workspace_settings(&mut config, workspace.path(), "rust");
 
         assert!(config.initialization_options.is_none());
         assert!(config.settings.is_none());


### PR DESCRIPTION
Restored sessions currently preserve only a thin slice of LSP presentation state. In large Rust repositories, Red can also launch separate rust-analyzer clients from member manifests, discard restored diagnostics on the first empty response, and miss repository-local startup settings. The result still feels like a cold restart even though a cache exists.

This change keeps the server lifecycle unchanged while making restarts useful:

- resolve Rust documents through the canonical Cargo workspace so members share one rust-analyzer client, without crossing repository boundaries
- cache validated diagnostics, document symbols, breadcrumbs, and inlay hints as provisional read-only display data, then replace them with live responses
- merge cache entries across concurrent sessions and invalidate them when document contents, LSP configuration, manifests, or repository settings change
- retain provisional Rust diagnostics through initial empty reports until cache priming finishes or a bounded retry confirms the empty result
- import safe repository-local rust-analyzer workload settings, including cargo targetDir, while preserving explicit Red configuration
- disable eager rust-analyzer cache priming by default unless the user or repository explicitly enables it

No language-server process is kept alive across Red sessions, and mutating LSP operations always use the live server.

## How to Test

1. Open files from two crates in one Cargo workspace. Confirm both documents resolve to the same workspace root and only one rust-analyzer client is started for that workspace.
2. Wait for diagnostics, breadcrumbs, and inlay hints, close Red, then reopen the same session. Confirm the cached display data appears immediately and is replaced by fresh live results without disappearing on the first empty diagnostic report.
3. Edit a cached file or change the repository rust-analyzer settings, then reopen the session. Confirm stale diagnostics, symbols, and inlay hints are not restored.

Focused regressions cover Cargo workspace routing and repository boundaries, workspace-setting precedence and path validation, provisional diagnostic refresh behavior, cache merging and invalidation, and live replacement of cached document symbols and inlay hints.

## Validation

- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- focused LSP, diagnostics, cache, breadcrumb, and inlay-hint suites

The full parallel suite reached 2,164 passing tests with one timing-sensitive Git dashboard test failing; that test passes standalone, and unchanged main also exhibits parallel-load Git plugin timeouts.