### PR TITLE
fix(completion): select top result after lsp updates

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -38758,6 +38758,72 @@ builtin = "rust"
     }
 
     #[tokio::test]
+    async fn delayed_lsp_completion_selects_its_best_match_over_buffer_words() {
+        let mut editor = completion_typing_editor();
+        let request_snapshot = editor.completion_snapshot();
+        let buffer_items = vec![completion_item("manual_seed")];
+        assert!(editor.show_completion_items(buffer_items.clone(), request_snapshot));
+        assert_eq!(
+            editor
+                .current_dialog
+                .as_ref()
+                .and_then(|dialog| dialog.selected_completion())
+                .map(|item| item.label.as_str()),
+            Some("manual_seed")
+        );
+        let pending_snapshot = editor.completion_snapshot.clone().unwrap();
+        editor.pending_completions.insert(
+            42,
+            PendingCompletion {
+                buffer_items,
+                snapshot: pending_snapshot,
+                displayed_immediately: true,
+                superseded: false,
+            },
+        );
+        let response = InboundMessage::Message(ResponseMessage {
+            id: 42,
+            result: serde_json::json!([{
+                "label": "many",
+                "sortText": "00",
+                "preselect": true
+            }]),
+            request: Some(crate::lsp::Request::new(
+                "textDocument/completion",
+                serde_json::json!({ "position": { "line": 0, "character": 9 } }),
+            )),
+        });
+
+        assert!(matches!(
+            editor.handle_lsp_message(&response, Some("textDocument/completion".to_string())),
+            Some(Action::ShowDialog)
+        ));
+        assert_eq!(
+            editor
+                .current_dialog
+                .as_ref()
+                .and_then(|dialog| dialog.selected_completion())
+                .map(|item| item.label.as_str()),
+            Some("many")
+        );
+
+        let mut render_buffer = RenderBuffer::new(80, 24, &Style::default());
+        let mut runtime = Runtime::new();
+        editor
+            .process_editor_event(
+                Event::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+                &mut render_buffer,
+                &mut runtime,
+                EventRenderMode::Immediate,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(editor.current_buffer().contents(), "torch.many");
+        assert!(editor.current_dialog.is_none());
+    }
+
+    #[tokio::test]
     async fn completion_merges_lsp_results_into_the_visible_menu_after_typing() {
         let mut editor = completion_typing_editor();
         let request_snapshot = editor.completion_snapshot();

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -57,6 +57,7 @@ pub struct CompletionUI {
     filter: String,
     last_filter: Option<String>,
     viewport: SelectionViewport,
+    selection_manually_changed: bool,
     visible: bool,
     anchor_x: usize,
     anchor_y: usize,
@@ -114,9 +115,12 @@ impl CompletionUI {
     }
 
     pub fn update_items(&mut self, items: Vec<CompletionResponseItem>, filter: &str) {
-        let selected = self
-            .selected_item()
-            .map(CompletionSelectionIdentity::from_item);
+        let selected = if self.selection_manually_changed {
+            self.selected_item()
+                .map(CompletionSelectionIdentity::from_item)
+        } else {
+            None
+        };
         self.filter.clear();
         self.filter.push_str(filter);
         self.replace_items(items, selected.as_ref());
@@ -159,6 +163,7 @@ impl CompletionUI {
         self.matched_label_indices.clear();
         self.filter.clear();
         self.last_filter = None;
+        self.selection_manually_changed = false;
     }
 
     pub fn is_visible(&self) -> bool {
@@ -298,13 +303,16 @@ impl CompletionUI {
         });
         if let Some(selection) = exact_selection.or(matching_label) {
             self.viewport.select(selection);
-        } else if let Some(preselected) = self.items.iter().position(|index| {
-            self.all_items
-                .get(*index)
-                .and_then(|item| item.preselect)
-                .unwrap_or(false)
-        }) {
-            self.viewport.select(preselected);
+        } else {
+            self.selection_manually_changed = false;
+            if let Some(preselected) = self.items.iter().position(|index| {
+                self.all_items
+                    .get(*index)
+                    .and_then(|item| item.preselect)
+                    .unwrap_or(false)
+            }) {
+                self.viewport.select(preselected);
+            }
         }
     }
 
@@ -375,7 +383,9 @@ impl CompletionUI {
             return;
         }
 
+        let previous_selection = self.viewport.selected();
         self.viewport.move_by(delta);
+        self.selection_manually_changed |= self.viewport.selected() != previous_selection;
     }
 
     fn move_page(&mut self, up: bool) {
@@ -953,6 +963,67 @@ mod tests {
     }
 
     #[test]
+    fn asynchronous_item_updates_select_the_new_highest_ranked_item() {
+        let mut buffer_item = item("printable_buffer", Some(CompletionItemKind::Text));
+        buffer_item.sort_text = Some("~buffer:printable_buffer".to_string());
+
+        let mut ui = CompletionUI::new();
+        ui.show(vec![buffer_item.clone()], 20, 0);
+        ui.set_filter("pri");
+        assert_eq!(ui.selected_item().unwrap().label, "printable_buffer");
+
+        let mut lsp_item = item("print", Some(CompletionItemKind::Function));
+        lsp_item.sort_text = Some("00".to_string());
+        ui.update_items(vec![buffer_item, lsp_item], "pri");
+
+        assert_eq!(ui.selected_item().unwrap().label, "print");
+    }
+
+    #[test]
+    fn asynchronous_item_updates_honor_server_preselection() {
+        let mut buffer_item = item("printable_buffer", Some(CompletionItemKind::Text));
+        buffer_item.sort_text = Some("~buffer:printable_buffer".to_string());
+
+        let mut ui = CompletionUI::new();
+        ui.show(vec![buffer_item.clone()], 20, 0);
+        ui.set_filter("pri");
+
+        let mut preferred_item = item("priority", Some(CompletionItemKind::Variable));
+        preferred_item.sort_text = Some("99".to_string());
+        preferred_item.preselect = Some(true);
+        let mut top_ranked_item = item("print", Some(CompletionItemKind::Function));
+        top_ranked_item.sort_text = Some("00".to_string());
+
+        ui.update_items(vec![buffer_item, top_ranked_item, preferred_item], "pri");
+
+        assert_eq!(ui.selected_item().unwrap().label, "priority");
+    }
+
+    #[test]
+    fn asynchronous_item_updates_preserve_manual_selection_over_server_preselection() {
+        let first_buffer_item = item("alpha", Some(CompletionItemKind::Text));
+        let selected_buffer_item = item("beta", Some(CompletionItemKind::Text));
+
+        let mut ui = CompletionUI::new();
+        ui.show(
+            vec![first_buffer_item.clone(), selected_buffer_item.clone()],
+            20,
+            0,
+        );
+        ui.move_selection(1);
+        assert_eq!(ui.selected_item().unwrap().label, "beta");
+
+        let mut preferred_item = item("aardvark", Some(CompletionItemKind::Function));
+        preferred_item.preselect = Some(true);
+        ui.update_items(
+            vec![first_buffer_item, selected_buffer_item, preferred_item],
+            "",
+        );
+
+        assert_eq!(ui.selected_item().unwrap().label, "beta");
+    }
+
+    #[test]
     fn asynchronous_item_updates_preserve_the_selected_label() {
         let mut ui = CompletionUI::new();
         ui.show(
@@ -981,6 +1052,40 @@ mod tests {
         );
 
         assert_eq!(ui.selected_item().unwrap().label, "manual_seed");
+    }
+
+    #[test]
+    fn changing_the_filter_releases_an_explicit_completion_selection() {
+        for (initial_filter, event) in [
+            ("pr", key(KeyCode::Char('i'), KeyModifiers::NONE)),
+            ("prin", key(KeyCode::Backspace, KeyModifiers::NONE)),
+        ] {
+            let mut ui = CompletionUI::new();
+            ui.show(
+                vec![
+                    item("printable_buffer", Some(CompletionItemKind::Text)),
+                    item("printer_buffer", Some(CompletionItemKind::Text)),
+                ],
+                20,
+                0,
+            );
+            ui.set_filter(initial_filter);
+            ui.move_selection(1);
+            ui.handle_event(&event);
+
+            let mut preferred_item = item("print", Some(CompletionItemKind::Function));
+            preferred_item.preselect = Some(true);
+            ui.update_items(
+                vec![
+                    item("printable_buffer", Some(CompletionItemKind::Text)),
+                    item("printer_buffer", Some(CompletionItemKind::Text)),
+                    preferred_item,
+                ],
+                "pri",
+            );
+
+            assert_eq!(ui.selected_item().unwrap().label, "print");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

Autocomplete opens immediately with matching buffer words while the language server is still responding. When LSP candidates arrive, the popup currently preserves that automatically selected buffer word, even when a better-ranked or explicitly preselected server result appears above it. Pressing Tab can therefore accept the wrong suggestion.

## What changed

- Track whether the completion selection was changed intentionally through keyboard navigation.
- Let delayed LSP results select their highest-ranked or server-preselected candidate until the user chooses an item; preserve deliberate selections across asynchronous updates.
- Reset explicit-selection tracking when the filter changes or the popup closes.
- Add popup-level regressions for ranking, server preselection, manual navigation, and filter changes, plus an editor-level delayed-response and Tab-acceptance regression.

## How to Test

1. Open a file with an active language server and an existing buffer word that matches a prefix, then type that prefix. Wait for the LSP results and verify the best server suggestion becomes highlighted; press Tab and verify that suggestion is inserted.
2. Trigger completion again, move to a different item with the arrow keys or Ctrl-N/Ctrl-P before the LSP response arrives, and verify the same manually selected item remains highlighted when the results refresh.
3. After selecting an item manually, type another character or press Backspace. Verify a subsequent LSP refresh again selects the best result for the updated prefix.
4. Run the focused automated coverage:

```sh
cargo test -p red --lib ui::completion::tests
cargo test -p red --lib delayed_lsp_completion_selects_its_best_match_over_buffer_words
cargo test -p red --test completion
```
