### PR TITLE
fix(editor): reindent pasted code without range formatting

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -189,14 +189,14 @@ waiting = "steady_underscore"
 # [lsp]
 # format_on_save = false # Legacy alias for formatting.on_save.
 #
-# Supported pasted ranges and documents are formatted by default. Set on_paste
-# or on_save to false to disable the corresponding behavior. The modern save
-# setting wins over the legacy alias in the same config layer; command-line
+# Pasted code is reindented and supported ranges and documents are formatted by
+# default. Set on_paste or on_save to false to disable that behavior. The modern
+# save setting wins over the legacy alias in the same config layer; command-line
 # overrides still take precedence over the user file.
 # Select an external language-pack formatter, LSP formatting, or automatic fallback:
 #
 # [formatting]
-# on_paste = true # Requires language-server range formatting support.
+# on_paste = true # Reindents locally; also uses LSP range formatting when supported.
 # on_save = false
 # trim_trailing_whitespace = true
 # trim_trailing_whitespace_exclude = ["gitcommit", "markdown"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1022,7 +1022,7 @@ pub enum FormattingProvider {
 #[serde(deny_unknown_fields)]
 /// Global document formatting behavior.
 pub struct FormattingConfig {
-    /// Format pasted text when the language server supports range formatting. Defaults to on.
+    /// Reindent pasted code and request language-server range formatting when available.
     #[serde(default = "default_true")]
     pub on_paste: bool,
     /// Format supported documents immediately before saving them. Defaults to on.

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -19415,6 +19415,102 @@ impl Editor {
         columns
     }
 
+    /// Aligns pasted source with its destination without discarding its relative indentation.
+    ///
+    /// This runs inside the paste transaction because many language servers, including
+    /// rust-analyzer, support whole-document formatting but not range formatting.
+    fn reindent_pasted_lines(&mut self, first_line: usize, text: &str) {
+        const MAX_PASTE_REINDENT_BYTES: usize = 256 * 1024;
+        const MAX_PASTE_REINDENT_LINES: usize = 512;
+
+        if !self.config.formatting.on_paste || text.len() > MAX_PASTE_REINDENT_BYTES {
+            return;
+        }
+
+        let lines = text.lines().collect::<Vec<_>>();
+        if lines.len() > MAX_PASTE_REINDENT_LINES {
+            return;
+        }
+        let Some((anchor_offset, anchor)) = lines
+            .iter()
+            .enumerate()
+            .find(|(_, line)| !line.trim().is_empty())
+        else {
+            return;
+        };
+        let anchor_line = first_line + anchor_offset;
+        let starts_document = (0..anchor_line).all(|line| {
+            self.current_buffer()
+                .get(line)
+                .is_none_or(|contents| contents.trim().is_empty())
+        });
+        let language =
+            self.highlight_language_id_for_buffer_index(self.buffer_manager.active_index());
+        let has_syntax_indentation = language.as_deref().is_some_and(|language| {
+            self.highlighter
+                .registry()
+                .indentation_language(language)
+                .is_some()
+        });
+        let destination_columns = match self.indentation_decision_for_line(anchor_line) {
+            IndentDecision::Columns(columns) => columns,
+            IndentDecision::Keep if starts_document && has_syntax_indentation => 0,
+            IndentDecision::Keep => return,
+        };
+
+        let tab_width = self.indentation().tab_width.max(1);
+        let anchor_columns =
+            display_width_with_tabs(Self::leading_indentation_text(anchor), tab_width);
+        let source = starts_document.then(|| self.current_buffer().contents());
+        let buffer_id = self.current_buffer().id();
+        let revision = self.current_buffer().revision();
+
+        // Classify every line against the same unmodified syntax snapshot so
+        // multiline strings and other ignored captures retain their exact bytes.
+        let lines_to_indent = lines
+            .into_iter()
+            .enumerate()
+            .filter_map(|(offset, line)| {
+                if line.trim().is_empty() {
+                    return None;
+                }
+
+                let source_columns =
+                    display_width_with_tabs(Self::leading_indentation_text(line), tab_width);
+                let columns = if source_columns >= anchor_columns {
+                    destination_columns.saturating_add(source_columns - anchor_columns)
+                } else {
+                    destination_columns.saturating_sub(anchor_columns - source_columns)
+                };
+                let destination_line = first_line + offset;
+                if offset != anchor_offset
+                    && self.indentation_columns_for_line(destination_line) != columns
+                    && self.indentation_decision_for_line(destination_line) == IndentDecision::Keep
+                    && (!starts_document
+                        || !has_syntax_indentation
+                        || source.as_deref().zip(language.as_deref()).is_some_and(
+                            |(source, language)| {
+                                self.syntax_indentation.line_is_ignored(
+                                    buffer_id,
+                                    revision,
+                                    language,
+                                    source,
+                                    destination_line,
+                                )
+                            },
+                        ))
+                {
+                    return None;
+                }
+                Some((destination_line, columns))
+            })
+            .collect::<Vec<_>>();
+
+        for (line, columns) in lines_to_indent {
+            self.apply_indentation_to_line(line, IndentDecision::Columns(columns));
+        }
+    }
+
     fn mark_generated_indent(&mut self, line: usize, columns: usize) {
         self.generated_indent = (columns > 0).then(|| GeneratedIndent {
             buffer_id: self.current_buffer().id(),
@@ -22983,6 +23079,9 @@ impl Editor {
                     .unwrap_or_else(|| TextRange::insertion(start));
                 self.replace_range(range, text);
                 self.move_to_insert_text_position(end);
+                if text.contains('\n') {
+                    self.reindent_pasted_lines(line, text);
+                }
                 if started_transaction {
                     self.commit_transaction(self.cursor_snapshot());
                 }
@@ -24373,6 +24472,12 @@ impl Editor {
         self.selection = None;
         self.move_to_text_position(plan.cursor);
         self.fix_cursor_pos();
+        if source.kind == ContentKind::Linewise
+            || self.mode == Mode::VisualLine
+            || (source.kind == ContentKind::Charwise && source.text.contains('\n'))
+        {
+            self.reindent_pasted_lines(plan.cursor.line, &source.text);
+        }
         if !preserve_default_register {
             self.set_default_register(replaced);
         }
@@ -24558,7 +24663,14 @@ impl Editor {
         if started_transaction {
             self.begin_transaction("paste");
         }
+        let first_line =
+            self.buffer_line() + usize::from(content.kind == ContentKind::Linewise && !before);
         self.insert_content(self.cx, self.buffer_line(), content, before);
+        if content.kind == ContentKind::Linewise
+            || (content.kind == ContentKind::Charwise && content.text.contains('\n'))
+        {
+            self.reindent_pasted_lines(first_line, &content.text);
+        }
         if started_transaction {
             self.commit_transaction(self.cursor_snapshot());
         }

--- a/src/syntax_indent.rs
+++ b/src/syntax_indent.rs
@@ -145,6 +145,44 @@ impl SyntaxIndentation {
         self.try_indent(request).unwrap_or(IndentDecision::Keep)
     }
 
+    /// Reports whether a line's first non-whitespace byte is inside an ignored syntax node.
+    pub(crate) fn line_is_ignored(
+        &mut self,
+        id: BufferId,
+        revision: u64,
+        language: &str,
+        source: &str,
+        line: usize,
+    ) -> bool {
+        if source.len() > MAX_BYTES {
+            return false;
+        }
+
+        let mut start = 0;
+        let Some(target) = source.split('\n').enumerate().find_map(|(index, text)| {
+            if index == line {
+                Some(text)
+            } else {
+                start += text.len() + 1;
+                None
+            }
+        }) else {
+            return false;
+        };
+        let first = start + target.len() - target.trim_start().len();
+
+        self.events(id, revision, language, source, start + target.len())
+            .ok()
+            .flatten()
+            .is_some_and(|events| {
+                events.iter().any(|event| {
+                    event.kind == Kind::Ignore
+                        && event.bytes.start < first
+                        && first < event.bytes.end
+                })
+            })
+    }
+
     fn try_indent(&mut self, request: IndentRequest<'_>) -> anyhow::Result<IndentDecision> {
         let IndentRequest {
             id,

--- a/tests/editing.rs
+++ b/tests/editing.rs
@@ -6708,6 +6708,347 @@ async fn bracketed_paste_inserts_multiline_text_once() {
 }
 
 #[tokio::test]
+async fn rust_linewise_paste_reindents_multiline_clipboard_without_range_formatting() {
+    let original = concat!(
+        "impl Recap {\n",
+        "    fn note_focus_gained(&mut self) {\n",
+        "        if let Some(task) = self.scheduled_check.take() {\n",
+        "            task.abort();\n",
+        "        }\n",
+        "\n",
+        "        self.retry_revision = None;\n",
+        "        self.in_flight_request_id = None;\n",
+        "    }\n",
+        "}\n",
+    );
+    let clipboard = concat!(
+        "self.retry_revision = None;\n",
+        "if self.in_flight_trigger == Some(RecapTrigger::Automatic) {\n",
+        "    self.clear_in_flight_request();\n",
+        "}\n",
+    );
+    let mut harness = comment_harness("main.rs", original);
+    harness
+        .editor
+        .test_set_default_register(Content::linewise(clipboard.to_string()));
+    harness
+        .execute_action(Action::SetCursor(8, 6))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::PasteBefore).await.unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "impl Recap {\n",
+        "    fn note_focus_gained(&mut self) {\n",
+        "        if let Some(task) = self.scheduled_check.take() {\n",
+        "            task.abort();\n",
+        "        }\n",
+        "\n",
+        "        self.retry_revision = None;\n",
+        "        if self.in_flight_trigger == Some(RecapTrigger::Automatic) {\n",
+        "            self.clear_in_flight_request();\n",
+        "        }\n",
+        "        self.retry_revision = None;\n",
+        "        self.in_flight_request_id = None;\n",
+        "    }\n",
+        "}\n",
+    ));
+    harness.assert_cursor_at(8, 6);
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents(original);
+}
+
+#[tokio::test]
+async fn rust_bracketed_paste_dedents_a_whole_file_with_a_leading_doc_comment() {
+    let clipboard = concat!(
+        "    //! Manual recap progress presentation for `ChatWidget`.\n",
+        "\n",
+        "    use super::*;\n",
+        "\n",
+        "    impl ChatWidget {\n",
+        "        pub(crate) fn show_recap_loading(&mut self) {\n",
+        "            self.flush_active_cell();\n",
+        "            self.request_redraw();\n",
+        "        }\n",
+        "    }\n",
+    );
+    let mut harness = comment_harness("recap.rs", "");
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+
+    harness
+        .execute_event(Event::Paste(clipboard.to_string()))
+        .await
+        .unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "//! Manual recap progress presentation for `ChatWidget`.\n",
+        "\n",
+        "use super::*;\n",
+        "\n",
+        "impl ChatWidget {\n",
+        "    pub(crate) fn show_recap_loading(&mut self) {\n",
+        "        self.flush_active_cell();\n",
+        "        self.request_redraw();\n",
+        "    }\n",
+        "}\n",
+    ));
+
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents("");
+}
+
+#[tokio::test]
+async fn rust_whole_file_paste_dedents_code_without_changing_raw_string_contents() {
+    let clipboard = concat!(
+        "    //! A module containing an intentionally indented raw string.\n",
+        "    const MESSAGE: &str = r#\"first\n",
+        "    literal indentation\n",
+        "    \"#;\n",
+    );
+    let mut harness = comment_harness("recap.rs", "");
+    harness
+        .editor
+        .test_set_default_register(Content::linewise(clipboard.to_string()));
+
+    harness.execute_action(Action::PasteBefore).await.unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "//! A module containing an intentionally indented raw string.\n",
+        "const MESSAGE: &str = r#\"first\n",
+        "    literal indentation\n",
+        "    \"#;\n",
+    ));
+}
+
+#[tokio::test]
+async fn rust_bracketed_paste_reindents_following_lines_without_range_formatting() {
+    let original = concat!(
+        "impl Recap {\n",
+        "    fn note_focus_gained(&mut self) {\n",
+        "        \n",
+        "        self.in_flight_request_id = None;\n",
+        "    }\n",
+        "}\n",
+    );
+    let clipboard = concat!(
+        "self.retry_revision = None;\n",
+        "if self.in_flight_trigger == Some(RecapTrigger::Automatic) {\n",
+        "    self.clear_in_flight_request();\n",
+        "}",
+    );
+    let mut harness = comment_harness("main.rs", original);
+    harness
+        .execute_action(Action::EnterMode(Mode::Insert))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::SetCursor(8, 2))
+        .await
+        .unwrap();
+
+    harness
+        .execute_event(Event::Paste(clipboard.to_string()))
+        .await
+        .unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "impl Recap {\n",
+        "    fn note_focus_gained(&mut self) {\n",
+        "        self.retry_revision = None;\n",
+        "        if self.in_flight_trigger == Some(RecapTrigger::Automatic) {\n",
+        "            self.clear_in_flight_request();\n",
+        "        }\n",
+        "        self.in_flight_request_id = None;\n",
+        "    }\n",
+        "}\n",
+    ));
+    harness.assert_cursor_at(9, 5);
+
+    harness
+        .execute_action(Action::EnterMode(Mode::Normal))
+        .await
+        .unwrap();
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents(original);
+}
+
+#[tokio::test]
+async fn rust_system_clipboard_paste_reindents_multiline_code() {
+    let original = "fn update() {\n    existing();\n}\n";
+    let clipboard = "if ready() {\n    update();\n}\n";
+    let mut harness = comment_harness("main.rs", original);
+    harness
+        .editor
+        .test_set_clipboard(Box::new(MemoryClipboardProvider::with_text(clipboard)));
+    harness
+        .execute_action(Action::SetCursor(0, 1))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::PasteBefore).await.unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "fn update() {\n",
+        "    if ready() {\n",
+        "        update();\n",
+        "    }\n",
+        "    existing();\n",
+        "}\n",
+    ));
+    harness.assert_cursor_at(4, 1);
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents(original);
+}
+
+#[tokio::test]
+async fn rust_visual_line_paste_reindents_multiline_code() {
+    let original = "fn update() {\n    replace();\n    existing();\n}\n";
+    let clipboard = "if ready() {\n    update();\n}";
+    let mut harness = comment_harness("main.rs", original);
+    harness
+        .editor
+        .test_set_clipboard(Box::new(MemoryClipboardProvider::with_text(clipboard)));
+    harness
+        .execute_action(Action::SetCursor(0, 1))
+        .await
+        .unwrap();
+    harness
+        .execute_action(Action::EnterMode(Mode::VisualLine))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::Paste).await.unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "fn update() {\n",
+        "    if ready() {\n",
+        "        update();\n",
+        "    }\n",
+        "    existing();\n",
+        "}\n",
+    ));
+    harness.assert_cursor_at(4, 1);
+
+    harness.execute_action(Action::Undo).await.unwrap();
+    harness.assert_buffer_contents(original);
+}
+
+#[tokio::test]
+async fn rust_paste_rebases_existing_clipboard_indentation() {
+    let original = "impl Recap {\n    fn update(&mut self) {\n        existing();\n    }\n}\n";
+    let clipboard = "    if ready() {\n        update();\n    }\n";
+    let mut harness = comment_harness("main.rs", original);
+    harness
+        .editor
+        .test_set_default_register(Content::linewise(clipboard.to_string()));
+    harness
+        .execute_action(Action::SetCursor(0, 2))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::PasteBefore).await.unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "impl Recap {\n",
+        "    fn update(&mut self) {\n",
+        "        if ready() {\n",
+        "            update();\n",
+        "        }\n",
+        "        existing();\n",
+        "    }\n",
+        "}\n",
+    ));
+}
+
+#[tokio::test]
+async fn rust_paste_preserves_multiline_raw_string_contents() {
+    let original = "fn update() {\n    existing();\n}\n";
+    let clipboard = "let message = r#\"first\nraw text\n\"#;\n";
+    let mut harness = comment_harness("main.rs", original);
+    harness
+        .editor
+        .test_set_default_register(Content::linewise(clipboard.to_string()));
+    harness
+        .execute_action(Action::SetCursor(0, 1))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::PasteBefore).await.unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "fn update() {\n",
+        "    let message = r#\"first\n",
+        "raw text\n",
+        "\"#;\n",
+        "    existing();\n",
+        "}\n",
+    ));
+}
+
+#[tokio::test]
+async fn rust_paste_preserves_raw_indentation_when_format_on_paste_is_disabled() {
+    let mut config = default_key_config();
+    config.formatting.on_paste = false;
+    let buffer = Buffer::new(
+        Some("main.rs".to_string()),
+        "fn update() {\n    existing();\n}\n".to_string(),
+    );
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness.editor.test_set_default_register(Content::linewise(
+        "if ready() {\n    update();\n}\n".to_string(),
+    ));
+    harness
+        .execute_action(Action::SetCursor(0, 1))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::PasteBefore).await.unwrap();
+
+    harness.assert_buffer_contents(
+        "fn update() {\nif ready() {\n    update();\n}\n    existing();\n}\n",
+    );
+}
+
+#[tokio::test]
+async fn rust_paste_reindents_when_lsp_is_disabled() {
+    let mut config = default_key_config();
+    config.lsp.enabled = false;
+    let buffer = Buffer::new(
+        Some("main.rs".to_string()),
+        "fn update() {\n    existing();\n}\n".to_string(),
+    );
+    let mut harness = EditorHarness::with_config(buffer, config);
+    harness.editor.test_set_default_register(Content::linewise(
+        "if ready() {\n    update();\n}\n".to_string(),
+    ));
+    harness
+        .execute_action(Action::SetCursor(0, 1))
+        .await
+        .unwrap();
+
+    harness.execute_action(Action::PasteBefore).await.unwrap();
+
+    harness.assert_buffer_contents(concat!(
+        "fn update() {\n",
+        "    if ready() {\n",
+        "        update();\n",
+        "    }\n",
+        "    existing();\n",
+        "}\n",
+    ));
+}
+
+#[tokio::test]
 async fn bracketed_paste_reveals_a_distant_endpoint_without_pin_to_top() {
     let content = (0..80)
         .map(|line| format!("line-{line:02}"))


### PR DESCRIPTION
## Why

#334 enabled format-on-paste by default, but its implementation relied entirely on LSP range formatting. rust-analyzer supports whole-document formatting but explicitly does not support range formatting, so pasted Rust snippets kept their original indentation instead of aligning with their destination. Whole-file pastes beginning with a module documentation comment could also remain uniformly indented.

## What changed

- Reindent register, system-clipboard, bracketed-terminal, and visual-line pastes with Red's existing Tree-sitter indentation engine, inside the original paste undo transaction.
- Align pasted snippets to their surrounding block, remove shared indentation from whole-file pastes, and preserve relative nesting, configured tabs/spaces, cursor position, and multiline raw-string contents.
- Keep LSP range formatting when available, honor `formatting.on_paste = false`, work when LSP is disabled, and bound local processing for large pastes.
- Update the formatting configuration documentation and add focused coverage for nested snippets, leading `//!` comments, whole files, protected string contents, undo, and disabled formatting/LSP.

## How to Test

1. Open a Rust method with an indented body and paste:

   ```rust
   self.retry_revision = None;
   if self.in_flight_trigger == Some(RecapTrigger::Automatic) {
       self.clear_in_flight_request();
   }
   ```

   Expect the first two lines and closing brace to align with the method body, the inner call to indent one additional level, and a single undo to remove the entire paste.

2. Paste a uniformly indented Rust module beginning with `//!` into an empty `.rs` file. Expect the module comment, `use` statements, and `impl` block to start at column zero while nested methods retain their relative indentation.

3. Paste a multiline raw string and verify its contents remain unchanged. Repeat with `[formatting] on_paste = false` and verify the pasted whitespace remains untouched.

4. Run `cargo test --test editing rust_`, `cargo test --lib paste`, and `cargo test --lib syntax_indent`. The complete editing suite also passes 413 tests with `--skip dot_repeats_linewise_paste_and_visual_block_insert`; that existing 2 MiB stack-overflow test fails unchanged on `main`. Strict all-target/all-feature Clippy passes.
