### PR TITLE
feat(editor): wrap directional window navigation

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -21,6 +21,9 @@ scrolloff = 3
 # Wrap long lines at the window edge. This matches Vim/Neovim's 'wrap'.
 wrap = true
 
+# Wrap Ctrl-w h/j/k/l focus across the opposite editor edge.
+wrap_window_navigation = true
+
 # Keep inline questions and answers in local editor recovery snapshots.
 persist_inline_history = true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,6 +225,8 @@ pub struct Config {
     pub scrolloff: Option<usize>,
     /// Whether long lines wrap to continuation rows.
     pub wrap: Option<bool>,
+    /// Wrap directional window focus across opposite editor edges. Defaults to on.
+    pub wrap_window_navigation: Option<bool>,
     /// Show the cursor line's absolute number and distances on other lines.
     /// Defaults to off.
     pub relative_line_numbers: Option<bool>,
@@ -2038,6 +2040,7 @@ fn known_top_level_field(field: &str) -> bool {
             | "mouse_scroll_lines"
             | "scrolloff"
             | "wrap"
+            | "wrap_window_navigation"
             | "relative_line_numbers"
             | "breakindent"
             | "sidescroll"
@@ -3209,6 +3212,37 @@ unknown_setting = true
         .unwrap();
         assert!(enabled.is_clean());
         assert_eq!(enabled.config.relative_line_numbers, Some(true));
+    }
+
+    #[test]
+    fn wrap_window_navigation_is_enabled_by_default_and_configurable() {
+        let defaults = Config::load_user_toml("", Path::new("/tmp/config.toml"), &[]).unwrap();
+        assert_eq!(defaults.config.wrap_window_navigation, Some(true));
+
+        let disabled = Config::load_user_toml(
+            "wrap_window_navigation = false",
+            Path::new("/tmp/config.toml"),
+            &[],
+        )
+        .unwrap();
+        assert!(disabled.is_clean());
+        assert_eq!(disabled.config.wrap_window_navigation, Some(false));
+    }
+
+    #[test]
+    fn invalid_wrap_window_navigation_falls_back_independently() {
+        let loaded = Config::load_user_toml(
+            r#"wrap_window_navigation = "yes""#,
+            Path::new("/tmp/config.toml"),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(loaded.config.wrap_window_navigation, Some(true));
+        assert!(loaded.diagnostics.iter().any(|diagnostic| {
+            diagnostic.path == "wrap_window_navigation"
+                && diagnostic.fallback == "kept the previous valid value"
+        }));
     }
 
     #[test]
@@ -4541,7 +4575,9 @@ groups = [["\\bif\\b", "\\belse\\b", "\\bendif\\b"]]
         assert_eq!(config.show_whats_new, Some(true));
         assert_eq!(config.fetch_release_notes, Some(true));
         assert_eq!(config.persist_inline_history, Some(true));
+        assert_eq!(config.wrap_window_navigation, Some(true));
         assert!(known_top_level_field("persist_inline_history"));
+        assert!(known_top_level_field("wrap_window_navigation"));
         assert_eq!(
             config.keys.normal.get("F1"),
             Some(&KeyAction::Single(Action::KeyboardShortcuts))

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -5715,6 +5715,17 @@ impl Editor {
             }
         }
 
+        if self.config.wrap_window_navigation.unwrap_or(true) {
+            if let Some(target_id) = self.window_manager.find_window_across_edge(direction) {
+                if self.set_active_window(target_id) {
+                    self.panel_manager.focus_editor();
+                    self.request_diagnostics().await?;
+                    self.render(buffer)?;
+                    return Ok(());
+                }
+            }
+        }
+
         let message = match direction {
             crate::window::Direction::Up => "no window above",
             crate::window::Direction::Down => "no window below",

--- a/src/window.rs
+++ b/src/window.rs
@@ -47,6 +47,19 @@ pub enum Direction {
     Right,
 }
 
+fn interval_gap(
+    first_start: usize,
+    first_len: usize,
+    second_start: usize,
+    second_len: usize,
+) -> usize {
+    let first_end = first_start.saturating_add(first_len);
+    let second_end = second_start.saturating_add(second_len);
+    second_start
+        .saturating_sub(first_end)
+        .max(first_start.saturating_sub(second_end))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DividerAxis {
     Vertical,
@@ -703,6 +716,39 @@ mod tests {
                     || contains_split_ratio(left, expected)
                     || contains_split_ratio(right, expected)
             }
+        }
+    }
+
+    #[test]
+    fn wrapped_navigation_uses_the_opposite_edge_and_preserves_alignment() {
+        let mut manager = nested_window_manager();
+
+        for (active, direction, expected) in [
+            (0, Direction::Left, 2),
+            (1, Direction::Left, 3),
+            (2, Direction::Right, 0),
+            (3, Direction::Right, 1),
+            (0, Direction::Up, 1),
+            (2, Direction::Up, 3),
+            (1, Direction::Down, 0),
+            (3, Direction::Down, 2),
+        ] {
+            manager.set_active(active);
+            assert_eq!(manager.find_window_across_edge(direction), Some(expected));
+        }
+    }
+
+    #[test]
+    fn wrapped_navigation_has_no_target_for_a_single_window() {
+        let manager = WindowManager::new(/*buffer_index*/ 0, (80, 26));
+
+        for direction in [
+            Direction::Left,
+            Direction::Right,
+            Direction::Up,
+            Direction::Down,
+        ] {
+            assert_eq!(manager.find_window_across_edge(direction), None);
         }
     }
 
@@ -2465,6 +2511,75 @@ impl WindowManager {
         }
 
         best_candidate.map(|(id, _)| id)
+    }
+
+    /// Find the best-aligned window on the edge opposite `direction`.
+    pub fn find_window_across_edge(&self, direction: Direction) -> Option<usize> {
+        let windows = self.root.windows();
+        let active_window = self.active_window()?;
+        let layout_left = windows.iter().map(|window| window.position.x).min()?;
+        let layout_top = windows.iter().map(|window| window.position.y).min()?;
+        let layout_right = windows
+            .iter()
+            .map(|window| window.position.x.saturating_add(window.size.0))
+            .max()?;
+        let layout_bottom = windows
+            .iter()
+            .map(|window| window.position.y.saturating_add(window.size.1))
+            .max()?;
+
+        windows
+            .iter()
+            .enumerate()
+            .filter(|(id, _)| *id != self.active_window_id)
+            .min_by_key(|(id, window)| {
+                let window_right = window.position.x.saturating_add(window.size.0);
+                let window_bottom = window.position.y.saturating_add(window.size.1);
+                let (edge_distance, orthogonal_gap, orthogonal_offset) = match direction {
+                    Direction::Left => (
+                        layout_right.saturating_sub(window_right),
+                        interval_gap(
+                            active_window.position.y,
+                            active_window.size.1,
+                            window.position.y,
+                            window.size.1,
+                        ),
+                        active_window.position.y.abs_diff(window.position.y),
+                    ),
+                    Direction::Right => (
+                        window.position.x.saturating_sub(layout_left),
+                        interval_gap(
+                            active_window.position.y,
+                            active_window.size.1,
+                            window.position.y,
+                            window.size.1,
+                        ),
+                        active_window.position.y.abs_diff(window.position.y),
+                    ),
+                    Direction::Up => (
+                        layout_bottom.saturating_sub(window_bottom),
+                        interval_gap(
+                            active_window.position.x,
+                            active_window.size.0,
+                            window.position.x,
+                            window.size.0,
+                        ),
+                        active_window.position.x.abs_diff(window.position.x),
+                    ),
+                    Direction::Down => (
+                        window.position.y.saturating_sub(layout_top),
+                        interval_gap(
+                            active_window.position.x,
+                            active_window.size.0,
+                            window.position.x,
+                            window.size.0,
+                        ),
+                        active_window.position.x.abs_diff(window.position.x),
+                    ),
+                };
+                (edge_distance, orthogonal_gap, orthogonal_offset, *id)
+            })
+            .map(|(id, _)| id)
     }
 
     /// Returns the current editor origin and dimensions without including docked panes.

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -8188,14 +8188,39 @@ async fn terminal_resize_preserves_independent_docked_pane_preferences() {
 
 #[tokio::test]
 async fn directional_window_chords_focus_and_leave_all_four_pane_edges() {
-    for (side, enter, leave, initial_size) in [
-        (PanelSide::Left, 'h', 'l', 20),
-        (PanelSide::Right, 'l', 'h', 20),
-        (PanelSide::Top, 'k', 'j', 6),
-        (PanelSide::Bottom, 'j', 'k', 6),
+    for (side, enter, leave, initial_size, split, move_to_edge) in [
+        (
+            PanelSide::Left,
+            'h',
+            'l',
+            20,
+            Action::SplitVertical,
+            Some(Action::MoveWindowLeft),
+        ),
+        (PanelSide::Right, 'l', 'h', 20, Action::SplitVertical, None),
+        (
+            PanelSide::Top,
+            'k',
+            'j',
+            6,
+            Action::SplitHorizontal,
+            Some(Action::MoveWindowUp),
+        ),
+        (
+            PanelSide::Bottom,
+            'j',
+            'k',
+            6,
+            Action::SplitHorizontal,
+            None,
+        ),
     ] {
         let buffer = Buffer::new(None, "first\nsecond\n".to_string());
         let mut harness = EditorHarness::with_config(buffer, default_key_config());
+        harness.execute_action(split).await.unwrap();
+        if let Some(action) = move_to_edge {
+            harness.execute_action(action).await.unwrap();
+        }
         harness.editor.test_create_panel(
             "inspector",
             PanelConfig {
@@ -8210,6 +8235,62 @@ async fn directional_window_chords_focus_and_leave_all_four_pane_edges() {
 
         execute_window_chord(&mut harness, leave).await;
         assert_eq!(harness.editor.test_focused_panel_id(), None);
+    }
+}
+
+#[tokio::test]
+async fn directional_window_chords_wrap_across_opposite_edges_by_default() {
+    for (split, wrap_from_second, wrap_from_first) in [
+        (Action::SplitVertical, 'l', 'h'),
+        (Action::SplitHorizontal, 'j', 'k'),
+    ] {
+        let buffer = Buffer::new(None, "first\nsecond\n".to_string());
+        let mut harness = EditorHarness::with_config(buffer, default_key_config());
+        harness.execute_action(split).await.unwrap();
+        assert_eq!(harness.active_window_id(), 1);
+
+        execute_window_chord(&mut harness, wrap_from_second).await;
+        assert_eq!(harness.active_window_id(), 0);
+
+        execute_window_chord(&mut harness, wrap_from_first).await;
+        assert_eq!(harness.active_window_id(), 1);
+    }
+}
+
+#[tokio::test]
+async fn directional_window_chords_stop_at_edges_when_wrapping_is_disabled() {
+    for (split, second_edge, toward_first, first_edge, messages) in [
+        (
+            Action::SplitVertical,
+            'l',
+            'h',
+            'h',
+            ("no window to the right", "no window to the left"),
+        ),
+        (
+            Action::SplitHorizontal,
+            'j',
+            'k',
+            'k',
+            ("no window below", "no window above"),
+        ),
+    ] {
+        let buffer = Buffer::new(None, "first\nsecond\n".to_string());
+        let mut config = default_key_config();
+        config.wrap_window_navigation = Some(false);
+        let mut harness = EditorHarness::with_config(buffer, config);
+        harness.execute_action(split).await.unwrap();
+
+        execute_window_chord(&mut harness, second_edge).await;
+        assert_eq!(harness.active_window_id(), 1);
+        assert!(harness.commandline_row().contains(messages.0));
+
+        execute_window_chord(&mut harness, toward_first).await;
+        assert_eq!(harness.active_window_id(), 0);
+
+        execute_window_chord(&mut harness, first_edge).await;
+        assert_eq!(harness.active_window_id(), 0);
+        assert!(harness.commandline_row().contains(messages.1));
     }
 }
 


### PR DESCRIPTION
Directional `Ctrl-W h/j/k/l` navigation currently stops at editor edges, which forces users to reverse direction or switch to linear window cycling.

This makes directional navigation wrap across the opposite editor edge by default. Wrapped targets are selected by edge position and orthogonal alignment so nested and asymmetric layouts remain predictable. Existing docked-panel targets retain priority, and users can restore edge-stop behavior with `wrap_window_navigation = false`.

## How to Test

1. Open both vertical and horizontal editor splits.
2. From the right or bottom edge, press `Ctrl-W l` or `Ctrl-W j`; focus should wrap to the aligned pane on the left or top edge. Repeat with `Ctrl-W h` and `Ctrl-W k` from the opposite edges.
3. Add a docked panel on the requested edge; the panel should receive focus before editor-window wraparound.
4. Set `wrap_window_navigation = false` and retry each edge; focus should stay put and the existing `no window ...` message should appear.

Automated coverage:

- `cargo test wrap_window_navigation`
- `cargo test --lib wrapped_navigation`
- `cargo test --test editing directional_window`
- `cargo test --test editing window_chords`
- `cargo clippy --all-targets --all-features -- -D warnings`
