### PR TITLE
fix(lsp): preserve auto-imports after continued typing

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3702,6 +3702,7 @@ pub struct Editor {
     /// Jumplist traversal typed while a definition request is still in flight.
     deferred_jump_navigation: VecDeque<Action>,
     pending_completion_resolutions: HashMap<i64, completion_resolve::PendingCompletionResolution>,
+    pending_completion_refreshes: HashMap<i64, completion_resolve::PendingCompletionRefresh>,
     scheduled_completion: Option<ScheduledCompletion>,
     // Keep optional AI state out of Editor values and the startup futures that own them.
     inline_completion: Box<inline_completion::InlineCompletionState>,
@@ -5167,6 +5168,7 @@ impl Editor {
             pending_definition_requests: HashSet::new(),
             deferred_jump_navigation: VecDeque::new(),
             pending_completion_resolutions: HashMap::new(),
+            pending_completion_refreshes: HashMap::new(),
             scheduled_completion: None,
             inline_completion: Box::default(),
             completion_snapshot: None,
@@ -14550,6 +14552,9 @@ impl Editor {
                     }
 
                     if method == "textDocument/completion" {
+                        if self.pending_completion_refreshes.contains_key(&msg.id) {
+                            return self.refreshed_completion_action(msg);
+                        }
                         let pending_edit = self.pending_lsp_edit_requests.remove(&msg.id);
                         let pending =
                             self.pending_completions.remove(&msg.id).unwrap_or_else(|| {
@@ -14681,6 +14686,11 @@ impl Editor {
                 if method.as_deref() == Some("completionItem/resolve") {
                     return self.completion_resolution_failed(id, &error_msg.message);
                 }
+                if method.as_deref() == Some("textDocument/completion")
+                    && self.pending_completion_refreshes.contains_key(&id)
+                {
+                    return self.completion_refresh_failed(id, &error_msg.message);
+                }
                 if method.as_deref() == Some("textDocument/inlayHint") {
                     if let Some(request_id) = self.pending_plugin_inlay_hints.remove(&id) {
                         return Some(Action::ResolvePluginRequest(
@@ -14770,6 +14780,11 @@ impl Editor {
                 }
                 if method.as_deref() == Some("completionItem/resolve") {
                     return self.completion_resolution_failed(*id, &error.to_string());
+                }
+                if method.as_deref() == Some("textDocument/completion")
+                    && self.pending_completion_refreshes.contains_key(id)
+                {
+                    return self.completion_refresh_failed(*id, &error.to_string());
                 }
                 if method.as_deref() == Some("textDocument/inlayHint") {
                     if let Some(request_id) = self.pending_plugin_inlay_hints.remove(id) {

--- a/src/editor/completion_resolve.rs
+++ b/src/editor/completion_resolve.rs
@@ -1,12 +1,49 @@
 //! Deferred completion details, including import edits computed only after selection.
 
-use super::{Action, CompletionResponseItem, CompletionSnapshot, Editor, ResponseMessage};
+use super::{
+    Action, CompletionResponse, CompletionResponseItem, CompletionSnapshot, Editor, ResponseMessage,
+};
 
 #[derive(Debug, Clone)]
 pub(super) struct PendingCompletionResolution {
     item: CompletionResponseItem,
     commit_character: Option<char>,
     snapshot: CompletionSnapshot,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PendingCompletionRefresh {
+    item: CompletionResponseItem,
+    commit_character: Option<char>,
+    snapshot: CompletionSnapshot,
+}
+
+fn completion_candidate_matches(
+    selected: &CompletionResponseItem,
+    candidate: &CompletionResponseItem,
+) -> bool {
+    selected.label == candidate.label
+        && selected.kind == candidate.kind
+        && selected.label_details == candidate.label_details
+        && selected.detail == candidate.detail
+}
+
+fn refreshed_completion_item(
+    selected: &CompletionResponseItem,
+    response: CompletionResponse,
+) -> Option<CompletionResponseItem> {
+    let mut candidates = response
+        .items()
+        .into_iter()
+        .filter(|candidate| completion_candidate_matches(selected, candidate))
+        .collect::<Vec<_>>();
+    if candidates.len() == 1 {
+        return candidates.pop();
+    }
+    let exact_data = candidates
+        .iter()
+        .position(|candidate| candidate.data == selected.data)?;
+    Some(candidates.swap_remove(exact_data))
 }
 
 impl Editor {
@@ -52,6 +89,35 @@ impl Editor {
             .unwrap_or_else(|| self.activate_completion_snapshot(self.completion_snapshot()));
         if !self.completion_snapshot_is_current(&snapshot) {
             return Ok(false);
+        }
+
+        if snapshot.initial_revision != snapshot.revision {
+            let position = self.cursor_lsp_position();
+            if let Some(uri) = snapshot.uri.as_deref() {
+                match self
+                    .lsp
+                    .request_completion(uri, position.line, position.character, None)
+                    .await
+                {
+                    Ok(request_id) if request_id > 0 => {
+                        self.pending_completion_refreshes.insert(
+                            request_id,
+                            PendingCompletionRefresh {
+                                item: item.clone(),
+                                commit_character,
+                                snapshot,
+                            },
+                        );
+                        return Ok(true);
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        self.set_legacy_message(Some(format!(
+                            "completion refresh failed; resolving the earlier item: {error}"
+                        )));
+                    }
+                }
+            }
         }
 
         let request_id = match self
@@ -133,6 +199,62 @@ impl Editor {
             commit_character: pending.commit_character,
         })
     }
+
+    pub(super) fn refreshed_completion_action(
+        &mut self,
+        response: &ResponseMessage,
+    ) -> Option<Action> {
+        let pending = self.pending_completion_refreshes.remove(&response.id)?;
+        if !self.is_insert() || !self.completion_snapshot_is_current(&pending.snapshot) {
+            self.set_legacy_message(Some(
+                "completion refresh response is stale; buffer or cursor changed".to_string(),
+            ));
+            return None;
+        }
+
+        let refreshed = serde_json::from_value::<CompletionResponse>(response.result.clone())
+            .ok()
+            .and_then(|response| refreshed_completion_item(&pending.item, response));
+        self.finish_completion_refresh(pending, refreshed)
+    }
+
+    pub(super) fn completion_refresh_failed(
+        &mut self,
+        request_id: i64,
+        error: &str,
+    ) -> Option<Action> {
+        let pending = self.pending_completion_refreshes.remove(&request_id)?;
+        self.set_legacy_message(Some(format!(
+            "completion refresh failed; inserting without deferred edits: {error}"
+        )));
+        self.finish_completion_refresh(pending, None)
+    }
+
+    fn finish_completion_refresh(
+        &mut self,
+        mut pending: PendingCompletionRefresh,
+        refreshed: Option<CompletionResponseItem>,
+    ) -> Option<Action> {
+        let action = if let Some(item) = refreshed {
+            pending.snapshot.initial_revision = pending.snapshot.revision;
+            pending.snapshot.original_range = pending.snapshot.current_range.clone();
+            Action::ApplyCompletion {
+                item: Box::new(item),
+                commit_character: pending.commit_character,
+            }
+        } else {
+            self.set_legacy_message(Some(
+                "completion refresh did not return the selected item; inserting without deferred edits"
+                    .to_string(),
+            ));
+            Action::ApplyResolvedCompletion {
+                item: Box::new(pending.item),
+                commit_character: pending.commit_character,
+            }
+        };
+        self.completion_snapshot = Some(pending.snapshot);
+        Some(action)
+    }
 }
 
 #[cfg(test)]
@@ -189,6 +311,29 @@ mod tests {
         .unwrap()
     }
 
+    fn deferred_completion(end_character: usize) -> CompletionResponseItem {
+        serde_json::from_value(json!({
+            "label": "GalacticWidget",
+            "textEdit": {
+                "range": {
+                    "start": { "line": 1, "character": 0 },
+                    "end": { "line": 1, "character": end_character }
+                },
+                "newText": "GalacticWidget"
+            },
+            "data": {
+                "position": {
+                    "textDocument": { "uri": "file:///tmp/red-completion-resolve.rs" },
+                    "position": { "line": 1, "character": 3 }
+                },
+                "imports": [{ "fullImportPath": "crate::symbols::GalacticWidget" }],
+                "version": 1,
+                "hash": "completion-hash"
+            }
+        }))
+        .unwrap()
+    }
+
     fn pending(editor: &mut Editor, request_id: i64) {
         let snapshot = editor.activate_completion_snapshot(editor.completion_snapshot());
         editor.pending_completion_resolutions.insert(
@@ -241,6 +386,77 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(editor.current_buffer().contents(), "mod symbols;\nGal\n");
+    }
+
+    #[tokio::test]
+    async fn resolved_import_after_passthrough_typing_uses_current_server_ranges() {
+        let mut editor = editor("mod symbols;\nGala\n");
+        editor.cx = 4;
+        let revision = editor.current_buffer().revision();
+        let snapshot = CompletionSnapshot {
+            buffer_id: editor.current_buffer().id(),
+            initial_revision: revision.wrapping_sub(1),
+            revision,
+            uri: editor.current_buffer().uri().unwrap(),
+            cursor: Some(editor.cursor_text_position()),
+            original_range: Some(Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 3,
+                },
+            }),
+            current_range: Some(Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 4,
+                },
+            }),
+        };
+        editor.pending_completion_refreshes.insert(
+            18,
+            PendingCompletionRefresh {
+                item: deferred_completion(3),
+                commit_character: None,
+                snapshot,
+            },
+        );
+        let mut resolved = deferred_completion(4);
+        resolved.additional_text_edits = Some(vec![TextEdit {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 0,
+                },
+            },
+            new_text: "use crate::symbols::GalacticWidget;\n".to_string(),
+        }]);
+        let response = InboundMessage::Message(ResponseMessage {
+            id: 18,
+            result: serde_json::to_value(CompletionResponse::Items(vec![resolved])).unwrap(),
+            request: None,
+        });
+
+        let action = editor
+            .handle_lsp_message(&response, Some("textDocument/completion".to_string()))
+            .expect("refreshed completion should produce an editor action");
+        editor.test_execute_production_action(action).await.unwrap();
+
+        assert_eq!(
+            editor.current_buffer().contents(),
+            "use crate::symbols::GalacticWidget;\nmod symbols;\nGalacticWidget\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Rust auto-import candidates defer their import edits until `completionItem/resolve`. When the user continued typing while the completion menu stayed open, the selected item still carried opaque server data and ranges from the earlier request. rust-analyzer could no longer match that stale item, so Red inserted the completion text without its import.

## What Changed

- Refresh a selected deferred completion at the current cursor position when the completion snapshot changed.
- Match the refreshed candidate using its stable visible identity, then resolve the fresh server item for import edits.
- Route refresh responses and failures separately from normal completion requests while preserving stale-response checks.
- Add regression coverage for applying refreshed server ranges after passthrough typing.

## How to Test

1. In a Rust file, define `module::Something` outside the current scope and type `Som` at a use site.
2. Open completion, type `e` while the menu remains open, then select `Something (auto import module::Something)`.
3. Verify Red inserts both `Something` and the corresponding `use` statement.
4. Undo once and verify the accepted completion and import are removed together while the character typed before acceptance remains.
5. As a regression check, accept a normal TypeScript auto-import completion and verify its eager import edit still applies.

Automated coverage:

- `cargo test completion_resolve -- --nocapture`
- `cargo test --test completion -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`