### PR TITLE
fix(notifications): make routine errors non-intrusive

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -16012,10 +16012,7 @@ impl Editor {
             if runtime.command_plugin(cmd).is_some() {
                 return vec![Action::PluginCommand(cmd.to_string())];
             }
-            self.set_notification_message(
-                Severity::Error,
-                Some(format!("unknown command {cmd:?}")),
-            );
+            self.set_routine_error(Some(format!("unknown command {cmd:?}")));
             return vec![];
         };
 
@@ -43843,15 +43840,16 @@ while True:
 
     #[tokio::test]
     async fn command_feedback_renders_after_prompt_closes() {
-        for (command, dirty, expected, marker) in [
+        for (command, dirty, expected, marker, needs_attention) in [
             (
                 "q",
                 true,
                 "The following buffers have unwritten changes: [No Name]",
                 "",
+                false,
             ),
-            ("w", true, "No file name", "× "),
-            ("xyz", false, "unknown command \"xyz\"", "× "),
+            ("w", true, "No file name", "× ", true),
+            ("xyz", false, "unknown command \"xyz\"", "× ", false),
         ] {
             let mut editor = test_editor(100, 5);
             editor.current_buffer_mut().dirty = dirty;
@@ -43873,13 +43871,13 @@ while True:
             assert!(!processed.quit, "command {command:?} unexpectedly quit");
             assert_eq!(editor.last_error.as_deref(), Some(expected));
             let row = render_row(&render_buffer, 4);
-            let message = if marker.is_empty() {
-                assert!(!row.contains(":messages"));
-                row.trim_end()
-            } else {
+            let message = if needs_attention {
                 row.trim_end()
                     .strip_suffix("[1 needs attention · :messages]")
                     .expect("errors should include the attention badge")
+            } else {
+                assert!(!row.contains(":messages"));
+                row.trim_end()
             };
             assert_eq!(message.trim_end(), format!("{marker}{expected}"));
         }

--- a/src/editor/notifications.rs
+++ b/src/editor/notifications.rs
@@ -131,6 +131,10 @@ impl Editor {
         self.set_message_with_attention(Severity::Info, AttentionPolicy::Quiet, message);
     }
 
+    pub(super) fn set_routine_error(&mut self, message: Option<String>) {
+        self.set_message_with_attention(Severity::Error, AttentionPolicy::Quiet, message);
+    }
+
     pub(super) fn set_notification_message(&mut self, severity: Severity, message: Option<String>) {
         self.set_message_with_attention(severity, AttentionPolicy::for_severity(severity), message);
     }
@@ -887,6 +891,17 @@ mod tests {
         assert_eq!(
             editor.notifications.records().next().unwrap().severity,
             Severity::Error
+        );
+        assert_eq!(
+            editor.notifications.records().next().unwrap().attention,
+            AttentionPolicy::Quiet
+        );
+        assert_eq!(
+            editor
+                .notifications
+                .counts(Instant::now())
+                .needs_acknowledgment,
+            0
         );
         assert_eq!(
             editor.handle_command("messages", &runtime),

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -296,11 +296,15 @@ impl Notice {
         self
     }
 
+    /// Sets both the user's attention obligation and its matching foreground lifetime.
     pub fn with_attention(mut self, attention: AttentionPolicy) -> Self {
         self.attention = attention;
-        if attention == AttentionPolicy::RequiresAcknowledgment {
-            self.lifetime = NoticeLifetime::UntilAcknowledged;
-        }
+        self.lifetime = match attention {
+            AttentionPolicy::Quiet | AttentionPolicy::IfMissed => {
+                NoticeLifetime::Transient(DEFAULT_NOTICE_DURATION)
+            }
+            AttentionPolicy::RequiresAcknowledgment => NoticeLifetime::UntilAcknowledged,
+        };
         self
     }
 

--- a/src/notification/tests.rs
+++ b/src/notification/tests.rs
@@ -19,16 +19,19 @@ fn quiet_feedback_is_retained_without_unread_attention() {
     for notice in [
         notice(Severity::Success, "saved"),
         notice(Severity::Info, "copied").with_attention(AttentionPolicy::Quiet),
+        notice(Severity::Error, "unknown command").with_attention(AttentionPolicy::Quiet),
     ] {
         center.publish(notice, now).unwrap();
     }
     for at in [now, later(now, 10)] {
         let counts = center.counts(at.monotonic);
-        assert_eq!(counts.total, 2);
+        assert_eq!(counts.total, 3);
         assert_eq!(counts.unread, 0);
         assert_eq!(counts.unseen, 0);
         assert_eq!(counts.needs_acknowledgment, 0);
     }
+    assert_eq!(center.counts(now.monotonic).active, 3);
+    assert_eq!(center.counts(later(now, 10).monotonic).active, 0);
 }
 
 #[test]

--- a/tests/notifications.rs
+++ b/tests/notifications.rs
@@ -46,7 +46,7 @@ async fn message_history_routes_real_keys_through_search_acknowledgement_and_cle
     }
     let status = harness.commandline_row();
     assert!(status.contains("unknown command \"bad-two\""), "{status}");
-    assert!(status.contains("2 need attention"), "{status}");
+    assert!(!status.contains(":messages"), "{status}");
 
     text(&mut harness, " m").await;
     let dialog = dialog_text(&mut harness);


### PR DESCRIPTION
Unknown Ex commands are immediate feedback about input the user just submitted. Treating them as acknowledgment-required errors leaves a typo active indefinitely, lets it resurface after newer messages, and makes the bottom-line attention badge imply an unresolved problem.

This change keeps unknown commands styled as errors and retained in message history, while classifying them as quiet, transient feedback. Attention overrides now select the matching foreground lifetime, so quiet and missed-only notices expire while acknowledgment-required conditions remain active.

## How to Test

1. Enter an unknown command such as `:not-a-command`. Confirm the red error appears without a `needs attention` or `:messages` badge, disappears after the transient display period, and remains available in message history.
2. In an unnamed modified buffer, run `:write`. Confirm `No file name` still carries the `needs attention` badge, preserving the non-happy-path behavior for an unresolved save failure.
3. Run the focused notification coverage: `cargo test --lib notification::tests`, `cargo test --lib editor::notifications::tests`, and `cargo test --test notifications`.