### PR TITLE
fix(editor): resolve recovered external-file warnings

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3704,6 +3704,7 @@ pub struct Editor {
     notification_fallback: Option<String>,
     config_notification: Option<NotificationId>,
     session_notification: Option<NotificationId>,
+    external_file_notifications: HashMap<BufferId, NotificationId>,
     persistent_notification_messages: [Option<String>; 2],
 
     /// Compatibility display slot while existing producers are migrated.
@@ -5235,6 +5236,7 @@ impl Editor {
             notification_fallback: None,
             config_notification: None,
             session_notification: None,
+            external_file_notifications: HashMap::new(),
             persistent_notification_messages: [None, None],
             last_error: None,
             current_dialog: None,
@@ -22253,6 +22255,8 @@ impl Editor {
                         self.sync_to_window();
                         self.commit_transaction(self.cursor_snapshot());
                         self.current_buffer_mut().mark_saved();
+                        let id = self.current_buffer().id();
+                        self.resolve_external_file_notification(id);
                         self.set_legacy_message(Some(format!(
                             "{file:?} {}L, {}B read",
                             self.current_buffer().len(),
@@ -24808,6 +24812,7 @@ impl Editor {
 
         self.sync_to_window();
         let removed_id = self.current_buffer().id();
+        self.resolve_external_file_notification(removed_id);
         self.detach_inline_history_buffer(removed_id);
         self.inline_comments
             .retain(|comment| comment.anchor.buffer_id != removed_id);
@@ -29402,6 +29407,8 @@ impl Editor {
 
         match save_result {
             Ok(msg) => {
+                let id = self.current_buffer().id();
+                self.resolve_external_file_notification(id);
                 let severity = if format_warning.is_some() {
                     Severity::Warning
                 } else {
@@ -29549,6 +29556,8 @@ impl Editor {
 
         match save_result {
             Ok(msg) => {
+                let id = self.current_buffer().id();
+                self.resolve_external_file_notification(id);
                 let severity = if format_warning.is_some() {
                     Severity::Warning
                 } else {

--- a/src/editor/file_watch.rs
+++ b/src/editor/file_watch.rs
@@ -11,7 +11,7 @@ use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 
 use crate::{
     buffer::{BufferId, ExternalFileChange},
-    notification::Severity,
+    notification::{Notice, NotificationSource, Severity},
     plugin::Runtime,
     undo::{TextPosition, TextRange},
 };
@@ -213,6 +213,45 @@ fn existing_parent(path: &Path) -> Option<PathBuf> {
 }
 
 impl Editor {
+    fn publish_external_file_notification(
+        &mut self,
+        id: BufferId,
+        path: &str,
+        change: ExternalFileChange,
+    ) {
+        let verb = match change {
+            ExternalFileChange::Modified => "changed",
+            ExternalFileChange::Created => "was created",
+            ExternalFileChange::Deleted => "was deleted",
+        };
+        let message = format!(
+            "{path} {verb} on disk; :diffdisk compares, :e! reloads, :w <file> saves elsewhere, :w! overwrites"
+        );
+        let notice = Notice::new(NotificationSource::Editor, Severity::Warning, &message)
+            .with_key(format!("external-file:{}", id.as_u64()))
+            .with_details(&message);
+        match self.publish_notification(notice) {
+            Ok(notification_id) => {
+                self.external_file_notifications.insert(id, notification_id);
+                self.notification_fallback = None;
+            }
+            Err(error) => {
+                self.notification_fallback = Some(crate::notification::single_line(
+                    super::truncate_chars(&message, 4_096),
+                ));
+                crate::log!("could not retain external file notification: {error}");
+            }
+        }
+        self.last_error = Some(message);
+    }
+
+    pub(super) fn resolve_external_file_notification(&mut self, id: BufferId) -> bool {
+        let Some(notification_id) = self.external_file_notifications.remove(&id) else {
+            return false;
+        };
+        self.notifications.resolve(notification_id).is_ok()
+    }
+
     /// Keeps diff construction and confirmation state out of the recursive action future.
     #[inline(never)]
     pub(super) fn open_disk_conflict_dialog(&mut self, runtime: &mut Runtime) -> bool {
@@ -238,7 +277,9 @@ impl Editor {
             .header("file on disk", "editor buffer")
             .to_string();
         if diff.is_empty() {
+            let id = self.current_buffer().id();
             self.current_buffer_mut().set_external_file_change(None);
+            self.resolve_external_file_notification(id);
             self.set_notification_message(
                 Severity::Success,
                 Some("The editor buffer already matches the file on disk".to_string()),
@@ -318,22 +359,13 @@ impl Editor {
 
             let Some(change) = change else {
                 needs_render |= self.buffer_manager[index].set_external_file_change(None);
+                needs_render |= self.resolve_external_file_notification(id);
                 continue;
             };
             if self.buffer_manager[index].is_dirty() || change == ExternalFileChange::Deleted {
                 if self.buffer_manager[index].set_external_file_change(Some(change)) {
                     let path = self.buffer_manager[index].name().to_string();
-                    let verb = match change {
-                        ExternalFileChange::Modified => "changed",
-                        ExternalFileChange::Created => "was created",
-                        ExternalFileChange::Deleted => "was deleted",
-                    };
-                    self.set_notification_message(
-                        Severity::Warning,
-                        Some(format!(
-                            "{path} {verb} on disk; :diffdisk compares, :e! reloads, :w <file> saves elsewhere, :w! overwrites"
-                        )),
-                    );
+                    self.publish_external_file_notification(id, &path, change);
                     self.plugin_registry
                         .notify(
                             runtime,
@@ -357,6 +389,7 @@ impl Editor {
             }
 
             if self.reload_changed_file(index, runtime).await? {
+                self.resolve_external_file_notification(id);
                 needs_render = true;
             }
         }
@@ -565,6 +598,46 @@ mod tests {
             Some(ExternalFileChange::Deleted)
         );
         assert!(editor.test_statusline_row().contains("[DELETED]"));
+    }
+
+    #[tokio::test]
+    async fn recreating_an_unchanged_file_resolves_its_deletion_notification() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("watched.rs");
+        std::fs::write(&path, "before\n").unwrap();
+        let source = Buffer::new(Some(path.to_string_lossy().into_owned()), "before\n".into());
+        let id = source.id();
+        let mut editor = editor_with_buffers(vec![source]);
+
+        poll_editor(&mut editor).await;
+        std::fs::remove_file(&path).unwrap();
+        poll_editor(&mut editor).await;
+
+        let notification_id = *editor.external_file_notifications.get(&id).unwrap();
+        assert!(editor
+            .notifications()
+            .get(notification_id)
+            .unwrap()
+            .is_active(std::time::Instant::now()));
+
+        std::fs::write(&path, "before\n").unwrap();
+        poll_editor(&mut editor).await;
+
+        assert_eq!(editor.current_buffer().contents(), "before\n");
+        assert!(!editor.current_buffer().has_external_file_conflict());
+        assert!(!editor.external_file_notifications.contains_key(&id));
+        assert!(!editor
+            .notifications()
+            .get(notification_id)
+            .unwrap()
+            .is_active(std::time::Instant::now()));
+        assert_eq!(
+            editor
+                .notifications()
+                .counts(std::time::Instant::now())
+                .needs_acknowledgment,
+            0
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
External-file warnings currently require explicit acknowledgment even after the underlying conflict disappears. This leaves a misleading deletion warning active when tools such as Git briefly remove and recreate an open file during a rebase or checkout.

This change tracks external-file warnings per buffer and resolves the active warning when the buffer and disk converge again. Recovery through the file watcher, reload, save or save-as, `:diffdisk`, and buffer close all clear the corresponding warning while retaining it in message history.

A regression test covers deleting an open clean file and recreating it with unchanged contents, including the conflict marker and notification attention counts.

## How to Test

1. Open a tracked file in Red, delete it externally, and wait for the file watcher. Confirm Red shows the `[DELETED]` marker and an external-file warning that needs attention.
2. Recreate the file with its original contents. Confirm the marker and active warning disappear without manual acknowledgment, while the resolved event remains available in `:messages`.
3. Run `cargo test editor::file_watch::tests`; all file-watch tests should pass, including `recreating_an_unchanged_file_resolves_its_deletion_notification`.
