### PR TITLE
feat(editor): warn on empty command targets

### DIFF
--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -3865,7 +3865,7 @@ fn hunk_cursor_loaded(cursor: GitCursorPosition) {
         selected = patch_for_hunk(patch, red::int(cursor.y, 0));
     }
     if selected == "" {
-        red::execute("Print", "No Git hunk under cursor");
+        red::execute("PrintWarning", "No Git hunk under cursor");
         return;
     }
     red::state_patch(GitPluginState { hunk_patch: selected });

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -354,7 +354,7 @@ fn show_document_symbols(result: SymbolsResult, request_id: i32) {
 
     let count = red::len(result.symbols);
     if count == 0 {
-        red::execute("Print", "No document symbols found");
+        red::execute("PrintWarning", "No document symbols found");
         return;
     }
 
@@ -606,7 +606,7 @@ fn show_references(result: ReferencesResult, request_id: i32) {
         }
         finish_symbol_flow();
         red::execute("ClosePicker", handle);
-        red::execute("Print", "No references found");
+        red::execute("PrintWarning", "No references found");
         return;
     }
     if count == 1 {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -5731,7 +5731,7 @@ impl Editor {
             crate::window::Direction::Left => "no window to the left",
             crate::window::Direction::Right => "no window to the right",
         };
-        self.set_legacy_message(Some(message.to_string()));
+        self.set_routine_warning(Some(message.to_string()));
         self.draw_commandline(buffer);
         Ok(())
     }
@@ -14404,15 +14404,17 @@ impl Editor {
                     }
 
                     if method == "textDocument/definition" {
-                        let result = match msg.result {
+                        let definition = match msg.result {
                             serde_json::Value::Array(ref arr) => {
-                                arr.first().and_then(|value| value.as_object())?
+                                arr.first().and_then(|value| value.as_object())
                             }
-                            serde_json::Value::Object(ref obj) => obj,
-                            _ => return None,
+                            serde_json::Value::Object(ref obj) => Some(obj),
+                            _ => None,
                         };
-
-                        return self.go_to_definition(result);
+                        return definition.map_or_else(
+                            || Some(Action::PrintWarning("No definition found".to_string())),
+                            |definition| self.go_to_definition(definition),
+                        );
                     }
 
                     if method == "textDocument/hover" {
@@ -16691,14 +16693,23 @@ impl Editor {
         self.set_legacy_message(None);
     }
 
-    fn finish_search_with_error(&mut self, session: SearchSession, error: String) {
+    fn finish_search_session(&mut self, session: SearchSession) {
         self.restore_search_origin(&session.origin, session.origin_vtop);
         self.search_term = session.draft;
         self.search_direction = session.direction;
         self.search_highlights_suppressed = false;
         self.active_search = None;
         self.mode = Mode::Normal;
+    }
+
+    fn finish_search_with_error(&mut self, session: SearchSession, error: String) {
+        self.finish_search_session(session);
         self.set_legacy_message(Some(error));
+    }
+
+    fn finish_search_without_match(&mut self, session: SearchSession, message: String) {
+        self.finish_search_session(session);
+        self.set_routine_warning(Some(message));
     }
 
     fn pattern_not_found_message(pattern: &str) -> String {
@@ -16736,7 +16747,7 @@ impl Editor {
             .to_string();
         if pattern.is_empty() {
             if self.active_search.is_none() {
-                self.set_legacy_message(Some("no previous search".to_string()));
+                self.set_routine_warning(Some("no previous search".to_string()));
                 self.draw_commandline(buffer);
             }
             return Ok(false);
@@ -16757,7 +16768,13 @@ impl Editor {
             }
         };
         if let Some(match_) = matched {
-            self.set_legacy_message(None);
+            let wrapped = self.config.search.wrapscan
+                && self.search_match_wrapped(match_, &origin, direction);
+            if wrapped {
+                self.set_search_wrap_warning(direction);
+            } else {
+                self.set_legacy_message(None);
+            }
             self.search_highlights_suppressed = false;
             self.move_to_search_match(match_);
             if let Some(active_search) = &mut self.active_search {
@@ -16766,11 +16783,33 @@ impl Editor {
             self.render(buffer)?;
             return Ok(true);
         } else {
-            self.set_legacy_message(Some(Self::pattern_not_found_message(&pattern)));
+            self.set_routine_warning(Some(Self::pattern_not_found_message(&pattern)));
             self.render(buffer)?;
         }
 
         Ok(false)
+    }
+
+    fn search_match_wrapped(
+        &self,
+        match_: SearchMatch,
+        origin: &HistoryEntry,
+        direction: SearchDirection,
+    ) -> bool {
+        let origin = (origin.y, self.grapheme_to_char_on_line(origin.x, origin.y));
+        let target = (match_.start_y, match_.start_x);
+        match direction {
+            SearchDirection::Forward => target <= origin,
+            SearchDirection::Backward => target >= origin,
+        }
+    }
+
+    fn set_search_wrap_warning(&mut self, direction: SearchDirection) {
+        let message = match direction {
+            SearchDirection::Forward => "search hit BOTTOM, continuing at TOP",
+            SearchDirection::Backward => "search hit TOP, continuing at BOTTOM",
+        };
+        self.set_routine_warning(Some(message.to_string()));
     }
 
     fn reset_command_history_navigation(&mut self) {
@@ -17741,7 +17780,7 @@ impl Editor {
                     self.vertical_motion_range(pending.count(), true),
                     "no line above cursor",
                 ),
-                '%' => self.operator_action_for_range(
+                '%' => self.operator_action_for_warning_range(
                     pending.operator,
                     self.matchit_motion_range(MatchDirection::Forward),
                     "match not found",
@@ -17846,7 +17885,7 @@ impl Editor {
             },
             PendingOperatorStep::FindForward => {
                 self.last_character_motion = Some((ForwardCharacterMotion::Find, c));
-                self.operator_action_for_range(
+                self.operator_action_for_warning_range(
                     pending.operator,
                     self.find_forward_motion_range(c, pending.count()),
                     "character not found",
@@ -17854,7 +17893,7 @@ impl Editor {
             }
             PendingOperatorStep::TillForward => {
                 self.last_character_motion = Some((ForwardCharacterMotion::Till, c));
-                self.operator_action_for_range(
+                self.operator_action_for_warning_range(
                     pending.operator,
                     self.till_forward_motion_range(c, pending.count()),
                     "character not found",
@@ -17862,7 +17901,7 @@ impl Editor {
             }
             PendingOperatorStep::FindBackward => {
                 self.last_character_motion = Some((ForwardCharacterMotion::FindBackward, c));
-                self.operator_action_for_range(
+                self.operator_action_for_warning_range(
                     pending.operator,
                     self.find_backward_motion_range(c, pending.count()),
                     "character not found",
@@ -17870,7 +17909,7 @@ impl Editor {
             }
             PendingOperatorStep::TillBackward => {
                 self.last_character_motion = Some((ForwardCharacterMotion::TillBackward, c));
-                self.operator_action_for_range(
+                self.operator_action_for_warning_range(
                     pending.operator,
                     self.till_backward_motion_range(c, pending.count()),
                     "character not found",
@@ -17979,6 +18018,21 @@ impl Editor {
             if self.last_error.is_none() {
                 self.set_navigation_boundary_warning(target);
             }
+            return Some(KeyAction::None);
+        }
+        self.operator_action_for_range(operator, range, "")
+    }
+
+    fn operator_action_for_warning_range(
+        &mut self,
+        operator: EditOperator,
+        range: Option<TextRange>,
+        warning: &str,
+    ) -> Option<KeyAction> {
+        if range.is_none() {
+            self.pending_operator = None;
+            self.waiting_command = None;
+            self.set_routine_warning(Some(warning.to_string()));
             return Some(KeyAction::None);
         }
         self.operator_action_for_range(operator, range, "")
@@ -19658,7 +19712,7 @@ impl Editor {
                     self.notify_change(runtime).await?;
                     self.finish_cursor_motion(buffer, false)?;
                 } else if self.last_error.is_none() {
-                    self.set_legacy_message(Some("adjacent text object not found".to_string()));
+                    self.set_routine_warning(Some("adjacent text object not found".to_string()));
                 }
             }
             Action::StartCommentOperator(count)
@@ -20627,6 +20681,9 @@ impl Editor {
                         .goto_definition(&file, position.character, position.line)
                         .await?;
                     self.pending_definition_requests.insert(request_id);
+                } else {
+                    self.set_routine_warning(Some("No definition found".to_string()));
+                    self.draw_commandline(buffer);
                 }
             }
             Action::Hover => {
@@ -20644,6 +20701,11 @@ impl Editor {
                     self.release_current_dialog_callbacks(runtime);
                     self.current_dialog = Some(Box::new(popup));
                     self.render(buffer)?;
+                } else {
+                    self.set_routine_warning(Some(
+                        "No diagnostics on the current line".to_string(),
+                    ));
+                    self.draw_commandline(buffer);
                 }
             }
             Action::NextDiagnostic | Action::PreviousDiagnostic => {
@@ -21312,16 +21374,23 @@ impl Editor {
                         self.config.search.wrapscan,
                     ) else {
                         let error = Self::pattern_not_found_message(&session.draft);
-                        self.finish_search_with_error(session, error);
+                        self.finish_search_without_match(session, error);
                         self.render(buffer)?;
                         return Ok(false);
                     };
+                    let wrapped = self.config.search.wrapscan
+                        && self.search_match_wrapped(match_, &session.origin, session.direction);
 
                     self.search_term = session.draft;
                     self.search_direction = session.direction;
                     self.search_highlights_suppressed = false;
                     self.active_search = None;
                     self.mode = Mode::Normal;
+                    if wrapped {
+                        self.set_search_wrap_warning(session.direction);
+                    } else {
+                        self.set_legacy_message(None);
+                    }
                     self.move_to_search_match(match_);
                     self.save_to_history(session.jump_origin);
                     self.render(buffer)?;
@@ -22369,7 +22438,7 @@ impl Editor {
                     self.remember_previous_context(self.current_jump_entry());
                     self.jump_to_entry(&entry, buffer, runtime).await?;
                 } else {
-                    self.set_legacy_message(Some("at start of jump list".to_string()));
+                    self.set_routine_warning(Some("at start of jump list".to_string()));
                     self.draw_commandline(buffer);
                 }
             }
@@ -22384,7 +22453,7 @@ impl Editor {
                     self.remember_previous_context(self.current_jump_entry());
                     self.jump_to_entry(&entry, buffer, runtime).await?;
                 } else {
-                    self.set_legacy_message(Some("at end of jump list".to_string()));
+                    self.set_routine_warning(Some("at end of jump list".to_string()));
                     self.draw_commandline(buffer);
                 }
             }
@@ -25969,7 +26038,7 @@ impl Editor {
             self.move_to_text_position(position);
             self.finish_cursor_motion(buffer, false)?;
         } else {
-            self.set_legacy_message(Some("character not found".to_string()));
+            self.set_routine_warning(Some("character not found".to_string()));
         }
         Ok(())
     }
@@ -25983,7 +26052,7 @@ impl Editor {
             self.move_to_text_position(motion.target);
             self.finish_cursor_motion(buffer, false)?;
         } else {
-            self.set_legacy_message(Some("match not found".to_string()));
+            self.set_routine_warning(Some("match not found".to_string()));
         }
         Ok(())
     }
@@ -26099,7 +26168,7 @@ impl Editor {
         buffer.refresh_dirty();
 
         let Some((cursor, edits)) = outcome else {
-            self.set_legacy_message(Some("already at oldest change".to_string()));
+            self.set_routine_warning(Some("already at oldest change".to_string()));
             self.draw_commandline(render_buffer);
             return Ok(());
         };
@@ -26131,7 +26200,7 @@ impl Editor {
         buffer.refresh_dirty();
 
         let Some((cursor, edits)) = outcome else {
-            self.set_legacy_message(Some("already at newest change".to_string()));
+            self.set_routine_warning(Some("already at newest change".to_string()));
             self.draw_commandline(render_buffer);
             return Ok(());
         };
@@ -40123,6 +40192,48 @@ builtin = "rust"
     }
 
     #[test]
+    fn empty_definition_response_returns_a_warning_action() {
+        let mut editor = test_editor(40, 10);
+
+        for result in [Value::Null, json!([])] {
+            let message = InboundMessage::Message(ResponseMessage {
+                id: 42,
+                result,
+                request: Some(crate::lsp::Request::new(
+                    "textDocument/definition",
+                    json!({}),
+                )),
+            });
+
+            assert!(matches!(
+                editor.handle_lsp_message(
+                    &message,
+                    Some("textDocument/definition".to_string())
+                ),
+                Some(Action::PrintWarning(message)) if message == "No definition found"
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn go_to_definition_warns_without_a_file_backed_buffer() {
+        let mut editor = test_editor(40, 10);
+        let mut buffer = RenderBuffer::new(40, 10, &Style::default());
+        let mut runtime = Runtime::new();
+
+        editor
+            .execute(&Action::GoToDefinition, &mut buffer, &mut runtime)
+            .await
+            .unwrap();
+
+        assert_eq!(editor.last_error.as_deref(), Some("No definition found"));
+        assert_eq!(
+            editor.notifications.records().next_back().unwrap().severity,
+            Severity::Warning
+        );
+    }
+
+    #[test]
     fn non_plugin_lsp_timeout_sets_last_error() {
         let mut editor = test_editor(40, 10);
         let message = InboundMessage::RequestError {
@@ -40642,7 +40753,7 @@ builtin = "rust"
     }
 
     #[tokio::test]
-    async fn show_line_diagnostics_is_a_safe_noop_without_a_matching_diagnostic() {
+    async fn show_line_diagnostics_warns_without_a_matching_diagnostic() {
         let root = tempfile::tempdir().unwrap();
         let file = root.path().join("main.py");
         let mut editor = lsp_test_editor(vec![Buffer::new(
@@ -40672,6 +40783,13 @@ builtin = "rust"
 
         assert!(editor.current_dialog.is_none());
         assert_eq!(editor.current_buffer().contents(), original);
+        assert_eq!(
+            editor.last_error.as_deref(),
+            Some("No diagnostics on the current line")
+        );
+        let warning = editor.notifications.records().next_back().unwrap();
+        assert_eq!(warning.severity, Severity::Warning);
+        assert_eq!(warning.attention, AttentionPolicy::Quiet);
     }
 
     #[tokio::test]

--- a/src/editor/inline_comments.rs
+++ b/src/editor/inline_comments.rs
@@ -1122,7 +1122,7 @@ impl Editor {
             .collect::<Vec<_>>();
         indices.sort_by_key(|&(index, start)| (start, index));
         if indices.is_empty() {
-            self.set_legacy_message(Some("no inline comments in this buffer".into()));
+            self.set_routine_warning(Some("no inline comments in this buffer".into()));
             return;
         }
         let current = self.current_inline_comment_index().and_then(|index| {
@@ -1222,7 +1222,7 @@ impl Editor {
             }
             self.layout_cache.borrow_mut().clear();
         } else {
-            self.set_legacy_message(Some("no inline comment at the cursor".into()));
+            self.set_routine_warning(Some("no inline comment at the cursor".into()));
         }
     }
 
@@ -1237,7 +1237,7 @@ impl Editor {
         self.check_bounds();
         self.sync_to_window();
         let Some(index) = self.current_inline_comment_index() else {
-            self.set_legacy_message(Some("no inline comment at the cursor".into()));
+            self.set_routine_warning(Some("no inline comment at the cursor".into()));
             return;
         };
         let comment = &self.inline_comments[index];

--- a/src/editor/inline_comments/tests.rs
+++ b/src/editor/inline_comments/tests.rs
@@ -740,6 +740,29 @@ async fn inline_comment_navigation_participates_in_the_jumplist() {
     assert_eq!(editor.buffer_line(), 0);
 }
 
+#[tokio::test]
+async fn inline_comment_commands_warn_when_no_comment_is_available() {
+    let mut editor = editor("no comments\n", 40, 10, false);
+
+    for action in [Action::NextInlineComment, Action::ShowInlineComment] {
+        editor.test_execute_production_action(action).await.unwrap();
+        assert_eq!(
+            editor
+                .notifications()
+                .records()
+                .next_back()
+                .unwrap()
+                .severity,
+            Severity::Warning
+        );
+    }
+
+    assert_eq!(
+        editor.test_last_error(),
+        Some("no inline comment at the cursor")
+    );
+}
+
 #[test]
 fn inline_comment_navigation_preserves_treesitter_class_motions() {
     let editor = editor("class Example {}\n", 60, 12, false);

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -15517,17 +15517,17 @@ mod tests {
             (
                 "GitHunkStage",
                 0,
-                Err("No Git hunk under cursor".to_string()),
+                Err("warning:No Git hunk under cursor".to_string()),
             ),
             (
                 "GitHunkUnstage",
                 0,
-                Err("No Git hunk under cursor".to_string()),
+                Err("warning:No Git hunk under cursor".to_string()),
             ),
             (
                 "GitHunkReset",
                 0,
-                Err("No Git hunk under cursor".to_string()),
+                Err("warning:No Git hunk under cursor".to_string()),
             ),
         ] {
             runtime.execute_command(command).await.unwrap();
@@ -17375,6 +17375,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lsp_document_symbols_warns_when_no_symbols_are_available() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        load_lsp_symbols(&mut runtime).await;
+
+        runtime.execute_command("LspDocumentSymbols").await.unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::DocumentSymbols { request_id, .. } => request_id,
+            _ => panic!("expected document-symbol request"),
+        };
+        runtime
+            .resolve_request(request_id, sample_symbol_payload_with_count(0))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::Action(Action::PrintWarning(message))
+                if message == "No document symbols found"
+        ));
+    }
+
+    #[tokio::test]
     async fn lsp_symbols_batches_pathological_document_symbol_results() {
         drain_requests();
 
@@ -17520,6 +17543,37 @@ mod tests {
                 include_declaration: true,
                 ..
             }
+        ));
+    }
+
+    #[tokio::test]
+    async fn lsp_references_warns_after_a_final_empty_result() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        load_lsp_symbols(&mut runtime).await;
+
+        runtime.execute_command("LspReferences").await.unwrap();
+        let handle = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackPicker { handle, .. } => handle,
+            _ => panic!("expected references loading picker"),
+        };
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::References { request_id, .. } => request_id,
+            _ => panic!("expected references request"),
+        };
+        runtime
+            .resolve_request(request_id, sample_reference_payload_with_count(0))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::ClosePicker { id } if id == handle.get()
+        ));
+        assert!(matches!(
+            ACTION_DISPATCHER.recv_request(),
+            PluginRequest::Action(Action::PrintWarning(message))
+                if message == "No references found"
         ));
     }
 

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -4553,6 +4553,16 @@ async fn test_delete_till_missing_target_does_not_edit() {
     harness.assert_buffer_contents("alpha beta");
     harness.assert_cursor_at(0, 0);
     assert_eq!(harness.last_error(), Some("character not found"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]
@@ -4658,6 +4668,16 @@ async fn missing_find_forward_target_does_not_move_or_edit() {
     harness.assert_buffer_contents("alpha beta");
     harness.assert_cursor_at(0, 0);
     assert_eq!(harness.last_error(), Some("character not found"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]
@@ -5425,11 +5445,31 @@ async fn undo_and_redo_boundaries_report_no_op() {
     assert!(harness
         .commandline_row()
         .contains("already at oldest change"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 
     harness.execute_action(Action::Redo).await.unwrap();
     assert!(harness
         .commandline_row()
         .contains("already at newest change"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]
@@ -8434,6 +8474,16 @@ async fn directional_window_boundaries_report_no_op() {
     ] {
         harness.execute_action(action).await.unwrap();
         assert!(harness.commandline_row().contains(message));
+        assert_eq!(
+            harness
+                .editor
+                .notifications()
+                .records()
+                .next_back()
+                .unwrap()
+                .severity,
+            Severity::Warning
+        );
     }
 }
 
@@ -10168,6 +10218,16 @@ async fn parameter_swaps_do_not_cross_argument_containers() {
 
     harness.assert_buffer_contents(original);
     assert_eq!(harness.last_error(), Some("adjacent text object not found"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -930,7 +930,62 @@ async fn search_navigation_without_previous_search_reports_no_op() {
     ] {
         harness.execute_action(action).await.unwrap();
         assert!(harness.commandline_row().contains("no previous search"));
+        assert_eq!(
+            harness
+                .editor
+                .notifications()
+                .records()
+                .next_back()
+                .unwrap()
+                .severity,
+            Severity::Warning
+        );
     }
+}
+
+#[tokio::test]
+async fn wrapped_search_reports_the_boundary_it_crossed() {
+    let mut harness = EditorHarness::with_content("alpha beta alpha");
+
+    harness.execute_action(Action::MoveTo(11, 1)).await.unwrap();
+    harness
+        .execute_action(Action::SearchWordUnderCursor)
+        .await
+        .unwrap();
+
+    harness.assert_cursor_at(0, 0);
+    assert_eq!(
+        harness.last_error(),
+        Some("search hit BOTTOM, continuing at TOP")
+    );
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
+
+    harness.execute_action(Action::FindPrevious).await.unwrap();
+
+    harness.assert_cursor_at(11, 0);
+    assert_eq!(
+        harness.last_error(),
+        Some("search hit TOP, continuing at BOTTOM")
+    );
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]
@@ -1001,7 +1056,7 @@ async fn search_enter_commits_preview_and_n_repeats_direction() {
 }
 
 #[tokio::test]
-async fn search_enter_without_match_exits_and_reports_error() {
+async fn search_enter_without_match_exits_and_warns() {
     let mut harness = EditorHarness::with_content("alpha\nbeta");
     harness
         .execute_action(Action::SetCursor(0, 1))
@@ -1027,7 +1082,17 @@ async fn search_enter_without_match_exits_and_reports_error() {
     harness.assert_cursor_at(0, 1);
     assert!(harness
         .commandline_row()
-        .starts_with("Pattern not found: missing"));
+        .contains("Pattern not found: missing"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]
@@ -1066,7 +1131,7 @@ async fn failed_search_becomes_the_most_recent_search() {
     harness.assert_cursor_at(0, 2);
     assert!(harness
         .commandline_row()
-        .starts_with("Pattern not found: missing"));
+        .contains("Pattern not found: missing"));
 }
 
 #[tokio::test]
@@ -1298,9 +1363,29 @@ async fn jump_list_boundaries_report_no_op() {
 
     harness.execute_action(Action::JumpBack).await.unwrap();
     assert!(harness.commandline_row().contains("at start of jump list"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 
     harness.execute_action(Action::JumpForward).await.unwrap();
     assert!(harness.commandline_row().contains("at end of jump list"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]
@@ -2313,6 +2398,42 @@ async fn test_operator_delete_percent_deletes_through_match() {
 
     type_normal_keys(&mut harness, "d%").await;
     harness.assert_buffer_contents(" beta");
+}
+
+#[tokio::test]
+async fn percent_without_a_match_warns_for_motion_and_operator_forms() {
+    let mut harness = EditorHarness::with_config(
+        Buffer::new(None, "alpha beta".to_string()),
+        default_key_config(),
+    );
+
+    type_normal_keys(&mut harness, "%").await;
+    harness.assert_cursor_at(0, 0);
+    assert_eq!(harness.last_error(), Some("match not found"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
+
+    type_normal_keys(&mut harness, "d%").await;
+    harness.assert_buffer_contents("alpha beta");
+    assert_eq!(harness.last_error(), Some("match not found"));
+    assert_eq!(
+        harness
+            .editor
+            .notifications()
+            .records()
+            .next_back()
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Commands that Red accepts but cannot complete still mix silent no-ops with ordinary informational messages. That makes it hard to distinguish a missing target from an ignored command. Building on #322, this follow-up applies the same transient, quiet warning contract to other discrete navigation and context-sensitive actions.

This change warns at match, character-search, syntax-swap, jumplist, undo/redo, and directional-window boundaries, including operator forms that must leave the buffer unchanged. Search misses and successful top/bottom wrapping now provide warning feedback without changing `wrapscan` behavior. LSP definition and diagnostic actions, document symbols, references, Git hunk actions, and inline-comment commands also warn when their final result has no eligible target.

Depends on #322.

## How to Test

1. In a buffer without a matching delimiter or requested character, run `%` and an operator motion such as `dfx`. Expect a transient warning, no cursor movement for `%`, and no edit for the operator motion.
2. At the start or end of the jumplist or undo history, or with no window in a requested `Ctrl-w` direction, repeat the command. Expect the existing boundary text with warning styling.
3. Run a search with no prior pattern or no matches. Expect a warning. With `wrapscan` enabled, repeat a search across the top or bottom and expect the cursor to move while the wrap boundary is reported.
4. Invoke go-to-definition, line diagnostics, document symbols, references, a Git hunk action, or an inline-comment action where no target exists. Expect a warning only after the final result is known.
5. Run the focused regressions:
   - `cargo test --test movement --no-default-features`
   - `cargo test --test editing boundaries_report_no_op --no-default-features`
   - `cargo test --lib warn --no-default-features`
   - `cargo test --lib git_hunk_navigation_targets_changed_lines_and_reports_boundaries --no-default-features`

The full Rust lint validation passes with `cargo clippy --all-targets --all-features -- -D warnings`.