### PR TITLE
feat(commands): add bufdo support

### DIFF
--- a/almanac/architecture/commands/command-discovery.md
+++ b/almanac/architecture/commands/command-discovery.md
@@ -15,6 +15,9 @@ sources:
   - id: editor-dispatch
     type: file
     path: src/editor.rs
+  - id: buffer-do
+    type: file
+    path: src/editor/buffer_do.rs
   - id: default-config
     type: file
     path: default_config.toml
@@ -39,11 +42,13 @@ The low-level parser in `src/command.rs` receives authoritative built-in command
 
 The editor adds command-specific handling around that parser. It special-cases register and join commands, uses parsed canonical names for syntax, set, and messages commands, and maps the remaining parsed command names to semantic `Action` values such as save, quit, buffer movement, deletion, edit/reload, split, and wrap [@editor-dispatch]. If built-in parsing fails but the runtime has a registered plugin command with the exact input name, the editor returns `Action::PluginCommand`; otherwise it records an unknown-command error [@editor-dispatch].
 
+`:bufdo` parses its optional range as stable buffer ids rather than line numbers, snapshots matching open-buffer ids, and reparses its nested command after activating each target so line ranges such as `%` resolve against that buffer. Traversal stops on parse, substitution, write, or reload errors and rejects nested actions that could invalidate the snapshot or open interactive UI. The outer force flag is accepted for Vim compatibility; Red already preserves dirty buffers during ordinary buffer switches [@editor-dispatch] [@buffer-do].
+
 Advertising a built-in colon form is a parser and dispatch change, not only palette metadata. A built-in command that appears in docs or `CommandPaletteEntry::colon` must also be present in the built-in command list passed to `command::parse` and must map to an `Action` in `Editor::handle_command`; otherwise the palette can describe a `:<name>` form that direct colon input still reports as unknown [@command-palette] [@editor-dispatch].
 
 ## Completion Names
 
-Colon completion uses the palette module's command-name inventory rather than the parser alone. `colon_completion_names` starts with built-in colon commands, adds special built-ins such as `commands`, `command-palette`, debug commands, registers, undotree, `j`, and `join`, and then appends plugin command names that do not collide with built-in colon names [@command-palette]. The editor uses that list for command-name completion. `src/command_completion.rs` selects argument providers after a space: fixed choices for commands such as `set`, `languages`, and `Copilot`, file paths for file commands, and language ids for syntax commands. `Tab` cycles forward and `Shift-Tab` cycles backward through the original matches; typing resets the cycle. Positional choices replace only the current argument; file completion retains its existing whole-path replacement behavior. Completion never executes a command or plugin callback [@command-completion] [@editor-dispatch].
+Colon completion uses the palette module's command-name inventory rather than the parser alone. `colon_completion_names` starts with built-in colon commands, adds special built-ins such as `commands`, `command-palette`, debug commands, registers, undotree, `j`, and `join`, and then appends plugin command names that do not collide with built-in colon names [@command-palette]. The editor uses that list for command-name completion. `src/command_completion.rs` selects argument providers after a space: fixed choices for commands such as `set`, `languages`, and `Copilot`, file paths for file commands, and language ids for syntax commands. After `bufdo`, completion restarts at the nested command, including optional stable-ID ranges, and excludes recursive `bufdo` completion. `Tab` cycles forward and `Shift-Tab` cycles backward through the original matches; typing resets the cycle. Positional choices replace only the current argument; file completion retains its existing whole-path replacement behavior. Completion never executes a command or plugin callback [@command-completion] [@editor-dispatch].
 
 Built-in precedence is intentional. `colon_name_is_builtin` treats special names and anything the built-in parser can resolve as reserved, so plugin commands with those names can still be active internally but do not create alternate colon command entries in discovery surfaces [@command-palette]. This matches the plugin API boundary described in [Red Host API](../plugins/red-host-api).
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -278,6 +278,7 @@ Enter Command mode with `:` or `;`.
 | `:e <file>` / `:e!` | Open or reload a file |
 | `:<number>` / `:$` | Jump to a line or the last line |
 | `:bn` / `:bd` | Select the next buffer or delete a buffer |
+| `:bufdo {command}` | Run a non-interactive Ex command in every open buffer |
 | `:sp [file]` / `:vs [file]` | Open a horizontal or vertical split |
 | `:close` / `:only` | Close the window or keep only the current window |
 | `:wrap` / `:nowrap` | Enable or disable wrapping |

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Red Vim compatibility matrix
 
-**Matrix version:** 1.7
+**Matrix version:** 1.8
 **Validated against:** Red 0.5.0, August 2026
 **Status vocabulary:** **supported**, **intentional difference**, **not yet supported**
 
@@ -79,7 +79,7 @@ the corresponding integration tests.
 | Empty buffers | **supported** | The synthetic editable line remains cursor-safe across insert, delete, render, and undo. |
 | Unnamed buffer creation | **supported** | `:enew` opens an empty unnamed buffer in the current window, preserves existing unsaved buffers, and reuses an already-empty unnamed buffer. |
 | Ex command abbreviations | **supported** | Built-in Vim commands honor their documented minimum prefixes, including `:e[dit]`, `:ene[w]`, `:sav[eas]`, `:se[t]`, and `:sy[ntax]`. Exact names and existing aliases take precedence; ambiguous and too-short prefixes are rejected. |
-| Buffer commands | **supported** | `:new` and `:vnew` create new buffers in splits; `:b[uffer] {name|number|#}`, `:bnext`, `:bprevious`, and `:ls`/`:buffers`/`:files` navigate or list stable buffer identities. `:saveas {path}` writes a new association, while `:file {path}` names the buffer without writing. |
+| Buffer commands | **supported** | `:new` and `:vnew` create new buffers in splits; `:b[uffer] {name|number|#}`, `:bnext`, `:bprevious`, and `:ls`/`:buffers`/`:files` navigate or list stable buffer identities. `:[buffer-id-range]bufd[o][!] {command}` snapshots the open buffers in stable-ID order, stops on the first error, and leaves the final or failing buffer active. Red treats every open buffer as listed and preserves dirty buffers while switching, so the outer `!` is accepted but does not change traversal. Nested non-interactive editing and buffer-local option commands are supported; buffer/window restructuring, modal UI, plugin commands, and `|` command chains are not. The substitute `e` flag suppresses missing-pattern errors during traversal. `:saveas {path}` writes a new association, while `:file {path}` names the buffer without writing. |
 | Final line / trailing newline | **supported** | Both forms render and edit without exposing a phantom gutter line. |
 | Multi-window and docked panes | **supported** | Active-buffer cursor, viewport, wrapping, gutter width, and focus-cycle state are window-aware. `Ctrl-w h/j/k/l` moves between editor windows and panes; `Ctrl-w H/J/K/L` moves the focused editor window, row pane, or text pane to the corresponding outer edge without replacing its identity, content, or draft. |
 | Embedded plugin text areas | **supported** | Agent dialogs and text-panel composers reuse Unicode-aware word, paragraph, and sentence motions, character searches, ordinary and sentence text objects, and transactional replacement. Counts, operators, Visual selections, local registers, undo/redo, dot-repeat, macros, and prompt-local search remain isolated. Tree-sitter structural objects and swaps stay editor-owned and are unavailable in grammar-free composers. |

--- a/src/command.rs
+++ b/src/command.rs
@@ -77,14 +77,19 @@ impl ParsedCommand {
         self.flags.contains(&CommandFlag::Force)
     }
 
-    /// Reassembles the single unexpanded path consumed by file commands.
+    /// Reassembles the unexpanded argument text following the command name.
     ///
-    /// Splitting and joining on literal spaces preserves whitespace inside the
-    /// path, including repeated spaces returned by command completion.
+    /// Splitting and joining on literal spaces preserves repeated spaces returned
+    /// by command completion and nested command arguments.
+    pub(crate) fn argument_text(&self) -> Option<String> {
+        let arguments = self.args.join(" ");
+        let arguments = arguments.trim_start();
+        (!arguments.is_empty()).then(|| arguments.to_string())
+    }
+
+    /// Reassembles the single unexpanded path consumed by file commands.
     pub(crate) fn file_argument(&self) -> Option<String> {
-        let path = self.args.join(" ");
-        let path = path.trim_start();
-        (!path.is_empty()).then(|| path.to_string())
+        self.argument_text()
     }
 }
 

--- a/src/command_completion.rs
+++ b/src/command_completion.rs
@@ -48,7 +48,7 @@ struct ArgumentContext<'a> {
 }
 
 impl<'a> ArgumentContext<'a> {
-    fn parse(line: &'a str) -> Option<Self> {
+    fn parse_at(line: &'a str, offset: usize) -> Option<Self> {
         let start = line.find(|ch: char| !ch.is_whitespace())?;
         let end = line[start..]
             .find(char::is_whitespace)
@@ -57,10 +57,10 @@ impl<'a> ArgumentContext<'a> {
         if end == line.len() {
             return Some(Self {
                 command,
-                command_end: end,
+                command_end: offset + end,
                 preceding: Vec::new(),
                 fragment: "",
-                replacement: end..end,
+                replacement: offset + end..offset + end,
                 needs_leading_space: true,
             });
         }
@@ -71,13 +71,63 @@ impl<'a> ArgumentContext<'a> {
             .map_or(end, |(offset, ch)| end + offset + ch.len_utf8());
         Some(Self {
             command,
-            command_end: end,
+            command_end: offset + end,
             preceding: line[end..argument_start].split_whitespace().collect(),
             fragment: &line[argument_start..],
-            replacement: argument_start..line.len(),
+            replacement: offset + argument_start..offset + line.len(),
             needs_leading_space: false,
         })
     }
+}
+
+fn bufdo_nested_start(line: &str) -> Option<usize> {
+    let mut command_start = line.find(|ch: char| !ch.is_whitespace())?;
+    let bytes = line.as_bytes();
+    if bytes.get(command_start) == Some(&b'%') {
+        command_start += 1;
+    } else {
+        let first_end = command_start
+            + bytes[command_start..]
+                .iter()
+                .take_while(|byte| byte.is_ascii_digit())
+                .count();
+        if first_end > command_start {
+            command_start = first_end;
+            if bytes.get(command_start) == Some(&b',') {
+                command_start += 1;
+                command_start += bytes[command_start..]
+                    .iter()
+                    .take_while(|byte| byte.is_ascii_digit())
+                    .count();
+            }
+        }
+    }
+    command_start += line[command_start..]
+        .chars()
+        .take_while(|ch| ch.is_whitespace())
+        .map(char::len_utf8)
+        .sum::<usize>();
+    let command_end = line[command_start..]
+        .find(char::is_whitespace)
+        .map_or(line.len(), |offset| command_start + offset);
+    if command_end == line.len() {
+        return None;
+    }
+    let parsed = command::parse(
+        command_palette::BUILTIN_COLON_COMMANDS,
+        &line[command_start..command_end],
+    )?;
+    if parsed.commands.as_slice() != ["bufdo"] {
+        return None;
+    }
+    Some(
+        command_end
+            + line[command_end..]
+                .chars()
+                .take_while(|ch| ch.is_whitespace())
+                .map(char::len_utf8)
+                .sum::<usize>(),
+    )
 }
 
 enum Source {
@@ -166,7 +216,29 @@ pub(crate) fn complete(
             return;
         }
     }
-    let Some(context) = ArgumentContext::parse(line) else {
+    let nested_start = bufdo_nested_start(line);
+    if nested_start == Some(line.len()) {
+        let candidates = command_palette::colon_completion_names(plugins)
+            .into_iter()
+            .filter(|name| name != "bufdo")
+            .collect::<Vec<_>>();
+        let selected = match direction {
+            CompletionDirection::Next => 0,
+            CompletionDirection::Previous => candidates.len() - 1,
+        };
+        let mut current = CommandCompletionState {
+            replacement: line.len()..line.len(),
+            candidates,
+            selected,
+            needs_leading_space: false,
+        };
+        current.apply(line);
+        *state = Some(current);
+        return;
+    }
+    let (completion_line, offset) =
+        nested_start.map_or((&line[..], 0), |start| (&line[start..], start));
+    let Some(context) = ArgumentContext::parse_at(completion_line, offset) else {
         return;
     };
     let argument_source = source(&context, plugins);
@@ -184,7 +256,9 @@ pub(crate) fn complete(
         let start = context.replacement.start - context.command.len();
         let names = command_palette::colon_completion_names(plugins)
             .into_iter()
-            .filter(|name| name.starts_with(context.command))
+            .filter(|name| {
+                name.starts_with(context.command) && (nested_start.is_none() || name != "bufdo")
+            })
             .collect();
         (start..line.len(), false, names)
     } else {
@@ -341,6 +415,10 @@ mod tests {
             ("syntax RU", "syntax rust"),
             ("sy ru", "sy rust"),
             ("syn ru", "syn rust"),
+            ("bufdo synt", "bufdo syntax"),
+            ("bufdo syntax RU", "bufdo syntax rust"),
+            ("bufd! synt", "bufd! syntax"),
+            ("2,4bufdo synt", "2,4bufdo syntax"),
             ("ft ", "ft auto"),
             ("syntax rust extra", "syntax rust extra"),
             ("q sr", "q sr"),
@@ -465,7 +543,7 @@ mod tests {
 
     #[test]
     fn context_preserves_whitespace_and_byte_boundaries() {
-        let context = ArgumentContext::parse("Service  one\u{2003}é").unwrap();
+        let context = ArgumentContext::parse_at("Service  one\u{2003}é", 0).unwrap();
         assert_eq!(context.preceding, ["one"]);
         assert_eq!(context.fragment, "é");
         assert_eq!(&"Service  one\u{2003}é"[context.replacement], "é");

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -28,6 +28,7 @@ pub(crate) const BUILTIN_COLON_COMMANDS: &[CommandSpec] = &[
     CommandSpec::exact("b#"),
     CommandSpec::exact("bd"),
     CommandSpec::new("bdelete", 2),
+    CommandSpec::new("bufdo", 4),
     CommandSpec::exact("buffer-delete"),
     CommandSpec::new("edit", 1),
     CommandSpec::new("enew", 3),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -19,6 +19,7 @@ mod agent_annotations;
 mod agent_manager;
 mod agent_models;
 mod buffer_actions;
+mod buffer_do;
 mod buffer_manager;
 mod command_mode;
 mod completion_resolve;
@@ -1008,6 +1009,8 @@ pub struct SubstituteCommand {
     replace_all: bool,
     case_insensitive: bool,
     confirm: bool,
+    #[serde(default)]
+    suppress_errors: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2615,6 +2618,12 @@ pub enum Action {
     DumpTimers,
     DoPing,
     Command(String),
+    /// Executes one non-interactive built-in Ex command over a stable buffer-ID snapshot.
+    BufferDo {
+        command: String,
+        start: Option<u64>,
+        end: Option<u64>,
+    },
     PluginCommand(String),
     SetCursor(usize, usize),
     SetWaitingKey(Box<KeyAction>),
@@ -15620,6 +15629,30 @@ impl Editor {
         })
     }
 
+    fn resolve_ex_buffer_range(range: &str) -> anyhow::Result<(Option<u64>, Option<u64>)> {
+        if range.is_empty() || range == "%" {
+            return Ok((None, None));
+        }
+        anyhow::ensure!(
+            range != "'<,'>",
+            "bufdo does not support the last visual range"
+        );
+        let mut ids = range.split(',');
+        let start = ids
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("bufdo range is empty"))?
+            .parse::<u64>()?;
+        let end = ids
+            .next()
+            .map(str::parse::<u64>)
+            .transpose()?
+            .unwrap_or(start);
+        anyhow::ensure!(ids.next().is_none(), "bufdo range has too many endpoints");
+        anyhow::ensure!(start > 0 && end > 0, "bufdo buffer IDs start at one");
+        anyhow::ensure!(start <= end, "bufdo range start exceeds its end");
+        Ok((Some(start), Some(end)))
+    }
+
     fn parse_substitute_command(&self, command: &str) -> anyhow::Result<Option<SubstituteCommand>> {
         let (range, command) = Self::split_ex_line_range(command);
         let command = command.trim_start();
@@ -15637,7 +15670,9 @@ impl Editor {
         let (replacement, flags) = parse_substitute_segment(remainder, delimiter)?;
         anyhow::ensure!(!pattern.is_empty(), "substitute pattern cannot be empty");
         anyhow::ensure!(
-            flags.chars().all(|flag| matches!(flag, 'g' | 'i' | 'c')),
+            flags
+                .chars()
+                .all(|flag| matches!(flag, 'g' | 'i' | 'c' | 'e')),
             "unsupported substitute flags: {flags}"
         );
 
@@ -15659,6 +15694,7 @@ impl Editor {
             replace_all: flags.contains('g'),
             case_insensitive: flags.contains('i'),
             confirm: flags.contains('c'),
+            suppress_errors: flags.contains('e'),
         }))
     }
 
@@ -15714,6 +15750,28 @@ impl Editor {
             .unwrap_or((ranged_command, ""));
         let keep_spaces = name.ends_with('!');
         let name = name.strip_suffix('!').unwrap_or(name);
+        let parsed_ranged_command =
+            command::parse(command_palette::BUILTIN_COLON_COMMANDS, ranged_command);
+        if let Some(parsed) =
+            parsed_ranged_command.filter(|parsed| parsed.commands.as_slice() == ["bufdo"])
+        {
+            let Some(command) = parsed.argument_text() else {
+                self.set_legacy_message(Some("usage: bufdo {command}".to_string()));
+                return Vec::new();
+            };
+            let (start, end) = match Self::resolve_ex_buffer_range(range) {
+                Ok(range) => range,
+                Err(error) => {
+                    self.set_legacy_message(Some(error.to_string()));
+                    return Vec::new();
+                }
+            };
+            return vec![Action::BufferDo {
+                command,
+                start,
+                end,
+            }];
+        }
         if matches!(name, "j" | "join") {
             if range.is_empty() {
                 let count = if arguments.trim().is_empty() {
@@ -19900,7 +19958,9 @@ impl Editor {
                         return Ok(false);
                     }
                 };
-                if command.confirm && !substitutions.is_empty() {
+                if substitutions.is_empty() && command.suppress_errors {
+                    self.render(buffer)?;
+                } else if command.confirm && !substitutions.is_empty() {
                     let confirmation = SubstituteConfirmation {
                         substitutions,
                         current: 0,
@@ -20359,6 +20419,14 @@ impl Editor {
                     return Ok(true);
                 }
                 self.render(buffer)?;
+            }
+            Action::BufferDo {
+                command,
+                start,
+                end,
+            } => {
+                self.execute_buffer_do(command, *start, *end, buffer, runtime)
+                    .await?;
             }
             Action::PluginCommand(cmd) => {
                 let demo = match (

--- a/src/editor/buffer_do.rs
+++ b/src/editor/buffer_do.rs
@@ -1,0 +1,155 @@
+//! Safe iteration of non-interactive Ex commands over open buffers.
+
+use super::*;
+
+impl Editor {
+    #[inline(never)]
+    pub(super) fn execute_buffer_do<'a>(
+        &'a mut self,
+        command: &'a str,
+        start: Option<u64>,
+        end: Option<u64>,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(self.execute_buffer_do_impl(command, start, end, buffer, runtime))
+    }
+
+    async fn execute_buffer_do_impl(
+        &mut self,
+        command: &str,
+        start: Option<u64>,
+        end: Option<u64>,
+        buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let mut targets = self
+            .buffer_manager
+            .iter()
+            .map(Buffer::id)
+            .filter(|id| start.is_none_or(|start| id.as_u64() >= start))
+            .filter(|id| end.is_none_or(|end| id.as_u64() <= end))
+            .collect::<Vec<_>>();
+        targets.sort_unstable_by_key(|id| id.as_u64());
+
+        if targets.is_empty() {
+            self.set_legacy_message(Some("No buffers in range".to_string()));
+            self.render(buffer)?;
+            return Ok(());
+        }
+
+        for target in targets {
+            let Some(index) = self
+                .buffer_manager
+                .iter()
+                .position(|source| source.id() == target)
+            else {
+                self.set_legacy_message(Some(
+                    "bufdo stopped because the buffer list changed".to_string(),
+                ));
+                self.render(buffer)?;
+                return Ok(());
+            };
+            self.set_current_buffer(buffer, index).await?;
+
+            let actions = self.handle_command(command, runtime);
+            if actions.is_empty() {
+                if self.last_error.is_none() {
+                    self.set_legacy_message(Some(format!("bufdo could not execute {command:?}")));
+                    self.render(buffer)?;
+                }
+                return Ok(());
+            }
+            if let Some(action) = actions
+                .iter()
+                .find(|action| !Self::action_is_buffer_do_safe(action))
+            {
+                let reason = if matches!(action, Action::Substitute(command) if command.confirm) {
+                    "interactive substitute confirmation"
+                } else {
+                    "commands outside its supported non-interactive subset"
+                };
+                self.set_legacy_message(Some(format!(
+                    "bufdo does not support {reason}: {command:?}"
+                )));
+                self.render(buffer)?;
+                return Ok(());
+            }
+
+            for action in actions {
+                if let Action::Substitute(substitute) = &action {
+                    let substitutions = match self.plan_substitutions(substitute) {
+                        Ok(substitutions) => substitutions,
+                        Err(error) => {
+                            self.set_legacy_message(Some(error.to_string()));
+                            self.render(buffer)?;
+                            return Ok(());
+                        }
+                    };
+                    if substitutions.is_empty() {
+                        if substitute.suppress_errors {
+                            self.set_legacy_message(None);
+                            continue;
+                        }
+                        self.set_legacy_message(Some("pattern not found".to_string()));
+                        self.render(buffer)?;
+                        return Ok(());
+                    }
+                }
+
+                let save_without_file =
+                    matches!(action, Action::Save) && self.current_buffer().file.is_none();
+                let invalid_syntax = matches!(
+                    &action,
+                    Action::SetSyntax(syntax)
+                        if !matches!(syntax.trim().to_ascii_lowercase().as_str(), "auto" | "off")
+                            && self.highlighter.language_id_for_name(syntax).is_none()
+                );
+                let dirty_before = self.current_buffer().is_dirty();
+                let blocked_reload = matches!(action, Action::ReloadFile(false)) && dirty_before;
+                if self.execute(&action, buffer, runtime).await? {
+                    return Ok(());
+                }
+                if blocked_reload || save_without_file || invalid_syntax {
+                    return Ok(());
+                }
+                if matches!(action, Action::Save)
+                    && dirty_before
+                    && self.current_buffer().is_dirty()
+                    && !self.buffer_has_pending_format_save(target)
+                {
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn action_is_buffer_do_safe(action: &Action) -> bool {
+        matches!(
+            action,
+            Action::Save
+                | Action::ReloadFile(_)
+                | Action::Substitute(SubstituteCommand { confirm: false, .. })
+                | Action::JoinLines(_)
+                | Action::JoinLinesKeepSpaces(_)
+                | Action::JoinLinesInRange { .. }
+                | Action::GoToLine(_)
+                | Action::MoveToBottom
+                | Action::Print(_)
+                | Action::ClearSearchHighlight
+                | Action::SetWrap(_)
+                | Action::SetRelativeLineNumbers(_)
+                | Action::SetSyntax(_)
+        )
+    }
+
+    fn buffer_has_pending_format_save(&self, buffer_id: BufferId) -> bool {
+        self.pending_lsp_format_saves.keys().any(|request_id| {
+            self.pending_lsp_edit_requests
+                .get(request_id)
+                .is_some_and(|pending| pending.buffer_id == buffer_id)
+        })
+    }
+}

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -2439,6 +2439,184 @@ async fn buffer_selection_rejects_ambiguous_names_and_supports_stable_ids() {
 }
 
 #[tokio::test]
+async fn bufdo_substitutes_all_buffers_and_finishes_on_the_last() {
+    let buffers = vec![
+        Buffer::new(/*file*/ None, "foo one\n".to_string()),
+        Buffer::new(/*file*/ None, "foo two\n".to_string()),
+        Buffer::new(/*file*/ None, "foo three\n".to_string()),
+    ];
+    let ids = buffers
+        .iter()
+        .map(|buffer| buffer.id().as_u64())
+        .collect::<Vec<_>>();
+    let mut editor = Editor::test_with_size(
+        Box::new(MockLsp),
+        /*width*/ 80,
+        /*height*/ 24,
+        Config::default(),
+        Theme::default(),
+        buffers,
+    )
+    .unwrap();
+    editor.test_disable_terminal_output();
+    let mut harness = EditorHarness { editor };
+
+    harness
+        .execute_action(Action::Command("bufd! %s/foo/bar/g".to_string()))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.current_buffer_index(), 2);
+    harness.assert_buffer_contents("bar three\n");
+    harness
+        .execute_action(Action::OpenBufferById(ids[0]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("bar one\n");
+    harness
+        .execute_action(Action::OpenBufferById(ids[1]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("bar two\n");
+}
+
+#[tokio::test]
+async fn bufdo_stops_on_substitute_error_unless_e_suppresses_it() {
+    let make_harness = || {
+        let buffers = vec![
+            Buffer::new(/*file*/ None, "foo one\n".to_string()),
+            Buffer::new(/*file*/ None, "no match\n".to_string()),
+            Buffer::new(/*file*/ None, "foo three\n".to_string()),
+        ];
+        let ids = buffers
+            .iter()
+            .map(|buffer| buffer.id().as_u64())
+            .collect::<Vec<_>>();
+        let mut editor = Editor::test_with_size(
+            Box::new(MockLsp),
+            /*width*/ 80,
+            /*height*/ 24,
+            Config::default(),
+            Theme::default(),
+            buffers,
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        (EditorHarness { editor }, ids)
+    };
+    let (mut harness, ids) = make_harness();
+
+    harness
+        .execute_action(Action::Command("bufdo %s/foo/bar/g".to_string()))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.current_buffer_index(), 1);
+    assert_eq!(harness.last_error(), Some("pattern not found"));
+    harness
+        .execute_action(Action::OpenBufferById(ids[0]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("bar one\n");
+    harness
+        .execute_action(Action::OpenBufferById(ids[2]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("foo three\n");
+
+    let (mut harness, ids) = make_harness();
+    harness
+        .execute_action(Action::Command("bufdo %s/foo/bar/ge".to_string()))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.current_buffer_index(), 2);
+    harness.assert_buffer_contents("bar three\n");
+    harness
+        .execute_action(Action::OpenBufferById(ids[0]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("bar one\n");
+    harness
+        .execute_action(Action::OpenBufferById(ids[1]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("no match\n");
+}
+
+#[tokio::test]
+async fn bufdo_uses_stable_buffer_id_ranges_and_rejects_interactive_commands() {
+    let buffers = vec![
+        Buffer::new(/*file*/ None, "foo one\n".to_string()),
+        Buffer::new(/*file*/ None, "foo two\n".to_string()),
+        Buffer::new(/*file*/ None, "foo three\n".to_string()),
+    ];
+    let ids = buffers
+        .iter()
+        .map(|buffer| buffer.id().as_u64())
+        .collect::<Vec<_>>();
+    let mut editor = Editor::test_with_size(
+        Box::new(MockLsp),
+        /*width*/ 80,
+        /*height*/ 24,
+        Config::default(),
+        Theme::default(),
+        buffers,
+    )
+    .unwrap();
+    editor.test_disable_terminal_output();
+    let mut harness = EditorHarness { editor };
+
+    harness
+        .execute_action(Action::Command(format!(
+            "{},{}bufdo %s/foo/bar/g",
+            ids[1], ids[2]
+        )))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.current_buffer_index(), 2);
+    harness
+        .execute_action(Action::OpenBufferById(ids[0]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("foo one\n");
+    harness
+        .execute_action(Action::OpenBufferById(ids[1]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("bar two\n");
+    harness
+        .execute_action(Action::OpenBufferById(ids[2]))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents("bar three\n");
+
+    harness
+        .execute_action(Action::Command("bufdo enew".to_string()))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.buffer_names().len(), 3);
+    assert_eq!(harness.current_buffer_index(), 0);
+    assert!(harness
+        .last_error()
+        .is_some_and(|message| message.contains("supported non-interactive subset")));
+
+    harness
+        .execute_action(Action::Command(
+            "bufdo syntax definitely-missing".to_string(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.current_buffer_index(), 0);
+    assert!(harness
+        .last_error()
+        .is_some_and(|message| message.contains("unknown syntax")));
+}
+
+#[tokio::test]
 async fn buffer_listing_aliases_show_stable_numbers_without_opening_splits() {
     for command in ["ls", "buffers", "files", "b", "buffer"] {
         let mut harness = EditorHarness::with_content("contents\n");


### PR DESCRIPTION
Red can navigate and edit multiple open buffers, but it lacks Vim's `:bufdo` workflow for applying one Ex command across them. That makes project-wide buffer edits repetitive and prevents familiar stop-on-error behavior.

This adds `:[buffer-id-range]bufd[o][!] {command}` with a stable snapshot of open buffer IDs. The command visits matching buffers in ID order, reparses the nested command for each buffer, stops on the first error, and leaves the last or failing buffer active. Nested completion works for command names and arguments, and substitute commands accept `e` to continue past missing matches.

Traversal is intentionally limited to non-interactive built-ins that do not restructure buffers or windows. Modal UI, plugin commands, recursive `:bufdo`, and `|` command chains are rejected before execution.

## How to Test

1. Run `CARGO_TARGET_DIR=/private/tmp/red-bufdo-target cargo test --test editing bufdo`. The three focused tests should pass, covering full traversal, stable-ID ranges, stop-on-error behavior, the substitute `e` flag, and unsupported nested commands.
2. Open several buffers containing `foo`, run `:bufdo %s/foo/bar/g`, and confirm every buffer is updated and the final buffer remains active.
3. Repeat with one buffer that has no match. Without `e`, traversal should stop on that buffer and leave later buffers unchanged; with `:bufdo %s/foo/bar/ge`, traversal should continue through the final buffer.
