### PR TITLE
fix(picker): prioritize distinctive primary labels

### DIFF
--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -539,6 +539,8 @@ written. `agent:model_changed` carries `{ session_id, model_info }`, where
 For name-oriented lists, `PickerOptions.item_layout: "label_first"` reserves the
 longest filtered label, then aligns annotations and descriptions in shared columns.
 Secondary fields disappear before labels are shortened; the default layout is unchanged.
+A row with a shortened filename or directory label can set `data.search_path` to its
+complete path so filtering and match highlights still include the parent directories.
 `UpdatePickerSelection(handle, item_id)` selects a currently visible item without
 resetting the query. This is useful after populating a loading picker in place.
 

--- a/plugins/agent.hk
+++ b/plugins/agent.hk
@@ -2372,7 +2372,6 @@ fn permission_requested(event: AgentPermissionEvent) {
             label: option.name,
             kind: "Permission",
             annotation: red::string(option.kind, "permission") + " · " + option.option_id,
-            detail: "Codex permission option " + option.option_id,
             data: Json { option_id: option.option_id },
         });
     }
@@ -2380,6 +2379,7 @@ fn permission_requested(event: AgentPermissionEvent) {
         placeholder: "Choose an exact option from the agent",
         status: red::len(items) + " options",
         presentation: "compact",
+        item_layout: "label_first",
     }, PickerHandlers {
         selected: permission_selected,
         cancelled: permission_cancelled,

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -2608,6 +2608,15 @@ fn open_items(title: String, items: [PickerItem]) {
     open_menu_picker(title, items, "Filter");
 }
 
+fn open_name_first_items(title: String, items: [PickerItem]) {
+    red::execute("OpenPicker", title, items, PickerOptions {
+        placeholder: "Filter",
+        item_layout: "label_first",
+    }, PickerHandlers {
+        selected: menu_selected,
+    });
+}
+
 fn open_menu_picker(title: String, items: [PickerItem], placeholder: String) {
     red::execute("OpenPicker", title, items, PickerOptions {
         placeholder: placeholder,
@@ -2898,17 +2907,27 @@ fn open_worktree_items(output: String) {
         let line = lines[index];
         if red::starts_with(line, "worktree ") {
             let path = red::slice(line, 9);
+            let normalized = red::replace_all(path, "\\", "/");
+            let parts = red::split(normalized, "/");
+            let name = red::string(parts[red::len(parts) - 1], normalized);
+            let parents = [];
+            let part_index = 0;
+            while part_index < red::len(parts) - 1 {
+                parents = red::push(parents, parts[part_index]);
+                part_index = part_index + 1;
+            }
             items = red::push(items, PickerItem {
                 id: path,
-                label: path,
+                label: name,
                 kind: "GitWorktree",
-                data: Json { menu_kind: "worktrees", value: path },
+                annotation: red::join(parents, "/"),
+                data: Json { menu_kind: "worktrees", value: path, search_path: normalized },
             });
         }
         index = index + 1;
     }
     items = red::push(items, PickerItem { id: "Cancel", label: "Cancel", kind: "Cancel" });
-    open_items("Worktrees", items);
+    open_name_first_items("Worktrees", items);
 }
 
 fn open_log_items(output: String) {
@@ -2926,7 +2945,7 @@ fn open_log_items(output: String) {
             });
         }
     }
-    open_items("Git log", items);
+    open_name_first_items("Git log", items);
 }
 
 fn start_rebase_plan(output: String) {

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -299,6 +299,7 @@ fn references() {
         placeholder: "Filter references",
         status: status,
         busy: true,
+        item_layout: "label_first",
     }, PickerHandlers {
         selected: open_reference_selection,
         cancelled: symbol_picker_cancelled,
@@ -363,6 +364,7 @@ fn show_document_symbols(result: SymbolsResult, request_id: i32) {
         let handle = red::execute("OpenPicker", "Document Symbols", items, PickerOptions {
             placeholder: "Filter document symbols",
             status: red::len(items) + " symbols",
+            item_layout: "label_first",
         }, PickerHandlers {
             selected: open_symbol_selection,
             cancelled: symbol_picker_cancelled,
@@ -376,6 +378,7 @@ fn show_document_symbols(result: SymbolsResult, request_id: i32) {
     let handle = red::execute("OpenPicker", "Document Symbols", [], PickerOptions {
         placeholder: "Filter document symbols",
         status: "Loading 0/" + count + " symbols",
+        item_layout: "label_first",
     }, PickerHandlers {
         selected: open_symbol_selection,
         cancelled: symbol_picker_cancelled,
@@ -502,7 +505,7 @@ fn symbol_batch_timeout(event: TimerEvent) {
                 batch = red::push(batch, reference_item(value));
             }
         } else if !workspace_only || is_workspace_symbol_kind(value.kind_name) {
-            batch = red::push(batch, symbol_item(value));
+            batch = red::push(batch, symbol_item(value, workspace_only));
         }
         index = index + 1;
         processed = processed + 1;
@@ -629,22 +632,26 @@ fn symbol_items(symbols: [LspSymbol], workspace_only: bool) -> [PickerItem] {
     let items: [PickerItem] = [];
     for symbol in symbols {
         if !workspace_only || is_workspace_symbol_kind(symbol.kind_name) {
-            items = red::push(items, symbol_item(symbol));
+            items = red::push(items, symbol_item(symbol, workspace_only));
         }
     }
     return items;
 }
 
-fn symbol_item(symbol: LspSymbol) -> PickerItem {
+fn symbol_item(symbol: LspSymbol, workspace: bool) -> PickerItem {
     let line = symbol.selection_range.start.line;
     let character = symbol.selection_range.start.character;
+    let location = (line + 1) + ":" + (character + 1);
+    if workspace {
+        location = symbol.file + ":" + location;
+    }
     return PickerItem {
         id: "symbol:" + symbol.kind_name + ":" + symbol.file + ":" + line + ":" + character + ":" + symbol.name,
         icon: symbol_icon(symbol.kind_name),
         label: symbol.name,
         kind: symbol.kind_name,
         annotation: symbol.detail,
-        detail: symbol.file + ":" + (line + 1) + ":" + (character + 1),
+        detail: location,
         data: Json { symbol: symbol },
         preview: Json { path: symbol.file, line: line, column: character },
     };
@@ -653,13 +660,23 @@ fn symbol_item(symbol: LspSymbol) -> PickerItem {
 fn reference_item(location: LspLocation) -> PickerItem {
     let line = location.range.start.line;
     let character = location.range.start.character;
+    let position = (line + 1) + ":" + (character + 1);
+    let path = red::replace_all(location.file, "\\", "/");
+    let parts = red::split(path, "/");
+    let filename = red::string(parts[red::len(parts) - 1], path);
+    let parents = [];
+    let index = 0;
+    while index < red::len(parts) - 1 {
+        parents = red::push(parents, parts[index]);
+        index = index + 1;
+    }
     return PickerItem {
         id: "reference:" + location.file + ":" + line + ":" + character,
         icon: symbol_icon("Reference"),
-        label: location.file,
+        label: filename + ":" + position,
         kind: "Reference",
-        annotation: ":" + (line + 1) + ":" + (character + 1),
-        data: Json { location: location },
+        annotation: red::join(parents, "/"),
+        data: Json { location: location, search_path: path + ":" + position },
         preview: Json { path: location.file, line: line, column: character },
     };
 }

--- a/plugins/theme_browser.hk
+++ b/plugins/theme_browser.hk
@@ -114,6 +114,7 @@ fn open_picker_if_ready() {
         status: status,
         initial_selection: red::string(state().original, ""),
         presentation: "compact",
+        item_layout: "label_first",
     }, ThemePickerHandlers {
         changed: theme_changed,
         cancelled: theme_cancelled,

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -165,9 +165,9 @@ use crate::{
         AgentComposer, CompletionUI, Component, Confirmation, CopilotSignInDialog,
         CopilotSignInModel, CopilotSignInPhase, DiagnosticInfo, FilePicker, HoverInfo,
         HoverInfoFormat, InlineAssistPopup, InlineAssistPopupState, InputPrompt,
-        LegacyPickerOptions, OverlayLayout, Picker, PickerItem, PickerOptions, PickerPreview,
-        PickerUpdate, ScreenRect, StatuslineLayoutPanel, TutorialDemoKind, TutorialDemoPanel,
-        WelcomePanel, WhatsNewPanel,
+        LegacyPickerOptions, OverlayLayout, Picker, PickerItem, PickerItemLayout, PickerOptions,
+        PickerPreview, PickerUpdate, ScreenRect, StatuslineLayoutPanel, TutorialDemoKind,
+        TutorialDemoPanel, WelcomePanel, WhatsNewPanel,
     },
     undo::{AppliedTextEdit, CursorSnapshot, EditOrigin, RevertEdit, TextPosition, TextRange},
     utils::{expand_user_path, get_workspace_path, normalized_file_path, same_file_path},
@@ -4835,12 +4835,16 @@ impl Editor {
                 PickerItem {
                     id: index.to_string(),
                     icon: None,
-                    label: format!("{}  {}", diagnostic.code, diagnostic.path),
+                    label: diagnostic.message.clone(),
                     kind: Some(format!("{:?}", diagnostic.severity)),
-                    annotation: Some(location),
-                    detail: Some(diagnostic.message.clone()),
+                    annotation: Some(format!("{}  {}", diagnostic.code, diagnostic.path)),
+                    detail: Some(location.clone()),
                     data: serde_json::json!({
                         "fallback": diagnostic.fallback,
+                        "search_text": format!(
+                            "{} {} {} {}",
+                            diagnostic.message, diagnostic.code, diagnostic.path, location
+                        ),
                     }),
                     matches: Vec::new(),
                     detail_matches: Vec::new(),
@@ -4851,6 +4855,8 @@ impl Editor {
         let picker = Picker::builder()
             .title("Configuration diagnostics")
             .structured_items(items)
+            .item_layout(PickerItemLayout::LabelFirst)
+            .filter_action(diagnostics_picker::diagnostic_filter_score)
             .placeholder("Filter configuration problems")
             .history_key("config-diagnostics")
             .select_action(move |item| {
@@ -14208,6 +14214,7 @@ impl Editor {
             .title("Code actions")
             .id(CODE_ACTION_PICKER_ID)
             .structured_items(items)
+            .item_layout(PickerItemLayout::LabelFirst)
             .select_action(move |item| {
                 actions.get(&item).cloned().unwrap_or_else(|| {
                     Action::Print("code action is no longer available".to_string())
@@ -36460,7 +36467,24 @@ builtin = "rust"
 
         editor.open_config_diagnostics();
         assert!(editor.config_diagnostics_acknowledged);
-        assert!(editor.current_dialog.is_some());
+        let dialog = editor.current_dialog.as_mut().unwrap();
+        let mut picker_buffer = RenderBuffer::new(100, 8, &Style::default());
+        dialog.draw(&mut picker_buffer).unwrap();
+        assert!(render_text_rows(&picker_buffer)
+            .join("\n")
+            .contains("unknown configuration field"));
+
+        for character in "CFG101 commands".chars() {
+            dialog.handle_event(&Event::Key(KeyEvent::new(
+                KeyCode::Char(character),
+                KeyModifiers::NONE,
+            )));
+        }
+        let mut filtered = RenderBuffer::new(100, 8, &Style::default());
+        dialog.draw(&mut filtered).unwrap();
+        assert!(render_text_rows(&filtered)
+            .join("\n")
+            .contains("unknown configuration field"));
     }
 
     #[tokio::test]
@@ -42043,7 +42067,7 @@ builtin = "rust"
         let message = InboundMessage::Message(ResponseMessage {
             id: 43,
             result: serde_json::json!([{
-                "title": "Remove unused binding",
+                "title": "Remove unused binding from request handler",
                 "kind": "quickfix",
                 "isPreferred": true,
                 "edit": { "changes": { (uri.clone()): [{
@@ -42071,7 +42095,7 @@ builtin = "rust"
             .unwrap();
         let loaded_frame = render_text_rows(&loaded).join("\n");
         assert!(
-            loaded_frame.contains("Remove unused binding"),
+            loaded_frame.contains("Remove unused binding from request handler"),
             "{loaded_frame}"
         );
         assert!(
@@ -42098,7 +42122,7 @@ builtin = "rust"
                 label,
             }) if documents.len() == 1
                 && expected_revisions == &vec![(documents[0].uri.clone(), revision)]
-                && label == "Remove unused binding"
+                && label == "Remove unused binding from request handler"
         ));
     }
 

--- a/src/editor/diagnostics_picker.rs
+++ b/src/editor/diagnostics_picker.rs
@@ -262,7 +262,7 @@ fn diagnostic_picker_model(
     DiagnosticPickerModel { items, actions }
 }
 
-fn diagnostic_filter_score(item: &PickerItem, query: &str) -> Option<i64> {
+pub(super) fn diagnostic_filter_score(item: &PickerItem, query: &str) -> Option<i64> {
     if query.trim().is_empty() {
         return Some(0);
     }

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -4661,10 +4661,14 @@ mod tests {
                 handle,
                 title,
                 items,
-                ..
+                options,
             } => {
                 assert_eq!(owner, "agent");
                 assert_eq!(title.as_deref(), Some(expected_title));
+                if expected_title == "Agent permission" {
+                    assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
+                    assert!(items.iter().all(|item| item.detail.is_none()));
+                }
                 (handle, items)
             }
             _ => panic!("expected callback-scoped agent picker"),
@@ -13731,6 +13735,160 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn git_log_and_worktree_pickers_prioritize_distinctive_names() {
+        async fn next_git_picker(
+            runtime: &mut Runtime,
+            expected_title: &str,
+        ) -> (PickerHandle, Vec<PickerItem>, PickerOptions) {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                pump_process_events(runtime).await.unwrap();
+                while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                    if let PluginRequest::OpenCallbackPicker {
+                        owner,
+                        handle,
+                        title,
+                        items,
+                        options,
+                    } = request
+                    {
+                        assert_eq!(owner, "git");
+                        assert_eq!(title.as_deref(), Some(expected_title));
+                        return (handle, items, options);
+                    }
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "{expected_title} picker did not open"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        let subject = "preserve distinctive commit subjects in picker rows";
+        for args in [
+            vec!["init", "-q", "-b", "main"],
+            vec![
+                "-c",
+                "user.name=Red Tests",
+                "-c",
+                "user.email=red@example.com",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--allow-empty",
+                "-qm",
+                subject,
+            ],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success());
+        }
+        let mut runtime = load_git_runtime(root).await;
+        drain_requests();
+        let startup_deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(&mut runtime).await.unwrap();
+            drain_requests();
+            if runtime
+                .inner
+                .lock()
+                .unwrap()
+                .host
+                .process_manager
+                .active_process_count("git")
+                == 0
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < startup_deadline,
+                "Git startup did not settle"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "l", "row": null }),
+            )
+            .await
+            .unwrap();
+        let (log_handle, commits, options) = next_git_picker(&mut runtime, "Git log").await;
+        assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
+        assert!(commits.iter().any(|item| item.label.contains(subject)));
+        assert!(runtime
+            .notify_picker(log_handle, PickerCallback::Cancelled)
+            .unwrap());
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "w", "row": null }),
+            )
+            .await
+            .unwrap();
+        let (menu_handle, list_item) = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackPicker {
+                handle,
+                title,
+                items,
+                options,
+                ..
+            } => {
+                assert_eq!(title.as_deref(), Some("Worktree"));
+                assert_eq!(options.item_layout, crate::ui::PickerItemLayout::Default);
+                (
+                    handle,
+                    items.into_iter().find(|item| item.id == "List").unwrap(),
+                )
+            }
+            _ => panic!("expected worktree action menu"),
+        };
+        assert!(runtime
+            .notify_picker(menu_handle, PickerCallback::Selected(list_item))
+            .unwrap());
+        let (_, worktrees, options) = next_git_picker(&mut runtime, "Worktrees").await;
+        assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
+        let canonical_root = root.canonicalize().unwrap();
+        let worktree = worktrees
+            .iter()
+            .find(|item| {
+                Path::new(&item.id)
+                    .canonicalize()
+                    .is_ok_and(|path| path == canonical_root)
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "current checkout {canonical_root:?} should appear in worktree rows: {:?}",
+                    worktrees.iter().map(|item| &item.id).collect::<Vec<_>>()
+                )
+            });
+        let expected_search_path = worktree.id.replace('\\', "/");
+        let expected_parent = expected_search_path
+            .rsplit_once('/')
+            .map(|(parent, _)| parent)
+            .unwrap_or_default();
+        assert_eq!(worktree.label, root.file_name().unwrap().to_string_lossy());
+        assert_eq!(worktree.annotation.as_deref(), Some(expected_parent));
+        assert_eq!(
+            worktree
+                .data
+                .get("search_path")
+                .and_then(serde_json::Value::as_str),
+            Some(expected_search_path.as_str())
+        );
+    }
+
     #[cfg(not(windows))]
     #[tokio::test]
     async fn git_push_previews_outgoing_commits_cancels_safely_and_reports_success() {
@@ -17201,6 +17359,7 @@ mod tests {
                 assert_eq!(title.as_deref(), Some("Themes"));
                 assert_eq!(options.initial_selection.as_deref(), Some("custom.json"));
                 assert_eq!(options.presentation, PickerPresentation::Compact);
+                assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
                 assert_eq!(items[0].label, "Mocha");
                 assert_eq!(items[0].kind.as_deref(), Some("Theme"));
                 assert_eq!(items[1].label, "Custom");
@@ -17567,11 +17726,14 @@ mod tests {
                 handle,
                 title,
                 items,
-                ..
+                options,
             } => {
                 assert_eq!(owner, "lsp_symbols");
                 assert_eq!(title.as_deref(), Some("Document Symbols"));
+                assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
                 assert_eq!(items[0].label, "main");
+                assert_eq!(items[0].annotation.as_deref(), Some("fn()"));
+                assert_eq!(items[0].detail.as_deref(), Some("5:4"));
                 assert_eq!(items[0].kind.as_deref(), Some("Function"));
                 handle
             }
@@ -17632,6 +17794,7 @@ mod tests {
             } => {
                 assert!(items.is_empty());
                 assert_eq!(options.status.as_deref(), Some("Loading 0/4097 symbols"));
+                assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
                 handle
             }
             _ => panic!("expected empty document-symbol picker"),
@@ -17673,6 +17836,7 @@ mod tests {
 
         assert_eq!(final_items.len(), 4_096);
         assert_eq!(final_items[4_095].label, "symbol_4095");
+        assert_eq!(final_items[4_095].detail.as_deref(), Some("4096:4"));
         assert_eq!(
             final_status.as_deref(),
             Some("4096 symbols (results truncated)")
@@ -17890,6 +18054,7 @@ mod tests {
                 assert!(items.is_empty());
                 assert_eq!(options.status.as_deref(), Some("Fetching references..."));
                 assert!(options.busy);
+                assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
                 handle
             }
             _ => panic!("expected references loading picker"),
@@ -17959,7 +18124,15 @@ mod tests {
         }
 
         assert_eq!(final_items.len(), 4_096);
-        assert_eq!(final_items[4_095].label, "src/reference_4095.rs");
+        assert_eq!(final_items[4_095].label, "reference_4095.rs:4096:2");
+        assert_eq!(final_items[4_095].annotation.as_deref(), Some("src"));
+        assert_eq!(
+            final_items[4_095]
+                .data
+                .get("search_path")
+                .and_then(serde_json::Value::as_str),
+            Some("src/reference_4095.rs:4096:2")
+        );
         assert_eq!(
             final_status.as_deref(),
             Some("4096 references (results truncated)")
@@ -18064,6 +18237,7 @@ mod tests {
                 assert_eq!(id, handle.get());
                 assert_eq!(items[0].label, "main");
                 assert_eq!(items[0].kind.as_deref(), Some("Function"));
+                assert_eq!(items[0].detail.as_deref(), Some("src/main.rs:5:4"));
             }
             _ => panic!("unexpected plugin request"),
         }
@@ -18347,7 +18521,15 @@ mod tests {
             PluginRequest::UpdatePickerItems { id, items } => {
                 assert_eq!(id, handle.get());
                 assert_eq!(items.len(), 2);
-                assert_eq!(items[0].label, "src/lib.rs");
+                assert_eq!(items[0].label, "lib.rs:9:3");
+                assert_eq!(items[0].annotation.as_deref(), Some("src"));
+                assert_eq!(
+                    items[0]
+                        .data
+                        .get("search_path")
+                        .and_then(serde_json::Value::as_str),
+                    Some("src/lib.rs:9:3")
+                );
                 items[0].clone()
             }
             _ => panic!("expected reference picker items"),

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -74,21 +74,22 @@ fn default_item_filter_score(
     item: &PickerItem,
     query: &str,
 ) -> Option<(PickerMatchKind, Reverse<i64>)> {
-    if item.kind.as_deref() != Some("FilePath") {
+    let Some(path) = picker_item_search_path(item) else {
         return default_filter_score(matcher, &item.label, query);
-    }
-
-    let path = item
-        .data
-        .get("search_path")
-        .and_then(Value::as_str)
-        .unwrap_or(&item.id);
+    };
     default_path_filter_score(
         matcher,
         PathCandidate::new(path, &item.label, item.annotation.as_deref()),
         &item.label,
         query,
     )
+}
+
+fn picker_item_search_path(item: &PickerItem) -> Option<&str> {
+    item.data
+        .get("search_path")
+        .and_then(Value::as_str)
+        .or_else(|| (item.kind.as_deref() == Some("FilePath")).then_some(item.id.as_str()))
 }
 
 fn default_path_filter_score(
@@ -403,6 +404,7 @@ pub struct Picker {
     dynamic_items: Option<Vec<PickerItem>>,
     visible_dynamic_items: Vec<usize>,
     command_column_widths: Cell<Option<CommandColumns>>,
+    label_first_column_widths: Cell<Option<LabelFirstColumns>>,
     external_filter: bool,
     status: Option<String>,
     busy_since: Option<Instant>,
@@ -584,6 +586,7 @@ impl Picker {
             dynamic_items: None,
             visible_dynamic_items: Vec::new(),
             command_column_widths: Cell::new(None),
+            label_first_column_widths: Cell::new(None),
             external_filter: false,
             status: None,
             busy_since: None,
@@ -742,29 +745,8 @@ impl Picker {
         picker.live = true;
         picker.visible_dynamic_items = (0..items.len()).collect();
         picker.list.set_item_count(items.len());
-        if items
-            .iter()
-            .any(|item| item.kind.as_deref() == Some("FilePath"))
-        {
-            let matcher = SkimMatcherV2::default();
-            picker.filter_highlight_action = Some(Box::new(move |item, query| {
-                if item.kind.as_deref() == Some("FilePath") {
-                    let path = item
-                        .data
-                        .get("search_path")
-                        .and_then(Value::as_str)
-                        .unwrap_or(&item.id);
-                    path_match_highlights(
-                        &matcher,
-                        PathCandidate::new(path, &item.label, item.annotation.as_deref()),
-                        query,
-                    )
-                } else {
-                    path_match_highlights(&matcher, PathCandidate::from_path(&item.label), query)
-                }
-            }));
-        }
         picker.dynamic_items = Some(items);
+        picker.install_path_filter_highlights();
         picker.external_filter = options.external_filter;
         picker.placeholder = options.placeholder;
         picker.status = options.status;
@@ -845,6 +827,30 @@ impl Picker {
 
     pub fn builder() -> PickerBuilder {
         PickerBuilder::new()
+    }
+
+    fn install_path_filter_highlights(&mut self) {
+        if self.filter_highlight_action.is_some()
+            || !self.dynamic_items.as_ref().is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|item| picker_item_search_path(item).is_some())
+            })
+        {
+            return;
+        }
+        let matcher = SkimMatcherV2::default();
+        self.filter_highlight_action = Some(Box::new(move |item, query| {
+            if let Some(path) = picker_item_search_path(item) {
+                path_match_highlights(
+                    &matcher,
+                    PathCandidate::new(path, &item.label, item.annotation.as_deref()),
+                    query,
+                )
+            } else {
+                path_match_highlights(&matcher, PathCandidate::from_path(&item.label), query)
+            }
+        }));
     }
 
     pub fn filter(&mut self, term: &str) {
@@ -939,6 +945,7 @@ impl Picker {
             self.filtered_query = Some(term.to_string());
             self.list.set_item_count(self.visible_dynamic_items.len());
             self.command_column_widths.set(None);
+            self.label_first_column_widths.set(None);
             return;
         }
         if term.is_empty() {
@@ -994,6 +1001,7 @@ impl Picker {
         self.item_preview_root = None;
         self.items.clear();
         self.dynamic_items = Some(items);
+        self.install_path_filter_highlights();
         self.filtered_query = None;
         self.filtered_history.clear();
         let search = self.search.clone();
@@ -1011,6 +1019,7 @@ impl Picker {
                 let previous = self.selected_item();
                 let selected_id = self.selected_dynamic_item().map(|item| item.id.clone());
                 self.dynamic_items = Some(items);
+                self.install_path_filter_highlights();
                 self.filtered_query = None;
                 self.filtered_history.clear();
                 let query = self.search.clone();
@@ -2145,17 +2154,21 @@ impl Picker {
     /// Use every filtered row, not just the current page, so scrolling does not
     /// move the columns. Labels take priority over status and descriptions.
     fn label_first_columns(&self, items: &[PickerItem], content_width: usize) -> LabelFirstColumns {
-        let mut columns = LabelFirstColumns::default();
-        for index in &self.visible_dynamic_items {
-            let item = &items[*index];
-            columns.label = columns.label.max(display_width(&item.label));
-            columns.annotation = columns
-                .annotation
-                .max(item.annotation.as_deref().map_or(0, display_width));
-            columns.detail = columns
-                .detail
-                .max(item.detail.as_deref().map_or(0, display_width));
-        }
+        let mut columns = self.label_first_column_widths.get().unwrap_or_else(|| {
+            let mut columns = LabelFirstColumns::default();
+            for index in &self.visible_dynamic_items {
+                let item = &items[*index];
+                columns.label = columns.label.max(display_width(&item.label));
+                columns.annotation = columns
+                    .annotation
+                    .max(item.annotation.as_deref().map_or(0, display_width));
+                columns.detail = columns
+                    .detail
+                    .max(item.detail.as_deref().map_or(0, display_width));
+            }
+            self.label_first_column_widths.set(Some(columns));
+            columns
+        });
         columns.label = columns.label.min(content_width);
         let mut remaining = content_width.saturating_sub(columns.label);
         if columns.annotation > 0 && columns.annotation + INTRINSIC_COLUMN_GAP <= remaining {
@@ -3818,6 +3831,7 @@ pub struct PickerBuilder {
     location_preview_contents: HashMap<String, Rope>,
     content_sizing: Option<PickerContentSizing>,
     status_on_query_line: bool,
+    item_layout: PickerItemLayout,
 }
 
 impl Default for PickerBuilder {
@@ -3845,6 +3859,7 @@ impl PickerBuilder {
             location_preview_contents: HashMap::new(),
             content_sizing: None,
             status_on_query_line: false,
+            item_layout: PickerItemLayout::Default,
         }
     }
 
@@ -3861,6 +3876,12 @@ impl PickerBuilder {
     /// Supplies precomputed picker rows with stable IDs and structured display fields.
     pub fn structured_items(mut self, items: Vec<PickerItem>) -> Self {
         self.structured_items = Some(items);
+        self
+    }
+
+    /// Selects how structured rows divide space between names and metadata.
+    pub fn item_layout(mut self, item_layout: PickerItemLayout) -> Self {
+        self.item_layout = item_layout;
         self
     }
 
@@ -3984,6 +4005,7 @@ impl PickerBuilder {
         let location_preview_contents = self.location_preview_contents;
         let content_sizing = self.content_sizing;
         let status_on_query_line = self.status_on_query_line;
+        let item_layout = self.item_layout;
 
         let mut picker = Picker::new(title, editor, &items, id);
         if let Some(structured_items) = structured_items {
@@ -3998,6 +4020,7 @@ impl PickerBuilder {
         picker.incremental_filter = incremental_filter;
         picker.filter_tie_breaker = filter_tie_breaker;
         picker.filter_highlight_action = filter_highlight_action;
+        picker.install_path_filter_highlights();
         picker.placeholder = placeholder;
         picker.status = status;
         picker.set_busy(busy);
@@ -4008,6 +4031,7 @@ impl PickerBuilder {
         picker.location_preview_overrides = location_preview_contents;
         picker.content_sizing = content_sizing;
         picker.status_on_query_line = status_on_query_line;
+        picker.item_layout = item_layout;
         picker.resize_to_viewport(editor.vwidth(), editor.vheight());
 
         picker
@@ -4825,6 +4849,25 @@ mod tests {
     }
 
     #[test]
+    fn picker_builder_prioritizes_editor_owned_primary_labels() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 80, 24);
+        let label = "load_review_requested_pull_requests_for_scope";
+        let mut item = dynamic_item("symbol", label);
+        item.detail = Some("crates/editor/src/really/long/document.rs:174:10".into());
+        let picker = Picker::builder()
+            .title("Document Symbols")
+            .structured_items(vec![item])
+            .item_layout(super::PickerItemLayout::LabelFirst)
+            .build(&editor);
+        let mut buffer = RenderBuffer::new(80, 24, &Style::default());
+
+        picker.draw(&mut buffer).unwrap();
+
+        let row = render_row(&buffer, picker.layout().results.y);
+        assert!(row.contains(label), "{row:?}");
+    }
+
+    #[test]
     fn label_first_picker_keeps_model_names_and_aligns_secondary_columns() {
         let editor = test_editor_with_theme_and_size(Theme::default(), 120, 30);
         let labels = ["GPT-5.6-Sol-OAI", "GPT-5.6-Sol", "漢字 model"];
@@ -4995,7 +5038,9 @@ mod tests {
             .results
             .width
             .saturating_sub(super::PICKER_ITEM_PREFIX_WIDTH);
+        assert!(picker.label_first_column_widths.get().is_none());
         let columns = picker.label_first_columns(picker.dynamic_items.as_ref().unwrap(), width);
+        assert!(picker.label_first_column_widths.get().is_some());
         picker.list.set_selected_index(20);
         assert_eq!(
             columns,
@@ -5006,6 +5051,7 @@ mod tests {
             display_width("Longest model on the next page")
         );
         picker.filter("Model 1");
+        assert!(picker.label_first_column_widths.get().is_none());
         assert!(
             picker
                 .label_first_columns(picker.dynamic_items.as_ref().unwrap(), width)
@@ -6981,6 +7027,65 @@ mod tests {
 
         picker.filter("no name");
         assert_eq!(visible_picker_labels(&picker), ["[No Name]"]);
+    }
+
+    #[test]
+    fn named_path_rows_preserve_parent_and_position_search() {
+        let editor = test_editor();
+        let mut reference = dynamic_item("reference", "main.rs:5:4");
+        reference.kind = Some("Reference".to_string());
+        reference.annotation = Some("src/editor".to_string());
+        reference.data = json!({ "search_path": "src/editor/main.rs:5:4" });
+        let mut worktree = dynamic_item("worktree", "red.feature");
+        worktree.kind = Some("GitWorktree".to_string());
+        worktree.annotation = Some("/workspace/code".to_string());
+        worktree.data = json!({ "search_path": "/workspace/code/red.feature" });
+        let mut picker = Picker::new_dynamic(
+            Some("Locations".to_string()),
+            &editor,
+            vec![reference, worktree],
+            31,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+
+        picker.filter("editor/main");
+        assert_eq!(visible_picker_labels(&picker), ["main.rs:5:4"]);
+        let selected = picker.selected_dynamic_item().unwrap();
+        let highlights = picker.filter_highlight_action.as_ref().unwrap()(selected, "editor");
+        assert!(!highlights.annotation.is_empty());
+
+        picker.filter(":5:4");
+        assert_eq!(visible_picker_labels(&picker), ["main.rs:5:4"]);
+
+        picker.filter("code/red.feature");
+        assert_eq!(visible_picker_labels(&picker), ["red.feature"]);
+    }
+
+    #[test]
+    fn async_named_path_rows_install_parent_highlights() {
+        let editor = test_editor();
+        let mut picker = Picker::new_dynamic(
+            Some("References".to_string()),
+            &editor,
+            vec![],
+            32,
+            PickerOptions::default(),
+        );
+        assert!(picker.filter_highlight_action.is_none());
+        let mut reference = dynamic_item("reference", "main.rs:5:4");
+        reference.kind = Some("Reference".to_string());
+        reference.annotation = Some("src/editor".to_string());
+        reference.data = json!({ "search_path": "src/editor/main.rs:5:4" });
+
+        assert!(picker.apply_update(32, PickerUpdate::Items(vec![reference])));
+        picker.filter("editor");
+
+        let selected = picker.selected_dynamic_item().unwrap();
+        let highlights = picker.filter_highlight_action.as_ref().unwrap()(selected, "editor");
+        assert!(!highlights.annotation.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Why

Name-oriented pickers currently give repeated paths and secondary metadata enough space to truncate long labels before their distinguishing suffixes appear. Document symbols are especially difficult to scan because every row repeats the current file.

## What changed

- Prioritize primary labels in document symbols, references, themes, agent permissions, code actions, Git history, worktrees, and configuration diagnostics while preserving specialized picker and action-menu layouts.
- Show current-document symbols as `line:column`; keep full workspace-symbol locations; and display references and worktrees basename-first without losing full-path filtering or highlighted parent-directory matches.
- Expose label-first layout to editor-owned pickers, cache aligned column measurements between filter changes, remove redundant permission descriptions, and keep configuration messages, codes, settings paths, and source locations searchable.
- Add coverage for long labels, asynchronously populated and 4,096-item picker batches, filename-first path matching, Git history/worktrees, permissions, themes, and configuration diagnostics.

## How to Test

1. Open a Rust file containing long, similarly prefixed function names and invoke **Document Symbols**. Expect symbol names to receive the available width first and document-local metadata to show only `line:column`. Invoke **Workspace Symbols** and confirm cross-file locations still include their paths.
2. Invoke **References** for a symbol used across multiple directories. Expect `filename:line:column` followed by its parent directory; search a directory name and then a `:line:column` suffix, confirm both still match, and select a result to verify it opens the original location.
3. Exercise **Themes**, **Agent permission**, **Code actions**, **Git log**, **Worktrees**, and **Configuration diagnostics**. Expect the distinctive name, action, commit subject, worktree basename, or diagnostic explanation to remain visible before metadata; verify Git action menus keep their existing layout and configuration diagnostics remain searchable by code/settings path.
4. Run `cargo test --lib` and `cargo test --test lsp_lazy --test self_check`; expect 2,374 library tests, 48 LSP integration tests, and both bundled-plugin executable checks to pass.
5. Run `cargo test --lib file_picker_large_workspace_performance -- --ignored --nocapture` and `cargo clippy --all-targets --all-features -- -D warnings`; expect the 12,000-file picker benchmark and warning-free all-feature linting to pass.
