### PR TITLE
ci: use smaller macOS test runners

### DIFF
--- a/docs/CI_COST_CONTROLS.md
+++ b/docs/CI_COST_CONTROLS.md
@@ -15,9 +15,10 @@ three-platform test matrix after every merge.
 - `CI Gate` is the stable terminal check for branch rules. It fails unless all
   jobs required by the selected mode reach their expected conclusions.
 
-The normal Ubuntu test runner is `warp-ubuntu-latest-x64-8x`. macOS remains on
-12x and Windows remains on 32x until paired benchmarks demonstrate that their
-smaller candidates reduce billed cost without hurting reliability.
+The normal test runners are `warp-ubuntu-latest-x64-8x` and
+`warp-macos-latest-arm64-6x`. Windows remains on 32x until a paired benchmark
+demonstrates that its smaller candidate reduces billed cost without hurting
+reliability or memory headroom.
 
 ## Runner sizing benchmark
 
@@ -32,6 +33,15 @@ Compare billed cost, p90 duration, CPU, memory, and failures in WarpBuild
 Reports. Keep the smaller runner only when its cost per successful run falls.
 Windows must also show safe memory headroom; the initial 32x sample was already
 near its reported memory ceiling.
+
+The August 24, 2026 macOS benchmark completed all three replicas on both runner
+sizes. The 12x replicas took 1:26-1:37 and cost $0.96 in total; the 6x replicas
+took 1:45-3:04 and cost $0.64 in total. The slow 6x replica spent 78 seconds
+restoring the cache rather than running tests, while the other two replicas
+finished in 1:45 with roughly 53% memory use. Based on that result, normal
+macOS validation uses 6x. Re-run the paired benchmark and revert to 12x if the
+rolling p90 reaches four billed minutes, platform-only failures increase, or
+cost per successful macOS job is no longer below the 12x baseline.
 
 ## Main branch ruleset
 

--- a/scripts/ci_matrix.py
+++ b/scripts/ci_matrix.py
@@ -17,7 +17,7 @@ UBUNTU = {
 MACOS = {
     "name": "macos-latest",
     "standard": "macos-latest",
-    "warp": "warp-macos-latest-arm64-12x",
+    "warp": "warp-macos-latest-arm64-6x",
 }
 WINDOWS = {
     "name": "windows-latest",

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -12,9 +12,16 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 class CiMatrixTest(unittest.TestCase):
     def test_internal_pull_requests_keep_the_cross_platform_matrix(self) -> None:
         self.assertEqual(select_mode("pull_request", ["src/main.rs"], "full"), "full")
+        matrix = matrix_for("full")["include"]
         self.assertEqual(
-            [entry["name"] for entry in matrix_for("full")["include"]],
+            [entry["name"] for entry in matrix],
             ["ubuntu-latest", "macos-latest", "windows-latest"],
+        )
+        self.assertEqual(
+            next(entry for entry in matrix if entry["name"] == "macos-latest")[
+                "warp"
+            ],
+            "warp-macos-latest-arm64-6x",
         )
 
     def test_documentation_only_pull_requests_skip_paid_tests(self) -> None:


### PR DESCRIPTION
The paired macOS runner benchmark showed that 6x runners lowered aggregate cost from $0.96 to $0.64 across three successful replicas while retaining adequate memory headroom. This applies that measured saving to normal pull request validation without changing the platforms or test scope.

## What Changed

- Use `warp-macos-latest-arm64-6x` for the macOS entry in the paid test matrix.
- Pin the selected macOS runner in the CI policy tests.
- Record the benchmark evidence and explicit rollback criteria in the CI cost-control runbook.

Benchmark: https://github.com/codersauce/red/actions/runs/32793496270

## How to Test

1. Run `python3 -m unittest tests.test_ci_policy tests.test_doctest_packages tests.test_test_performance`; all policy and performance tests should pass.
2. Open or synchronize this pull request; the macOS matrix job should run on `warp-macos-latest-arm64-6x`, while Ubuntu and Windows retain their existing runner sizes.
3. Run a documentation-only pull request through the selector; paid tests should remain skipped, confirming the runner assertion does not alter mode selection.

Also validated with Actionlint, Python bytecode compilation, Markdown link checks, `cargo fmt --all -- --check`, and `git diff --check`.
