### PR TITLE
feat(neotree): open file tree from insert mode

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -295,6 +295,7 @@ Tab = "InsertTab"
 "Ctrl-Space" = "RequestCompletion"
 "Alt-\\" = "RequestInlineCompletion"
 "Ctrl-k" = "SignatureHelp"
+"Ctrl-e" = [ { EnterMode = "Normal" }, { PluginCommand = "NeoTree" } ]
 Esc = { EnterMode = "Normal" }
 
 [keys.normal]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4689,6 +4689,25 @@ max_buffer_words = 20
     }
 
     #[test]
+    fn default_config_maps_ctrl_e_to_neotree_in_normal_and_insert_modes() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.keys.normal.get("Ctrl-e"),
+            Some(&KeyAction::Single(Action::PluginCommand(
+                "NeoTree".to_string()
+            )))
+        );
+        assert_eq!(
+            config.keys.insert.get("Ctrl-e"),
+            Some(&KeyAction::Multiple(vec![
+                Action::EnterMode(Mode::Normal),
+                Action::PluginCommand("NeoTree".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
     fn default_config_maps_alt_a_to_agent_toggle() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -43813,6 +43813,115 @@ while True:
         ));
     }
 
+    #[tokio::test]
+    async fn insert_mode_neotree_shortcut_commits_edits_and_toggles_panel_focus() {
+        drain_plugin_requests();
+        let mut editor = test_editor(/*width*/ 80, /*height*/ 24);
+        editor.config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+        let mut render_buffer =
+            RenderBuffer::new(/*width*/ 80, /*height*/ 24, &Style::default());
+        let mut runtime = Runtime::new();
+        runtime
+            .load_plugin(
+                "navigation",
+                r#"
+                    pub fn activate() {
+                        red::state_set("open", false);
+                        red::add_command("NeoTree", toggle, Json { scope: "global" });
+                    }
+
+                    fn toggle() {
+                        if red::bool(red::state("open"), false) {
+                            red::execute("ClosePanel", "neotree");
+                            red::execute("FocusEditor");
+                            red::state_set("open", false);
+                        } else {
+                            red::execute("CreatePanel", "neotree", PanelConfig {
+                                side: "left",
+                                width: 20,
+                            });
+                            red::execute("FocusPanel", "neotree");
+                            red::state_set("open", true);
+                        }
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!(editor.current_buffer().contents(), "xhello");
+        assert!(editor.current_buffer().undo_history.is_transaction_active());
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        editor
+            .service_background(&mut render_buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!(editor.current_buffer().contents(), "xhello");
+        assert!(!editor.current_buffer().undo_history.is_transaction_active());
+        assert_eq!(editor.panel_manager.focused_panel_id(), Some("neotree"));
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        editor
+            .service_background(&mut render_buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!(editor.panel_manager.focused_panel_id(), None);
+        assert_eq!(editor.panel_manager.panel_layout("neotree"), None);
+        assert_eq!(editor.current_buffer().contents(), "xhello");
+
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+        assert_eq!(editor.current_buffer().contents(), "hello");
+    }
+
     #[test]
     fn focused_panel_repaints_the_editor_cursor_cell() {
         let mut editor = test_editor(40, 10);


### PR DESCRIPTION
## Why

`Ctrl-e` only opened NeoTree from Normal mode. Pressing it while editing instead inserted a literal `e`, unexpectedly modifying the buffer and requiring users to leave Insert mode manually.

## What Changed

- Map Insert-mode `Ctrl-e` to `EnterMode(Normal)` followed by the existing global `NeoTree` command while preserving the Normal-mode toggle.
- Finish the active insert transaction before focusing NeoTree so closing the tree returns to Normal mode and undo treats the preceding edit as one change.
- Cover both default keymaps and the complete open, focus, close, unchanged-buffer, transaction, and undo flow with focused regression tests.

## How to Test

1. Run `cargo test --locked --lib neotree`; all 14 NeoTree-focused tests should pass, including `insert_mode_neotree_shortcut_commits_edits_and_toggles_panel_focus`.
2. Run `cargo test --locked --lib config::test::`; all 96 configuration tests should pass, including `default_config_maps_ctrl_e_to_neotree_in_normal_and_insert_modes`.
3. Open a file in Red, press `i`, type `x`, then press `Ctrl-e`; NeoTree should open and receive focus, the editor should leave Insert mode, and the buffer should contain only the intended `x`.
4. Press `Ctrl-e` again, then `u`; the tree should close, focus should return to the editor in Normal mode, and one undo should remove the entire preceding insert transaction.
