### PR TITLE
fix(session): scope restore state by workspace

### DIFF
--- a/docs/SESSION_RECOVERY.md
+++ b/docs/SESSION_RECOVERY.md
@@ -5,7 +5,10 @@ file-backed buffers, cursor positions, viewports, and split layout. Starting
 `red` again without file arguments in the same working directory restores that
 lightweight workspace automatically. Supplying files starts the requested
 workspace instead, and dirty buffers remain the responsibility of core crash
-recovery.
+recovery. Each canonical working directory has an independent lightweight
+snapshot, so exiting Red in another workspace does not replace its saved state.
+The former global `latest` value remains readable by its matching workspace and
+is replaced by a workspace-scoped value on the next clean exit.
 
 Red's core writes versioned recovery snapshots under `sessions/<owner>/latest.json` in the configuration directory. Each editor and named detached owner has an independent namespace, so concurrent sessions cannot replace one another's recovery point. Run `red --resume` after a crash to restore the newest valid snapshot containing dirty buffers, falling back to the newest clean snapshot when no work is pending; legacy `sessions/latest.json` snapshots remain supported. An interactive resume continues the selected owner namespace so a subsequent clean save replaces the stale dirty recovery point. Recovery is deliberately separate from opening files: restored dirty contents remain in memory and Red never writes them to disk until an explicit save. Do not resume an editor that is still running, since interactive owners do not currently hold an exclusive recovery lock.
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1667,12 +1667,40 @@ fn resolve_agent_tool_path_kind(
     Ok(normalized)
 }
 
-fn scoped_plugin_storage_key(plugin: &str, key: &str) -> String {
-    if plugin == "agent" && matches!(key, "transcript" | "prompt_history") {
-        format!("{key}:{}", get_workspace_path().display())
+fn scoped_plugin_storage_key_for_workspace(plugin: &str, key: &str, workspace: &Path) -> String {
+    if (plugin == "agent" && matches!(key, "transcript" | "prompt_history"))
+        || (plugin == "session_restore" && key == "latest")
+    {
+        format!("{key}:{}", workspace.display())
     } else {
         key.to_string()
     }
+}
+
+fn scoped_plugin_storage_key(plugin: &str, key: &str) -> String {
+    scoped_plugin_storage_key_for_workspace(plugin, key, &get_workspace_path())
+}
+
+fn plugin_storage_value_for_workspace<'a>(
+    preferences: &'a PreferencesStore,
+    plugin: &str,
+    key: &str,
+    workspace: &Path,
+) -> Option<&'a serde_json::Value> {
+    let scoped_key = scoped_plugin_storage_key_for_workspace(plugin, key, workspace);
+    preferences.plugin_storage(plugin, &scoped_key).or_else(|| {
+        (plugin == "session_restore" && key == "latest")
+            .then(|| preferences.plugin_storage(plugin, key))
+            .flatten()
+    })
+}
+
+fn plugin_storage_value<'a>(
+    preferences: &'a PreferencesStore,
+    plugin: &str,
+    key: &str,
+) -> Option<&'a serde_json::Value> {
+    plugin_storage_value_for_workspace(preferences, plugin, key, &get_workspace_path())
 }
 
 fn snake_case_key(key: &str) -> String {
@@ -11841,10 +11869,7 @@ impl Editor {
                     key,
                     request_id,
                 } => {
-                    let key = scoped_plugin_storage_key(&plugin, &key);
-                    let value = self
-                        .preferences
-                        .plugin_storage(&plugin, &key)
+                    let value = plugin_storage_value(&self.preferences, &plugin, &key)
                         .cloned()
                         .unwrap_or(serde_json::Value::Null);
                     self.plugin_registry
@@ -31814,7 +31839,68 @@ impl Editor {
 mod test {
     use super::*;
     use crate::lsp::DiagnosticSeverity;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn session_restore_storage_is_scoped_by_workspace() {
+        assert_eq!(
+            scoped_plugin_storage_key_for_workspace(
+                "session_restore",
+                "latest",
+                Path::new("/workspace/one"),
+            ),
+            "latest:/workspace/one"
+        );
+        assert_eq!(
+            scoped_plugin_storage_key_for_workspace(
+                "session_restore",
+                "latest",
+                Path::new("/workspace/two"),
+            ),
+            "latest:/workspace/two"
+        );
+    }
+
+    #[test]
+    fn session_restore_storage_reads_legacy_value_until_workspace_value_exists() {
+        let mut preferences = PreferencesStore::in_memory();
+        preferences
+            .set_plugin_storage("session_restore", "latest", json!({ "cwd": "/legacy" }))
+            .unwrap();
+
+        assert_eq!(
+            plugin_storage_value_for_workspace(
+                &preferences,
+                "session_restore",
+                "latest",
+                Path::new("/workspace"),
+            ),
+            Some(&json!({ "cwd": "/legacy" }))
+        );
+
+        let scoped_key = scoped_plugin_storage_key_for_workspace(
+            "session_restore",
+            "latest",
+            Path::new("/workspace"),
+        );
+        preferences
+            .set_plugin_storage(
+                "session_restore",
+                &scoped_key,
+                json!({ "cwd": "/workspace" }),
+            )
+            .unwrap();
+
+        assert_eq!(
+            plugin_storage_value_for_workspace(
+                &preferences,
+                "session_restore",
+                "latest",
+                Path::new("/workspace"),
+            ),
+            Some(&json!({ "cwd": "/workspace" }))
+        );
+    }
 
     #[test]
     fn changed_char_range_bounds_insertions_replacements_and_unicode() {


### PR DESCRIPTION
Clean session restore currently keeps one global `latest` plugin value. Exiting Red from a different working directory replaces the previous workspace's saved buffers, so returning to the original directory no longer restores its context.

This change scopes the session-restore value by canonical working directory at the plugin-storage boundary. Existing unscoped state remains available as a migration fallback until that workspace exits cleanly and writes its scoped value. Other plugin storage behavior, including existing workspace-scoped Agent history, is preserved.

The recovery documentation now describes the per-workspace behavior, and focused tests cover independent keys and legacy fallback precedence.

## How to Test

1. From workspace A, run Red with a clean file, exit, then start Red again without file arguments. The file and editor layout should restore.
2. Start and exit Red without files from workspace B, then start Red again from workspace A. Workspace A's file and layout should still restore, while workspace B retains its own empty state.
3. Run `cargo test --lib session_restore_` to cover workspace scoping, legacy migration, file alias repair, and core-recovery non-interference.
4. Run `cargo clippy --all-targets --all-features -- -D warnings`.

The full `cargo test --lib --all-features` suite also passed except for one unrelated Git-context deadline on its first parallel run; that exact test passed immediately when rerun in isolation.
