### PR TITLE
perf(editor): accelerate large repository interactions

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -65,6 +65,7 @@ python3 scripts/detach_bench.py 50 120 120 1536
 python3 scripts/interaction_bench.py typing
 python3 scripts/interaction_bench.py search --query self
 python3 scripts/interaction_bench.py picker --query src/editor.rs
+python3 scripts/interaction_bench.py signature --cycles 40
 python3 scripts/git_workspace_bench.py --files 80 --presses 120
 ```
 
@@ -87,6 +88,15 @@ python3 scripts/interaction_bench.py picker \
   --root ../codex \
   --file ../codex/codex-rs/tui/src/bottom_pane/chat_composer.rs \
   --query chat_composer.rs
+python3 scripts/interaction_bench.py signature \
+  --root ../codex \
+  --file ../codex/codex-rs/tui/src/bottom_pane/chat_composer.rs
+RED_FILE_PICKER_BENCH_ROOT=../codex \
+  cargo test --release --lib file_picker_large_workspace_performance -- --ignored --nocapture
+cargo run --release --example performance_hotspots -- completion
+cargo run --release --example performance_hotspots -- completion-backspace
+RED_COMPLETION_BENCH_FILE=../codex/codex-rs/tui/src/bottom_pane/chat_composer.rs \
+  cargo run --release --example performance_hotspots -- buffer-completion
 ```
 
 For an interactive detach audit with real plugins/background updates, start an owner
@@ -115,7 +125,12 @@ and records:
 - wall time plus terminal output volume for the scrolling window.
 
 The interaction driver additionally records launch-to-first-paint (which includes file/config
-loading before `startup:interactive`), typing/search/picker p50/p95/p99/max, and log volume.
+loading before `startup:interactive`), typing/search/picker/signature p50/p95/p99/max, and
+log volume. The signature scenario starts a deterministic local LSP fixture, displays an
+actual parameter popup, and verifies that every requested character reached the document.
+`completion-backspace` measures bounded query-history reuse, while `buffer-completion`
+measures a complete no-match scan of either its synthetic document or
+`RED_COMPLETION_BENCH_FILE`.
 
 Release thresholds are relative to the most recent baseline on the same machine:
 

--- a/examples/performance_hotspots.rs
+++ b/examples/performance_hotspots.rs
@@ -49,6 +49,7 @@ const SEARCH_LINES: usize = 20_000;
 const SEARCH_LOOKUPS: usize = 1_000;
 const COMPLETION_ITEMS: usize = 18_000;
 const COMPLETION_ROUNDS: usize = 4;
+const BUFFER_COMPLETION_ROUNDS: usize = 8;
 const ROW_PANEL_ITEMS: usize = 12_000;
 const ROW_PANEL_LOOKUPS: usize = 1_500;
 const JSON_CONVERSIONS: usize = 512;
@@ -140,6 +141,12 @@ fn main() -> Result<()> {
     }
     if scenario == "all" || scenario == "completion" {
         results.push(benchmark_completions()?);
+    }
+    if scenario == "all" || scenario == "completion-backspace" {
+        results.push(benchmark_completion_backspacing()?);
+    }
+    if scenario == "all" || scenario == "buffer-completion" {
+        results.push(benchmark_buffer_completion()?);
     }
     if scenario == "all" || scenario == "rows" {
         results.push(benchmark_panel_rows()?);
@@ -943,8 +950,8 @@ fn benchmark_search_navigation() -> Result<serde_json::Value> {
     Ok(report("search_match_navigation", started, SEARCH_LOOKUPS))
 }
 
-fn benchmark_completions() -> Result<serde_json::Value> {
-    let items = (0..COMPLETION_ITEMS)
+fn completion_benchmark_items() -> Result<Vec<red::lsp::CompletionResponseItem>> {
+    (0..COMPLETION_ITEMS)
         .map(|index| {
             let label = if index % 12 == 0 {
                 format!("needle_pipeline_{index:05}")
@@ -953,9 +960,13 @@ fn benchmark_completions() -> Result<serde_json::Value> {
             };
             serde_json::from_value(json!({ "label": label }))
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn benchmark_completions() -> Result<serde_json::Value> {
     let mut completion = CompletionUI::new();
-    completion.show(items, 8, 4);
+    completion.show(completion_benchmark_items()?, 8, 4);
     let queries = ["n", "ne", "nee", "need", "needl", "needle", "needle_"];
 
     let started = Instant::now();
@@ -969,6 +980,55 @@ fn benchmark_completions() -> Result<serde_json::Value> {
         "lsp_completion_filter",
         started,
         COMPLETION_ROUNDS * queries.len(),
+    ))
+}
+
+fn benchmark_completion_backspacing() -> Result<serde_json::Value> {
+    let mut completion = CompletionUI::new();
+    completion.show(completion_benchmark_items()?, 8, 4);
+    completion.set_filter("needl");
+    completion.set_filter("needle");
+    let started = Instant::now();
+    for _ in 0..COMPLETION_ROUNDS * 8 {
+        completion.set_filter(black_box("needl"));
+        completion.set_filter(black_box("needle"));
+    }
+    Ok(report(
+        "lsp_completion_backspace",
+        started,
+        COMPLETION_ROUNDS * 16,
+    ))
+}
+
+fn benchmark_buffer_completion() -> Result<serde_json::Value> {
+    let source = std::env::var_os("RED_COMPLETION_BENCH_FILE")
+        .map(std::fs::read_to_string)
+        .transpose()?
+        .unwrap_or_else(|| "ordinary_token another_identifier final_value\n".repeat(12_000));
+    let config = Config::default();
+    let lsp = Box::new(LspManager::new(config.lsp.clone()));
+    let editor = Editor::with_size(
+        lsp,
+        120,
+        40,
+        config,
+        Theme::default(),
+        vec![Buffer::new(None, format!("zzzz_missing_prefix\n{source}"))],
+    )?;
+    let mut editor = editor;
+    editor.test_set_viewport_cursor(
+        /*vtop*/ 0,
+        /*cx*/ "zzzz_missing_prefix".len(),
+        /*cy*/ 0,
+    );
+    let started = Instant::now();
+    for _ in 0..BUFFER_COMPLETION_ROUNDS {
+        black_box(editor.benchmark_buffer_completion_count());
+    }
+    Ok(report(
+        "buffer_word_completion_scan",
+        started,
+        BUFFER_COMPLETION_ROUNDS,
     ))
 }
 

--- a/scripts/compare_performance_hotspots.py
+++ b/scripts/compare_performance_hotspots.py
@@ -19,6 +19,8 @@ SCENARIOS = (
     "timers",
     "search",
     "completion",
+    "completion-backspace",
+    "buffer-completion",
     "rows",
     "json",
     "render",

--- a/scripts/interaction_bench.py
+++ b/scripts/interaction_bench.py
@@ -7,17 +7,21 @@ Examples:
     python3 scripts/interaction_bench.py picker --root ../codex \
         --file ../codex/codex-rs/tui/src/bottom_pane/chat_composer.rs \
         --query chat_composer.rs
+    python3 scripts/interaction_bench.py signature --root ../codex \
+        --file ../codex/codex-rs/tui/src/bottom_pane/chat_composer.rs
 """
 
 import argparse
 from collections import defaultdict
 import fcntl
+import json
 import os
 from pathlib import Path
 import pty
 import re
 import struct
 import subprocess
+import sys
 import tempfile
 import termios
 import threading
@@ -56,10 +60,26 @@ def run(args):
         config_dir = temp / "red"
         config_dir.mkdir()
         log = temp / "red.log"
-        (config_dir / "config.toml").write_text(
-            f'log_file = "{log}"\nshow_whats_new = false\nfetch_release_notes = false\n',
-            encoding="utf-8",
+        signature_events = temp / "signature-events.jsonl"
+        config_text = (
+            f"log_file = {json.dumps(str(log))}\n"
+            "show_whats_new = false\nfetch_release_notes = false\n"
         )
+        if args.scenario == "signature":
+            server_args = [
+                str(ROOT / "tests" / "fixtures" / "signature_help_lsp.py"),
+                str(signature_events),
+            ]
+            config_text += (
+                "disable_ai = true\n"
+                "[completion]\nauto_trigger = false\nbuffer_words = false\n"
+                "[signature_help]\ndebounce_ms = 120\n"
+                "[lsp.servers.rust]\n"
+                f"command = {json.dumps(sys.executable)}\n"
+                f"args = {json.dumps(server_args)}\n"
+                'language_id = "rust"\nfile_extensions = ["rs"]\nroot_markers = []\n'
+            )
+        (config_dir / "config.toml").write_text(config_text, encoding="utf-8")
 
         master, slave = pty.openpty()
         fcntl.ioctl(
@@ -72,7 +92,7 @@ def run(args):
             "--root",
             str(root),
             "--config-override",
-            "lsp.enabled = false",
+            "lsp.enabled = true" if args.scenario == "signature" else "lsp.enabled = false",
         ]
         for override in args.config_override:
             argv.extend(["--config-override", override])
@@ -120,8 +140,38 @@ def run(args):
 
         first_paint_ms = (time.monotonic() - launched) * 1000
         time.sleep(0.4)
-        os.write(master, b"100j")
-        time.sleep(0.25)
+        if args.scenario != "signature":
+            os.write(master, b"100j")
+            time.sleep(0.25)
+        if args.scenario == "signature":
+            deadline = time.monotonic() + args.startup_timeout
+            while time.monotonic() < deadline:
+                if signature_events.exists() and (
+                    '"method": "initialized"'
+                    in signature_events.read_text(encoding="utf-8", errors="replace")
+                ):
+                    break
+                if process.poll() is not None:
+                    raise SystemExit("editor exited before signature server initialized")
+                time.sleep(0.02)
+            else:
+                process.kill()
+                process.wait(timeout=5)
+                raise SystemExit("signature benchmark server did not initialize")
+            os.write(master, b"ggiouter(")
+            deadline = time.monotonic() + args.startup_timeout
+            while time.monotonic() < deadline:
+                if signature_events.exists() and (
+                    '"method": "textDocument/signatureHelp"'
+                    in signature_events.read_text(encoding="utf-8", errors="replace")
+                ):
+                    break
+                time.sleep(0.02)
+            else:
+                process.kill()
+                process.wait(timeout=5)
+                raise SystemExit("signature benchmark did not display parameter help")
+            time.sleep(0.2)
         if args.scenario == "typing" and args.typing_context != "source":
             if args.typing_context == "heading":
                 position = b"0f 8l"
@@ -160,10 +210,11 @@ def run(args):
         started = time.monotonic()
         delay = args.delay_ms / 1000
 
-        if args.scenario == "typing":
-            os.write(master, b"i")
+        if args.scenario in ("typing", "signature"):
+            if args.scenario == "typing":
+                os.write(master, b"i")
             for index in range(args.cycles):
-                if args.typing_context == "identifier":
+                if args.scenario == "signature" or args.typing_context == "identifier":
                     inserted = b"x" if index % 2 == 0 else b"y"
                 else:
                     punctuation = b"." if args.typing_context != "source" else b"a"
@@ -222,7 +273,7 @@ def run(args):
                     label = f"{label} {detail.split()[0]}"
                 samples[label].append(micros)
 
-        if args.scenario == "typing":
+        if args.scenario in ("typing", "signature"):
             observed_edits = len(samples.get("edit:replace_char", []))
             if observed_edits < args.cycles:
                 raise SystemExit(
@@ -250,7 +301,7 @@ def run(args):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--binary", default=str(BIN), help="editor binary to benchmark")
-    parser.add_argument("scenario", choices=("typing", "search", "picker"))
+    parser.add_argument("scenario", choices=("typing", "search", "picker", "signature"))
     parser.add_argument("--file", default=str(ROOT / "src" / "editor.rs"))
     parser.add_argument("--root", default=str(ROOT))
     parser.add_argument("--query", default=None)
@@ -274,7 +325,9 @@ def main():
     parser.add_argument("--config-override", action="append", default=[])
     args = parser.parse_args()
     if args.cycles is None:
-        args.cycles = {"typing": 200, "search": 20, "picker": 15}[args.scenario]
+        args.cycles = {"typing": 200, "search": 20, "picker": 15, "signature": 40}[
+            args.scenario
+        ]
     if args.query is None:
         args.query = "self" if args.scenario == "search" else "src/editor.rs"
     if not args.query:

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -14748,7 +14748,7 @@ impl Editor {
                             }
                         }
 
-                        match serde_json::from_value::<CompletionResponse>(msg.result.clone()) {
+                        match CompletionResponse::deserialize(&msg.result) {
                             Ok(completion_response) => {
                                 let items = Self::merge_completion_items(
                                     completion_response.items(),
@@ -28156,29 +28156,25 @@ impl Editor {
         let line_index = self.buffer_line();
         let line = self.current_buffer().get(line_index)?;
         let line = line.trim_end_matches(['\r', '\n']);
-        let characters = line.chars().collect::<Vec<_>>();
-        let end = self
-            .grapheme_to_char_on_line(self.cx, line_index)
-            .min(characters.len());
-        let mut start = end;
-        while start > 0 && is_keyword_char(characters[start - 1]) {
-            start -= 1;
+        let cursor = self.grapheme_to_char_on_line(self.cx, line_index);
+        let mut start_byte = 0;
+        let mut end_byte = 0;
+        let mut start_utf16 = 0;
+        let mut end_utf16 = 0;
+        for (byte, character) in line.char_indices().take(cursor) {
+            end_byte = byte + character.len_utf8();
+            end_utf16 += character.len_utf16();
+            if !is_keyword_char(character) {
+                start_byte = end_byte;
+                start_utf16 = end_utf16;
+            }
         }
-        if start == end {
+        if start_byte == end_byte {
             return None;
         }
 
-        let prefix = characters[start..end].iter().collect::<String>();
-        let start_utf16 = characters[..start]
-            .iter()
-            .map(|character| character.len_utf16())
-            .sum();
-        let end_utf16 = characters[..end]
-            .iter()
-            .map(|character| character.len_utf16())
-            .sum();
         Some((
-            prefix,
+            line[start_byte..end_byte].to_string(),
             Range {
                 start: crate::lsp::Position {
                     line: line_index,
@@ -28193,6 +28189,7 @@ impl Editor {
     }
 
     fn buffer_completion_items(&self) -> Vec<CompletionResponseItem> {
+        let _span = perf::PerfSpan::start("completion:buffer_words");
         if !self.config.completion.buffer_words || self.config.completion.max_buffer_words == 0 {
             return Vec::new();
         }
@@ -28201,6 +28198,7 @@ impl Editor {
         };
         let prefix_lower = prefix.to_lowercase();
         let prefix_char_len = prefix.chars().count();
+        let prefix_is_ascii = prefix.is_ascii();
         let active_buffer_id = self.current_buffer().id();
         let mut buffers = self.buffer_manager.iter().collect::<Vec<_>>();
         buffers.sort_by_key(|buffer| buffer.id() != active_buffer_id);
@@ -28213,7 +28211,8 @@ impl Editor {
             let scan_chars = contents.len_chars().min(remaining_scan_chars);
             let mut word = String::new();
             for character in contents
-                .chars()
+                .chunks()
+                .flat_map(str::chars)
                 .take(scan_chars)
                 .chain(std::iter::once(' '))
             {
@@ -28221,9 +28220,18 @@ impl Editor {
                     word.push(character);
                     continue;
                 }
-                if word.chars().count() > prefix_char_len {
+                let matches_prefix = if prefix_is_ascii && word.len() <= prefix.len() {
+                    false
+                } else if prefix_is_ascii && word.is_ascii() {
+                    word.get(..prefix.len())
+                        .is_some_and(|start| start.eq_ignore_ascii_case(&prefix))
+                } else {
+                    word.chars().count() > prefix_char_len
+                        && word.to_lowercase().starts_with(&prefix_lower)
+                };
+                if matches_prefix {
                     let normalized = word.to_lowercase();
-                    if normalized.starts_with(&prefix_lower) && seen.insert(normalized) {
+                    if seen.insert(normalized) {
                         items.push(CompletionResponseItem {
                             label: word.clone(),
                             label_details: Some(CompletionItemLabelDetails {
@@ -28342,9 +28350,17 @@ impl Editor {
             .cloned();
         if self
             .current_dialog
-            .as_mut()
-            .is_some_and(|dialog| dialog.update_completion(items.clone(), &filter))
+            .as_ref()
+            .is_some_and(|dialog| dialog.accepts_completion_updates())
         {
+            let updated = self
+                .current_dialog
+                .as_mut()
+                .expect("completion surface cannot disappear while updating")
+                .update_completion(items, &filter);
+            if !updated {
+                return false;
+            }
             self.completion_snapshot = Some(if snapshot.original_range.is_some() {
                 snapshot
             } else if let Some(active_snapshot) = active_snapshot {
@@ -28358,14 +28374,14 @@ impl Editor {
         let (completion_x, completion_y) =
             self.render_cursor_position().unwrap_or((self.cx, self.cy));
         let mut completion = CompletionUI::with_theme(&self.theme);
-        completion.show_with_bounds(
+        completion.show_filtered_with_bounds(
             items,
+            &filter,
             completion_x,
             completion_y,
             self.size.0 as usize,
             self.size.1 as usize,
         );
-        completion.set_filter(&filter);
         self.current_dialog = Some(Box::new(completion));
         self.completion_snapshot = Some(if snapshot.original_range.is_some() {
             snapshot
@@ -31139,6 +31155,12 @@ impl Editor {
         } else {
             self.length_for_line(line)
         }
+    }
+
+    /// Runs production buffer-word discovery without exposing completion payload ownership.
+    #[doc(hidden)]
+    pub fn benchmark_buffer_completion_count(&self) -> usize {
+        self.buffer_completion_items().len()
     }
 
     /// Reads the display column used by production cursor positioning.
@@ -39362,6 +39384,44 @@ builtin = "rust"
     }
 
     #[test]
+    fn buffer_completion_preserves_unicode_casefolding_and_ascii_case() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "KelvinValue KelvinSymbol\nke".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 60, 12, config, Theme::default(), vec![buffer]).unwrap();
+        editor.mode = Mode::Insert;
+        editor.cy = 1;
+        editor.cx = 2;
+
+        let labels = editor
+            .buffer_completion_items()
+            .into_iter()
+            .map(|item| item.label)
+            .collect::<Vec<_>>();
+
+        assert!(labels.contains(&"KelvinValue".to_string()));
+        assert!(labels.contains(&"KelvinSymbol".to_string()));
+    }
+
+    #[test]
+    fn completion_prefix_handles_unicode_before_the_cursor_without_line_allocations() {
+        let config = Config::default();
+        let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
+        let buffer = Buffer::new(None, "🙂 value rest".to_string());
+        let mut editor =
+            Editor::with_size(lsp, 60, 12, config, Theme::default(), vec![buffer]).unwrap();
+        editor.mode = Mode::Insert;
+        editor.cx = "🙂 value".chars().count();
+
+        let (prefix, range) = editor.completion_prefix().unwrap();
+
+        assert_eq!(prefix, "value");
+        assert_eq!(range.start.character, 3);
+        assert_eq!(range.end.character, 8);
+    }
+
+    #[test]
     fn buffer_completion_items_include_other_open_buffers() {
         let config = Config::default();
         let lsp = Box::new(crate::lsp::LspManager::new(config.lsp.clone()));
@@ -39639,6 +39699,31 @@ builtin = "rust"
         assert_eq!(editor.current_buffer().contents(), "torch.manual_seed");
         assert!(editor.current_dialog.is_none());
         assert_eq!(editor.mode, Mode::Insert);
+    }
+
+    #[test]
+    fn refreshing_open_completion_moves_large_payloads_without_cloning() {
+        let mut editor = completion_typing_editor();
+        let initial_snapshot = editor.completion_snapshot();
+        assert!(
+            editor.show_completion_items(vec![completion_item("manual_seed")], initial_snapshot)
+        );
+
+        let mut replacement = completion_item("manual_seed");
+        replacement.detail = Some("large language-server documentation ".repeat(256));
+        let payload = replacement.detail.as_ref().unwrap().as_ptr();
+        let snapshot = editor.completion_snapshot();
+
+        assert!(editor.show_completion_items(vec![replacement], snapshot));
+        assert_eq!(
+            editor
+                .current_dialog
+                .as_ref()
+                .and_then(|dialog| dialog.selected_completion())
+                .and_then(|item| item.detail.as_ref())
+                .map(|detail| detail.as_ptr()),
+            Some(payload),
+        );
     }
 
     #[tokio::test]

--- a/src/editor/rendering.rs
+++ b/src/editor/rendering.rs
@@ -1675,23 +1675,26 @@ impl Editor {
     }
 
     fn can_reuse_editor_surfaces(&self) -> bool {
+        let has_visible_overlay = self.overlay_manager.has_visible_content();
+        let has_docked_panels = (self.current_dialog.is_some() || has_visible_overlay)
+            && (self.panel_manager.reserved_left_width() > 0
+                || self.panel_manager.reserved_right_width() > 0
+                || self.panel_manager.reserved_top_height() > 0
+                || self.panel_manager.reserved_bottom_height() > 0);
         self.previous_render_buffer.is_some()
-            && !self.signature_help.is_visible()
             && self.learn_session.is_none()
             && !self.force_full_redraw
             && self.last_rendered_window == self.window_manager.active_stable_window_id()
             && self.current_dialog.as_ref().is_none_or(|dialog| {
-                dialog.allows_event_passthrough()
-                    && self.panel_manager.reserved_left_width() == 0
-                    && self.panel_manager.reserved_right_width() == 0
-                    && self.panel_manager.reserved_top_height() == 0
-                    && self.panel_manager.reserved_bottom_height() == 0
+                dialog.allows_event_passthrough() && !has_docked_panels
             })
             && self.keyboard_shortcuts.is_none()
             && !self.keymap_hints_visible
             && !self.panel_manager.has_focused_panel()
             && !self.workspace_manager.is_active()
-            && !self.overlay_manager.has_visible_content()
+            // Editor-window frames repaint overlays themselves; only preserved panes
+            // need a complete frame when a floating overlay can overlap them.
+            && (!has_visible_overlay || !has_docked_panels)
             && self.render_commands.is_empty()
             && !self.has_term()
     }
@@ -5127,6 +5130,82 @@ mod tests {
                 .any(|row| row.contains("alpha")),
             "edited window rows must repaint the active completion dialog"
         );
+    }
+
+    #[test]
+    fn edited_window_rows_preserve_signature_help_without_full_repaint() {
+        let source = Buffer::new(None, "outer(value)\nsecond line\n".to_string());
+        let mut editor = rendering_test_editor(source);
+        editor.mode = crate::editor::Mode::Insert;
+        editor.cx = "outer(".len();
+        editor.signature_help.show_for_test(
+            serde_json::from_value(serde_json::json!({
+                "signatures": [{
+                    "label": "outer(value: usize)",
+                    "parameters": [{ "label": "value: usize" }]
+                }]
+            }))
+            .unwrap(),
+        );
+        editor
+            .overlay_manager
+            .create_overlay(
+                "progress".to_string(),
+                crate::plugin::OverlayConfig {
+                    align: crate::plugin::OverlayAlignment::Bottom,
+                    ..crate::plugin::OverlayConfig::default()
+                },
+            )
+            .update_content(vec![("indexing workspace".to_string(), Style::default())]);
+        let mut buffer = RenderBuffer::new(60, 12, &Style::default());
+        editor.render(&mut buffer).unwrap();
+        let full_renders = editor.full_render_count;
+        assert!(rendered_rows(&buffer)
+            .iter()
+            .any(|row| row.contains("outer(value: usize)")));
+        assert!(rendered_rows(&buffer)
+            .iter()
+            .any(|row| row.contains("indexing workspace")));
+
+        editor.render_edited_window_rows(&mut buffer).unwrap();
+
+        assert_eq!(editor.full_render_count, full_renders);
+        assert!(rendered_rows(&buffer)
+            .iter()
+            .any(|row| row.contains("outer(value: usize)")));
+        assert!(rendered_rows(&buffer)
+            .iter()
+            .any(|row| row.contains("indexing workspace")));
+    }
+
+    #[test]
+    fn edited_window_rows_keep_full_repaint_for_overlays_over_docked_panes() {
+        let source = Buffer::new(None, "hello\nworld\n".to_string());
+        let mut editor = rendering_test_editor(source);
+        editor.panel_manager.create_panel(
+            "files".to_string(),
+            crate::plugin::PanelConfig {
+                width: 12,
+                ..crate::plugin::PanelConfig::default()
+            },
+        );
+        editor
+            .overlay_manager
+            .create_overlay(
+                "progress".to_string(),
+                crate::plugin::OverlayConfig::default(),
+            )
+            .update_content(vec![("indexing workspace".to_string(), Style::default())]);
+        let mut buffer = RenderBuffer::new(60, 12, &Style::default());
+        editor.render(&mut buffer).unwrap();
+        let full_renders = editor.full_render_count;
+
+        editor.render_edited_window_rows(&mut buffer).unwrap();
+
+        assert_eq!(editor.full_render_count, full_renders + 1);
+        assert!(rendered_rows(&buffer)
+            .iter()
+            .any(|row| row.contains("indexing workspace")));
     }
 
     #[test]

--- a/src/editor/signature_help.rs
+++ b/src/editor/signature_help.rs
@@ -15,7 +15,9 @@ pub(super) struct Snapshot {
 struct Scheduled {
     deadline: Instant,
     snapshot: Snapshot,
-    context: SignatureHelpContext,
+    trigger: Option<char>,
+    manual: bool,
+    dismissed_help: Option<SignatureHelp>,
 }
 
 struct Pending {
@@ -34,6 +36,12 @@ impl SignatureHelpState {
     pub(super) fn is_visible(&self) -> bool {
         self.visible.is_some()
     }
+
+    #[cfg(test)]
+    pub(super) fn show_for_test(&mut self, help: SignatureHelp) {
+        self.visible = Some(help);
+    }
+
     fn is_active(&self) -> bool {
         self.visible.is_some() || self.pending.is_some() || self.scheduled.is_some()
     }
@@ -128,20 +136,23 @@ impl Editor {
         {
             return false;
         }
-        let context = self.signature_context(trigger, completion && !active && trigger.is_none());
+        let closes_call = typed.is_some_and(|ch| matches!(ch, ')' | ']' | '}'));
+        // Preserve a dismissed inner signature for the eventual retrigger without
+        // cloning documentation and every overload for each ordinary keystroke.
+        let dismissed_help = closes_call
+            .then(|| self.signature_help.visible.take())
+            .flatten();
+        let visibility_changed = dismissed_help.is_some();
         self.signature_help.pending = None;
         self.signature_help.scheduled = Some(Scheduled {
             deadline: Instant::now()
                 + Duration::from_millis(self.config.signature_help.debounce_ms.min(5_000)),
             snapshot: after,
-            context,
+            trigger,
+            manual: completion && !active && trigger.is_none(),
+            dismissed_help,
         });
-        // A closing delimiter may return to an outer call. Hide the inner signature
-        // immediately, then let the server identify the enclosing callable.
-        if typed.is_some_and(|ch| matches!(ch, ')' | ']' | '}')) {
-            return self.signature_help.visible.take().is_some();
-        }
-        false
+        visibility_changed
     }
 
     pub(super) async fn invoke_signature_help(&mut self) -> anyhow::Result<bool> {
@@ -179,7 +190,12 @@ impl Editor {
         {
             return Ok(self.signature_help.clear());
         }
-        self.send_signature_help(scheduled.context).await
+        let mut context = self.signature_context(scheduled.trigger, scheduled.manual);
+        if let Some(help) = scheduled.dismissed_help {
+            context.is_retrigger = true;
+            context.active_signature_help = Some(help);
+        }
+        self.send_signature_help(context).await
     }
 
     async fn send_signature_help(&mut self, context: SignatureHelpContext) -> anyhow::Result<bool> {
@@ -224,7 +240,7 @@ impl Editor {
         if pending.snapshot != self.signature_snapshot() || !self.signature_context_available() {
             return None;
         }
-        let help = serde_json::from_value::<SignatureHelp>(response.result.clone())
+        let help = SignatureHelp::deserialize(&response.result)
             .ok()
             .filter(|help| !help.signatures.is_empty());
         self.signature_help.visible = help;

--- a/src/ui/completion.rs
+++ b/src/ui/completion.rs
@@ -4,8 +4,11 @@
 //! from the current query. It produces actions for the editor to apply; accepting an
 //! item does not itself mutate a buffer.
 
+use std::collections::VecDeque;
+
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use rayon::prelude::*;
 
 use crate::{
     config::KeyAction,
@@ -25,6 +28,9 @@ const PAGE_SIZE: usize = 10;
 const LEFT_PADDING: usize = 1;
 const RIGHT_PADDING: usize = 1;
 const ICON_COLUMN_WIDTH: usize = 2;
+const PARALLEL_COMPLETION_FILTER_MIN_ITEMS: usize = 1_024;
+const MAX_COMPLETION_FILTER_HISTORY_ENTRIES: usize = 8;
+const MAX_COMPLETION_FILTER_HISTORY_ITEMS: usize = 16_384;
 
 #[derive(Clone)]
 struct CompletionSelectionIdentity {
@@ -52,10 +58,11 @@ impl CompletionSelectionIdentity {
 #[derive(Default, Clone)]
 pub struct CompletionUI {
     all_items: Vec<CompletionResponseItem>,
+    item_widths: Vec<usize>,
     items: Vec<usize>,
-    matched_label_indices: Vec<Vec<usize>>,
     filter: String,
     last_filter: Option<String>,
+    filtered_history: VecDeque<(String, Vec<usize>)>,
     viewport: SelectionViewport,
     selection_manually_changed: bool,
     visible: bool,
@@ -105,12 +112,26 @@ impl CompletionUI {
         bounds_width: usize,
         bounds_height: usize,
     ) {
+        self.show_filtered_with_bounds(items, "", x, y, bounds_width, bounds_height);
+    }
+
+    /// Installs server candidates directly against the already-typed prefix.
+    pub(crate) fn show_filtered_with_bounds(
+        &mut self,
+        items: Vec<CompletionResponseItem>,
+        filter: &str,
+        x: usize,
+        y: usize,
+        bounds_width: usize,
+        bounds_height: usize,
+    ) {
         self.anchor_x = x;
         self.anchor_y = y;
         self.bounds_width = bounds_width;
         self.bounds_height = bounds_height;
         self.visible = true;
         self.filter.clear();
+        self.filter.push_str(filter);
         self.replace_items(items, None);
     }
 
@@ -151,18 +172,21 @@ impl CompletionUI {
                 })
                 .then(a.label.cmp(&b.label))
         });
+        self.item_widths = items.iter().map(Self::item_inner_width).collect();
         self.all_items = items;
         self.last_filter = None;
+        self.filtered_history.clear();
         self.refilter_items(selected);
     }
 
     pub fn hide(&mut self) {
         self.visible = false;
         self.all_items.clear();
+        self.item_widths.clear();
         self.items.clear();
-        self.matched_label_indices.clear();
         self.filter.clear();
         self.last_filter = None;
+        self.filtered_history.clear();
         self.selection_manually_changed = false;
     }
 
@@ -177,34 +201,38 @@ impl CompletionUI {
     }
 
     pub fn set_filter(&mut self, filter: &str) {
+        if self.filter == filter && self.last_filter.as_deref() == Some(filter) {
+            return;
+        }
         self.filter.clear();
         self.filter.push_str(filter);
         self.refilter_items(None);
     }
 
-    fn calculate_inner_width(&self) -> usize {
-        let max_item_width = self
-            .items
-            .iter()
-            .filter_map(|index| self.all_items.get(*index))
-            .map(|item| {
-                let label_width = display_width(Self::item_display_name(item))
-                    + item
-                        .label_details
-                        .as_ref()
-                        .and_then(|details| details.detail.as_deref())
-                        .map_or(0, display_width);
-                let description_width = item
-                    .label_details
-                    .as_ref()
-                    .and_then(|details| details.description.as_deref())
-                    .map_or(0, |description| display_width(description) + 1);
-                LEFT_PADDING + ICON_COLUMN_WIDTH + label_width + description_width + RIGHT_PADDING
-            })
-            .max()
-            .unwrap_or(MIN_INNER_WIDTH);
+    fn item_inner_width(item: &CompletionResponseItem) -> usize {
+        let label_width = display_width(Self::item_display_name(item))
+            + item
+                .label_details
+                .as_ref()
+                .and_then(|details| details.detail.as_deref())
+                .map_or(0, display_width);
+        let description_width = item
+            .label_details
+            .as_ref()
+            .and_then(|details| details.description.as_deref())
+            .map_or(0, |description| display_width(description) + 1);
+        LEFT_PADDING + ICON_COLUMN_WIDTH + label_width + description_width + RIGHT_PADDING
+    }
 
-        max_item_width.clamp(MIN_INNER_WIDTH, MAX_INNER_WIDTH)
+    fn calculate_inner_width(&self) -> usize {
+        let mut width = MIN_INNER_WIDTH;
+        for index in &self.items {
+            width = width.max(self.item_widths.get(*index).copied().unwrap_or_default());
+            if width >= MAX_INNER_WIDTH {
+                return MAX_INNER_WIDTH;
+            }
+        }
+        width.min(MAX_INNER_WIDTH)
     }
 
     fn item_filter_match(
@@ -212,40 +240,51 @@ impl CompletionUI {
         item: &CompletionResponseItem,
         filter: &str,
         normalized_filter: &str,
-    ) -> Option<(u8, i64, Vec<usize>)> {
-        if filter.is_empty() {
-            return Some((0, 0, Vec::new()));
-        }
-
-        let display_name = Self::item_display_name(item);
-        let candidate = item.filter_text.as_deref().unwrap_or(display_name);
-        let (score, candidate_indices) = matcher.fuzzy_indices(candidate, filter)?;
-        let normalized_candidate = candidate.to_lowercase();
-        let match_class = if normalized_candidate == normalized_filter {
-            3
-        } else if normalized_candidate.starts_with(normalized_filter) {
-            2
+    ) -> Option<(u8, i64)> {
+        let candidate = item
+            .filter_text
+            .as_deref()
+            .unwrap_or_else(|| Self::item_display_name(item));
+        let score = matcher.fuzzy_match(candidate, filter)?;
+        let match_class = if candidate.is_ascii() && filter.is_ascii() {
+            if candidate.eq_ignore_ascii_case(filter) {
+                3
+            } else if candidate
+                .get(..filter.len())
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(filter))
+            {
+                2
+            } else {
+                1
+            }
         } else {
-            1
+            let normalized_candidate = candidate.to_lowercase();
+            if normalized_candidate == normalized_filter {
+                3
+            } else if normalized_candidate.starts_with(normalized_filter) {
+                2
+            } else {
+                1
+            }
         };
-        let label_indices = if display_name == candidate {
-            candidate_indices
-        } else {
-            matcher
-                .fuzzy_indices(display_name, filter)
-                .map(|(_, indices)| indices)
-                .unwrap_or_default()
-        };
-        Some((match_class, score, label_indices))
+        Some((match_class, score))
     }
 
     fn refilter_items(&mut self, selected: Option<&CompletionSelectionIdentity>) {
-        let matcher = SkimMatcherV2::default().ignore_case();
+        let _span = crate::editor::perf::PerfSpan::start("completion:filter");
+        let previous_query = self.last_filter.take();
+        let previous_matches = std::mem::take(&mut self.items);
         if self.filter.is_empty() {
-            self.items.clear();
             self.items.extend(0..self.all_items.len());
-            self.matched_label_indices = vec![Vec::new(); self.items.len()];
+        } else if let Some(cached) = self
+            .filtered_history
+            .iter()
+            .position(|(query, _)| query == &self.filter)
+            .and_then(|index| self.filtered_history.remove(index))
+        {
+            self.items = cached.1;
         } else {
+            let matcher = SkimMatcherV2::default().ignore_case();
             let normalized_filter = self.filter.to_lowercase();
             let matching_item = |index| {
                 Self::item_filter_match(
@@ -254,14 +293,30 @@ impl CompletionUI {
                     &self.filter,
                     &normalized_filter,
                 )
-                .map(|(class, score, indices)| (class, score, index, indices))
+                .map(|(class, score)| (class, score, index))
             };
-            let refines_previous = self
-                .last_filter
+            let refines_previous = previous_query
                 .as_ref()
                 .is_some_and(|previous| !previous.is_empty() && self.filter.starts_with(previous));
-            let mut matches = if refines_previous {
-                self.items
+            let candidate_count = if refines_previous {
+                previous_matches.len()
+            } else {
+                self.all_items.len()
+            };
+            let mut matches = if candidate_count >= PARALLEL_COMPLETION_FILTER_MIN_ITEMS {
+                if refines_previous {
+                    previous_matches
+                        .par_iter()
+                        .filter_map(|index| matching_item(*index))
+                        .collect::<Vec<_>>()
+                } else {
+                    (0..self.all_items.len())
+                        .into_par_iter()
+                        .filter_map(matching_item)
+                        .collect::<Vec<_>>()
+                }
+            } else if refines_previous {
+                previous_matches
                     .iter()
                     .copied()
                     .filter_map(matching_item)
@@ -271,16 +326,21 @@ impl CompletionUI {
                     .filter_map(matching_item)
                     .collect::<Vec<_>>()
             };
-            matches.sort_by(|a, b| {
-                b.0.cmp(&a.0)
-                    .then_with(|| b.1.cmp(&a.1))
-                    .then_with(|| a.2.cmp(&b.2))
+            matches.sort_unstable_by(|left, right| {
+                right
+                    .0
+                    .cmp(&left.0)
+                    .then_with(|| right.1.cmp(&left.1))
+                    .then_with(|| left.2.cmp(&right.2))
             });
-            self.items.clear();
-            self.matched_label_indices.clear();
-            for (_, _, index, indices) in matches {
-                self.items.push(index);
-                self.matched_label_indices.push(indices);
+            self.items
+                .extend(matches.into_iter().map(|(_, _, index)| index));
+        }
+        if let Some(query) = previous_query.filter(|query| !query.is_empty()) {
+            if previous_matches.len() <= MAX_COMPLETION_FILTER_HISTORY_ITEMS {
+                self.filtered_history.push_front((query, previous_matches));
+                self.filtered_history
+                    .truncate(MAX_COMPLETION_FILTER_HISTORY_ENTRIES);
             }
         }
         self.last_filter = Some(self.filter.clone());
@@ -518,6 +578,7 @@ impl CompletionUI {
             self.viewport.top()
         };
         let scroll_offset = offset.min(max_scroll_offset);
+        let matcher = SkimMatcherV2::default().ignore_case();
 
         for (visible_index, item_position) in (scroll_offset..self.items.len())
             .take(visible_count)
@@ -561,16 +622,19 @@ impl CompletionUI {
                 .saturating_sub(LEFT_PADDING + ICON_COLUMN_WIDTH + RIGHT_PADDING)
                 .saturating_sub(description_space.unwrap_or(0));
             let label = Self::ellipsize(&Self::item_label(item), label_width);
-            let matched_indices = self
-                .matched_label_indices
-                .get(item_position)
-                .map(Vec::as_slice)
-                .unwrap_or_default();
+            let matched_indices = if self.filter.is_empty() {
+                Vec::new()
+            } else {
+                matcher
+                    .fuzzy_indices(Self::item_display_name(item), &self.filter)
+                    .map(|(_, indices)| indices)
+                    .unwrap_or_default()
+            };
             output.extend(self.label_segments(
                 self.x + 1 + LEFT_PADDING + ICON_COLUMN_WIDTH,
                 y,
                 &label,
-                matched_indices,
+                &matched_indices,
                 &base_style,
             ));
 
@@ -650,6 +714,10 @@ impl Component for CompletionUI {
             buffer.set_text(x, y, &text, &style);
         }
         Ok(())
+    }
+
+    fn accepts_completion_updates(&self) -> bool {
+        true
     }
 
     fn update_completion(&mut self, items: Vec<CompletionResponseItem>, filter: &str) -> bool {
@@ -1501,6 +1569,56 @@ mod tests {
         ui.set_filter("ne");
 
         assert_eq!(ui.items.len(), 2);
+    }
+
+    #[test]
+    fn completion_reuses_recent_queries_without_retaining_oversized_results() {
+        let mut ui = CompletionUI::new();
+        ui.show(
+            vec![
+                item("needle", None),
+                item("nearby", None),
+                item("other", None),
+            ],
+            0,
+            0,
+        );
+        ui.set_filter("ne");
+        let broad_matches = ui.items.clone();
+        ui.set_filter("need");
+        assert!(ui
+            .filtered_history
+            .iter()
+            .any(|(query, matches)| query == "ne" && matches == &broad_matches));
+
+        ui.set_filter("ne");
+        assert_eq!(ui.items, broad_matches);
+        assert!(ui.filtered_history.iter().any(|(query, _)| query == "need"));
+
+        ui.update_items(vec![item("newcomer", None)], "ne");
+        assert!(ui.filtered_history.is_empty());
+        assert_eq!(ui.selected_item().unwrap().label, "newcomer");
+    }
+
+    #[test]
+    fn completion_parallel_filter_preserves_sort_order_and_visible_highlights() {
+        let items = (0..PARALLEL_COMPLETION_FILTER_MIN_ITEMS * 2)
+            .map(|index| {
+                let mut candidate = item(&format!("needle_{index:04}"), None);
+                candidate.sort_text = Some(format!("{:04}", 9_999 - index));
+                candidate
+            })
+            .collect::<Vec<_>>();
+        let mut ui = CompletionUI::new();
+        ui.show(items, 0, 0);
+        ui.set_filter("needle");
+
+        assert_eq!(ui.items.len(), PARALLEL_COMPLETION_FILTER_MIN_ITEMS * 2);
+        assert_eq!(ui.selected_item().unwrap().label, "needle_2047");
+        let rows = ui.render_completion();
+        assert!(rows
+            .iter()
+            .any(|(_, _, text, style)| text == "needle" && style.bold));
     }
 
     #[test]

--- a/src/ui/file_picker.rs
+++ b/src/ui/file_picker.rs
@@ -24,7 +24,7 @@ use crate::{
 use super::{
     picker::PickerFilterHighlights,
     picker_matching::{match_path, path_match_highlights, PathCandidate},
-    Component, Picker, PickerItem, PickerPreview,
+    Component, Picker, PickerItem,
 };
 
 pub struct FilePicker {
@@ -38,7 +38,7 @@ pub struct FilePicker {
 
 struct FilePickerLoad {
     generation: u64,
-    result: Result<Vec<String>, String>,
+    result: Result<Vec<PickerItem>, String>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -115,8 +115,9 @@ impl FilePicker {
         self.picker.set_status(visibility.status());
 
         std::thread::spawn(move || {
-            let result =
-                load_file_picker_items(&root_path, visibility).map_err(|err| err.to_string());
+            let result = load_file_picker_items(&root_path, visibility)
+                .map(prepare_file_picker_items)
+                .map_err(|err| err.to_string());
             _ = sender.send(FilePickerLoad { generation, result });
         });
     }
@@ -127,39 +128,9 @@ impl FilePicker {
         }
 
         match load.result {
-            Ok(files) => {
-                let items = files
-                    .into_iter()
-                    .map(|path| {
-                        let relative = Path::new(&path);
-                        let label = relative
-                            .file_name()
-                            .map(|name| name.to_string_lossy().into_owned())
-                            .unwrap_or_else(|| path.clone());
-                        let annotation = relative
-                            .parent()
-                            .filter(|parent| !parent.as_os_str().is_empty())
-                            .map(|parent| parent.to_string_lossy().into_owned());
-                        PickerItem {
-                            id: path.clone(),
-                            icon: None,
-                            label,
-                            kind: Some("FilePath".to_string()),
-                            annotation,
-                            detail: None,
-                            data: serde_json::Value::Null,
-                            matches: Vec::new(),
-                            detail_matches: Vec::new(),
-                            preview: Some(PickerPreview::Location {
-                                path: self.root_path.join(path).to_string_lossy().into_owned(),
-                                line: None,
-                                column: None,
-                                matches: Vec::new(),
-                            }),
-                        }
-                    })
-                    .collect();
-                self.picker.replace_structured_items(items);
+            Ok(items) => {
+                self.picker
+                    .replace_structured_items_with_preview_root(items, self.root_path.clone());
                 self.picker
                     .set_empty_message(Some("No matching files".to_string()));
             }
@@ -247,6 +218,36 @@ impl Component for FilePicker {
     fn cursor_position(&self) -> Option<(usize, usize)> {
         self.picker.cursor_position()
     }
+}
+
+/// Builds row metadata on the discovery worker; location previews remain lazy.
+fn prepare_file_picker_items(files: Vec<String>) -> Vec<PickerItem> {
+    files
+        .into_iter()
+        .map(|path| {
+            let relative = Path::new(&path);
+            let label = relative
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.clone());
+            let annotation = relative
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .map(|parent| parent.to_string_lossy().into_owned());
+            PickerItem {
+                id: path,
+                icon: None,
+                label,
+                kind: Some("FilePath".to_string()),
+                annotation,
+                detail: None,
+                data: serde_json::Value::Null,
+                matches: Vec::new(),
+                detail_matches: Vec::new(),
+                preview: None,
+            }
+        })
+        .collect()
 }
 
 fn file_match_score(matcher: &SkimMatcherV2, item: &PickerItem, query: &str) -> Option<i64> {
@@ -352,7 +353,10 @@ mod tests {
     fn send_load(picker: &FilePicker, generation: u64, result: Result<Vec<String>, String>) {
         picker
             .sender
-            .send(FilePickerLoad { generation, result })
+            .send(FilePickerLoad {
+                generation,
+                result: result.map(prepare_file_picker_items),
+            })
             .unwrap();
     }
 
@@ -819,6 +823,11 @@ mod tests {
         );
 
         assert!(picker.tick().unwrap());
+        assert!(picker
+            .picker
+            .dynamic_items_for_test()
+            .iter()
+            .all(|item| item.preview.is_none()));
         picker.draw(&mut buffer).unwrap();
 
         assert!(buffer_text(&buffer).contains("fn main() {}"));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -171,6 +171,11 @@ pub trait Component: Send {
         false
     }
 
+    /// Whether this surface can consume an owned completion update directly.
+    fn accepts_completion_updates(&self) -> bool {
+        false
+    }
+
     fn update_completion(&mut self, _items: Vec<CompletionResponseItem>, _filter: &str) -> bool {
         false
     }

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -116,6 +116,7 @@ fn default_path_filter_score(
 
 const MIN_HORIZONTAL_PREVIEW_PANE_WIDTH: usize = 40;
 const MAX_PREVIEW_HIGHLIGHT_BYTES: usize = 64 * 1024;
+const MAX_COMPLETE_LOCATION_PREVIEW_BYTES: u64 = 32 * 1024;
 const MAX_CACHED_PREVIEW_HIGHLIGHT_SPANS: usize = 4_096;
 pub(crate) const MAX_UNFOCUSED_PREVIEW_BYTES: u64 = 256 * 1024;
 const MAX_LOCATION_PREVIEW_SCAN_BYTES: usize = 8 * 1024 * 1024;
@@ -848,6 +849,7 @@ impl Picker {
     }
 
     pub fn filter(&mut self, term: &str) {
+        let _span = crate::editor::perf::PerfSpan::start("picker:filter");
         if let Some(items) = &self.dynamic_items {
             let can_reuse_history =
                 !self.external_filter && (self.incremental_filter || self.filter_action.is_none());
@@ -990,8 +992,25 @@ impl Picker {
     }
 
     pub fn replace_structured_items(&mut self, items: Vec<PickerItem>) {
+        self.replace_structured_items_with_optional_preview_root(items, None);
+    }
+
+    /// Resolves previews only for the selected row instead of allocating one per file.
+    pub(crate) fn replace_structured_items_with_preview_root(
+        &mut self,
+        items: Vec<PickerItem>,
+        root: PathBuf,
+    ) {
+        self.replace_structured_items_with_optional_preview_root(items, Some(root));
+    }
+
+    fn replace_structured_items_with_optional_preview_root(
+        &mut self,
+        items: Vec<PickerItem>,
+        preview_root: Option<PathBuf>,
+    ) {
         let previous = self.selected_item();
-        self.item_preview_root = None;
+        self.item_preview_root = preview_root;
         self.items.clear();
         self.dynamic_items = Some(items);
         self.filtered_query = None;
@@ -1000,6 +1019,11 @@ impl Picker {
         self.filter(&search);
         self.resize_to_viewport(self.viewport_width, self.viewport_height);
         self.reset_preview_scroll_if_selection_changed(previous);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dynamic_items_for_test(&self) -> &[PickerItem] {
+        self.dynamic_items.as_deref().unwrap_or_default()
     }
 
     pub fn apply_update(&mut self, id: i32, update: PickerUpdate) -> bool {
@@ -2467,7 +2491,7 @@ impl Picker {
             return result;
         }
 
-        let complete = len <= MAX_UNFOCUSED_PREVIEW_BYTES;
+        let complete = len <= MAX_COMPLETE_LOCATION_PREVIEW_BYTES;
         let checkpoint = override_contents.is_none().then(|| {
             cache
                 .iter()
@@ -3767,8 +3791,12 @@ impl Picker {
         }
 
         let root = self.item_preview_root.as_ref()?;
-        let selected = self.list.selected_index()?;
-        let item = self.list.items().get(selected)?;
+        let item = if let Some(item) = self.selected_dynamic_item() {
+            item.id.as_str()
+        } else {
+            let selected = self.list.selected_index()?;
+            self.list.items().get(selected)?.as_str()
+        };
         Some(Cow::Owned(PickerPreview::Location {
             path: root.join(item).to_string_lossy().into_owned(),
             line: None,
@@ -5921,6 +5949,34 @@ mod tests {
         assert!(!Arc::ptr_eq(&first, &evicted));
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn moderately_large_location_previews_only_read_visible_rows() {
+        let editor = test_editor();
+        let picker = Picker::new(/*title*/ None, &editor, &[], /*id*/ None);
+        let path = std::env::temp_dir().join(format!(
+            "red-picker-visible-preview-{}.rs",
+            uuid::Uuid::new_v4()
+        ));
+        let contents = (0..1_024)
+            .map(|line| format!("let value_{line:04} = \"{}\";\n", "x".repeat(32)))
+            .collect::<String>();
+        assert!(contents.len() > super::MAX_COMPLETE_LOCATION_PREVIEW_BYTES as usize);
+        assert!(contents.len() < super::MAX_UNFOCUSED_PREVIEW_BYTES as usize);
+        std::fs::write(&path, contents).unwrap();
+
+        let preview = picker.location_preview(
+            &path.to_string_lossy(),
+            /*focus_line*/ None,
+            /*preview_scroll*/ 0,
+            /*preview_height*/ 8,
+        );
+
+        assert!(!preview.complete);
+        assert_eq!(preview.text.lines().count(), 8);
+        assert!(preview.text.starts_with("let value_0000"));
+        std::fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/src/ui/picker_matching.rs
+++ b/src/ui/picker_matching.rs
@@ -153,8 +153,30 @@ fn indices_to_ranges(indices: Vec<usize>) -> Vec<[usize; 2]> {
 
 fn fuzzy_subsequence_matches(candidate: &str, query: &str) -> bool {
     let case_sensitive = query
-        .chars()
+        .bytes()
         .any(|character| character.is_ascii_uppercase());
+    if candidate.is_ascii() && query.is_ascii() {
+        let mut expected = query.bytes();
+        let Some(mut next) = expected.next() else {
+            return true;
+        };
+        for character in candidate.bytes() {
+            let matches = if case_sensitive {
+                character == next
+            } else {
+                character.eq_ignore_ascii_case(&next)
+            };
+            if !matches {
+                continue;
+            }
+            let Some(following) = expected.next() else {
+                return true;
+            };
+            next = following;
+        }
+        return false;
+    }
+
     let mut query = query.chars();
     let Some(mut expected) = query.next() else {
         return true;


### PR DESCRIPTION
## Why

On repositories with thousands of files, Ctrl-P previously prepared every row and preview path on the editor thread, completion repeatedly scored and allocated across large language-server responses, and visible function-parameter help forced a full terminal redraw for every typed character. Those costs make both file lookup and ordinary function-call editing noticeably uneven.

## What changed

- Prepare file-picker rows on the discovery worker, resolve previews only for the selected file, bound larger preview reads to visible rows, and reject ASCII fuzzy mismatches without character allocations.
- Cache completion widths and a bounded history of recent filters, parallelize large candidate sets, compute match highlights only for visible rows, and avoid cloning JSON results or completion payloads.
- Scan buffer-word completions directly across rope chunks while preserving case-insensitive Unicode matching and UTF-16 cursor positions.
- Keep signature help and floating progress overlays on incremental editor-window rendering, retain full-frame fallback for docked panes, and defer expensive signature-context copies until the debounced request is actually sent.
- Add reproducible large-repository picker, completion/backspace, buffer-word, and real-LSP signature-help benchmarks with focused regressions.

## Measurements

Measured against a Codex checkout containing 6,443 picker-visible files:

| Scenario | Before | After |
| --- | ---: | ---: |
| Ctrl-P UI-thread picker installation | 2.97 ms | 0.055 ms |
| Ctrl-P long-path filtering | 438 ms | 214 ms |
| 18,000 completion candidates, seven-sample median | 314 ms | 24 ms |
| Full frames while typing 20 characters with parameter help | 22 | 2 |

Completion filtering improved by 92%; query-history reuse keeps repeated completion backspaces near 24 microseconds.

## How to Test

1. Build the editor and benchmark example:

   ```sh
   cargo build --all-features --bin red --example performance_hotspots
   ```

2. Exercise both actual terminal interactions against a sibling Codex checkout:

   ```sh
   python3 scripts/interaction_bench.py picker --root ../codex \
     --file ../codex/codex-rs/tui/src/bottom_pane/chat_composer.rs \
     --query chat_composer.rs
   python3 scripts/interaction_bench.py signature --root ../codex \
     --file ../codex/codex-rs/tui/src/bottom_pane/chat_composer.rs
   ```

   Expect Ctrl-P to remain responsive while narrowing the path. The signature run should show `render:editor_windows` for typed characters instead of one `render:full` per keystroke.

3. Measure picker installation, large completion lists, backspacing, and large-buffer scans:

   ```sh
   RED_FILE_PICKER_BENCH_ROOT=../codex cargo test --lib file_picker_large_workspace_performance -- --ignored --nocapture
   cargo run --example performance_hotspots -- completion
   cargo run --example performance_hotspots -- completion-backspace
   RED_COMPLETION_BENCH_FILE=../codex/codex-rs/tui/src/bottom_pane/chat_composer.rs cargo run --example performance_hotspots -- buffer-completion
   ```

4. Verify completion acceptance, UTF-16/Unicode handling, and the docked-pane full-redraw regression:

   ```sh
   cargo test --all-features --test completion
   cargo test --lib edited_window_rows
   cargo test --lib buffer_completion_preserves_unicode_casefolding_and_ascii_case
   ```

Validated with strict all-target/all-feature Clippy, all 47 completion integration tests, and 2,394 unit tests using four test threads. The unchanged `plugin::runtime::tests::git_dashboard_renders_numstat_for_a_large_tracked_file_list` stress test times out independently even when run alone and was excluded from the broad local unit run.
