### PR TITLE
feat(picker): add symbol tree guides and aligned locations

### DIFF
--- a/almanac/reference/configuration/default-config.md
+++ b/almanac/reference/configuration/default-config.md
@@ -45,7 +45,7 @@ The top-level schema accepts keys for editor behavior, keymaps, theme, cursor, p
 | --- | --- |
 | `[search]` | `incsearch = true`, `hlsearch = true`, `wrapscan = true`, `ignorecase = false`, `smartcase = false` [@defaults] [@config]. |
 | `[completion]` | `auto_trigger = true`, `min_prefix_length = 1`, `debounce_ms = 120`, `buffer_words = true`, `max_buffer_words = 100` [@defaults] [@config]. |
-| `[picker]` | `input_position = "bottom"` [@defaults] [@config]. |
+| `[picker]` | `input_position = "bottom"`, `tree_guides = true`; disable tree guides to hide hierarchy connectors in document-symbol pickers [@defaults] [@config]. |
 | `[picker.icons]` | `style = "nerd_font"`, `color = true`; code also accepts `unicode`, `ascii`, and `none` icon styles [@defaults] [@config]. |
 | `[diagnostics]` | `gutter_signs = true`, `icon_style = "nerd_font"`; code also accepts `unicode`, `ascii`, and `none` icon styles for diagnostic gutter signs [@defaults] [@config]. |
 | `[statusline]` | `left = ["mode", "diagnostics", "git_branch", "filename"]`, `right = ["position", "syntax"]`; the configuration schema lets supported statusline sections move between sides [@defaults] [@config]. |

--- a/default_config.toml
+++ b/default_config.toml
@@ -138,6 +138,8 @@ excluded_patterns = [".env", ".env.*", "*.pem", "*.key", "**/.git/**"]
 # Query input position in picker dialogs. Supported values are "bottom" and
 # "top". Bottom matches the default command-line-oriented picker layout.
 input_position = "bottom"
+# Draw hierarchy connectors before icons in tree-aware picker rows.
+tree_guides = true
 
 # Picker icons use nvim-web-devicons-compatible glyphs and colors by default
 # and require Nerd Font 3.3+. "unicode" and "ascii" are portable fallbacks;

--- a/plugins/lsp_symbols.hk
+++ b/plugins/lsp_symbols.hk
@@ -652,7 +652,7 @@ fn symbol_item(symbol: LspSymbol, workspace: bool) -> PickerItem {
         kind: symbol.kind_name,
         annotation: symbol.detail,
         detail: location,
-        data: Json { symbol: symbol },
+        data: Json { symbol: symbol, tree: !workspace },
         preview: Json { path: symbol.file, line: line, column: character },
     };
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -408,11 +408,14 @@ impl Default for DiagnosticsConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
-/// Picker input placement.
+/// Picker layout and hierarchy presentation.
 pub struct PickerConfig {
     /// Whether the query row appears above or below results.
     #[serde(default)]
     pub input_position: PickerInputPosition,
+    /// Draw hierarchy connectors for picker rows that expose tree metadata.
+    #[serde(default = "default_true")]
+    pub tree_guides: bool,
     #[serde(default)]
     pub icons: PickerIconsConfig,
 }
@@ -473,6 +476,7 @@ impl Default for PickerConfig {
     fn default() -> Self {
         Self {
             input_position: PickerInputPosition::Bottom,
+            tree_guides: true,
             icons: PickerIconsConfig::default(),
         }
     }
@@ -2236,7 +2240,7 @@ fn known_schema_path(path: &[String]) -> bool {
             *field,
             "enabled" | "command" | "args" | "debounce_ms" | "max_file_bytes" | "excluded_patterns"
         ),
-        ["picker", "input_position"] => true,
+        ["picker", field] => matches!(*field, "input_position" | "tree_guides"),
         ["picker", "icons", field] => matches!(*field, "style" | "color"),
         ["statusline", field] => matches!(*field, "left" | "right" | "icons"),
         ["statusline", "icons", field] => matches!(*field, "style" | "color"),
@@ -3993,8 +3997,22 @@ theme = "mocha.json"
         .unwrap();
 
         assert_eq!(config.picker.input_position, PickerInputPosition::Bottom);
+        assert!(config.picker.tree_guides);
         assert_eq!(config.picker.icons.style, PickerIconStyle::NerdFont);
         assert!(config.picker.icons.color);
+    }
+
+    #[test]
+    fn picker_tree_guides_can_be_disabled() {
+        let loaded = Config::load_user_toml(
+            "[picker]\ntree_guides = false\n",
+            Path::new("/tmp/config.toml"),
+            &[],
+        )
+        .unwrap();
+
+        assert!(!loaded.config.picker.tree_guides);
+        assert!(loaded.diagnostics.is_empty(), "{:?}", loaded.diagnostics);
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -6586,6 +6586,10 @@ impl Editor {
         self.config.picker.icons
     }
 
+    pub(crate) fn picker_tree_guides(&self) -> bool {
+        self.config.picker.tree_guides
+    }
+
     pub(crate) fn statusline_config(&self) -> &StatuslineConfig {
         &self.config.statusline
     }

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -4931,6 +4931,8 @@ mod tests {
         serde_json::json!({
             "ok": true,
             "symbols": [{
+                "id": "root:0:main",
+                "parent_id": null,
                 "name": "main",
                 "detail": "fn()",
                 "kind": 12,
@@ -4953,6 +4955,8 @@ mod tests {
         let symbols = (0..count)
             .map(|index| {
                 serde_json::json!({
+                    "id": format!("root:{index}:symbol_{index}"),
+                    "parent_id": null,
                     "name": format!("symbol_{index}"),
                     "detail": "fn()",
                     "kind": 12,
@@ -17735,6 +17739,12 @@ mod tests {
                 assert_eq!(items[0].annotation.as_deref(), Some("fn()"));
                 assert_eq!(items[0].detail.as_deref(), Some("5:4"));
                 assert_eq!(items[0].kind.as_deref(), Some("Function"));
+                assert_eq!(items[0].data["tree"], true);
+                assert_eq!(items[0].data["symbol"]["id"], "root:0:main");
+                assert_eq!(
+                    items[0].data["symbol"]["parent_id"],
+                    serde_json::Value::Null
+                );
                 handle
             }
             _ => panic!("unexpected plugin request"),
@@ -17743,6 +17753,42 @@ mod tests {
             runtime.picker_plugin(handle).as_deref(),
             Some("lsp_symbols")
         );
+    }
+
+    #[tokio::test]
+    async fn lsp_document_symbols_preserve_nested_picker_tree_metadata() {
+        drain_requests();
+        let mut runtime = Runtime::new();
+        load_lsp_symbols(&mut runtime).await;
+
+        runtime.execute_command("LspDocumentSymbols").await.unwrap();
+        let request_id = match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::DocumentSymbols { request_id, .. } => request_id,
+            _ => panic!("expected document-symbol request"),
+        };
+        let mut payload = sample_symbol_payload();
+        let mut child = payload["symbols"][0].clone();
+        child["id"] = serde_json::json!("root:0:main:0:helper");
+        child["parent_id"] = serde_json::json!("root:0:main");
+        child["name"] = serde_json::json!("helper");
+        child["depth"] = serde_json::json!(1);
+        child["selection_range"]["start"]["line"] = serde_json::json!(12);
+        payload["symbols"].as_array_mut().unwrap().push(child);
+
+        runtime.resolve_request(request_id, payload).await.unwrap();
+        match ACTION_DISPATCHER.recv_request() {
+            PluginRequest::OpenCallbackPicker { items, .. } => {
+                assert_eq!(items.len(), 2);
+                assert_eq!(items[0].data["tree"], true);
+                assert_eq!(items[0].data["symbol"]["id"], "root:0:main");
+                assert_eq!(items[1].label, "helper");
+                assert_eq!(items[1].detail.as_deref(), Some("13:4"));
+                assert_eq!(items[1].data["tree"], true);
+                assert_eq!(items[1].data["symbol"]["id"], "root:0:main:0:helper");
+                assert_eq!(items[1].data["symbol"]["parent_id"], "root:0:main");
+            }
+            _ => panic!("expected hierarchical document-symbol picker"),
+        }
     }
 
     #[tokio::test]
@@ -18238,6 +18284,7 @@ mod tests {
                 assert_eq!(items[0].label, "main");
                 assert_eq!(items[0].kind.as_deref(), Some("Function"));
                 assert_eq!(items[0].detail.as_deref(), Some("src/main.rs:5:4"));
+                assert_eq!(items[0].data["tree"], false);
             }
             _ => panic!("unexpected plugin request"),
         }

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -124,6 +124,8 @@ const LOCATION_PREVIEW_CACHE_CAPACITY: usize = 8;
 const COMMAND_COLUMN_GAP: usize = 2;
 const PICKER_ICON_WIDTH: usize = 2;
 const PICKER_ITEM_PREFIX_WIDTH: usize = 2 + PICKER_ICON_WIDTH;
+const MIN_TREE_GUIDE_LABEL_WIDTH: usize = 8;
+const MAX_PICKER_TREE_DEPTH: usize = 64;
 const PARALLEL_FILTER_MIN_ITEMS: usize = 1_024;
 const MAX_FILTER_HISTORY_ENTRIES: usize = 8;
 const MAX_FILTER_HISTORY_ITEMS_PER_ENTRY: usize = 16_384;
@@ -405,6 +407,7 @@ pub struct Picker {
     visible_dynamic_items: Vec<usize>,
     command_column_widths: Cell<Option<CommandColumns>>,
     label_first_column_widths: Cell<Option<LabelFirstColumns>>,
+    tree_prefixes: RefCell<Option<Arc<[String]>>>,
     external_filter: bool,
     status: Option<String>,
     busy_since: Option<Instant>,
@@ -423,6 +426,7 @@ pub struct Picker {
     history_navigation: Option<PickerHistoryNavigation>,
     input_position: PickerInputPosition,
     icons: PickerIconsConfig,
+    tree_guides: bool,
     item_layout: PickerItemLayout,
     presentation: PickerPresentation,
     viewport_width: usize,
@@ -480,6 +484,24 @@ struct LabelFirstColumns {
     label: usize,
     annotation: usize,
     detail: usize,
+    position_line: usize,
+    position_column: usize,
+}
+
+impl LabelFirstColumns {
+    fn position_width(self) -> usize {
+        if self.position_line == 0 || self.position_column == 0 {
+            0
+        } else {
+            self.position_line + 1 + self.position_column
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PickerTreeNode<'a> {
+    id: &'a str,
+    parent_id: Option<&'a str>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -587,6 +609,7 @@ impl Picker {
             visible_dynamic_items: Vec::new(),
             command_column_widths: Cell::new(None),
             label_first_column_widths: Cell::new(None),
+            tree_prefixes: RefCell::new(None),
             external_filter: false,
             status: None,
             busy_since: None,
@@ -605,6 +628,7 @@ impl Picker {
             history_navigation: None,
             input_position: editor.picker_input_position(),
             icons: editor.picker_icons(),
+            tree_guides: editor.picker_tree_guides(),
             item_layout: PickerItemLayout::Default,
             presentation,
             viewport_width: editor.vwidth(),
@@ -974,6 +998,7 @@ impl Picker {
         let previous = self.selected_item();
         self.item_preview_root = None;
         self.dynamic_items = None;
+        self.tree_prefixes.get_mut().take();
         self.filtered_query = None;
         self.filtered_history.clear();
         self.visible_dynamic_items.clear();
@@ -987,6 +1012,7 @@ impl Picker {
         let previous = self.selected_item();
         self.item_preview_root = Some(root);
         self.dynamic_items = None;
+        self.tree_prefixes.get_mut().take();
         self.filtered_query = None;
         self.filtered_history.clear();
         self.visible_dynamic_items.clear();
@@ -1001,6 +1027,7 @@ impl Picker {
         self.item_preview_root = None;
         self.items.clear();
         self.dynamic_items = Some(items);
+        self.tree_prefixes.get_mut().take();
         self.install_path_filter_highlights();
         self.filtered_query = None;
         self.filtered_history.clear();
@@ -1019,6 +1046,7 @@ impl Picker {
                 let previous = self.selected_item();
                 let selected_id = self.selected_dynamic_item().map(|item| item.id.clone());
                 self.dynamic_items = Some(items);
+                self.tree_prefixes.get_mut().take();
                 self.install_path_filter_highlights();
                 self.filtered_query = None;
                 self.filtered_history.clear();
@@ -1450,15 +1478,131 @@ impl Picker {
             })
     }
 
+    fn tree_node(item: &PickerItem) -> Option<PickerTreeNode<'_>> {
+        if item.data.get("tree").and_then(Value::as_bool) != Some(true) {
+            return None;
+        }
+        let symbol = item.data.get("symbol")?;
+        Some(PickerTreeNode {
+            id: symbol
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or(item.id.as_str()),
+            parent_id: symbol.get("parent_id").and_then(Value::as_str),
+        })
+    }
+
+    /// Computes stable Snacks-style ancestry guides once per authoritative item set.
+    fn tree_prefixes(&self, items: &[PickerItem]) -> Option<Arc<[String]>> {
+        if !self.tree_guides {
+            return None;
+        }
+        if let Some(prefixes) = self.tree_prefixes.borrow().as_ref() {
+            return (!prefixes.is_empty()).then(|| Arc::clone(prefixes));
+        }
+
+        let nodes = items.iter().map(Self::tree_node).collect::<Vec<_>>();
+        if nodes.iter().all(Option::is_none) {
+            self.tree_prefixes
+                .replace(Some(Arc::<[String]>::from(Vec::<String>::new())));
+            return None;
+        }
+
+        let node_indices = nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, node)| node.as_ref().map(|node| (node.id, index)))
+            .collect::<HashMap<_, _>>();
+        let mut last_siblings = HashMap::new();
+        for (index, node) in nodes.iter().enumerate() {
+            if let Some(node) = node {
+                last_siblings.insert(node.parent_id, index);
+            }
+        }
+        let (vertical, middle, last) = if self.icons.style == PickerIconStyle::Ascii {
+            ("| ", "|-", "`-")
+        } else {
+            ("│ ", "├╴", "└╴")
+        };
+
+        let mut prefixes = vec![String::new(); items.len()];
+        for (index, node) in nodes.iter().enumerate() {
+            let Some(mut current) = node.as_ref().copied() else {
+                continue;
+            };
+            let mut current_index = index;
+            let mut segments = Vec::new();
+            for depth in 0..MAX_PICKER_TREE_DEPTH {
+                let is_last = last_siblings.get(&current.parent_id) == Some(&current_index);
+                segments.push(if depth == 0 {
+                    if is_last {
+                        last
+                    } else {
+                        middle
+                    }
+                } else if is_last {
+                    "  "
+                } else {
+                    vertical
+                });
+                let Some(parent_id) = current.parent_id else {
+                    break;
+                };
+                let Some(parent_index) = node_indices.get(parent_id).copied() else {
+                    break;
+                };
+                if parent_index == current_index {
+                    break;
+                }
+                let Some(parent) = nodes[parent_index] else {
+                    break;
+                };
+                current = parent;
+                current_index = parent_index;
+            }
+            segments.reverse();
+            prefixes[index] = segments.concat();
+        }
+
+        let prefixes: Arc<[String]> = prefixes.into();
+        self.tree_prefixes.replace(Some(Arc::clone(&prefixes)));
+        Some(prefixes)
+    }
+
+    fn visible_tree_prefix(
+        prefixes: Option<&[String]>,
+        index: usize,
+        content_width: usize,
+    ) -> &str {
+        let Some(prefix) = prefixes.and_then(|prefixes| prefixes.get(index)) else {
+            return "";
+        };
+        let available = content_width.saturating_sub(MIN_TREE_GUIDE_LABEL_WIDTH.min(content_width));
+        display_width_tail(prefix, available)
+    }
+
+    fn tree_position(item: &PickerItem) -> Option<(&str, &str)> {
+        if item.data.get("tree").and_then(Value::as_bool) != Some(true) {
+            return None;
+        }
+        let (line, column) = item.detail.as_deref()?.split_once(':')?;
+        (!line.is_empty()
+            && !column.is_empty()
+            && line.bytes().all(|digit| digit.is_ascii_digit())
+            && column.bytes().all(|digit| digit.is_ascii_digit()))
+        .then_some((line, column))
+    }
+
     fn draw_item_prefix(
         &self,
         buffer: &mut RenderBuffer,
-        x: usize,
-        y: usize,
+        position: (usize, usize),
         item: &PickerItem,
+        tree_prefix: &str,
         row_style: &Style,
         selected: bool,
     ) {
+        let (x, y) = position;
         if selected {
             let marker_style = self.semantic_foreground(
                 row_style,
@@ -1468,9 +1612,22 @@ impl Picker {
             buffer.set_text(x, y, "›", &marker_style);
         }
 
+        let mut icon_x = x + 2;
+        if !tree_prefix.is_empty() {
+            let semantic = self
+                .color_style(&[
+                    "tree.indentGuidesStroke",
+                    "editorIndentGuide.background",
+                    "editorIndentGuide.background1",
+                ])
+                .or_else(|| Some(self.theme.ui_style.muted.clone()));
+            let guide_style = self.semantic_foreground(row_style, semantic, selected);
+            buffer.set_text(icon_x, y, tree_prefix, &guide_style);
+            icon_x += display_width(tree_prefix);
+        }
         let icon = fit_display_width(self.item_icon(item), PICKER_ICON_WIDTH);
         let icon_style = self.result_icon_style(item, row_style, selected);
-        buffer.set_text(x + 2, y, &icon, &icon_style);
+        buffer.set_text(icon_x, y, &icon, &icon_style);
     }
 
     fn result_annotation_style(&self, base: &Style, selected: bool) -> Style {
@@ -1850,6 +2007,7 @@ impl Picker {
         };
         let content_width = rect.width.saturating_sub(PICKER_ITEM_PREFIX_WIDTH);
         let command_columns = self.command_columns(items, content_width);
+        let tree_prefixes = self.tree_prefixes(items);
         let label_first_columns = (self.item_layout == PickerItemLayout::LabelFirst)
             .then(|| self.label_first_columns(items, content_width));
         let selected = self.list.selected_index();
@@ -1878,8 +2036,18 @@ impl Picker {
             let y = rect.y + offset;
             buffer.fill_ascii_spaces(rect.x, y, rect.width, &row_style);
 
-            self.draw_item_prefix(buffer, rect.x, y, item, &row_style, is_selected);
-            let x = rect.x + PICKER_ITEM_PREFIX_WIDTH;
+            let tree_prefix =
+                Self::visible_tree_prefix(tree_prefixes.as_deref(), *index, content_width);
+            let tree_width = display_width(tree_prefix);
+            self.draw_item_prefix(
+                buffer,
+                (rect.x, y),
+                item,
+                tree_prefix,
+                &row_style,
+                is_selected,
+            );
+            let x = rect.x + PICKER_ITEM_PREFIX_WIDTH + tree_width;
             if item.kind.as_deref() == Some("Command") {
                 let category = item.annotation.as_deref().unwrap_or_default().trim_end();
                 if command_columns.category > 0 {
@@ -1962,12 +2130,12 @@ impl Picker {
                     x,
                     y,
                     &item.label,
-                    columns.label,
+                    columns.label.saturating_sub(tree_width),
                     &label_style,
                     &label_match_style,
                     label_matches,
                 );
-                let mut column_x = x + columns.label;
+                let mut column_x = rect.x + PICKER_ITEM_PREFIX_WIDTH + columns.label;
                 if columns.annotation > 0 {
                     column_x += INTRINSIC_COLUMN_GAP;
                     let style = self.result_annotation_style(&row_style, is_selected);
@@ -2001,9 +2169,30 @@ impl Picker {
                         &item.detail_matches,
                     );
                 }
+                if columns.position_width() > 0 {
+                    if let Some((line, column)) = Self::tree_position(item) {
+                        let position = format!(
+                            "{line:>line_width$}:{column:>column_width$}",
+                            line_width = columns.position_line,
+                            column_width = columns.position_column,
+                        );
+                        let style = self.result_content_style(&row_style, is_selected);
+                        self.draw_text_with_matches(
+                            buffer,
+                            rect.x + rect.width - columns.position_width(),
+                            y,
+                            &position,
+                            columns.position_width(),
+                            &style,
+                            &self.result_match_style(&style),
+                            &item.detail_matches,
+                        );
+                    }
+                }
                 continue;
             }
 
+            let content_width = content_width.saturating_sub(tree_width);
             let detail_separator_width = 2;
             let min_primary_width = if item.kind.as_deref() == Some("FileMatch") {
                 let max_primary_width = content_width.saturating_sub(detail_separator_width + 8);
@@ -2152,25 +2341,47 @@ impl Picker {
     }
 
     /// Use every filtered row, not just the current page, so scrolling does not
-    /// move the columns. Labels take priority over status and descriptions.
+    /// move the columns. Labels take priority over annotations and descriptions;
+    /// document-symbol positions occupy a stable right-aligned numeric gutter.
     fn label_first_columns(&self, items: &[PickerItem], content_width: usize) -> LabelFirstColumns {
         let mut columns = self.label_first_column_widths.get().unwrap_or_else(|| {
             let mut columns = LabelFirstColumns::default();
+            let tree_prefixes = self.tree_prefixes(items);
             for index in &self.visible_dynamic_items {
                 let item = &items[*index];
-                columns.label = columns.label.max(display_width(&item.label));
+                let tree_width = tree_prefixes
+                    .as_ref()
+                    .and_then(|prefixes| prefixes.get(*index))
+                    .map_or(0, |prefix| display_width(prefix));
+                columns.label = columns
+                    .label
+                    .max(display_width(&item.label).saturating_add(tree_width));
                 columns.annotation = columns
                     .annotation
                     .max(item.annotation.as_deref().map_or(0, display_width));
-                columns.detail = columns
-                    .detail
-                    .max(item.detail.as_deref().map_or(0, display_width));
+                if let Some((line, column)) = Self::tree_position(item) {
+                    columns.position_line = columns.position_line.max(line.len());
+                    columns.position_column = columns.position_column.max(column.len());
+                } else {
+                    columns.detail = columns
+                        .detail
+                        .max(item.detail.as_deref().map_or(0, display_width));
+                }
             }
             self.label_first_column_widths.set(Some(columns));
             columns
         });
         columns.label = columns.label.min(content_width);
         let mut remaining = content_width.saturating_sub(columns.label);
+        let position_width = columns.position_width();
+        if position_width > 0 {
+            if position_width + INTRINSIC_COLUMN_GAP <= remaining {
+                remaining -= position_width + INTRINSIC_COLUMN_GAP;
+            } else {
+                columns.position_line = 0;
+                columns.position_column = 0;
+            }
+        }
         if columns.annotation > 0 && columns.annotation + INTRINSIC_COLUMN_GAP <= remaining {
             remaining -= columns.annotation + INTRINSIC_COLUMN_GAP;
         } else {
@@ -4130,6 +4341,26 @@ mod tests {
         }
     }
 
+    fn document_symbol_item(
+        id: &str,
+        parent_id: Option<&str>,
+        label: &str,
+        line: usize,
+        column: usize,
+    ) -> PickerItem {
+        let mut item = dynamic_item(id, label);
+        item.kind = Some("Function".to_string());
+        item.detail = Some(format!("{line}:{column}"));
+        item.data = json!({
+            "tree": true,
+            "symbol": {
+                "id": id,
+                "parent_id": parent_id,
+            }
+        });
+        item
+    }
+
     #[test]
     fn ctrl_h_and_ctrl_l_browse_picker_query_history() {
         let editor = test_editor();
@@ -4865,6 +5096,209 @@ mod tests {
 
         let row = render_row(&buffer, picker.layout().results.y);
         assert!(row.contains(label), "{row:?}");
+    }
+
+    #[test]
+    fn document_symbol_picker_draws_tree_guides_and_aligns_numeric_positions() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 140, 24);
+        let picker = Picker::new_dynamic(
+            Some("Document Symbols".to_string()),
+            &editor,
+            vec![
+                document_symbol_item("outer", None, "outer", 7, 2),
+                document_symbol_item("first", Some("outer"), "first_child", 28, 21),
+                document_symbol_item("second", Some("outer"), "second_child", 109, 3),
+                document_symbol_item("tail", None, "tail", 150, 5),
+            ],
+            41,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+        let mut buffer = RenderBuffer::new(140, 24, &Style::default());
+        picker.draw(&mut buffer).unwrap();
+
+        let rect = picker.layout().results;
+        let rows = (0..4)
+            .map(|index| render_row(&buffer, rect.y + index))
+            .collect::<Vec<_>>();
+        assert!(rows[0].contains("├╴"), "{:?}", rows[0]);
+        assert!(rows[1].contains("│ ├╴"), "{:?}", rows[1]);
+        assert!(rows[2].contains("│ └╴"), "{:?}", rows[2]);
+        assert!(rows[3].contains("└╴"), "{:?}", rows[3]);
+        for (row, expected) in rows.iter().zip(["  7: 2", " 28:21", "109: 3", "150: 5"]) {
+            assert!(row.contains(expected), "{row:?}");
+            assert_eq!(display_column(row, ":"), display_column(&rows[0], ":"));
+        }
+        assert_eq!(
+            display_column(&rows[0], ":").unwrap() + 3,
+            rect.x + rect.width
+        );
+    }
+
+    #[test]
+    fn disabled_picker_tree_guides_keep_positions_aligned() {
+        let mut config = Config::default();
+        config.picker.tree_guides = false;
+        let editor = test_editor_with_config_and_size(config, Theme::default(), 100, 20);
+        let picker = Picker::new_dynamic(
+            Some("Document Symbols".to_string()),
+            &editor,
+            vec![
+                document_symbol_item("first", None, "first_symbol", 7, 2),
+                document_symbol_item("second", None, "second_symbol", 150, 21),
+            ],
+            42,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+        let mut buffer = RenderBuffer::new(100, 20, &Style::default());
+        picker.draw(&mut buffer).unwrap();
+
+        let rect = picker.layout().results;
+        let first = render_row(&buffer, rect.y);
+        let second = render_row(&buffer, rect.y + 1);
+        assert!(!first.contains('├') && !first.contains('└'), "{first:?}");
+        assert_eq!(
+            display_column(&first, "first_symbol"),
+            Some(rect.x + super::PICKER_ITEM_PREFIX_WIDTH)
+        );
+        assert!(first.contains("  7: 2"), "{first:?}");
+        assert!(second.contains("150:21"), "{second:?}");
+        assert_eq!(display_column(&first, ":"), display_column(&second, ":"));
+    }
+
+    #[test]
+    fn document_symbol_positions_stop_at_the_preview_divider() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 140, 24);
+        let mut first = document_symbol_item("first", None, "first_symbol", 7, 2);
+        first.preview = Some(PickerPreview::Text {
+            text: "preview source".to_string(),
+            language: None,
+        });
+        let picker = Picker::new_dynamic(
+            Some("Document Symbols".to_string()),
+            &editor,
+            vec![
+                first,
+                document_symbol_item("second", None, "second_symbol", 150, 21),
+            ],
+            45,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+        let mut buffer = RenderBuffer::new(140, 24, &Style::default());
+        picker.draw(&mut buffer).unwrap();
+
+        let rect = picker.layout().results;
+        let row = render_row(&buffer, rect.y);
+        assert!(row.contains("  7: 2│preview source"), "{row:?}");
+        assert_eq!(
+            buffer.cells[rect.y * buffer.width + rect.x + rect.width].c,
+            '│'
+        );
+    }
+
+    #[test]
+    fn document_symbol_tree_guides_preserve_names_in_narrow_viewports() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 34, 18);
+        let picker = Picker::new_dynamic(
+            Some("Document Symbols".to_string()),
+            &editor,
+            vec![document_symbol_item(
+                "first",
+                None,
+                "start_structured_turn",
+                125,
+                21,
+            )],
+            46,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+        let mut buffer = RenderBuffer::new(34, 18, &Style::default());
+        picker.draw(&mut buffer).unwrap();
+
+        let rect = picker.layout().results;
+        let row = render_row(&buffer, rect.y);
+        assert!(row.contains("└╴"), "{row:?}");
+        assert!(row.contains("start_structured_turn"), "{row:?}");
+        assert!(!row.contains("125:21"), "{row:?}");
+        assert_eq!(
+            buffer.cells[rect.y * buffer.width + rect.x + rect.width].c,
+            '│'
+        );
+    }
+
+    #[test]
+    fn document_symbol_tree_guides_update_with_batched_items() {
+        let editor = test_editor_with_theme_and_size(Theme::default(), 100, 20);
+        let mut picker = Picker::new_dynamic(
+            Some("Document Symbols".to_string()),
+            &editor,
+            vec![document_symbol_item("first", None, "first_symbol", 7, 2)],
+            43,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+        let mut buffer = RenderBuffer::new(100, 20, &Style::default());
+        picker.draw(&mut buffer).unwrap();
+        assert!(render_row(&buffer, picker.layout().results.y).contains("└╴"));
+
+        assert!(picker.apply_update(
+            43,
+            PickerUpdate::Items(vec![
+                document_symbol_item("first", None, "first_symbol", 7, 2),
+                document_symbol_item("second", None, "second_symbol", 150, 21),
+            ]),
+        ));
+        let mut updated = RenderBuffer::new(100, 20, &Style::default());
+        picker.draw(&mut updated).unwrap();
+        let rect = picker.layout().results;
+        assert!(render_row(&updated, rect.y).contains("├╴"));
+        assert!(render_row(&updated, rect.y + 1).contains("└╴"));
+
+        picker.filter("second");
+        let mut filtered = RenderBuffer::new(100, 20, &Style::default());
+        picker.draw(&mut filtered).unwrap();
+        let row = render_row(&filtered, picker.layout().results.y);
+        assert!(row.contains("└╴"), "{row:?}");
+        assert!(row.contains("150:21"), "{row:?}");
+    }
+
+    #[test]
+    fn document_symbol_tree_guides_use_ascii_fallback() {
+        let mut config = Config::default();
+        config.picker.icons.style = PickerIconStyle::Ascii;
+        let editor = test_editor_with_config_and_size(config, Theme::default(), 100, 20);
+        let picker = Picker::new_dynamic(
+            Some("Document Symbols".to_string()),
+            &editor,
+            vec![
+                document_symbol_item("first", None, "first_symbol", 7, 2),
+                document_symbol_item("second", None, "second_symbol", 150, 21),
+            ],
+            44,
+            PickerOptions {
+                item_layout: super::PickerItemLayout::LabelFirst,
+                ..PickerOptions::default()
+            },
+        );
+        let mut buffer = RenderBuffer::new(100, 20, &Style::default());
+        picker.draw(&mut buffer).unwrap();
+
+        let rect = picker.layout().results;
+        assert!(render_row(&buffer, rect.y).contains("|-"));
+        assert!(render_row(&buffer, rect.y + 1).contains("`-"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

#331 preserved long symbol names, but document symbols still appear as a flat list and their `line:column` values cluster beside the longest name. That hides real symbol hierarchy and makes positions difficult to scan, especially beside the source preview.

## What changed

- Render theme-aware `├╴`, `└╴`, and `│ ` guides from actual document-symbol parent IDs, with cached ancestry, correct async-batch invalidation, and ASCII fallbacks.
- Align line and column numbers independently in a right-justified position gutter without overlapping previews; preserve primary labels when the viewport is narrow.
- Add default-on `[picker] tree_guides = true`. Disabling it hides only the guides; aligned positions remain, and workspace symbols always stay flat.
- Cover nested payloads, sibling and ancestor branches, preview boundaries, filtering, batched updates, narrow viewports, disabled guides, and ASCII terminals.

```text
├╴ impl Dashboard        5: 6
│ ├╴ first_child         6: 8
│ └╴ second_child        7: 8
├╴ long_tail           110: 4
└╴ main                112: 4
```

## How to Test

1. Open a Rust file containing nested `impl` methods or modules and symbols on both short and three-digit line numbers. Invoke **Document Symbols** with `Ctrl-t`; expect real hierarchy connectors, vertically aligned colons and column numbers, and a position gutter that ends exactly at the preview divider.
2. Filter to a nested symbol and narrow the terminal. Expect ancestry guides to remain correct, long symbol names to stay visible, and positions to disappear before names are truncated.
3. Set `[picker] tree_guides = false`, reopen Red, and invoke **Document Symbols** again. Expect a flat list with the same aligned position gutter. Open **Workspace Symbols** and confirm it remains flat and still includes file paths.
4. Set `[picker.icons] style = "ascii"` and reopen **Document Symbols**; expect `|-` and `` `-`` connectors instead of Unicode box-drawing characters.
5. Run `cargo test --lib document_symbol`, `cargo test --lib picker_tree_guides`, and `cargo test --test lsp_lazy --test self_check`; expect the hierarchy, configuration, LSP, and bundled-plugin checks to pass.

Validated locally with 2,399 passing library tests, 48 LSP integration tests, both bundled-plugin checks, the 12,000-file picker benchmark, and warning-free all-target/all-feature Clippy.
