### PR TITLE
fix(editor): smooth distant cursor reveals

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7462,6 +7462,21 @@ impl Editor {
             .any(|segment| segment.line == line_index && segment.contains_cursor_col(display_col))
     }
 
+    fn cursor_has_display_row_margin(&self, line_index: usize, display_col: usize) -> bool {
+        let Some(window) = self.active_window_with_editor_view() else {
+            return false;
+        };
+        let layout = self.layout_for_window(&window);
+        let Some(bounds) = self.viewport_cursor_row_bounds(&layout) else {
+            return false;
+        };
+        layout.rows.iter().any(|segment| {
+            segment.line == line_index
+                && segment.contains_cursor_col(display_col)
+                && bounds.contains(&segment.row)
+        })
+    }
+
     /// Best-effort scrolloff bounds in physical rows, excluding virtual comments.
     fn viewport_cursor_row_bounds(
         &self,
@@ -7524,7 +7539,7 @@ impl Editor {
     }
 
     fn scroll_wrapped_viewport_down_one_screen_line(&mut self) -> bool {
-        if !self.wrap {
+        if !self.wrap && !self.has_inline_comments(self.current_buffer().id()) {
             return false;
         }
         let Some(window) = self.active_window_with_editor_view() else {
@@ -7541,8 +7556,17 @@ impl Editor {
     }
 
     fn scroll_wrapped_viewport_up_one_screen_line(&mut self) -> bool {
-        if !self.wrap {
+        if !self.wrap && !self.has_inline_comments(self.current_buffer().id()) {
             return false;
+        }
+
+        if !self.wrap {
+            let Some(previous_line) = self.vtop.checked_sub(1) else {
+                return false;
+            };
+            self.vtop = previous_line;
+            self.skipcol = 0;
+            return true;
         }
 
         let width = self.active_content_width();
@@ -7578,6 +7602,126 @@ impl Editor {
         self.vtop = previous_top.line;
         self.skipcol = previous_top.start_col;
         true
+    }
+
+    /// Reveals a cursor destination with the same three-stage policy used by
+    /// Vim-like editors: preserve an already-safe viewport, minimally scroll a
+    /// nearby destination into the scrolloff margin, and center a distant jump.
+    /// At EOF, centering is backfilled so the last source row sits at the bottom
+    /// instead of leaving a mostly blank viewport.
+    fn reveal_cursor_destination(&mut self, line_index: usize) {
+        let height = self.vheight().max(1);
+        let last_line = if self.is_insert() {
+            self.current_buffer().len()
+        } else {
+            self.last_navigable_line()
+        };
+
+        if !self.wrap && !self.has_inline_comments(self.current_buffer().id()) {
+            let scrolloff = self
+                .config
+                .scrolloff
+                .unwrap_or(0)
+                .min(height.saturating_sub(1) / 2);
+            let top_margin = scrolloff.min(line_index);
+            let bottom_margin = scrolloff.min(last_line.saturating_sub(line_index));
+            let safe_start = self.vtop.saturating_add(top_margin);
+            let safe_end = self
+                .vtop
+                .saturating_add(height.saturating_sub(1))
+                .saturating_sub(bottom_margin);
+            if (safe_start..=safe_end).contains(&line_index) {
+                self.cy = line_index.saturating_sub(self.vtop);
+                return;
+            }
+
+            let viewport_start = self.vtop;
+            let viewport_end = self.vtop.saturating_add(height.saturating_sub(1));
+            let distance = if line_index < viewport_start {
+                viewport_start - line_index
+            } else {
+                line_index.saturating_sub(viewport_end)
+            };
+            let max_vtop = last_line.saturating_sub(height.saturating_sub(1));
+            self.vtop = if distance >= height {
+                line_index
+                    .saturating_sub(height.saturating_sub(1) / 2)
+                    .min(max_vtop)
+            } else if line_index < safe_start {
+                line_index.saturating_sub(top_margin)
+            } else {
+                line_index
+                    .saturating_add(bottom_margin)
+                    .saturating_add(1)
+                    .saturating_sub(height)
+                    .min(max_vtop)
+            };
+            self.cy = line_index.saturating_sub(self.vtop);
+            return;
+        }
+
+        let display_col = self
+            .current_buffer()
+            .get(line_index)
+            .map(|line| {
+                grapheme_to_column_with_tabs(
+                    trim_line_ending(&line),
+                    self.cx,
+                    self.active_tab_width(),
+                )
+            })
+            .unwrap_or(self.cx);
+        if self.cursor_has_display_row_margin(line_index, display_col) {
+            self.cy = line_index.saturating_sub(self.vtop);
+            return;
+        }
+
+        let target_is_below =
+            line_index > self.vtop || (line_index == self.vtop && display_col >= self.skipcol);
+        for _ in 0..height {
+            let scrolled = if target_is_below {
+                self.scroll_wrapped_viewport_down_one_screen_line()
+            } else {
+                self.scroll_wrapped_viewport_up_one_screen_line()
+            };
+            if !scrolled {
+                break;
+            }
+            self.cy = line_index.saturating_sub(self.vtop);
+            if self.cursor_has_display_row_margin(line_index, display_col) {
+                return;
+            }
+        }
+
+        self.vtop = line_index;
+        self.skipcol = if self.wrap {
+            let width = self.active_content_width();
+            self.wrapped_line_segments_for_width(line_index, width)
+                .into_iter()
+                .find(|segment| segment.contains_cursor_col(display_col))
+                .map_or(0, |segment| segment.start_col)
+        } else {
+            0
+        };
+
+        for _ in 0..height.saturating_sub(1) / 2 {
+            if !self.scroll_wrapped_viewport_up_one_screen_line() {
+                break;
+            }
+        }
+
+        for _ in 0..height {
+            let needs_backfill = self
+                .active_window_with_editor_view()
+                .is_some_and(|window| self.layout_for_window(&window).screen_height() < height);
+            if !needs_backfill {
+                break;
+            }
+            if !self.scroll_wrapped_viewport_up_one_screen_line() {
+                break;
+            }
+        }
+        self.cy = line_index.saturating_sub(self.vtop);
     }
 
     fn ensure_wrapped_cursor_segment_visible(&mut self, delta: isize) {
@@ -25891,24 +26035,18 @@ impl Editor {
 
     fn move_to_text_position(&mut self, position: TextPosition) {
         let y = position.line.min(self.last_navigable_line());
-        if !self.is_within_viewport(y) {
-            self.vtop = y;
-        }
-        self.cy = y.saturating_sub(self.vtop);
         let char_x = position.character.min(self.line_character_len(y));
         self.cx = self.char_to_grapheme_on_line(char_x, y);
+        self.reveal_cursor_destination(y);
     }
 
     /// Insert mode permits the cursor on the empty line after a trailing
     /// newline. Normal motions intentionally clamp to the last navigable line.
     fn move_to_insert_text_position(&mut self, position: TextPosition) {
         let y = position.line.min(self.current_buffer().len());
-        if !self.is_within_viewport(y) {
-            self.vtop = y;
-        }
-        self.cy = y.saturating_sub(self.vtop);
         let char_x = position.character.min(self.line_character_len(y));
         self.cx = self.char_to_grapheme_on_line(char_x, y);
+        self.reveal_cursor_destination(y);
     }
 
     fn move_to_forward_character(

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -210,6 +210,36 @@ async fn apply_completion_uses_text_edit_additional_edits_and_one_undo_step() {
 }
 
 #[tokio::test]
+async fn multiline_completion_centers_a_distant_endpoint() {
+    let mut lines = (0..80)
+        .map(|line| format!("line-{line:02}"))
+        .collect::<Vec<_>>();
+    lines[19] = "seed".to_string();
+    let (mut editor, _) = recording_editor(Buffer::new(None, lines.join("\n")));
+    let mut completion = item("expanded");
+    completion.text_edit = Some(text_edit(
+        range(19, 0, 19, 4),
+        &format!("{}done", "item\n".repeat(39)),
+    ));
+    editor
+        .test_execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    editor.test_set_viewport_cursor(9, 4, 10);
+
+    editor
+        .test_execute_action(Action::ApplyCompletion {
+            item: Box::new(completion),
+            commit_character: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(editor.test_cursor_position(), (4, 58));
+    assert_eq!(editor.test_viewport_top(), 48);
+}
+
+#[tokio::test]
 async fn apply_completion_converts_utf16_main_and_additional_edits_on_crlf_text() {
     let (mut editor, _) = recording_editor(Buffer::new(None, "😀 use\r\n😀 old\r\n".to_string()));
     let mut completion = item("new");

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -835,6 +835,28 @@ async fn format_gqq_reflows_plain_text_without_a_comment_language() {
 }
 
 #[tokio::test]
+async fn format_gqq_centers_a_distant_reflow_endpoint() {
+    let mut config = default_key_config();
+    config.commenting.text_width = 10;
+    config.scrolloff = Some(3);
+    config.wrap = Some(true);
+    let mut lines = (0..19)
+        .map(|line| format!("prefix-{line:02}"))
+        .collect::<Vec<_>>();
+    lines.push(vec!["word"; 80].join(" "));
+    lines.extend((0..30).map(|line| format!("suffix-{line:02}")));
+    let buffer = Buffer::new(None, lines.join("\n"));
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 80, 24);
+    harness.set_viewport_cursor(9, 0, 10);
+
+    type_normal_keys(&mut harness, "gqq").await;
+
+    assert_eq!(harness.buffer_line(), 58);
+    assert_eq!(harness.viewport_top(), 48);
+    assert_eq!(harness.buffer_line() - harness.viewport_top(), 10);
+}
+
+#[tokio::test]
 async fn insert_mode_wraps_line_comments_and_undoes_the_session_atomically() {
     let mut config = default_key_config();
     config.commenting.text_width = 24;
@@ -1658,8 +1680,11 @@ async fn confirmed_substitute_scrolls_to_an_offscreen_match() {
     type_normal_keys(&mut harness, "y").await;
 
     assert_eq!(harness.buffer_line(), 9);
-    assert_eq!(harness.viewport_top(), 9);
-    assert_eq!(harness.render_cursor_position(), Some(first_match));
+    assert_eq!(harness.viewport_top(), 7);
+    assert_eq!(
+        harness.render_cursor_position(),
+        Some((first_match.0, first_match.1 + 2))
+    );
 }
 
 #[tokio::test]
@@ -6384,6 +6409,47 @@ async fn bracketed_paste_inserts_multiline_text_once() {
     harness.assert_buffer_contents("\n");
 
     let _ = fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn bracketed_paste_reveals_a_distant_endpoint_without_pin_to_top() {
+    let content = (0..80)
+        .map(|line| format!("line-{line:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let config = Config {
+        scrolloff: Some(3),
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let buffer = Buffer::new(None, content);
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 80, 24);
+    harness.set_viewport_cursor(9, 0, 10);
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+
+    harness
+        .execute_event(Event::Paste("pasted\n".repeat(40)))
+        .await
+        .unwrap();
+
+    assert_eq!(harness.buffer_line(), 59);
+    assert_eq!(harness.viewport_top(), 49);
+    assert_eq!(harness.buffer_line() - harness.viewport_top(), 10);
+
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    harness.execute_action(Action::Undo).await.unwrap();
+    assert_eq!(harness.buffer_line(), 19);
+    assert_eq!(harness.viewport_top(), 9);
+
+    harness.execute_action(Action::Redo).await.unwrap();
+    assert_eq!(harness.buffer_line(), 59);
+    assert_eq!(harness.viewport_top(), 49);
 }
 
 #[tokio::test]

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -2150,6 +2150,134 @@ async fn test_mouse_scroll_down_at_wrapped_eof_does_not_underflow() {
 }
 
 #[tokio::test]
+async fn distant_mark_jump_centers_the_destination_like_neovim() {
+    let content = (0..100)
+        .map(|line| format!("line-{line:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let config = Config {
+        scrolloff: Some(3),
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let buffer = Buffer::new(None, content);
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 80, 24);
+    harness
+        .execute_action(Action::SetCursor(0, 69))
+        .await
+        .unwrap();
+    harness.execute_action(Action::SetMark('a')).await.unwrap();
+    harness.set_viewport_cursor(9, 0, 10);
+
+    harness
+        .execute_action(Action::JumpToMark {
+            mark: 'a',
+            linewise: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(harness.buffer_line(), 69);
+    assert_eq!(harness.viewport_top(), 59);
+    assert_eq!(harness.buffer_line() - harness.viewport_top(), 10);
+}
+
+#[tokio::test]
+async fn nearby_cursor_reveal_scrolls_only_enough_for_scrolloff() {
+    let content = (0..100)
+        .map(|line| format!("line-{line:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let config = Config {
+        scrolloff: Some(3),
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let buffer = Buffer::new(None, content);
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 80, 24);
+    harness
+        .execute_action(Action::SetCursor(0, 31))
+        .await
+        .unwrap();
+    harness.execute_action(Action::SetMark('a')).await.unwrap();
+    harness.set_viewport_cursor(9, 0, 10);
+
+    harness
+        .execute_action(Action::JumpToMark {
+            mark: 'a',
+            linewise: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(harness.buffer_line(), 31);
+    assert_eq!(harness.viewport_top(), 13);
+    assert_eq!(harness.buffer_line() - harness.viewport_top(), 18);
+}
+
+#[tokio::test]
+async fn distant_cursor_reveal_backfills_the_viewport_at_eof() {
+    let content = (0..80)
+        .map(|line| format!("line-{line:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let config = Config {
+        scrolloff: Some(3),
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let buffer = Buffer::new(None, content);
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 80, 24);
+    harness
+        .execute_action(Action::SetCursor(0, 79))
+        .await
+        .unwrap();
+    harness.execute_action(Action::SetMark('a')).await.unwrap();
+    harness.set_viewport_cursor(9, 0, 10);
+
+    harness
+        .execute_action(Action::JumpToMark {
+            mark: 'a',
+            linewise: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(harness.buffer_line(), 79);
+    assert_eq!(harness.viewport_top(), 58);
+    assert_eq!(harness.buffer_line() - harness.viewport_top(), 21);
+}
+
+#[tokio::test]
+async fn distant_insert_centers_a_wrapped_segment() {
+    let content = "\ntail".to_string();
+    let config = Config {
+        scrolloff: Some(2),
+        wrap: Some(true),
+        ..Default::default()
+    };
+    let buffer = Buffer::new(None, content);
+    let mut harness = EditorHarness::with_config_and_size(buffer, config, 30, 10);
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::InsertPastedText("x".repeat(600)))
+        .await
+        .unwrap();
+
+    let (_, screen_row) = harness.render_cursor_position().unwrap();
+    assert_eq!(harness.buffer_line(), 0);
+    harness.assert_cursor_at(600, 0);
+    assert!(harness.skipcol() > 0);
+    assert!(
+        (2..=6).contains(&screen_row),
+        "wrapped destination should land away from the viewport edges, got row {screen_row}"
+    );
+}
+
+#[tokio::test]
 async fn test_move_to_specific_position() {
     let mut harness = EditorHarness::with_content("Hello\nWorld\nTest");
 


### PR DESCRIPTION
Large insertions and other operations that move the cursor offscreen currently put the destination at the top of the viewport. That makes pasted or generated content appear to jump away from its insertion point, and the same rough transition affects formatting, mark jumps, substitute confirmation, and multiline completion.

This adds one shared Vim-like cursor reveal policy:

- preserve the viewport when the destination is already safely visible
- minimally scroll nearby destinations into the configured scrolloff margin
- center distant destinations, including wrapped display rows
- backfill at EOF instead of leaving a mostly blank viewport
- keep manual wheel scrolling and undo/redo viewport snapshots authoritative

Tests cover bracketed paste, gq reflow, mark jumps, substitute confirmation, multiline completion, wrapped rows, nearby scrolling, EOF backfill, and manual-scroll regression behavior.

## How to Test

1. Open a file with at least 80 lines, place the cursor around line 20, enter insert mode, and paste roughly 40 newline-terminated lines.
   - Expected: the insertion endpoint remains near the middle of the viewport instead of becoming its top row.
2. Undo and redo that paste.
   - Expected: undo restores the original cursor and viewport exactly; redo restores the centered post-paste viewport.
3. Jump to a mark just outside the viewport, then to one more than a viewport away, and finally to EOF.
   - Expected: the nearby jump scrolls only to the scrolloff boundary, the distant jump centers, and EOF is backfilled with the final line at the bottom.
4. Paste a long single line in a narrow wrapped window.
   - Expected: the destination wrapped segment is centered and remains visible.
5. Run the focused parity tests:
   - bracketed_paste_reveals_a_distant_endpoint_without_pin_to_top
   - format_gqq_centers_a_distant_reflow_endpoint
   - multiline_completion_centers_a_distant_endpoint
   - distant_mark_jump_centers_the_destination_like_neovim
   - nearby_cursor_reveal_scrolls_only_enough_for_scrolloff
   - distant_cursor_reveal_backfills_the_viewport_at_eof
   - distant_insert_centers_a_wrapped_segment

Validated with cargo clippy --all-targets --all-features -- -D warnings, the full movement and completion suites, the editing suite excluding one unchanged baseline stack-budget overflow, and navigation frame-equivalence tests.