### PR TITLE
feat(fidget): improve progress overlay rendering

### DIFF
--- a/plugins/fidget.hk
+++ b/plugins/fidget.hk
@@ -97,6 +97,9 @@ fn info_loaded(info: FidgetEditorInfo) {
         x_padding: 1,
         y_padding: 0,
         relative: "editor",
+        max_width: 60,
+        overflow: "truncate_left",
+        truncate_marker: "…",
     });
     refresh();
 }
@@ -325,30 +328,16 @@ fn refresh() {
                 if red::string(item.title, "") != "" {
                     text = text + " " + item.title;
                 }
-                lines = red::push(lines, (truncate_line(text), message_style()));
+                lines = red::push(lines, (text, message_style()));
                 count = count + 1;
             }
         }
     }
     let rendered: [(String, Style)] = [];
     for line in red::reverse(lines) {
-        rendered = red::push(rendered, (truncate_line(red::string(line[0], "")), line[1]));
+        rendered = red::push(rendered, (red::string(line[0], ""), line[1]));
     }
     red::execute("UpdateOverlay", "fidget-progress", rendered);
-}
-
-fn truncate_line(text: String) -> String {
-    let Some(info) = state().info else {
-        return text;
-    };
-    let width = red::int(info.size[0], 80) - 2;
-    if width <= 0 {
-        return "";
-    }
-    if red::len(text) <= width {
-        return text;
-    }
-    return red::slice(text, 0, width);
 }
 
 fn group_active(group: String) -> bool {
@@ -375,6 +364,7 @@ fn header_style() -> Style {
     if style == red::null() {
         return Style { fg: red::null(), bg: red::null(), bold: false, italic: false };
     }
+    style.bg = red::null();
     return style;
 }
 
@@ -386,6 +376,7 @@ fn message_style() -> Style {
     if style == red::null() {
         return Style { fg: red::null(), bg: red::null(), bold: false, italic: false };
     }
+    style.bg = red::null();
     return style;
 }
 

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -4289,6 +4289,7 @@ mod tests {
                     x_padding: 0,
                     y_padding: top + 2,
                     relative: "editor".into(),
+                    ..crate::plugin::OverlayConfig::default()
                 },
             )
             .update_content(vec![("Z".repeat(60), Style::default())]);

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -38,7 +38,7 @@ pub use document::{DocumentEdit, DocumentSnapshot};
 pub use gutter::{GutterSign, GutterSignManager};
 pub use location::{LocationColumnEncoding, OpenLocationTarget, PluginLocation};
 pub use metadata::PluginMetadata;
-pub use overlay::{OverlayAlignment, OverlayConfig, OverlayManager};
+pub use overlay::{OverlayAlignment, OverlayConfig, OverlayManager, OverlayOverflow};
 pub use panel::{
     PanelConfig, PanelManager, PanelManagerSnapshot, PanelRow, PanelRowKind, PanelSegment,
     PanelSessionSnapshot, PanelSide, PanelSnapshotKind, TextPanelBlock, TextPanelBlockFormat,

--- a/src/plugin/overlay.rs
+++ b/src/plugin/overlay.rs
@@ -13,7 +13,7 @@ use crate::{
     editor::{render_buffer::RenderBuffer, Point},
     theme::Style,
     ui::{spinner_frame, SPINNER_FRAME_INTERVAL_MS},
-    unicode_utils::display_width,
+    unicode_utils::{display_width, truncate_display_width_with_marker, TruncationSide},
 };
 
 #[derive(Debug, Clone, Deserialize)]
@@ -24,6 +24,14 @@ pub enum OverlayAlignment {
     AvoidCursor,
 }
 
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum OverlayOverflow {
+    TruncateRight,
+    #[default]
+    TruncateLeft,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct OverlayConfig {
@@ -31,6 +39,12 @@ pub struct OverlayConfig {
     pub x_padding: usize,
     pub y_padding: usize,
     pub relative: String, // "editor" or "window"
+    #[serde(default)]
+    pub max_width: usize,
+    #[serde(default)]
+    pub overflow: OverlayOverflow,
+    #[serde(default = "default_truncate_marker")]
+    pub truncate_marker: String,
 }
 
 impl Default for OverlayConfig {
@@ -40,8 +54,15 @@ impl Default for OverlayConfig {
             x_padding: 1,
             y_padding: 0,
             relative: "editor".to_string(),
+            max_width: 0,
+            overflow: OverlayOverflow::TruncateLeft,
+            truncate_marker: default_truncate_marker(),
         }
     }
+}
+
+fn default_truncate_marker() -> String {
+    "…".to_string()
 }
 
 #[derive(Debug)]
@@ -94,16 +115,19 @@ impl PluginOverlay {
 
     fn update_dimensions(&mut self) {
         self.height = self.content.lines.len();
-        self.width = self
+        let content_width = self
             .content
             .lines
             .iter()
             .map(|(text, _)| display_width(text))
             .max()
             .unwrap_or(0);
-        if self.busy_since.is_some() && self.has_content() {
-            self.width = self.width.saturating_add(2);
-        }
+        let busy_width = usize::from(self.busy_since.is_some() && self.has_content()) * 2;
+        let natural_width = content_width.saturating_add(busy_width);
+        self.width = match self.config.max_width {
+            0 => natural_width,
+            max_width => natural_width.min(max_width),
+        };
     }
 
     /// Enables or disables host-driven spinner animation for this overlay.
@@ -142,6 +166,11 @@ impl PluginOverlay {
         editor_height: usize,
         cursor_pos: Option<Point>,
     ) -> Point {
+        let previous_width = self.width;
+        self.update_dimensions();
+        self.width = self
+            .width
+            .min(editor_width.saturating_sub(self.config.x_padding));
         let x = if self.width + self.config.x_padding > editor_width {
             0
         } else {
@@ -178,7 +207,7 @@ impl PluginOverlay {
         };
 
         let position = Point::new(x, y);
-        if self.position != Some(position) {
+        if self.position != Some(position) || self.width != previous_width {
             self.content.dirty = true;
         }
         self.position = Some(position);
@@ -196,18 +225,25 @@ impl PluginOverlay {
                     break;
                 }
 
-                let rendered = if i == 0 {
-                    self.busy_since
-                        .map(|started| {
-                            format!(
-                                "{} {text}",
-                                spinner_frame(started.elapsed().as_millis() as u64)
-                            )
-                        })
-                        .unwrap_or_else(|| text.clone())
+                let spinner = if i == 0 {
+                    self.busy_since.map(|started| {
+                        format!("{} ", spinner_frame(started.elapsed().as_millis() as u64))
+                    })
                 } else {
-                    text.clone()
+                    None
                 };
+                let spinner_width = spinner.as_deref().map(display_width).unwrap_or(0);
+                let text_width = self.width.saturating_sub(spinner_width);
+                let text = truncate_display_width_with_marker(
+                    text,
+                    text_width,
+                    &self.config.truncate_marker,
+                    match self.config.overflow {
+                        OverlayOverflow::TruncateRight => TruncationSide::Right,
+                        OverlayOverflow::TruncateLeft => TruncationSide::Left,
+                    },
+                );
+                let rendered = spinner.unwrap_or_default() + &text;
                 let text_width = display_width(&rendered);
                 let text_x = pos.x.saturating_add(self.width.saturating_sub(text_width));
                 buffer.set_text(text_x, y, &rendered, style);
@@ -316,7 +352,7 @@ mod tests {
         theme::Style,
     };
 
-    use super::{OverlayManager, PluginOverlay, SPINNER_FRAME_INTERVAL_MS};
+    use super::{OverlayManager, OverlayOverflow, PluginOverlay, SPINNER_FRAME_INTERVAL_MS};
 
     fn render_row(buffer: &RenderBuffer, y: usize) -> String {
         buffer.cells[y * buffer.width..(y + 1) * buffer.width]
@@ -401,6 +437,50 @@ mod tests {
 
         assert_eq!(row(0), "...long.");
         assert_eq!(row(1), ".....👋 .");
+    }
+
+    #[test]
+    fn overlay_max_width_left_truncates_by_display_width() {
+        let mut overlay = PluginOverlay::new(
+            "progress".to_string(),
+            OverlayConfig {
+                align: OverlayAlignment::Top,
+                x_padding: 0,
+                max_width: 6,
+                overflow: OverlayOverflow::TruncateLeft,
+                ..OverlayConfig::default()
+            },
+        );
+        overlay.update_content(vec![("prefix/👋end".to_string(), Style::default())]);
+        overlay.calculate_position(10, 6, None);
+
+        let mut buffer = RenderBuffer::new(10, 6, &Style::default());
+        overlay.render(&mut buffer);
+
+        assert_eq!(overlay.width, 6);
+        assert_eq!(render_row(&buffer, 0), "    …👋 end");
+    }
+
+    #[test]
+    fn overlay_width_recovers_after_a_narrow_terminal_resize() {
+        let mut overlay = PluginOverlay::new(
+            "progress".to_string(),
+            OverlayConfig {
+                align: OverlayAlignment::Top,
+                max_width: 60,
+                ..OverlayConfig::default()
+            },
+        );
+        overlay.update_content(vec![(
+            "a reasonably long progress message".into(),
+            Style::default(),
+        )]);
+
+        overlay.calculate_position(12, 6, None);
+        assert_eq!(overlay.width, 11);
+
+        overlay.calculate_position(80, 6, None);
+        assert_eq!(overlay.width, 34);
     }
 
     #[test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -12479,12 +12479,38 @@ mod tests {
         runtime
             .resolve_request(
                 request_id,
-                serde_json::json!({ "size": [80, 24], "theme": { "ui_style": {} } }),
+                serde_json::json!({
+                    "size": [80, 24],
+                    "theme": {
+                        "ui_style": {
+                            "muted": {
+                                "fg": { "Rgb": { "r": 153, "g": 153, "b": 153 } },
+                                "bg": { "Rgb": { "r": 17, "g": 17, "b": 17 } },
+                                "bold": false,
+                                "italic": false
+                            },
+                            "popup_title": {
+                                "fg": { "Rgb": { "r": 238, "g": 238, "b": 238 } },
+                                "bg": { "Rgb": { "r": 34, "g": 34, "b": 34 } },
+                                "bold": true,
+                                "italic": false
+                            }
+                        }
+                    }
+                }),
             )
             .await
             .unwrap();
         match ACTION_DISPATCHER.recv_request() {
-            PluginRequest::CreateOverlay { id, .. } => assert_eq!(id, "fidget-progress"),
+            PluginRequest::CreateOverlay { id, config } => {
+                assert_eq!(id, "fidget-progress");
+                assert_eq!(config.max_width, 60);
+                assert!(matches!(
+                    config.overflow,
+                    crate::plugin::OverlayOverflow::TruncateLeft
+                ));
+                assert_eq!(config.truncate_marker, "…");
+            }
             _ => panic!("unexpected plugin request"),
         }
         match ACTION_DISPATCHER.recv_request() {
@@ -12517,6 +12543,7 @@ mod tests {
                 assert_eq!(lines.len(), 2);
                 assert_eq!(lines[0].0, "Loading (25%) Indexing");
                 assert_eq!(lines[1].0, "rust-analyzer ⠋");
+                assert!(lines.iter().all(|(_, style)| style.bg.is_none()));
             }
             _ => panic!("unexpected plugin request"),
         }


### PR DESCRIPTION
Long LSP progress messages can stretch across most of the editor, and Fidget currently inherits popup backgrounds that make the overlay look like an opaque block. This keeps progress visible without letting it dominate the editing surface.

- add optional maximum-width and overflow behavior to generic plugin overlays
- truncate by terminal display width with a configurable Unicode marker while preserving the useful suffix
- configure Fidget for a 60-column cap and transparent header/message backgrounds
- recompute the effective width across narrow and wide terminal resizes

## How to Test

1. Open a large Rust workspace with Fidget enabled and wait for rust-analyzer progress. Confirm the bottom-right overlay uses the editor background and long paths are capped with a leading `…` while retaining their suffix.
2. Resize the terminal narrower and then wider while progress is visible. Confirm the overlay stays inside the viewport and returns to its configured width after expanding.
3. Run `cargo test -p red plugin::overlay::tests --lib` and `cargo test -p red fidget_ --lib`; the overlay width, Unicode truncation, resize recovery, styling, and progress regressions should pass.