### PR TITLE
feat(editor): support newlines in substitute replacements

### DIFF
--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Red Vim compatibility matrix
 
-**Matrix version:** 1.8
+**Matrix version:** 1.9
 **Validated against:** Red 0.5.0, August 2026
 **Status vocabulary:** **supported**, **intentional difference**, **not yet supported**
 
@@ -62,7 +62,7 @@ the corresponding integration tests.
 | Search syntax | **intentional difference** | Patterns use Rust `regex` syntax rather than Vim's regex dialect. |
 | Substitute ranges | **supported** | Current line, `%`, one-based numeric line/range, and `'<,'>` last-Visual range. Visual `:` prefills that range, so substitution applies to every line touched by character, line, or block selections. |
 | Substitute flags | **supported** | `g`, `i`, and explicit `c` confirmation with `y/n/a/q/l`. All accepted replacements from one command form one transaction. |
-| Substitute syntax | **intentional difference** | Patterns and capture expansion use Rust `regex`; delimiters may be escaped. Vim magic modes, expression replacement, and omitted trailing delimiters are not supported. |
+| Substitute syntax | **intentional difference** | Patterns and capture expansion use Rust `regex`; delimiters may be escaped. Replacement `\r` splits the line and preserves its LF or CRLF ending, and `\\` inserts one backslash. Captures use Rust forms such as `$0`, `$1`, and `$name`, rather than Vim's `&`, `\0`, and `\1`. Unlike Neovim, `\n` remains the two literal characters instead of inserting NUL. Vim magic modes, expression replacement, and omitted trailing delimiters are not supported. |
 | Undo/redo | **supported** | Linear, per-buffer transactions with dirty-state checkpoints. |
 | Undo tree | **supported** | Undo followed by a new edit creates a sibling branch. `g-`/`g+` select a sibling deterministically and redo traverses it; `:undotree` opens the small visual navigator. |
 | Jumplist | **supported** | Search, long/file motions, structural motions, and structural swaps record window-local jumps; splits copy their source window's list, positions follow edits, same-line entries are cleaned up, and `Ctrl-o` / `Ctrl-i` (`Tab`) traverse backward/forward without discarding the forward branch. |

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -915,6 +915,39 @@ fn parse_substitute_segment(input: &str, delimiter: char) -> anyhow::Result<(Str
     anyhow::bail!("substitute is missing a closing {delimiter}")
 }
 
+fn decode_substitute_replacement(input: &str) -> String {
+    let mut decoded = String::with_capacity(input.len());
+    let mut characters = input.chars();
+    while let Some(character) = characters.next() {
+        if character != '\\' {
+            decoded.push(character);
+            continue;
+        }
+
+        match characters.next() {
+            Some('r') => decoded.push('\n'),
+            Some('\\') => decoded.push('\\'),
+            Some(character) => {
+                decoded.push('\\');
+                decoded.push(character);
+            }
+            None => decoded.push('\\'),
+        }
+    }
+    decoded
+}
+
+fn substitute_replacement_with_line_ending<'a>(
+    replacement: &'a str,
+    line_ending: &str,
+) -> Cow<'a, str> {
+    if line_ending == "\n" || !replacement.contains('\n') {
+        Cow::Borrowed(replacement)
+    } else {
+        Cow::Owned(replacement.replace('\n', line_ending))
+    }
+}
+
 #[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EditorViewState {
@@ -15674,6 +15707,7 @@ impl Editor {
         let body = &body[delimiter.len_utf8()..];
         let (pattern, remainder) = parse_substitute_segment(body, delimiter)?;
         let (replacement, flags) = parse_substitute_segment(remainder, delimiter)?;
+        let replacement = decode_substitute_replacement(&replacement);
         anyhow::ensure!(!pattern.is_empty(), "substitute pattern cannot be empty");
         anyhow::ensure!(
             flags
@@ -16211,6 +16245,15 @@ impl Editor {
             .build()
             .map_err(|error| anyhow::anyhow!("invalid substitute pattern: {error}"))?;
         let mut substitutions = Vec::new();
+        let default_line_ending = if self
+            .current_buffer()
+            .get(0)
+            .is_some_and(|line| line.ends_with("\r\n"))
+        {
+            "\r\n"
+        } else {
+            "\n"
+        };
         let snapshot = self.current_buffer().contents_snapshot();
         let mut line_start = snapshot.line_to_char(command.start_line);
         for (offset, contents) in snapshot
@@ -16224,6 +16267,15 @@ impl Editor {
                 .as_str()
                 .map(Cow::Borrowed)
                 .unwrap_or_else(|| Cow::Owned(contents.to_string()));
+            let line_ending = if contents.ends_with("\r\n") {
+                "\r\n"
+            } else if contents.ends_with('\n') {
+                "\n"
+            } else {
+                default_line_ending
+            };
+            let replacement =
+                substitute_replacement_with_line_ending(&command.replacement, line_ending);
             let line = contents
                 .strip_suffix("\r\n")
                 .or_else(|| contents.strip_suffix('\n'))
@@ -16252,21 +16304,21 @@ impl Editor {
                 });
             };
 
-            if command.replacement.contains('$') {
+            if replacement.contains('$') {
                 for captures in regex.captures_iter(line) {
                     let matched = captures
                         .get(/*index*/ 0)
                         .expect("regex captures always include the full match");
-                    let mut replacement = String::new();
-                    captures.expand(&command.replacement, &mut replacement);
-                    append(matched, replacement);
+                    let mut replacement_text = String::new();
+                    captures.expand(&replacement, &mut replacement_text);
+                    append(matched, replacement_text);
                     if !command.replace_all {
                         break;
                     }
                 }
             } else {
                 for matched in regex.find_iter(line) {
-                    append(matched, command.replacement.clone());
+                    append(matched, replacement.to_string());
                     if !command.replace_all {
                         break;
                     }

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -1676,6 +1676,58 @@ async fn substitute_uses_rust_regex_captures_and_escaped_delimiters() {
 }
 
 #[tokio::test]
+async fn visual_substitute_replacement_supports_vim_line_breaks() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "one two\nthree four\nkeep same".to_string()),
+        default_key_config(),
+    );
+    harness
+        .execute_action(Action::EnterMode(Mode::VisualLine))
+        .await
+        .unwrap();
+    harness.execute_action(Action::MoveDown).await.unwrap();
+
+    command_key(&mut harness, KeyCode::Char(':')).await;
+    type_normal_keys(&mut harness, r"s/ /\r/g").await;
+    command_key(&mut harness, KeyCode::Enter).await;
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_buffer_contents("one\ntwo\nthree\nfour\nkeep same");
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("one two\nthree four\nkeep same");
+}
+
+#[tokio::test]
+async fn substitute_line_break_replacement_preserves_crlf() {
+    let buffer = Buffer::new(None, "one two\r\nthree four\r\n".to_string());
+    let mut harness = EditorHarness::with_config(buffer, default_key_config());
+
+    harness
+        .execute_action(Action::Command(r"%s/ /\r/g".to_string()))
+        .await
+        .unwrap();
+
+    harness.assert_buffer_contents("one\r\ntwo\r\nthree\r\nfour\r\n");
+}
+
+#[tokio::test]
+async fn substitute_replacement_preserves_non_newline_escapes() {
+    let mut harness = EditorHarness::with_content("value");
+    harness
+        .execute_action(Action::Command(r"s/value/\n/".to_string()))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents(r"\n");
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness
+        .execute_action(Action::Command(r"s/value/\\r/".to_string()))
+        .await
+        .unwrap();
+    harness.assert_buffer_contents(r"\r");
+}
+
+#[tokio::test]
 async fn substitute_does_not_match_the_carriage_return_in_crlf_buffers() {
     let buffer = Buffer::new(None, "abc\r\ndef\r\n".to_string());
     let mut harness = EditorHarness::with_config(buffer, default_key_config());


### PR DESCRIPTION
Visual-range substitutions could only insert literal escape text, leaving no interactive way to split matches into new lines.

This adds Vim-style `\r` decoding for substitute replacement templates before Rust capture expansion. Inserted line breaks preserve the target line LF or CRLF ending, while `\\` inserts a literal backslash. The compatibility matrix documents the remaining Rust-regex differences, including `$0`/`$1`/`$name` captures and literal `\n` behavior.

Focused integration coverage exercises the Visual-line command path, undo, CRLF preservation, and non-newline escapes.

## How to Test

1. Select two lines containing spaces in Visual-line mode, press `:`, and run `s/ /\r/g`.
   Expected: every selected space becomes a line break, and one undo restores the original selected lines.
2. Run `cargo test --test editing substitute_`.
   Expected: all 11 substitution tests pass, including `visual_substitute_replacement_supports_vim_line_breaks`, `substitute_line_break_replacement_preserves_crlf`, and `substitute_replacement_preserves_non_newline_escapes`.