### PR TITLE
feat(release): curate cross-channel release campaigns

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,17 +1,24 @@
 ## Why
 
-Prepare Red {{VERSION}} with a reviewed version bump and a changelog generated from Git history.
+Prepare Red {{VERSION}} with a reviewed version bump, an evidence-backed release
+campaign, and a changelog generated from Git history.
 
 ## What changed
 
 - Updated the package, lockfile, and README release versions.
 - Prepended the generated release section to `CHANGELOG.md`.
+- Resolved the reviewed release campaign to the exact release version.
 
 ## How to test
 
-1. Confirm the package and README versions are `{{VERSION}}` and match the
-   requested release tag.
+1. Confirm the package, README, and release campaign versions are `{{VERSION}}`.
 2. Review every generated changelog group and entry.
-3. Confirm CI, including Clippy and the packaged runtime self-check, passes.
+3. Confirm the flagship stories distinguish new capabilities from existing improvements.
+4. Verify shortcuts, supported platforms, prerequisites, safety claims, and linked PRs.
+5. Preview the GitHub, Discord, X, and Bluesky campaign copy; social previews are not posted.
+6. Promote or remove upcoming-release wording in the README and website copy.
+7. Check demo media and coordinate the separate website release update.
+8. Confirm CI, including Clippy and the packaged runtime self-check, passes.
 
-Merging this PR does not publish the release. After merge, create and push the annotated `v{{VERSION}}` tag to start the release workflow.
+Merging this PR does not publish the release. After merge, create and push the
+annotated `v{{VERSION}}` tag to start the release workflow.

--- a/.github/workflows/announce-discord.yml
+++ b/.github/workflows/announce-discord.yml
@@ -53,12 +53,41 @@ jobs:
           if [[ "$MENTION_EVERYONE" == "true" ]]; then
             mention_args+=(--mention-everyone)
           fi
+          campaign_args=()
+          if python3 scripts/release_campaign.py validate --version "${TAG_NAME#v}"; then
+            campaign_args+=(--campaign release/campaign.toml)
+          else
+            echo "No matching reviewed campaign; using changelog-only announcement."
+          fi
           python3 scripts/discord_release.py \
             --release-json "$RUNNER_TEMP/release.json" \
             --output "$RUNNER_TEMP/discord-release.json" \
             --summary "$RUNNER_TEMP/discord-release.md" \
-            "${mention_args[@]}"
+            "${mention_args[@]}" \
+            "${campaign_args[@]}"
           cat "$RUNNER_TEMP/discord-release.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Preview X and Bluesky announcements
+        run: |
+          set -euo pipefail
+          if ! python3 scripts/release_campaign.py validate --version "${TAG_NAME#v}"; then
+            echo "No matching reviewed social previews are available." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          for channel in x bluesky; do
+            python3 scripts/release_campaign.py render \
+              --channel "$channel" \
+              --version "${TAG_NAME#v}" \
+              --output "$RUNNER_TEMP/red-release-${channel}.md"
+            python3 scripts/social_release.py \
+              --platform "$channel" \
+              --text-file "$RUNNER_TEMP/red-release-${channel}.md" \
+              --json > "$RUNNER_TEMP/red-release-${channel}.json"
+            {
+              printf '\n## %s preview (not posted)\n\n' "$channel"
+              cat "$RUNNER_TEMP/red-release-${channel}.md"
+            } >> "$GITHUB_STEP_SUMMARY"
+          done
 
       - name: Check webhook configuration
         if: env.DRY_RUN != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,11 @@ jobs:
       - name: Validate main branch ruleset recipe
         run: python3 -m json.tool .github/rulesets/main.json > /dev/null
 
-      - name: Test Discord release announcements
-        run: python3 -m unittest tests.test_discord_release
+      - name: Validate reviewed release campaign
+        run: python3 scripts/release_campaign.py validate
+
+      - name: Test release campaign and Discord announcements
+        run: python3 -m unittest tests.test_release_campaign tests.test_discord_release tests.test_social_release
 
       - name: Test validation helpers
         run: python3 -m unittest tests.test_ci_policy tests.test_doctest_packages tests.test_test_performance
@@ -216,6 +219,12 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: echo "version=${HEAD_REF#release/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release PR campaign version
+        if: startsWith(github.head_ref, 'release/v')
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: python3 scripts/release_campaign.py validate --version "$VERSION"
 
       - name: Regenerate release PR changelog
         if: startsWith(github.head_ref, 'release/v')

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -109,6 +109,8 @@ jobs:
           grep -Fq "## [$VERSION]" CHANGELOG.md
           python3 scripts/readme_release.py --set "$VERSION"
           python3 scripts/readme_release.py --check
+          python3 scripts/release_campaign.py set-version "$VERSION"
+          python3 scripts/release_campaign.py validate --version "$VERSION"
 
       - name: Create or update release pull request
         shell: bash
@@ -117,7 +119,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
-          git add Cargo.toml Cargo.lock CHANGELOG.md README.md
+          git add Cargo.toml Cargo.lock CHANGELOG.md README.md release/campaign.toml
           git commit -m "chore(release): prepare v$VERSION"
           git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
           git push --force-with-lease origin "$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,24 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Add reviewed release highlights
+        env:
+          TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG_NAME#v}"
+          python3 scripts/release_campaign.py validate --version "$version"
+          python3 scripts/release_campaign.py render \
+            --channel github \
+            --version "$version" \
+            --output "$RUNNER_TEMP/release-introduction.md"
+          {
+            cat "$RUNNER_TEMP/release-introduction.md"
+            printf '\n'
+            cat RELEASE_NOTES.md
+          } > "$RUNNER_TEMP/release-notes.md"
+          mv "$RUNNER_TEMP/release-notes.md" RELEASE_NOTES.md
+
       - name: Generate checksums
         run: |
           set -euo pipefail

--- a/cliff.release.toml
+++ b/cliff.release.toml
@@ -5,7 +5,7 @@ header = """
 """
 body = """
 {% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
+### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
 {% set message = commit.message | split(pat="\n") | first | trim -%}
 {% if commit.remote.pr_number -%}
@@ -34,18 +34,18 @@ conventional_commits = true
 filter_unconventional = false
 split_commits = false
 tag_pattern = "v[0-9].*"
-sort_commits = "oldest"
+sort_commits = "newest"
 
 commit_parsers = [
   { message = "^Merge", skip = true },
   { message = "^chore\\(release\\): prepare v", skip = true },
   { message = "^almanac", skip = true },
-  { message = "^feat", group = "Features" },
-  { message = "^fix", group = "Bug Fixes" },
-  { message = "^perf", group = "Performance" },
-  { message = "^refactor", group = "Refactoring" },
-  { message = "^docs", group = "Documentation" },
-  { message = "^test", group = "Tests" },
-  { message = "^chore", group = "Maintenance" },
-  { message = ".*", group = "Other" },
+  { message = "^feat", group = "<!-- 00 -->Features" },
+  { message = "^perf", group = "<!-- 01 -->Performance" },
+  { message = "^fix", group = "<!-- 02 -->Bug Fixes" },
+  { message = "^refactor", group = "<!-- 03 -->Refactoring" },
+  { message = "^docs", group = "<!-- 04 -->Documentation" },
+  { message = "^test", group = "<!-- 05 -->Tests" },
+  { message = "^chore", group = "<!-- 06 -->Maintenance" },
+  { message = ".*", group = "<!-- 07 -->Other" },
 ]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,8 +17,33 @@ release, so `.github/workflows/release.yml` grants `contents: write` only to
 the release publishing job.
 
 `cliff.toml` generates the versioned `CHANGELOG.md` embedded in Red as an
-offline fallback. `cliff.release.toml` separately generates the public GitHub
-release notes, including pull request authors and first-time contributors.
+offline fallback. `cliff.release.toml` separately generates the complete public GitHub release
+changelog, including pull request authors and first-time contributors.
+
+`release/campaign.toml` is the reviewed editorial source of truth for the GitHub
+release introduction, Discord highlights, in-app release highlights, and X and
+Bluesky previews. Keep its version as `next` while preparing an upcoming release;
+the release-preparation workflow resolves it to the selected exact version.
+Campaign stories must distinguish genuinely new features from improvements to
+existing capabilities, and their order determines how users encounter them.
+
+Preview the current campaign without choosing a release version:
+
+```shell
+python3 scripts/release_campaign.py validate
+python3 scripts/release_campaign.py render --channel github
+python3 scripts/release_campaign.py render --channel discord
+python3 scripts/release_campaign.py render --channel x
+python3 scripts/release_campaign.py render --channel bluesky
+```
+
+X and Bluesky are preview-only in release workflows: no credentials are
+required, no network request is made, and nothing is published to either
+service. `scripts/social_release.py` validates the rendered previews without
+publishing. Its explicit `--publish` option is reserved for a separate,
+deliberate invocation after the account credentials and final copy have been
+reviewed; release workflows never pass that flag. Discord remains the only
+automatically posted announcement.
 
 ## Release Process
 
@@ -30,13 +55,36 @@ release notes, including pull request authors and first-time contributors.
    ```
 
    The workflow generates the release changelog from Conventional Commit
-   subjects, updates `Cargo.toml`, `Cargo.lock`, and the release references in
-   `README.md`, and opens or updates a ready-for-review `release/v0.2.0` pull
-   request.
+   subjects, updates `Cargo.toml`, `Cargo.lock`, the release references in
+   `README.md`, and the version in `release/campaign.toml`, then opens or updates
+   a ready-for-review `release/v0.2.0` pull request.
 
-3. Review the generated changelog, package version, README release link, and
-   pinned installer example, then wait for every release-PR gate to pass. In
-   particular, Clippy, the bundled-runtime self-check, README version check, and
+3. Review the generated changelog, package version, README release link, pinned
+   installer example, and release campaign. Confirm each flagship story is
+   evidence-backed, accurately labeled as new or improved, and references real
+   keyboard shortcuts, feature prerequisites, and supported platforms.
+
+   In particular, full Agent edits are mediated by the editor and saved to disk.
+   Exact foreground inline edits apply unsaved by default and remain undoable;
+   wider or background inline changes require explicit review. Normal-mode inline
+   assistance targets the enclosing function when available, while a visual
+   selection preserves its exact boundaries. Detachable sessions require macOS
+   or Linux, and Agent support requires an installed and authenticated Codex CLI.
+
+   Preview every destination against the exact release version:
+
+   ```shell
+   python3 scripts/release_campaign.py validate --version 0.2.0
+   python3 scripts/release_campaign.py render --all \
+     --version 0.2.0 --output-dir /private/tmp/red-release-preview
+   ```
+
+   Promote or remove any "Coming in the next release" wording from the README,
+   documentation, and separate website before publication. Review screenshots or
+   recordings, verify that website copy matches the shipping Agent and inline
+   safety behavior, and coordinate the website release update. Wait for every
+   release-PR gate to pass. In particular, Clippy, the
+   bundled-runtime self-check, README and campaign version checks, and the
    generated-versus-committed changelog comparison must be green.
 4. Merge the release pull request and update the local `main` branch:
 
@@ -55,17 +103,22 @@ release notes, including pull request authors and first-time contributors.
 6. Watch the **Release** workflow in GitHub Actions. It verifies the package version
    and matching `CHANGELOG.md` section, builds all four archives, and runs the
    extracted editor's embedded-runtime self-check on each target platform. It also
-   generates GitHub release notes with grouped changes, pull request authors, and a
-   contributors section that identifies first-time contributors.
+   generates GitHub release notes with the reviewed campaign highlights followed
+   by the complete grouped changelog, pull request authors, and a contributors
+   section that identifies first-time contributors.
 7. Review the draft GitHub release and confirm:
    - all four archives are attached
    - `SHA256SUMS.txt` is attached
    - `install.sh` and `install.ps1` are attached
    - install instructions match the release tag
+   - the curated flagship stories lead the complete changelog
    - change authors, pull requests, and first-time contributors are credited correctly
-8. Publish the draft release.
+8. Publish the draft release only after the announcement copy and website plan
+   have been reviewed.
 9. Watch the **Release** workflow run triggered by the `release.published`
-   event. This updates `Formula/red.rb` in `codersauce/homebrew-tap`.
+   event. This updates `Formula/red.rb` in `codersauce/homebrew-tap`. The
+   **Announce Discord release** workflow posts the reviewed Discord announcement
+   and adds X and Bluesky previews to its job summary without posting them.
 10. Verify Homebrew:
 
    ```shell
@@ -124,7 +177,11 @@ git push origin v0.2.0-rc1
   confirm `RELEASE_PR_TOKEN` is present and has Contents and Pull requests read/write
   permissions.
 - If the release workflow rejects the tag before packaging, confirm the merged
-  `Cargo.toml`/`Cargo.lock` version and `CHANGELOG.md` section match the tag exactly.
+  `Cargo.toml`/`Cargo.lock` version, `CHANGELOG.md` section, and
+  `release/campaign.toml` version match the tag exactly.
+- If an older release announcement has no matching reviewed campaign, the Discord
+  workflow safely falls back to its existing changelog-based highlights and skips
+  X and Bluesky previews.
 - If the Homebrew job fails at checkout, confirm `codersauce/homebrew-tap`
   exists and `HOMEBREW_TAP_TOKEN` can push to it.
 - If the Homebrew formula is not updated, confirm the GitHub release was

--- a/release/campaign.toml
+++ b/release/campaign.toml
@@ -1,0 +1,53 @@
+schema_version = 1
+# Release preparation replaces "next" with the selected semantic version.
+version = "next"
+headline = "A modal editor with an agent that understands your code"
+summary = "Source-linked agent walkthroughs, focused inline assistance, Vim-style multi-cursor editing, and a faster workspace."
+website = "https://getred.dev"
+
+[[stories]]
+id = "agent-source-walkthroughs"
+title = "Ask your agent to explain code and jump to the exact source"
+summary = "Agent answers can link directly to source annotations in your editor."
+status = "new"
+pull_requests = [282, 283]
+channels = ["github", "discord", "x", "bluesky", "in_app"]
+
+[[stories]]
+id = "inline-agent"
+title = "Review or refactor code without leaving your editor"
+summary = "Press Space i for focused assistance on the enclosing function or an exact visual selection."
+status = "improved"
+channels = ["github", "discord", "x", "bluesky", "in_app"]
+
+[[stories]]
+id = "vim-multicursor"
+title = "Edit multiple occurrences with Vim-style Ctrl-n"
+summary = "Add successive occurrences and edit all selections together."
+status = "new"
+pull_requests = [326]
+channels = ["github", "discord", "x", "bluesky", "in_app"]
+
+[[stories]]
+id = "agent-model-selection"
+title = "Choose the model and reasoning effort per Agent conversation"
+summary = "Change your active conversation's model directly from the Agent panel."
+status = "new"
+pull_requests = [273]
+channels = ["github", "discord", "bluesky", "in_app"]
+
+[[stories]]
+id = "large-repositories"
+title = "Move through large repositories without slowing down"
+summary = "Faster file trees, file searches, editor interactions, and plugin hot paths."
+status = "improved"
+pull_requests = [289, 298, 309, 332]
+channels = ["github", "discord", "bluesky", "in_app"]
+
+[[stories]]
+id = "external-file-conflicts"
+title = "Protect unsaved work when files change outside the editor"
+summary = "Detect external modifications and resolve conflicts without silently overwriting work."
+status = "new"
+pull_requests = [330]
+channels = ["github", "discord", "bluesky", "in_app"]

--- a/scripts/discord_release.py
+++ b/scripts/discord_release.py
@@ -118,9 +118,12 @@ def ranked_items(items: list[str]) -> list[str]:
     return [item for _, item in [*diverse, *repeated]]
 
 
-def limited_bullets(items: list[str], limit: int, max_chars: int = 950) -> str:
+def limited_bullets(
+    items: list[str], limit: int, max_chars: int = 950, *, preserve_order: bool = False
+) -> str:
     selected: list[str] = []
-    for item in ranked_items(items)[:limit]:
+    candidates = items if preserve_order else ranked_items(items)
+    for item in candidates[:limit]:
         candidate = "\n".join([*selected, f"• {item}"])
         if len(candidate) > max_chars:
             break
@@ -128,8 +131,14 @@ def limited_bullets(items: list[str], limit: int, max_chars: int = 950) -> str:
     return "\n".join(selected)
 
 
-def build_payload(release: dict[str, Any], mention_everyone: bool = False) -> dict[str, Any]:
+def build_payload(
+    release: dict[str, Any],
+    mention_everyone: bool = False,
+    campaign: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     tag = str(release["tagName"])
+    if campaign is not None and campaign.get("version") != tag.removeprefix("v"):
+        raise ValueError("campaign version must match the announced release")
     body = str(release.get("body") or "")
     sections = release_sections(body)
     features = sections.get("Features", [])
@@ -152,9 +161,19 @@ def build_payload(release: dict[str, Any], mention_everyone: bool = False) -> di
     description = "A new release of **Red** is available."
     if count_summary:
         description = f"A new release of **Red** is available with {count_summary}."
+    if campaign is not None:
+        description = f"{campaign['summary']}\n\n{description}"
 
     fields: list[dict[str, Any]] = []
-    feature_highlights = limited_bullets(features, 5)
+    if campaign is None:
+        feature_highlights = limited_bullets(features, 5)
+    else:
+        reviewed = [
+            story["title"]
+            for story in campaign["stories"]
+            if "discord" in story["channels"]
+        ]
+        feature_highlights = limited_bullets(reviewed, 5, preserve_order=True)
     if feature_highlights:
         fields.append({"name": "✨ Highlights", "value": feature_highlights, "inline": False})
 
@@ -221,11 +240,20 @@ def main() -> None:
     parser.add_argument("--release-json", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--summary", type=Path)
+    parser.add_argument("--campaign", type=Path)
     parser.add_argument("--mention-everyone", action="store_true")
     args = parser.parse_args()
 
     release = json.loads(args.release_json.read_text(encoding="utf-8"))
-    payload = build_payload(release, mention_everyone=args.mention_everyone)
+    campaign = None
+    if args.campaign is not None:
+        from release_campaign import load_campaign, validate_campaign
+
+        campaign = load_campaign(args.campaign)
+        validate_campaign(campaign, expected_version=release["tagName"].removeprefix("v"))
+    payload = build_payload(
+        release, mention_everyone=args.mention_everyone, campaign=campaign
+    )
     args.output.write_text(
         json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
     )

--- a/scripts/release_campaign.py
+++ b/scripts/release_campaign.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Validate and render Red's reviewed, version-specific release campaign."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from collections.abc import Mapping
+from pathlib import Path
+import re
+import sys
+import tomllib
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CAMPAIGN = ROOT / "release" / "campaign.toml"
+SEMVER = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:[+-][0-9A-Za-z.-]+)?")
+STORY_ID = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+SUPPORTED_CHANNELS = ("github", "discord", "x", "bluesky", "in_app")
+SUPPORTED_STATUSES = ("new", "improved", "existing")
+SOCIAL_LIMITS = {"x": 280, "bluesky": 300}
+
+
+class CampaignError(ValueError):
+    """A release campaign cannot be safely validated or rendered."""
+
+
+def load_campaign(path: Path = DEFAULT_CAMPAIGN) -> dict[str, Any]:
+    """Read and validate the dependency-free TOML campaign manifest."""
+    try:
+        with path.open("rb") as source:
+            campaign = tomllib.load(source)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise CampaignError(f"cannot read campaign {path}: {error}") from error
+    validate_campaign(campaign)
+    return campaign
+
+
+def validate_campaign(
+    campaign: Mapping[str, Any], expected_version: str | None = None
+) -> None:
+    """Reject ambiguous stories, unsupported channels, and version mismatches."""
+    if campaign.get("schema_version") != 1:
+        raise CampaignError("schema_version must be 1")
+
+    version = campaign.get("version")
+    if not isinstance(version, str) or (
+        version != "next" and SEMVER.fullmatch(version) is None
+    ):
+        raise CampaignError("version must be next or a semantic version")
+    if expected_version is not None and version != expected_version:
+        raise CampaignError(
+            f"campaign version {version!r} does not match expected {expected_version!r}"
+        )
+
+    for key in ("headline", "summary", "website"):
+        value = campaign.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise CampaignError(f"{key} must be a nonempty string")
+    if not campaign["website"].startswith("https://"):
+        raise CampaignError("website must be an HTTPS URL")
+
+    stories = campaign.get("stories")
+    if not isinstance(stories, list) or not stories:
+        raise CampaignError("at least one campaign story is required")
+
+    seen: set[str] = set()
+    for position, story in enumerate(stories, start=1):
+        if not isinstance(story, dict):
+            raise CampaignError(f"story {position} must be a TOML table")
+        story_id = story.get("id")
+        if not isinstance(story_id, str) or STORY_ID.fullmatch(story_id) is None:
+            raise CampaignError(f"story {position} needs a lowercase hyphenated id")
+        if story_id in seen:
+            raise CampaignError(f"duplicate story id: {story_id}")
+        seen.add(story_id)
+
+        for key in ("title", "summary"):
+            value = story.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise CampaignError(f"story {story_id}: {key} must be nonempty")
+        if story.get("status") not in SUPPORTED_STATUSES:
+            raise CampaignError(f"story {story_id}: unsupported status")
+
+        channels = story.get("channels")
+        if not isinstance(channels, list) or not channels:
+            raise CampaignError(f"story {story_id}: channels must be a nonempty list")
+        if len(channels) != len(set(channels)):
+            raise CampaignError(f"story {story_id}: duplicate channel")
+        unsupported = set(channels).difference(SUPPORTED_CHANNELS)
+        if unsupported:
+            raise CampaignError(
+                f"story {story_id}: unsupported channels: {', '.join(sorted(unsupported))}"
+            )
+
+        pull_requests = story.get("pull_requests", [])
+        if not isinstance(pull_requests, list) or any(
+            not isinstance(number, int) or isinstance(number, bool) or number <= 0
+            for number in pull_requests
+        ):
+            raise CampaignError(f"story {story_id}: pull_requests must contain positive integers")
+
+
+def stories_for_channel(campaign: Mapping[str, Any], channel: str) -> list[dict[str, Any]]:
+    """Preserve reviewed editorial order while filtering for one destination."""
+    if channel not in SUPPORTED_CHANNELS:
+        raise CampaignError(f"unsupported channel: {channel}")
+    return [story for story in campaign["stories"] if channel in story["channels"]]
+
+
+def render_github(campaign: Mapping[str, Any]) -> str:
+    """Render a reviewed introduction that precedes the complete changelog."""
+    version = campaign["version"]
+    heading = (
+        f"## Red v{version}: {campaign['headline']}"
+        if version != "next"
+        else f"## Red: {campaign['headline']}"
+    )
+    lines = [heading, "", campaign["summary"], "", "### Release highlights", ""]
+    for story in stories_for_channel(campaign, "github"):
+        label = "New" if story["status"] == "new" else "Improved"
+        lines.append(f"- **{label}: {story['title']}.** {story['summary']}")
+    lines.extend(("", "Agent support requires an installed Codex CLI and `codex login`."))
+    return "\n".join(lines) + "\n"
+
+
+def render_bullets(campaign: Mapping[str, Any], channel: str) -> str:
+    """Render ordered channel-specific bullets for Discord or in-app previews."""
+    return "\n".join(
+        f"- {story['title']}" for story in stories_for_channel(campaign, channel)
+    ) + "\n"
+
+
+def render_social(campaign: Mapping[str, Any], channel: str) -> str:
+    """Build a bounded, preview-only social post without publishing anything."""
+    limit = SOCIAL_LIMITS[channel]
+    version = campaign["version"]
+    introduction = "Red: a modal editor with an editor-aware coding agent"
+    if version != "next":
+        introduction = f"Red v{version}: modal editing meets editor-aware agents"
+    ending = "\n\n" + campaign["website"]
+    lines = [introduction]
+    for story in stories_for_channel(campaign, channel):
+        candidate = "\n".join([*lines, f"- {story['title']}"]) + ending
+        if len(candidate) <= limit:
+            lines.append(f"- {story['title']}")
+    result = "\n".join(lines) + ending
+    if len(lines) == 1:
+        raise CampaignError(f"no campaign stories fit within the {channel} limit")
+    if len(result) > limit:
+        raise CampaignError(f"{channel} preview exceeds {limit} characters")
+    return result + "\n"
+
+
+def render(campaign: Mapping[str, Any], channel: str) -> str:
+    """Render one reviewed channel without network access or posting."""
+    if channel == "github":
+        return render_github(campaign)
+    if channel in ("discord", "in_app"):
+        return render_bullets(campaign, channel)
+    if channel in SOCIAL_LIMITS:
+        return render_social(campaign, channel)
+    raise CampaignError(f"unsupported channel: {channel}")
+
+
+def set_version(path: Path, version: str) -> None:
+    """Update only the unique root-level version while preserving human edits."""
+    if SEMVER.fullmatch(version) is None:
+        raise CampaignError(f"{version!r} is not a supported semantic version")
+    campaign = load_campaign(path)
+    current = campaign["version"]
+    contents = path.read_text(encoding="utf-8")
+    expression = re.compile(
+        rf'(?m)^(version\s*=\s*"){re.escape(current)}("\s*)$'
+    )
+    contents, count = expression.subn(
+        lambda match: f"{match.group(1)}{version}{match.group(2)}", contents
+    )
+    if count != 1:
+        raise CampaignError("campaign must contain exactly one root version field")
+    path.write_text(contents, encoding="utf-8")
+    validate_campaign(load_campaign(path), expected_version=version)
+
+
+def main() -> None:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--campaign", type=Path, default=DEFAULT_CAMPAIGN)
+    actions = parser.add_subparsers(dest="action", required=True)
+
+    validate = actions.add_parser("validate", help="validate the reviewed campaign")
+    validate.add_argument("--version", help="require this exact resolved version")
+
+    update = actions.add_parser("set-version", help="resolve the selected release version")
+    update.add_argument("version")
+
+    render_command = actions.add_parser("render", help="render one or all preview channels")
+    selection = render_command.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--channel", choices=SUPPORTED_CHANNELS)
+    selection.add_argument("--all", action="store_true")
+    render_command.add_argument("--output", type=Path)
+    render_command.add_argument("--output-dir", type=Path)
+    render_command.add_argument("--version", help="require this exact resolved version")
+    args = parser.parse_args()
+
+    if args.action == "set-version":
+        set_version(args.campaign, args.version)
+        print(f"resolved release campaign version to {args.version}")
+        return
+
+    campaign = load_campaign(args.campaign)
+    validate_campaign(campaign, expected_version=args.version)
+    if args.action == "validate":
+        print(f"validated {len(campaign['stories'])} stories for {campaign['version']}")
+        return
+
+    if args.all:
+        if args.output is not None or args.output_dir is None:
+            raise CampaignError("render --all requires --output-dir and cannot use --output")
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        for channel in SUPPORTED_CHANNELS:
+            destination = args.output_dir / f"{channel}.md"
+            destination.write_text(render(campaign, channel), encoding="utf-8")
+        print(f"rendered {len(SUPPORTED_CHANNELS)} channel previews to {args.output_dir}")
+    else:
+        if args.output_dir is not None:
+            raise CampaignError("--output-dir is only valid with --all")
+        output = render(campaign, args.channel)
+        if args.output is not None:
+            args.output.write_text(output, encoding="utf-8")
+        else:
+            sys.stdout.write(output)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except CampaignError as error:
+        raise SystemExit(f"release_campaign.py: {error}") from error

--- a/scripts/social_release.py
+++ b/scripts/social_release.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Preview release posts safely, or publish explicitly to X and Bluesky."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import mimetypes
+import os
+from pathlib import Path
+import re
+import sys
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
+from uuid import uuid4
+
+
+POST_LIMITS = {"x": 280, "bluesky": 300}
+X_API = "https://api.x.com/2"
+BLUESKY_API = "https://bsky.social/xrpc"
+X_CHUNK_BYTES = 4 * 1024 * 1024
+X_IMAGE_BYTES = 5 * 1024 * 1024
+X_GIF_BYTES = 15 * 1024 * 1024
+X_VIDEO_BYTES = 512 * 1024 * 1024
+BLUESKY_IMAGE_BYTES = 1_000_000
+REQUEST_TIMEOUT_SECONDS = 30
+MAX_PROCESSING_CHECKS = 12
+LINK = re.compile(r'https?://[^\s<>"\]]+', re.IGNORECASE)
+
+
+class SocialReleaseError(ValueError):
+    """A reviewed post cannot be validated, previewed, or safely published."""
+
+
+@dataclass(frozen=True)
+class Attachment:
+    """One validated local media file, with optional accessible alt text."""
+
+    path: Path
+    kind: str
+    media_type: str
+    size: int
+    alt_text: str = ""
+
+    @property
+    def x_category(self) -> str:
+        if self.kind == "video":
+            return "tweet_video"
+        return "tweet_gif" if self.media_type == "image/gif" else "tweet_image"
+
+
+def read_post_text(path: Path, platform: str) -> str:
+    """Load reviewed UTF-8 copy and reject empty or oversized public posts."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise SocialReleaseError(f"cannot read post text from {path}: {error}") from error
+
+    text = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if not text:
+        raise SocialReleaseError("post text must not be empty")
+    if any(ord(character) < 32 and character != "\n" for character in text):
+        raise SocialReleaseError("post text contains unsupported control characters")
+
+    limit = POST_LIMITS[platform]
+    if len(text) > limit:
+        raise SocialReleaseError(
+            f"{platform} post exceeds the {limit}-character limit: {len(text)} characters"
+        )
+    return text
+
+
+def validate_attachment(
+    path: Path, *, kind: str, platform: str, alt_text: str = ""
+) -> Attachment:
+    """Validate supported media and size before credentials or network access."""
+    if platform == "bluesky" and kind == "video":
+        raise SocialReleaseError("Bluesky video publishing is not supported")
+    if kind == "video" and alt_text:
+        raise SocialReleaseError("alt text is currently supported only for images")
+    if len(alt_text) > 1_000:
+        raise SocialReleaseError("image alt text must not exceed 1,000 characters")
+
+    try:
+        if not path.is_file():
+            raise SocialReleaseError(f"media file does not exist: {path}")
+        size = path.stat().st_size
+    except OSError as error:
+        raise SocialReleaseError(f"cannot inspect media file {path}: {error}") from error
+    if size <= 0:
+        raise SocialReleaseError("media file must not be empty")
+
+    media_type, _ = mimetypes.guess_type(path.name)
+    allowed = (
+        {"image/jpeg", "image/png", "image/gif", "image/webp"}
+        if kind == "image"
+        else {"video/mp4", "video/webm", "video/quicktime"}
+    )
+    if media_type not in allowed:
+        raise SocialReleaseError(f"unsupported {kind} media type for {path.name}")
+
+    if platform == "bluesky":
+        maximum = BLUESKY_IMAGE_BYTES
+    elif kind == "video":
+        maximum = X_VIDEO_BYTES
+    elif media_type == "image/gif":
+        maximum = X_GIF_BYTES
+    else:
+        maximum = X_IMAGE_BYTES
+    if size > maximum:
+        raise SocialReleaseError(
+            f"{platform} {kind} exceeds its {maximum}-byte limit: {size} bytes"
+        )
+
+    return Attachment(path=path, kind=kind, media_type=media_type, size=size, alt_text=alt_text)
+
+
+def link_facets(text: str) -> list[dict[str, Any]]:
+    """Return Bluesky link facets indexed in UTF-8 bytes, not characters."""
+    facets = []
+    for match in LINK.finditer(text):
+        url = match.group().rstrip(".,!?;:")
+        while url.endswith(")") and url.count(")") > url.count("("):
+            url = url[:-1]
+        if not url:
+            continue
+        start = len(text[: match.start()].encode("utf-8"))
+        end = start + len(url.encode("utf-8"))
+        facets.append(
+            {
+                "index": {"byteStart": start, "byteEnd": end},
+                "features": [{"$type": "app.bsky.richtext.facet#link", "uri": url}],
+            }
+        )
+    return facets
+
+
+def preview_post(
+    platform: str, text: str, attachment: Attachment | None = None
+) -> dict[str, Any]:
+    """Describe an intended post without inspecting credentials or using the network."""
+    preview: dict[str, Any] = {
+        "platform": platform,
+        "mode": "preview",
+        "published": False,
+        "text": text,
+        "character_count": len(text),
+        "character_limit": POST_LIMITS[platform],
+    }
+    if platform == "bluesky":
+        preview["facets"] = link_facets(text)
+    if attachment is not None:
+        preview["media"] = {
+            "path": str(attachment.path),
+            "kind": attachment.kind,
+            "content_type": attachment.media_type,
+            "bytes": attachment.size,
+            "alt_text": attachment.alt_text,
+        }
+    return preview
+
+
+def _credential(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SocialReleaseError(f"{name} is required only when --publish is requested")
+    if "\r" in value or "\n" in value:
+        raise SocialReleaseError(f"{name} must be a single-line credential")
+    return value
+
+
+def _request_json(
+    url: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    data: bytes | None = None,
+    token: str | None = None,
+    content_type: str | None = None,
+    method: str = "POST",
+) -> dict[str, Any]:
+    """Make one bounded request without exposing request bodies or credentials."""
+    headers = {"Accept": "application/json", "User-Agent": "red-release-publisher/1"}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    if payload is not None:
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        headers["Content-Type"] = "application/json; charset=utf-8"
+    elif content_type is not None:
+        headers["Content-Type"] = content_type
+
+    request = Request(url, data=data, headers=headers, method=method)
+    try:
+        with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            body = response.read()
+    except HTTPError as error:
+        endpoint = urlparse(url).path
+        raise SocialReleaseError(
+            f"request to {endpoint} failed with HTTP {error.code} ({error.reason})"
+        ) from error
+    except (OSError, URLError) as error:
+        endpoint = urlparse(url).path
+        raise SocialReleaseError(f"request to {endpoint} failed: {error}") from error
+
+    if not body:
+        return {}
+    try:
+        result = json.loads(body.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise SocialReleaseError("social API returned an invalid JSON response") from error
+    if not isinstance(result, dict):
+        raise SocialReleaseError("social API returned an unexpected JSON response")
+    return result
+
+
+def _multipart_chunk(attachment: Attachment, chunk: bytes, segment: int) -> tuple[bytes, str]:
+    boundary = f"red-release-{uuid4().hex}"
+    filename = re.sub(r"[^A-Za-z0-9_.-]", "_", attachment.path.name)
+    body = bytearray()
+    body.extend(f"--{boundary}\r\n".encode("ascii"))
+    body.extend(b'Content-Disposition: form-data; name="segment_index"\r\n\r\n')
+    body.extend(f"{segment}\r\n".encode("ascii"))
+    body.extend(f"--{boundary}\r\n".encode("ascii"))
+    body.extend(
+        f'Content-Disposition: form-data; name="media"; filename="{filename}"\r\n'.encode(
+            "ascii"
+        )
+    )
+    body.extend(f"Content-Type: {attachment.media_type}\r\n\r\n".encode("ascii"))
+    body.extend(chunk)
+    body.extend(f"\r\n--{boundary}--\r\n".encode("ascii"))
+    return bytes(body), f"multipart/form-data; boundary={boundary}"
+
+
+def _wait_for_x_media(media_id: str, info: dict[str, Any], token: str) -> None:
+    for _ in range(MAX_PROCESSING_CHECKS):
+        state = info.get("state")
+        if state in (None, "succeeded"):
+            return
+        if state == "failed":
+            raise SocialReleaseError("X rejected the uploaded media during processing")
+        if state not in {"pending", "in_progress"}:
+            raise SocialReleaseError(f"X returned unknown media processing state {state!r}")
+
+        delay = info.get("check_after_secs", 1)
+        if not isinstance(delay, (int, float)) or isinstance(delay, bool):
+            delay = 1
+        time.sleep(min(max(float(delay), 0), 5))
+        status = _request_json(
+            f"{X_API}/media/upload?command=STATUS&media_id={quote(media_id, safe='')}",
+            token=token,
+            method="GET",
+        )
+        info = status.get("data", {}).get("processing_info", {})
+        if not isinstance(info, dict):
+            raise SocialReleaseError("X returned invalid media processing details")
+
+    raise SocialReleaseError("X media processing did not finish before the retry limit")
+
+
+def _upload_x_media(attachment: Attachment, token: str) -> str:
+    initialized = _request_json(
+        f"{X_API}/media/upload/initialize",
+        token=token,
+        payload={
+            "media_type": attachment.media_type,
+            "media_category": attachment.x_category,
+            "total_bytes": attachment.size,
+        },
+    )
+    response_data = initialized.get("data", {})
+    media_id = response_data.get("id") if isinstance(response_data, dict) else None
+    if not isinstance(media_id, str) or re.fullmatch(r"[0-9]{1,19}", media_id) is None:
+        raise SocialReleaseError("X media initialization did not return a valid media ID")
+
+    try:
+        with attachment.path.open("rb") as source:
+            segment = 0
+            while chunk := source.read(X_CHUNK_BYTES):
+                data, content_type = _multipart_chunk(attachment, chunk, segment)
+                _request_json(
+                    f"{X_API}/media/upload/{media_id}/append",
+                    token=token,
+                    data=data,
+                    content_type=content_type,
+                )
+                segment += 1
+    except OSError as error:
+        raise SocialReleaseError(f"cannot read media file {attachment.path}: {error}") from error
+
+    finalized = _request_json(
+        f"{X_API}/media/upload/{media_id}/finalize", token=token, data=b""
+    )
+    response_data = finalized.get("data", {})
+    info = response_data.get("processing_info", {}) if isinstance(response_data, dict) else {}
+    if not isinstance(info, dict):
+        raise SocialReleaseError("X returned invalid media processing details")
+    _wait_for_x_media(media_id, info, token)
+
+    if attachment.alt_text:
+        _request_json(
+            f"{X_API}/media/metadata",
+            token=token,
+            payload={"id": media_id, "metadata": {"alt_text": {"text": attachment.alt_text}}},
+        )
+    return media_id
+
+
+def publish_x(text: str, attachment: Attachment | None = None) -> dict[str, Any]:
+    """Publish one reviewed post using an OAuth 2.0 user-context access token."""
+    token = _credential("X_ACCESS_TOKEN")
+    post: dict[str, Any] = {"text": text}
+    if attachment is not None:
+        post["media"] = {"media_ids": [_upload_x_media(attachment, token)]}
+
+    response = _request_json(f"{X_API}/tweets", token=token, payload=post)
+    response_data = response.get("data", {})
+    post_id = response_data.get("id") if isinstance(response_data, dict) else None
+    if not isinstance(post_id, str) or not post_id:
+        raise SocialReleaseError("X did not return the published post ID")
+    return {
+        "platform": "x",
+        "mode": "published",
+        "published": True,
+        "post_id": post_id,
+        "url": f"https://x.com/i/web/status/{quote(post_id, safe='')}",
+    }
+
+
+def publish_bluesky(text: str, attachment: Attachment | None = None) -> dict[str, Any]:
+    """Create one authenticated Bluesky post with UTF-8-indexed link facets."""
+    identifier = _credential("BLUESKY_IDENTIFIER")
+    password = _credential("BLUESKY_APP_PASSWORD")
+    session = _request_json(
+        f"{BLUESKY_API}/com.atproto.server.createSession",
+        payload={"identifier": identifier, "password": password},
+    )
+    access_token = session.get("accessJwt")
+    did = session.get("did")
+    if not isinstance(access_token, str) or not isinstance(did, str):
+        raise SocialReleaseError("Bluesky did not return a usable authenticated session")
+    if "\r" in access_token or "\n" in access_token:
+        raise SocialReleaseError("Bluesky returned an invalid session credential")
+
+    record: dict[str, Any] = {
+        "$type": "app.bsky.feed.post",
+        "text": text,
+        "createdAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    if facets := link_facets(text):
+        record["facets"] = facets
+
+    if attachment is not None:
+        try:
+            image = attachment.path.read_bytes()
+        except OSError as error:
+            raise SocialReleaseError(
+                f"cannot read media file {attachment.path}: {error}"
+            ) from error
+        uploaded = _request_json(
+            f"{BLUESKY_API}/com.atproto.repo.uploadBlob",
+            token=access_token,
+            data=image,
+            content_type=attachment.media_type,
+        )
+        blob = uploaded.get("blob")
+        if not isinstance(blob, dict):
+            raise SocialReleaseError("Bluesky image upload did not return a blob reference")
+        record["embed"] = {
+            "$type": "app.bsky.embed.images",
+            "images": [{"alt": attachment.alt_text, "image": blob}],
+        }
+
+    response = _request_json(
+        f"{BLUESKY_API}/com.atproto.repo.createRecord",
+        token=access_token,
+        payload={"repo": did, "collection": "app.bsky.feed.post", "record": record},
+    )
+    uri = response.get("uri")
+    if not isinstance(uri, str) or not uri.startswith("at://"):
+        raise SocialReleaseError("Bluesky did not return the published record URI")
+    handle = session.get("handle")
+    profile = handle if isinstance(handle, str) and handle else did
+    record_key = uri.rstrip("/").rsplit("/", 1)[-1]
+    return {
+        "platform": "bluesky",
+        "mode": "published",
+        "published": True,
+        "uri": uri,
+        "url": (
+            f"https://bsky.app/profile/{quote(profile, safe='.:')}/post/"
+            f"{quote(record_key, safe='')}"
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--platform", choices=tuple(POST_LIMITS), required=True)
+    parser.add_argument("--text-file", type=Path, required=True)
+    media = parser.add_mutually_exclusive_group()
+    media.add_argument("--image", type=Path, help="attach one supported image")
+    media.add_argument("--video", type=Path, help="attach one supported X video")
+    parser.add_argument("--alt-text", default="", help="accessible image description")
+    parser.add_argument(
+        "--publish", action="store_true", help="explicitly authorize authenticated publication"
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable safe output")
+    args = parser.parse_args(argv)
+
+    text = read_post_text(args.text_file, args.platform)
+    attachment = None
+    if args.image is not None:
+        attachment = validate_attachment(
+            args.image, kind="image", platform=args.platform, alt_text=args.alt_text
+        )
+    elif args.video is not None:
+        attachment = validate_attachment(
+            args.video, kind="video", platform=args.platform, alt_text=args.alt_text
+        )
+    elif args.alt_text:
+        raise SocialReleaseError("--alt-text requires an --image attachment")
+
+    if not args.publish:
+        result = preview_post(args.platform, text, attachment)
+    elif args.platform == "x":
+        result = publish_x(text, attachment)
+    else:
+        result = publish_bluesky(text, attachment)
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    elif args.publish:
+        print(f"Published {args.platform} release announcement: {result['url']}")
+    else:
+        print(f"{args.platform} preview ({len(text)}/{POST_LIMITS[args.platform]}):")
+        print(text)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SocialReleaseError as error:
+        raise SystemExit(f"social_release.py: {error}") from error

--- a/src/whats_new.rs
+++ b/src/whats_new.rs
@@ -12,6 +12,7 @@ use semver::Version;
 use serde::Deserialize;
 
 const EMBEDDED_CHANGELOG: &str = include_str!("../CHANGELOG.md");
+const EMBEDDED_RELEASE_CAMPAIGN: &str = include_str!("../release/campaign.toml");
 const REPOSITORY: &str = "codersauce/red";
 const MAX_RELEASE_NOTES_BYTES: usize = 128 * 1024;
 const RELEASE_REQUEST_TIMEOUT: Duration = Duration::from_secs(4);
@@ -34,6 +35,18 @@ pub struct ReleaseNotes {
 struct ChangelogSection {
     version: Version,
     markdown: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseCampaign {
+    version: String,
+    stories: Vec<ReleaseCampaignStory>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseCampaignStory {
+    title: String,
+    channels: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -127,10 +140,37 @@ impl ReleaseNotes {
             }
         }
 
+        if let Some(highlights) = self.campaign_highlights(EMBEDDED_RELEASE_CAMPAIGN) {
+            sections.insert(0, highlights);
+        }
+
         if sections.is_empty() {
             self.markdown.clone()
         } else {
             sections.join("\n\n")
+        }
+    }
+
+    fn campaign_highlights(&self, contents: &str) -> Option<String> {
+        let campaign = toml::from_str::<ReleaseCampaign>(contents).ok()?;
+        if campaign.version != self.version {
+            return None;
+        }
+
+        let highlights = campaign
+            .stories
+            .into_iter()
+            .filter(|story| story.channels.iter().any(|channel| channel == "in_app"))
+            .take(MAX_HIGHLIGHTS_PER_SECTION)
+            .map(|story| format!("- {}", story.title))
+            .collect::<Vec<_>>();
+        if highlights.is_empty() {
+            None
+        } else {
+            Some(format!(
+                "## Release highlights\n\n{}",
+                highlights.join("\n")
+            ))
         }
     }
 
@@ -325,6 +365,31 @@ mod tests {
         assert!(highlights.contains("## Fixes"));
         assert!(highlights.contains("issues/2"));
         assert!(!highlights.contains("commit/abcdef"));
+    }
+
+    #[test]
+    fn campaign_highlights_require_an_exact_release_match() {
+        let notes = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", None);
+        let campaign = "version = \"0.5.0\"\n\n[[stories]]\ntitle = \"Jump to annotated source\"\nchannels = [\"in_app\"]\n\n[[stories]]\ntitle = \"Social only\"\nchannels = [\"x\"]\n";
+
+        let highlights = notes.campaign_highlights(campaign).unwrap();
+
+        assert!(highlights.contains("Jump to annotated source"));
+        assert!(!highlights.contains("Social only"));
+    }
+
+    #[test]
+    fn unresolved_mismatched_or_invalid_campaigns_keep_changelog_fallback() {
+        let notes = ReleaseNotes::from_changelog(CHANGELOG, "0.5.0", None);
+
+        for campaign in [
+            "version = \"next\"\nstories = []",
+            "version = \"0.6.0\"\nstories = []",
+            "not valid toml = [",
+        ] {
+            assert!(notes.campaign_highlights(campaign).is_none());
+        }
+        assert!(notes.highlights_markdown().contains("New thing"));
     }
 
     #[test]

--- a/tests/test_discord_release.py
+++ b/tests/test_discord_release.py
@@ -63,6 +63,30 @@ class DiscordReleaseTest(unittest.TestCase):
         self.assertEqual(payload["allowed_mentions"], {"parse": []})
         self.assertNotIn("content", payload)
 
+    def test_reviewed_campaign_stories_override_commit_ranking(self) -> None:
+        campaign = {
+            "version": "0.2.4",
+            "summary": "Editor-aware agents and Vim-style editing.",
+            "stories": [
+                {"title": "Jump from agent explanations into source", "channels": ["discord"]},
+                {"title": "Review an exact visual selection inline", "channels": ["discord"]},
+                {"title": "Internal detail", "channels": ["github"]},
+            ],
+        }
+
+        payload = build_payload(RELEASE, campaign=campaign)
+        embed = payload["embeds"][0]
+        highlights = embed["fields"][0]["value"]
+
+        self.assertTrue(embed["description"].startswith(campaign["summary"]))
+        self.assertIn("2 new features and 1 fix", embed["description"])
+        self.assertLess(highlights.index("agent explanations"), highlights.index("selection inline"))
+        self.assertNotIn("Internal detail", highlights)
+
+    def test_rejects_a_campaign_for_another_release(self) -> None:
+        with self.assertRaisesRegex(ValueError, "campaign version"):
+            build_payload(RELEASE, campaign={"version": "0.9.0"})
+
     def test_everyone_mention_must_be_enabled_explicitly(self) -> None:
         payload = build_payload(RELEASE, mention_everyone=True)
 

--- a/tests/test_release_campaign.py
+++ b/tests/test_release_campaign.py
@@ -1,0 +1,95 @@
+import copy
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.release_campaign import (
+    CampaignError,
+    DEFAULT_CAMPAIGN,
+    SEMVER,
+    SOCIAL_LIMITS,
+    load_campaign,
+    render,
+    set_version,
+    stories_for_channel,
+    validate_campaign,
+)
+
+
+class ReleaseCampaignTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.campaign = load_campaign(DEFAULT_CAMPAIGN)
+
+    def test_checked_in_campaign_accepts_next_or_a_resolved_release_version(self) -> None:
+        version = self.campaign["version"]
+
+        self.assertTrue(version == "next" or SEMVER.fullmatch(version) is not None)
+        self.assertGreaterEqual(len(self.campaign["stories"]), 3)
+
+    def test_preserves_editorial_story_order(self) -> None:
+        stories = stories_for_channel(self.campaign, "discord")
+
+        self.assertEqual(stories[0]["id"], "agent-source-walkthroughs")
+        self.assertEqual(stories[1]["id"], "inline-agent")
+        self.assertEqual(stories[2]["id"], "vim-multicursor")
+
+    def test_rejects_duplicate_story_ids(self) -> None:
+        campaign = copy.deepcopy(self.campaign)
+        campaign["stories"].append(copy.deepcopy(campaign["stories"][0]))
+
+        with self.assertRaisesRegex(CampaignError, "duplicate story id"):
+            validate_campaign(campaign)
+
+    def test_rejects_unknown_channels(self) -> None:
+        campaign = copy.deepcopy(self.campaign)
+        campaign["stories"][0]["channels"].append("unreviewed")
+
+        with self.assertRaisesRegex(CampaignError, "unsupported channels"):
+            validate_campaign(campaign)
+
+    def test_requires_exact_release_version_when_requested(self) -> None:
+        with self.assertRaisesRegex(CampaignError, "does not match"):
+            validate_campaign(self.campaign, expected_version="0.7.0")
+
+    def test_updates_only_the_resolved_campaign_version(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "campaign.toml"
+            path.write_text(DEFAULT_CAMPAIGN.read_text(encoding="utf-8"), encoding="utf-8")
+
+            set_version(path, "0.7.0")
+            campaign = load_campaign(path)
+
+            self.assertEqual(campaign["version"], "0.7.0")
+            self.assertEqual(campaign["stories"], self.campaign["stories"])
+
+    def test_renders_github_intro_with_prerequisites_and_ordered_stories(self) -> None:
+        output = render(self.campaign, "github")
+
+        self.assertIn("### Release highlights", output)
+        self.assertIn("codex login", output)
+        self.assertLess(output.index("jump to the exact source"), output.index("Vim-style Ctrl-n"))
+
+    def test_social_previews_are_bounded_and_include_destination(self) -> None:
+        for channel, limit in SOCIAL_LIMITS.items():
+            with self.subTest(channel=channel):
+                output = render(self.campaign, channel)
+
+                self.assertLessEqual(len(output.rstrip("\n")), limit)
+                self.assertIn("https://getred.dev", output)
+                self.assertIn("jump to the exact source", output)
+
+    def test_channel_specific_stories_do_not_leak_into_x_preview(self) -> None:
+        output = render(self.campaign, "x")
+
+        self.assertNotIn("reasoning effort", output)
+
+    def test_rejects_boolean_pull_request_numbers(self) -> None:
+        campaign = copy.deepcopy(self.campaign)
+        campaign["stories"][0]["pull_requests"] = [True]
+
+        with self.assertRaisesRegex(CampaignError, "positive integers"):
+            validate_campaign(campaign)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_social_release.py
+++ b/tests/test_social_release.py
@@ -1,0 +1,348 @@
+from contextlib import redirect_stdout
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+from scripts.social_release import (
+    BLUESKY_IMAGE_BYTES,
+    SocialReleaseError,
+    link_facets,
+    main,
+    preview_post,
+    publish_bluesky,
+    publish_x,
+    read_post_text,
+    validate_attachment,
+)
+
+
+class Response:
+    def __init__(self, body):
+        self.body = json.dumps(body).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self.body
+
+
+class SocialReleaseTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.post = self.root / "post.md"
+        self.post.write_text("Red is ready. https://getred.dev\n", encoding="utf-8")
+
+    def image(self, contents=b"image-bytes"):
+        path = self.root / "capture.png"
+        path.write_bytes(contents)
+        return path
+
+    def test_preview_defaults_to_no_network_and_needs_no_credentials(self):
+        for platform in ("x", "bluesky"):
+            with self.subTest(platform=platform):
+                output = io.StringIO()
+                with (
+                    patch.dict(os.environ, {}, clear=True),
+                    patch("scripts.social_release.urlopen") as request,
+                    redirect_stdout(output),
+                ):
+                    main(["--platform", platform, "--text-file", str(self.post), "--json"])
+
+                result = json.loads(output.getvalue())
+                self.assertEqual(result["platform"], platform)
+                self.assertEqual(result["mode"], "preview")
+                self.assertFalse(result["published"])
+                self.assertEqual(result["text"], "Red is ready. https://getred.dev")
+                request.assert_not_called()
+
+    def test_human_readable_preview_does_not_publish(self):
+        output = io.StringIO()
+        with patch("scripts.social_release.urlopen") as request, redirect_stdout(output):
+            main(["--platform", "x", "--text-file", str(self.post)])
+
+        self.assertIn("x preview", output.getvalue())
+        self.assertIn("https://getred.dev", output.getvalue())
+        request.assert_not_called()
+
+    def test_missing_x_credentials_fail_without_network(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("scripts.social_release.urlopen") as request:
+                with self.assertRaisesRegex(SocialReleaseError, "X_ACCESS_TOKEN.*--publish"):
+                    publish_x("Red is ready")
+
+        request.assert_not_called()
+
+    def test_missing_bluesky_credentials_fail_without_network(self):
+        with patch.dict(os.environ, {"BLUESKY_IDENTIFIER": "red.bsky.social"}, clear=True):
+            with patch("scripts.social_release.urlopen") as request:
+                with self.assertRaisesRegex(SocialReleaseError, "BLUESKY_APP_PASSWORD"):
+                    publish_bluesky("Red is ready")
+
+        request.assert_not_called()
+
+    def test_rejects_empty_post(self):
+        self.post.write_text("\n  \n", encoding="utf-8")
+        with self.assertRaisesRegex(SocialReleaseError, "must not be empty"):
+            read_post_text(self.post, "x")
+
+    def test_rejects_oversized_posts_for_each_platform(self):
+        for platform, limit in (("x", 280), ("bluesky", 300)):
+            with self.subTest(platform=platform):
+                self.post.write_text("x" * (limit + 1), encoding="utf-8")
+                with self.assertRaisesRegex(SocialReleaseError, f"{limit}-character limit"):
+                    read_post_text(self.post, platform)
+
+    def test_rejects_control_characters(self):
+        self.post.write_text("Red\x00editor", encoding="utf-8")
+        with self.assertRaisesRegex(SocialReleaseError, "control characters"):
+            read_post_text(self.post, "bluesky")
+
+    def test_bluesky_link_facets_use_utf8_byte_offsets(self):
+        text = "🚀 Red: https://getred.dev/docs. More: https://example.com/a_(b)."
+        facets = link_facets(text)
+
+        self.assertEqual(len(facets), 2)
+        first = facets[0]
+        self.assertEqual(first["index"]["byteStart"], len("🚀 Red: ".encode("utf-8")))
+        self.assertEqual(first["features"][0]["uri"], "https://getred.dev/docs")
+        self.assertEqual(facets[1]["features"][0]["uri"], "https://example.com/a_(b)")
+
+    def test_bluesky_preview_includes_link_facets(self):
+        preview = preview_post("bluesky", "🚀 https://getred.dev")
+
+        self.assertEqual(preview["facets"][0]["index"]["byteStart"], 5)
+        self.assertFalse(preview["published"])
+
+    def test_x_post_uses_official_endpoint_and_user_token(self):
+        with patch.dict(os.environ, {"X_ACCESS_TOKEN": "secret-x-token"}, clear=True):
+            with patch(
+                "scripts.social_release.urlopen",
+                return_value=Response({"data": {"id": "12345", "text": "Red is ready"}}),
+            ) as request:
+                result = publish_x("Red is ready")
+
+        sent = request.call_args.args[0]
+        self.assertEqual(sent.full_url, "https://api.x.com/2/tweets")
+        self.assertEqual(sent.get_header("Authorization"), "Bearer secret-x-token")
+        self.assertEqual(json.loads(sent.data), {"text": "Red is ready"})
+        self.assertEqual(result["url"], "https://x.com/i/web/status/12345")
+        self.assertNotIn("secret-x-token", json.dumps(result))
+
+    def test_x_image_uses_native_chunked_upload_and_alt_text(self):
+        attachment = validate_attachment(
+            self.image(), kind="image", platform="x", alt_text="Red editor with agent pane"
+        )
+        responses = [
+            Response({"data": {"id": "2468"}}),
+            Response({"data": {}}),
+            Response({"data": {"id": "2468"}}),
+            Response({"data": {"id": "2468"}}),
+            Response({"data": {"id": "12345"}}),
+        ]
+        with patch.dict(os.environ, {"X_ACCESS_TOKEN": "secret-x-token"}, clear=True):
+            with patch("scripts.social_release.urlopen", side_effect=responses) as request:
+                result = publish_x("Red ships agents", attachment)
+
+        requests = [call.args[0] for call in request.call_args_list]
+        self.assertEqual(
+            [sent.full_url for sent in requests],
+            [
+                "https://api.x.com/2/media/upload/initialize",
+                "https://api.x.com/2/media/upload/2468/append",
+                "https://api.x.com/2/media/upload/2468/finalize",
+                "https://api.x.com/2/media/metadata",
+                "https://api.x.com/2/tweets",
+            ],
+        )
+        initialized = json.loads(requests[0].data)
+        self.assertEqual(initialized["media_category"], "tweet_image")
+        self.assertEqual(initialized["total_bytes"], len(b"image-bytes"))
+        self.assertIn(b"image-bytes", requests[1].data)
+        self.assertIn(b'name="segment_index"', requests[1].data)
+        metadata = json.loads(requests[3].data)
+        self.assertEqual(metadata["metadata"]["alt_text"]["text"], attachment.alt_text)
+        self.assertEqual(json.loads(requests[4].data)["media"], {"media_ids": ["2468"]})
+        self.assertTrue(result["published"])
+
+    def test_x_video_streams_multiple_chunks(self):
+        video = self.root / "demo.mp4"
+        video.write_bytes(b"1234567")
+        attachment = validate_attachment(video, kind="video", platform="x")
+        responses = [
+            Response({"data": {"id": "2468"}}),
+            Response({"data": {}}),
+            Response({"data": {}}),
+            Response({"data": {}}),
+            Response({"data": {"id": "2468"}}),
+            Response({"data": {"id": "12345"}}),
+        ]
+        with patch.dict(os.environ, {"X_ACCESS_TOKEN": "secret-x-token"}, clear=True):
+            with (
+                patch("scripts.social_release.X_CHUNK_BYTES", 3),
+                patch("scripts.social_release.urlopen", side_effect=responses) as request,
+            ):
+                publish_x("Watch Red edit", attachment)
+
+        requests = [call.args[0] for call in request.call_args_list]
+        self.assertEqual(json.loads(requests[0].data)["media_category"], "tweet_video")
+        self.assertIn(b"123", requests[1].data)
+        self.assertIn(b"456", requests[2].data)
+        self.assertIn(b"7", requests[3].data)
+
+    def test_x_waits_for_asynchronous_video_processing(self):
+        attachment = validate_attachment(self.image(), kind="image", platform="x")
+        responses = [
+            Response({"data": {"id": "2468"}}),
+            Response({"data": {}}),
+            Response(
+                {"data": {"id": "2468", "processing_info": {"state": "pending", "check_after_secs": 0}}}
+            ),
+            Response({"data": {"processing_info": {"state": "succeeded"}}}),
+            Response({"data": {"id": "12345"}}),
+        ]
+        with patch.dict(os.environ, {"X_ACCESS_TOKEN": "secret-x-token"}, clear=True):
+            with (
+                patch("scripts.social_release.time.sleep") as sleep,
+                patch("scripts.social_release.urlopen", side_effect=responses) as request,
+            ):
+                publish_x("Watch Red", attachment)
+
+        status = request.call_args_list[3].args[0]
+        self.assertEqual(status.get_method(), "GET")
+        self.assertIn("command=STATUS&media_id=2468", status.full_url)
+        sleep.assert_called_once_with(0.0)
+
+    def test_x_rejects_failed_media_processing(self):
+        attachment = validate_attachment(self.image(), kind="image", platform="x")
+        responses = [
+            Response({"data": {"id": "2468"}}),
+            Response({"data": {}}),
+            Response({"data": {"processing_info": {"state": "failed"}}}),
+        ]
+        with patch.dict(os.environ, {"X_ACCESS_TOKEN": "secret-x-token"}, clear=True):
+            with patch("scripts.social_release.urlopen", side_effect=responses):
+                with self.assertRaisesRegex(SocialReleaseError, "rejected the uploaded media"):
+                    publish_x("Watch Red", attachment)
+
+    def test_http_failures_never_expose_credentials_or_response_body(self):
+        response = io.BytesIO(b"server echoed secret-x-token")
+        failure = HTTPError("https://api.x.com/2/tweets", 403, "Forbidden", None, response)
+        with patch.dict(os.environ, {"X_ACCESS_TOKEN": "secret-x-token"}, clear=True):
+            with patch("scripts.social_release.urlopen", side_effect=failure):
+                with self.assertRaises(SocialReleaseError) as context:
+                    publish_x("Red is ready")
+
+        self.assertIn("HTTP 403", str(context.exception))
+        self.assertNotIn("secret-x-token", str(context.exception))
+
+    def test_bluesky_session_and_record_include_utf8_link_facets(self):
+        session = {
+            "accessJwt": "secret-session-token",
+            "refreshJwt": "secret-refresh-token",
+            "did": "did:plc:red123",
+            "handle": "red.bsky.social",
+        }
+        uri = "at://did:plc:red123/app.bsky.feed.post/abc123"
+        with patch.dict(
+            os.environ,
+            {"BLUESKY_IDENTIFIER": "red.bsky.social", "BLUESKY_APP_PASSWORD": "secret-app-password"},
+            clear=True,
+        ):
+            with patch(
+                "scripts.social_release.urlopen",
+                side_effect=[Response(session), Response({"uri": uri, "cid": "bafy123"})],
+            ) as request:
+                result = publish_bluesky("🚀 Red https://getred.dev")
+
+        login, posted = [call.args[0] for call in request.call_args_list]
+        self.assertEqual(login.full_url, "https://bsky.social/xrpc/com.atproto.server.createSession")
+        self.assertEqual(json.loads(login.data)["password"], "secret-app-password")
+        self.assertEqual(posted.get_header("Authorization"), "Bearer secret-session-token")
+        body = json.loads(posted.data)
+        self.assertEqual(body["repo"], "did:plc:red123")
+        self.assertEqual(body["collection"], "app.bsky.feed.post")
+        self.assertEqual(body["record"]["facets"][0]["index"]["byteStart"], 9)
+        self.assertTrue(body["record"]["createdAt"].endswith("Z"))
+        self.assertEqual(result["url"], "https://bsky.app/profile/red.bsky.social/post/abc123")
+        self.assertNotIn("secret", json.dumps(result))
+
+    def test_bluesky_image_upload_embeds_blob_and_alt_text(self):
+        attachment = validate_attachment(
+            self.image(), kind="image", platform="bluesky", alt_text="Red showing inline assist"
+        )
+        blob = {"$type": "blob", "ref": {"$link": "bafy123"}, "mimeType": "image/png"}
+        session = {"accessJwt": "secret-session-token", "did": "did:plc:red123"}
+        uri = "at://did:plc:red123/app.bsky.feed.post/post456"
+        with patch.dict(
+            os.environ,
+            {"BLUESKY_IDENTIFIER": "person@example.test", "BLUESKY_APP_PASSWORD": "secret-password"},
+            clear=True,
+        ):
+            with patch(
+                "scripts.social_release.urlopen",
+                side_effect=[Response(session), Response({"blob": blob}), Response({"uri": uri})],
+            ) as request:
+                result = publish_bluesky("Inline help", attachment)
+
+        login, uploaded, posted = [call.args[0] for call in request.call_args_list]
+        self.assertIn("createSession", login.full_url)
+        self.assertEqual(uploaded.full_url, "https://bsky.social/xrpc/com.atproto.repo.uploadBlob")
+        self.assertEqual(uploaded.get_header("Content-type"), "image/png")
+        self.assertEqual(uploaded.data, b"image-bytes")
+        image = json.loads(posted.data)["record"]["embed"]["images"][0]
+        self.assertEqual(image, {"alt": "Red showing inline assist", "image": blob})
+        self.assertEqual(result["url"], "https://bsky.app/profile/did:plc:red123/post/post456")
+        self.assertNotIn("person@example.test", json.dumps(result))
+
+    def test_rejects_bluesky_video(self):
+        video = self.root / "demo.mp4"
+        video.write_bytes(b"video")
+        with self.assertRaisesRegex(SocialReleaseError, "Bluesky video"):
+            validate_attachment(video, kind="video", platform="bluesky")
+
+    def test_rejects_oversized_bluesky_image(self):
+        image = self.image(b"x" * (BLUESKY_IMAGE_BYTES + 1))
+        with self.assertRaisesRegex(SocialReleaseError, "1000000-byte limit"):
+            validate_attachment(image, kind="image", platform="bluesky")
+
+    def test_rejects_unsupported_media(self):
+        document = self.root / "not-image.txt"
+        document.write_text("not an image", encoding="utf-8")
+        with self.assertRaisesRegex(SocialReleaseError, "unsupported image"):
+            validate_attachment(document, kind="image", platform="x")
+
+    def test_rejects_alt_text_without_an_image(self):
+        with self.assertRaisesRegex(SocialReleaseError, "requires an --image"):
+            main(
+                [
+                    "--platform",
+                    "x",
+                    "--text-file",
+                    str(self.post),
+                    "--alt-text",
+                    "a missing image",
+                ]
+            )
+
+    def test_rejects_credentials_with_header_injection(self):
+        with patch.dict(os.environ, {"X_ACCESS_TOKEN": "secret\ninjected"}, clear=True):
+            with patch("scripts.social_release.urlopen") as request:
+                with self.assertRaisesRegex(SocialReleaseError, "single-line credential"):
+                    publish_x("Red is ready")
+
+        request.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Recent releases hide Red's most distinctive Agent, inline-assist, Vim, and performance improvements inside commit-ordered changelogs. GitHub releases, Discord, and the in-app What's New panel also choose highlights independently, so users miss the same flagship work across every surface.

## What Changed

- Add a reviewed, version-specific `release/campaign.toml` with six ordered stories covering source-linked Agent explanations, inline assistance, Vim-style multi-cursor editing, conversation model selection, large-repository performance, and external-file protection.
- Render the same editorial campaign for GitHub release introductions, Discord, in-app highlights, X, and Bluesky while preserving complete contributor-attributed changelogs and falling back safely when versions do not match.
- Resolve and validate the campaign version during release preparation; prioritize features and performance in public changelogs; and preserve the latest upstream CI planning and branch-ruleset checks.
- Add dependency-free X and Bluesky adapters with optional images, X video, accessible alt text, bounded post lengths, and credential-safe errors. Workflows generate offline previews only: authenticated posting requires a separate explicit `--publish` invocation.
- Update release-review checklists and document the real Agent/inline safety boundaries, campaign review requirements, and promotion of upcoming-feature language.

Merging this change does not publish a release or a social post. Release publication still starts only through the existing separate tag action; Discord retains its existing release-published behavior.

## How to Test

1. Run `python3 -m unittest tests.test_release_campaign tests.test_discord_release tests.test_social_release`; all 39 tests should pass, including mismatched-version rejection, no-network social previews, media handling, and credential-safe failures.
2. Run `cargo test --lib whats_new`; all 21 release-panel tests should pass, including exact-version campaign highlights and fallback for unresolved, mismatched, or invalid campaigns.
3. Run `python3 scripts/release_campaign.py validate` and `python3 scripts/release_campaign.py render --channel github`; confirm the six reviewed stories appear before the full changelog and genuinely new features are distinguished from improvements.
4. Render X or Bluesky copy and pass it to `scripts/social_release.py --platform <x|bluesky> --text-file <rendered-file> --json` without `--publish`; confirm the result reports `"published": false` and requires no credentials.
