### PR TITLE
fix(lsp): retain diagnostics across code actions

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -28005,17 +28005,21 @@ impl Editor {
             if self.transaction_active() {
                 self.commit_transaction(self.cursor_snapshot());
             }
-            let end = self.current_buffer().char_idx_to_position(usize::MAX);
             self.begin_transaction_with_origin(
                 label,
                 EditOrigin::Lsp {
                     server: "language server".to_string(),
                 },
             );
-            self.replace_range(
-                TextRange::new(TextPosition::new(0, 0), end),
-                &document.contents,
-            );
+            for batch in document.edit_batches {
+                // Ranges in a protocol batch refer to the same pre-edit snapshot.
+                for edit in batch.into_iter().rev() {
+                    let start = self.current_buffer().char_idx_to_position(edit.start);
+                    let end = self.current_buffer().char_idx_to_position(edit.end);
+                    self.replace_range(TextRange::new(start, end), &edit.new_text);
+                }
+            }
+            debug_assert_eq!(self.current_buffer().contents(), document.contents);
             self.commit_transaction(self.cursor_snapshot());
             changed.push(index);
         }
@@ -41326,6 +41330,93 @@ builtin = "rust"
                 .map(|tx| &tx.origin),
             Some(EditOrigin::Lsp { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn workspace_edit_rebases_diagnostics_until_each_channel_refreshes() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("main.rs");
+        let original = "fn main() {\n    missing();\n    other();\n}\n";
+        std::fs::write(&path, original).unwrap();
+        let mut editor = lsp_test_editor(vec![Buffer::new(
+            Some(path.to_string_lossy().into_owned()),
+            original.to_string(),
+        )]);
+        let uri = editor.buffer_manager[0].uri().unwrap().unwrap();
+        let pushed = line_diagnostic(
+            (1, 4),
+            (1, 11),
+            DiagnosticSeverity::Error,
+            "missing import",
+            None,
+        );
+        let pulled = line_diagnostic(
+            (2, 4),
+            (2, 9),
+            DiagnosticSeverity::Warning,
+            "other warning",
+            None,
+        );
+        editor.add_diagnostics(Some(&uri), &[pushed]);
+        editor.update_diagnostics(
+            Some(&uri),
+            &[pulled],
+            diagnostics::DiagnosticReportKind::Pull,
+        );
+        let revision = editor.buffer_manager[0].revision();
+
+        editor
+            .test_execute_production_action(Action::ApplyLspWorkspaceEdit {
+                documents: vec![LspDocumentEdit {
+                    uri: uri.clone(),
+                    version: None,
+                    edits: vec![lsp_edit((0, 0), (0, 0), "use crate::missing;\n")],
+                }],
+                expected_revisions: vec![(uri.clone(), revision)],
+                command: None,
+                label: "import missing item".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            editor.current_buffer().contents(),
+            "use crate::missing;\nfn main() {\n    missing();\n    other();\n}\n"
+        );
+        assert!(editor.current_buffer().is_dirty());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+        let diagnostics = &editor.diagnostics[&uri];
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.message == "missing import")
+                .unwrap()
+                .range
+                .start
+                .line,
+            2
+        );
+        assert_eq!(
+            diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.message == "other warning")
+                .unwrap()
+                .range
+                .start
+                .line,
+            3
+        );
+
+        editor.update_diagnostics(Some(&uri), &[], diagnostics::DiagnosticReportKind::Pull);
+
+        assert_eq!(editor.diagnostics[&uri].len(), 1);
+        assert_eq!(editor.diagnostics[&uri][0].message, "missing import");
+        assert_eq!(editor.diagnostics[&uri][0].range.start.line, 2);
+
+        editor.add_diagnostics(Some(&uri), &[]);
+
+        assert!(editor.diagnostics[&uri].is_empty());
     }
 
     #[tokio::test]

--- a/src/lsp/workspace_edit.rs
+++ b/src/lsp/workspace_edit.rs
@@ -34,7 +34,9 @@ use {
     std::os::fd::{AsRawFd, FromRawFd},
 };
 
-use super::{apply_text_edits, file_path, file_uri, LspError, WorkspaceEditOperation};
+use super::{
+    apply_text_edits, file_path, file_uri, text_edit_char_range, LspError, WorkspaceEditOperation,
+};
 
 const MAX_WORKSPACE_EDIT_OPERATIONS: usize = 1024;
 #[cfg(unix)]
@@ -54,6 +56,14 @@ pub struct OpenWorkspaceDocument {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedWorkspaceTextEdit {
+    /// Unicode scalar offsets in the document contents before this batch.
+    pub start: usize,
+    pub end: usize,
+    pub new_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreparedWorkspaceDocument {
     pub index: Option<usize>,
     pub original_uri: Option<String>,
@@ -61,6 +71,8 @@ pub struct PreparedWorkspaceDocument {
     pub original_contents: String,
     pub contents: String,
     pub text_changed: bool,
+    /// Validated batches in protocol order, sorted by range within each batch.
+    pub edit_batches: Vec<Vec<PreparedWorkspaceTextEdit>>,
 }
 
 #[derive(Debug)]
@@ -90,6 +102,7 @@ struct VirtualDocument {
     dirty: bool,
     exists: bool,
     text_changed: bool,
+    edit_batches: Vec<Vec<PreparedWorkspaceTextEdit>>,
     resource_changed: bool,
 }
 
@@ -106,6 +119,7 @@ impl VirtualDocument {
             dirty: false,
             exists: false,
             text_changed: false,
+            edit_batches: Vec::new(),
             resource_changed: true,
         }
     }
@@ -182,6 +196,7 @@ pub fn prepare_workspace_edit(
                     dirty: document.dirty,
                     exists: true,
                     text_changed: false,
+                    edit_batches: Vec::new(),
                     resource_changed: false,
                 },
             )
@@ -233,6 +248,7 @@ pub fn prepare_workspace_edit(
                             dirty: false,
                             exists: true,
                             text_changed: false,
+                            edit_batches: Vec::new(),
                             resource_changed: false,
                         },
                     );
@@ -272,7 +288,32 @@ pub fn prepare_workspace_edit(
                 }
 
                 let updated = apply_text_edits(&document.contents, &edit.edits)?;
-                document.text_changed |= updated != document.contents;
+                if updated != document.contents {
+                    let mut prepared = edit
+                        .edits
+                        .iter()
+                        .enumerate()
+                        .map(|(index, edit)| {
+                            let (start, end) =
+                                text_edit_char_range(&document.contents, &edit.range)?;
+                            Ok((
+                                start,
+                                end,
+                                index,
+                                PreparedWorkspaceTextEdit {
+                                    start,
+                                    end,
+                                    new_text: edit.new_text.clone(),
+                                },
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, LspError>>()?;
+                    prepared.sort_by_key(|(start, end, index, _)| (*start, *end, *index));
+                    document
+                        .edit_batches
+                        .push(prepared.into_iter().map(|(_, _, _, edit)| edit).collect());
+                    document.text_changed = true;
+                }
                 document.contents = updated;
             }
             WorkspaceEditOperation::Create {
@@ -322,6 +363,7 @@ pub fn prepare_workspace_edit(
                         dirty: false,
                         exists: true,
                         text_changed: false,
+                        edit_batches: Vec::new(),
                         resource_changed: true,
                     },
                 );
@@ -408,6 +450,7 @@ pub fn prepare_workspace_edit(
                         dirty: false,
                         exists: true,
                         text_changed: false,
+                        edit_batches: Vec::new(),
                         resource_changed: true,
                     }
                 };
@@ -486,6 +529,7 @@ pub fn prepare_workspace_edit(
             original_contents: document.original_contents,
             contents: document.contents,
             text_changed: document.text_changed,
+            edit_batches: document.edit_batches,
         })
         .collect::<Vec<_>>();
     prepared_documents.sort_by(|left, right| left.uri.cmp(&right.uri));
@@ -1646,6 +1690,22 @@ mod tests {
             assert_eq!(prepared.documents[0].index, open.then_some(0));
             assert_eq!(prepared.documents[0].uri, uri(&path));
             assert_eq!(prepared.documents[0].contents, "before base after");
+            assert_eq!(
+                prepared.documents[0].edit_batches,
+                vec![
+                    vec![PreparedWorkspaceTextEdit {
+                        start: 0,
+                        end: 0,
+                        new_text: "before ".to_string(),
+                    }],
+                    vec![PreparedWorkspaceTextEdit {
+                        start: 11,
+                        end: 11,
+                        new_text: " after".to_string(),
+                    }],
+                ],
+                "open: {open}"
+            );
             assert_eq!(fs::read_to_string(&path).unwrap(), "base");
         }
     }
@@ -2509,6 +2569,7 @@ mod tests {
                 dirty: true,
                 exists: true,
                 text_changed: true,
+                edit_batches: Vec::new(),
                 resource_changed: false,
             },
         )]);


### PR DESCRIPTION
Applying an LSP code action currently replays the prepared workspace edit as a full-buffer replacement. The diagnostic rebase logic therefore treats every range as edited and removes all diagnostics immediately, even when the action only inserts an import and the buffer has not been saved.

Preserve the validated text-edit batches produced during workspace-edit preparation and replay their precise Unicode scalar ranges in protocol order. Each batch is applied from the end inside the existing LSP undo transaction, so unaffected push and pull diagnostics remain attached to their source lines until their respective server channel publishes a fresh report. Atomic validation, resource-operation ordering, and the final-content invariant remain unchanged.

The regression test covers an unsaved import code action, verifies that push and pull diagnostics move with the inserted line, and confirms that each channel clears only when that channel refreshes.

## How to Test

1. Run `cargo test --lib workspace_edit_rebases_diagnostics_until_each_channel_refreshes`. Expect the unsaved import edit to retain and rebase both diagnostic channels, then clear each only on its own refresh.
2. Run `cargo test --lib lsp::workspace_edit::tests`. Expect all workspace-edit ordering, rename, validation, and rollback tests to pass.
3. Open a Rust file with several diagnostics and accept an import quick fix. Before saving, expect the other diagnostics to remain visible on their shifted lines until rust-analyzer publishes updated diagnostics.
4. Run `cargo clippy --all-targets --all-features -- -D warnings` and expect no warnings.
