### PR TITLE
feat(editor): detect and resolve external file conflicts

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -128,6 +128,17 @@ pub enum SyntaxSelection {
     Language(String),
 }
 
+/// How the on-disk file diverged from the buffer's last loaded or saved version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalFileChange {
+    /// The existing file now contains different bytes.
+    Modified,
+    /// A file appeared where the buffer originally represented a missing path.
+    Created,
+    /// The file was removed after the buffer loaded or saved it.
+    Deleted,
+}
+
 /// Exact disk state last observed for the file associated with a buffer.
 #[derive(Debug)]
 struct BackingFileSnapshot {
@@ -153,6 +164,9 @@ pub struct Buffer {
 
     /// Last known disk contents; `None` contents represent a file that did not exist.
     backing_file: Option<BackingFileSnapshot>,
+
+    /// An observed external change that still needs an explicit user decision.
+    external_file_change: Option<ExternalFileChange>,
 
     /// Content revision for which `dirty` was last computed.
     dirty_revision: u64,
@@ -201,6 +215,7 @@ impl Buffer {
             file,
             saved_content: Some(content.clone()),
             backing_file,
+            external_file_change: None,
             content,
             dirty_revision: 0,
             dirty: false,
@@ -553,13 +568,113 @@ impl Buffer {
         self.refresh_dirty();
     }
 
+    /// Returns the unresolved way this buffer's backing file changed on disk.
+    pub fn external_file_change(&self) -> Option<ExternalFileChange> {
+        self.external_file_change
+    }
+
+    /// Returns whether an external change needs to be reloaded, saved elsewhere, or overwritten.
+    pub fn has_external_file_conflict(&self) -> bool {
+        self.external_file_change.is_some()
+    }
+
+    /// Accepts only proposed edits that leave every unsaved user-edited range intact.
+    ///
+    /// Comparing both edit scripts in current-buffer coordinates lets an agent keep
+    /// working beside unsaved human changes without silently replacing those changes.
+    pub(crate) fn preserves_unsaved_edits(&self, proposed: &str) -> bool {
+        if !self.is_dirty() || self.content == proposed {
+            return true;
+        }
+        let Some(saved) = self.saved_content.as_ref() else {
+            return false;
+        };
+        let saved = saved.to_string();
+        let current = self.contents();
+        let user_diff = similar::TextDiff::configure()
+            .timeout(std::time::Duration::from_millis(250))
+            .diff_chars(saved.as_str(), current.as_str());
+        let proposed_diff = similar::TextDiff::configure()
+            .timeout(std::time::Duration::from_millis(250))
+            .diff_chars(current.as_str(), proposed);
+
+        !user_diff
+            .ops()
+            .iter()
+            .filter(|operation| operation.tag() != similar::DiffTag::Equal)
+            .any(|user_change| {
+                let protected = user_change.new_range();
+                proposed_diff
+                    .ops()
+                    .iter()
+                    .filter(|operation| operation.tag() != similar::DiffTag::Equal)
+                    .any(|agent_change| {
+                        let changed = agent_change.old_range();
+                        match (protected.is_empty(), changed.is_empty()) {
+                            (true, true) => protected.start == changed.start,
+                            (true, false) => {
+                                changed.start <= protected.start && protected.start < changed.end
+                            }
+                            (false, true) => {
+                                protected.start < changed.start && changed.start < protected.end
+                            }
+                            (false, false) => {
+                                protected.start < changed.end && changed.start < protected.end
+                            }
+                        }
+                    })
+            })
+    }
+
+    /// Compares the backing file's exact bytes with its last loaded or saved baseline.
+    pub(crate) fn detect_external_file_change(&self) -> anyhow::Result<Option<ExternalFileChange>> {
+        let Some(backing_file) = self.backing_file.as_ref() else {
+            return Ok(None);
+        };
+        let disk_contents = Self::read_disk_contents(&backing_file.path)?;
+        Ok(match (&backing_file.contents, disk_contents.as_deref()) {
+            (None, None) => None,
+            (None, Some(_)) => Some(ExternalFileChange::Created),
+            (Some(_), None) => Some(ExternalFileChange::Deleted),
+            (Some(expected), Some(actual)) => (!Self::rope_matches_disk_contents(expected, actual))
+                .then_some(ExternalFileChange::Modified),
+        })
+    }
+
+    /// Updates conflict state without mutating the text, history, or saved baseline.
+    pub(crate) fn set_external_file_change(&mut self, change: Option<ExternalFileChange>) -> bool {
+        if self.external_file_change == change {
+            return false;
+        }
+        self.external_file_change = change;
+        true
+    }
+
+    fn read_disk_contents(path: &Path) -> anyhow::Result<Option<Vec<u8>>> {
+        match std::fs::read(path) {
+            Ok(contents) => Ok(Some(contents)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn rope_matches_disk_contents(expected: &Rope, actual: &[u8]) -> bool {
+        if expected.len_bytes() != actual.len() {
+            return false;
+        }
+        let mut remaining = actual;
+        expected.chunks().all(|chunk| {
+            let Some(rest) = remaining.strip_prefix(chunk.as_bytes()) else {
+                return false;
+            };
+            remaining = rest;
+            true
+        }) && remaining.is_empty()
+    }
+
     /// Rejects writes when the destination no longer matches its last known disk state.
     pub(crate) fn ensure_backing_file_unchanged(&self, path: &Path) -> anyhow::Result<()> {
-        let disk_contents = match std::fs::read(path) {
-            Ok(contents) => Some(contents),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-            Err(error) => return Err(error.into()),
-        };
+        let disk_contents = Self::read_disk_contents(path)?;
 
         let Some(backing_file) = self
             .backing_file
@@ -576,22 +691,13 @@ impl Buffer {
 
         let unchanged = match (&backing_file.contents, disk_contents.as_deref()) {
             (None, None) => true,
-            (Some(expected), Some(actual)) if expected.len_bytes() == actual.len() => {
-                let mut remaining = actual;
-                expected.chunks().all(|chunk| {
-                    let Some(rest) = remaining.strip_prefix(chunk.as_bytes()) else {
-                        return false;
-                    };
-                    remaining = rest;
-                    true
-                }) && remaining.is_empty()
-            }
+            (Some(expected), Some(actual)) => Self::rope_matches_disk_contents(expected, actual),
             _ => false,
         };
 
         anyhow::ensure!(
             unchanged,
-            "File changed on disk since Red last read or saved it: {:?}; save your changes to another file or reload",
+            "File changed on disk since Red last read or saved it: {:?}; use :diffdisk to compare, :e! to reload, :w <file> to save elsewhere, or :w! to overwrite",
             path.display().to_string()
         );
         Ok(())
@@ -602,25 +708,28 @@ impl Buffer {
         if let Some(backing_file) = &mut self.backing_file {
             backing_file.path = path.to_path_buf();
         }
+        self.external_file_change = None;
     }
 
     /// Drops the backing identity when a removed file becomes an unnamed scratch buffer.
     pub(crate) fn detach_backing_file(&mut self) {
         self.backing_file = None;
+        self.external_file_change = None;
     }
 
     /// Saves the buffer contents to its associated file
     pub fn save(&mut self) -> anyhow::Result<String> {
         if let Some(file) = self.file.clone() {
-            let path = normalized_file_path(&file)?;
-            let file = path.to_string_lossy().into_owned();
-            self.ensure_backing_file_unchanged(&path)?;
-            let contents = self.contents();
-            std::fs::write(&path, &contents)?;
-            self.file = Some(file.clone());
-            self.mark_saved();
-            let message = format!("{:?} {}L, {}B written", file, self.len(), contents.len());
-            Ok(message)
+            self.save_to_path(&file, /*force*/ false)
+        } else {
+            Err(anyhow::anyhow!("No file name"))
+        }
+    }
+
+    /// Overwrites the associated file only after an explicit forced-save action.
+    pub fn force_save(&mut self) -> anyhow::Result<String> {
+        if let Some(file) = self.file.clone() {
+            self.save_to_path(&file, /*force*/ true)
         } else {
             Err(anyhow::anyhow!("No file name"))
         }
@@ -628,9 +737,31 @@ impl Buffer {
 
     /// Saves the buffer contents to a new file path
     pub fn save_as(&mut self, new_file_name: &str) -> anyhow::Result<String> {
+        self.save_to_path(new_file_name, /*force*/ false)
+    }
+
+    /// Overwrites an explicitly requested destination after a forced Save As command.
+    pub fn force_save_as(&mut self, new_file_name: &str) -> anyhow::Result<String> {
+        self.save_to_path(new_file_name, /*force*/ true)
+    }
+
+    fn save_to_path(&mut self, new_file_name: &str, force: bool) -> anyhow::Result<String> {
         let path = normalized_file_path(new_file_name)?;
         let file = path.to_string_lossy().into_owned();
-        self.ensure_backing_file_unchanged(&path)?;
+        if !force {
+            if let Err(error) = self.ensure_backing_file_unchanged(&path) {
+                if self
+                    .backing_file
+                    .as_ref()
+                    .is_some_and(|backing_file| same_file_path(&backing_file.path, &path))
+                {
+                    if let Ok(change) = self.detect_external_file_change() {
+                        self.set_external_file_change(change);
+                    }
+                }
+                return Err(error);
+            }
+        }
         let contents = self.contents();
         std::fs::write(&path, &contents)?;
         self.file = Some(file.clone());
@@ -1311,6 +1442,7 @@ impl Buffer {
             path: PathBuf::from(file),
             contents: Some(self.content.clone()),
         });
+        self.external_file_change = None;
         self.undo_history.mark_saved();
         self.dirty = false;
         self.dirty_revision = self.revision;
@@ -1606,6 +1738,110 @@ mod test {
         assert_eq!(fs::read_to_string(&path).unwrap(), "other\n");
         assert_eq!(buffer.contents(), "local\n");
         assert!(buffer.is_dirty());
+        assert_eq!(
+            buffer.external_file_change(),
+            Some(ExternalFileChange::Modified)
+        );
+        assert!(buffer.has_external_file_conflict());
+    }
+
+    #[tokio::test]
+    async fn backing_file_change_distinguishes_modification_creation_and_deletion() {
+        let directory = tempfile::tempdir().unwrap();
+        let existing_path = directory.path().join("existing.txt");
+        fs::write(&existing_path, "first\n").unwrap();
+        let existing = Buffer::load_or_create(Some(existing_path.to_string_lossy().into_owned()))
+            .await
+            .unwrap();
+
+        assert_eq!(existing.detect_external_file_change().unwrap(), None);
+        fs::write(&existing_path, "other\n").unwrap();
+        assert_eq!(
+            existing.detect_external_file_change().unwrap(),
+            Some(ExternalFileChange::Modified)
+        );
+        fs::write(&existing_path, "first\n").unwrap();
+        assert_eq!(existing.detect_external_file_change().unwrap(), None);
+        fs::remove_file(&existing_path).unwrap();
+        assert_eq!(
+            existing.detect_external_file_change().unwrap(),
+            Some(ExternalFileChange::Deleted)
+        );
+
+        let missing_path = directory.path().join("created.txt");
+        let missing = Buffer::load_or_create(Some(missing_path.to_string_lossy().into_owned()))
+            .await
+            .unwrap();
+        assert_eq!(missing.detect_external_file_change().unwrap(), None);
+        fs::write(&missing_path, "created\n").unwrap();
+        assert_eq!(
+            missing.detect_external_file_change().unwrap(),
+            Some(ExternalFileChange::Created)
+        );
+    }
+
+    #[tokio::test]
+    async fn forced_save_explicitly_overwrites_and_refreshes_the_disk_baseline() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("document.txt");
+        fs::write(&path, "first\n").unwrap();
+        let mut buffer = Buffer::load_or_create(Some(path.to_string_lossy().into_owned()))
+            .await
+            .unwrap();
+        replace_all(&mut buffer, "local\n");
+        fs::write(&path, "other\n").unwrap();
+
+        assert!(buffer.save().is_err());
+        assert!(buffer.has_external_file_conflict());
+        buffer.force_save().unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "local\n");
+        assert!(!buffer.is_dirty());
+        assert!(!buffer.has_external_file_conflict());
+        fs::write(&path, "again\n").unwrap();
+        assert!(buffer.save().is_err());
+    }
+
+    #[tokio::test]
+    async fn forced_save_as_overwrites_only_the_explicit_destination() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source.txt");
+        let destination = directory.path().join("destination.txt");
+        fs::write(&source, "source\n").unwrap();
+        fs::write(&destination, "destination\n").unwrap();
+        let mut buffer = Buffer::load_or_create(Some(source.to_string_lossy().into_owned()))
+            .await
+            .unwrap();
+        replace_all(&mut buffer, "local\n");
+
+        assert!(buffer.save_as(&destination.to_string_lossy()).is_err());
+        buffer
+            .force_save_as(&destination.to_string_lossy())
+            .unwrap();
+
+        assert_eq!(fs::read_to_string(&source).unwrap(), "source\n");
+        assert_eq!(fs::read_to_string(&destination).unwrap(), "local\n");
+        assert_eq!(buffer.file.as_deref(), destination.to_str());
+        assert!(!buffer.has_external_file_conflict());
+    }
+
+    #[test]
+    fn agent_edits_can_extend_but_cannot_replace_unsaved_human_changes() {
+        let mut buffer = Buffer::new(None, "first\nsecond\n".to_string());
+        replace_all(&mut buffer, "human first\nsecond\n");
+
+        assert!(buffer.preserves_unsaved_edits("human first\nagent second\n"));
+        assert!(!buffer.preserves_unsaved_edits("agent first\nsecond\n"));
+        assert!(!buffer.preserves_unsaved_edits("first\nsecond\n"));
+    }
+
+    #[test]
+    fn agent_edits_do_not_reinsert_text_deleted_by_the_user() {
+        let mut buffer = Buffer::new(None, "remove\nkeep\n".to_string());
+        replace_all(&mut buffer, "keep\n");
+
+        assert!(!buffer.preserves_unsaved_edits("remove\nkeep\n"));
+        assert!(buffer.preserves_unsaved_edits("keep\nagent\n"));
     }
 
     #[tokio::test]

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -20,6 +20,7 @@ pub(crate) const BUILTIN_COLON_COMMANDS: &[CommandSpec] = &[
     CommandSpec::new("quit", 1),
     CommandSpec::new("write", 1),
     CommandSpec::new("wall", 2),
+    CommandSpec::exact("diffdisk"),
     CommandSpec::exact("buffer-next"),
     CommandSpec::new("bnext", 2),
     CommandSpec::exact("buffer-prev"),
@@ -569,6 +570,15 @@ fn builtin_commands() -> Vec<BuiltinCommand> {
             Some(":wa"),
             &[":wall"],
             Action::SaveAll,
+        ),
+        builtin(
+            "file.compare_on_disk",
+            "Compare with file on disk",
+            "File",
+            "Inspect external file changes and explicitly resolve a save conflict",
+            Some(":diffdisk"),
+            &["external changes", "save conflict", "overwrite"],
+            Action::CompareFileOnDisk,
         ),
         builtin(
             "file.save_and_quit",
@@ -1454,7 +1464,10 @@ fn action_label(action: &Action) -> String {
         Action::OpenStatuslineManager => "Configure status line".to_string(),
         Action::PluginCommand(name) => humanize_identifier(name),
         Action::Save => "Save file".to_string(),
+        Action::ForceSave => "Overwrite file on disk".to_string(),
         Action::SaveAll => "Save all files".to_string(),
+        Action::ForceSaveAs(_) => "Overwrite selected file".to_string(),
+        Action::CompareFileOnDisk => "Compare with file on disk".to_string(),
         Action::NewBuffer => "New buffer".to_string(),
         Action::ListBuffers => "List buffers".to_string(),
         Action::Quit(_) => "Quit".to_string(),
@@ -1738,6 +1751,21 @@ mod tests {
         assert!(colon_completion_names(&[])
             .iter()
             .any(|name| name == "wall"));
+    }
+
+    #[test]
+    fn palette_exposes_disk_conflict_comparison() {
+        let entries = entries(&default_keys(), &[]);
+        let entry = entries
+            .iter()
+            .find(|entry| entry.id == "file.compare_on_disk")
+            .unwrap();
+
+        assert_eq!(entry.colon.as_deref(), Some(":diffdisk"));
+        assert_eq!(entry.action, Action::CompareFileOnDisk);
+        assert!(colon_completion_names(&[])
+            .iter()
+            .any(|name| name == "diffdisk"));
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -28,6 +28,7 @@ mod diagnostics;
 mod diagnostics_picker;
 mod display_layout;
 mod edit_batch;
+mod file_watch;
 mod inline_actions;
 mod inline_agent_outcomes;
 mod inline_changes;
@@ -106,7 +107,7 @@ use crate::{
         EditorOpenTarget, EditorSelectionKind, EditorToolCall, EditorToolHost, EditorToolRequest,
         PendingEditorToolResponse, MAX_AGENT_READ_BYTES,
     },
-    buffer::{Buffer, BufferId, SearchMatch, SyntaxSelection},
+    buffer::{Buffer, BufferId, ExternalFileChange, SearchMatch, SyntaxSelection},
     clipboard::{ClipboardProvider, DisabledClipboardProvider, NativeClipboardProvider},
     codex::{
         start_codex, AgentRuntimePolicy, CodexBridge, CodexCommand, CodexEvent, CodexProcessSpec,
@@ -2389,8 +2390,14 @@ impl PickerCallback {
 pub enum Action {
     Quit(bool),
     Save,
+    /// Overwrites the backing file after an explicit `:w!` or conflict confirmation.
+    ForceSave,
     SaveAll,
     SaveAs(String),
+    /// Overwrites an explicitly selected destination after `:w! {file}`.
+    ForceSaveAs(String),
+    /// Shows the backing file beside the current buffer as a unified conflict diff.
+    CompareFileOnDisk,
     EnterMode(Mode),
     RestoreLastVisualSelection,
     /// Opens a bounded inline edit for the enclosing function or exact selection.
@@ -3326,6 +3333,9 @@ pub struct Editor {
 
     /// Plugin-owned scratch buffers and the commands that finish their workflows.
     scratch_buffers: HashMap<BufferId, ScratchBufferCommands>,
+
+    /// Native open-buffer watches plus a bounded fallback for dropped or unavailable events.
+    open_file_watcher: Box<file_watch::OpenFileWatcher>,
 
     /// Domain sub-controller managing session recovery and snapshots
     session_manager: session_manager::SessionManager,
@@ -5030,6 +5040,7 @@ impl Editor {
         Ok(Editor {
             buffer_manager,
             scratch_buffers: HashMap::new(),
+            open_file_watcher: Box::default(),
             session_manager,
             lsp_coordinator,
             agent_manager,
@@ -8086,8 +8097,11 @@ impl Editor {
                 | Action::PluginCommand(_)
                 | Action::Quit(_)
                 | Action::Save
+                | Action::ForceSave
                 | Action::SaveAll
                 | Action::SaveAs(_)
+                | Action::ForceSaveAs(_)
+                | Action::CompareFileOnDisk
                 | Action::DumpHistory
                 | Action::DumpBuffer
                 | Action::DumpDiagnostics
@@ -9345,6 +9359,34 @@ impl Editor {
             !contents.contains('\0'),
             "agent file contents cannot contain NUL bytes"
         );
+        if self.current_buffer().is_dirty()
+            && !self.current_buffer().preserves_unsaved_edits(&contents)
+        {
+            return Ok(json!({
+                "ok": false,
+                "applied": false,
+                "saved": false,
+                "error": format!(
+                    "Refusing to overwrite unsaved editor changes in {:?}; ask the user to save or discard them before retrying",
+                    path.display().to_string()
+                ),
+                "path": path,
+                "revision": current_revision,
+            }));
+        }
+        if let Err(error) = self.current_buffer().ensure_backing_file_unchanged(path) {
+            if let Ok(change) = self.current_buffer().detect_external_file_change() {
+                self.current_buffer_mut().set_external_file_change(change);
+                return Ok(json!({
+                    "ok": false,
+                    "applied": false,
+                    "saved": false,
+                    "error": format!("{error}; reread the file before retrying"),
+                    "path": path,
+                    "revision": current_revision,
+                }));
+            }
+        }
         let before = self.current_buffer().contents();
         let created = !path.exists();
         self.check_inline_agent_receipt_capacity(session_id, &before, &contents)?;
@@ -10292,6 +10334,7 @@ impl Editor {
         buffer: &mut RenderBuffer,
         runtime: &mut Runtime,
     ) -> anyhow::Result<()> {
+        self.service_open_file_changes(buffer, runtime).await?;
         if let Some(completed) = self
             .agent_manager
             .take_ready_playback_response(Instant::now())
@@ -16484,10 +16527,26 @@ impl Editor {
 
             if cmd == "write" {
                 if let Some(file) = parsed.file_argument() {
-                    actions.push(Action::SaveAs(file));
+                    actions.push(if parsed.is_forced() {
+                        Action::ForceSaveAs(file)
+                    } else {
+                        Action::SaveAs(file)
+                    });
                 } else {
-                    actions.push(Action::Save);
+                    actions.push(if parsed.is_forced() {
+                        Action::ForceSave
+                    } else {
+                        Action::Save
+                    });
                 }
+            }
+
+            if cmd == "diffdisk" {
+                if parsed.file_argument().is_some() {
+                    self.set_legacy_message(Some("usage: diffdisk".to_string()));
+                    return Vec::new();
+                }
+                actions.push(Action::CompareFileOnDisk);
             }
 
             if cmd == "wall" {
@@ -16503,7 +16562,11 @@ impl Editor {
                     self.set_legacy_message(Some("usage: saveas <file>".to_string()));
                     return Vec::new();
                 };
-                actions.push(Action::SaveAs(file));
+                actions.push(if parsed.is_forced() {
+                    Action::ForceSaveAs(file)
+                } else {
+                    Action::SaveAs(file)
+                });
             }
 
             if cmd == "file" {
@@ -19495,11 +19558,13 @@ impl Editor {
         if self.intercept_learn_action(action, buffer, runtime)? {
             return Ok(false);
         }
-        if matches!(action, Action::Save | Action::SaveAs(_))
-            && self
-                .tutorial_controller
-                .as_ref()
-                .is_some_and(|tutorial| tutorial.practice_buffer_id == self.current_buffer().id())
+        if matches!(
+            action,
+            Action::Save | Action::ForceSave | Action::SaveAs(_) | Action::ForceSaveAs(_)
+        ) && self
+            .tutorial_controller
+            .as_ref()
+            .is_some_and(|tutorial| tutorial.practice_buffer_id == self.current_buffer().id())
         {
             self.last_error = Some("the Red tutorial practice buffer cannot be saved".to_string());
             self.render(buffer)?;
@@ -21823,6 +21888,13 @@ impl Editor {
                 self.sync_inline_change_summaries();
                 self.render(buffer)?;
             }
+            Action::ForceSave => {
+                if !self.force_save_action(buffer, runtime).await? {
+                    return Ok(false);
+                }
+                self.sync_inline_change_summaries();
+                self.render(buffer)?;
+            }
             Action::SaveAll => {
                 self.execute_write_all(buffer, runtime).await?;
             }
@@ -21832,6 +21904,23 @@ impl Editor {
                 }
                 self.sync_inline_change_summaries();
                 self.render(buffer)?;
+            }
+            Action::ForceSaveAs(new_file_name) => {
+                if !self
+                    .force_save_as_action(new_file_name, buffer, runtime)
+                    .await?
+                {
+                    return Ok(false);
+                }
+                self.sync_inline_change_summaries();
+                self.render(buffer)?;
+            }
+            Action::CompareFileOnDisk => {
+                let opened = self.open_disk_conflict_dialog(runtime);
+                self.render(buffer)?;
+                if !opened {
+                    return Ok(false);
+                }
             }
             Action::CommitSearch => {
                 add_to_history = false;
@@ -29096,13 +29185,23 @@ impl Editor {
         buffer: &'a mut RenderBuffer,
         runtime: &'a mut Runtime,
     ) -> BoxFuture<'a, anyhow::Result<bool>> {
-        Box::pin(self.save_action_impl(buffer, runtime))
+        Box::pin(self.save_action_impl(buffer, runtime, /*force*/ false))
+    }
+
+    #[inline(never)]
+    fn force_save_action<'a>(
+        &'a mut self,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<bool>> {
+        Box::pin(self.save_action_impl(buffer, runtime, /*force*/ true))
     }
 
     async fn save_action_impl(
         &mut self,
         buffer: &mut RenderBuffer,
         runtime: &mut Runtime,
+        force: bool,
     ) -> anyhow::Result<bool> {
         let scratch_command = self
             .scratch_buffers
@@ -29113,7 +29212,7 @@ impl Editor {
             return Ok(false);
         }
         let resume_insert_transaction = self.commit_active_transaction_before_save();
-        let format_on_save = self.config.formatting.on_save;
+        let format_on_save = self.config.formatting.on_save && !force;
         let mut format_warning = None;
         let mut use_lsp = format_on_save;
         if format_on_save {
@@ -29164,7 +29263,11 @@ impl Editor {
                 }
             }
         }
-        let save_result = self.current_buffer_mut().save();
+        let save_result = if force {
+            self.current_buffer_mut().force_save()
+        } else {
+            self.current_buffer_mut().save()
+        };
         self.resume_insert_transaction_after_save(resume_insert_transaction);
 
         match save_result {
@@ -29203,7 +29306,17 @@ impl Editor {
         buffer: &'a mut RenderBuffer,
         runtime: &'a mut Runtime,
     ) -> BoxFuture<'a, anyhow::Result<bool>> {
-        Box::pin(self.save_as_action_impl(new_file_name, buffer, runtime))
+        Box::pin(self.save_as_action_impl(new_file_name, buffer, runtime, /*force*/ false))
+    }
+
+    #[inline(never)]
+    fn force_save_as_action<'a>(
+        &'a mut self,
+        new_file_name: &'a str,
+        buffer: &'a mut RenderBuffer,
+        runtime: &'a mut Runtime,
+    ) -> BoxFuture<'a, anyhow::Result<bool>> {
+        Box::pin(self.save_as_action_impl(new_file_name, buffer, runtime, /*force*/ true))
     }
 
     async fn save_as_action_impl(
@@ -29211,6 +29324,7 @@ impl Editor {
         new_file_name: &str,
         buffer: &mut RenderBuffer,
         runtime: &mut Runtime,
+        force: bool,
     ) -> anyhow::Result<bool> {
         if self
             .scratch_buffers
@@ -29243,7 +29357,7 @@ impl Editor {
         let previous_uri = self.current_buffer().uri()?;
         let previous_file = self.current_buffer().file.clone();
         let resume_insert_transaction = self.commit_active_transaction_before_save();
-        let format_on_save = self.config.formatting.on_save;
+        let format_on_save = self.config.formatting.on_save && !force;
         let mut format_warning = None;
         let mut use_lsp = format_on_save;
         if format_on_save {
@@ -29296,7 +29410,11 @@ impl Editor {
                 }
             }
         }
-        let save_result = self.current_buffer_mut().save_as(new_file_name);
+        let save_result = if force {
+            self.current_buffer_mut().force_save_as(new_file_name)
+        } else {
+            self.current_buffer_mut().save_as(new_file_name)
+        };
         self.resume_insert_transaction_after_save(resume_insert_transaction);
 
         match save_result {
@@ -30314,6 +30432,7 @@ pub struct BufferInfo {
     path: Option<String>,
     display_path: Option<String>,
     dirty: bool,
+    conflict: bool,
     active: bool,
     alternate: bool,
     line: usize,
@@ -30365,6 +30484,7 @@ impl From<&Editor> for EditorInfo {
                     path: buffer.file.clone(),
                     display_path,
                     dirty: buffer.is_dirty(),
+                    conflict: buffer.has_external_file_conflict(),
                     active,
                     alternate: Some(buffer.id()) == alternate_id,
                     line,
@@ -33036,12 +33156,59 @@ mod test {
             .await
             .unwrap();
 
+        assert_eq!(result["applied"], false);
         assert_eq!(result["saved"], false);
         assert!(result["error"]
             .as_str()
             .is_some_and(|error| error.contains("changed on disk")));
         assert_eq!(fs::read_to_string(&path).unwrap(), "external\n");
-        assert_eq!(editor.current_buffer().contents(), "agent edit\n");
+        assert_eq!(editor.current_buffer().contents(), "original\n");
+        assert!(!editor.current_buffer().is_dirty());
+        assert!(editor.current_buffer().has_external_file_conflict());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn agent_file_writes_never_replace_unsaved_human_edits() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("document.rs");
+        fs::write(&path, "original\n").unwrap();
+        let mut editor = test_editor(/*width*/ 80, /*height*/ 24);
+        editor.test_set_agent_root(root.path());
+        let request = |call| EditorToolRequest {
+            session_id: "unsaved-human-edit".to_string(),
+            call,
+        };
+        let read = editor
+            .test_run_agent_editor_tool(request(EditorToolCall::ReadFile {
+                path: "document.rs".to_string(),
+                start_line: 1,
+                line_count: 20,
+            }))
+            .await
+            .unwrap();
+        editor
+            .current_buffer_mut()
+            .replace_range_raw(TextRange::insertion(TextPosition::new(0, 0)), "human ");
+        let revision = editor.current_buffer().revision();
+        assert_ne!(read["revision"].as_u64().unwrap(), revision);
+
+        let result = editor
+            .test_run_agent_editor_tool(request(EditorToolCall::WriteFile {
+                path: "document.rs".to_string(),
+                expected_revision: revision,
+                content: "agent edit\n".to_string(),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["applied"], false);
+        assert_eq!(result["saved"], false);
+        assert!(result["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("unsaved editor changes")));
+        assert_eq!(fs::read_to_string(&path).unwrap(), "original\n");
+        assert_eq!(editor.current_buffer().contents(), "human original\n");
         assert!(editor.current_buffer().is_dirty());
     }
 

--- a/src/editor/buffer_do.rs
+++ b/src/editor/buffer_do.rs
@@ -235,8 +235,8 @@ impl Editor {
                     }
                 }
 
-                let save_without_file =
-                    matches!(action, Action::Save) && self.current_buffer().file.is_none();
+                let save_without_file = matches!(action, Action::Save | Action::ForceSave)
+                    && self.current_buffer().file.is_none();
                 let invalid_syntax = matches!(
                     &action,
                     Action::SetSyntax(syntax)
@@ -252,7 +252,7 @@ impl Editor {
                 if blocked_reload || blocked_delete || save_without_file || invalid_syntax {
                     return Ok(());
                 }
-                if matches!(action, Action::Save)
+                if matches!(action, Action::Save | Action::ForceSave)
                     && dirty_before
                     && self.current_buffer().is_dirty()
                     && !self.buffer_has_pending_format_save(target)
@@ -269,6 +269,7 @@ impl Editor {
         matches!(
             action,
             Action::Save
+                | Action::ForceSave
                 | Action::ReloadFile(_)
                 | Action::Substitute(SubstituteCommand { confirm: false, .. })
                 | Action::JoinLines(_)

--- a/src/editor/file_watch.rs
+++ b/src/editor/file_watch.rs
@@ -1,0 +1,636 @@
+//! Native open-buffer file watches with a bounded metadata-polling fallback.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+    sync::mpsc::{self, Receiver},
+    time::{Duration, Instant, SystemTime},
+};
+
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+
+use crate::{
+    buffer::{BufferId, ExternalFileChange},
+    notification::Severity,
+    plugin::Runtime,
+    undo::{TextPosition, TextRange},
+};
+
+use super::{Editor, RenderBuffer};
+
+const OPEN_FILE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+struct NativeFileWatcher {
+    watcher: RecommendedWatcher,
+    events: Receiver<notify::Result<Event>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FileFingerprint {
+    Missing,
+    Unavailable,
+    Present {
+        len: u64,
+        modified: Option<SystemTime>,
+        #[cfg(unix)]
+        device: u64,
+        #[cfg(unix)]
+        inode: u64,
+        #[cfg(unix)]
+        changed_seconds: i64,
+        #[cfg(unix)]
+        changed_nanoseconds: i64,
+    },
+}
+
+impl FileFingerprint {
+    fn capture(path: &Path) -> Self {
+        let metadata = match std::fs::metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Self::Missing,
+            Err(_) => return Self::Unavailable,
+        };
+
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt as _;
+
+        Self::Present {
+            len: metadata.len(),
+            modified: metadata.modified().ok(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            changed_seconds: metadata.ctime(),
+            #[cfg(unix)]
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TrackedFile {
+    path: PathBuf,
+    fingerprint: FileFingerprint,
+}
+
+/// Watches every named, non-scratch buffer regardless of workspace or LSP configuration.
+pub(super) struct OpenFileWatcher {
+    native: Option<NativeFileWatcher>,
+    native_attempted: bool,
+    directories: HashSet<PathBuf>,
+    files: HashMap<BufferId, TrackedFile>,
+    last_poll: Instant,
+}
+
+impl Default for OpenFileWatcher {
+    fn default() -> Self {
+        Self {
+            native: None,
+            native_attempted: false,
+            directories: HashSet::new(),
+            files: HashMap::new(),
+            last_poll: Instant::now(),
+        }
+    }
+}
+
+impl OpenFileWatcher {
+    /// Returns tracked buffers whose disk state may have changed since the previous tick.
+    pub(super) fn poll(&mut self, watched: &[(BufferId, PathBuf)]) -> Vec<BufferId> {
+        self.sync_directories(watched);
+
+        let live = watched.iter().map(|(id, _)| *id).collect::<HashSet<_>>();
+        self.files.retain(|id, _| live.contains(id));
+        for (id, path) in watched {
+            match self.files.get_mut(id) {
+                Some(tracked) if tracked.path == *path => {}
+                Some(tracked) => {
+                    tracked.path.clone_from(path);
+                    tracked.fingerprint = FileFingerprint::capture(path);
+                }
+                None => {
+                    self.files.insert(
+                        *id,
+                        TrackedFile {
+                            path: path.clone(),
+                            fingerprint: FileFingerprint::capture(path),
+                        },
+                    );
+                }
+            }
+        }
+
+        let mut changed = HashSet::new();
+        if let Some(native) = &self.native {
+            while let Ok(event) = native.events.try_recv() {
+                match event {
+                    Ok(event) => {
+                        for (id, tracked) in &self.files {
+                            if event
+                                .paths
+                                .iter()
+                                .any(|path| tracked.path == *path || tracked.path.starts_with(path))
+                            {
+                                changed.insert(*id);
+                            }
+                        }
+                    }
+                    Err(error) => crate::log!("[editor] open-file watcher error: {error}"),
+                }
+            }
+        }
+
+        let poll_fallback = self.last_poll.elapsed() >= OPEN_FILE_POLL_INTERVAL;
+        if poll_fallback {
+            self.last_poll = Instant::now();
+        }
+        for (id, tracked) in &mut self.files {
+            if poll_fallback || changed.contains(id) {
+                let current = FileFingerprint::capture(&tracked.path);
+                if current != tracked.fingerprint {
+                    changed.insert(*id);
+                }
+                tracked.fingerprint = current;
+            }
+        }
+
+        watched
+            .iter()
+            .filter_map(|(id, _)| changed.contains(id).then_some(*id))
+            .collect()
+    }
+
+    fn sync_directories(&mut self, watched: &[(BufferId, PathBuf)]) {
+        if !watched.is_empty() && self.native.is_none() && !self.native_attempted {
+            self.native_attempted = true;
+            let (sender, events) = mpsc::channel();
+            match notify::recommended_watcher(move |event| {
+                let _ = sender.send(event);
+            }) {
+                Ok(watcher) => self.native = Some(NativeFileWatcher { watcher, events }),
+                Err(error) => {
+                    crate::log!("[editor] native open-file watcher unavailable: {error}")
+                }
+            }
+        }
+
+        let desired = watched
+            .iter()
+            .filter_map(|(_, path)| existing_parent(path))
+            .collect::<HashSet<_>>();
+        let Some(native) = &mut self.native else {
+            self.directories.clear();
+            return;
+        };
+
+        for directory in self.directories.difference(&desired) {
+            if let Err(error) = native.watcher.unwatch(directory) {
+                crate::log!("[editor] failed to stop watching {:?}: {error}", directory);
+            }
+        }
+        for directory in desired.difference(&self.directories) {
+            if let Err(error) = native.watcher.watch(directory, RecursiveMode::NonRecursive) {
+                crate::log!("[editor] failed to watch {:?}: {error}", directory);
+            }
+        }
+        self.directories = desired;
+    }
+
+    #[cfg(test)]
+    pub(super) fn force_poll(&mut self) {
+        self.last_poll = Instant::now() - OPEN_FILE_POLL_INTERVAL;
+    }
+}
+
+fn existing_parent(path: &Path) -> Option<PathBuf> {
+    let mut parent = path.parent()?;
+    while !parent.is_dir() {
+        parent = parent.parent()?;
+    }
+    Some(parent.to_path_buf())
+}
+
+impl Editor {
+    /// Keeps diff construction and confirmation state out of the recursive action future.
+    #[inline(never)]
+    pub(super) fn open_disk_conflict_dialog(&mut self, runtime: &mut Runtime) -> bool {
+        let Some(file) = self.current_buffer().file.clone() else {
+            self.set_legacy_message(Some("No file name".to_string()));
+            return false;
+        };
+        let disk = match std::fs::read_to_string(&file) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                "[file was deleted on disk]\n".to_string()
+            }
+            Err(error) => {
+                self.set_legacy_message(Some(error.to_string()));
+                return false;
+            }
+        };
+        let local = self.current_buffer().contents();
+        let diff = similar::TextDiff::configure()
+            .timeout(Duration::from_millis(250))
+            .diff_lines(&disk, &local)
+            .unified_diff()
+            .header("file on disk", "editor buffer")
+            .to_string();
+        if diff.is_empty() {
+            self.current_buffer_mut().set_external_file_change(None);
+            self.set_notification_message(
+                Severity::Success,
+                Some("The editor buffer already matches the file on disk".to_string()),
+            );
+            return false;
+        }
+        const MAX_CONFLICT_DIFF_CHARS: usize = 16_384;
+        let visible_diff = super::truncate_chars(&diff, MAX_CONFLICT_DIFF_CHARS);
+        let truncation = if visible_diff.len() == diff.len() {
+            ""
+        } else {
+            "\n… [diff truncated]"
+        };
+        let message = format!(
+            "{file}\n\n{visible_diff}{truncation}\n\nOverwrite replaces the disk version. Keep edits preserves both versions; use :e! to discard your edits or :w <file> to save elsewhere."
+        );
+        self.release_current_dialog_callbacks(runtime);
+        self.current_dialog = Some(Box::new(super::Confirmation::new_actions(
+            self,
+            "File changed on disk",
+            message,
+            "Overwrite",
+            "Keep edits",
+            super::Action::ForceSave,
+            super::Action::Print("Local edits kept; the file on disk was not changed".to_string()),
+        )));
+        true
+    }
+
+    /// Reloads clean external edits and leaves dirty or deleted files explicitly conflicted.
+    pub(super) async fn service_open_file_changes(
+        &mut self,
+        render_buffer: &mut RenderBuffer,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<()> {
+        let watched = self
+            .buffer_manager
+            .iter()
+            .filter(|buffer| !self.scratch_buffers.contains_key(&buffer.id()))
+            .filter_map(|buffer| {
+                buffer
+                    .file
+                    .as_ref()
+                    .map(|path| (buffer.id(), PathBuf::from(path)))
+            })
+            .collect::<Vec<_>>();
+        let mut changed = self.open_file_watcher.poll(&watched);
+        for buffer in self.buffer_manager.iter() {
+            if buffer.has_external_file_conflict()
+                && !buffer.is_dirty()
+                && buffer.external_file_change() != Some(ExternalFileChange::Deleted)
+                && !changed.contains(&buffer.id())
+            {
+                changed.push(buffer.id());
+            }
+        }
+
+        let mut needs_render = false;
+        for id in changed {
+            let Some(index) = self
+                .buffer_manager
+                .iter()
+                .position(|buffer| buffer.id() == id)
+            else {
+                continue;
+            };
+            let change = match self.buffer_manager[index].detect_external_file_change() {
+                Ok(change) => change,
+                Err(error) => {
+                    crate::log!(
+                        "[editor] failed to inspect {:?} after a filesystem event: {error}",
+                        self.buffer_manager[index].file
+                    );
+                    continue;
+                }
+            };
+
+            let Some(change) = change else {
+                needs_render |= self.buffer_manager[index].set_external_file_change(None);
+                continue;
+            };
+            if self.buffer_manager[index].is_dirty() || change == ExternalFileChange::Deleted {
+                if self.buffer_manager[index].set_external_file_change(Some(change)) {
+                    let path = self.buffer_manager[index].name().to_string();
+                    let verb = match change {
+                        ExternalFileChange::Modified => "changed",
+                        ExternalFileChange::Created => "was created",
+                        ExternalFileChange::Deleted => "was deleted",
+                    };
+                    self.set_notification_message(
+                        Severity::Warning,
+                        Some(format!(
+                            "{path} {verb} on disk; :diffdisk compares, :e! reloads, :w <file> saves elsewhere, :w! overwrites"
+                        )),
+                    );
+                    self.plugin_registry
+                        .notify(
+                            runtime,
+                            "file:external_change",
+                            serde_json::json!({
+                                "file": path,
+                                "buffer_index": index,
+                                "document_id": id,
+                                "change": match change {
+                                    ExternalFileChange::Modified => "modified",
+                                    ExternalFileChange::Created => "created",
+                                    ExternalFileChange::Deleted => "deleted",
+                                },
+                                "dirty": self.buffer_manager[index].is_dirty(),
+                            }),
+                        )
+                        .await?;
+                    needs_render = true;
+                }
+                continue;
+            }
+
+            if self.reload_changed_file(index, runtime).await? {
+                needs_render = true;
+            }
+        }
+
+        if needs_render {
+            self.render(render_buffer)?;
+        }
+        Ok(())
+    }
+
+    async fn reload_changed_file(
+        &mut self,
+        index: usize,
+        runtime: &mut Runtime,
+    ) -> anyhow::Result<bool> {
+        let (path, contents) = match self.buffer_manager[index].read_backing_file() {
+            Ok(result) => result,
+            Err(error) => {
+                crate::log!(
+                    "[editor] failed to reload {:?} after an external edit: {error}",
+                    self.buffer_manager[index].file
+                );
+                return Ok(false);
+            }
+        };
+        if self.buffer_manager[index].is_dirty() {
+            return Ok(false);
+        }
+
+        let original = self.buffer_manager.active_index();
+        let original_view = (self.cx, self.cy, self.vtop, self.vleft, self.skipcol);
+        if index != original {
+            self.select_buffer_for_lsp_edit(index);
+        }
+        let resume_insert_transaction = self.commit_active_transaction_before_save();
+        let end = self.current_buffer().char_idx_to_position(usize::MAX);
+        self.begin_transaction("reload externally changed file");
+        self.replace_range(TextRange::new(TextPosition::new(0, 0), end), &contents);
+        self.current_buffer_mut().file = Some(path.clone());
+        self.commit_transaction(self.cursor_snapshot());
+        self.current_buffer_mut().mark_saved();
+        self.resume_insert_transaction_after_save(resume_insert_transaction);
+
+        if index != original {
+            self.select_buffer_for_lsp_edit(original);
+            (self.cx, self.cy, self.vtop, self.vleft, self.skipcol) = original_view;
+        }
+        self.check_bounds();
+        self.sync_to_window();
+        self.notify_buffer_change(index, runtime).await?;
+        self.plugin_registry
+            .notify(
+                runtime,
+                "file:reloaded",
+                serde_json::json!({
+                    "file": path,
+                    "buffer_index": index,
+                    "document_id": self.buffer_manager[index].id(),
+                    "external": true,
+                }),
+            )
+            .await?;
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        buffer::{Buffer, ExternalFileChange},
+        config::Config,
+        editor::{Action, Editor, RenderBuffer},
+        lsp::LspManager,
+        plugin::Runtime,
+        theme::{Style, Theme},
+        undo::{TextPosition, TextRange},
+    };
+
+    use super::OpenFileWatcher;
+
+    fn editor_with_buffers(buffers: Vec<Buffer>) -> Editor {
+        let config = Config::default();
+        let mut editor = Editor::test_with_size(
+            Box::new(LspManager::new(config.lsp.clone())),
+            /*width*/ 80,
+            /*height*/ 24,
+            config,
+            Theme::default(),
+            buffers,
+        )
+        .unwrap();
+        editor.test_disable_terminal_output();
+        editor
+    }
+
+    async fn poll_editor(editor: &mut Editor) {
+        editor.open_file_watcher.force_poll();
+        let mut frame = RenderBuffer::new(/*width*/ 80, /*height*/ 24, &Style::default());
+        let mut runtime = Runtime::new();
+        editor
+            .service_open_file_changes(&mut frame, &mut runtime)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn polling_detects_rewrites_deletions_and_recreation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("watched.rs");
+        std::fs::write(&path, "before\n").unwrap();
+        let buffer = Buffer::new(Some(path.to_string_lossy().into_owned()), "before\n".into());
+        let watched = [(buffer.id(), path.clone())];
+        let mut watcher = OpenFileWatcher::default();
+
+        assert!(watcher.poll(&watched).is_empty());
+        std::fs::write(&path, "changed\n").unwrap();
+        watcher.force_poll();
+        assert_eq!(watcher.poll(&watched), [buffer.id()]);
+
+        std::fs::remove_file(&path).unwrap();
+        watcher.force_poll();
+        assert_eq!(watcher.poll(&watched), [buffer.id()]);
+
+        std::fs::write(&path, "restored\n").unwrap();
+        watcher.force_poll();
+        assert_eq!(watcher.poll(&watched), [buffer.id()]);
+    }
+
+    #[test]
+    fn closing_a_buffer_stops_reporting_its_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("watched.rs");
+        std::fs::write(&path, "before\n").unwrap();
+        let buffer = Buffer::new(Some(path.to_string_lossy().into_owned()), "before\n".into());
+        let mut watcher = OpenFileWatcher::default();
+
+        assert!(watcher.poll(&[(buffer.id(), path.clone())]).is_empty());
+        std::fs::write(path, "changed\n").unwrap();
+        watcher.force_poll();
+        assert!(watcher.poll(&[]).is_empty());
+    }
+
+    #[tokio::test]
+    async fn external_edits_reload_clean_buffers_through_undoable_transactions() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("watched.rs");
+        std::fs::write(&path, "before\n").unwrap();
+        let source = Buffer::new(Some(path.to_string_lossy().into_owned()), "before\n".into());
+        let mut editor = editor_with_buffers(vec![source]);
+
+        poll_editor(&mut editor).await;
+        std::fs::write(&path, "outside\n").unwrap();
+        poll_editor(&mut editor).await;
+
+        assert_eq!(editor.current_buffer().contents(), "outside\n");
+        assert!(!editor.current_buffer().is_dirty());
+        assert!(!editor.current_buffer().has_external_file_conflict());
+
+        editor
+            .test_execute_production_action(Action::Undo)
+            .await
+            .unwrap();
+        assert_eq!(editor.current_buffer().contents(), "before\n");
+        assert!(editor.current_buffer().is_dirty());
+    }
+
+    #[tokio::test]
+    async fn external_edits_mark_dirty_buffers_without_touching_either_version() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("watched.rs");
+        std::fs::write(&path, "before\n").unwrap();
+        let source = Buffer::new(Some(path.to_string_lossy().into_owned()), "before\n".into());
+        let mut editor = editor_with_buffers(vec![source]);
+
+        poll_editor(&mut editor).await;
+        editor.buffer_manager[0]
+            .replace_range_raw(TextRange::insertion(TextPosition::new(0, 0)), "local ");
+        std::fs::write(&path, "outside\n").unwrap();
+        poll_editor(&mut editor).await;
+
+        assert_eq!(editor.current_buffer().contents(), "local before\n");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "outside\n");
+        assert_eq!(
+            editor.current_buffer().external_file_change(),
+            Some(ExternalFileChange::Modified)
+        );
+        assert!(editor.test_statusline_row().contains("[CONFLICT]"));
+    }
+
+    #[tokio::test]
+    async fn deleted_clean_files_remain_open_with_a_distinct_conflict_marker() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("watched.rs");
+        std::fs::write(&path, "before\n").unwrap();
+        let source = Buffer::new(Some(path.to_string_lossy().into_owned()), "before\n".into());
+        let mut editor = editor_with_buffers(vec![source]);
+
+        poll_editor(&mut editor).await;
+        std::fs::remove_file(&path).unwrap();
+        poll_editor(&mut editor).await;
+
+        assert_eq!(editor.current_buffer().contents(), "before\n");
+        assert!(!editor.current_buffer().is_dirty());
+        assert_eq!(
+            editor.current_buffer().external_file_change(),
+            Some(ExternalFileChange::Deleted)
+        );
+        assert!(editor.test_statusline_row().contains("[DELETED]"));
+    }
+
+    #[tokio::test]
+    async fn newly_created_files_reload_pristine_missing_file_buffers() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("created.rs");
+        let source = Buffer::load_or_create(Some(path.to_string_lossy().into_owned()))
+            .await
+            .unwrap();
+        let mut editor = editor_with_buffers(vec![source]);
+
+        poll_editor(&mut editor).await;
+        std::fs::write(&path, "created outside\n").unwrap();
+        poll_editor(&mut editor).await;
+
+        assert_eq!(editor.current_buffer().contents(), "created outside\n");
+        assert!(!editor.current_buffer().is_dirty());
+        assert!(!editor.current_buffer().has_external_file_conflict());
+    }
+
+    #[tokio::test]
+    async fn background_buffer_reloads_do_not_change_focus_or_active_cursor() {
+        let directory = tempfile::tempdir().unwrap();
+        let first = directory.path().join("first.rs");
+        let second = directory.path().join("second.rs");
+        std::fs::write(&first, "first\n").unwrap();
+        std::fs::write(&second, "second\n").unwrap();
+        let mut editor = editor_with_buffers(vec![
+            Buffer::new(Some(first.to_string_lossy().into_owned()), "first\n".into()),
+            Buffer::new(
+                Some(second.to_string_lossy().into_owned()),
+                "second\n".into(),
+            ),
+        ]);
+        let active_id = editor.current_buffer().id();
+        editor.cx = 2;
+
+        poll_editor(&mut editor).await;
+        std::fs::write(&second, "outside\n").unwrap();
+        poll_editor(&mut editor).await;
+
+        assert_eq!(editor.current_buffer().id(), active_id);
+        assert_eq!(editor.cx, 2);
+        assert_eq!(editor.buffer_manager[1].contents(), "outside\n");
+        assert!(!editor.buffer_manager[1].is_dirty());
+    }
+
+    #[tokio::test]
+    async fn restoring_the_original_disk_contents_clears_a_conflict() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("watched.rs");
+        std::fs::write(&path, "before\n").unwrap();
+        let source = Buffer::new(Some(path.to_string_lossy().into_owned()), "before\n".into());
+        let mut editor = editor_with_buffers(vec![source]);
+
+        poll_editor(&mut editor).await;
+        editor.buffer_manager[0]
+            .replace_range_raw(TextRange::insertion(TextPosition::new(0, 0)), "local ");
+        std::fs::write(&path, "outside\n").unwrap();
+        poll_editor(&mut editor).await;
+        assert!(editor.current_buffer().has_external_file_conflict());
+
+        std::fs::write(&path, "before\n").unwrap();
+        poll_editor(&mut editor).await;
+
+        assert_eq!(editor.current_buffer().contents(), "local before\n");
+        assert!(!editor.current_buffer().has_external_file_conflict());
+    }
+}

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -195,6 +195,7 @@ struct StatuslineContext<'a> {
     line_endings: &'static str,
     read_only: bool,
     modified: bool,
+    external_file_change: Option<super::ExternalFileChange>,
     workspace: String,
     relative_path: Option<String>,
     buffer_index: String,
@@ -228,7 +229,37 @@ fn statusline_segment(
             };
             (statusline_icon_label(glyph, branch), Vec::new())
         }
-        StatuslineSection::Filename => (format!(" {} ", context.filename), Vec::new()),
+        StatuslineSection::Filename => {
+            let text = format!(" {} ", context.filename);
+            let accents = context
+                .external_file_change
+                .and_then(|change| {
+                    let marker = if change == super::ExternalFileChange::Deleted {
+                        "[DELETED]"
+                    } else {
+                        "[CONFLICT]"
+                    };
+                    let offset = text.find(marker)?;
+                    let color = theme
+                        .colors
+                        .get("editorWarning.foreground")
+                        .copied()
+                        .unwrap_or(Color::Rgb {
+                            r: 213,
+                            g: 164,
+                            b: 88,
+                        });
+                    Some(StatuslineAccent {
+                        column: display_width(&text[..offset]),
+                        text: marker.to_string(),
+                        color,
+                        minimum_contrast: None,
+                    })
+                })
+                .into_iter()
+                .collect();
+            (text, accents)
+        }
         StatuslineSection::Syntax => {
             let syntax = context.syntax.as_deref()?;
             let icon = IconCatalog::file(
@@ -343,13 +374,18 @@ fn statusline_segment(
             )
         }
         StatuslineSection::Modified => {
-            if !context.modified {
+            if !context.modified && context.external_file_change.is_none() {
                 return None;
             }
+            let label = match context.external_file_change {
+                Some(super::ExternalFileChange::Deleted) => "deleted on disk",
+                Some(_) => "conflict",
+                None => "modified",
+            };
             (
                 statusline_icon_label(
                     statusline_section_icon(StatuslineSection::Modified, icon_style),
-                    "modified",
+                    label,
                 ),
                 Vec::new(),
             )
@@ -3506,6 +3542,7 @@ impl Editor {
             filename,
             file_path,
             dirty,
+            external_file_change,
             position,
             buffer_index,
             cursor_line,
@@ -3529,6 +3566,7 @@ impl Editor {
                 window_buffer.name().to_string(),
                 window_buffer.file.clone(),
                 dirty,
+                window_buffer.external_file_change(),
                 format!(
                     " {}:{}{}",
                     window.vtop + window.cy + 1,
@@ -3554,6 +3592,7 @@ impl Editor {
                 current.name().to_string(),
                 current.file.clone(),
                 current.is_dirty(),
+                current.external_file_change(),
                 format!(" {}:{} ", self.vtop + self.cy + 1, self.cx + 1),
                 self.buffer_manager.active_index(),
                 self.vtop + self.cy,
@@ -3598,7 +3637,14 @@ impl Editor {
         } else {
             current_folder.clone()
         };
-        let filename = statusline_file_name(&filename, &current_folder);
+        let mut filename = statusline_file_name(&filename, &current_folder);
+        if let Some(change) = external_file_change {
+            filename.push_str(if change == super::ExternalFileChange::Deleted {
+                " [DELETED]"
+            } else {
+                " [CONFLICT]"
+            });
+        }
         let diagnostics = configured(StatuslineSection::Diagnostics)
             .then(|| self.statusline_diagnostic_counts(buffer_index))
             .flatten();
@@ -3693,6 +3739,7 @@ impl Editor {
             line_endings,
             read_only,
             modified: dirty,
+            external_file_change,
             workspace: if configured(StatuslineSection::Workspace) {
                 statusline_workspace_name(&workspace_root)
             } else {
@@ -4230,7 +4277,7 @@ fn format_mode_name(mode: &Mode) -> String {
 mod tests {
     use super::*;
     use crate::{
-        buffer::Buffer,
+        buffer::{Buffer, ExternalFileChange},
         config::Config,
         editor::{display_layout::LineSegment, HighlightSpan},
         lsp::{LspManager, Position, Range},
@@ -5232,6 +5279,54 @@ mod tests {
 
         assert!(row.contains(&relative.to_string_lossy().into_owned()));
         assert!(!row.contains(&current_folder.to_string_lossy().into_owned()));
+    }
+
+    #[test]
+    fn rendered_statusline_marks_external_conflicts_with_the_warning_color() {
+        const WIDTH: usize = 80;
+        const HEIGHT: usize = 5;
+
+        let mut source = Buffer::new(Some("document.rs".to_string()), "before\n".to_string());
+        source.set_external_file_change(Some(ExternalFileChange::Modified));
+        let mut config = Config::default();
+        config.statusline.left = vec![StatuslineSection::Filename, StatuslineSection::Modified];
+        config.statusline.right.clear();
+        let mut theme = Theme::default();
+        let warning = Color::Rgb {
+            r: 242,
+            g: 181,
+            b: 75,
+        };
+        theme
+            .colors
+            .insert("editorWarning.foreground".to_string(), warning);
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let mut editor =
+            Editor::with_size(lsp, WIDTH, HEIGHT, config, theme, vec![source]).unwrap();
+
+        let frame = rendered_statusline(&mut editor, WIDTH, HEIGHT);
+        let row = editor.test_statusline_row();
+
+        assert!(row.contains("[CONFLICT]"));
+        assert!(row.contains("conflict"));
+        assert_eq!(statusline_cell(&frame, HEIGHT, "[").style.fg, Some(warning));
+    }
+
+    #[test]
+    fn rendered_statusline_marks_clean_deleted_files() {
+        let mut source = Buffer::new(Some("document.rs".to_string()), "before\n".to_string());
+        source.set_external_file_change(Some(ExternalFileChange::Deleted));
+        let mut config = Config::default();
+        config.statusline.left = vec![StatuslineSection::Filename, StatuslineSection::Modified];
+        config.statusline.right.clear();
+        let lsp = Box::new(LspManager::new(config.lsp.clone()));
+        let mut editor =
+            Editor::with_size(lsp, 80, 5, config, Theme::default(), vec![source]).unwrap();
+
+        let row = editor.test_statusline_row();
+
+        assert!(row.contains("[DELETED]"));
+        assert!(row.contains("deleted on disk"));
     }
 
     #[test]

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -2972,6 +2972,129 @@ async fn wall_preserves_external_changes_while_saving_other_modified_buffers() {
 }
 
 #[tokio::test]
+async fn forced_write_explicitly_resolves_an_external_file_conflict() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("document.txt");
+    fs::write(&path, "original\n").unwrap();
+    let source = Buffer::new(
+        Some(path.to_string_lossy().into_owned()),
+        "original\n".to_string(),
+    );
+    let mut harness = EditorHarness::with_buffer(source);
+    harness
+        .execute_action(Action::InsertCharAtCursorPos('!'))
+        .await
+        .unwrap();
+    fs::write(&path, "external\n").unwrap();
+
+    harness
+        .execute_action(Action::Command("w".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), "external\n");
+    assert!(harness
+        .editor
+        .test_current_buffer()
+        .has_external_file_conflict());
+
+    harness
+        .execute_action(Action::Command("w!".to_string()))
+        .await
+        .unwrap();
+
+    assert_eq!(fs::read_to_string(&path).unwrap(), "!original\n");
+    assert!(!harness.is_dirty());
+    assert!(!harness
+        .editor
+        .test_current_buffer()
+        .has_external_file_conflict());
+}
+
+#[tokio::test]
+async fn forced_write_with_a_filename_overwrites_only_the_requested_destination() {
+    let directory = tempfile::tempdir().unwrap();
+    let source_path = directory.path().join("source.txt");
+    let destination = directory.path().join("destination.txt");
+    fs::write(&source_path, "original\n").unwrap();
+    fs::write(&destination, "destination\n").unwrap();
+    let source = Buffer::new(
+        Some(source_path.to_string_lossy().into_owned()),
+        "original\n".to_string(),
+    );
+    let mut harness = EditorHarness::with_buffer(source);
+    harness
+        .execute_action(Action::InsertCharAtCursorPos('!'))
+        .await
+        .unwrap();
+
+    harness
+        .execute_action(Action::Command(format!("w {}", destination.display())))
+        .await
+        .unwrap();
+    assert_eq!(fs::read_to_string(&destination).unwrap(), "destination\n");
+
+    harness
+        .execute_action(Action::Command(format!("w! {}", destination.display())))
+        .await
+        .unwrap();
+
+    assert_eq!(fs::read_to_string(&source_path).unwrap(), "original\n");
+    assert_eq!(fs::read_to_string(&destination).unwrap(), "!original\n");
+    assert!(!harness.is_dirty());
+}
+
+#[tokio::test]
+async fn disk_conflict_comparison_defaults_to_preserving_both_versions() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("document.txt");
+    fs::write(&path, "original\n").unwrap();
+    let source = Buffer::new(
+        Some(path.to_string_lossy().into_owned()),
+        "original\n".to_string(),
+    );
+    let mut harness = EditorHarness::with_buffer(source);
+    harness
+        .execute_action(Action::InsertCharAtCursorPos('!'))
+        .await
+        .unwrap();
+    fs::write(&path, "external\n").unwrap();
+
+    harness
+        .execute_action(Action::Command("diffdisk".to_string()))
+        .await
+        .unwrap();
+    let rows = (0..24)
+        .map(|row| harness.editor.test_render_row(row).unwrap())
+        .collect::<Vec<_>>();
+    assert!(rows.iter().any(|row| row.contains("File changed on disk")));
+
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), "external\n");
+    assert_eq!(harness.buffer_contents(), "!original\n");
+    assert!(harness.is_dirty());
+
+    harness
+        .execute_action(Action::Command("diffdisk".to_string()))
+        .await
+        .unwrap();
+    harness
+        .execute_event(Event::Key(KeyEvent::new(
+            KeyCode::Char('y'),
+            KeyModifiers::NONE,
+        )))
+        .await
+        .unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), "!original\n");
+    assert!(!harness.is_dirty());
+}
+
+#[tokio::test]
 async fn wall_saves_named_buffers_before_reporting_a_dirty_unnamed_buffer() {
     let directory = tempfile::tempdir().unwrap();
     let first_path = directory.path().join("first.txt");


### PR DESCRIPTION
## Why

The save-time protection already prevents Red from silently overwriting files changed outside the editor, but users still discover conflicts only when they try to save. Clean buffers do not follow external changes, dirty buffers have no persistent conflict indicator, and agent writes can replace unsaved edits before persistence fails.

## What changed

- Watch every named, non-scratch buffer with native filesystem notifications and a metadata-polling fallback; verify suspected changes against the exact last-loaded or saved file contents.
- Automatically reload clean buffers through undoable editor transactions while preserving focus, cursor position, and LSP/plugin notifications; retain deleted files and unsaved edits instead of discarding either version.
- Surface external modifications and deletions through warning notifications, `[CONFLICT]` / `[DELETED]` statusline markers, buffer metadata, and plugin events.
- Add `:diffdisk` with a safe-by-default conflict comparison, explicit `:w!` / `:w! <file>` overrides, and guidance for `:e!` or saving local changes elsewhere.
- Reject agent writes before mutation when the backing file changed or the proposed edit overlaps unsaved human changes, while allowing edits to unrelated ranges.

## How to Test

1. Open an existing file in Red without editing it, change the file from another terminal, and verify Red reloads the new contents automatically without marking the buffer dirty. Undo once and verify the previous contents remain recoverable.
2. Make an unsaved edit in Red, modify the same file externally, and verify the statusline shows `[CONFLICT]`. Run `:w` and confirm both the external file contents and local buffer contents remain unchanged.
3. Run `:diffdisk` and verify it displays both versions. Press Enter to accept the default **Keep edits** action and confirm nothing is overwritten; reopen the comparison and choose **Overwrite**, or run `:w!`, to explicitly replace the file and clear the conflict.
4. Delete an open file externally and verify `[DELETED]` remains visible without discarding the buffer. Save to a new path with `:w <file>` and confirm the deleted source is not recreated.
5. Run `cargo test --lib file_watch`, `cargo test --test editing forced_write`, and `cargo test --test editing disk_conflict_comparison_defaults_to_preserving_both_versions` to cover watching, explicit overwrite, and the safe-default comparison flow.

Validated on the PR branch: 2,372 library tests and 483 editor/LSP integration tests pass; formatting and `cargo clippy --all-targets --all-features -- -D warnings` are clean. The same change rebased locally onto current `main` also passes 2,385 library tests and all 483 editor/LSP integration tests.
