### PR TITLE
feat(git): browse committed files in dashboard

### DIFF
--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -38,6 +38,11 @@ struct GitState {
     truncated: bool,
 }
 
+struct GitCommitFiles {
+    entries: [GitEntry],
+    truncated: bool,
+}
+
 struct GitSignGlyphs {
     add: String,
     change: String,
@@ -277,6 +282,13 @@ struct GitPluginState {
     staged_sign_glyphs: GitSignGlyphs,
     root: String,
     state: GitState,
+    commit_view_oid: String,
+    commit_view_label: String,
+    commit_view_entries: [GitEntry],
+    commit_view_truncated: bool,
+    commit_view_process: String,
+    commit_view_output: String,
+    commit_view_error: String,
     hunk_action: String,
     hunk_path: String,
     hunk_patch: String,
@@ -403,6 +415,13 @@ fn initial_state() -> GitPluginState {
         },
         root: ".",
         state: empty_state(),
+        commit_view_oid: "",
+        commit_view_label: "",
+        commit_view_entries: [],
+        commit_view_truncated: false,
+        commit_view_process: "",
+        commit_view_output: "",
+        commit_view_error: "",
         hunk_action: "",
         hunk_path: "",
         hunk_patch: "",
@@ -554,6 +573,10 @@ fn dashboard() {
 
 fn close_dashboard() {
     cancel_detail_timer();
+    let commit_process = red::string(plugin_state().commit_view_process, "");
+    if commit_process != "" {
+        red::execute("KillProcess", commit_process);
+    }
     if plugin_state().stats_process != "" {
         red::execute("KillProcess", plugin_state().stats_process);
         red::state_patch(GitPluginState { stats_process: "" });
@@ -563,7 +586,16 @@ fn close_dashboard() {
         red::execute("KillProcess", detail_process);
         red::state_patch(GitPluginState { detail_process: "" });
     }
-    red::state_patch(GitPluginState { dashboard_open: false });
+    red::state_patch(GitPluginState {
+        dashboard_open: false,
+        commit_view_oid: "",
+        commit_view_label: "",
+        commit_view_entries: [],
+        commit_view_truncated: false,
+        commit_view_process: "",
+        commit_view_output: "",
+        commit_view_error: "",
+    });
     red::execute("CloseWorkspace", "git-dashboard");
 }
 
@@ -818,7 +850,7 @@ fn update_status(output: String) {
     let safe_sync_pending = plugin_state().safe_sync_pending;
     if changed || forced {
         render_dashboard();
-        if plugin_state().dashboard_open { refresh_stats(); }
+        if plugin_state().dashboard_open && plugin_state().commit_view_oid == "" { refresh_stats(); }
     }
     if changed || forced {
         red::request("GetWindows", sign_windows_loaded);
@@ -837,6 +869,31 @@ fn refresh_selected_detail(render_loading: bool) {
         return;
     }
     let path = red::string(plugin_state().detail_path, "");
+    if plugin_state().commit_view_oid != "" {
+        if plugin_state().commit_view_process != "" {
+            return;
+        }
+        let entries = plugin_state().commit_view_entries;
+        if red::len(entries) == 0 {
+            clear_detail("This commit has no file changes.", true);
+            if render_loading { render_dashboard(); }
+            return;
+        }
+        let entry = entries[0];
+        for candidate in entries {
+            if candidate.path == path {
+                entry = candidate;
+            }
+        }
+        show_detail(Some(GitWorkspaceRow {
+            data: Some(GitWorkspaceRowData {
+                section: "commit",
+                path: entry.path,
+                entry: Some(entry),
+            }),
+        }), render_loading);
+        return;
+    }
     let state = plugin_state().state;
     if path == "" {
         for section in ["conflicted", "staged", "unstaged", "untracked"] {
@@ -1257,36 +1314,63 @@ fn render_dashboard() {
     let state = plugin_state().state;
     let stats = plugin_state().stats;
     let rows: [GitWorkspaceRow] = [];
-    if red::string(plugin_state().operation, "") != "" {
-        rows = red::push(rows, GitWorkspaceRow {
-            id: "section:operation",
-            selectable: false,
-            segments: [PanelSegment {
-                text: "Ongoing " + red::string(plugin_state().operation, ""),
-                style: warning_style(),
-            }],
-        });
-    }
-    rows = append_section(rows, "Conflicts", "conflicted", state.conflicted, stats);
-    rows = append_section(rows, "Staged", "staged", state.staged, stats);
-    rows = append_section(rows, "Unstaged", "unstaged", state.unstaged, stats);
-    rows = append_section(rows, "Untracked", "untracked", state.untracked, stats);
-    if red::bool(state.truncated, false) {
-        rows = red::push(rows, GitWorkspaceRow {
-            id: "status-truncated",
-            selectable: false,
-            segments: [PanelSegment {
-                text: "… status limited to 500 entries",
-                style: muted_style(),
-            }],
-        });
-    }
-    if red::len(rows) == 0 {
-        rows = red::push(rows, GitWorkspaceRow {
-            id: "clean",
-            selectable: false,
-            segments: [PanelSegment { text: "Working tree clean", style: success_style() }],
-        });
+    if plugin_state().commit_view_oid != "" {
+        rows = append_section(rows, "Commit changes", "commit", plugin_state().commit_view_entries, stats);
+        if plugin_state().commit_view_truncated {
+            rows = red::push(rows, GitWorkspaceRow {
+                id: "commit-truncated",
+                selectable: false,
+                segments: [PanelSegment {
+                    text: "… commit limited to 500 entries",
+                    style: muted_style(),
+                }],
+            });
+        }
+        if red::len(rows) == 0 {
+            let message = "This commit has no file changes";
+            if plugin_state().commit_view_process != "" {
+                message = "Loading commit files…";
+            } else if plugin_state().commit_view_error != "" {
+                message = "Could not load commit: " + bounded_git_error(plugin_state().commit_view_error);
+            }
+            rows = red::push(rows, GitWorkspaceRow {
+                id: "commit-empty",
+                selectable: false,
+                segments: [PanelSegment { text: message, style: muted_style() }],
+            });
+        }
+    } else {
+        if red::string(plugin_state().operation, "") != "" {
+            rows = red::push(rows, GitWorkspaceRow {
+                id: "section:operation",
+                selectable: false,
+                segments: [PanelSegment {
+                    text: "Ongoing " + red::string(plugin_state().operation, ""),
+                    style: warning_style(),
+                }],
+            });
+        }
+        rows = append_section(rows, "Conflicts", "conflicted", state.conflicted, stats);
+        rows = append_section(rows, "Staged", "staged", state.staged, stats);
+        rows = append_section(rows, "Unstaged", "unstaged", state.unstaged, stats);
+        rows = append_section(rows, "Untracked", "untracked", state.untracked, stats);
+        if red::bool(state.truncated, false) {
+            rows = red::push(rows, GitWorkspaceRow {
+                id: "status-truncated",
+                selectable: false,
+                segments: [PanelSegment {
+                    text: "… status limited to 500 entries",
+                    style: muted_style(),
+                }],
+            });
+        }
+        if red::len(rows) == 0 {
+            rows = red::push(rows, GitWorkspaceRow {
+                id: "clean",
+                selectable: false,
+                segments: [PanelSegment { text: "Working tree clean", style: success_style() }],
+            });
+        }
     }
     red::execute("UpdateWorkspace", "git-dashboard", GitWorkspaceModel {
         header: header_segments(state),
@@ -1313,6 +1397,15 @@ fn dashboard_action(id: String, key: String, label: String, focus: String, secti
 }
 
 fn dashboard_actions() -> [GitWorkspaceAction] {
+    if plugin_state().commit_view_oid != "" {
+        return [
+            dashboard_action("q", "q", "back", "", [], "essential"),
+            dashboard_action("activate", "Enter", "open", "", [], "primary"),
+            dashboard_action("L", "L", "full patch", "detail", [], "secondary"),
+            dashboard_action("r", "r", "refresh", "", [], "secondary"),
+            dashboard_action("l", "l", "log", "rows", [], "secondary"),
+        ];
+    }
     return [
         dashboard_action("s", "s", "stage {scope}", "", ["unstaged", "untracked"], "essential"),
         dashboard_action("u", "u", "unstage {scope}", "", ["staged"], "essential"),
@@ -1353,14 +1446,15 @@ fn append_section(rows: [GitWorkspaceRow], title: String, section: String, entri
     let status_style = section_style(section);
     let secondary_style = muted_style();
     let display_entries: [GitDisplayEntry] = red::git_core("display_entries", entries);
+    let entry_index = 0;
     for display in display_entries {
-        let entry = display.entry;
+        let entry = entries[entry_index];
         rows = red::push(rows, GitWorkspaceRow {
             id: section + ":" + entry.path,
             selectable: true,
             depth: 1,
             path: Some(entry.path),
-            segments: entry_path_segments(display, secondary_style),
+            segments: entry_path_segments(display, entry, secondary_style),
             right_segments: entry_stat_segments(display, section, status_style, stats),
             data: Some(GitWorkspaceRowData {
                 section: section,
@@ -1368,6 +1462,7 @@ fn append_section(rows: [GitWorkspaceRow], title: String, section: String, entri
                 entry: Some(entry),
             }),
         });
+        entry_index = entry_index + 1;
     }
     return rows;
 }
@@ -1389,7 +1484,22 @@ fn entry_stat_segments(display: GitDisplayEntry, section: String, status_style: 
 fn refresh_stats() {
     if plugin_state().stats_process != "" { red::execute("KillProcess", plugin_state().stats_process); }
     red::state_patch(GitPluginState { stats: Json {} });
+    if plugin_state().commit_view_oid != "" {
+        start_commit_stats();
+        return;
+    }
     start_stats("staged");
+}
+
+fn start_commit_stats() {
+    let process_id = red::execute("SpawnProcess", Process {
+        command: "git",
+        args: ["show", "--format=", "--first-parent", "--numstat", "-z", "--find-renames", plugin_state().commit_view_oid],
+        raw_output: true,
+        cwd: plugin_state().root,
+    });
+    red::state_patch(GitPluginState { stats_process: process_id, stats_section: "commit", stats_output: "" });
+    red::on("process:" + process_id, stats_event);
 }
 
 fn start_stats(section: String) {
@@ -1431,7 +1541,7 @@ fn stats_event(event: ProcessEvent) {
                 index = index + 1;
             }
             red::state_patch(GitPluginState { stats: stats, stats_process: "" });
-            if section == "staged" && plugin_state().dashboard_open { start_stats("unstaged"); }
+            if section == "staged" && plugin_state().dashboard_open && plugin_state().commit_view_oid == "" { start_stats("unstaged"); }
             else { render_dashboard(); }
         }
         ProcessEvent::Error { process_id, message, plugin_name } => {
@@ -1441,15 +1551,14 @@ fn stats_event(event: ProcessEvent) {
     }
 }
 
-fn entry_path_segments(display: GitDisplayEntry, secondary_style: Style) -> [PanelSegment] {
-    let entry = display.entry;
+fn entry_path_segments(display: GitDisplayEntry, entry: GitEntry, secondary_style: Style) -> [PanelSegment] {
     let segments = [
         PanelSegment { text: display.filename },
     ];
     if display.parent != "" {
         segments = red::push(segments, PanelSegment { text: "  " + display.parent, style: secondary_style });
     }
-    if entry.kind == "renamed" {
+    if entry.kind == "renamed" || entry.kind == "copied" {
         if let Some(original_path) = entry.original_path {
             segments = red::push(segments, PanelSegment {
                 text: "  ← " + original_path,
@@ -1469,12 +1578,19 @@ fn header_segments(state: GitState) -> [PanelSegment] {
     if red::string(state.upstream, "") != "" {
         tracking = " → " + state.upstream;
     }
-    return [
+    let segments = [
         PanelSegment { text: branch, style: branch_style() },
         PanelSegment { text: tracking, style: muted_style() },
         PanelSegment { text: "  ↑" + state.ahead + " ↓" + state.behind, style: muted_style() },
         PanelSegment { text: operation_header(), style: warning_style() },
     ];
+    if plugin_state().commit_view_oid != "" {
+        segments = red::push(segments, PanelSegment {
+            text: "  ·  " + plugin_state().commit_view_label,
+            style: heading_style(),
+        });
+    }
+    return segments;
 }
 
 fn operation_header() -> String {
@@ -1531,11 +1647,19 @@ fn workspace_event(event: GitWorkspaceEvent) {
         return;
     }
     if event.action == "q" || event.action == "escape" {
-        close_dashboard();
+        if plugin_state().commit_view_oid != "" {
+            close_commit_view();
+        } else {
+            close_dashboard();
+        }
         return;
     }
     if event.action == "r" {
-        force_refresh();
+        if plugin_state().commit_view_oid != "" {
+            open_commit_view(plugin_state().commit_view_oid, plugin_state().commit_view_label);
+        } else {
+            force_refresh();
+        }
         return;
     }
     if event.action == "$" {
@@ -1576,6 +1700,12 @@ fn workspace_event(event: GitWorkspaceEvent) {
                 return;
             }
         }
+    }
+    if plugin_state().commit_view_oid != "" {
+        if event.action == "l" {
+            log_view();
+        }
+        return;
     }
     if event.focus == "detail" && (
         event.action == "s" || event.action == "u" || event.action == "x" ||
@@ -1693,9 +1823,19 @@ fn show_detail(row: Option<GitWorkspaceRow>, render_loading: bool) {
     red::state_patch(GitPluginState { detail_error: "", detail_status: "Loading " + data.path + "…" });
     red::state_patch(GitPluginState { detail_path: data.path });
     red::state_patch(GitPluginState { detail_section: data.section });
+    let args = red::git_core("detail_diff_args", data.section, data.path);
+    if data.section == "commit" {
+        args = ["show", "--format=", "--first-parent", "--find-renames", "--no-ext-diff", "--color=never", plugin_state().commit_view_oid, "--"];
+        if let Some(entry) = data.entry {
+            if let Some(original_path) = entry.original_path {
+                args = red::push(args, original_path);
+            }
+        }
+        args = red::push(args, data.path);
+    }
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
-        args: red::git_core("detail_diff_args", data.section, data.path),
+        args: args,
         raw_output: true,
         cwd: red::string(plugin_state().root, "."),
     });
@@ -2755,8 +2895,6 @@ fn capture_finished() {
     } else if kind == "detail" {
         red::state_patch(GitPluginState { detail: detail_lines(output) });
         render_dashboard();
-    } else if kind == "log-detail" {
-        open_detail_items(output);
     } else if kind == "branches-checkout" || kind == "branches-delete" || kind == "branches-merge" || kind == "branches-rebase" {
         open_line_items(kind, "Branches", output);
     } else if kind == "tags-delete" {
@@ -2794,23 +2932,6 @@ fn open_line_items(kind: String, title: String, output: String) {
     }
     items = red::push(items, PickerItem { id: "Cancel", label: "Cancel", kind: "Cancel" });
     open_items(title, items);
-}
-
-fn open_detail_items(output: String) {
-    let items = [];
-    let lines = red::split(output, "\n");
-    let index = 0;
-    while index < red::len(lines) && index < 500 {
-        items = red::push(items, PickerItem {
-            id: "detail:" + index,
-            label: lines[index],
-            kind: "Text",
-            data: Json { menu_kind: "log-detail-view" },
-        });
-        index = index + 1;
-    }
-    items = red::push(items, PickerItem { id: "Close", label: "Close", kind: "Close" });
-    open_items("Commit details", items);
 }
 
 fn open_tag_push_items(output: String) {
@@ -2936,13 +3057,17 @@ fn open_log_items(output: String) {
         if red::trim(line) != "" {
             let clean = red::trim(line);
             let fields = red::split(clean, "\t");
-            items = red::push(items, PickerItem {
-                id: fields[0],
-                label: fields[1] + " " + fields[4],
-                kind: "GitCommit",
-                detail: fields[2] + " " + fields[3],
-                data: Json { menu_kind: "log-select", oid: fields[0] },
-            });
+            if red::len(fields) >= 5 {
+                let graph_fields = red::split(red::trim(fields[0]), " ");
+                let oid = graph_fields[red::len(graph_fields) - 1];
+                items = red::push(items, PickerItem {
+                    id: oid,
+                    label: fields[1] + " " + fields[4],
+                    kind: "GitCommit",
+                    detail: fields[2] + " " + fields[3],
+                    data: Json { menu_kind: "log-select", oid: oid },
+                });
+            }
         }
     }
     open_name_first_items("Git log", items);
@@ -3168,11 +3293,12 @@ fn operation_item_selected(value: String) {
 fn log_item_selected(kind: String, item: PickerItem, value: String) {
     if kind == "log-select" {
         red::state_patch(GitPluginState { log_oid: item.data.oid });
-        open_choices("log-action", item.label, ["Show details", "Cherry-pick", "Revert", "Create branch", "Create tag", "Cancel"]);
+        red::state_patch(GitPluginState { commit_view_label: item.label });
+        open_choices("log-action", item.label, ["Open", "Cherry-pick", "Revert", "Create branch", "Create tag", "Cancel"]);
     } else {
         let oid = red::string(plugin_state().log_oid, "");
-        if value == "Show details" {
-            capture_git("log-detail", ["show", "--stat", "--patch", "--color=never", oid]);
+        if value == "Open" {
+            open_commit_view(oid, red::string(plugin_state().commit_view_label, oid));
         } else if value == "Cherry-pick" {
             run_simple_git(["cherry-pick", oid]);
         } else if value == "Revert" {
@@ -3183,6 +3309,122 @@ fn log_item_selected(kind: String, item: PickerItem, value: String) {
             open_prompt("log-tag-create", "Tag name", "");
         }
     }
+}
+
+fn open_commit_view(oid: String, label: String) {
+    let previous = red::string(plugin_state().commit_view_process, "");
+    if previous != "" {
+        red::execute("KillProcess", previous);
+    }
+    let stats_process = red::string(plugin_state().stats_process, "");
+    if stats_process != "" {
+        red::execute("KillProcess", stats_process);
+    }
+    clear_detail("Loading commit files…", true);
+    red::state_patch(GitPluginState {
+        commit_view_oid: oid,
+        commit_view_label: label,
+        commit_view_entries: [],
+        commit_view_truncated: false,
+        commit_view_output: "",
+        commit_view_error: "",
+        detail_suppressed: false,
+        stats: Json {},
+        stats_process: "",
+    });
+    let args = ["show", "--format=", "--first-parent", "--name-status", "-z", "--find-renames", oid];
+    record_command(args);
+    let process_id = red::execute("SpawnProcess", Process {
+        command: "git",
+        args: args,
+        raw_output: true,
+        cwd: red::string(plugin_state().root, "."),
+    });
+    red::state_patch(GitPluginState { commit_view_process: process_id });
+    red::on("process:" + process_id, commit_view_event);
+    render_dashboard();
+}
+
+fn commit_view_event(event: ProcessEvent) {
+    match event {
+        ProcessEvent::Stdout { process_id, line, plugin_name } => {
+            if process_id == plugin_state().commit_view_process {
+                red::state_patch(GitPluginState {
+                    commit_view_output: plugin_state().commit_view_output + line,
+                });
+            }
+        }
+        ProcessEvent::Stderr { process_id, line, plugin_name } => {
+            if process_id == plugin_state().commit_view_process {
+                red::state_patch(GitPluginState {
+                    commit_view_error: plugin_state().commit_view_error + line,
+                });
+            }
+        }
+        ProcessEvent::Exit { process_id, code, plugin_name } => {
+            if process_id != plugin_state().commit_view_process {
+                return;
+            }
+            red::state_patch(GitPluginState { commit_view_process: "" });
+            let exit_code = 1;
+            if let Some(value) = code {
+                exit_code = value;
+            }
+            if exit_code != 0 {
+                if plugin_state().commit_view_error == "" {
+                    red::state_patch(GitPluginState {
+                        commit_view_error: "git show exited with code " + exit_code,
+                    });
+                }
+                clear_detail("Could not load commit changes.", true);
+                render_dashboard();
+                return;
+            }
+            let files: GitCommitFiles = red::git_core("parse_commit_files", plugin_state().commit_view_output);
+            red::state_patch(GitPluginState {
+                commit_view_entries: files.entries,
+                commit_view_truncated: files.truncated,
+            });
+            refresh_selected_detail(true);
+            refresh_stats();
+        }
+        ProcessEvent::Error { process_id, message, plugin_name } => {
+            if process_id == plugin_state().commit_view_process {
+                red::state_patch(GitPluginState {
+                    commit_view_process: "",
+                    commit_view_error: message,
+                });
+                clear_detail("Could not load commit changes.", true);
+                render_dashboard();
+            }
+        }
+    }
+}
+
+fn close_commit_view() {
+    let process_id = red::string(plugin_state().commit_view_process, "");
+    if process_id != "" {
+        red::execute("KillProcess", process_id);
+    }
+    let stats_process = red::string(plugin_state().stats_process, "");
+    if stats_process != "" {
+        red::execute("KillProcess", stats_process);
+    }
+    clear_detail("Select a change to inspect its diff.", true);
+    red::state_patch(GitPluginState {
+        commit_view_oid: "",
+        commit_view_label: "",
+        commit_view_entries: [],
+        commit_view_truncated: false,
+        commit_view_process: "",
+        commit_view_output: "",
+        commit_view_error: "",
+        detail_suppressed: false,
+        stats: Json {},
+        stats_process: "",
+    });
+    refresh_selected_detail(true);
+    force_refresh();
 }
 
 fn rebase_item_selected(value: String) {
@@ -4031,6 +4273,7 @@ fn deactivate() {
         red::string(plugin_state().commit_process, ""),
         red::string(plugin_state().commit_context_process, ""),
         red::string(plugin_state().commit_history_process, ""),
+        red::string(plugin_state().commit_view_process, ""),
     ] {
         if process_id != "" { red::execute("KillProcess", process_id); }
     }

--- a/plugins/git_core/src/status.hk
+++ b/plugins/git_core/src/status.hk
@@ -71,6 +71,11 @@ pub struct GitState {
     truncated: bool,
 }
 
+pub struct GitCommitFiles {
+    entries: [GitEntry],
+    truncated: bool,
+}
+
 pub struct DisplayEntry {
     entry: GitEntry,
     filename: String,
@@ -97,6 +102,58 @@ pub fn display_entries(entries: [GitEntry]) -> [DisplayEntry] {
 
 pub fn parse_status(output: String) -> GitState {
     status_view(parse_porcelain(output, 500))
+}
+
+pub fn parse_commit_files(output: String) -> GitCommitFiles {
+    let records = output.split("\0");
+    let mut entries = [];
+    let mut index = 0;
+    let mut truncated = false;
+
+    while index < records.len() {
+        let status = records[index];
+        if status.is_empty() {
+            index += 1;
+            continue;
+        }
+        if entries.len() >= 500 {
+            truncated = true;
+            break;
+        }
+
+        let code = status.char_at(0);
+        if index + 1 >= records.len() {
+            break;
+        }
+        let mut path = records[index + 1];
+        let mut original_path = None;
+        let mut kind = "changed";
+        index += 2;
+
+        if code == "R" || code == "C" {
+            if index >= records.len() {
+                break;
+            }
+            original_path = Some(path);
+            path = records[index];
+            index += 1;
+            if code == "R" {
+                kind = "renamed";
+            } else {
+                kind = "copied";
+            }
+        }
+
+        entries.push(GitEntry {
+            path: path,
+            original_path: original_path,
+            x: code,
+            y: ".",
+            kind: kind,
+        });
+    }
+
+    GitCommitFiles { entries: entries, truncated: truncated }
 }
 
 fn parse_porcelain(output: String, limit: i32) -> GitStatus {
@@ -352,6 +409,21 @@ fn parses_branch_changed_renamed_untracked_and_conflicted_records() {
     assert(state.untracked[0].path == "notes/todo.txt");
     assert(state.untracked[0].original_path == None);
     assert(state.conflicted[0].path == "src/conflict.rs");
+}
+
+#[test]
+fn parses_nul_delimited_commit_changes_and_rename_paths() {
+    let files = parse_commit_files("M\0src/changed file.rs\0A\0notes/new\tfile.txt\0R100\0src/old name.rs\0src/new name.rs\0D\0removed.rs\0");
+
+    assert(!files.truncated);
+    assert(files.entries.len() == 4);
+    assert(files.entries[0].path == "src/changed file.rs");
+    assert(files.entries[0].x == "M");
+    assert(files.entries[1].path == "notes/new\tfile.txt");
+    assert(files.entries[2].kind == "renamed");
+    assert(files.entries[2].original_path == Some("src/old name.rs"));
+    assert(files.entries[2].path == "src/new name.rs");
+    assert(files.entries[3].x == "D");
 }
 
 #[test]

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -2759,6 +2759,7 @@ impl RedHost {
                 let value = self.call_git_core(operation, &args[1..])?;
                 let record = match operation {
                     "parse_status" => Some("GitState"),
+                    "parse_commit_files" => Some("GitCommitFiles"),
                     "detail_document" => Some("GitWorkspaceDocument"),
                     _ => None,
                 };
@@ -2798,6 +2799,7 @@ impl RedHost {
         let args = preview.as_ref().map_or(args, |(args, _)| args.as_slice());
         let function = match operation {
             "parse_status" => "status::parse_status",
+            "parse_commit_files" => "status::parse_commit_files",
             "display_entries" => "status::display_entries",
             "sign_hunks" => "patch::sign_hunks",
             "detail_document" => "patch::detail_document",
@@ -5175,6 +5177,168 @@ mod tests {
         runtime
     }
 
+    #[cfg(not(windows))]
+    async fn next_git_callback_picker(
+        runtime: &mut Runtime,
+        expected_title: &str,
+    ) -> (PickerHandle, Vec<PickerItem>) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(runtime).await.unwrap();
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::OpenCallbackPicker {
+                    owner,
+                    handle,
+                    title,
+                    items,
+                    ..
+                } = request
+                {
+                    assert_eq!(owner, "git");
+                    assert_eq!(title.as_deref(), Some(expected_title));
+                    return (handle, items);
+                }
+            }
+            assert!(Instant::now() < deadline, "{expected_title} did not open");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[cfg(not(windows))]
+    async fn wait_for_git_dashboard_model(
+        runtime: &mut Runtime,
+        predicate: impl Fn(&WorkspaceModel) -> bool,
+        failure: &str,
+    ) -> WorkspaceModel {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut observed = "no workspace update".to_string();
+        loop {
+            pump_process_events(runtime).await.unwrap();
+            while let Some(request) = ACTION_DISPATCHER.try_recv_request() {
+                if let PluginRequest::UpdateWorkspace { id, model } = request {
+                    assert_eq!(id, "git-dashboard");
+                    if predicate(&model) {
+                        return model;
+                    }
+                    observed = format!(
+                        "rows={:?}, detail={:?}, status={:?}",
+                        model
+                            .rows
+                            .iter()
+                            .map(|row| {
+                                (
+                                    &row.id,
+                                    row.segments
+                                        .iter()
+                                        .map(|segment| &segment.text)
+                                        .collect::<Vec<_>>(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                        model
+                            .detail_document
+                            .as_ref()
+                            .map(|document| &document.path),
+                        model.status
+                    );
+                }
+            }
+            assert!(Instant::now() < deadline, "{failure}: {observed}");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[cfg(not(windows))]
+    async fn open_git_dashboard_commit(runtime: &mut Runtime, subject: &str) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(runtime).await.unwrap();
+            drain_requests();
+            if runtime
+                .inner
+                .lock()
+                .unwrap()
+                .host
+                .process_manager
+                .active_process_count("git")
+                == 0
+            {
+                break;
+            }
+            assert!(Instant::now() < deadline, "Git dashboard did not settle");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "l", "focus": "rows", "row": null }),
+            )
+            .await
+            .unwrap();
+        let (log_handle, commits) = next_git_callback_picker(runtime, "Git log").await;
+        let commit = commits
+            .iter()
+            .find(|item| item.label.contains(subject))
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!(
+                    "commit {subject:?} did not appear in the Git log: {:?}",
+                    commits.iter().map(|item| &item.label).collect::<Vec<_>>()
+                )
+            });
+        let title = commit.label.clone();
+        assert!(runtime
+            .notify_picker(log_handle, PickerCallback::Selected(commit))
+            .unwrap());
+        let (action_handle, actions) = next_git_callback_picker(runtime, &title).await;
+        assert_eq!(actions.first().map(|item| item.id.as_str()), Some("Open"));
+        assert!(actions.iter().any(|item| item.id == "Cherry-pick"));
+        assert!(actions.iter().any(|item| item.id == "Revert"));
+        assert!(actions.iter().all(|item| item.id != "Show details"));
+        let open = actions.into_iter().find(|item| item.id == "Open").unwrap();
+        assert!(runtime
+            .notify_picker(action_handle, PickerCallback::Selected(open))
+            .unwrap());
+    }
+
+    #[cfg(not(windows))]
+    async fn select_git_dashboard_commit_file(
+        runtime: &mut Runtime,
+        row: &crate::plugin::WorkspaceRow,
+    ) -> WorkspaceModel {
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "down", "focus": "rows", "row": row }),
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(70)).await;
+        for callback in runtime.poll_timer_callbacks() {
+            if let PluginRequest::TimeoutCallback { timer_id } = callback {
+                runtime
+                    .notify(
+                        "timeout:callback",
+                        serde_json::json!({ "timer_id": timer_id }),
+                    )
+                    .await
+                    .unwrap();
+            }
+        }
+        let path = row.path.as_deref().unwrap();
+        wait_for_git_dashboard_model(
+            runtime,
+            |model| {
+                model
+                    .detail_document
+                    .as_ref()
+                    .is_some_and(|document| document.path == path)
+            },
+            "selected commit file did not render a structured diff",
+        )
+        .await
+    }
+
     #[test]
     fn embedded_git_core_compiles_as_a_native_multi_file_package_and_normalizes_options() {
         let program = git_core_program().unwrap();
@@ -5195,6 +5359,21 @@ mod tests {
         assert_eq!(status["head"], "native");
         assert_eq!(status["untracked"][0]["path"], "src/new file.rs");
         assert!(status["untracked"][0]["original_path"].is_null());
+
+        let commit = host
+            .call_git_core(
+                "parse_commit_files",
+                &[Value::String(
+                    "M\0changed.rs\0R100\0old name.rs\0new name.rs\0D\0removed.rs\0".to_string(),
+                )],
+            )
+            .unwrap()
+            .to_json();
+        assert_eq!(commit["entries"].as_array().unwrap().len(), 3);
+        assert_eq!(commit["entries"][1]["path"], "new name.rs");
+        assert_eq!(commit["entries"][1]["original_path"], "old name.rs");
+        assert_eq!(commit["entries"][2]["x"], "D");
+        assert_eq!(commit["truncated"], false);
 
         let document = host
             .call_git_core(
@@ -13830,6 +14009,14 @@ mod tests {
         let (log_handle, commits, options) = next_git_picker(&mut runtime, "Git log").await;
         assert_eq!(options.item_layout, crate::ui::PickerItemLayout::LabelFirst);
         assert!(commits.iter().any(|item| item.label.contains(subject)));
+        assert!(commits.iter().all(|item| {
+            item.data
+                .get("oid")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|oid| {
+                    oid.len() == 40 && oid.bytes().all(|character| character.is_ascii_hexdigit())
+                })
+        }));
         assert!(runtime
             .notify_picker(log_handle, PickerCallback::Cancelled)
             .unwrap());
@@ -13891,6 +14078,375 @@ mod tests {
                 .and_then(serde_json::Value::as_str),
             Some(expected_search_path.as_str())
         );
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_dashboard_opens_commits_as_read_only_file_and_diff_views() {
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        let commit = |subject: &str| {
+            git(&[
+                "-c",
+                "user.name=Red Test",
+                "-c",
+                "user.email=red@example.test",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-qm",
+                subject,
+            ]);
+        };
+
+        git(&["init", "-q", "-b", "main"]);
+        fs::write(root.join("changed.rs"), "before\n").unwrap();
+        fs::write(root.join("old name.rs"), "renamed contents\n").unwrap();
+        fs::write(root.join("removed.rs"), "deleted contents\n").unwrap();
+        fs::write(root.join("binary.bin"), b"\0before").unwrap();
+        git(&["add", "."]);
+        commit("initial files");
+
+        fs::write(root.join("changed.rs"), "after\n").unwrap();
+        fs::rename(root.join("old name.rs"), root.join("new name.rs")).unwrap();
+        fs::remove_file(root.join("removed.rs")).unwrap();
+        fs::write(root.join("added.rs"), "new commit contents\n").unwrap();
+        fs::write(root.join("binary.bin"), b"\0after").unwrap();
+        git(&["add", "-A"]);
+        commit("inspect committed file changes");
+        fs::write(root.join("pending.rs"), "live working tree contents\n").unwrap();
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        wait_for_git_dashboard_model(
+            &mut runtime,
+            |model| {
+                model
+                    .rows
+                    .iter()
+                    .any(|row| row.id == "untracked:pending.rs")
+            },
+            "live working-tree change did not render before opening the commit",
+        )
+        .await;
+
+        open_git_dashboard_commit(&mut runtime, "inspect committed file changes").await;
+        let model = wait_for_git_dashboard_model(
+            &mut runtime,
+            |model| {
+                let changed = model.rows.iter().find(|row| row.id == "commit:changed.rs");
+                let binary = model.rows.iter().find(|row| row.id == "commit:binary.bin");
+                changed.is_some_and(|row| {
+                    row.right_segments
+                        .iter()
+                        .any(|segment| segment.text.contains("+1 −1"))
+                }) && binary.is_some_and(|row| {
+                    row.right_segments
+                        .iter()
+                        .any(|segment| segment.text.contains("binary"))
+                }) && model
+                    .detail_document
+                    .as_ref()
+                    .is_some_and(|document| document.path == "added.rs")
+            },
+            "commit files, statistics, and initial structured diff did not render",
+        )
+        .await;
+
+        for path in [
+            "added.rs",
+            "binary.bin",
+            "changed.rs",
+            "new name.rs",
+            "removed.rs",
+        ] {
+            assert!(
+                model
+                    .rows
+                    .iter()
+                    .any(|row| row.id == format!("commit:{path}")),
+                "commit file {path:?} was missing"
+            );
+        }
+        assert!(model
+            .header
+            .iter()
+            .any(|segment| segment.text.contains("inspect committed file changes")));
+        assert!(model
+            .rows
+            .iter()
+            .all(|row| row.id != "untracked:pending.rs"));
+        let renamed = model
+            .rows
+            .iter()
+            .find(|row| row.id == "commit:new name.rs")
+            .unwrap();
+        assert_eq!(
+            renamed.data["entry"]["original_path"].as_str(),
+            Some("old name.rs")
+        );
+        assert!(
+            renamed
+                .segments
+                .iter()
+                .any(|segment| segment.text.contains("old name.rs")),
+            "rename segments {:?} did not contain the original path; entry {:?}",
+            renamed.segments,
+            renamed.data["entry"]
+        );
+        assert!(model
+            .actions
+            .iter()
+            .any(|action| action.hint.id == "q" && action.hint.label == "back"));
+        assert!(model.actions.iter().all(|action| {
+            !matches!(
+                action.hint.id.as_str(),
+                "s" | "u" | "x" | "S" | "U" | "X" | "c"
+            )
+        }));
+
+        let changed = model
+            .rows
+            .iter()
+            .find(|row| row.id == "commit:changed.rs")
+            .unwrap()
+            .clone();
+        let changed_model = select_git_dashboard_commit_file(&mut runtime, &changed).await;
+        let changed_document = changed_model.detail_document.unwrap();
+        assert!(changed_document
+            .lines
+            .iter()
+            .any(|line| line.kind == "removed" && line.text == "before"));
+        assert!(changed_document
+            .lines
+            .iter()
+            .any(|line| line.kind == "added" && line.text == "after"));
+
+        let removed = model
+            .rows
+            .iter()
+            .find(|row| row.id == "commit:removed.rs")
+            .unwrap()
+            .clone();
+        let removed_model = select_git_dashboard_commit_file(&mut runtime, &removed).await;
+        assert!(removed_model
+            .detail_document
+            .unwrap()
+            .lines
+            .iter()
+            .any(|line| line.kind == "removed" && line.text == "deleted contents"));
+
+        let status_before = Command::new("git")
+            .args(["status", "--porcelain=v1", "-z"])
+            .current_dir(root)
+            .output()
+            .unwrap()
+            .stdout;
+        for action in ["s", "u", "x", "S", "U", "X", "c"] {
+            runtime
+                .notify(
+                    "workspace:event:git-dashboard",
+                    serde_json::json!({
+                        "action": action,
+                        "focus": "rows",
+                        "row": changed,
+                    }),
+                )
+                .await
+                .unwrap();
+        }
+        pump_process_events(&mut runtime).await.unwrap();
+        let status_after = Command::new("git")
+            .args(["status", "--porcelain=v1", "-z"])
+            .current_dir(root)
+            .output()
+            .unwrap()
+            .stdout;
+        assert_eq!(status_after, status_before);
+
+        runtime
+            .notify(
+                "workspace:event:git-dashboard",
+                serde_json::json!({ "action": "q", "focus": "rows", "row": removed }),
+            )
+            .await
+            .unwrap();
+        let restored = wait_for_git_dashboard_model(
+            &mut runtime,
+            |model| {
+                model
+                    .rows
+                    .iter()
+                    .any(|row| row.id == "untracked:pending.rs")
+            },
+            "leaving commit view did not restore the working-tree dashboard",
+        )
+        .await;
+        assert!(restored
+            .rows
+            .iter()
+            .all(|row| !row.id.starts_with("commit:")));
+        assert!(restored.actions.iter().any(|action| action.hint.id == "s"));
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_dashboard_commit_view_includes_root_commit_files() {
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        assert!(Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(root.join("root-file.rs"), "initial commit contents\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "root-file.rs"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args([
+                "-c",
+                "user.name=Red Test",
+                "-c",
+                "user.email=red@example.test",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-qm",
+                "root commit changes",
+            ])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        wait_for_git_dashboard_model(
+            &mut runtime,
+            |model| model.rows.iter().any(|row| row.id == "clean"),
+            "clean working-tree dashboard did not open",
+        )
+        .await;
+        open_git_dashboard_commit(&mut runtime, "root commit changes").await;
+        let model = wait_for_git_dashboard_model(
+            &mut runtime,
+            |model| {
+                model.rows.iter().any(|row| row.id == "commit:root-file.rs")
+                    && model.detail_document.is_some()
+            },
+            "root commit file and structured diff did not render",
+        )
+        .await;
+        assert!(model
+            .detail_document
+            .unwrap()
+            .lines
+            .iter()
+            .any(|line| line.kind == "added" && line.text == "initial commit contents"));
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn git_dashboard_commit_view_compares_merge_commits_with_the_first_parent() {
+        drain_requests();
+        let repository = tempfile::tempdir().unwrap();
+        let root = repository.path();
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        let commit = |subject: &str| {
+            git(&[
+                "-c",
+                "user.name=Red Test",
+                "-c",
+                "user.email=red@example.test",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-qm",
+                subject,
+            ]);
+        };
+
+        git(&["init", "-q", "-b", "main"]);
+        fs::write(root.join("base.rs"), "shared history\n").unwrap();
+        git(&["add", "."]);
+        commit("shared baseline");
+        git(&["switch", "-qc", "side"]);
+        fs::write(root.join("side.rs"), "merged branch contents\n").unwrap();
+        git(&["add", "."]);
+        commit("side change");
+        git(&["switch", "-q", "main"]);
+        fs::write(root.join("main.rs"), "first parent contents\n").unwrap();
+        git(&["add", "."]);
+        commit("main change");
+        git(&[
+            "-c",
+            "user.name=Red Test",
+            "-c",
+            "user.email=red@example.test",
+            "-c",
+            "commit.gpgsign=false",
+            "merge",
+            "--no-ff",
+            "-qm",
+            "merge side changes",
+            "side",
+        ]);
+
+        let mut runtime = load_git_runtime(root).await;
+        runtime.execute_command("GitDashboard").await.unwrap();
+        wait_for_git_dashboard_model(
+            &mut runtime,
+            |model| model.rows.iter().any(|row| row.id == "clean"),
+            "clean merge working-tree dashboard did not open",
+        )
+        .await;
+        open_git_dashboard_commit(&mut runtime, "merge side changes").await;
+        let model = wait_for_git_dashboard_model(
+            &mut runtime,
+            |model| {
+                model.rows.iter().any(|row| row.id == "commit:side.rs")
+                    && model.detail_document.is_some()
+            },
+            "merge commit did not show changes relative to its first parent",
+        )
+        .await;
+        assert!(model.rows.iter().all(|row| row.id != "commit:main.rs"));
+        assert!(model
+            .detail_document
+            .unwrap()
+            .lines
+            .iter()
+            .any(|line| line.kind == "added" && line.text == "merged branch contents"));
     }
 
     #[cfg(not(windows))]

--- a/src/plugin/workspace.rs
+++ b/src/plugin/workspace.rs
@@ -1261,7 +1261,11 @@ impl PluginWorkspace {
             );
             actions
                 .push(UiAction::new("?", "?", "actions").with_priority(ActionPriority::Essential));
-            actions.push(UiAction::new("q", "q", "close").with_priority(ActionPriority::Essential));
+            if !actions.iter().any(|action| action.id == "q") {
+                actions.push(
+                    UiAction::new("q", "q", "close").with_priority(ActionPriority::Essential),
+                );
+            }
             actions.extend(crate::ui::reference_actions(&[
                 ("Navigation", "j / k / ↑ / ↓", "Move down / up"),
                 ("Navigation", "Ctrl+u / Ctrl+d", "Move half a page"),
@@ -2847,6 +2851,29 @@ mod tests {
         assert_eq!(stage.focus, WorkspaceFocus::Rows);
         assert_eq!(stage.row.unwrap().id, "untracked:new-file.txt");
         assert!(stage.detail_line.is_none());
+    }
+
+    #[test]
+    fn workspace_preserves_plugin_owned_back_action() {
+        let mut workspace = PluginWorkspace::new("git".to_string(), WorkspaceConfig::default());
+        let mut model = model_with_document();
+        model.actions = vec![WorkspaceAction {
+            hint: UiAction::new("q", "q", "back"),
+            focus: String::new(),
+            sections: Vec::new(),
+            selection: String::new(),
+            change_only: false,
+            hunk_only: false,
+        }];
+        workspace.update(model, &Theme::default());
+
+        let actions = workspace.actions();
+        let quit_actions = actions
+            .iter()
+            .filter(|action| action.id == "q")
+            .collect::<Vec<_>>();
+        assert_eq!(quit_actions.len(), 1);
+        assert_eq!(quit_actions[0].label, "back");
     }
 
     #[test]


### PR DESCRIPTION
## Why

The Git log currently sends **Show details** into a separate text picker instead of the dashboard's existing file-and-diff interface. It also stores graph-decorated commit IDs such as `* <sha>` from `git log --graph`, so commit actions receive invalid revisions.

## What changed

- Replace **Show details** with **Open** as the first commit action and display the selected commit in the existing Git dashboard.
- Add a read-only commit mode with changed-file rows, addition/deletion counts, rename origins, binary indicators, and the existing structured per-file diff viewer.
- Parse NUL-delimited commit changes safely, preserve original paths across the native Git-core boundary, and compare merge commits against their first parent.
- Keep normal staging, unstaging, discard, and commit shortcuts unavailable while inspecting history; `q` returns to the live working-tree dashboard.
- Strip graph prefixes from stored commit IDs so existing cherry-pick, revert, branch, and tag actions also receive valid revisions.
- Cover root commits, merge commits, added/modified/deleted/renamed/binary files, read-only behavior, working-tree restoration, and plugin-owned back actions.

## How to Test

1. Open Red in a repository with at least one existing commit and an uncommitted working-tree change.
2. Press `Space G`, then `l`, select a commit, and choose the default **Open** action. Confirm the dashboard shows that commit's changed files, change indicators, and per-file addition/deletion counts.
3. Move between modified, added, deleted, renamed, and binary files. Confirm textual files show their commit-specific structured diffs and renamed files retain their original paths.
4. While viewing the commit, press staging/discard shortcuts such as `s`, `u`, and `x`; confirm the repository and index remain unchanged. Press `q` and confirm the original working-tree changes and normal actions return.
5. Repeat with an initial commit and a merge commit; confirm initial files appear and merge changes are shown relative to the first parent.
6. Run the focused automated coverage:

   ```sh
   cargo test -p red git_dashboard_ --lib -- --test-threads=1
   cargo run --all-features -p husk-cli -- test --locked plugins/git_core
   ```

Also verified the complete Git-focused Rust subset (54 tests), the workspace back-action regression, formatting, and `cargo clippy --all-targets --all-features -- -D warnings`.
