### PR TITLE
fix(editor): preserve indent after compound closers

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -19227,6 +19227,112 @@ impl Editor {
         self.commit_transaction(self.cursor_snapshot())
     }
 
+    // Mode transitions can recursively execute pending visual-block actions. Keep their async
+    // state out of the main action-dispatch future so dot-repeat fits the normal thread stack.
+    #[inline(never)]
+    fn execute_enter_mode<'a>(
+        &'a mut self,
+        new_mode: Mode,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<bool>> {
+        Box::pin(async move {
+            if matches!(new_mode, Mode::Normal) && self.finish_multi_cursor_insert() {
+                self.render(buffer)?;
+                self.flush_edit_batch_events(runtime).await?;
+                self.flush_edit_batch_changes(runtime).await?;
+                self.request_diagnostics().await?;
+                self.draw_statusline(buffer);
+                return Ok(true);
+            }
+            let old_mode = self.mode;
+            if !matches!(new_mode, Mode::Insert) {
+                self.snippet_session = None;
+            }
+            if matches!(
+                old_mode,
+                Mode::Visual | Mode::VisualLine | Mode::VisualBlock
+            ) && !matches!(
+                new_mode,
+                Mode::Visual | Mode::VisualLine | Mode::VisualBlock
+            ) {
+                self.capture_last_visual_selection();
+            }
+            self.selection = None;
+            self.pending_visual_text_object_scope = None;
+            self.pending_operator = None;
+            self.pending_character_motion = None;
+
+            let pending_select_action = self.pending_select_action.clone();
+            if let Some(select_action) = pending_select_action {
+                self.execute(&select_action.action, buffer, runtime).await?;
+            }
+
+            if matches!(old_mode, Mode::Normal) && matches!(new_mode, Mode::Insert) {
+                self.insert_entry_cursor = Some(self.cursor_snapshot());
+                self.begin_transaction("insert");
+            }
+
+            if matches!(old_mode, Mode::Insert) && matches!(new_mode, Mode::Normal) {
+                let cleaned_generated_indent = self.cleanup_generated_indent();
+                if self.insert_entry_cursor.is_some_and(|entry| {
+                    let y = self.buffer_line();
+                    y > entry.y || (y == entry.y && self.cx > entry.x)
+                }) {
+                    self.cx = self.cx.saturating_sub(1);
+                }
+                self.cx = self.cx.min(self.line_length().saturating_sub(1));
+                // EnterMode renders before the generic post-action cursor-goal refresh.
+                self.refresh_cursor_goal();
+                self.insert_entry_cursor = None;
+                let after_cursor = self.cursor_snapshot();
+                self.commit_transaction(after_cursor);
+                self.cancel_transaction_if_empty();
+                if cleaned_generated_indent {
+                    self.notify_change(runtime).await?;
+                }
+            }
+
+            if matches!(new_mode, Mode::Search) {
+                self.begin_search(SearchDirection::Forward);
+                self.render(buffer)?;
+                return Ok(true);
+            }
+
+            if matches!(new_mode, Mode::Command) {
+                self.reset_command_history_navigation();
+                self.reset_command_completion();
+                if matches!(
+                    old_mode,
+                    Mode::Visual | Mode::VisualLine | Mode::VisualBlock
+                ) {
+                    self.command = "'<,'>".to_string();
+                }
+            }
+
+            self.flush_edit_batch_events(runtime).await?;
+            self.mode = new_mode;
+
+            if matches!(
+                new_mode,
+                Mode::Visual | Mode::VisualLine | Mode::VisualBlock
+            ) {
+                self.start_selection();
+            } else {
+                self.selection = None;
+            }
+            self.render(buffer)?;
+
+            if !matches!(old_mode, Mode::Normal) && matches!(new_mode, Mode::Normal) {
+                self.flush_edit_batch_changes(runtime).await?;
+                self.request_diagnostics().await?;
+            }
+
+            self.draw_statusline(buffer);
+            Ok(false)
+        })
+    }
+
     /// Executes a single editor action
     ///
     /// This is the core action dispatcher that:
@@ -19673,105 +19779,13 @@ impl Editor {
             }
             Action::EnterMode(new_mode) => {
                 add_to_history = false;
-                if matches!(new_mode, Mode::Normal) && self.finish_multi_cursor_insert() {
-                    self.render(buffer)?;
-                    self.flush_edit_batch_events(runtime).await?;
-                    self.flush_edit_batch_changes(runtime).await?;
-                    self.request_diagnostics().await?;
-                    self.draw_statusline(buffer);
+                if self.execute_enter_mode(*new_mode, buffer, runtime).await? {
                     return Ok(false);
                 }
-                let old_mode = self.mode;
-                if !matches!(new_mode, Mode::Insert) {
-                    self.snippet_session = None;
-                }
-                if matches!(
-                    old_mode,
-                    Mode::Visual | Mode::VisualLine | Mode::VisualBlock
-                ) && !matches!(
-                    new_mode,
-                    Mode::Visual | Mode::VisualLine | Mode::VisualBlock
-                ) {
-                    self.capture_last_visual_selection();
-                }
-                self.selection = None;
-                self.pending_visual_text_object_scope = None;
-                self.pending_operator = None;
-                self.pending_character_motion = None;
-
-                // check for a pending action to be executed on the selection
-                let pending_select_action = self.pending_select_action.clone();
-                if let Some(select_action) = pending_select_action {
-                    self.execute(&select_action.action, buffer, runtime).await?;
-                }
-
-                if matches!(old_mode, Mode::Normal) && matches!(new_mode, Mode::Insert) {
-                    self.insert_entry_cursor = Some(self.cursor_snapshot());
-                    self.begin_transaction("insert");
-                }
-
-                if matches!(old_mode, Mode::Insert) && matches!(new_mode, Mode::Normal) {
-                    let cleaned_generated_indent = self.cleanup_generated_indent();
-                    if self.insert_entry_cursor.is_some_and(|entry| {
-                        let y = self.buffer_line();
-                        y > entry.y || (y == entry.y && self.cx > entry.x)
-                    }) {
-                        self.cx = self.cx.saturating_sub(1);
-                    }
-                    self.cx = self.cx.min(self.line_length().saturating_sub(1));
-                    // EnterMode renders before the generic post-action cursor-goal refresh.
-                    self.refresh_cursor_goal();
-                    self.insert_entry_cursor = None;
-                    let after_cursor = self.cursor_snapshot();
-                    self.commit_transaction(after_cursor);
-                    self.cancel_transaction_if_empty();
-                    if cleaned_generated_indent {
-                        self.notify_change(runtime).await?;
-                    }
-                }
-
-                if matches!(new_mode, Mode::Search) {
-                    self.begin_search(SearchDirection::Forward);
-                    self.render(buffer)?;
-                    return Ok(false);
-                }
-
-                if matches!(new_mode, Mode::Command) {
-                    self.reset_command_history_navigation();
-                    self.reset_command_completion();
-                    if matches!(
-                        old_mode,
-                        Mode::Visual | Mode::VisualLine | Mode::VisualBlock
-                    ) {
-                        self.command = "'<,'>".to_string();
-                    }
-                }
-
-                self.flush_edit_batch_events(runtime).await?;
-                self.mode = *new_mode;
-
-                if matches!(
-                    new_mode,
-                    Mode::Visual | Mode::VisualLine | Mode::VisualBlock
-                ) {
-                    self.start_selection();
-                    self.render(buffer)?;
-                } else {
-                    self.selection = None;
-                    self.render(buffer)?;
-                }
-
-                if !matches!(old_mode, Mode::Normal) && matches!(new_mode, Mode::Normal) {
-                    self.flush_edit_batch_changes(runtime).await?;
-                    self.request_diagnostics().await?;
-                }
-
-                self.draw_statusline(buffer);
             }
             Action::InsertCharAtCursorPos(c) => {
                 if self.insert_at_multi_cursors(&c.to_string()) {
-                    self.notify_change(runtime).await?;
-                    self.render(buffer)?;
+                    self.publish_multi_cursor_edit(buffer, runtime).await?;
                     return Ok(false);
                 }
                 let completion_dialog_open = self
@@ -20767,8 +20781,7 @@ impl Editor {
             }
             Action::DeletePreviousChar => {
                 if self.delete_before_multi_cursors() {
-                    self.notify_change(runtime).await?;
-                    self.render(buffer)?;
+                    self.publish_multi_cursor_edit(buffer, runtime).await?;
                     return Ok(false);
                 }
                 let completion_dialog_open = self
@@ -21804,130 +21817,32 @@ impl Editor {
                     }
                 }
             }
-            Action::SelectNextOccurrence => {
+            Action::SelectNextOccurrence
+            | Action::AddCursorUp
+            | Action::AddCursorDown
+            | Action::ToggleMultiCursorExtendMode
+            | Action::ExtendMultiSelectionLeft
+            | Action::ExtendMultiSelectionRight
+            | Action::ExtendMultiSelectionWordForward
+            | Action::ExtendMultiSelectionWordEnd
+            | Action::ExtendMultiSelectionLineStart
+            | Action::ExtendMultiSelectionLineEnd
+            | Action::InvertMultiSelection
+            | Action::SelectPreviousOccurrence
+            | Action::SkipMultiSelection
+            | Action::RemoveActiveMultiSelection
+            | Action::ChangeMultiSelection
+            | Action::InsertAtMultiSelectionStart
+            | Action::AppendAtMultiSelectionEnd
+            | Action::DeleteMultiSelection
+            | Action::DeleteMultiSelectionBlackHole
+            | Action::PasteAfterMultiSelection
+            | Action::PasteBeforeMultiSelection
+            | Action::YankMultiSelection
+            | Action::ClearMultiSelection => {
                 add_to_history = false;
-                self.select_next_occurrence();
-                self.render(buffer)?;
-            }
-            Action::AddCursorUp => {
-                add_to_history = false;
-                self.add_vertical_cursor(multi_cursor::VerticalCursorDirection::Up);
-                self.render(buffer)?;
-            }
-            Action::AddCursorDown => {
-                add_to_history = false;
-                self.add_vertical_cursor(multi_cursor::VerticalCursorDirection::Down);
-                self.render(buffer)?;
-            }
-            Action::ToggleMultiCursorExtendMode => {
-                add_to_history = false;
-                self.toggle_multi_cursor_extend_mode();
-                self.render(buffer)?;
-            }
-            Action::ExtendMultiSelectionLeft => {
-                add_to_history = false;
-                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::Left);
-                self.render(buffer)?;
-            }
-            Action::ExtendMultiSelectionRight => {
-                add_to_history = false;
-                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::Right);
-                self.render(buffer)?;
-            }
-            Action::ExtendMultiSelectionWordForward => {
-                add_to_history = false;
-                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::WordForward);
-                self.render(buffer)?;
-            }
-            Action::ExtendMultiSelectionWordEnd => {
-                add_to_history = false;
-                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::WordEnd);
-                self.render(buffer)?;
-            }
-            Action::ExtendMultiSelectionLineStart => {
-                add_to_history = false;
-                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::LineStart);
-                self.render(buffer)?;
-            }
-            Action::ExtendMultiSelectionLineEnd => {
-                add_to_history = false;
-                self.extend_multi_cursor_selections(multi_cursor::MultiCursorMotion::LineEnd);
-                self.render(buffer)?;
-            }
-            Action::InvertMultiSelection => {
-                add_to_history = false;
-                self.invert_multi_cursor_selections();
-                self.render(buffer)?;
-            }
-            Action::SelectPreviousOccurrence => {
-                add_to_history = false;
-                self.select_previous_occurrence();
-                self.render(buffer)?;
-            }
-            Action::SkipMultiSelection => {
-                add_to_history = false;
-                self.skip_multi_cursor_occurrence();
-                self.render(buffer)?;
-            }
-            Action::RemoveActiveMultiSelection => {
-                add_to_history = false;
-                self.remove_active_multi_cursor_selection();
-                self.render(buffer)?;
-            }
-            Action::ChangeMultiSelection => {
-                add_to_history = false;
-                if self.begin_multi_cursor_insert(multi_cursor::MultiCursorInsertAnchor::Replace) {
-                    self.notify_change(runtime).await?;
-                }
-                self.render(buffer)?;
-            }
-            Action::InsertAtMultiSelectionStart => {
-                add_to_history = false;
-                self.begin_multi_cursor_insert(multi_cursor::MultiCursorInsertAnchor::Start);
-                self.render(buffer)?;
-            }
-            Action::AppendAtMultiSelectionEnd => {
-                add_to_history = false;
-                self.begin_multi_cursor_insert(multi_cursor::MultiCursorInsertAnchor::End);
-                self.render(buffer)?;
-            }
-            Action::DeleteMultiSelection => {
-                add_to_history = false;
-                if self.delete_multi_cursor_selections(/*preserve_register*/ false) {
-                    self.notify_change(runtime).await?;
-                }
-                self.render(buffer)?;
-            }
-            Action::DeleteMultiSelectionBlackHole => {
-                add_to_history = false;
-                if self.delete_multi_cursor_selections(/*preserve_register*/ true) {
-                    self.notify_change(runtime).await?;
-                }
-                self.render(buffer)?;
-            }
-            Action::PasteAfterMultiSelection => {
-                add_to_history = false;
-                if self.paste_at_multi_cursors(multi_cursor::MultiCursorPasteAnchor::After) {
-                    self.notify_change(runtime).await?;
-                }
-                self.render(buffer)?;
-            }
-            Action::PasteBeforeMultiSelection => {
-                add_to_history = false;
-                if self.paste_at_multi_cursors(multi_cursor::MultiCursorPasteAnchor::Before) {
-                    self.notify_change(runtime).await?;
-                }
-                self.render(buffer)?;
-            }
-            Action::YankMultiSelection => {
-                add_to_history = false;
-                self.yank_multi_cursor_selections();
-                self.render(buffer)?;
-            }
-            Action::ClearMultiSelection => {
-                add_to_history = false;
-                self.clear_multi_cursor();
-                self.render(buffer)?;
+                self.execute_multi_cursor_action(action, buffer, runtime)
+                    .await?;
             }
             Action::DeleteWord => {
                 if let Some(range) = self.word_motion_range(1, false, false) {
@@ -22723,8 +22638,7 @@ impl Editor {
             }
             Action::InsertPastedText(text) => {
                 if self.insert_at_multi_cursors(text) {
-                    self.notify_change(runtime).await?;
-                    self.render(buffer)?;
+                    self.publish_multi_cursor_edit(buffer, runtime).await?;
                     return Ok(false);
                 }
                 let line = self.buffer_line();

--- a/src/editor/multi_cursor.rs
+++ b/src/editor/multi_cursor.rs
@@ -7,8 +7,9 @@ use crate::{
     },
     window::WindowId,
 };
+use futures::future::BoxFuture;
 
-use super::{Content, ContentKind, Editor};
+use super::{Action, Content, ContentKind, Editor, RenderBuffer, Runtime};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum VerticalCursorDirection {
@@ -95,6 +96,103 @@ impl MultiCursorSession {
 }
 
 impl Editor {
+    // These async paths are reached through the recursive action dispatcher. Boxing them here
+    // keeps multi-cursor support from increasing every nested dispatch frame.
+    #[inline(never)]
+    pub(super) fn publish_multi_cursor_edit<'a>(
+        &'a mut self,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async move {
+            self.notify_change(runtime).await?;
+            self.render(buffer)
+        })
+    }
+
+    #[inline(never)]
+    pub(super) fn execute_multi_cursor_action<'a>(
+        &'a mut self,
+        action: &'a Action,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async move {
+            match action {
+                Action::SelectNextOccurrence => self.select_next_occurrence(),
+                Action::AddCursorUp => {
+                    self.add_vertical_cursor(VerticalCursorDirection::Up);
+                }
+                Action::AddCursorDown => {
+                    self.add_vertical_cursor(VerticalCursorDirection::Down);
+                }
+                Action::ToggleMultiCursorExtendMode => self.toggle_multi_cursor_extend_mode(),
+                Action::ExtendMultiSelectionLeft => {
+                    self.extend_multi_cursor_selections(MultiCursorMotion::Left);
+                }
+                Action::ExtendMultiSelectionRight => {
+                    self.extend_multi_cursor_selections(MultiCursorMotion::Right);
+                }
+                Action::ExtendMultiSelectionWordForward => {
+                    self.extend_multi_cursor_selections(MultiCursorMotion::WordForward);
+                }
+                Action::ExtendMultiSelectionWordEnd => {
+                    self.extend_multi_cursor_selections(MultiCursorMotion::WordEnd);
+                }
+                Action::ExtendMultiSelectionLineStart => {
+                    self.extend_multi_cursor_selections(MultiCursorMotion::LineStart);
+                }
+                Action::ExtendMultiSelectionLineEnd => {
+                    self.extend_multi_cursor_selections(MultiCursorMotion::LineEnd);
+                }
+                Action::InvertMultiSelection => self.invert_multi_cursor_selections(),
+                Action::SelectPreviousOccurrence => self.select_previous_occurrence(),
+                Action::SkipMultiSelection => self.skip_multi_cursor_occurrence(),
+                Action::RemoveActiveMultiSelection => {
+                    self.remove_active_multi_cursor_selection();
+                }
+                Action::ChangeMultiSelection => {
+                    if self.begin_multi_cursor_insert(MultiCursorInsertAnchor::Replace) {
+                        self.notify_change(runtime).await?;
+                    }
+                }
+                Action::InsertAtMultiSelectionStart => {
+                    self.begin_multi_cursor_insert(MultiCursorInsertAnchor::Start);
+                }
+                Action::AppendAtMultiSelectionEnd => {
+                    self.begin_multi_cursor_insert(MultiCursorInsertAnchor::End);
+                }
+                Action::DeleteMultiSelection => {
+                    if self.delete_multi_cursor_selections(/*preserve_register*/ false) {
+                        self.notify_change(runtime).await?;
+                    }
+                }
+                Action::DeleteMultiSelectionBlackHole => {
+                    if self.delete_multi_cursor_selections(/*preserve_register*/ true) {
+                        self.notify_change(runtime).await?;
+                    }
+                }
+                Action::PasteAfterMultiSelection => {
+                    if self.paste_at_multi_cursors(MultiCursorPasteAnchor::After) {
+                        self.notify_change(runtime).await?;
+                    }
+                }
+                Action::PasteBeforeMultiSelection => {
+                    if self.paste_at_multi_cursors(MultiCursorPasteAnchor::Before) {
+                        self.notify_change(runtime).await?;
+                    }
+                }
+                Action::YankMultiSelection => {
+                    self.yank_multi_cursor_selections();
+                }
+                Action::ClearMultiSelection => self.clear_multi_cursor(),
+                _ => unreachable!("non-multi-cursor action reached multi-cursor dispatcher"),
+            }
+            self.render(buffer)?;
+            Ok(())
+        })
+    }
+
     pub(super) fn has_multi_cursor_session(&self) -> bool {
         self.multi_cursor
             .as_ref()

--- a/src/syntax_indent.rs
+++ b/src/syntax_indent.rs
@@ -231,20 +231,21 @@ impl SyntaxIndentation {
         let previous_first =
             previous_start + lines[previous].len() - lines[previous].trim_start().len();
         stack.clear();
-        for event in events
-            .iter()
-            .take_while(|e| e.bytes.start <= previous_first)
+        let first_event = events.partition_point(|event| event.bytes.start < previous_first);
+        for event in &events[..first_event] {
+            apply_event(&mut stack, event);
+        }
+        if let Some(event) = events
+            .get(first_event)
+            .filter(|event| event.bytes.start == previous_first)
         {
-            if event.bytes.start == previous_first && event.kind == Kind::Branch {
+            if event.kind == Kind::Branch {
                 if let Some(index) = stack.iter().rposition(|open| open.key == event.key) {
                     stack.truncate(index);
                 }
-                break;
+            } else if event.kind == Kind::End {
+                apply_leading_closer_group(&mut stack, &events[first_event..], source);
             }
-            if event.bytes.start == previous_first && event.kind != Kind::End {
-                break;
-            }
-            apply_event(&mut stack, event);
         }
         let delta = target_depth as isize - depth(&stack) as isize;
         let expected = columns(lines[previous], widths.1)
@@ -466,6 +467,46 @@ fn apply_event<'a>(stack: &mut Vec<&'a Event>, event: &'a Event) {
     }
 }
 
+/// Applies adjacent leading closers that unwind one visual indentation level.
+///
+/// Multiple openers on one source line contribute one level, so their matching
+/// closers must leave that level together. A closer for an opener on an earlier
+/// line starts a separate group and remains available to the ordinary depth delta.
+fn apply_leading_closer_group<'a>(stack: &mut Vec<&'a Event>, events: &'a [Event], source: &str) {
+    let Some(first) = events.first().filter(|event| event.kind == Kind::End) else {
+        return;
+    };
+    let Some(opener_line) = stack
+        .iter()
+        .rfind(|open| open.key == first.key)
+        .map(|open| open.line)
+    else {
+        apply_event(stack, first);
+        return;
+    };
+
+    let closer_line = first.line;
+    let mut previous_end = first.bytes.end;
+    apply_event(stack, first);
+    for event in &events[1..] {
+        if event.kind != Kind::End
+            || event.line != closer_line
+            || event.bytes.start < previous_end
+            || !source.as_bytes()[previous_end..event.bytes.start]
+                .iter()
+                .all(|byte| matches!(byte, b' ' | b'\t'))
+            || stack
+                .iter()
+                .rfind(|open| open.key == event.key)
+                .is_none_or(|open| open.line != opener_line)
+        {
+            break;
+        }
+        previous_end = event.bytes.end;
+        apply_event(stack, event);
+    }
+}
+
 fn depth(stack: &[&Event]) -> usize {
     stack.iter().map(|e| e.line).collect::<HashSet<_>>().len()
 }
@@ -596,7 +637,7 @@ mod tests {
         ));
         assert_eq!(
             check_fixtures(path, Arc::new(LanguageRegistry::bundled())).unwrap(),
-            14
+            18
         );
     }
 
@@ -658,6 +699,48 @@ mod tests {
             ("fn wrap() {\n    let s = r###\"{[(\"###;\n\n}", 2, 4),
             ("fn wrap() {\n    // {[(\n\n}", 2, 4),
             ("fn wrap() {\n    if ready {}\n\n}", 2, 4),
+        ] {
+            assert_eq!(
+                decision(source, line),
+                IndentDecision::Columns(expected),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn rust_compound_closers_preserve_grouped_opener_depth() {
+        for (source, line, expected) in [
+            (
+                "        let isolated_client = Self {\n            state: Arc::new(ModelClientState {\n            }),\n            \n        };",
+                3,
+                12,
+            ),
+            (
+                "fn f() {\n    let value = wrap(Inner {\n    });\n    \n}",
+                3,
+                4,
+            ),
+            (
+                "fn f() {\n    let value = outer(inner(Inner {\n    }));\n    \n}",
+                3,
+                4,
+            ),
+            (
+                "fn f() {\n    let value = wrap(Inner {\n    } );\n    \n}",
+                3,
+                4,
+            ),
+            (
+                "fn f() {\n    outer(\n        inner(Inner {\n        }));\n    \n}",
+                4,
+                4,
+            ),
+            (
+                "fn f() {\n    outer(\n        inner(\n            value,\n        ));\n    \n}",
+                5,
+                4,
+            ),
         ] {
             assert_eq!(
                 decision(source, line),

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -556,6 +556,75 @@ async fn rust_syntax_indentation_open_above_closer() {
 }
 
 #[tokio::test]
+async fn rust_syntax_indentation_open_below_compound_closers() {
+    let source = "        let isolated_client = Self {\n            state: Arc::new(ModelClientState {\n            }),\n        };";
+    let mut harness = comment_harness("main.rs", source);
+    harness.execute_action(Action::MoveDown).await.unwrap();
+    harness.execute_action(Action::MoveDown).await.unwrap();
+
+    harness
+        .execute_action(Action::InsertLineBelowCursor)
+        .await
+        .unwrap();
+
+    harness.assert_cursor_at(12, 3);
+    harness.assert_buffer_contents(
+        "        let isolated_client = Self {\n            state: Arc::new(ModelClientState {\n            }),\n            \n        };",
+    );
+    harness.type_text("next: true,").await.unwrap();
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents(source);
+}
+
+#[tokio::test]
+async fn rust_syntax_indentation_enter_after_compound_closers() {
+    let mut harness = comment_harness(
+        "main.rs",
+        "        let isolated_client = Self {\n            state: Arc::new(ModelClientState {\n            }),\n        };",
+    );
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::SetCursor(15, 2))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::InsertNewLine).await.unwrap();
+
+    harness.assert_cursor_at(12, 3);
+    harness.assert_buffer_contents(
+        "        let isolated_client = Self {\n            state: Arc::new(ModelClientState {\n            }),\n            \n        };",
+    );
+}
+
+#[tokio::test]
+async fn rust_syntax_indentation_open_above_after_compound_closers() {
+    let mut harness = comment_harness(
+        "main.rs",
+        "        let isolated_client = Self {\n            state: Arc::new(ModelClientState {\n            }),\n        };",
+    );
+    for _ in 0..3 {
+        harness.execute_action(Action::MoveDown).await.unwrap();
+    }
+
+    harness
+        .execute_action(Action::InsertLineAtCursor)
+        .await
+        .unwrap();
+
+    harness.assert_cursor_at(12, 3);
+    harness.assert_buffer_contents(
+        "        let isolated_client = Self {\n            state: Arc::new(ModelClientState {\n            }),\n            \n        };",
+    );
+}
+
+#[tokio::test]
 async fn comment_gcc_toggles_the_current_line() {
     let mut harness = comment_harness("main.rs", "    let value = 1;");
 

--- a/tests/fixtures/indent/bundled.json
+++ b/tests/fixtures/indent/bundled.json
@@ -1,9 +1,11 @@
 [
   {"name":"javascript block","language":"javascript","source":"function f() {\n  if (ready) {\n\n  }\n}","line":2,"expected":4,"width":2},
+  {"name":"javascript compound closers","language":"javascript","source":"function f() {\n  const value = {\n    field: wrap({\n    }),\n    \n  };\n}","line":4,"expected":4,"width":2},
   {"name":"typescript block","language":"typescript","source":"function f(): void {\n  if (ready) {\n\n  }\n}","line":2,"expected":4,"width":2},
   {"name":"jsx block","language":"jsx","source":"function f() {\n\n}","line":1,"expected":2,"width":2},
   {"name":"tsx block","language":"tsx","source":"function f(): void {\n\n}","line":1,"expected":2,"width":2},
   {"name":"json array","language":"json","source":"{\n  \"items\": [\n\n  ]\n}","line":2,"expected":4,"width":2},
+  {"name":"json compound closers","language":"json","source":"{\n  \"items\": [{\n  }],\n  \n  \"next\": 0\n}","line":3,"expected":2,"width":2},
   {"name":"toml array","language":"toml","source":"items = [\n\n]","line":1,"expected":2,"width":2},
   {"name":"yaml flow array","language":"yaml","source":"items: [\n\n]","line":1,"expected":2,"width":2},
   {"name":"powershell block","language":"powershell","source":"function Test-Thing {\n\n}","line":1,"expected":4},
@@ -12,5 +14,7 @@
   {"name":"fish if","language":"fish","source":"if true\n\nend","line":1,"expected":4},
   {"name":"fish else","language":"fish","source":"if true\n    echo yes\nelse\n\nend","line":3,"expected":4},
   {"name":"lua function","language":"lua","source":"function f()\n\nend","line":1,"expected":4},
-  {"name":"lua branch","language":"lua","source":"if ready then\n    work()\nelse\n\nend","line":3,"expected":4}
+  {"name":"lua branch","language":"lua","source":"if ready then\n    work()\nelse\n\nend","line":3,"expected":4},
+  {"name":"lua compound closers","language":"lua","source":"local values = {\n    field = wrap(function()\n    end),\n    \n}","line":3,"expected":4},
+  {"name":"rust compound closers","language":"rust","source":"        let isolated_client = Self {\n            state: Arc::new(ModelClientState {\n            }),\n            \n        };","line":3,"expected":12}
 ]


### PR DESCRIPTION
Opening a line after compound closing delimiters could over-dedent it. In Rust, for example, pressing `o` after `}),` moved the new line and cursor to the enclosing block instead of keeping them aligned with the sibling field. The same shared indentation logic affected JavaScript, JSON, Lua, and other delimiter-based language packs.

This change treats adjacent leading closers as one visual indentation group when their matching openers originated on the same source line. Closers for openers on earlier lines remain separate, preserving genuine structural dedents. It also adds editor-level coverage for `o`, `O`, and Enter, plus portable Rust, JavaScript, JSON, and Lua fixtures.

## How to Test

1. Open a Rust buffer containing:

   ```rust
   let isolated_client = Self {
       state: Arc::new(ModelClientState {
       }),
   };
   ```

   Place the cursor on `}),` and press `o`. The new line and cursor should remain aligned with `state`, not the enclosing `let`.
2. Run `cargo test --lib syntax_indent::tests::`. All provider tests should pass, including the grouped-closer and cross-language fixtures.
3. Run `cargo test --test editing rust_syntax_indentation_`. All six focused editor tests should pass, covering `o`, `O`, Enter, undo, typed closers, and the distinct-opener-line dedent regression.
