### PR TITLE
ci: reduce repeated validation spend

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,48 @@
+{
+  "name": "Protect main with CI Gate",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/main"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "CI Gate"
+          }
+        ],
+        "strict_required_status_checks_policy": true
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,12 +128,10 @@ jobs:
           python3 scripts/test_keyboard_protocol.py
 
   clippy:
-    name: Clippy (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
+    name: Clippy
+    needs: plan
+    if: github.event_name != 'push' && needs.plan.outputs.mode != 'docs'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,19 @@ on:
   pull_request:
     branches: [main, develop]
   workflow_dispatch:
+    inputs:
+      validation_scope:
+        description: Paid test coverage to run
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+          - smoke
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -21,6 +30,35 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  plan:
+    name: Plan validation
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      mode: ${{ steps.plan.outputs.mode }}
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect pull request paths
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/changed-paths.txt"
+
+      - name: Select paid test coverage
+        id: plan
+        env:
+          MANUAL_SCOPE: ${{ inputs.validation_scope || 'full' }}
+        run: >-
+          python3 scripts/ci_matrix.py
+          --event "$GITHUB_EVENT_NAME"
+          --changed-paths "$RUNNER_TEMP/changed-paths.txt"
+          --manual-scope "$MANUAL_SCOPE"
+
   workflow-lint:
     name: Workflow lint
     runs-on: ubuntu-latest
@@ -36,33 +74,30 @@ jobs:
       - name: Verify README release version
         run: python3 scripts/readme_release.py --check
 
+      - name: Validate main branch ruleset recipe
+        run: python3 -m json.tool .github/rulesets/main.json > /dev/null
+
       - name: Test Discord release announcements
         run: python3 -m unittest tests.test_discord_release
 
       - name: Test validation helpers
-        run: python3 -m unittest tests.test_doctest_packages tests.test_test_performance
+        run: python3 -m unittest tests.test_ci_policy tests.test_doctest_packages tests.test_test_performance
 
   test:
-    name: Test Suite (${{ matrix.platform.standard }}, ${{ matrix.rust }})
+    name: Test Suite (${{ matrix.name }}, stable)
+    needs: plan
+    if: needs.plan.outputs.mode != 'docs'
     runs-on: >-
       ${{
         (
           github.event_name != 'pull_request' ||
           github.event.pull_request.head.repo.full_name == github.repository
-        ) && matrix.platform.warp || matrix.platform.standard
+        ) && matrix.warp || matrix.standard
       }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        platform:
-          - standard: ubuntu-latest
-            warp: warp-ubuntu-latest-x64-32x
-          - standard: macos-latest
-            warp: warp-macos-latest-arm64-12x
-          - standard: windows-latest
-            warp: warp-windows-latest-x64-32x
-        rust: [stable]
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -70,7 +105,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
 
       - name: Install ripgrep
         uses: ./.github/actions/install-ripgrep
@@ -290,3 +325,31 @@ jobs:
         run: |
           python3 scripts/check_markdown_links.py --self-test
           python3 scripts/check_markdown_links.py
+
+  gate:
+    name: CI Gate
+    if: always()
+    needs:
+      - plan
+      - workflow-lint
+      - test
+      - clippy
+      - fmt
+      - self-check
+      - changelog
+      - build
+      - docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Require the planned terminal results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          VALIDATION_MODE: ${{ needs.plan.outputs.mode }}
+        run: >-
+          python3 scripts/ci_gate.py
+          --event "$GITHUB_EVENT_NAME"
+          --mode "$VALIDATION_MODE"
+          --needs-json "$NEEDS_JSON"

--- a/.github/workflows/runner-sizing.yml
+++ b/.github/workflows/runner-sizing.yml
@@ -1,0 +1,90 @@
+name: Runner Sizing
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Baseline and candidate runner pair to compare
+        required: true
+        default: ubuntu
+        type: choice
+        options:
+          - ubuntu
+          - macos
+          - windows
+      confirm_paid_benchmark:
+        description: Run six paid jobs (two sizes with three replicas each)
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: runner-sizing-${{ inputs.platform }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  RUST_BACKTRACE: 1
+
+jobs:
+  benchmark:
+    name: ${{ matrix.runner }} replica ${{ matrix.replica }}
+    if: inputs.confirm_paid_benchmark
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: >-
+          ${{ fromJSON(
+            inputs.platform == 'ubuntu' && '["warp-ubuntu-latest-x64-32x","warp-ubuntu-latest-x64-8x"]' ||
+            inputs.platform == 'macos' && '["warp-macos-latest-arm64-12x","warp-macos-latest-arm64-6x"]' ||
+            '["warp-windows-latest-x64-32x","warp-windows-latest-x64-16x"]'
+          ) }}
+        replica: [1, 2, 3]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Install ripgrep
+        uses: ./.github/actions/install-ripgrep
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: validation-${{ runner.os }}
+          save-if: false
+
+      - name: Run tests
+        run: cargo test --all-targets --all-features --verbose
+
+      - name: Test platform keyboard decoder
+        run: cargo test --locked --manifest-path vendor/crossterm/Cargo.toml --lib red_
+
+      - name: Test terminal keyboard protocol
+        if: runner.os != 'Windows'
+        run: |
+          cargo build --locked --bin red
+          python3 scripts/test_keyboard_protocol.py
+
+      - name: Record comparison metadata
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Runner sizing sample"
+            echo "- Platform: ${{ inputs.platform }}"
+            echo "- Runner: ${{ matrix.runner }}"
+            echo "- Replica: ${{ matrix.replica }}"
+            echo "- Commit: $GITHUB_SHA"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/CI_COST_CONTROLS.md
+++ b/docs/CI_COST_CONTROLS.md
@@ -1,0 +1,58 @@
+# CI Cost Controls
+
+Red keeps cross-platform pull request coverage while avoiding a second paid
+three-platform test matrix after every merge.
+
+## Validation modes
+
+- Pull requests run Ubuntu, macOS, and Windows tests. Documentation-only pull
+  requests skip the paid test matrix.
+- Pushes to `main` or `develop` run one Ubuntu smoke suite.
+- Manual CI runs can select either the full matrix or the smoke suite.
+- Newer runs cancel older work in the same workflow and branch or pull request.
+- `CI Gate` is the stable terminal check for branch rules. It fails unless all
+  jobs required by the selected mode reach their expected conclusions.
+
+The normal Ubuntu test runner is `warp-ubuntu-latest-x64-8x`. macOS remains on
+12x and Windows remains on 32x until paired benchmarks demonstrate that their
+smaller candidates reduce billed cost without hurting reliability.
+
+## Runner sizing benchmark
+
+Run **Runner Sizing** manually and explicitly confirm the paid benchmark. It
+launches three clean replicas on each runner in the selected pair:
+
+- Ubuntu: 32x versus 8x
+- macOS: 12x versus 6x
+- Windows: 32x versus 16x
+
+Compare billed cost, p90 duration, CPU, memory, and failures in WarpBuild
+Reports. Keep the smaller runner only when its cost per successful run falls.
+Windows must also show safe memory headroom; the initial 32x sample was already
+near its reported memory ceiling.
+
+## Main branch ruleset
+
+After a pull request containing `CI Gate` has run successfully, import
+`.github/rulesets/main.json` at **Settings -> Rules -> Rulesets -> New ruleset
+-> Import a ruleset**. Review it before creation. The ruleset:
+
+- requires changes to reach `main` through a pull request;
+- requires the `CI Gate` check;
+- requires the checked commit to include the latest `main`;
+- blocks deletion and force pushes.
+
+Do not activate the ruleset before `CI Gate` exists on the default branch, or
+future pull requests will wait for a check that GitHub has not seen yet.
+
+## WarpBuild budget
+
+In WarpBuild billing settings, set alerts at 50%, 75%, and 90% of the agreed
+monthly budget. The initial target is $250 per month. Enable a $250 hard limit
+only after confirming who can raise it and how WarpBuild handles jobs that are
+already running when the limit is reached.
+
+Review the first seven days after rollout using cost per merged pull request,
+job count, billed minutes, p90 duration, cancellations, and platform-only
+failures. Roll back an individual runner change when reliability falls or cost
+per successful run rises.

--- a/docs/CI_COST_CONTROLS.md
+++ b/docs/CI_COST_CONTROLS.md
@@ -9,6 +9,8 @@ three-platform test matrix after every merge.
   requests skip the paid test matrix.
 - Pushes to `main` or `develop` run one Ubuntu smoke suite.
 - Manual CI runs can select either the full matrix or the smoke suite.
+- Clippy runs once on Ubuntu for code pull requests and manual runs. It is
+  skipped for documentation-only pull requests and post-merge pushes.
 - Newer runs cancel older work in the same workflow and branch or pull request.
 - `CI Gate` is the stable terminal check for branch rules. It fails unless all
   jobs required by the selected mode reach their expected conclusions.

--- a/scripts/ci_gate.py
+++ b/scripts/ci_gate.py
@@ -20,6 +20,9 @@ ALWAYS_REQUIRED = (
 
 def gate_errors(*, event: str, mode: str, needs: dict[str, dict[str, object]]) -> list[str]:
     expected = {job: "success" for job in ALWAYS_REQUIRED}
+    expected["clippy"] = (
+        "skipped" if event == "push" or mode == "docs" else "success"
+    )
     expected["test"] = "skipped" if mode == "docs" else "success"
     expected["build"] = "skipped" if event == "pull_request" else "success"
 

--- a/scripts/ci_gate.py
+++ b/scripts/ci_gate.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Validate the terminal results behind Red's stable CI Gate check."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+ALWAYS_REQUIRED = (
+    "plan",
+    "workflow-lint",
+    "clippy",
+    "fmt",
+    "self-check",
+    "changelog",
+    "docs",
+)
+
+
+def gate_errors(*, event: str, mode: str, needs: dict[str, dict[str, object]]) -> list[str]:
+    expected = {job: "success" for job in ALWAYS_REQUIRED}
+    expected["test"] = "skipped" if mode == "docs" else "success"
+    expected["build"] = "skipped" if event == "pull_request" else "success"
+
+    errors = []
+    for job, expected_result in expected.items():
+        actual = needs.get(job, {}).get("result", "missing")
+        if actual != expected_result:
+            errors.append(f"{job}: expected {expected_result}, got {actual}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--mode", choices=("docs", "full", "smoke"), required=True)
+    parser.add_argument("--needs-json", required=True)
+    args = parser.parse_args()
+
+    errors = gate_errors(
+        event=args.event,
+        mode=args.mode,
+        needs=json.loads(args.needs_json),
+    )
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+    print(f"CI gate passed for {args.event}/{args.mode}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_matrix.py
+++ b/scripts/ci_matrix.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Select the paid test matrix for a GitHub Actions CI event."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+UBUNTU = {
+    "name": "ubuntu-latest",
+    "standard": "ubuntu-latest",
+    "warp": "warp-ubuntu-latest-x64-8x",
+}
+MACOS = {
+    "name": "macos-latest",
+    "standard": "macos-latest",
+    "warp": "warp-macos-latest-arm64-12x",
+}
+WINDOWS = {
+    "name": "windows-latest",
+    "standard": "windows-latest",
+    "warp": "warp-windows-latest-x64-32x",
+}
+
+
+def is_documentation_path(path: str) -> bool:
+    normalized = path.strip().lstrip("./")
+    return bool(normalized) and (
+        normalized.endswith(".md")
+        or normalized == "LICENSE"
+        or normalized.startswith("almanac/")
+        or normalized.startswith("docs/")
+    )
+
+
+def select_mode(event: str, changed_paths: list[str], manual_scope: str) -> str:
+    if event == "workflow_dispatch":
+        return manual_scope
+    if event == "pull_request":
+        if changed_paths and all(is_documentation_path(path) for path in changed_paths):
+            return "docs"
+        return "full"
+    if event == "push":
+        return "smoke"
+    raise ValueError(f"unsupported event: {event}")
+
+
+def matrix_for(mode: str) -> dict[str, list[dict[str, str]]]:
+    if mode == "full":
+        return {"include": [UBUNTU, MACOS, WINDOWS]}
+    if mode == "smoke":
+        return {"include": [UBUNTU]}
+    if mode == "docs":
+        # The test job is skipped for this mode, but a valid matrix keeps the
+        # workflow expression well-formed before the job-level condition runs.
+        return {"include": [UBUNTU]}
+    raise ValueError(f"unsupported validation mode: {mode}")
+
+
+def write_outputs(path: Path, *, mode: str, matrix: dict[str, object]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"mode={mode}\n")
+        output.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--changed-paths", type=Path)
+    parser.add_argument("--manual-scope", choices=("full", "smoke"), default="full")
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        default=Path(os.environ["GITHUB_OUTPUT"]) if "GITHUB_OUTPUT" in os.environ else None,
+    )
+    args = parser.parse_args()
+
+    changed_paths = []
+    if args.changed_paths is not None and args.changed_paths.exists():
+        changed_paths = args.changed_paths.read_text(encoding="utf-8").splitlines()
+
+    mode = select_mode(args.event, changed_paths, args.manual_scope)
+    matrix = matrix_for(mode)
+    if args.github_output is not None:
+        write_outputs(args.github_output, mode=mode, matrix=matrix)
+    else:
+        print(json.dumps({"mode": mode, "matrix": matrix}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -54,8 +54,11 @@ class CiMatrixTest(unittest.TestCase):
 
 class CiGateTest(unittest.TestCase):
     @staticmethod
-    def successful_needs(*, test: str, build: str) -> dict[str, dict[str, str]]:
+    def successful_needs(
+        *, clippy: str = "success", test: str, build: str
+    ) -> dict[str, dict[str, str]]:
         needs = {job: {"result": "success"} for job in ALWAYS_REQUIRED}
+        needs["clippy"] = {"result": clippy}
         needs["test"] = {"result": test}
         needs["build"] = {"result": build}
         return needs
@@ -75,15 +78,29 @@ class CiGateTest(unittest.TestCase):
             gate_errors(
                 event="pull_request",
                 mode="docs",
-                needs=self.successful_needs(test="skipped", build="skipped"),
+                needs=self.successful_needs(
+                    clippy="skipped", test="skipped", build="skipped"
+                ),
             ),
             [],
         )
 
-    def test_push_gate_requires_smoke_tests_and_builds(self) -> None:
+    def test_push_gate_accepts_skipped_clippy_and_requires_tests_and_builds(self) -> None:
         self.assertEqual(
             gate_errors(
                 event="push",
+                mode="smoke",
+                needs=self.successful_needs(
+                    clippy="skipped", test="success", build="success"
+                ),
+            ),
+            [],
+        )
+
+    def test_manual_gate_requires_one_clippy_job(self) -> None:
+        self.assertEqual(
+            gate_errors(
+                event="workflow_dispatch",
                 mode="smoke",
                 needs=self.successful_needs(test="success", build="success"),
             ),
@@ -91,7 +108,9 @@ class CiGateTest(unittest.TestCase):
         )
 
     def test_gate_reports_every_failed_or_missing_job(self) -> None:
-        needs = self.successful_needs(test="failure", build="success")
+        needs = self.successful_needs(
+            clippy="skipped", test="failure", build="success"
+        )
         needs["docs"] = {"result": "cancelled"}
         del needs["fmt"]
 

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -1,0 +1,129 @@
+import json
+import unittest
+from pathlib import Path
+
+from scripts.ci_gate import ALWAYS_REQUIRED, gate_errors
+from scripts.ci_matrix import matrix_for, select_mode
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+class CiMatrixTest(unittest.TestCase):
+    def test_internal_pull_requests_keep_the_cross_platform_matrix(self) -> None:
+        self.assertEqual(select_mode("pull_request", ["src/main.rs"], "full"), "full")
+        self.assertEqual(
+            [entry["name"] for entry in matrix_for("full")["include"]],
+            ["ubuntu-latest", "macos-latest", "windows-latest"],
+        )
+
+    def test_documentation_only_pull_requests_skip_paid_tests(self) -> None:
+        self.assertEqual(
+            select_mode(
+                "pull_request",
+                ["README.md", "almanac/reference/validation/ci-and-validation.md"],
+                "full",
+            ),
+            "docs",
+        )
+
+    def test_empty_or_mixed_pull_request_diff_fails_safe(self) -> None:
+        self.assertEqual(select_mode("pull_request", [], "full"), "full")
+        self.assertEqual(
+            select_mode("pull_request", ["docs/ci.md", ".github/workflows/ci.yml"], "full"),
+            "full",
+        )
+
+    def test_pushes_use_one_linux_smoke_runner(self) -> None:
+        self.assertEqual(select_mode("push", [], "full"), "smoke")
+        self.assertEqual(
+            matrix_for("smoke")["include"],
+            [
+                {
+                    "name": "ubuntu-latest",
+                    "standard": "ubuntu-latest",
+                    "warp": "warp-ubuntu-latest-x64-8x",
+                }
+            ],
+        )
+
+    def test_manual_dispatch_honors_the_requested_scope(self) -> None:
+        self.assertEqual(select_mode("workflow_dispatch", [], "full"), "full")
+        self.assertEqual(select_mode("workflow_dispatch", [], "smoke"), "smoke")
+
+
+class CiGateTest(unittest.TestCase):
+    @staticmethod
+    def successful_needs(*, test: str, build: str) -> dict[str, dict[str, str]]:
+        needs = {job: {"result": "success"} for job in ALWAYS_REQUIRED}
+        needs["test"] = {"result": test}
+        needs["build"] = {"result": build}
+        return needs
+
+    def test_pull_request_gate_accepts_successful_matrix_and_skipped_build(self) -> None:
+        self.assertEqual(
+            gate_errors(
+                event="pull_request",
+                mode="full",
+                needs=self.successful_needs(test="success", build="skipped"),
+            ),
+            [],
+        )
+
+    def test_documentation_gate_requires_the_test_job_to_be_skipped(self) -> None:
+        self.assertEqual(
+            gate_errors(
+                event="pull_request",
+                mode="docs",
+                needs=self.successful_needs(test="skipped", build="skipped"),
+            ),
+            [],
+        )
+
+    def test_push_gate_requires_smoke_tests_and_builds(self) -> None:
+        self.assertEqual(
+            gate_errors(
+                event="push",
+                mode="smoke",
+                needs=self.successful_needs(test="success", build="success"),
+            ),
+            [],
+        )
+
+    def test_gate_reports_every_failed_or_missing_job(self) -> None:
+        needs = self.successful_needs(test="failure", build="success")
+        needs["docs"] = {"result": "cancelled"}
+        del needs["fmt"]
+
+        self.assertEqual(
+            gate_errors(event="push", mode="smoke", needs=needs),
+            [
+                "fmt: expected success, got missing",
+                "docs: expected success, got cancelled",
+                "test: expected success, got failure",
+            ],
+        )
+
+    def test_main_ruleset_requires_the_workflow_gate_name(self) -> None:
+        ruleset = json.loads(
+            (REPOSITORY_ROOT / ".github/rulesets/main.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        status_rule = next(
+            rule for rule in ruleset["rules"] if rule["type"] == "required_status_checks"
+        )
+        contexts = {
+            check["context"]
+            for check in status_rule["parameters"]["required_status_checks"]
+        }
+        workflow = (REPOSITORY_ROOT / ".github/workflows/ci.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertEqual(contexts, {"CI Gate"})
+        self.assertIn("    name: CI Gate\n", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Repeated pushes and merge events currently rerun the full paid WarpBuild matrix, including work already validated on the pull request. This change keeps cross-platform PR coverage while making post-merge validation substantially cheaper and cancelling superseded work.

The workflow now selects paid coverage by event: code PRs retain Ubuntu, macOS, and Windows; documentation-only PRs skip paid tests; pushes use one Ubuntu 8x smoke runner; and manual runs can request either scope. A stable `CI Gate` validates the expected success or skip result for every terminal job. Clippy is reduced to one Ubuntu job on code PRs and manual runs, with post-merge and docs-only Clippy skipped.

The PR also adds a confirmation-gated runner-sizing benchmark, an importable `main` ruleset recipe, policy regression tests, and a rollout runbook covering WarpBuild budgets and monitoring.

## How to Test

1. Inspect `Plan validation` on this PR and confirm it selects `full`; verify one Ubuntu 8x, one macOS 12x, and one Windows 32x test job run and `CI Gate` passes.
2. Run `python3 -m unittest tests.test_ci_policy tests.test_doctest_packages tests.test_test_performance`; expect all policy and helper tests to pass, including docs-only and post-merge skip behavior.
3. Run actionlint against `.github/workflows/ci.yml` and `.github/workflows/runner-sizing.yml`; expect both workflows to validate.
4. For the regression path, change a simulated required result in a `gate_errors` test from its expected success or skip value and confirm the aggregate gate test fails.