### PR TITLE
feat(editor): add vim-style multi-cursor editing

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -367,6 +367,8 @@ Esc = { EnterMode = "Normal" }
 # "_" = "SplitVertical"
 "Ctrl-p" = "FilePicker"
 "Ctrl-n" = "SelectNextOccurrence"
+"Ctrl-Up" = "AddCursorUp"
+"Ctrl-Down" = "AddCursorDown"
 "Ctrl-Shift-p" = "CommandPalette"
 "Alt-a" = { PluginCommand = "AgentToggle" }
 "Alt-x" = "CommandPalette"

--- a/default_config.toml
+++ b/default_config.toml
@@ -366,6 +366,7 @@ Esc = { EnterMode = "Normal" }
 # "|" = "Split" 
 # "_" = "SplitVertical"
 "Ctrl-p" = "FilePicker"
+"Ctrl-n" = "SelectNextOccurrence"
 "Ctrl-Shift-p" = "CommandPalette"
 "Alt-a" = { PluginCommand = "AgentToggle" }
 "Alt-x" = "CommandPalette"

--- a/src/config.rs
+++ b/src/config.rs
@@ -3876,6 +3876,20 @@ enabled_codex_features = ["apps", "plugins", "orchestrator_mcp"]
     }
 
     #[test]
+    fn default_config_maps_ctrl_arrows_to_vertical_cursors() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.keys.normal.get("Ctrl-Up"),
+            Some(&KeyAction::Single(Action::AddCursorUp))
+        );
+        assert_eq!(
+            config.keys.normal.get("Ctrl-Down"),
+            Some(&KeyAction::Single(Action::AddCursorDown))
+        );
+    }
+
+    #[test]
     fn default_config_maps_shift_d_to_line_diagnostics() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3866,6 +3866,16 @@ enabled_codex_features = ["apps", "plugins", "orchestrator_mcp"]
     }
 
     #[test]
+    fn default_config_maps_ctrl_n_to_next_occurrence() {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+
+        assert_eq!(
+            config.keys.normal.get("Ctrl-n"),
+            Some(&KeyAction::Single(Action::SelectNextOccurrence))
+        );
+    }
+
+    #[test]
     fn default_config_maps_shift_d_to_line_diagnostics() {
         let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
 

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -6,12 +6,14 @@
 //! commands, filesystem access, LSP notifications, and rendering remain host concerns.
 
 mod motion;
+mod multi_selection;
 mod reflow;
 mod textarea;
 mod transaction;
 
 pub(crate) use motion::text_object_kind_for_key;
 pub use motion::{CharacterMotion, MotionResolver, TextObjectKind, TextObjectScope};
+pub(crate) use multi_selection::{CharRange, SelectionSet};
 pub(crate) use reflow::{plain_line, reflow_text, ReflowLine};
 pub use textarea::{EditState, RegisterContent, TextArea, TextAreaOutcome};
 pub(crate) use transaction::apply_transactional_replacement;

--- a/src/editing/multi_selection.rs
+++ b/src/editing/multi_selection.rs
@@ -1,0 +1,218 @@
+use regex::RegexBuilder;
+
+use crate::{
+    buffer::Buffer,
+    undo::{TextPosition, TextRange},
+};
+
+/// Half-open range in document-wide Unicode scalar coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CharRange {
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+}
+
+impl CharRange {
+    pub(crate) const fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+
+    pub(crate) const fn is_empty(self) -> bool {
+        self.start == self.end
+    }
+}
+
+/// Ordered occurrences and selected ranges for one Ctrl-N session.
+#[derive(Debug, Clone)]
+pub(crate) struct SelectionSet {
+    candidates: Vec<CharRange>,
+    selections: Vec<CharRange>,
+    active_candidate: usize,
+}
+
+impl SelectionSet {
+    /// Selects the exact keyword run or single punctuation/whitespace scalar under `cursor`.
+    pub(crate) fn from_cursor(
+        buffer: &Buffer,
+        cursor: TextPosition,
+        ignorecase: bool,
+        smartcase: bool,
+    ) -> Option<Self> {
+        let contents = buffer.contents();
+        let characters = contents.chars().collect::<Vec<_>>();
+        let cursor_index = buffer.position_to_char_idx(cursor);
+        let current = *characters.get(cursor_index)?;
+        if is_line_ending(current) {
+            return None;
+        }
+
+        let mut start = cursor_index;
+        let mut end = cursor_index + 1;
+        if is_keyword_char(current) {
+            while start > 0 && is_keyword_char(characters[start - 1]) {
+                start -= 1;
+            }
+            while end < characters.len() && is_keyword_char(characters[end]) {
+                end += 1;
+            }
+        }
+
+        let needle = characters[start..end].iter().collect::<String>();
+        let case_insensitive = ignorecase && !(smartcase && needle.chars().any(char::is_uppercase));
+        let regex = RegexBuilder::new(&regex::escape(&needle))
+            .case_insensitive(case_insensitive)
+            .build()
+            .ok()?;
+        let keyword = needle.chars().all(is_keyword_char);
+        let candidates = buffer
+            .regex_matches(&regex)
+            .into_iter()
+            .filter_map(|match_| {
+                let start =
+                    buffer.position_to_char_idx(TextPosition::new(match_.start_y, match_.start_x));
+                let end =
+                    buffer.position_to_char_idx(TextPosition::new(match_.end_y, match_.end_x));
+                let has_keyword_neighbor = keyword
+                    && (start
+                        .checked_sub(1)
+                        .and_then(|index| characters.get(index))
+                        .is_some_and(|character| is_keyword_char(*character))
+                        || characters
+                            .get(end)
+                            .is_some_and(|character| is_keyword_char(*character)));
+                (!has_keyword_neighbor).then_some(CharRange::new(start, end))
+            })
+            .collect::<Vec<_>>();
+        let active_candidate = candidates
+            .iter()
+            .position(|candidate| *candidate == CharRange::new(start, end))?;
+
+        Some(Self {
+            candidates,
+            selections: vec![CharRange::new(start, end)],
+            active_candidate,
+        })
+    }
+
+    /// Adds the next occurrence, wrapping at the end of the document.
+    pub(crate) fn select_next(&mut self) {
+        if self.candidates.is_empty() {
+            return;
+        }
+        self.active_candidate = (self.active_candidate + 1) % self.candidates.len();
+        let candidate = self.candidates[self.active_candidate];
+        if !self.selections.contains(&candidate) {
+            self.selections.push(candidate);
+            self.selections.sort_by_key(|range| range.start);
+        }
+    }
+
+    pub(crate) fn ranges(&self) -> &[CharRange] {
+        &self.selections
+    }
+
+    pub(crate) fn active_range(&self) -> CharRange {
+        self.candidates[self.active_candidate]
+    }
+
+    pub(crate) fn replace_ranges(&mut self, ranges: Vec<CharRange>, active: usize) {
+        self.candidates = ranges.clone();
+        self.selections = ranges;
+        self.active_candidate = active.min(self.candidates.len().saturating_sub(1));
+    }
+
+    pub(crate) fn text_ranges(&self, buffer: &Buffer) -> Vec<TextRange> {
+        self.selections
+            .iter()
+            .map(|range| {
+                TextRange::new(
+                    buffer.char_idx_to_position(range.start),
+                    buffer.char_idx_to_position(range.end),
+                )
+            })
+            .collect()
+    }
+}
+
+fn is_keyword_char(character: char) -> bool {
+    character.is_alphanumeric() || character == '_'
+}
+
+fn is_line_ending(character: char) -> bool {
+    matches!(
+        character,
+        '\n' | '\r' | '\u{000B}' | '\u{000C}' | '\u{0085}' | '\u{2028}' | '\u{2029}'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_at(contents: &str, character: usize, case_insensitive: bool) -> SelectionSet {
+        let buffer = Buffer::new(None, contents.to_string());
+        SelectionSet::from_cursor(
+            &buffer,
+            TextPosition::new(0, character),
+            case_insensitive,
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn keyword_matches_are_whole_words_and_wrap() {
+        let mut set = set_at("foo foo_bar foo", 1, false);
+        assert_eq!(set.ranges(), &[CharRange::new(0, 3)]);
+
+        set.select_next();
+        assert_eq!(
+            set.ranges(),
+            &[CharRange::new(0, 3), CharRange::new(12, 15)]
+        );
+        assert_eq!(set.active_range(), CharRange::new(12, 15));
+
+        set.select_next();
+        assert_eq!(set.active_range(), CharRange::new(0, 3));
+    }
+
+    #[test]
+    fn punctuation_and_whitespace_select_one_scalar() {
+        let punctuation = set_at("foo.bar", 3, false);
+        assert_eq!(punctuation.ranges(), &[CharRange::new(3, 4)]);
+
+        let whitespace = set_at("foo bar", 3, false);
+        assert_eq!(whitespace.ranges(), &[CharRange::new(3, 4)]);
+    }
+
+    #[test]
+    fn case_insensitive_matching_preserves_ranges() {
+        let mut set = set_at("foo Foo FOO", 1, true);
+        set.select_next();
+        set.select_next();
+        assert_eq!(
+            set.ranges(),
+            &[
+                CharRange::new(0, 3),
+                CharRange::new(4, 7),
+                CharRange::new(8, 11)
+            ]
+        );
+    }
+
+    #[test]
+    fn smartcase_keeps_uppercase_needles_case_sensitive() {
+        let buffer = Buffer::new(None, "Foo foo Foo".to_string());
+        let mut set =
+            SelectionSet::from_cursor(&buffer, TextPosition::new(0, 1), true, true).unwrap();
+        set.select_next();
+        assert_eq!(set.ranges(), &[CharRange::new(0, 3), CharRange::new(8, 11)]);
+    }
+
+    #[test]
+    fn unicode_ranges_use_scalar_offsets() {
+        let mut set = set_at("café café", 2, false);
+        set.select_next();
+        assert_eq!(set.ranges(), &[CharRange::new(0, 4), CharRange::new(5, 9)]);
+    }
+}

--- a/src/editing/multi_selection.rs
+++ b/src/editing/multi_selection.rs
@@ -66,22 +66,7 @@ impl SelectionSet {
     ) -> Option<Self> {
         let contents = buffer.contents();
         let characters = contents.chars().collect::<Vec<_>>();
-        let cursor_index = buffer.position_to_char_idx(cursor);
-        let current = *characters.get(cursor_index)?;
-        if is_line_ending(current) {
-            return None;
-        }
-
-        let mut start = cursor_index;
-        let mut end = cursor_index + 1;
-        if is_keyword_char(current) {
-            while start > 0 && is_keyword_char(characters[start - 1]) {
-                start -= 1;
-            }
-            while end < characters.len() && is_keyword_char(characters[end]) {
-                end += 1;
-            }
-        }
+        let CharRange { start, end } = Self::range_at_cursor(buffer, cursor)?;
 
         let needle = characters[start..end].iter().collect::<String>();
         let case_insensitive = ignorecase && !(smartcase && needle.chars().any(char::is_uppercase));
@@ -119,6 +104,28 @@ impl SelectionSet {
             active_candidate,
             direction: TraversalDirection::Forward,
         })
+    }
+
+    /// Returns the keyword run or single punctuation/whitespace scalar under `cursor`.
+    pub(crate) fn range_at_cursor(buffer: &Buffer, cursor: TextPosition) -> Option<CharRange> {
+        let characters = buffer.contents().chars().collect::<Vec<_>>();
+        let cursor_index = buffer.position_to_char_idx(cursor);
+        let current = *characters.get(cursor_index)?;
+        if is_line_ending(current) {
+            return None;
+        }
+
+        let mut start = cursor_index;
+        let mut end = cursor_index + 1;
+        if is_keyword_char(current) {
+            while start > 0 && is_keyword_char(characters[start - 1]) {
+                start -= 1;
+            }
+            while end < characters.len() && is_keyword_char(characters[end]) {
+                end += 1;
+            }
+        }
+        Some(CharRange::new(start, end))
     }
 
     /// Adds the next occurrence, wrapping at the end of the document.

--- a/src/editing/multi_selection.rs
+++ b/src/editing/multi_selection.rs
@@ -28,6 +28,13 @@ pub(crate) struct SelectionSet {
     candidates: Vec<CharRange>,
     selections: Vec<CharRange>,
     active_candidate: usize,
+    direction: TraversalDirection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TraversalDirection {
+    Forward,
+    Backward,
 }
 
 impl SelectionSet {
@@ -91,20 +98,78 @@ impl SelectionSet {
             candidates,
             selections: vec![CharRange::new(start, end)],
             active_candidate,
+            direction: TraversalDirection::Forward,
         })
     }
 
     /// Adds the next occurrence, wrapping at the end of the document.
     pub(crate) fn select_next(&mut self) {
+        self.select_in_direction(TraversalDirection::Forward);
+    }
+
+    /// Adds the previous occurrence, wrapping at the start of the document.
+    pub(crate) fn select_previous(&mut self) {
+        self.select_in_direction(TraversalDirection::Backward);
+    }
+
+    /// Drops the active occurrence and selects the next one in the current direction.
+    pub(crate) fn skip_active(&mut self) {
         if self.candidates.is_empty() {
             return;
         }
-        self.active_candidate = (self.active_candidate + 1) % self.candidates.len();
+        let active = self.active_range();
+        self.selections.retain(|range| *range != active);
+        self.advance_candidate(self.direction);
         let candidate = self.candidates[self.active_candidate];
         if !self.selections.contains(&candidate) {
             self.selections.push(candidate);
             self.selections.sort_by_key(|range| range.start);
         }
+    }
+
+    /// Removes the active selection and activates its previous selected neighbor.
+    pub(crate) fn remove_active(&mut self) -> bool {
+        let active = self.active_range();
+        let selected_index = self
+            .selections
+            .iter()
+            .position(|range| *range == active)
+            .unwrap_or(0);
+        self.selections.retain(|range| *range != active);
+        if self.selections.is_empty() {
+            return false;
+        }
+
+        let next_active = self.selections[selected_index.saturating_sub(1)];
+        self.active_candidate = self
+            .candidates
+            .iter()
+            .position(|candidate| *candidate == next_active)
+            .expect("selected ranges must remain candidates");
+        true
+    }
+
+    fn select_in_direction(&mut self, direction: TraversalDirection) {
+        if self.candidates.is_empty() {
+            return;
+        }
+        self.direction = direction;
+        self.advance_candidate(direction);
+        let candidate = self.candidates[self.active_candidate];
+        if !self.selections.contains(&candidate) {
+            self.selections.push(candidate);
+            self.selections.sort_by_key(|range| range.start);
+        }
+    }
+
+    fn advance_candidate(&mut self, direction: TraversalDirection) {
+        self.active_candidate = match direction {
+            TraversalDirection::Forward => (self.active_candidate + 1) % self.candidates.len(),
+            TraversalDirection::Backward => self
+                .active_candidate
+                .checked_sub(1)
+                .unwrap_or(self.candidates.len() - 1),
+        };
     }
 
     pub(crate) fn ranges(&self) -> &[CharRange] {
@@ -113,6 +178,18 @@ impl SelectionSet {
 
     pub(crate) fn active_range(&self) -> CharRange {
         self.candidates[self.active_candidate]
+    }
+
+    pub(crate) fn active_selection(&self) -> (usize, usize) {
+        let current = if self.candidates == self.selections {
+            self.active_candidate
+        } else {
+            self.selections
+                .iter()
+                .position(|range| *range == self.active_range())
+                .unwrap_or(0)
+        };
+        (current + 1, self.selections.len())
     }
 
     pub(crate) fn replace_ranges(&mut self, ranges: Vec<CharRange>, active: usize) {
@@ -174,6 +251,67 @@ mod tests {
 
         set.select_next();
         assert_eq!(set.active_range(), CharRange::new(0, 3));
+    }
+
+    #[test]
+    fn next_and_previous_activate_existing_or_add_wrapped_matches() {
+        let mut set = set_at("foo foo foo foo", 1, false);
+        set.select_next();
+        assert_eq!(set.active_selection(), (2, 2));
+
+        set.select_previous();
+        assert_eq!(set.active_selection(), (1, 2));
+
+        set.select_previous();
+        assert_eq!(set.active_range(), CharRange::new(12, 15));
+        assert_eq!(set.active_selection(), (3, 3));
+    }
+
+    #[test]
+    fn skip_follows_direction_and_remove_chooses_selected_neighbor() {
+        let mut set = set_at("foo foo foo foo", 1, false);
+        set.select_next();
+        set.select_previous();
+        set.skip_active();
+        assert_eq!(
+            set.ranges(),
+            &[CharRange::new(4, 7), CharRange::new(12, 15)]
+        );
+        assert_eq!(set.active_range(), CharRange::new(12, 15));
+
+        assert!(set.remove_active());
+        assert_eq!(set.ranges(), &[CharRange::new(4, 7)]);
+        assert_eq!(set.active_selection(), (1, 1));
+        assert!(!set.remove_active());
+    }
+
+    #[test]
+    fn skipping_after_selecting_every_match_reduces_the_set() {
+        let mut set = set_at("foo foo", 1, false);
+        set.select_next();
+        set.skip_active();
+        assert_eq!(set.ranges(), &[CharRange::new(0, 3)]);
+        assert_eq!(set.active_selection(), (1, 1));
+    }
+
+    #[test]
+    fn removing_the_first_selection_activates_the_next_remaining_one() {
+        let mut set = set_at("foo foo", 1, false);
+        set.select_next();
+        set.select_previous();
+
+        assert!(set.remove_active());
+        assert_eq!(set.ranges(), &[CharRange::new(4, 7)]);
+        assert_eq!(set.active_range(), CharRange::new(4, 7));
+    }
+
+    #[test]
+    fn collapsed_duplicate_cursors_keep_the_active_selection_index() {
+        let mut set = set_at("..", 0, false);
+        set.select_next();
+        set.replace_ranges(vec![CharRange::new(0, 0), CharRange::new(0, 0)], 1);
+
+        assert_eq!(set.active_selection(), (2, 2));
     }
 
     #[test]

--- a/src/editing/multi_selection.rs
+++ b/src/editing/multi_selection.rs
@@ -38,6 +38,25 @@ enum TraversalDirection {
 }
 
 impl SelectionSet {
+    /// Creates a selection set from explicit ranges and activates `active`.
+    pub(crate) fn from_ranges(mut ranges: Vec<CharRange>, active: usize) -> Option<Self> {
+        if ranges.is_empty() {
+            return None;
+        }
+        let active_range = ranges[active.min(ranges.len() - 1)];
+        ranges.sort_by_key(|range| range.start);
+        let active_candidate = ranges
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        Some(Self {
+            candidates: ranges.clone(),
+            selections: ranges,
+            active_candidate,
+            direction: TraversalDirection::Forward,
+        })
+    }
+
     /// Selects the exact keyword run or single punctuation/whitespace scalar under `cursor`.
     pub(crate) fn from_cursor(
         buffer: &Buffer,
@@ -196,6 +215,20 @@ impl SelectionSet {
         self.candidates = ranges.clone();
         self.selections = ranges;
         self.active_candidate = active.min(self.candidates.len().saturating_sub(1));
+    }
+
+    /// Adds `range` in document order, or activates it if it already exists.
+    pub(crate) fn add_or_activate(&mut self, range: CharRange) {
+        if !self.selections.contains(&range) {
+            self.selections.push(range);
+            self.selections.sort_by_key(|candidate| candidate.start);
+            self.candidates = self.selections.clone();
+        }
+        self.active_candidate = self
+            .candidates
+            .iter()
+            .position(|candidate| *candidate == range)
+            .expect("added ranges must remain candidates");
     }
 
     pub(crate) fn text_ranges(&self, buffer: &Buffer) -> Vec<TextRange> {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2523,6 +2523,10 @@ pub enum Action {
     #[serde(skip)]
     DeleteMultiSelectionBlackHole,
     #[serde(skip)]
+    PasteAfterMultiSelection,
+    #[serde(skip)]
+    PasteBeforeMultiSelection,
+    #[serde(skip)]
     ClearMultiSelection,
 
     MoveUp,
@@ -4519,6 +4523,8 @@ fn is_keyword_char(c: char) -> bool {
 pub struct Content {
     kind: ContentKind,
     text: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    multi_cursor_segments: Vec<String>,
 }
 
 struct VisualPastePlan {
@@ -4531,6 +4537,7 @@ impl Content {
         Self {
             kind: ContentKind::Charwise,
             text,
+            multi_cursor_segments: Vec::new(),
         }
     }
 
@@ -4538,6 +4545,7 @@ impl Content {
         Self {
             kind: ContentKind::Linewise,
             text,
+            multi_cursor_segments: Vec::new(),
         }
     }
 
@@ -4545,6 +4553,15 @@ impl Content {
         Self {
             kind: ContentKind::Blockwise,
             text,
+            multi_cursor_segments: Vec::new(),
+        }
+    }
+
+    fn multi_cursor_blockwise(segments: Vec<String>) -> Self {
+        Self {
+            kind: ContentKind::Blockwise,
+            text: segments.join("\n"),
+            multi_cursor_segments: segments,
         }
     }
 }
@@ -17237,6 +17254,12 @@ impl Editor {
                     {
                         return Some(KeyAction::Single(Action::DeleteMultiSelectionBlackHole));
                     }
+                    (KeyCode::Char('p'), KeyModifiers::NONE) => {
+                        return Some(KeyAction::Single(Action::PasteAfterMultiSelection));
+                    }
+                    (KeyCode::Char('P'), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                        return Some(KeyAction::Single(Action::PasteBeforeMultiSelection));
+                    }
                     (KeyCode::Char('n'), KeyModifiers::CONTROL) => {}
                     (KeyCode::Char('n'), KeyModifiers::NONE)
                         if self.can_navigate_multi_cursor_occurrences() =>
@@ -21502,6 +21525,20 @@ impl Editor {
                 }
                 self.render(buffer)?;
             }
+            Action::PasteAfterMultiSelection => {
+                add_to_history = false;
+                if self.paste_at_multi_cursors(multi_cursor::MultiCursorPasteAnchor::After) {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::PasteBeforeMultiSelection => {
+                add_to_history = false;
+                if self.paste_at_multi_cursors(multi_cursor::MultiCursorPasteAnchor::Before) {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
             Action::ClearMultiSelection => {
                 add_to_history = false;
                 self.clear_multi_cursor();
@@ -23619,6 +23656,7 @@ impl Editor {
                 let content = Content {
                     kind: self.mode.into(),
                     text: selected_text.clone(),
+                    multi_cursor_segments: Vec::new(),
                 };
 
                 self.set_default_register(content.clone());
@@ -27311,6 +27349,7 @@ impl Editor {
         Some(Content {
             kind: self.mode.into(),
             text,
+            multi_cursor_segments: Vec::new(),
         })
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2507,6 +2507,12 @@ pub enum Action {
     SearchWordUnderCursor,
     SelectNextOccurrence,
     #[serde(skip)]
+    SelectPreviousOccurrence,
+    #[serde(skip)]
+    SkipMultiSelection,
+    #[serde(skip)]
+    RemoveActiveMultiSelection,
+    #[serde(skip)]
     ChangeMultiSelection,
     #[serde(skip)]
     InsertAtMultiSelectionStart,
@@ -17218,6 +17224,26 @@ impl Editor {
                         return Some(KeyAction::Single(Action::AppendAtMultiSelectionEnd));
                     }
                     (KeyCode::Char('n'), KeyModifiers::CONTROL) => {}
+                    (KeyCode::Char('n'), KeyModifiers::NONE)
+                        if self.can_navigate_multi_cursor_occurrences() =>
+                    {
+                        return Some(KeyAction::Single(Action::SelectNextOccurrence));
+                    }
+                    (KeyCode::Char('N'), KeyModifiers::NONE | KeyModifiers::SHIFT)
+                        if self.can_navigate_multi_cursor_occurrences() =>
+                    {
+                        return Some(KeyAction::Single(Action::SelectPreviousOccurrence));
+                    }
+                    (KeyCode::Char('q'), KeyModifiers::NONE)
+                        if self.can_navigate_multi_cursor_occurrences() =>
+                    {
+                        return Some(KeyAction::Single(Action::SkipMultiSelection));
+                    }
+                    (KeyCode::Char('Q'), KeyModifiers::NONE | KeyModifiers::SHIFT)
+                        if self.can_navigate_multi_cursor_occurrences() =>
+                    {
+                        return Some(KeyAction::Single(Action::RemoveActiveMultiSelection));
+                    }
                     _ => self.clear_multi_cursor(),
                 }
             }
@@ -21414,6 +21440,21 @@ impl Editor {
             Action::SelectNextOccurrence => {
                 add_to_history = false;
                 self.select_next_occurrence();
+                self.render(buffer)?;
+            }
+            Action::SelectPreviousOccurrence => {
+                add_to_history = false;
+                self.select_previous_occurrence();
+                self.render(buffer)?;
+            }
+            Action::SkipMultiSelection => {
+                add_to_history = false;
+                self.skip_multi_cursor_occurrence();
+                self.render(buffer)?;
+            }
+            Action::RemoveActiveMultiSelection => {
+                add_to_history = false;
+                self.remove_active_multi_cursor_selection();
                 self.render(buffer)?;
             }
             Action::ChangeMultiSelection => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2506,6 +2506,8 @@ pub enum Action {
     ClearSearchHighlight,
     SearchWordUnderCursor,
     SelectNextOccurrence,
+    AddCursorUp,
+    AddCursorDown,
     #[serde(skip)]
     SelectPreviousOccurrence,
     #[serde(skip)]
@@ -17268,6 +17270,7 @@ impl Editor {
                         return Some(KeyAction::Single(Action::YankMultiSelection));
                     }
                     (KeyCode::Char('n'), KeyModifiers::CONTROL) => {}
+                    (KeyCode::Up | KeyCode::Down, KeyModifiers::CONTROL) => {}
                     (KeyCode::Char('n'), KeyModifiers::NONE)
                         if self.can_navigate_multi_cursor_occurrences() =>
                     {
@@ -21484,6 +21487,16 @@ impl Editor {
             Action::SelectNextOccurrence => {
                 add_to_history = false;
                 self.select_next_occurrence();
+                self.render(buffer)?;
+            }
+            Action::AddCursorUp => {
+                add_to_history = false;
+                self.add_vertical_cursor(multi_cursor::VerticalCursorDirection::Up);
+                self.render(buffer)?;
+            }
+            Action::AddCursorDown => {
+                add_to_history = false;
+                self.add_vertical_cursor(multi_cursor::VerticalCursorDirection::Down);
                 self.render(buffer)?;
             }
             Action::SelectPreviousOccurrence => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2509,6 +2509,10 @@ pub enum Action {
     #[serde(skip)]
     ChangeMultiSelection,
     #[serde(skip)]
+    InsertAtMultiSelectionStart,
+    #[serde(skip)]
+    AppendAtMultiSelectionEnd,
+    #[serde(skip)]
     ClearMultiSelection,
 
     MoveUp,
@@ -17207,6 +17211,12 @@ impl Editor {
                     (KeyCode::Char('c'), KeyModifiers::NONE) => {
                         return Some(KeyAction::Single(Action::ChangeMultiSelection));
                     }
+                    (KeyCode::Char('i'), KeyModifiers::NONE) => {
+                        return Some(KeyAction::Single(Action::InsertAtMultiSelectionStart));
+                    }
+                    (KeyCode::Char('a'), KeyModifiers::NONE) => {
+                        return Some(KeyAction::Single(Action::AppendAtMultiSelectionEnd));
+                    }
                     (KeyCode::Char('n'), KeyModifiers::CONTROL) => {}
                     _ => self.clear_multi_cursor(),
                 }
@@ -21408,9 +21418,19 @@ impl Editor {
             }
             Action::ChangeMultiSelection => {
                 add_to_history = false;
-                if self.begin_multi_cursor_change() {
+                if self.begin_multi_cursor_insert(multi_cursor::MultiCursorInsertAnchor::Replace) {
                     self.notify_change(runtime).await?;
                 }
+                self.render(buffer)?;
+            }
+            Action::InsertAtMultiSelectionStart => {
+                add_to_history = false;
+                self.begin_multi_cursor_insert(multi_cursor::MultiCursorInsertAnchor::Start);
+                self.render(buffer)?;
+            }
+            Action::AppendAtMultiSelectionEnd => {
+                add_to_history = false;
+                self.begin_multi_cursor_insert(multi_cursor::MultiCursorInsertAnchor::End);
                 self.render(buffer)?;
             }
             Action::ClearMultiSelection => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -42,6 +42,7 @@ mod inline_notifications;
 mod keyboard_shortcuts;
 mod learning;
 mod lsp_coordinator;
+mod multi_cursor;
 #[cfg(test)]
 mod navigation_perf_tests;
 mod notifications;
@@ -2504,6 +2505,11 @@ pub enum Action {
     CancelSearch,
     ClearSearchHighlight,
     SearchWordUnderCursor,
+    SelectNextOccurrence,
+    #[serde(skip)]
+    ChangeMultiSelection,
+    #[serde(skip)]
+    ClearMultiSelection,
 
     MoveUp,
     MoveDown,
@@ -3449,6 +3455,9 @@ pub struct Editor {
 
     /// Current editor mode (normal, insert, visual, etc)
     mode: Mode,
+
+    /// Ctrl-N selections scoped to one stable buffer/window/revision owner.
+    multi_cursor: Option<multi_cursor::MultiCursorSession>,
 
     /// Captured dividers moved by directional keys while pane resize mode is active.
     pane_resize_mode: Option<PaneResizeMode>,
@@ -5003,6 +5012,7 @@ impl Editor {
             prev_highlight_y: None,
             vx,
             mode: Mode::Normal,
+            multi_cursor: None,
             pane_resize_mode: None,
             zoomed_pane: None,
             insert_entry_cursor: None,
@@ -17182,6 +17192,27 @@ impl Editor {
     }
 
     fn handle_normal_event(&mut self, ev: &event::Event) -> Option<KeyAction> {
+        if self.has_multi_cursor_session() {
+            if let Event::Key(KeyEvent {
+                code,
+                modifiers,
+                kind: KeyEventKind::Press | KeyEventKind::Repeat,
+                ..
+            }) = ev
+            {
+                match (*code, *modifiers) {
+                    (KeyCode::Esc, _) => {
+                        return Some(KeyAction::Single(Action::ClearMultiSelection));
+                    }
+                    (KeyCode::Char('c'), KeyModifiers::NONE) => {
+                        return Some(KeyAction::Single(Action::ChangeMultiSelection));
+                    }
+                    (KeyCode::Char('n'), KeyModifiers::CONTROL) => {}
+                    _ => self.clear_multi_cursor(),
+                }
+            }
+        }
+
         if self.pending_replace {
             return self.handle_replace_event(ev);
         }
@@ -19258,6 +19289,14 @@ impl Editor {
             }
             Action::EnterMode(new_mode) => {
                 add_to_history = false;
+                if matches!(new_mode, Mode::Normal) && self.finish_multi_cursor_insert() {
+                    self.render(buffer)?;
+                    self.flush_edit_batch_events(runtime).await?;
+                    self.flush_edit_batch_changes(runtime).await?;
+                    self.request_diagnostics().await?;
+                    self.draw_statusline(buffer);
+                    return Ok(false);
+                }
                 let old_mode = self.mode;
                 if !matches!(new_mode, Mode::Insert) {
                     self.snippet_session = None;
@@ -19346,6 +19385,11 @@ impl Editor {
                 self.draw_statusline(buffer);
             }
             Action::InsertCharAtCursorPos(c) => {
+                if self.insert_at_multi_cursors(&c.to_string()) {
+                    self.notify_change(runtime).await?;
+                    self.render(buffer)?;
+                    return Ok(false);
+                }
                 let completion_dialog_open = self
                     .current_dialog
                     .as_ref()
@@ -20338,6 +20382,11 @@ impl Editor {
                 self.render(buffer)?;
             }
             Action::DeletePreviousChar => {
+                if self.delete_before_multi_cursors() {
+                    self.notify_change(runtime).await?;
+                    self.render(buffer)?;
+                    return Ok(false);
+                }
                 let completion_dialog_open = self
                     .current_dialog
                     .as_ref()
@@ -21352,6 +21401,23 @@ impl Editor {
                     }
                 }
             }
+            Action::SelectNextOccurrence => {
+                add_to_history = false;
+                self.select_next_occurrence();
+                self.render(buffer)?;
+            }
+            Action::ChangeMultiSelection => {
+                add_to_history = false;
+                if self.begin_multi_cursor_change() {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::ClearMultiSelection => {
+                add_to_history = false;
+                self.clear_multi_cursor();
+                self.render(buffer)?;
+            }
             Action::DeleteWord => {
                 if let Some(range) = self.word_motion_range(1, false, false) {
                     self.begin_transaction("delete word");
@@ -22141,6 +22207,11 @@ impl Editor {
                 self.render_edited_window_rows(buffer)?;
             }
             Action::InsertPastedText(text) => {
+                if self.insert_at_multi_cursors(text) {
+                    self.notify_change(runtime).await?;
+                    self.render(buffer)?;
+                    return Ok(false);
+                }
                 let line = self.buffer_line();
                 let char_cx = self.grapheme_to_char_on_line(self.cx, line);
                 let start = TextPosition::new(line, char_cx);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2519,6 +2519,10 @@ pub enum Action {
     #[serde(skip)]
     AppendAtMultiSelectionEnd,
     #[serde(skip)]
+    DeleteMultiSelection,
+    #[serde(skip)]
+    DeleteMultiSelectionBlackHole,
+    #[serde(skip)]
     ClearMultiSelection,
 
     MoveUp,
@@ -17223,6 +17227,16 @@ impl Editor {
                     (KeyCode::Char('a'), KeyModifiers::NONE) => {
                         return Some(KeyAction::Single(Action::AppendAtMultiSelectionEnd));
                     }
+                    (KeyCode::Char('d'), KeyModifiers::NONE)
+                        if self.can_navigate_multi_cursor_occurrences() =>
+                    {
+                        return Some(KeyAction::Single(Action::DeleteMultiSelection));
+                    }
+                    (KeyCode::Char('x'), KeyModifiers::NONE)
+                        if self.can_navigate_multi_cursor_occurrences() =>
+                    {
+                        return Some(KeyAction::Single(Action::DeleteMultiSelectionBlackHole));
+                    }
                     (KeyCode::Char('n'), KeyModifiers::CONTROL) => {}
                     (KeyCode::Char('n'), KeyModifiers::NONE)
                         if self.can_navigate_multi_cursor_occurrences() =>
@@ -21472,6 +21486,20 @@ impl Editor {
             Action::AppendAtMultiSelectionEnd => {
                 add_to_history = false;
                 self.begin_multi_cursor_insert(multi_cursor::MultiCursorInsertAnchor::End);
+                self.render(buffer)?;
+            }
+            Action::DeleteMultiSelection => {
+                add_to_history = false;
+                if self.delete_multi_cursor_selections(/*preserve_register*/ false) {
+                    self.notify_change(runtime).await?;
+                }
+                self.render(buffer)?;
+            }
+            Action::DeleteMultiSelectionBlackHole => {
+                add_to_history = false;
+                if self.delete_multi_cursor_selections(/*preserve_register*/ true) {
+                    self.notify_change(runtime).await?;
+                }
                 self.render(buffer)?;
             }
             Action::ClearMultiSelection => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2527,6 +2527,8 @@ pub enum Action {
     #[serde(skip)]
     PasteBeforeMultiSelection,
     #[serde(skip)]
+    YankMultiSelection,
+    #[serde(skip)]
     ClearMultiSelection,
 
     MoveUp,
@@ -17260,6 +17262,11 @@ impl Editor {
                     (KeyCode::Char('P'), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
                         return Some(KeyAction::Single(Action::PasteBeforeMultiSelection));
                     }
+                    (KeyCode::Char('y'), KeyModifiers::NONE)
+                        if self.can_navigate_multi_cursor_occurrences() =>
+                    {
+                        return Some(KeyAction::Single(Action::YankMultiSelection));
+                    }
                     (KeyCode::Char('n'), KeyModifiers::CONTROL) => {}
                     (KeyCode::Char('n'), KeyModifiers::NONE)
                         if self.can_navigate_multi_cursor_occurrences() =>
@@ -21537,6 +21544,11 @@ impl Editor {
                 if self.paste_at_multi_cursors(multi_cursor::MultiCursorPasteAnchor::Before) {
                     self.notify_change(runtime).await?;
                 }
+                self.render(buffer)?;
+            }
+            Action::YankMultiSelection => {
+                add_to_history = false;
+                self.yank_multi_cursor_selections();
                 self.render(buffer)?;
             }
             Action::ClearMultiSelection => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2509,6 +2509,22 @@ pub enum Action {
     AddCursorUp,
     AddCursorDown,
     #[serde(skip)]
+    ToggleMultiCursorExtendMode,
+    #[serde(skip)]
+    ExtendMultiSelectionLeft,
+    #[serde(skip)]
+    ExtendMultiSelectionRight,
+    #[serde(skip)]
+    ExtendMultiSelectionWordForward,
+    #[serde(skip)]
+    ExtendMultiSelectionWordEnd,
+    #[serde(skip)]
+    ExtendMultiSelectionLineStart,
+    #[serde(skip)]
+    ExtendMultiSelectionLineEnd,
+    #[serde(skip)]
+    InvertMultiSelection,
+    #[serde(skip)]
     SelectPreviousOccurrence,
     #[serde(skip)]
     SkipMultiSelection,
@@ -17249,12 +17265,12 @@ impl Editor {
                         return Some(KeyAction::Single(Action::AppendAtMultiSelectionEnd));
                     }
                     (KeyCode::Char('d'), KeyModifiers::NONE)
-                        if self.can_navigate_multi_cursor_occurrences() =>
+                        if self.has_multi_cursor_selections() =>
                     {
                         return Some(KeyAction::Single(Action::DeleteMultiSelection));
                     }
                     (KeyCode::Char('x'), KeyModifiers::NONE)
-                        if self.can_navigate_multi_cursor_occurrences() =>
+                        if self.has_multi_cursor_selections() =>
                     {
                         return Some(KeyAction::Single(Action::DeleteMultiSelectionBlackHole));
                     }
@@ -17265,12 +17281,58 @@ impl Editor {
                         return Some(KeyAction::Single(Action::PasteBeforeMultiSelection));
                     }
                     (KeyCode::Char('y'), KeyModifiers::NONE)
-                        if self.can_navigate_multi_cursor_occurrences() =>
+                        if self.has_multi_cursor_selections() =>
                     {
                         return Some(KeyAction::Single(Action::YankMultiSelection));
                     }
                     (KeyCode::Char('n'), KeyModifiers::CONTROL) => {}
                     (KeyCode::Up | KeyCode::Down, KeyModifiers::CONTROL) => {}
+                    (KeyCode::Tab, KeyModifiers::NONE) => {
+                        return Some(KeyAction::Single(Action::ToggleMultiCursorExtendMode));
+                    }
+                    (KeyCode::Left, KeyModifiers::SHIFT) => {
+                        return Some(KeyAction::Single(Action::ExtendMultiSelectionLeft));
+                    }
+                    (KeyCode::Right, KeyModifiers::SHIFT) => {
+                        return Some(KeyAction::Single(Action::ExtendMultiSelectionRight));
+                    }
+                    (KeyCode::Left, KeyModifiers::NONE)
+                    | (KeyCode::Char('h'), KeyModifiers::NONE)
+                        if self.multi_cursor_is_extending() =>
+                    {
+                        return Some(KeyAction::Single(Action::ExtendMultiSelectionLeft));
+                    }
+                    (KeyCode::Right, KeyModifiers::NONE)
+                    | (KeyCode::Char('l'), KeyModifiers::NONE)
+                        if self.multi_cursor_is_extending() =>
+                    {
+                        return Some(KeyAction::Single(Action::ExtendMultiSelectionRight));
+                    }
+                    (KeyCode::Char('w'), KeyModifiers::NONE)
+                        if self.multi_cursor_is_extending() =>
+                    {
+                        return Some(KeyAction::Single(Action::ExtendMultiSelectionWordForward));
+                    }
+                    (KeyCode::Char('e'), KeyModifiers::NONE)
+                        if self.multi_cursor_is_extending() =>
+                    {
+                        return Some(KeyAction::Single(Action::ExtendMultiSelectionWordEnd));
+                    }
+                    (KeyCode::Char('0'), KeyModifiers::NONE)
+                        if self.multi_cursor_is_extending() =>
+                    {
+                        return Some(KeyAction::Single(Action::ExtendMultiSelectionLineStart));
+                    }
+                    (KeyCode::Char('$'), KeyModifiers::NONE | KeyModifiers::SHIFT)
+                        if self.multi_cursor_is_extending() =>
+                    {
+                        return Some(KeyAction::Single(Action::ExtendMultiSelectionLineEnd));
+                    }
+                    (KeyCode::Char('o'), KeyModifiers::NONE)
+                        if self.multi_cursor_is_extending() =>
+                    {
+                        return Some(KeyAction::Single(Action::InvertMultiSelection));
+                    }
                     (KeyCode::Char('n'), KeyModifiers::NONE)
                         if self.can_navigate_multi_cursor_occurrences() =>
                     {
@@ -21497,6 +21559,46 @@ impl Editor {
             Action::AddCursorDown => {
                 add_to_history = false;
                 self.add_vertical_cursor(multi_cursor::VerticalCursorDirection::Down);
+                self.render(buffer)?;
+            }
+            Action::ToggleMultiCursorExtendMode => {
+                add_to_history = false;
+                self.toggle_multi_cursor_extend_mode();
+                self.render(buffer)?;
+            }
+            Action::ExtendMultiSelectionLeft => {
+                add_to_history = false;
+                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::Left);
+                self.render(buffer)?;
+            }
+            Action::ExtendMultiSelectionRight => {
+                add_to_history = false;
+                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::Right);
+                self.render(buffer)?;
+            }
+            Action::ExtendMultiSelectionWordForward => {
+                add_to_history = false;
+                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::WordForward);
+                self.render(buffer)?;
+            }
+            Action::ExtendMultiSelectionWordEnd => {
+                add_to_history = false;
+                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::WordEnd);
+                self.render(buffer)?;
+            }
+            Action::ExtendMultiSelectionLineStart => {
+                add_to_history = false;
+                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::LineStart);
+                self.render(buffer)?;
+            }
+            Action::ExtendMultiSelectionLineEnd => {
+                add_to_history = false;
+                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::LineEnd);
+                self.render(buffer)?;
+            }
+            Action::InvertMultiSelection => {
+                add_to_history = false;
+                self.invert_multi_cursor_selections();
                 self.render(buffer)?;
             }
             Action::SelectPreviousOccurrence => {

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -71,6 +71,9 @@ impl Editor {
                         | Mode::VisualLine
                         | Mode::VisualBlock
                 ) | Action::RepeatLastChange
+                    | Action::SelectNextOccurrence
+                    | Action::ChangeMultiSelection
+                    | Action::ClearMultiSelection
                     | Action::PlayMacro(_)
                     | Action::InsertBlock
                     | Action::MoveToLineEnd

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -78,6 +78,8 @@ impl Editor {
                     | Action::ChangeMultiSelection
                     | Action::InsertAtMultiSelectionStart
                     | Action::AppendAtMultiSelectionEnd
+                    | Action::DeleteMultiSelection
+                    | Action::DeleteMultiSelectionBlackHole
                     | Action::ClearMultiSelection
                     | Action::PlayMacro(_)
                     | Action::InsertBlock

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -72,6 +72,9 @@ impl Editor {
                         | Mode::VisualBlock
                 ) | Action::RepeatLastChange
                     | Action::SelectNextOccurrence
+                    | Action::SelectPreviousOccurrence
+                    | Action::SkipMultiSelection
+                    | Action::RemoveActiveMultiSelection
                     | Action::ChangeMultiSelection
                     | Action::InsertAtMultiSelectionStart
                     | Action::AppendAtMultiSelectionEnd

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -73,6 +73,8 @@ impl Editor {
                 ) | Action::RepeatLastChange
                     | Action::SelectNextOccurrence
                     | Action::ChangeMultiSelection
+                    | Action::InsertAtMultiSelectionStart
+                    | Action::AppendAtMultiSelectionEnd
                     | Action::ClearMultiSelection
                     | Action::PlayMacro(_)
                     | Action::InsertBlock

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -82,6 +82,7 @@ impl Editor {
                     | Action::DeleteMultiSelectionBlackHole
                     | Action::PasteAfterMultiSelection
                     | Action::PasteBeforeMultiSelection
+                    | Action::YankMultiSelection
                     | Action::ClearMultiSelection
                     | Action::PlayMacro(_)
                     | Action::InsertBlock

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -80,6 +80,8 @@ impl Editor {
                     | Action::AppendAtMultiSelectionEnd
                     | Action::DeleteMultiSelection
                     | Action::DeleteMultiSelectionBlackHole
+                    | Action::PasteAfterMultiSelection
+                    | Action::PasteBeforeMultiSelection
                     | Action::ClearMultiSelection
                     | Action::PlayMacro(_)
                     | Action::InsertBlock

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -72,6 +72,8 @@ impl Editor {
                         | Mode::VisualBlock
                 ) | Action::RepeatLastChange
                     | Action::SelectNextOccurrence
+                    | Action::AddCursorUp
+                    | Action::AddCursorDown
                     | Action::SelectPreviousOccurrence
                     | Action::SkipMultiSelection
                     | Action::RemoveActiveMultiSelection

--- a/src/editor/edit_batch.rs
+++ b/src/editor/edit_batch.rs
@@ -74,6 +74,14 @@ impl Editor {
                     | Action::SelectNextOccurrence
                     | Action::AddCursorUp
                     | Action::AddCursorDown
+                    | Action::ToggleMultiCursorExtendMode
+                    | Action::ExtendMultiSelectionLeft
+                    | Action::ExtendMultiSelectionRight
+                    | Action::ExtendMultiSelectionWordForward
+                    | Action::ExtendMultiSelectionWordEnd
+                    | Action::ExtendMultiSelectionLineStart
+                    | Action::ExtendMultiSelectionLineEnd
+                    | Action::InvertMultiSelection
                     | Action::SelectPreviousOccurrence
                     | Action::SkipMultiSelection
                     | Action::RemoveActiveMultiSelection

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -5,7 +5,7 @@ use crate::{
     window::WindowId,
 };
 
-use super::Editor;
+use super::{Content, Editor};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum MultiCursorPhase {
@@ -274,6 +274,37 @@ impl Editor {
         true
     }
 
+    pub(super) fn delete_multi_cursor_selections(&mut self, preserve_register: bool) -> bool {
+        if !self.can_navigate_multi_cursor_occurrences() {
+            return false;
+        }
+        let targets = self
+            .multi_cursor
+            .as_ref()
+            .expect("session was checked above")
+            .selections
+            .ranges()
+            .to_vec();
+        let deleted = targets
+            .iter()
+            .map(|range| {
+                self.current_buffer().text_in_range(TextRange::new(
+                    self.current_buffer().char_idx_to_position(range.start),
+                    self.current_buffer().char_idx_to_position(range.end),
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        self.begin_transaction("delete multi-cursor selections");
+        if !preserve_register {
+            self.set_default_register(Content::blockwise(deleted.join("\n")));
+        }
+        self.replace_multi_cursor_targets(targets, "");
+        self.move_to_active_multi_cursor(false);
+        self.commit_transaction(self.cursor_snapshot());
+        true
+    }
+
     fn replace_multi_cursor_targets(&mut self, targets: Vec<CharRange>, replacement: &str) {
         let active_range = self
             .multi_cursor
@@ -313,6 +344,11 @@ impl Editor {
             updated.push(CharRange::new(cursor, cursor));
             shift += replacement_len as isize - (target.end - target.start) as isize;
         }
+        let active_range = updated.get(active).copied();
+        updated.dedup();
+        let active = active_range
+            .and_then(|active_range| updated.iter().position(|range| *range == active_range))
+            .unwrap_or(0);
         let revision = self.current_buffer().revision();
         let session = self
             .multi_cursor

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -1,0 +1,280 @@
+use crate::{
+    buffer::BufferId,
+    editing::{CharRange, SelectionSet},
+    undo::TextRange,
+    window::WindowId,
+};
+
+use super::Editor;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MultiCursorPhase {
+    Selecting,
+    Inserting,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct MultiCursorSession {
+    buffer_id: BufferId,
+    window_id: WindowId,
+    revision: u64,
+    phase: MultiCursorPhase,
+    selections: SelectionSet,
+}
+
+impl MultiCursorSession {
+    fn belongs_to(&self, editor: &Editor) -> bool {
+        self.buffer_id == editor.current_buffer().id()
+            && Some(self.window_id) == editor.window_manager.active_stable_window_id()
+            && self.revision == editor.current_buffer().revision()
+    }
+
+    pub(super) fn ranges_for_buffer(
+        &self,
+        editor: &Editor,
+        buffer_id: BufferId,
+        window_id: WindowId,
+    ) -> Vec<TextRange> {
+        if self.buffer_id != buffer_id
+            || self.window_id != window_id
+            || self.revision != editor.current_buffer().revision()
+        {
+            return Vec::new();
+        }
+        self.selections.text_ranges(editor.current_buffer())
+    }
+}
+
+impl Editor {
+    pub(super) fn has_multi_cursor_session(&self) -> bool {
+        self.multi_cursor
+            .as_ref()
+            .is_some_and(|session| session.belongs_to(self))
+    }
+
+    pub(super) fn multi_cursor_is_inserting(&self) -> bool {
+        self.multi_cursor.as_ref().is_some_and(|session| {
+            session.belongs_to(self) && session.phase == MultiCursorPhase::Inserting
+        })
+    }
+
+    pub(super) fn clear_multi_cursor(&mut self) {
+        self.multi_cursor = None;
+    }
+
+    pub(super) fn select_next_occurrence(&mut self) {
+        let valid_selecting_session = self.multi_cursor.as_ref().is_some_and(|session| {
+            session.belongs_to(self)
+                && session.phase == MultiCursorPhase::Selecting
+                && session
+                    .selections
+                    .ranges()
+                    .iter()
+                    .all(|range| !range.is_empty())
+        });
+
+        if valid_selecting_session {
+            let session = self
+                .multi_cursor
+                .as_mut()
+                .expect("session was checked above");
+            session.selections.select_next();
+        } else {
+            let buffer_id = self.current_buffer().id();
+            let Some(window_id) = self.window_manager.active_stable_window_id() else {
+                return;
+            };
+            let revision = self.current_buffer().revision();
+            let cursor = self.cursor_text_position();
+            let Some(selections) = SelectionSet::from_cursor(
+                self.current_buffer(),
+                cursor,
+                self.config.search.ignorecase,
+                self.config.search.smartcase,
+            ) else {
+                self.multi_cursor = None;
+                return;
+            };
+            self.multi_cursor = Some(MultiCursorSession {
+                buffer_id,
+                window_id,
+                revision,
+                phase: MultiCursorPhase::Selecting,
+                selections,
+            });
+        }
+
+        self.move_to_active_multi_cursor(false);
+    }
+
+    pub(super) fn begin_multi_cursor_change(&mut self) -> bool {
+        if !self.has_multi_cursor_session() {
+            self.multi_cursor = None;
+            return false;
+        }
+        let ranges = self
+            .multi_cursor
+            .as_ref()
+            .expect("session was checked above")
+            .selections
+            .ranges()
+            .to_vec();
+        if ranges.is_empty() {
+            return false;
+        }
+
+        self.begin_transaction("multi-cursor change");
+        self.replace_multi_cursor_targets(ranges, "");
+        if let Some(session) = self.multi_cursor.as_mut() {
+            session.phase = MultiCursorPhase::Inserting;
+        }
+        self.mode = super::Mode::Insert;
+        self.insert_entry_cursor = None;
+        self.generated_indent = None;
+        self.move_to_active_multi_cursor(true);
+        true
+    }
+
+    pub(super) fn insert_at_multi_cursors(&mut self, text: &str) -> bool {
+        if !self.multi_cursor_is_inserting() {
+            return false;
+        }
+        let targets = self
+            .multi_cursor
+            .as_ref()
+            .expect("session was checked above")
+            .selections
+            .ranges()
+            .to_vec();
+        self.replace_multi_cursor_targets(targets, text);
+        self.move_to_active_multi_cursor(true);
+        true
+    }
+
+    pub(super) fn delete_before_multi_cursors(&mut self) -> bool {
+        if !self.multi_cursor_is_inserting() {
+            return false;
+        }
+        let targets = self
+            .multi_cursor
+            .as_ref()
+            .expect("session was checked above")
+            .selections
+            .ranges()
+            .iter()
+            .map(|cursor| CharRange::new(cursor.start.saturating_sub(1), cursor.start))
+            .collect::<Vec<_>>();
+        self.replace_multi_cursor_targets(targets, "");
+        self.move_to_active_multi_cursor(true);
+        true
+    }
+
+    pub(super) fn finish_multi_cursor_insert(&mut self) -> bool {
+        if !self.multi_cursor_is_inserting() {
+            return false;
+        }
+        self.mode = super::Mode::Normal;
+        self.insert_entry_cursor = None;
+        self.commit_transaction(self.cursor_snapshot());
+        self.cancel_transaction_if_empty();
+        if let Some(session) = self.multi_cursor.as_mut() {
+            session.phase = MultiCursorPhase::Selecting;
+        }
+        self.move_to_active_multi_cursor(false);
+        true
+    }
+
+    fn replace_multi_cursor_targets(&mut self, targets: Vec<CharRange>, replacement: &str) {
+        let active_range = self
+            .multi_cursor
+            .as_ref()
+            .expect("multi-cursor replacement requires a session")
+            .selections
+            .active_range();
+        let active = self
+            .multi_cursor
+            .as_ref()
+            .expect("multi-cursor replacement requires a session")
+            .selections
+            .ranges()
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        let text_ranges = targets
+            .iter()
+            .map(|range| {
+                TextRange::new(
+                    self.current_buffer().char_idx_to_position(range.start),
+                    self.current_buffer().char_idx_to_position(range.end),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        for range in text_ranges.into_iter().rev() {
+            self.replace_range(range, replacement);
+        }
+
+        let replacement_len = replacement.chars().count();
+        let mut shift = 0isize;
+        let mut updated = Vec::with_capacity(targets.len());
+        for target in targets {
+            let start = target.start.saturating_add_signed(shift);
+            let cursor = start + replacement_len;
+            updated.push(CharRange::new(cursor, cursor));
+            shift += replacement_len as isize - (target.end - target.start) as isize;
+        }
+        let revision = self.current_buffer().revision();
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("multi-cursor replacement requires a session");
+        session.revision = revision;
+        session.selections.replace_ranges(updated, active);
+    }
+
+    fn move_to_active_multi_cursor(&mut self, insert: bool) {
+        let Some(range) = self
+            .multi_cursor
+            .as_ref()
+            .filter(|session| session.belongs_to(self))
+            .map(|session| session.selections.active_range())
+        else {
+            return;
+        };
+        let index = if insert || range.is_empty() {
+            range.end
+        } else {
+            range.end.saturating_sub(1)
+        };
+        let position = self.current_buffer().char_idx_to_position(index);
+        if insert {
+            self.move_to_insert_text_position(position);
+        } else {
+            self.move_to_text_position(position);
+        }
+        self.refresh_cursor_goal();
+    }
+
+    pub(super) fn multi_cursor_render_ranges(
+        &self,
+        buffer_id: BufferId,
+        window_id: WindowId,
+    ) -> Vec<(TextRange, bool)> {
+        self.multi_cursor
+            .as_ref()
+            .map(|session| {
+                let collapsed = session.phase == MultiCursorPhase::Inserting
+                    || session
+                        .selections
+                        .ranges()
+                        .iter()
+                        .all(|range| range.is_empty());
+                session
+                    .ranges_for_buffer(self, buffer_id, window_id)
+                    .into_iter()
+                    .map(|range| (range, collapsed))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -1,11 +1,20 @@
 use crate::{
     buffer::BufferId,
     editing::{CharRange, SelectionSet},
-    undo::TextRange,
+    undo::{TextPosition, TextRange},
+    unicode_utils::{
+        column_to_grapheme_with_tabs, grapheme_len, grapheme_to_column_with_tabs, trim_line_ending,
+    },
     window::WindowId,
 };
 
 use super::{Content, ContentKind, Editor};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum VerticalCursorDirection {
+    Up,
+    Down,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum MultiCursorPhase {
@@ -120,6 +129,112 @@ impl Editor {
         }
 
         self.move_to_active_multi_cursor(false);
+    }
+
+    pub(super) fn add_vertical_cursor(&mut self, direction: VerticalCursorDirection) {
+        let compatible_session = self.multi_cursor.as_ref().is_some_and(|session| {
+            session.belongs_to(self)
+                && session.phase == MultiCursorPhase::Selecting
+                && session
+                    .selections
+                    .ranges()
+                    .iter()
+                    .all(|range| range.is_empty())
+        });
+        if self.has_multi_cursor_session() && !compatible_session {
+            return;
+        }
+
+        let (origin, origin_line, display_column) = if compatible_session {
+            let session = self
+                .multi_cursor
+                .as_ref()
+                .expect("compatible session was checked above");
+            let origin = session.selections.active_range();
+            let origin_line = self
+                .current_buffer()
+                .char_idx_to_position(origin.start)
+                .line;
+            let display_column = self.current_cursor_display_col();
+            (origin, origin_line, display_column)
+        } else {
+            let position = self.cursor_text_position();
+            let index = self.current_buffer().position_to_char_idx(position);
+            (
+                CharRange::new(index, index),
+                position.line,
+                self.current_cursor_display_col(),
+            )
+        };
+
+        let Some(target) = self.vertical_cursor_target(origin_line, display_column, direction)
+        else {
+            return;
+        };
+
+        if compatible_session {
+            let session = self
+                .multi_cursor
+                .as_mut()
+                .expect("compatible session was checked above");
+            session.selections.add_or_activate(target);
+        } else {
+            let buffer_id = self.current_buffer().id();
+            let Some(window_id) = self.window_manager.active_stable_window_id() else {
+                return;
+            };
+            let revision = self.current_buffer().revision();
+            let Some(selections) = SelectionSet::from_ranges(vec![origin, target], 1) else {
+                return;
+            };
+            self.multi_cursor = Some(MultiCursorSession {
+                buffer_id,
+                window_id,
+                revision,
+                phase: MultiCursorPhase::Selecting,
+                selections,
+            });
+        }
+
+        self.move_to_active_multi_cursor(false);
+    }
+
+    fn vertical_cursor_target(
+        &self,
+        origin_line: usize,
+        display_column: usize,
+        direction: VerticalCursorDirection,
+    ) -> Option<CharRange> {
+        let last_line = self.current_buffer().len();
+        let tab_width = self.active_tab_width();
+        let mut line_index = origin_line;
+
+        loop {
+            line_index = match direction {
+                VerticalCursorDirection::Up => line_index.checked_sub(1)?,
+                VerticalCursorDirection::Down => {
+                    if line_index >= last_line {
+                        return None;
+                    }
+                    line_index + 1
+                }
+            };
+            let line = self.current_buffer().get(line_index)?;
+            let line = trim_line_ending(&line);
+            let grapheme = column_to_grapheme_with_tabs(line, display_column, tab_width);
+            let exact_column =
+                grapheme_to_column_with_tabs(line, grapheme, tab_width) == display_column;
+            let cursor_exists = display_column == 0 || grapheme < grapheme_len(line);
+            if !exact_column || !cursor_exists {
+                continue;
+            }
+
+            let character = self.grapheme_to_char_on_line(grapheme, line_index);
+            let index = self
+                .current_buffer()
+                .position_to_char_idx(TextPosition::new(line_index, character));
+            return Some(CharRange::new(index, index));
+        }
     }
 
     pub(super) fn select_previous_occurrence(&mut self) {

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -59,6 +59,18 @@ impl Editor {
             .is_some_and(|session| session.belongs_to(self))
     }
 
+    pub(super) fn can_navigate_multi_cursor_occurrences(&self) -> bool {
+        self.multi_cursor.as_ref().is_some_and(|session| {
+            session.belongs_to(self)
+                && session.phase == MultiCursorPhase::Selecting
+                && session
+                    .selections
+                    .ranges()
+                    .iter()
+                    .all(|range| !range.is_empty())
+        })
+    }
+
     pub(super) fn multi_cursor_is_inserting(&self) -> bool {
         self.multi_cursor.as_ref().is_some_and(|session| {
             session.belongs_to(self) && session.phase == MultiCursorPhase::Inserting
@@ -70,17 +82,7 @@ impl Editor {
     }
 
     pub(super) fn select_next_occurrence(&mut self) {
-        let valid_selecting_session = self.multi_cursor.as_ref().is_some_and(|session| {
-            session.belongs_to(self)
-                && session.phase == MultiCursorPhase::Selecting
-                && session
-                    .selections
-                    .ranges()
-                    .iter()
-                    .all(|range| !range.is_empty())
-        });
-
-        if valid_selecting_session {
+        if self.can_navigate_multi_cursor_occurrences() {
             let session = self
                 .multi_cursor
                 .as_mut()
@@ -111,6 +113,50 @@ impl Editor {
             });
         }
 
+        self.move_to_active_multi_cursor(false);
+    }
+
+    pub(super) fn select_previous_occurrence(&mut self) {
+        if !self.can_navigate_multi_cursor_occurrences() {
+            self.multi_cursor = None;
+            return;
+        }
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("session was checked above");
+        session.selections.select_previous();
+        self.move_to_active_multi_cursor(false);
+    }
+
+    pub(super) fn skip_multi_cursor_occurrence(&mut self) {
+        if !self.can_navigate_multi_cursor_occurrences() {
+            self.multi_cursor = None;
+            return;
+        }
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("session was checked above");
+        session.selections.skip_active();
+        self.move_to_active_multi_cursor(false);
+    }
+
+    pub(super) fn remove_active_multi_cursor_selection(&mut self) {
+        if !self.can_navigate_multi_cursor_occurrences() {
+            self.multi_cursor = None;
+            return;
+        }
+        let retained_selection = self
+            .multi_cursor
+            .as_mut()
+            .expect("session was checked above")
+            .selections
+            .remove_active();
+        if !retained_selection {
+            self.multi_cursor = None;
+            return;
+        }
         self.move_to_active_multi_cursor(false);
     }
 
@@ -320,5 +366,18 @@ impl Editor {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    pub(super) fn multi_cursor_status_label(&self) -> Option<String> {
+        let session = self
+            .multi_cursor
+            .as_ref()
+            .filter(|session| session.belongs_to(self))?;
+        let (current, total) = session.selections.active_selection();
+        let mode = match session.phase {
+            MultiCursorPhase::Selecting => "MULTI",
+            MultiCursorPhase::Inserting => "MULTI-I",
+        };
+        Some(format!("{mode} {current}/{total}"))
     }
 }

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -5,7 +5,7 @@ use crate::{
     window::WindowId,
 };
 
-use super::{Content, Editor};
+use super::{Content, ContentKind, Editor};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum MultiCursorPhase {
@@ -18,6 +18,12 @@ pub(super) enum MultiCursorInsertAnchor {
     Start,
     End,
     Replace,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MultiCursorPasteAnchor {
+    Before,
+    After,
 }
 
 #[derive(Debug, Clone)]
@@ -297,12 +303,278 @@ impl Editor {
 
         self.begin_transaction("delete multi-cursor selections");
         if !preserve_register {
-            self.set_default_register(Content::blockwise(deleted.join("\n")));
+            self.set_default_register(Content::multi_cursor_blockwise(deleted));
         }
         self.replace_multi_cursor_targets(targets, "");
         self.move_to_active_multi_cursor(false);
         self.commit_transaction(self.cursor_snapshot());
         true
+    }
+
+    pub(super) fn paste_at_multi_cursors(&mut self, anchor: MultiCursorPasteAnchor) -> bool {
+        if !self.has_multi_cursor_session() {
+            return false;
+        }
+        self.refresh_default_register_from_system_clipboard();
+        let Some(content) = self.registers.get(&super::DEFAULT_REGISTER).cloned() else {
+            return false;
+        };
+        let targets = self
+            .multi_cursor
+            .as_ref()
+            .expect("session was checked above")
+            .selections
+            .ranges()
+            .to_vec();
+        if targets.is_empty() || content.text.is_empty() {
+            return false;
+        }
+
+        if content.kind == ContentKind::Linewise {
+            return self.paste_linewise_at_multi_cursors(targets, &content);
+        }
+
+        let selecting = targets.iter().any(|range| !range.is_empty());
+        let replaced = targets
+            .iter()
+            .map(|range| {
+                self.current_buffer().text_in_range(TextRange::new(
+                    self.current_buffer().char_idx_to_position(range.start),
+                    self.current_buffer().char_idx_to_position(range.end),
+                ))
+            })
+            .collect::<Vec<_>>();
+        let replacements =
+            self.multi_cursor_paste_replacements(&content, &replaced, targets.len(), selecting);
+
+        self.begin_transaction("paste at multi-cursors");
+        if selecting {
+            self.apply_multi_cursor_replacements(targets, replacements, |start, replacement| {
+                CharRange::new(start, start + replacement.chars().count())
+            });
+        } else {
+            let insertion_targets = targets
+                .iter()
+                .map(|range| {
+                    let cursor = self.normal_multi_cursor_index(range.start);
+                    let position = self.current_buffer().char_idx_to_position(cursor);
+                    let line_len = self.line_character_len(position.line);
+                    let insertion = match anchor {
+                        MultiCursorPasteAnchor::Before => cursor,
+                        MultiCursorPasteAnchor::After if line_len == 0 => cursor,
+                        MultiCursorPasteAnchor::After => cursor + 1,
+                    };
+                    CharRange::new(insertion, insertion)
+                })
+                .collect();
+            self.apply_multi_cursor_replacements(
+                insertion_targets,
+                replacements,
+                |start, replacement| {
+                    let replacement_len = replacement.chars().count();
+                    let cursor = match anchor {
+                        MultiCursorPasteAnchor::Before => start,
+                        MultiCursorPasteAnchor::After => start + replacement_len.saturating_sub(1),
+                    };
+                    CharRange::new(cursor, cursor)
+                },
+            );
+        }
+        self.move_to_active_multi_cursor(false);
+        self.commit_transaction(self.cursor_snapshot());
+        self.cancel_transaction_if_empty();
+        true
+    }
+
+    fn multi_cursor_paste_replacements(
+        &self,
+        content: &Content,
+        replaced: &[String],
+        count: usize,
+        selecting: bool,
+    ) -> Vec<String> {
+        if content.kind == ContentKind::Charwise {
+            return vec![content.text.clone(); count];
+        }
+
+        let mut replacements = if content.multi_cursor_segments.is_empty() {
+            content.text.lines().map(str::to_string).collect::<Vec<_>>()
+        } else {
+            content.multi_cursor_segments.clone()
+        };
+        replacements.truncate(count);
+        if replacements.len() < count {
+            if selecting {
+                replacements.extend(replaced.iter().skip(replacements.len()).cloned());
+            } else {
+                replacements.resize(count, String::new());
+            }
+        }
+        replacements
+    }
+
+    fn paste_linewise_at_multi_cursors(
+        &mut self,
+        targets: Vec<CharRange>,
+        content: &Content,
+    ) -> bool {
+        let lines = content.text.lines().collect::<Vec<_>>().join("\n");
+        if lines.is_empty() {
+            return false;
+        }
+        let selecting = targets.iter().any(|range| !range.is_empty());
+        let active_range = self
+            .multi_cursor
+            .as_ref()
+            .expect("session was checked above")
+            .selections
+            .active_range();
+        let active = targets
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        let source_lines = targets
+            .iter()
+            .map(|range| {
+                let cursor = self.normal_multi_cursor_index(range.start);
+                self.current_buffer().char_idx_to_position(cursor).line
+            })
+            .collect::<Vec<_>>();
+        let active_source_line = source_lines.get(active).copied();
+        let mut replacements = Vec::with_capacity(targets.len());
+        let insertion_targets = targets
+            .into_iter()
+            .map(|range| {
+                let cursor = self.normal_multi_cursor_index(range.start);
+                let position = self.current_buffer().char_idx_to_position(cursor);
+                let last_unterminated_line = position.line == self.current_buffer().len()
+                    && self
+                        .current_buffer()
+                        .get(position.line)
+                        .is_some_and(|line| !line.ends_with('\n'));
+                if last_unterminated_line {
+                    replacements.push(format!("\n{lines}"));
+                    let end = self.current_buffer().contents().chars().count();
+                    CharRange::new(end, end)
+                } else {
+                    replacements.push(format!("{lines}\n"));
+                    let start = self
+                        .current_buffer()
+                        .position_to_char_idx(crate::undo::TextPosition::new(position.line + 1, 0));
+                    CharRange::new(start, start)
+                }
+            })
+            .collect();
+
+        self.begin_transaction("paste lines at multi-cursors");
+        self.apply_multi_cursor_replacements(
+            insertion_targets,
+            replacements,
+            |start, replacement| {
+                let cursor = start + usize::from(replacement.starts_with('\n'));
+                CharRange::new(cursor, cursor)
+            },
+        );
+        if selecting {
+            let updated = self
+                .multi_cursor
+                .as_ref()
+                .expect("multi-cursor replacement requires a session")
+                .selections
+                .ranges()
+                .to_vec();
+            let mut retained_lines = Vec::new();
+            let mut retained = Vec::new();
+            let mut active = 0;
+            for (source_line, range) in source_lines.into_iter().zip(updated) {
+                if retained_lines.contains(&source_line) {
+                    continue;
+                }
+                if Some(source_line) == active_source_line {
+                    active = retained.len();
+                }
+                retained_lines.push(source_line);
+                retained.push(range);
+            }
+            self.multi_cursor
+                .as_mut()
+                .expect("multi-cursor replacement requires a session")
+                .selections
+                .replace_ranges(retained, active);
+        }
+        self.move_to_active_multi_cursor(false);
+        self.commit_transaction(self.cursor_snapshot());
+        true
+    }
+
+    fn normal_multi_cursor_index(&self, index: usize) -> usize {
+        let position = self.current_buffer().char_idx_to_position(index);
+        let line_len = self.line_character_len(position.line);
+        let character = if line_len == 0 {
+            0
+        } else {
+            position.character.min(line_len - 1)
+        };
+        self.current_buffer()
+            .position_to_char_idx(crate::undo::TextPosition::new(position.line, character))
+    }
+
+    fn apply_multi_cursor_replacements(
+        &mut self,
+        targets: Vec<CharRange>,
+        replacements: Vec<String>,
+        result_range: impl Fn(usize, &str) -> CharRange,
+    ) {
+        let active_range = self
+            .multi_cursor
+            .as_ref()
+            .expect("multi-cursor replacement requires a session")
+            .selections
+            .active_range();
+        let active = self
+            .multi_cursor
+            .as_ref()
+            .expect("multi-cursor replacement requires a session")
+            .selections
+            .ranges()
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        let edits = targets
+            .iter()
+            .zip(&replacements)
+            .map(|(range, replacement)| {
+                (
+                    TextRange::new(
+                        self.current_buffer().char_idx_to_position(range.start),
+                        self.current_buffer().char_idx_to_position(range.end),
+                    ),
+                    replacement,
+                )
+            })
+            .collect::<Vec<_>>();
+        for (range, replacement) in edits.into_iter().rev() {
+            self.replace_range(range, replacement);
+        }
+
+        let mut shift = 0isize;
+        let updated = targets
+            .into_iter()
+            .zip(replacements)
+            .map(|(target, replacement)| {
+                let start = target.start.saturating_add_signed(shift);
+                shift +=
+                    replacement.chars().count() as isize - (target.end - target.start) as isize;
+                result_range(start, &replacement)
+            })
+            .collect();
+        let revision = self.current_buffer().revision();
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("multi-cursor replacement requires a session");
+        session.revision = revision;
+        session.selections.replace_ranges(updated, active);
     }
 
     fn replace_multi_cursor_targets(&mut self, targets: Vec<CharRange>, replacement: &str) {

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -311,6 +311,33 @@ impl Editor {
         true
     }
 
+    pub(super) fn yank_multi_cursor_selections(&mut self) -> bool {
+        if !self.can_navigate_multi_cursor_occurrences() {
+            return false;
+        }
+        let ranges = self
+            .multi_cursor
+            .as_ref()
+            .expect("session was checked above")
+            .selections
+            .ranges()
+            .to_vec();
+        let yanked = ranges
+            .iter()
+            .map(|range| {
+                self.current_buffer().text_in_range(TextRange::new(
+                    self.current_buffer().char_idx_to_position(range.start),
+                    self.current_buffer().char_idx_to_position(range.end),
+                ))
+            })
+            .collect();
+
+        self.set_default_register(Content::multi_cursor_blockwise(yanked));
+        self.collapse_multi_cursor_ranges(&ranges, |range| range.start);
+        self.move_to_active_multi_cursor(false);
+        true
+    }
+
     pub(super) fn paste_at_multi_cursors(&mut self, anchor: MultiCursorPasteAnchor) -> bool {
         if !self.has_multi_cursor_session() {
             return false;

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -13,6 +13,13 @@ pub(super) enum MultiCursorPhase {
     Inserting,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MultiCursorInsertAnchor {
+    Start,
+    End,
+    Replace,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct MultiCursorSession {
     buffer_id: BufferId,
@@ -107,7 +114,7 @@ impl Editor {
         self.move_to_active_multi_cursor(false);
     }
 
-    pub(super) fn begin_multi_cursor_change(&mut self) -> bool {
+    pub(super) fn begin_multi_cursor_insert(&mut self, anchor: MultiCursorInsertAnchor) -> bool {
         if !self.has_multi_cursor_session() {
             self.multi_cursor = None;
             return false;
@@ -123,8 +130,21 @@ impl Editor {
             return false;
         }
 
-        self.begin_transaction("multi-cursor change");
-        self.replace_multi_cursor_targets(ranges, "");
+        let label = match anchor {
+            MultiCursorInsertAnchor::Start => "multi-cursor insert",
+            MultiCursorInsertAnchor::End => "multi-cursor append",
+            MultiCursorInsertAnchor::Replace => "multi-cursor change",
+        };
+        self.begin_transaction(label);
+        match anchor {
+            MultiCursorInsertAnchor::Start => {
+                self.collapse_multi_cursor_ranges(&ranges, |range| range.start);
+            }
+            MultiCursorInsertAnchor::End => {
+                self.collapse_multi_cursor_ranges(&ranges, |range| range.end);
+            }
+            MultiCursorInsertAnchor::Replace => self.replace_multi_cursor_targets(ranges, ""),
+        }
         if let Some(session) = self.multi_cursor.as_mut() {
             session.phase = MultiCursorPhase::Inserting;
         }
@@ -133,6 +153,30 @@ impl Editor {
         self.generated_indent = None;
         self.move_to_active_multi_cursor(true);
         true
+    }
+
+    fn collapse_multi_cursor_ranges(
+        &mut self,
+        ranges: &[CharRange],
+        position: impl Fn(CharRange) -> usize,
+    ) {
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("multi-cursor collapse requires a session");
+        let active_range = session.selections.active_range();
+        let active = ranges
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        let cursors = ranges
+            .iter()
+            .map(|range| {
+                let position = position(*range);
+                CharRange::new(position, position)
+            })
+            .collect();
+        session.selections.replace_ranges(cursors, active);
     }
 
     pub(super) fn insert_at_multi_cursors(&mut self, text: &str) -> bool {

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffer::BufferId,
-    editing::{CharRange, SelectionSet},
+    editing::{CharRange, MotionResolver, SelectionSet},
     undo::{TextPosition, TextRange},
     unicode_utils::{
         column_to_grapheme_with_tabs, grapheme_len, grapheme_to_column_with_tabs, trim_line_ending,
@@ -14,6 +14,31 @@ use super::{Content, ContentKind, Editor};
 pub(super) enum VerticalCursorDirection {
     Up,
     Down,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MultiCursorMotion {
+    Left,
+    Right,
+    WordForward,
+    WordEnd,
+    LineStart,
+    LineEnd,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MultiCursorSelection {
+    anchor: usize,
+    head: usize,
+}
+
+impl MultiCursorSelection {
+    fn range(self, selection_end: Option<usize>) -> CharRange {
+        let Some(selection_end) = selection_end else {
+            return CharRange::new(self.head, self.head);
+        };
+        CharRange::new(self.anchor.min(self.head), selection_end)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,6 +67,8 @@ pub(super) struct MultiCursorSession {
     revision: u64,
     phase: MultiCursorPhase,
     selections: SelectionSet,
+    extend_selections: Option<Vec<MultiCursorSelection>>,
+    occurrence_navigation: bool,
 }
 
 impl MultiCursorSession {
@@ -77,12 +104,33 @@ impl Editor {
     pub(super) fn can_navigate_multi_cursor_occurrences(&self) -> bool {
         self.multi_cursor.as_ref().is_some_and(|session| {
             session.belongs_to(self)
+                && session.occurrence_navigation
                 && session.phase == MultiCursorPhase::Selecting
                 && session
                     .selections
                     .ranges()
                     .iter()
                     .all(|range| !range.is_empty())
+        })
+    }
+
+    pub(super) fn has_multi_cursor_selections(&self) -> bool {
+        self.multi_cursor.as_ref().is_some_and(|session| {
+            session.belongs_to(self)
+                && session.phase == MultiCursorPhase::Selecting
+                && session
+                    .selections
+                    .ranges()
+                    .iter()
+                    .all(|range| !range.is_empty())
+        })
+    }
+
+    pub(super) fn multi_cursor_is_extending(&self) -> bool {
+        self.multi_cursor.as_ref().is_some_and(|session| {
+            session.belongs_to(self)
+                && session.phase == MultiCursorPhase::Selecting
+                && session.extend_selections.is_some()
         })
     }
 
@@ -103,6 +151,9 @@ impl Editor {
                 .as_mut()
                 .expect("session was checked above");
             session.selections.select_next();
+            self.refresh_multi_cursor_extend_selections();
+        } else if self.has_collapsed_multi_cursor_session() {
+            self.promote_multi_cursors_to_words();
         } else {
             let buffer_id = self.current_buffer().id();
             let Some(window_id) = self.window_manager.active_stable_window_id() else {
@@ -119,11 +170,19 @@ impl Editor {
                 self.multi_cursor = None;
                 return;
             };
+            let extend_selections = selections
+                .ranges()
+                .iter()
+                .copied()
+                .map(|range| self.multi_cursor_selection_from_range(range))
+                .collect();
             self.multi_cursor = Some(MultiCursorSession {
                 buffer_id,
                 window_id,
                 revision,
                 phase: MultiCursorPhase::Selecting,
+                extend_selections: Some(extend_selections),
+                occurrence_navigation: true,
                 selections,
             });
         }
@@ -131,10 +190,58 @@ impl Editor {
         self.move_to_active_multi_cursor(false);
     }
 
+    fn has_collapsed_multi_cursor_session(&self) -> bool {
+        self.multi_cursor.as_ref().is_some_and(|session| {
+            session.belongs_to(self)
+                && session.phase == MultiCursorPhase::Selecting
+                && session
+                    .selections
+                    .ranges()
+                    .iter()
+                    .all(|range| range.is_empty())
+        })
+    }
+
+    fn promote_multi_cursors_to_words(&mut self) {
+        let session = self
+            .multi_cursor
+            .as_ref()
+            .expect("collapsed session was checked above");
+        let active_range = session.selections.active_range();
+        let active = session
+            .selections
+            .ranges()
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        let ranges = session
+            .selections
+            .ranges()
+            .iter()
+            .map(|cursor| {
+                let position = self.current_buffer().char_idx_to_position(cursor.start);
+                SelectionSet::range_at_cursor(self.current_buffer(), position).unwrap_or(*cursor)
+            })
+            .collect::<Vec<_>>();
+        let extend_selections = ranges
+            .iter()
+            .copied()
+            .map(|range| self.multi_cursor_selection_from_range(range))
+            .collect();
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("collapsed session was checked above");
+        session.selections.replace_ranges(ranges, active);
+        session.extend_selections = Some(extend_selections);
+        session.occurrence_navigation = false;
+    }
+
     pub(super) fn add_vertical_cursor(&mut self, direction: VerticalCursorDirection) {
         let compatible_session = self.multi_cursor.as_ref().is_some_and(|session| {
             session.belongs_to(self)
                 && session.phase == MultiCursorPhase::Selecting
+                && session.extend_selections.is_none()
                 && session
                     .selections
                     .ranges()
@@ -193,6 +300,8 @@ impl Editor {
                 revision,
                 phase: MultiCursorPhase::Selecting,
                 selections,
+                extend_selections: None,
+                occurrence_navigation: false,
             });
         }
 
@@ -237,6 +346,231 @@ impl Editor {
         }
     }
 
+    pub(super) fn toggle_multi_cursor_extend_mode(&mut self) {
+        if !self.has_multi_cursor_session() {
+            return;
+        }
+        if self.multi_cursor_is_extending() {
+            self.collapse_multi_cursor_to_heads();
+        } else {
+            self.enter_multi_cursor_extend_mode();
+        }
+        self.move_to_active_multi_cursor(false);
+    }
+
+    pub(super) fn extend_multi_cursor_selections(&mut self, motion: MultiCursorMotion) {
+        if !self.has_multi_cursor_session() {
+            return;
+        }
+        if !self.multi_cursor_is_extending() {
+            self.enter_multi_cursor_extend_mode();
+        }
+
+        let session = self
+            .multi_cursor
+            .as_ref()
+            .expect("session was checked above");
+        let active_range = session.selections.active_range();
+        let active = session
+            .selections
+            .ranges()
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        let mut selections = session
+            .extend_selections
+            .clone()
+            .expect("extend mode requires oriented selections");
+        for selection in &mut selections {
+            selection.head = self.multi_cursor_motion_target(selection.head, motion);
+        }
+        let ranges = selections
+            .iter()
+            .map(|selection| {
+                selection
+                    .range(self.multi_cursor_grapheme_end(selection.anchor.max(selection.head)))
+            })
+            .collect();
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("session was checked above");
+        session.selections.replace_ranges(ranges, active);
+        session.extend_selections = Some(selections);
+        session.occurrence_navigation = false;
+        self.move_to_active_multi_cursor(false);
+    }
+
+    pub(super) fn invert_multi_cursor_selections(&mut self) {
+        if !self.multi_cursor_is_extending() {
+            return;
+        }
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("extend session was checked above");
+        for selection in session
+            .extend_selections
+            .as_mut()
+            .expect("extend mode requires oriented selections")
+        {
+            std::mem::swap(&mut selection.anchor, &mut selection.head);
+        }
+        self.move_to_active_multi_cursor(false);
+    }
+
+    fn enter_multi_cursor_extend_mode(&mut self) {
+        let session = self
+            .multi_cursor
+            .as_ref()
+            .expect("multi-cursor extend requires a session");
+        let active_range = session.selections.active_range();
+        let active = session
+            .selections
+            .ranges()
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        let ranges = session.selections.ranges().to_vec();
+        let selections = ranges
+            .iter()
+            .map(|range| self.multi_cursor_selection_from_range(*range))
+            .collect::<Vec<_>>();
+        let ranges = selections
+            .iter()
+            .map(|selection| {
+                selection
+                    .range(self.multi_cursor_grapheme_end(selection.anchor.max(selection.head)))
+            })
+            .collect();
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("multi-cursor extend requires a session");
+        session.selections.replace_ranges(ranges, active);
+        session.extend_selections = Some(selections);
+    }
+
+    fn collapse_multi_cursor_to_heads(&mut self) {
+        let session = self
+            .multi_cursor
+            .as_ref()
+            .expect("multi-cursor collapse requires a session");
+        let active_range = session.selections.active_range();
+        let active = session
+            .selections
+            .ranges()
+            .iter()
+            .position(|range| *range == active_range)
+            .unwrap_or(0);
+        let cursors = session
+            .extend_selections
+            .as_ref()
+            .expect("extend mode requires oriented selections")
+            .iter()
+            .map(|selection| CharRange::new(selection.head, selection.head))
+            .collect();
+        let session = self
+            .multi_cursor
+            .as_mut()
+            .expect("multi-cursor collapse requires a session");
+        session.selections.replace_ranges(cursors, active);
+        session.extend_selections = None;
+        session.occurrence_navigation = false;
+    }
+
+    fn multi_cursor_motion_target(&self, index: usize, motion: MultiCursorMotion) -> usize {
+        let position = self.current_buffer().char_idx_to_position(index);
+        let line = position.line;
+        let line_contents = self.current_buffer().get(line).unwrap_or_default();
+        let line_contents = trim_line_ending(&line_contents);
+        let line_graphemes = grapheme_len(line_contents);
+        let current_grapheme = self.char_to_grapheme_on_line(position.character, line);
+        let last_grapheme = line_graphemes.saturating_sub(1);
+        let target = match motion {
+            MultiCursorMotion::Left => current_grapheme.saturating_sub(1),
+            MultiCursorMotion::Right => current_grapheme.saturating_add(1).min(last_grapheme),
+            MultiCursorMotion::LineStart => 0,
+            MultiCursorMotion::LineEnd => last_grapheme,
+            MultiCursorMotion::WordForward | MultiCursorMotion::WordEnd => {
+                let end = motion == MultiCursorMotion::WordEnd;
+                let target = MotionResolver::new(self.current_buffer(), position)
+                    .word_target(
+                        /*count*/ 1, /*backward*/ false, end, /*big_word*/ false,
+                    )
+                    .filter(|target| target.line == line);
+                return target
+                    .map(|target| self.current_buffer().position_to_char_idx(target))
+                    .unwrap_or_else(|| {
+                        self.current_buffer()
+                            .position_to_char_idx(TextPosition::new(
+                                line,
+                                self.grapheme_to_char_on_line(last_grapheme, line),
+                            ))
+                    });
+            }
+        };
+        self.current_buffer()
+            .position_to_char_idx(TextPosition::new(
+                line,
+                self.grapheme_to_char_on_line(target, line),
+            ))
+    }
+
+    fn multi_cursor_grapheme_end(&self, index: usize) -> Option<usize> {
+        let position = self.current_buffer().char_idx_to_position(index);
+        let line_length = self.line_character_len(position.line);
+        if position.character >= line_length {
+            return None;
+        }
+        let grapheme = self.char_to_grapheme_on_line(position.character, position.line);
+        let end = self.grapheme_to_char_on_line(grapheme + 1, position.line);
+        Some(
+            self.current_buffer()
+                .position_to_char_idx(TextPosition::new(position.line, end)),
+        )
+    }
+
+    fn multi_cursor_selection_from_range(&self, range: CharRange) -> MultiCursorSelection {
+        if range.is_empty() {
+            return MultiCursorSelection {
+                anchor: range.start,
+                head: range.start,
+            };
+        }
+        let last_character = range.end - 1;
+        let position = self.current_buffer().char_idx_to_position(last_character);
+        let grapheme = self.char_to_grapheme_on_line(position.character, position.line);
+        let head = self
+            .current_buffer()
+            .position_to_char_idx(TextPosition::new(
+                position.line,
+                self.grapheme_to_char_on_line(grapheme, position.line),
+            ));
+        MultiCursorSelection {
+            anchor: range.start,
+            head,
+        }
+    }
+
+    fn refresh_multi_cursor_extend_selections(&mut self) {
+        let Some(ranges) = self
+            .multi_cursor
+            .as_ref()
+            .map(|session| session.selections.ranges().to_vec())
+        else {
+            return;
+        };
+        let selections = ranges
+            .into_iter()
+            .map(|range| self.multi_cursor_selection_from_range(range))
+            .collect();
+        self.multi_cursor
+            .as_mut()
+            .expect("multi-cursor session was checked above")
+            .extend_selections = Some(selections);
+    }
+
     pub(super) fn select_previous_occurrence(&mut self) {
         if !self.can_navigate_multi_cursor_occurrences() {
             self.multi_cursor = None;
@@ -247,6 +581,7 @@ impl Editor {
             .as_mut()
             .expect("session was checked above");
         session.selections.select_previous();
+        self.refresh_multi_cursor_extend_selections();
         self.move_to_active_multi_cursor(false);
     }
 
@@ -260,6 +595,7 @@ impl Editor {
             .as_mut()
             .expect("session was checked above");
         session.selections.skip_active();
+        self.refresh_multi_cursor_extend_selections();
         self.move_to_active_multi_cursor(false);
     }
 
@@ -278,6 +614,7 @@ impl Editor {
             self.multi_cursor = None;
             return;
         }
+        self.refresh_multi_cursor_extend_selections();
         self.move_to_active_multi_cursor(false);
     }
 
@@ -344,6 +681,8 @@ impl Editor {
             })
             .collect();
         session.selections.replace_ranges(cursors, active);
+        session.extend_selections = None;
+        session.occurrence_navigation = false;
     }
 
     pub(super) fn insert_at_multi_cursors(&mut self, text: &str) -> bool {
@@ -390,13 +729,14 @@ impl Editor {
         self.cancel_transaction_if_empty();
         if let Some(session) = self.multi_cursor.as_mut() {
             session.phase = MultiCursorPhase::Selecting;
+            session.extend_selections = None;
         }
         self.move_to_active_multi_cursor(false);
         true
     }
 
     pub(super) fn delete_multi_cursor_selections(&mut self, preserve_register: bool) -> bool {
-        if !self.can_navigate_multi_cursor_occurrences() {
+        if !self.has_multi_cursor_selections() {
             return false;
         }
         let targets = self
@@ -427,7 +767,7 @@ impl Editor {
     }
 
     pub(super) fn yank_multi_cursor_selections(&mut self) -> bool {
-        if !self.can_navigate_multi_cursor_occurrences() {
+        if !self.has_multi_cursor_selections() {
             return false;
         }
         let ranges = self
@@ -457,6 +797,7 @@ impl Editor {
         if !self.has_multi_cursor_session() {
             return false;
         }
+        let extending = self.multi_cursor_is_extending();
         self.refresh_default_register_from_system_clipboard();
         let Some(content) = self.registers.get(&super::DEFAULT_REGISTER).cloned() else {
             return false;
@@ -521,6 +862,9 @@ impl Editor {
                     CharRange::new(cursor, cursor)
                 },
             );
+        }
+        if selecting && extending {
+            self.refresh_multi_cursor_extend_selections();
         }
         self.move_to_active_multi_cursor(false);
         self.commit_transaction(self.cursor_snapshot());
@@ -717,6 +1061,8 @@ impl Editor {
             .expect("multi-cursor replacement requires a session");
         session.revision = revision;
         session.selections.replace_ranges(updated, active);
+        session.extend_selections = None;
+        session.occurrence_navigation = false;
     }
 
     fn replace_multi_cursor_targets(&mut self, targets: Vec<CharRange>, replacement: &str) {
@@ -770,18 +1116,31 @@ impl Editor {
             .expect("multi-cursor replacement requires a session");
         session.revision = revision;
         session.selections.replace_ranges(updated, active);
+        session.extend_selections = None;
+        session.occurrence_navigation = false;
     }
 
     fn move_to_active_multi_cursor(&mut self, insert: bool) {
-        let Some(range) = self
+        let Some((range, extend_head)) = self
             .multi_cursor
             .as_ref()
             .filter(|session| session.belongs_to(self))
-            .map(|session| session.selections.active_range())
+            .map(|session| {
+                let range = session.selections.active_range();
+                let active = session.selections.active_selection().0.saturating_sub(1);
+                let extend_head = session
+                    .extend_selections
+                    .as_ref()
+                    .and_then(|selections| selections.get(active))
+                    .map(|selection| selection.head);
+                (range, extend_head)
+            })
         else {
             return;
         };
-        let index = if insert || range.is_empty() {
+        let index = if let Some(head) = extend_head {
+            head
+        } else if insert || range.is_empty() {
             range.end
         } else {
             range.end.saturating_sub(1)

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -2813,6 +2813,46 @@ impl Editor {
         self.render_search_highlights_in_window(buffer, window)?;
         self.render_matching_brackets_in_window(buffer, window, None);
 
+        let multi_cursor_ranges = self
+            .multi_cursor_render_ranges(self.buffer_manager[window.buffer_index].id(), window.id);
+        for (range, collapsed) in multi_cursor_ranges {
+            let Some(line) = self.buffer_manager[window.buffer_index].get(range.start.line) else {
+                continue;
+            };
+            let line = trim_line_ending(&line);
+            let tab_width = self.tab_width_for_buffer_index(window.buffer_index);
+            let start_col =
+                display_width_with_tabs(char_prefix(line, range.start.character), tab_width);
+            let end_col = if collapsed {
+                let next_character = (range.start.character + 1).min(line.chars().count());
+                display_width_with_tabs(char_prefix(line, next_character), tab_width)
+                    .max(start_col + 1)
+            } else {
+                display_width_with_tabs(char_prefix(line, range.end.character), tab_width)
+            };
+            let points = self.display_col_range_points_in_window(
+                window,
+                range.start.line,
+                start_col,
+                end_col,
+            );
+            if collapsed {
+                for point in points {
+                    let position = point.y * buffer.width + point.x;
+                    if let Some(cell) = buffer.cells.get_mut(position) {
+                        cell.style = self.theme.synthetic_cursor_style(&cell.style);
+                    }
+                }
+            } else {
+                buffer.apply_selection_for_points(
+                    points,
+                    &self.theme.editor_selection_style(),
+                    &self.theme,
+                    SelectionForegroundPriority::Selection,
+                );
+            }
+        }
+
         if let Some(range) = self.selected_snippet_range() {
             let selection_style = self.theme.editor_selection_style();
             for line_index in range.start.line..=range.end.line {

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -3660,6 +3660,8 @@ impl Editor {
         let context = StatuslineContext {
             mode: if self.pane_resize_mode.is_some() {
                 "RESIZE".to_string()
+            } else if let Some(multi_cursor) = self.multi_cursor_status_label() {
+                multi_cursor
             } else {
                 format_mode_name(&self.mode)
             },

--- a/tests/multi_cursor.rs
+++ b/tests/multi_cursor.rs
@@ -17,6 +17,100 @@ async fn key(harness: &mut EditorHarness, code: KeyCode, modifiers: KeyModifiers
 }
 
 #[tokio::test]
+async fn ctrl_down_skips_shorter_lines_and_inserts_at_each_vertical_cursor() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "abcdef\nab\n\nabcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness.execute_action(Action::MoveTo(4, 0)).await.unwrap();
+
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+    harness.assert_cursor_at(4, 3);
+
+    key(&mut harness, KeyCode::Char('i'), KeyModifiers::NONE).await;
+    harness.type_text("X").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("abcdXef\nab\n\nabcdXef");
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("abcdef\nab\n\nabcdef");
+}
+
+#[tokio::test]
+async fn vertical_cursor_direction_changes_activate_existing_cursors_before_adding() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "abcd\nabcd\nabcd\nabcd".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness.execute_action(Action::MoveTo(2, 2)).await.unwrap();
+    harness.assert_cursor_at(2, 1);
+
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+    harness.assert_cursor_at(2, 2);
+    key(&mut harness, KeyCode::Up, KeyModifiers::CONTROL).await;
+    harness.assert_cursor_at(2, 1);
+    assert!(harness.statusline_row().contains("MULTI 1/2"));
+    key(&mut harness, KeyCode::Up, KeyModifiers::CONTROL).await;
+
+    harness.assert_cursor_at(2, 0);
+    assert!(harness.statusline_row().contains("MULTI 1/3"));
+}
+
+#[tokio::test]
+async fn ctrl_up_orders_cursors_by_document_position() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "abcd\nabcd".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness.execute_action(Action::MoveTo(2, 2)).await.unwrap();
+
+    key(&mut harness, KeyCode::Up, KeyModifiers::CONTROL).await;
+
+    harness.assert_cursor_at(2, 0);
+    assert!(harness.statusline_row().contains("MULTI 1/2"));
+}
+
+#[tokio::test]
+async fn vertical_cursors_include_empty_lines_at_column_zero() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "a\n\nb".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+    harness.assert_cursor_at(0, 1);
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+
+    harness.assert_cursor_at(0, 2);
+    assert!(harness.statusline_row().contains("MULTI 3/3"));
+}
+
+#[tokio::test]
+async fn vertical_cursors_preserve_display_columns_across_tabs_and_spaces() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "\tabc\n    abc\n\tabc".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness.execute_action(Action::MoveTo(1, 0)).await.unwrap();
+
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+    harness.assert_cursor_at(4, 1);
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+
+    harness.assert_cursor_at(1, 2);
+    assert!(harness.statusline_row().contains("MULTI 3/3"));
+}
+
+#[tokio::test]
+async fn vertical_cursor_at_a_document_boundary_is_a_noop() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "only line".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+
+    assert!(!harness.statusline_row().contains("MULTI"));
+    harness.assert_cursor_at(0, 0);
+}
+
+#[tokio::test]
 async fn ctrl_n_change_types_at_each_selected_occurrence_as_one_undo() {
     let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
     let buffer = Buffer::new(None, "foo foo foo_bar foo".to_string());

--- a/tests/multi_cursor.rs
+++ b/tests/multi_cursor.rs
@@ -16,6 +16,156 @@ async fn key(harness: &mut EditorHarness, code: KeyCode, modifiers: KeyModifiers
         .unwrap();
 }
 
+async fn assert_vertical_selection_change(
+    contents: &str,
+    cursor_x: usize,
+    selection_keys: &[(KeyCode, KeyModifiers)],
+    expected: &str,
+) {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, contents.to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness
+        .execute_action(Action::MoveTo(cursor_x, 0))
+        .await
+        .unwrap();
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+    for (code, modifiers) in selection_keys {
+        key(&mut harness, *code, *modifiers).await;
+    }
+    key(&mut harness, KeyCode::Char('c'), KeyModifiers::NONE).await;
+    harness.type_text("X").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents(expected);
+}
+
+#[tokio::test]
+async fn shift_arrows_expand_vertical_cursors_like_visual_multi() {
+    assert_vertical_selection_change(
+        "abcdef\nabcdef",
+        2,
+        &[(KeyCode::Right, KeyModifiers::SHIFT)],
+        "abXef\nabXef",
+    )
+    .await;
+    assert_vertical_selection_change(
+        "abcdef\nabcdef",
+        2,
+        &[(KeyCode::Left, KeyModifiers::SHIFT)],
+        "aXdef\naXdef",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn tab_enters_extend_mode_and_tab_again_collapses_at_each_head() {
+    assert_vertical_selection_change(
+        "abcdef\nabcdef",
+        2,
+        &[(KeyCode::Tab, KeyModifiers::NONE)],
+        "abXdef\nabXdef",
+    )
+    .await;
+
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "abcdef\nabcdef".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness.execute_action(Action::MoveTo(2, 0)).await.unwrap();
+    key(&mut harness, KeyCode::Down, KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Tab, KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Char('e'), KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Tab, KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Char('i'), KeyModifiers::NONE).await;
+    harness.type_text("X").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("abcdeXf\nabcdeXf");
+}
+
+#[tokio::test]
+async fn extend_mode_supports_word_and_line_motions() {
+    assert_vertical_selection_change(
+        "abcdef\nabcdef",
+        2,
+        &[
+            (KeyCode::Tab, KeyModifiers::NONE),
+            (KeyCode::Char('e'), KeyModifiers::NONE),
+        ],
+        "abX\nabX",
+    )
+    .await;
+    assert_vertical_selection_change(
+        "foo bar\nfoo baz",
+        0,
+        &[
+            (KeyCode::Tab, KeyModifiers::NONE),
+            (KeyCode::Char('w'), KeyModifiers::NONE),
+        ],
+        "Xar\nXaz",
+    )
+    .await;
+    assert_vertical_selection_change(
+        "abcdef\nabcdef",
+        2,
+        &[
+            (KeyCode::Tab, KeyModifiers::NONE),
+            (KeyCode::Char('0'), KeyModifiers::NONE),
+        ],
+        "Xdef\nXdef",
+    )
+    .await;
+    assert_vertical_selection_change(
+        "abcdef\nabcdef",
+        2,
+        &[
+            (KeyCode::Tab, KeyModifiers::NONE),
+            (KeyCode::Char('$'), KeyModifiers::SHIFT),
+        ],
+        "abX\nabX",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn o_flips_each_extend_mode_anchor() {
+    assert_vertical_selection_change(
+        "abcdef\nabcdef",
+        2,
+        &[
+            (KeyCode::Tab, KeyModifiers::NONE),
+            (KeyCode::Char('l'), KeyModifiers::NONE),
+            (KeyCode::Char('o'), KeyModifiers::NONE),
+            (KeyCode::Char('h'), KeyModifiers::NONE),
+            (KeyCode::Char('h'), KeyModifiers::NONE),
+        ],
+        "Xef\nXef",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn ctrl_n_promotes_each_vertical_cursor_to_its_word() {
+    assert_vertical_selection_change(
+        "foo bar\nfoo baz",
+        0,
+        &[(KeyCode::Char('n'), KeyModifiers::CONTROL)],
+        "X bar\nX baz",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn extend_mode_moves_by_grapheme_and_selects_complete_unicode_clusters() {
+    assert_vertical_selection_change(
+        "a👨‍👩‍👧b\na👨‍👩‍👧b",
+        1,
+        &[(KeyCode::Right, KeyModifiers::SHIFT)],
+        "aX\naX",
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn ctrl_down_skips_shorter_lines_and_inserts_at_each_vertical_cursor() {
     let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();

--- a/tests/multi_cursor.rs
+++ b/tests/multi_cursor.rs
@@ -79,10 +79,12 @@ async fn multi_cursor_i_inserts_at_each_selection_start_as_one_undo() {
     key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
     key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
     key(&mut harness, KeyCode::Char('i'), KeyModifiers::NONE).await;
+    assert!(harness.statusline_row().contains("MULTI-I 2/2"));
     harness.type_text("☕").await.unwrap();
     key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
 
     harness.assert_mode(Mode::Normal);
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
     harness.assert_buffer_contents("☕café ☕café");
 
     harness.execute_action(Action::Undo).await.unwrap();
@@ -109,4 +111,86 @@ async fn multi_cursor_a_appends_to_each_selection_end_as_one_undo() {
 
     harness.execute_action(Action::Undo).await.unwrap();
     harness.assert_buffer_contents("foo foo");
+}
+
+#[tokio::test]
+async fn multi_cursor_navigation_wraps_and_reports_the_active_selection() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+    harness.assert_cursor_at(6, 0);
+
+    key(&mut harness, KeyCode::Char('N'), KeyModifiers::SHIFT).await;
+    assert!(harness.statusline_row().contains("MULTI 1/2"));
+    harness.assert_cursor_at(2, 0);
+
+    key(&mut harness, KeyCode::Char('N'), KeyModifiers::SHIFT).await;
+    assert!(harness.statusline_row().contains("MULTI 3/3"));
+    harness.assert_cursor_at(14, 0);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::NONE).await;
+    assert!(harness.statusline_row().contains("MULTI 1/3"));
+    harness.assert_cursor_at(2, 0);
+}
+
+#[tokio::test]
+async fn q_skips_in_the_last_direction_and_shift_q_removes_the_active_selection() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('N'), KeyModifiers::SHIFT).await;
+    key(&mut harness, KeyCode::Char('q'), KeyModifiers::NONE).await;
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+    harness.assert_cursor_at(14, 0);
+
+    key(&mut harness, KeyCode::Char('Q'), KeyModifiers::SHIFT).await;
+    assert!(harness.statusline_row().contains("MULTI 1/1"));
+    harness.assert_cursor_at(6, 0);
+
+    key(&mut harness, KeyCode::Char('Q'), KeyModifiers::SHIFT).await;
+    assert!(!harness.statusline_row().contains("MULTI"));
+}
+
+#[tokio::test]
+async fn skipped_occurrences_are_excluded_from_the_following_edit() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('q'), KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Char('c'), KeyModifiers::NONE).await;
+    harness.type_text("x").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("x foo x foo");
+}
+
+#[tokio::test]
+async fn multi_cursor_navigation_does_not_replace_normal_search_state() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo bar foo bar".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    harness.execute_action(Action::MoveTo(4, 0)).await.unwrap();
+    harness
+        .execute_action(Action::SearchWordUnderCursor)
+        .await
+        .unwrap();
+    harness.execute_action(Action::MoveTo(0, 0)).await.unwrap();
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::NONE).await;
+
+    harness.assert_cursor_at(12, 0);
 }

--- a/tests/multi_cursor.rs
+++ b/tests/multi_cursor.rs
@@ -5,7 +5,7 @@ use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use red::{
     buffer::Buffer,
     config::Config,
-    editor::{Action, Mode},
+    editor::{Action, Content, Mode},
 };
 
 async fn key(harness: &mut EditorHarness, code: KeyCode, modifiers: KeyModifiers) {
@@ -193,4 +193,87 @@ async fn multi_cursor_navigation_does_not_replace_normal_search_state() {
     key(&mut harness, KeyCode::Char('n'), KeyModifiers::NONE).await;
 
     harness.assert_cursor_at(12, 0);
+}
+
+#[tokio::test]
+async fn d_deletes_selected_occurrences_into_the_default_register_as_one_undo() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "café café café".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('d'), KeyModifiers::NONE).await;
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_buffer_contents("  café");
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+    harness.assert_cursor_at(1, 0);
+    harness
+        .execute_action(Action::PrintRegisters)
+        .await
+        .unwrap();
+    assert_eq!(harness.last_error(), Some("\": café\ncafé"));
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("café café café");
+}
+
+#[tokio::test]
+async fn x_deletes_selected_occurrences_without_replacing_the_default_register() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness
+        .editor
+        .test_set_default_register(Content::charwise("seed".to_string()));
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('x'), KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents(" ");
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+    harness
+        .execute_action(Action::PrintRegisters)
+        .await
+        .unwrap();
+    assert_eq!(harness.last_error(), Some("\": seed"));
+}
+
+#[tokio::test]
+async fn deleting_adjacent_selections_merges_the_collapsed_cursors() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "..x".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('d'), KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("x");
+    assert!(harness.statusline_row().contains("MULTI 1/1"));
+    harness.assert_cursor_at(0, 0);
+}
+
+#[tokio::test]
+async fn deleted_selections_leave_editable_cursors_across_lines() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo\nfoo\nkeep".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('d'), KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Char('i'), KeyModifiers::NONE).await;
+    harness.type_text("x").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("x\nx\nkeep");
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("\n\nkeep");
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("foo\nfoo\nkeep");
 }

--- a/tests/multi_cursor.rs
+++ b/tests/multi_cursor.rs
@@ -432,3 +432,74 @@ async fn linewise_register_pastes_once_per_selected_region_and_merges_same_line_
     harness.execute_action(Action::Undo).await.unwrap();
     harness.assert_buffer_contents("foo foo\ntail");
 }
+
+#[tokio::test]
+async fn y_yanks_ordered_unicode_regions_and_collapses_to_their_starts() {
+    let mut config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    config.search.ignorecase = true;
+    config.search.smartcase = false;
+    let buffer = Buffer::new(None, "café CAFÉ tail".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    let clipboard = MemoryClipboardProvider::default();
+    let clipboard_text = clipboard.shared_text();
+    harness.editor.test_set_clipboard(Box::new(clipboard));
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('y'), KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("café CAFÉ tail");
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+    harness.assert_cursor_at(5, 0);
+    assert_eq!(
+        clipboard_text.lock().unwrap().as_deref(),
+        Some("café\nCAFÉ")
+    );
+    harness
+        .execute_action(Action::PrintRegisters)
+        .await
+        .unwrap();
+    assert_eq!(harness.last_error(), Some("\": café\nCAFÉ"));
+}
+
+#[tokio::test]
+async fn yanked_multi_cursor_payloads_paste_back_in_region_order() {
+    let mut config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    config.search.ignorecase = true;
+    config.search.smartcase = false;
+    let buffer = Buffer::new(None, "foo FOO".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('y'), KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Char('p'), KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("ffoooo FFOOOO");
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+}
+
+#[tokio::test]
+async fn y_respects_skipped_regions_and_does_not_create_an_undo_entry() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    harness.execute_action(Action::MoveTo(10, 0)).await.unwrap();
+    key(&mut harness, KeyCode::Char('a'), KeyModifiers::NONE).await;
+    harness.type_text("!").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+    harness.execute_action(Action::MoveTo(0, 0)).await.unwrap();
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('q'), KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Char('y'), KeyModifiers::NONE).await;
+
+    harness
+        .execute_action(Action::PrintRegisters)
+        .await
+        .unwrap();
+    assert_eq!(harness.last_error(), Some("\": foo\nfoo"));
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("foo foo foo");
+}

--- a/tests/multi_cursor.rs
+++ b/tests/multi_cursor.rs
@@ -69,3 +69,44 @@ async fn multi_cursor_insert_supports_backspace_and_paste() {
 
     harness.assert_buffer_contents("aZ aZ");
 }
+
+#[tokio::test]
+async fn multi_cursor_i_inserts_at_each_selection_start_as_one_undo() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "café café".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('i'), KeyModifiers::NONE).await;
+    harness.type_text("☕").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_buffer_contents("☕café ☕café");
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("café café");
+}
+
+#[tokio::test]
+async fn multi_cursor_a_appends_to_each_selection_end_as_one_undo() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('a'), KeyModifiers::NONE).await;
+    harness
+        .execute_event(Event::Paste("_id".to_string()))
+        .await
+        .unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_buffer_contents("foo_id foo_id");
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("foo foo");
+}

--- a/tests/multi_cursor.rs
+++ b/tests/multi_cursor.rs
@@ -4,6 +4,7 @@ use common::EditorHarness;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use red::{
     buffer::Buffer,
+    clipboard::MemoryClipboardProvider,
     config::Config,
     editor::{Action, Content, Mode},
 };
@@ -276,4 +277,158 @@ async fn deleted_selections_leave_editable_cursors_across_lines() {
     harness.assert_buffer_contents("\n\nkeep");
     harness.execute_action(Action::Undo).await.unwrap();
     harness.assert_buffer_contents("foo\nfoo\nkeep");
+}
+
+#[tokio::test]
+async fn p_and_shift_p_replace_selected_occurrences_and_reselect_them() {
+    for (paste, modifiers) in [
+        (KeyCode::Char('p'), KeyModifiers::NONE),
+        (KeyCode::Char('P'), KeyModifiers::SHIFT),
+    ] {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+        let buffer = Buffer::new(None, "foo foo".to_string());
+        let mut harness = EditorHarness::with_config(buffer, config);
+        harness
+            .editor
+            .test_set_clipboard(Box::new(MemoryClipboardProvider::with_text("X")));
+
+        key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+        key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+        key(&mut harness, paste, modifiers).await;
+
+        harness.assert_buffer_contents("X X");
+        assert!(harness.statusline_row().contains("MULTI 2/2"));
+        harness.assert_cursor_at(2, 0);
+
+        harness.execute_action(Action::Undo).await.unwrap();
+        harness.assert_buffer_contents("foo foo");
+    }
+}
+
+#[tokio::test]
+async fn p_and_shift_p_paste_after_and_before_collapsed_cursors() {
+    for (paste, modifiers, expected, cursor) in [
+        (KeyCode::Char('p'), KeyModifiers::NONE, " XX", (2, 0)),
+        (KeyCode::Char('P'), KeyModifiers::SHIFT, "XX ", (1, 0)),
+    ] {
+        let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+        let buffer = Buffer::new(None, "foo foo".to_string());
+        let mut harness = EditorHarness::with_config(buffer, config);
+        harness
+            .editor
+            .test_set_clipboard(Box::new(MemoryClipboardProvider::with_text("X")));
+
+        key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+        key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+        key(&mut harness, KeyCode::Char('x'), KeyModifiers::NONE).await;
+        key(&mut harness, paste, modifiers).await;
+
+        harness.assert_buffer_contents(expected);
+        assert!(harness.statusline_row().contains("MULTI 2/2"));
+        harness.assert_cursor_at(cursor.0, cursor.1);
+    }
+}
+
+#[tokio::test]
+async fn multi_cursor_delete_payloads_survive_clipboard_sync_and_paste_in_order() {
+    let mut config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    config.search.ignorecase = true;
+    config.search.smartcase = false;
+    let buffer = Buffer::new(None, "foo FOO".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    let clipboard = MemoryClipboardProvider::default();
+    let clipboard_text = clipboard.shared_text();
+    harness.editor.test_set_clipboard(Box::new(clipboard));
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('d'), KeyModifiers::NONE).await;
+    assert_eq!(clipboard_text.lock().unwrap().as_deref(), Some("foo\nFOO"));
+
+    key(&mut harness, KeyCode::Char('P'), KeyModifiers::SHIFT).await;
+
+    harness.assert_buffer_contents("fooFOO ");
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+    harness.assert_cursor_at(3, 0);
+}
+
+#[tokio::test]
+async fn blockwise_payload_mismatch_preserves_unmatched_selected_regions() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness
+        .editor
+        .test_set_default_register(Content::blockwise("A\nBB".to_string()));
+
+    for _ in 0..3 {
+        key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    }
+    key(&mut harness, KeyCode::Char('p'), KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("A BB foo");
+    assert!(harness.statusline_row().contains("MULTI 3/3"));
+    harness.assert_cursor_at(7, 0);
+}
+
+#[tokio::test]
+async fn blockwise_payload_mismatch_inserts_nothing_at_extra_collapsed_cursors() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness
+        .editor
+        .test_set_default_register(Content::blockwise("A\nBB".to_string()));
+
+    for _ in 0..3 {
+        key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    }
+    key(&mut harness, KeyCode::Char('x'), KeyModifiers::NONE).await;
+    key(&mut harness, KeyCode::Char('p'), KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents(" A BB");
+    assert!(harness.statusline_row().contains("MULTI 3/3"));
+    harness.assert_cursor_at(4, 0);
+}
+
+#[tokio::test]
+async fn external_clipboard_changes_replace_structured_multi_cursor_payloads() {
+    let mut config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    config.search.ignorecase = true;
+    config.search.smartcase = false;
+    let buffer = Buffer::new(None, "foo FOO".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    let clipboard = MemoryClipboardProvider::default();
+    let clipboard_text = clipboard.shared_text();
+    harness.editor.test_set_clipboard(Box::new(clipboard));
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('d'), KeyModifiers::NONE).await;
+    *clipboard_text.lock().unwrap() = Some("X".to_string());
+    key(&mut harness, KeyCode::Char('P'), KeyModifiers::SHIFT).await;
+
+    harness.assert_buffer_contents("XX ");
+    assert!(harness.statusline_row().contains("MULTI 2/2"));
+}
+
+#[tokio::test]
+async fn linewise_register_pastes_once_per_selected_region_and_merges_same_line_cursors() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo\ntail".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness
+        .editor
+        .test_set_default_register(Content::linewise("AA\n".to_string()));
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('p'), KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("foo foo\nAA\nAA\ntail");
+    assert!(harness.statusline_row().contains("MULTI 1/1"));
+    harness.assert_cursor_at(0, 1);
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("foo foo\ntail");
 }

--- a/tests/multi_cursor.rs
+++ b/tests/multi_cursor.rs
@@ -1,0 +1,71 @@
+mod common;
+
+use common::EditorHarness;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use red::{
+    buffer::Buffer,
+    config::Config,
+    editor::{Action, Mode},
+};
+
+async fn key(harness: &mut EditorHarness, code: KeyCode, modifiers: KeyModifiers) {
+    harness
+        .execute_event(Event::Key(KeyEvent::new(code, modifiers)))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn ctrl_n_change_types_at_each_selected_occurrence_as_one_undo() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo foo_bar foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('c'), KeyModifiers::NONE).await;
+    harness.type_text("bar").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_mode(Mode::Normal);
+    harness.assert_buffer_contents("bar bar foo_bar foo");
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("foo foo foo_bar foo");
+}
+
+#[tokio::test]
+async fn ctrl_n_wraps_without_adding_duplicate_selections() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    for _ in 0..3 {
+        key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    }
+    key(&mut harness, KeyCode::Char('c'), KeyModifiers::NONE).await;
+    harness.type_text("x").await.unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("x x");
+}
+
+#[tokio::test]
+async fn multi_cursor_insert_supports_backspace_and_paste() {
+    let config: Config = toml::from_str(include_str!("../default_config.toml")).unwrap();
+    let buffer = Buffer::new(None, "foo foo".to_string());
+    let mut harness = EditorHarness::with_config(buffer, config);
+
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('n'), KeyModifiers::CONTROL).await;
+    key(&mut harness, KeyCode::Char('c'), KeyModifiers::NONE).await;
+    harness.type_text("ab").await.unwrap();
+    key(&mut harness, KeyCode::Backspace, KeyModifiers::NONE).await;
+    harness
+        .execute_event(Event::Paste("Z".to_string()))
+        .await
+        .unwrap();
+    key(&mut harness, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    harness.assert_buffer_contents("aZ aZ");
+}


### PR DESCRIPTION
Red currently requires repeated edits or blockwise workarounds when the same text needs to change in several places. This adds a Vim-style multi-cursor workflow for selecting repeated occurrences or aligned positions and editing them as one operation.

## What Changed

- Add `Ctrl-n` occurrence selection with forward/backward navigation, wrapping, skipping, removal, smart-case matching, and stable buffer/window ownership.
- Apply insert, append, change, delete, yank, and paste across all selected regions as one undoable edit while preserving ordered per-region register payloads.
- Add `Ctrl-Up` and `Ctrl-Down` vertical cursors with display-column alignment, shorter-line skipping, empty-line handling at column zero, and tab-aware positioning.
- Add extend mode with `Tab`, Shift-arrow selection, `h`/`l`/`w`/`e`/`0`/`$` motions, anchor inversion with `o`, and `Ctrl-n` word promotion for vertical cursors.
- Render active multi-cursor regions and expose their position in the status line without replacing normal search state.

## How to Test

1. Open a buffer containing `foo one foo two foo`. Place the cursor on the first `foo`, press `Ctrl-n` twice, then type `cbar<Esc>`. The first two occurrences should become `bar`; one `u` should restore both edits.
2. Put the cursor at the same display column on several lines, including a shorter line and lines that mix tabs with spaces. Press `Ctrl-Down` repeatedly. Cursors should stay aligned by display column and skip lines that cannot reach it; at column zero, empty lines should receive a cursor.
3. With vertical cursors active, press `Shift-Right` or `Tab` followed by `e`, then `cX<Esc>`. Every selected range should be replaced. Pressing `o` before another motion should extend from the opposite endpoint.
4. Select repeated regions, yank with `y`, and paste with `p` or `P`. Each cursor should receive its corresponding payload in document order. Changing the system clipboard should replace the structured payload rather than replay stale regions.

Focused automated coverage:

- `cargo test --test multi_cursor`
- `cargo test editing::multi_selection::tests --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
