### PR TITLE
docs(editor): clarify agent workflows and upcoming release features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-Join%20us-7289DA?logo=discord&logoColor=white)](https://discord.gg/5PWvAUNRHU)
 
-> The modal editor for the agent era.
+> The Vim-style terminal editor where your coding agent works through your editor.
 
-Fast, familiar editing with modern code intelligence and a safer way to work
-with agents. One self-contained Rust binary. No required configuration. Your
-files stay yours.
+Vim muscle memory, editor-aware Codex agents, focused inline assistance, and
+modern code intelligence in one self-contained Rust binary. Red works without
+configuration; optional agent support requires an installed, authenticated Codex CLI.
 
 [Website](https://getred.dev) ·
 [Download](https://github.com/codersauce/red/releases/latest) ·
@@ -24,15 +24,6 @@ The current documented release is
 [v0.6.0](https://github.com/codersauce/red/releases/tag/v0.6.0).
 
 ![Red editing its Rust rendering pipeline with the project tree open](docs/images/editor-overview.jpg)
-
-## Husk language
-
-The source tree contains the extracted Husk embedding API, standalone CLI, local
-package resolver, and portable WebAssembly Component extension runtime. Start
-with the [language and embedding guide](docs/HUSK_LANGUAGE_GUIDE.md). The
-[research and implementation plan](docs/HUSK_LANGUAGE_EXTRACTION_PLAN.md) and
-[card-by-card status](docs/HUSK_IMPLEMENTATION_STATUS.md) explain the dynamic
-Rust-crate design, completed work, and remaining release-hardening tasks.
 
 ## Install
 
@@ -78,20 +69,44 @@ completed `codex login`.
 
 ## Why Red
 
-- **Stay in flow.** Vim-inspired modes, motions, text objects, splits, and
-  pickers are paired with tree-sitter highlighting and asynchronous language
-  tools.
-- **Find the signal.** Jump to files, commands, symbols, definitions,
-  references, diagnostics, or Git changes without leaving the keyboard.
-- **Make it yours.** Embedded Husk plugins power the file tree, project search,
-  Git workspace, and theme browser. Defaults work immediately; configuration
-  remains optional.
-- **See the work happen.** Red gives Codex editor context, including unsaved
-  buffers, and follows each tool call by revealing the file and edit before it
-  is applied and saved.
-- **Work reliably.** Atomic recovery works across platforms, and Unix
-  detach/attach sessions preserve buffers, plugins, LSP state, and running
-  agents across terminal or SSH disconnects.
+- **Keep your Vim muscle memory.** Familiar modes, motions, operators, text
+  objects, splits, and keyboard-first pickers work alongside Tree-sitter and LSP.
+- **Give your agent the real editor.** Codex sees open buffers, unsaved changes,
+  diagnostics, and selections. Its validated edits pass through Red's editor
+  transactions and save paths instead of modifying files behind the editor.
+- **Ask right where you are.** Inline assistance reviews, explains, or refactors
+  an exact selection or enclosing function; code changes stay unsaved and undoable.
+- **Keep the whole workflow in your terminal.** File search, language servers,
+  a full Git workspace, plugins, themes, and sessions are bundled with Red.
+- **Reconnect without losing your work.** On macOS and Linux, detachable
+  sessions retain buffers, plugins, LSP state, and running agents across
+  terminal or SSH disconnects.
+
+## Coming in the next release
+
+The following capabilities are available on `main` and are **not included in
+the published v0.6.0 release**:
+
+- **An agent that points to the code it means.** Ask Agent to explain a
+  subsystem, then follow links in its answer directly to source-anchored
+  annotations. Choose the conversation's model and reasoning effort without
+  changing your global Codex settings.
+- **Real Vim-style multi-cursor editing.** Press `Ctrl-n` to select repeated
+  occurrences or `Ctrl-Up` / `Ctrl-Down` for vertical cursors. Extend each
+  selection with familiar motions and apply one Unicode-aware, undoable edit.
+- **Inline help that gets out of the way.** Exact foreground edits can apply
+  immediately while remaining unsaved; background and wider same-file edits
+  always require explicit review. Keep the full history, inspect changes, or
+  continue a discussion in Agent.
+- **Your files stay protected when another tool changes them.** Clean buffers
+  reload automatically. Dirty buffers keep both versions until you compare,
+  reload, save elsewhere, or explicitly overwrite.
+- **A faster, more complete editing workspace.** Browse large file trees,
+  coordinate LSP and optional Copilot completions, and format supported
+  pasted ranges.
+
+These features become part of the supported release after the next version is
+published. Until then, [build from source](#development) to try them.
 
 ## First five minutes
 
@@ -101,9 +116,10 @@ Open a file:
 red path/to/file
 ```
 
-The first interactive launch offers a guided tour, release highlights, and an
-immediate exit into the editor. The tour uses a disposable practice buffer and
-safe Git/agent demonstrations; reopen it with `:welcome` or `:tutorial`.
+On `main`, the first interactive launch offers a guided tour, release
+highlights, and an immediate exit into the editor. The tour uses a disposable
+practice buffer and safe Git/agent demonstrations; reopen it with `:welcome` or
+`:tutorial`. This guided onboarding is coming in the next release.
 Starter configuration remains optional: embedded defaults, plugins, and themes
 are enough to begin editing.
 
@@ -115,7 +131,7 @@ are enough to begin editing.
 | `Ctrl-e`, then `/` | Open the file tree and search files or directories |
 | `Space G` | Open the Git status workspace |
 | `Space A` | Ask the agent with editor context |
-| `Space i` | Refactor the current line or visual selection inline |
+| `Space i` | Review, explain, or refactor the enclosing function or exact selection |
 | `Space t` | Browse themes with live preview |
 
 See [Getting started](docs/GETTING_STARTED.md) for editing, navigation,
@@ -123,33 +139,43 @@ configuration, language servers, Git, CLI, and troubleshooting guidance. The
 [Vim compatibility matrix](docs/VIM_COMPATIBILITY.md) is the precise,
 versioned behavior contract.
 
-## A visible agent workflow
+## Agents that understand your editor
 
 ![Red preparing a contextual agent prompt over the active source file](docs/images/agent-workflow.jpg)
 
-Agent edits happen through Red's editor transaction and save paths while you
-follow along in the active buffer.
+### The full Agent workspace
 
-1. **Ask.** Open the agent with `Space A`; Red includes a bounded selection or
-   cursor excerpt, unsaved contents, and relevant diagnostics.
-2. **Follow.** Red reveals the target file and cursor before each bounded tool
-   call, then briefly pauses so the change is readable.
-3. **Continue.** Revision-checked edits are attributed to the Codex session,
-   applied to the visible buffer, and saved to disk through Red.
+1. **Ask.** Press `Space A`; Red provides a bounded source excerpt, current
+   selection, relevant diagnostics, and authoritative unsaved buffer contents.
+2. **Work through the editor.** Codex reads and changes files only through
+   Red's workspace-confined, revision-checked editor tools. Agent edits are
+   attributed to their conversation and **saved to disk** through Red.
+3. **Keep the conversation.** Follow tool progress, queue another request, and
+   resume the same conversation without losing editor context. On `main`,
+   source-linked annotations turn explanations into navigable code walkthroughs.
 
-The integration uses the Codex app-server directly and supports persistent
-conversation, queued follow-ups, live tool progress, and explicit session
-controls. Ignored, out-of-workspace, binary, and common secret files are
-excluded from context. Read the
-[agent workflow and safety contract](docs/AGENT_WORKFLOW.md) for prerequisites,
-limits, commands, and failure behavior.
+In v0.6.0, Red follows each file tool visually. On `main`, playback is optional
+and disabled by default; set `[agent] follow_tool_calls = true` to reveal each
+target and pause before the operation. Full Agent writes still save to disk in
+both versions.
 
-For a smaller blast radius, press `Space i` on a line or visual selection.
-Inline assist opens beside the target, gives an ephemeral Codex thread only the
-selected text and bounded surroundings, and accepts only one complete
-replacement. The result is an unsaved, agent-attributed editor transaction;
-keep it, undo it, refine it in the same popup, or escalate the changed range to
-the full Agent panel.
+### Focused inline assistance
+
+Press `Space i` to review, explain, or refactor the enclosing function, falling
+back to the current line when syntax is unavailable. In Visual or Visual Line
+mode, the target is exactly the selected text. Requests use an ephemeral Codex
+thread with bounded read-only project context; visual-block targets are not
+supported. Inline code edits form one **unsaved, undoable editor transaction**.
+
+In v0.6.0, every inline code change requires explicit review. On `main`, an
+exact-target edit may apply immediately when its original popup is in the
+foreground; set `[agent] auto_apply_inline_edits = false` to review it first.
+Background results and wider same-file proposals always require an explicit
+review and approval. Use `Space H` to revisit inline history or `A` to prepare
+a full Agent follow-up without sending it automatically.
+
+The [agent workflow and safety contract](docs/AGENT_WORKFLOW.md) explains
+prerequisites, path protections, exact boundaries, commands, and failure modes.
 
 ## What Red ships today
 
@@ -164,7 +190,10 @@ The current release includes:
 - command and keymap discovery, fuzzy files, buffer navigation, symbols,
   references, project search, and diagnostics
 - native Git gutter signs, hunk actions, and a full-screen workspace for
-  staging, commits, branches, remotes, stashes, logs, and rebases
+  staging, commits, Codex-generated commit messages, branches, remotes,
+  stashes, logs, and rebases
+- a persistent full Agent workspace and bounded inline assistance with
+  source-anchored comments, retained history, and reviewable local edits
 - an embedded Husk runtime with bundled file tree, search, Git, progress,
   inlay-hint, symbol, theme, and agent plugins
 - a branded startup splash, the Red theme, accessible selection and cursor
@@ -211,6 +240,15 @@ servers through a unified `[languages.<id>]` configuration or an installable
 language pack. Native Tree-sitter grammars require explicit digest-bound trust;
 `:languages reload` applies validated changes without restarting the editor.
 See the [language extensions guide](docs/LANGUAGES.md).
+
+## Husk language
+
+The source tree contains the extracted Husk embedding API, standalone CLI, local
+package resolver, and portable WebAssembly Component extension runtime. Start
+with the [language and embedding guide](docs/HUSK_LANGUAGE_GUIDE.md). The
+[research and implementation plan](docs/HUSK_LANGUAGE_EXTRACTION_PLAN.md) and
+[card-by-card status](docs/HUSK_IMPLEMENTATION_STATUS.md) explain the dynamic
+Rust-crate design, completed work, and remaining release-hardening tasks.
 
 ## Plugins and themes
 

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -504,7 +504,7 @@ protocol is unavailable; it does not fall back to `codex exec` or native edits.
 
 | Command | Purpose |
 | --- | --- |
-| `Space i` | Edit the current line or visual selection in a bounded popup. |
+| `Space i` | Review, explain, or edit the enclosing function, current-line fallback, or exact visual selection in a bounded popup. |
 | `:Agent` / `:AgentPrompt` | Open the prompt composer. |
 | `:AgentOpen` | Show and focus the conversation pane without opening a prompt. |
 | `:AgentModel` / `Alt+m` in the Agent pane | Choose this conversation’s model and reasoning effort. |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,7 +1,9 @@
 # Getting started with Red
 
-This guide covers the day-to-day editor workflow. For installation, see the
-[README](../README.md#install).
+This guide covers the day-to-day editor workflow on the current development
+branch. The latest published release is v0.6.0; features labeled **coming in
+the next release** are available on `main` but not in that published binary.
+For installation, see the [README](../README.md#install).
 
 ## First launch
 
@@ -18,16 +20,17 @@ Set an explicit workspace root with `-r`:
 red -r path/to/project src/main.rs
 ```
 
-The first interactive launch opens a keyboard-first welcome screen inside the
-editor. Start its guided tour, press `i` for a shorter tour, view release
+**Coming in the next release:** The first interactive launch opens a
+keyboard-first welcome screen inside the editor. Start its guided tour, press
+`i` for a shorter tour, view release
 highlights, or press `Esc` to begin editing immediately. Use `:welcome` to
 reopen it later.
 
 The guided tour uses an unnamed practice buffer and simulated Git and agent
 previews; it never saves the practice buffer, changes your repository, or
 starts Codex. The full tour covers modal editing, command discovery, fuzzy
-navigation, completion, Git, reviewable agent proposals, and themes. Start or
-control it at any time:
+navigation, completion, Git, a safe local Agent demonstration, and themes.
+Start or control it at any time:
 
 ```text
 :tutorial          # start the full guided tour
@@ -52,7 +55,7 @@ Red uses Vim-inspired modes. `Esc` returns to Normal mode.
 | Visual | `v` | Select by character |
 | Visual Line | `V` | Select whole lines |
 | Visual Block | `Ctrl-v` | Select a rectangle |
-| Command | `:` or `;` | Run named commands |
+| Command | `:` | Run named commands |
 
 The [Vim compatibility matrix](VIM_COMPATIBILITY.md) records supported behavior
 and intentional differences precisely.
@@ -100,6 +103,30 @@ Text objects include `iw` for a word and `i(`/`a(`, `i[`/`a[`, `i{`/`a{`,
 `i<`/`a<`, and quoted equivalents for delimited text. `a%` selects a matchit
 pair.
 
+## Multi-cursor editing
+
+**Coming in the next release:** Red supports built-in, Vim-style multi-cursor
+editing without an extra plugin. In Normal mode:
+
+| Key | Action |
+| --- | --- |
+| `Ctrl-n` | Select the word under the cursor, then add the next occurrence |
+| `Ctrl-Up` / `Ctrl-Down` | Add a cursor on the previous or next suitable line |
+| `n` / `N` | Move forward or backward through matching selections |
+| `q` / `Q` | Skip the current occurrence or remove its selection |
+| `Tab` | Enter extend mode; press again to collapse to each selection head |
+| `Shift-Left` / `Shift-Right` | Extend each selection by a grapheme |
+| `h`, `l`, `w`, `e`, `0`, `$` | Extend with Vim motions while extend mode is active |
+| `o` | Swap the anchor and head of every extended selection |
+| `c`, `i`, `a` | Replace, insert before, or append after every selection |
+| `d`, `x`, `y`, `p`, `P` | Delete, yank, or paste across the selected ranges |
+| `Esc` | Finish an insertion or clear the active multi-cursor session |
+
+For example, press `Ctrl-n` twice over `foo`, type `cbar`, and press `Esc` to
+replace both selected occurrences with `bar`. One `u` undoes the entire edit.
+Selections respect complete Unicode graphemes, and vertical cursors preserve
+display columns across tabs and spaces.
+
 ## Searching
 
 - `/` and `?` search forward and backward with live preview.
@@ -129,9 +156,9 @@ Patterns use Rust regular-expression syntax. `incsearch`, `hlsearch`,
 | `Space .` | Show code actions and quick fixes |
 | `Space r` | Rename the current symbol |
 
-Ordinary completion and Copilot can be enabled independently. The default
-completion menu takes priority over Copilot ghost text. To try coordinated
-previews instead, add:
+Ordinary completion and Copilot can be enabled independently. By default, the
+completion menu takes priority over Copilot ghost text. **Coming in the next
+release:** Try coordinated previews instead by adding:
 
 ```toml
 [completion]
@@ -150,13 +177,16 @@ Ctrl-Space and language-server trigger characters. To stop only identifier-prefi
 popups, use `auto_trigger = false` instead; Ctrl-Space and language-server trigger
 characters remain available. Neither setting enables or disables Copilot.
 
-Supported documents are formatted on save by default. Red prefers an installed
-language-pack formatter and otherwise uses LSP. To disable automatic formatting,
-add this to `~/.config/red/config.toml`:
+**Coming in the next release:** Supported documents are formatted on save by
+default, and pasted ranges are formatted when the active language server
+supports range formatting. Red prefers an installed language-pack formatter
+for whole-document formatting and otherwise uses LSP. Disable either behavior
+in `~/.config/red/config.toml`:
 
 ```toml
 [formatting]
 on_save = false
+on_paste = false
 ```
 
 `Space f` still formats explicitly. The same section accepts
@@ -194,9 +224,9 @@ is available, its type-aware candidates are merged in and ranked ahead of
 buffer words. `Ctrl-Space` requests both sources explicitly; typing an
 identifier prefix requests them automatically. Language-server trigger
 characters such as `.` also request completion immediately. While the menu is
-open, use `Ctrl-n`/`Ctrl-p` or the arrow keys to select a candidate, `Tab` to
-accept it, and `Ctrl-e` to dismiss the menu. `Enter` continues to insert a
-newline.
+open, use `Ctrl-n`/`Ctrl-p` or the arrow keys to select a candidate, `Tab` or
+`Enter` to accept the selected item, and `Ctrl-e` to dismiss the menu. `Enter`
+inserts a newline only when no completion is selected.
 
 Tune or disable either behavior in `config.toml`:
 
@@ -290,15 +320,18 @@ and never traverses `.git` metadata. It runs in the background without requiring
 
 ## Command mode
 
-Enter Command mode with `:` or `;`.
+Enter Command mode with `:`. By default, `;` repeats the previous character
+search, as in Vim; it can be remapped explicitly in your configuration.
 
 | Command | Action |
 | --- | --- |
 | `:w [file]` | Save, optionally under another name |
+| `:w! [file]` | Explicitly overwrite a changed file or existing destination |
 | `:wa` / `:wall` | Save every modified file buffer |
 | `:wq` | Save and quit |
 | `:q` / `:q!` | Quit, or quit while discarding changes |
-| `:e <file>` / `:e!` | Open or reload a file |
+| `:e <file>` / `:e!` | Open a file or discard local edits and reload from disk |
+| `:diffdisk` | Compare a locally edited file with its changed disk version |
 | `:<number>` / `:$` | Jump to a line or the last line |
 | `:bn` / `:bd` | Select the next buffer or delete a buffer |
 | `:bufdo {command}` | Run a non-interactive Ex command in every open buffer |
@@ -338,6 +371,20 @@ active, needs-attention, and warning/error filters,
 scroll long details; `D` clears inactive history. Messages are retained for
 the current Red session, subject to the history limit.
 
+## Files changed outside Red
+
+**Coming in the next release:** Red watches open files and protects your work
+when another editor, formatter, Git operation, or agent changes them on disk.
+A clean buffer reloads automatically. A dirty buffer remains unchanged, and Red
+marks the conflict instead of overwriting either version. Deleted files stay
+open and receive their own conflict indicator.
+
+Run `:diffdisk` to compare the disk and buffer versions in a unified diff.
+The default choice keeps your local edits and leaves the disk
+untouched. Use `:e!` to discard your edits and reload, `:w <file>` to save
+them elsewhere, or `:w!` to overwrite the changed disk version deliberately.
+Ordinary `:w` and `:wall` never silently overwrite an external change.
+
 ## Git workspace
 
 The bundled Git plugin provides gutter signs and a full-screen status
@@ -348,6 +395,10 @@ workspace. Open it with `Space G`.
 - `Space c c` submits a commit message; `Space c q` cancels it.
 - The commit editor shows branch and working-tree status followed by the staged diff.
   `:w` or `:wq` submits the message and returns to the workspace; `:q` cancels.
+
+The commit menu also offers **Generate message**. With Codex installed and
+authenticated, Red drafts a message from the staged diff while using recent
+commit messages only as style examples; you can edit the draft before committing.
 
 The workspace covers staged, unstaged, untracked, and conflicted files with an
 adaptive diff pane. It also exposes synchronization, branch, remote, tag,
@@ -382,23 +433,51 @@ confirmation-gated.
 
 ## Agent workflow
 
-For a bounded one-range edit, put the cursor on a line or make a character or
-linewise visual selection and press `Space i`. Enter a request such as
-`extract the condition into a named boolean`. Red anchors a small, auto-growing
-prompt inside the initiating editor split, beside but never over the target,
-and applies the completed replacement as one unsaved transaction.
-Press Enter to keep it, `u` to undo, `r` to refine, or `A` to continue in the
-full Agent panel. Visual-block selections are rejected in this first version.
+Agent features require Codex CLI 0.144.1 or newer and a completed `codex login`.
+Run `red --agent-check` for an offline prerequisite report, or use
+`red --agent-check --strict` to return a non-zero status when setup is incomplete.
 
-Install and authenticate Codex separately, then press `Space A` from Normal or
-Visual mode. Red sends a bounded source excerpt, unsaved contents, and relevant
-diagnostics. Red reveals each file operation as it happens, applies
-revision-checked edits through the editor, and saves them with agent attribution.
+### Ask inline
 
-Run `red --agent-check` for an offline prerequisite report or
-`red --agent-check --strict` for a non-zero exit when setup is incomplete.
-See the [agent workflow and safety contract](AGENT_WORKFLOW.md) for the complete
-interaction model and command list.
+Press `Space i` to review, explain, or refactor code beside the current source.
+In Normal mode, Red targets the enclosing function when syntax information is
+available, falling back to the current line. In Visual or Visual Line mode, it
+targets exactly your selection. Visual-block targets are rejected. Enter a
+request such as `extract the condition into a named boolean` or `review this
+function for edge cases`.
+
+Inline code changes are one **unsaved, undoable editor transaction**. Comments
+and explanations never modify source. The published v0.6.0 release requires
+explicit review for every code change. **Coming in the next release:** Exact
+foreground results apply immediately by default; set
+`[agent] auto_apply_inline_edits = false` to review them first. Background
+results and wider same-file edits always require explicit approval. In a review
+diff, `a` approves, `d` declines, and `Enter` does not apply the change.
+
+Use `u` to undo an applied result, `r` to refine it, `Space H` to inspect retained
+inline history, or `A` to prepare a full Agent follow-up. The follow-up remains
+an unsent draft until you submit it yourself.
+
+### Open the full Agent workspace
+
+Press `Space A` from Normal or Visual mode. Red sends a bounded source excerpt,
+selection, relevant diagnostics, and authoritative unsaved buffer contents.
+Codex reads and changes files through Red's workspace-confined editor tools;
+revision-checked Agent writes are attributed to the conversation and **saved
+to disk**. This differs intentionally from unsaved inline edits.
+
+The published v0.6.0 release follows every file tool visually. **Coming in the
+next release:** Tool calls run without forced playback pauses by default; set
+`[agent] follow_tool_calls = true` to reveal each target and pause before it runs.
+
+**Also coming in the next release:** Ask the Agent to explain a subsystem and
+follow links in its answer directly to source-anchored annotations. Click the
+model in the Agent header, press `Alt+m`, or run `:AgentModel` to choose the
+model and reasoning effort for this conversation without modifying global Codex
+configuration.
+
+See the [agent workflow and safety contract](AGENT_WORKFLOW.md) for the full
+interaction model, commands, path boundaries, and failure behavior.
 
 ## Configuration
 

--- a/docs/RELEASE_COMMUNICATIONS_CONVERSATION.md
+++ b/docs/RELEASE_COMMUNICATIONS_CONVERSATION.md
@@ -1,0 +1,582 @@
+# Release Communications and Launch Strategy: Conversation Archive
+
+> **Archived:** 2026-08-27
+>
+> **Scope:** The original release-communications audit, launch strategy,
+> implementation handoff, branch locations, and resulting commit references.
+> This archive preserves substantive user prompts and assistant answers. Tool
+> output, intermediate progress messages, runtime configuration, and internal
+> citation bookkeeping are intentionally omitted. Local machine paths have
+> been normalized for portability.
+>
+> **Point-in-time context:** Release versions, public metrics, website state,
+> branch status, and platform capabilities describe the conversation when it
+> occurred. Recheck current state before acting on time-sensitive claims.
+
+---
+
+## 1. User — 2026-08-23T21:11:27.109Z
+
+I will release a Red version soon and there will be a massive number of new features, improvements and fixes.
+
+Can you review our release process but mostly the communications we do around each release, on GitHub release bodies and Discord announcements, and anything else I might be missing?
+
+I feel like people don't know about how far we are, specially on the agentic side panel, inline agent and also feature parity to neovim and better yet, innovative features we might have.
+
+I want to make it in a way that we get more hype for the cool features, improvements and bug fixes that really stand out.
+
+Can you come up with ideas to improve it and add a new integrated way to also post to X and maybe even other places?
+
+Don't limit yourself to these though, please be welcome to provide more ideas, suggestions and insights to make the full thing more "viral" if at all possible.
+
+---
+
+## 2. Assistant — 2026-08-23T21:20:42.081Z
+
+### Red needs a launch system, not just better release notes
+
+Red has a compelling story, but its release process currently turns that story into a chronological inventory of commits. The result is that some genuinely distinctive capabilities are effectively invisible.
+
+My recommended positioning:
+
+> **Red is the Vim-style terminal editor where your coding agent works through your editor, not around it.**
+
+Supporting message:
+
+> Vim muscle memory. Editor-aware Codex agents. Focused inline assistance. One Rust binary.
+
+That framing gives you three audiences simultaneously: Vim users, developers interested in agentic coding, and people who want a capable terminal editor without assembling a plugin stack.
+
+#### What I found
+
+As of August 23, the latest published release is [Red v0.6.0](https://github.com/codersauce/red/releases/tag/v0.6.0), while `main` is already **100 commits ahead**:
+
+- 35 feature-labeled commits.
+- 44 fix-labeled commits.
+- Five performance-labeled commits.
+- The remainder are merges and other changes.
+
+Those are commit categories, not a claim that there are exactly 35 distinct user-facing features.
+
+The release mechanics themselves are solid: release-preparation PR, version synchronization, generated changelog, cross-platform builds, runtime checks, checksums, draft release, Homebrew updates, and automated Discord announcements. The process is documented in [RELEASING.md](../docs/RELEASING.md).
+
+The communication layer is where things fall apart.
+
+##### GitHub releases bury the best work
+
+The v0.6.0 release opens with **23 bug-fix bullets**, followed by **41 feature bullets**. Within those features:
+
+- Live agent-driven edits appear twelfth.
+- Persistent agent conversations appear thirteenth.
+- Inline assistance appears eighteenth.
+- Inline history and source-linked comments appear twenty-fifth.
+- Richer inline outcomes appear forty-first.
+
+A visitor has to work unreasonably hard to discover what makes Red interesting.
+
+The underlying issue is [cliff.release.toml](../cliff.release.toml): release sections are grouped alphabetically and commits are ordered oldest-first. That is useful provenance, but a poor product narrative.
+
+##### Discord repeats the same editorial mistake
+
+I reconstructed the current v0.6.0 announcement. Its five featured highlights are:
+
+1. LSP diagnostic counts in the status line.
+2. A diagnostic popup.
+3. Modal editing inside the agent composer.
+4. Diagnostic gutter signs.
+5. General improvements to the agent pane.
+
+The first “Fixes & polish” entry promotes **faster CI**.
+
+Meanwhile, the announcement completely omits inline assistance, live agent edits, persistent conversations, source-linked comments, and Codex-generated commit messages.
+
+The ranking vocabulary in [discord_release.py](../scripts/discord_release.py) does not include “agent,” “Codex,” “inline,” “Neovim,” or “multi-cursor.”
+
+##### The website is substantially out of date
+
+The separate [red-website repository](https://github.com/codersauce/red-website) was last updated July 25.
+
+Its generated release metadata still says **v0.2.4**. A browser-side component fetches the latest release after the page loads, but search engines, server-rendered HTML, and structured metadata still receive the stale version.
+
+Worse, both the [homepage](https://getred.dev/) and [documentation](https://getred.dev/docs) advertise an old proposal-review workflow and reference `:AgentReview`.
+
+That no longer accurately describes the current full Agent panel:
+
+- Full Agent edits go through Red’s validated editor tools and **are saved to disk**.
+- Exact inline edits can apply immediately by default but remain **unsaved and undoable**.
+- Wider inline edits require explicit review.
+- Followed visual playback is configurable and currently **disabled by default**.
+
+The actual behavior is documented in [AGENT_WORKFLOW.md](../docs/AGENT_WORKFLOW.md) and [default_config.toml](../default_config.toml).
+
+This discrepancy is more than stale marketing. It misrepresents the product’s safety model.
+
+There is also a structural reason the website stays stale: its tests literally assert that the version is `0.2.4`. Updating installer metadata without fixing those tests would fail CI.
+
+##### Your strongest discovery surfaces are underused
+
+Current GitHub snapshot:
+
+- **219 stars.**
+- **Four repository watchers.**
+- **Zero repository topics.**
+- Repository description: “Vimlike Modal Text Editor in Rust.”
+- Repository homepage points to `rededitor.app`, while the documented canonical site is `getred.dev`.
+- GitHub Discussions are disabled.
+
+Over the last 14 days, GitHub recorded **218 page views from 73 unique visitors**. The latest release page had only **five unique visitors** in the popular-path report.
+
+The latest release has **60 binary-archive downloads**. Those numbers are directional, not a complete installation count.
+
+GitHub also reports thousands of clones, but that is likely inflated by CI and automation and should not be treated as user adoption.
+
+#### The features that deserve the spotlight
+
+I would organize the upcoming launch around five stories.
+
+##### 1. “Your agent can point at the code it means”
+
+The Agent panel can create source-linked annotations and include clickable links in its explanations. Clicking a link jumps directly to the relevant code and opens the associated annotation.
+
+That is far more interesting than “improved agent pane.”
+
+Suggested framing:
+
+> Ask Codex to explain a subsystem, and its answer becomes a guided walkthrough through the actual source.
+
+This is newly added in [PR #282](https://github.com/codersauce/red/pull/282).
+
+##### 2. “An inline agent with a real memory”
+
+`Space i` can provide focused reviews, explanations, source-anchored comments, and bounded refactors.
+
+The broader workflow includes:
+
+- Exact visual-selection boundaries.
+- Review requirements for wider changes.
+- Persistent inline discussion history.
+- Reviewable diffs and change attribution.
+- Background jobs.
+- Escalation from inline assistance into the full Agent panel.
+
+Much of this already exists in v0.6.0, but it has not been presented as a coherent product capability. Market it as something Red offers today, while identifying which improvements are actually new.
+
+##### 3. “Vim-style multi-cursor editing, built in”
+
+The upcoming release includes:
+
+- `Ctrl-n` to select successive occurrences.
+- `Ctrl-Up` and `Ctrl-Down` for vertical cursors.
+- Extension with Vim motions.
+- Unicode-aware editing.
+- Changes grouped into one undoable operation.
+
+This is genuinely prominent launch material, yet it currently does not appear in the README, getting-started guide, or Vim compatibility matrix.
+
+See [PR #326](https://github.com/codersauce/red/pull/326) and [default_config.toml](../default_config.toml).
+
+##### 4. “A proper agent workspace, not just a prompt”
+
+The full panel supports persistent conversations, unsaved-buffer awareness, prompt history, queued follow-ups, source-linked walkthroughs, and per-conversation model/reasoning selection.
+
+The model picker is new in [PR #273](https://github.com/codersauce/red/pull/273).
+
+A particularly good message:
+
+> Your agent sees the code you are actually editing, including changes you have not saved.
+
+##### 5. “Terminal-editor capabilities people do not expect”
+
+These deserve individual follow-up posts:
+
+- **Detached agent sessions:** On macOS and Linux, disconnect from SSH and reconnect to the same running editor and agent. See [DETACH.md](../docs/DETACH.md).
+- **Large repository performance:** The documented benchmark fully opens an 8,192-entry tree in 47.17 ms, with 0.566 ms p95 navigation under the recorded test conditions. See [the benchmark report](../docs/performance-neotree-unbounded-2026-08-21.md).
+- **External-change protection:** Detect changes made outside Red, preserve unsaved work, and resolve conflicts explicitly. See [PR #330](https://github.com/codersauce/red/pull/330).
+- **Coordinated LSP and Copilot completion:** An optional mode combines conventional completion with compatible AI suggestions. See [PR #281](https://github.com/codersauce/red/pull/281).
+- **Interactive onboarding:** A guided first-run experience helps people understand the editor quickly.
+- **Full Git workspace, Codex-generated commit messages, Tree-sitter text objects, crash recovery, and the Husk plugin runtime.**
+
+The central distinction should be:
+
+> **New in this release** versus **already possible in Red and worth finally showing properly**.
+
+#### Build one editorial source of truth
+
+I would add a small, human-reviewed release campaign manifest, something like:
+
+```toml
+version = "<next-version>"
+tier = "landmark"
+headline = "The modal editor where your coding agent works through your editor"
+canonical_url = "https://getred.dev/releases/<next-version>"
+
+[[stories]]
+id = "source-linked-walkthroughs"
+status = "new"
+title = "Your agent can point at the code it means"
+pull_requests = [282]
+audiences = ["agent", "vim", "terminal"]
+demo = "agent-walkthrough.mp4"
+
+[[stories]]
+id = "inline-agent"
+status = "existing-improved"
+title = "Focused inline reviews and refactors with persistent history"
+audiences = ["agent", "vim"]
+demo = "inline-agent.mp4"
+
+[[stories]]
+id = "multi-cursor"
+status = "new"
+title = "Real Vim-style multi-cursor editing"
+pull_requests = [326]
+audiences = ["vim", "editor"]
+demo = "multi-cursor.mp4"
+```
+
+Then render every release surface from that reviewed manifest:
+
+```mermaid
+flowchart LR
+    A[Reviewed release stories and demo assets]
+    A --> B[GitHub release]
+    A --> C[Discord announcement]
+    A --> D[X post and follow-ups]
+    A --> E[Bluesky / Mastodon]
+    A --> F[Website release page and SEO]
+    A --> G[In-app What's New]
+    A --> H[HN / Reddit / YouTube drafts]
+```
+
+Keep the complete generated changelog underneath the editorial introduction. Contributor credit and detailed commit history remain intact.
+
+##### Make the release-preparation PR include launch review
+
+Extend the existing release checklist to require:
+
+- Three to five reviewed flagship stories.
+- Accurate “new” versus “already available” labels.
+- A real demo clip or screenshot for each major story.
+- Verified keyboard shortcuts and feature prerequisites.
+- Accurate statements about saves, approvals, scope, and supported platforms.
+- Website synchronization.
+- Previewed Discord, X, and Bluesky copy.
+- A checked social-preview image.
+- Installation instructions tested against the actual release candidate.
+
+This fits naturally into the current [release PR template](../.github/release-pr-body.md).
+
+##### Fix the in-app “What’s New” panel too
+
+Red already has a valuable distribution channel: its default-on release announcement inside the editor.
+
+However, [whats_new.rs](../src/whats_new.rs) currently takes only the first five entries from conventional changelog sections. A beautifully written GitHub introduction would still disappear inside Red.
+
+The same curated highlights should be embedded in the release binary for offline use and refreshed from the exact matching GitHub release when available.
+
+Existing users should immediately see:
+
+> New: source-linked Agent walkthroughs, Vim-style multi-cursor, model selection, faster large repositories.
+
+#### Integrating X and other channels
+
+| Channel | Recommended approach | What to publish |
+|---|---|---|
+| GitHub Releases | Automatically generated, editorially reviewed | Canonical release story, hero video, installation, detailed changelog |
+| Website | Synchronize and deploy for each release | Search-indexable release page, current screenshots, accurate safety model |
+| Discord | Automatic | Three strong highlights, one demo, installation command, discussion prompt |
+| X | Approval-gated automatic publishing | Short founder-style post with native video; follow-up feature clips |
+| Bluesky | Automatic or approval-gated | Native screenshot/video and a developer-focused explanation |
+| GitHub Discussions | Optional | Searchable release discussion and feedback, if you want another maintained community surface |
+| Reddit | Manual, tailored to each community | Specific demos for relevant Rust, Vim, terminal, or programming audiences |
+| Hacker News | Manual | A substantive “Show HN” for the overall product or major overhaul |
+| YouTube | Manual initially | One flagship walkthrough plus short clips showing individual workflows |
+| DEV Community | Automatically prepared draft | A substantive technical article about editor-mediated agent workflows |
+| Mastodon | Optional automatic publishing | Native screenshot/video if you establish an appropriate account |
+| Product Hunt | Manual | Reserve for a genuinely major milestone with polished launch assets |
+
+##### X integration is feasible
+
+Use X’s official API with:
+
+- OAuth authorization for the account that will publish.
+- `tweet.write` and `media.write` permissions.
+- `offline.access` for renewable credentials.
+- Native video upload followed by post creation.
+- Protected GitHub Actions secrets.
+- A human approval gate before the first public post.
+- Per-release delivery tracking to prevent duplicates.
+
+X currently documents a **pay-per-use, prepaid-credit model with no monthly minimum**, but the actual endpoint prices are visible only in its Developer Console. Check the account’s current pricing before committing to the integration. [X API usage and billing](https://docs.x.com/x-api/fundamentals/post-cap), [X OAuth permissions](https://docs.x.com/fundamentals/authentication/oauth-2-0/authorization-code), [X media uploads](https://docs.x.com/x-api/media/quickstart/media-upload-chunked).
+
+Do **not** automate the X website through browser scripting or repeatedly publish substantially identical posts. X explicitly prohibits both patterns. [X automation rules](https://help.x.com/en/rules-and-policies/x-automation).
+
+##### Bluesky is the easiest additional social integration
+
+Bluesky has a documented posting API with support for links, images, and rich embeds. Its published service limits are generous relative to a normal release workflow. [Bluesky posting guide](https://atproto.com/blog/create-post), [Bluesky rate limits](https://bsky.network/docs/rate-limits/).
+
+##### Some channels should remain human-led
+
+Hacker News explicitly says routine version updates generally do not qualify as Show HN, while a major overhaul can qualify. It also prohibits asking friends to vote or comment. Present Red itself and its distinctive workflows, rather than posting “Red vX.Y released.” [Show HN guidelines](https://news.ycombinator.com/showhn.html).
+
+YouTube’s upload API is usable, but uploads from unaudited API projects are restricted to private visibility. Manual publication is the practical initial choice. [YouTube upload API](https://developers.google.com/youtube/v3/docs/videos/insert).
+
+For Rust-specific distribution, **This Week in Rust currently says it no longer accepts direct submissions for its project/tooling updates section and instead monitors `r/rust`**. Its editors prefer substantial technical material over generic changelogs and ask for disclosure when an article is LLM-written. That makes a thoughtful, human-edited Rust engineering article considerably more useful than syndicating the release bullets. [This Week in Rust contribution guidelines](https://github.com/rust-lang/this-week-in-rust).
+
+##### Preserve the current working release trigger
+
+Today, a human publishes the draft release, so the existing `release.published` workflow runs correctly.
+
+If release publication itself is later automated using GitHub’s built-in `GITHUB_TOKEN`, GitHub generally suppresses subsequent workflows triggered by that token. In that case, run announcement jobs within the publishing workflow, explicitly dispatch a second workflow, or use an appropriately scoped GitHub App token. [GitHub token workflow-trigger behavior](https://docs.github.com/en/actions/concepts/security/github_token).
+
+GitHub environments can also require approval before publishing jobs receive their social-account credentials. [GitHub protected environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments).
+
+#### What the actual announcement could look like
+
+##### GitHub release opening
+
+> # Red [version]: Vim muscle memory meets editor-aware agents
+>
+> Red is a fast, Vim-style terminal editor with a coding agent that understands the code you actually have open.
+>
+> This release introduces source-linked Agent walkthroughs, built-in Vim-style multi-cursor editing, conversation-specific model selection, stronger large-repository performance, and safer handling of externally modified files.
+>
+> **Three things to try first**
+>
+> 1. Ask Agent to explain a subsystem, then follow its links directly into annotated source.
+> 2. Select code and press `Space i` for a focused review, explanation, or refactor.
+> 3. Press `Ctrl-n` to select repeated occurrences and edit them together.
+>
+> **Install:** `brew install codersauce/tap/red`
+>
+> **Agent setup:** Install Codex separately and run `codex login`.
+
+After that:
+
+1. Embed the flagship demo.
+2. Explain the five strongest stories with screenshots or short clips.
+3. Clearly state the Agent versus inline safety behavior.
+4. Summarize significant Vim-compatibility additions.
+5. Highlight measured performance improvements.
+6. Provide complete categorized changes and contributor credits.
+
+##### Example X post
+
+> I’m building Red: a Vim-style terminal editor with an agent that understands your editor.
+>
+> → Codex annotates the exact code it means
+> → Scoped inline reviews and refactors
+> → Ctrl-N multi-cursor
+> → Agents survive SSH drops (macOS/Linux)
+>
+> https://getred.dev
+
+Attach a short, captioned recording. The video should make the claim self-evident without requiring audio.
+
+##### Example Discord announcement
+
+> **Red [version] is out: agent-aware editing, real Vim multi-cursor, and a much smarter workspace.**
+>
+> **Try these first:**
+>
+> - Ask Codex to explain code and jump directly from its answer to source annotations.
+> - Select code and press `Space i` for an inline review or focused refactor.
+> - Press `Ctrl-n` to edit repeated occurrences together.
+> - Choose the model and reasoning effort directly inside the Agent panel.
+>
+> Also included: faster large repositories, safer external-file conflict handling, improved LSP behavior, and dozens of fixes.
+>
+> `brew install codersauce/tap/red`
+>
+> **Which Neovim workflow should we make agent-aware next?**
+
+That last question gives the announcement a useful conversational entry point without manufacturing engagement.
+
+#### Make the launch visually convincing
+
+Record one **30–45 second flagship demo**:
+
+1. Open a real Rust file in Red.
+2. Ask the Agent panel to explain a subsystem.
+3. Click a response link and jump to an annotated source location.
+4. Select code and use `Space i` for a comments-only review or bounded edit.
+5. Use `Ctrl-n` to select multiple occurrences.
+6. Show that one undo reverts the grouped edit.
+7. End with the installation command.
+
+Then create separate short clips for:
+
+- Agent source walkthroughs.
+- Inline review and retained history.
+- Multi-cursor editing.
+- Dropped-SSH session recovery.
+- Model selection.
+- Large-repository browsing.
+- External-file conflict recovery.
+
+Use real key overlays, captions, and actual release-candidate behavior. If showing followed agent playback, enable `follow_tool_calls` explicitly because it is not the default.
+
+Also replace the GitHub repository social card with a feature-focused image. GitHub recommends **1280 × 640 pixels** for best display. [GitHub social preview guidance](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/customizing-your-repositorys-social-media-preview).
+
+#### Additional changes that would materially help
+
+**Fix GitHub positioning immediately.** Update the description to something like:
+
+> Vim-style terminal editor with Codex agents, inline AI review, LSP, Git, and one-binary setup.
+
+Add relevant repository topics: `vim`, `neovim`, `modal-editor`, `terminal`, `tui`, `rust`, `code-editor`, `coding-agent`, `codex`, `lsp`, and `tree-sitter`.
+
+**Make `getred.dev` the consistent public destination.** Update GitHub repository metadata, social links, release URLs, canonical pages, and campaign links accordingly.
+
+**Move the main product story above Husk in the README.** Husk is interesting, but a new visitor should encounter the flagship editor and agent workflows before implementation-oriented language details.
+
+**Create durable feature pages.** Pages such as `/agent`, `/inline`, `/vim`, `/sessions`, and `/releases/<version>` are easier to discover, share, and keep current than one large README.
+
+**Turn Vim compatibility into a credibility asset.** Maintain a dated compatibility matrix, show supported behavior and intentional differences, and record short demonstrations of real Vim workflows.
+
+However, the current matrix still says it was validated against Red 0.5.0, and the two required external Vim-user trials are unassigned in [VIM_DOGFOOD.md](../docs/VIM_DOGFOOD.md). Until that changes, avoid claiming complete or independently validated Neovim parity.
+
+**Keep release messaging honest about prerequisites.** Red itself needs no required configuration, but the agent requires an installed and authenticated Codex CLI. Copilot is separately installed and opt-in. Detached sessions are macOS/Linux only.
+
+**Introduce release tiers.** Landmark releases get a campaign, flagship video, social rollout, and community posts. Smaller releases get concise GitHub/Discord updates and perhaps one targeted social post. Not every patch needs a launch.
+
+**Publish one release as several stories.** Launch the overall release first, then spend the following week showing one concrete workflow per day. This creates more opportunities for discovery without repeatedly posting the same announcement.
+
+**Measure actual distribution.** Track release-page traffic, referring sites, release-asset downloads, channel-specific landing visits, and engagement on individual feature clips. Do not interpret automated clone counts as adoption, and avoid adding invasive editor telemetry.
+
+#### Recommended implementation order
+
+1. Correct the website’s outdated version, agent safety claims, and hard-coded version tests.
+2. Refresh the README, compatibility matrix, GitHub description, homepage, topics, and social preview.
+3. Add a reviewed release-campaign manifest and generate curated GitHub/Discord/in-app highlights from it.
+4. Integrate approval-gated X publishing and Bluesky posting into the existing release-announcement workflow.
+5. Synchronize and deploy the separate website repository for each published release.
+6. Prepare tailored, human-reviewed drafts for Hacker News, Reddit, YouTube, and a Rust-focused technical article.
+7. Add release analytics and a repeatable demo-recording checklist.
+
+The biggest opportunity is to **reintroduce Red around workflows people can immediately understand and watch**: an agent that annotates real source, an inline assistant with clear boundaries, serious Vim-style editing, and terminal-native capabilities that remain useful even when the network connection disappears.
+
+---
+
+## 3. User — 2026-08-23T22:34:54.922Z
+
+I want you to take on as much as possible of the tasks here. We are about to close out the release soon but not there yet, what can you start working on in parallel and autonomously now?
+
+---
+
+## 4. Assistant — 2026-08-23T22:50:03.456Z
+
+I completed three independent, release-ready workstreams without publishing anything.
+
+##### 1. Release communications and social distribution
+
+**Branch:** `fcoury/release-campaign`
+
+Created a shared [release campaign manifest](../../red.fcoury-release-campaign/release/campaign.toml) that controls messaging across:
+
+- GitHub release introductions.
+- Discord announcements.
+- Red’s in-app release highlights.
+- X and Bluesky previews.
+
+The campaign highlights source-linked Agent walkthroughs, inline assistance, Vim-style multi-cursor editing, per-conversation model selection, performance, and external-file protection.
+
+GitHub releases now lead with curated highlights while retaining the complete changelog. Discord uses the same editorial priorities.
+
+The new [social publisher](../../red.fcoury-release-campaign/scripts/social_release.py) supports X and Bluesky, including images, X videos, and accessibility descriptions. **It defaults to preview mode; posting requires an explicit `--publish`.**
+
+Example X preview:
+
+> Red: a modal editor with an editor-aware coding agent
+> - Ask your agent to explain code and jump to the exact source
+> - Review or refactor code without leaving your editor
+> - Edit multiple occurrences with Vim-style Ctrl-n
+>
+> https://getred.dev
+
+**Verified:** 39 release/social tests, 21 Rust tests, full Clippy, formatting, and workflow validation.
+
+##### 2. Product documentation and onboarding
+
+**Branch:** `fcoury/release-docs`
+
+Updated the [README](../README.md) and [getting-started documentation](../docs/GETTING_STARTED.md) to prominently explain:
+
+- The Agent side panel and inline assistance.
+- Upcoming source-linked explanations and model selection.
+- Vim-style multi-cursor commands.
+- External-file conflict protection.
+- Completion, formatting, and other compatibility improvements.
+
+Corrected misleading safety descriptions: **full Agent changes are saved to disk; inline changes remain unsaved and undoable.** Unreleased features are explicitly marked as upcoming.
+
+**Verified:** 77 focused tests and release-version consistency checks.
+
+##### 3. Marketing website and release landing page
+
+**Branch:** `fcoury/release-refresh`
+
+Refreshed the [homepage](../../red-website.fcoury-release-refresh/app/page.tsx), [documentation](../../red-website.fcoury-release-refresh/app/docs/page.tsx), and added a dedicated [release-highlights page](../../red-website.fcoury-release-refresh/app/releases/page.tsx).
+
+Changes include:
+
+- Agent-first product positioning.
+- Clear distinctions between published and upcoming capabilities.
+- Accurate Agent and inline-edit safety explanations.
+- Installer and structured metadata updated from **v0.2.4 to the actually published v0.6.0**.
+- Improved search metadata and sitemap.
+- Fixed an existing TypeScript error and added lint/typecheck enforcement to CI.
+
+**Local preview:** [Open the refreshed website](http://localhost:3000/) · [Release highlights](http://localhost:3000/releases)
+
+**Verified:** Production build, nine rendered-page tests, ESLint, TypeScript checks, and all three routes.
+
+##### GitHub discoverability
+
+Added **17 public repository topics**, including `coding-agent`, `ai-agent`, `vim`, `neovim`, `lsp`, and `terminal-editor`.
+
+Updating the repository description and homepage requires administrator permissions; the authenticated account only has maintainer access.
+
+**Everything remains uncommitted. No releases, social posts, pushes, pull requests, or website deployments were performed.**
+
+---
+
+## 5. User — 2026-08-24T01:53:25.236Z
+
+Where were the changes made?
+
+---
+
+## 6. Assistant — 2026-08-24T01:53:29.151Z
+
+Changes are in three separate sibling worktrees:
+
+- **Release automation, Discord, X, Bluesky:** `../../red.fcoury-release-campaign`
+- **Product documentation and onboarding:** `..`
+- **Marketing website:** `../../red-website.fcoury-release-refresh`
+
+All changes are uncommitted. The original `..` checkout was left unchanged.
+
+---
+
+## 7. User — 2026-08-24T02:01:02.760Z
+
+Commit all the branches
+
+---
+
+## 8. Assistant — 2026-08-24T02:04:03.242Z
+
+Committed all three branches:
+
+- `fcoury/release-campaign`: `e6e1fcdf`
+- `fcoury/release-docs`: `2fc8c1b6`
+- `fcoury/release-refresh`: `69fa704`
+
+All worktrees are clean, validations passed, and nothing was pushed.
+
+---
+
+## 9. User — 2026-08-27T13:50:35.162Z
+
+Can you dump this conversation on fcoury/release-docs somewhere suitable?

--- a/docs/RELEASE_COMMUNICATIONS_CONVERSATION.md
+++ b/docs/RELEASE_COMMUNICATIONS_CONVERSATION.md
@@ -472,7 +472,9 @@ I completed three independent, release-ready workstreams without publishing anyt
 
 **Branch:** `fcoury/release-campaign`
 
-Created a shared [release campaign manifest](../../red.fcoury-release-campaign/release/campaign.toml) that controls messaging across:
+Created a shared release campaign manifest
+(`release/campaign.toml` in the `red.fcoury-release-campaign` sibling worktree)
+that controls messaging across:
 
 - GitHub release introductions.
 - Discord announcements.
@@ -483,7 +485,11 @@ The campaign highlights source-linked Agent walkthroughs, inline assistance, Vim
 
 GitHub releases now lead with curated highlights while retaining the complete changelog. Discord uses the same editorial priorities.
 
-The new [social publisher](../../red.fcoury-release-campaign/scripts/social_release.py) supports X and Bluesky, including images, X videos, and accessibility descriptions. **It defaults to preview mode; posting requires an explicit `--publish`.**
+The new social publisher
+(`scripts/social_release.py` in the `red.fcoury-release-campaign` sibling
+worktree) supports X and Bluesky, including images, X videos, and accessibility
+descriptions. **It defaults to preview mode; posting requires an explicit
+`--publish`.**
 
 Example X preview:
 
@@ -516,7 +522,9 @@ Corrected misleading safety descriptions: **full Agent changes are saved to disk
 
 **Branch:** `fcoury/release-refresh`
 
-Refreshed the [homepage](../../red-website.fcoury-release-refresh/app/page.tsx), [documentation](../../red-website.fcoury-release-refresh/app/docs/page.tsx), and added a dedicated [release-highlights page](../../red-website.fcoury-release-refresh/app/releases/page.tsx).
+Refreshed the homepage (`app/page.tsx`), documentation (`app/docs/page.tsx`),
+and added a dedicated release-highlights page (`app/releases/page.tsx`) in the
+`red-website.fcoury-release-refresh` sibling worktree.
 
 Changes include:
 

--- a/docs/VIM_COMPATIBILITY.md
+++ b/docs/VIM_COMPATIBILITY.md
@@ -1,12 +1,13 @@
 # Red Vim compatibility matrix
 
-**Matrix version:** 1.9
-**Validated against:** Red 0.5.0, August 2026
+**Matrix version:** 1.10
+**Tracked against:** Red `main`, August 2026; the latest published release is 0.6.0
 **Status vocabulary:** **supported**, **intentional difference**, **not yet supported**
 
 “Real Vim keys” means the rows marked **supported** below. It does not mean complete
 Vim emulation. Every release that changes editing behavior must update this document and
-the corresponding integration tests.
+the corresponding integration tests. Rows explicitly marked **next release**
+describe tested behavior on `main`, not the currently published v0.6.0 binary.
 
 ## Normal editing
 
@@ -49,6 +50,7 @@ the corresponding integration tests.
 | Visual character | **supported** | Motions, supported text objects, yank/delete/change/paste, and Unicode selections. |
 | Visual line | **supported** | Linewise yank/delete/change/paste, including whole-document and interior replacements. |
 | Visual block | **supported** | Block delete/change/insert, one-transaction replay, undo/redo, and dot-repeat for block insert. |
+| Multi-cursor selections (**next release**) | **supported** | `Ctrl-n` selects successive whole-word occurrences; `Ctrl-Up` / `Ctrl-Down` add vertical cursors while preserving display columns. `n` / `N` navigate matches, `q` skips, and `Q` removes the active selection. `Tab` toggles extend mode; Shift-arrows and `h`, `l`, `w`, `e`, `0`, and `$` extend complete Unicode graphemes, and `o` reverses each anchor. `c`, `i`, `a`, `d`, `x`, `y`, `p`, and `P` apply across selections. Insert, change, delete, and paste are grouped into one undoable edit. |
 | Restore Visual selection | **supported** | `gv` restores the previous buffer-local Visual area with its character, line, or block shape and original direction. In Visual mode it exchanges the current and previous areas. Selection metadata survives session recovery, while `<` and `>` continue to track edits. |
 | Visual indent | **supported** | `[count]>` and `[count]<` shift every covered line right or left by `count × shiftwidth` in one undoable transaction for character, line, and block selections. Empty lines remain empty, indentation saturates at column zero, and `gv` restores the shifted range. |
 | Visual `r` replace and case changes | **supported** | Visual `r{char}`, `u`, `U`, and `~` replace/change the selection in one transaction, including shifted terminal key events and Visual-line/block selections. |
@@ -85,7 +87,7 @@ the corresponding integration tests.
 | Final line / trailing newline | **supported** | Both forms render and edit without exposing a phantom gutter line. |
 | Multi-window and docked panes | **supported** | Active-buffer cursor, viewport, wrapping, gutter width, and focus-cycle state are window-aware. `Ctrl-w h/j/k/l` moves between editor windows and panes; `Ctrl-w H/J/K/L` moves the focused editor window, row pane, or text pane to the corresponding outer edge without replacing its identity, content, or draft. |
 | Embedded plugin text areas | **supported** | Agent dialogs and text-panel composers reuse Unicode-aware word, paragraph, and sentence motions, character searches, ordinary and sentence text objects, and transactional replacement. Counts, operators, Visual selections, local registers, undo/redo, dot-repeat, macros, and prompt-local search remain isolated. Tree-sitter structural objects and swaps stay editor-owned and are unavailable in grammar-free composers. |
-| Inline assist selection | **intentional difference** | `Space i` targets the complete current line in Normal mode or the exact character/linewise Visual selection. Visual-block targets are rejected. The popup has its own Insert-like, soft-wrapped prompt, remains within the initiating split, and its applied result is one unsaved, undoable editor transaction. |
+| Inline assist selection | **intentional difference** | `Space i` targets the enclosing function in Normal mode when syntax information is available, otherwise the current line; characterwise and linewise Visual selections remain exact. Visual-block targets are rejected. The popup has its own Insert-like, soft-wrapped prompt, remains within the initiating split, and its applied result is one unsaved, undoable editor transaction. |
 | Window and pane resizing | **supported** | `Ctrl-w >` / `<` grow or shrink vertical panes and editor splits; `Ctrl-w +` / `-` grow or shrink horizontal panes and editor splits. Counts are supported. `Ctrl-w =` balances editor splits or restores the focused pane's original size. Mouse dragging immediately highlights the captured pane or nested split divider without stealing focus; release or `Esc` restores its normal appearance. |
 | Multi-window Vim window command parity | **intentional difference** | Red supports the documented navigation, edge-movement, resizing, and balancing commands; arbitrary Vim layouts and undocumented window commands are not promised. |
 

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -69,7 +69,7 @@ pub enum TutorialLesson {
     Completion,
     /// Inspect a simulated Git diff without touching the real repository.
     Git,
-    /// Inspect and accept or reject a simulated agent proposal.
+    /// Inspect a simulated editor-owned agent change without launching Codex.
     Agent,
     /// Preview an installed theme and explicitly decide whether to keep it.
     Themes,
@@ -101,7 +101,7 @@ impl TutorialLesson {
             Self::Navigation => "Find files and search projects",
             Self::Completion => "Code intelligence, immediately",
             Self::Git => "Git without leaving Red",
-            Self::Agent => "The agent asks permission",
+            Self::Agent => "An agent that knows your editor",
             Self::Themes => "Make Red yours",
         }
     }
@@ -154,10 +154,13 @@ impl TutorialLesson {
             (Self::Git, 0) => format!("Press {} to inspect a safe sample diff.", key("Space G")),
             (Self::Git, _) => "Inspect the sample diff, then press Esc to continue.".to_string(),
             (Self::Agent, 0) => {
-                format!("Press {} to inspect a simulated proposal.", key("Space A"))
+                format!(
+                    "Press {} to inspect a safe Agent demonstration.",
+                    key("Space A")
+                )
             }
             (Self::Agent, _) => {
-                "Press a to accept or r to reject the practice-only proposal.".to_string()
+                "Press a to apply the practice edit, or r to continue without it.".to_string()
             }
             (Self::Themes, 0) => format!("Press {} to browse installed themes.", key("Space t")),
             (Self::Themes, _) => {
@@ -175,7 +178,7 @@ impl TutorialLesson {
             Self::Navigation => "Fuzzy previews and project search keep your hands on the keys.",
             Self::Completion => "Open buffers supply suggestions even without a language server.",
             Self::Git => "Real Git changes always remain under your control.",
-            Self::Agent => "Nothing changes on disk until you review and accept it.",
+            Self::Agent => "Agent writes save through Red; inline edits stay unsaved and undoable.",
             Self::Themes => "Bundled themes and plugins work without a config file.",
         }
     }
@@ -393,6 +396,20 @@ mod tests {
                 TutorialLesson::Agent,
             ]
         );
+    }
+
+    #[test]
+    fn agent_lesson_describes_real_editor_save_boundaries() {
+        assert_eq!(
+            TutorialLesson::Agent.title(),
+            "An agent that knows your editor"
+        );
+        assert!(TutorialLesson::Agent
+            .explanation()
+            .contains("Agent writes save through Red"));
+        assert!(TutorialLesson::Agent
+            .explanation()
+            .contains("inline edits stay unsaved"));
     }
 
     #[test]

--- a/src/ui/welcome.rs
+++ b/src/ui/welcome.rs
@@ -243,7 +243,7 @@ impl WelcomePanel {
         self.center(
             buffer,
             brand_row + 3,
-            "An agent that asks permission.",
+            "An agent that knows your editor.",
             palette.style(Role::Muted),
         );
 
@@ -520,7 +520,7 @@ impl TutorialDemoPanel {
         let theme = editor.theme.clone();
         let title = match kind {
             TutorialDemoKind::Git => "GIT · SAFE PRACTICE DIFF",
-            TutorialDemoKind::Agent => "AGENT · REVIEW REQUIRED",
+            TutorialDemoKind::Agent => "AGENT · SAFE PRACTICE",
         };
         let mut dialog = Dialog::new(
             Some(title.to_string()),
@@ -537,9 +537,9 @@ impl TutorialDemoPanel {
             TutorialDemoKind::Git => vec![UiAction::new("continue", "Esc", "Continue")
                 .with_priority(ActionPriority::Essential)],
             TutorialDemoKind::Agent => vec![
-                UiAction::new("accept", "a", "Accept practice change")
+                UiAction::new("accept", "a", "Apply practice change")
                     .with_priority(ActionPriority::Essential),
-                UiAction::new("reject", "r", "Reject").with_priority(ActionPriority::Essential),
+                UiAction::new("reject", "r", "Skip").with_priority(ActionPriority::Essential),
             ],
         };
         dialog.set_actions(actions);
@@ -568,11 +568,11 @@ impl Component for TutorialDemoPanel {
             TutorialDemoKind::Agent => [
                 "  Agent request: Explain and improve total_price.",
                 "",
-                "  PROPOSED CHANGE · NOT APPLIED",
+                "  SAMPLE CHANGE · NOT APPLIED",
                 "  -    prices.iter().sum()",
                 "  +    prices.iter().copied().sum()",
                 "",
-                "  Accept changes only the unnamed practice buffer.",
+                "  This demo changes only the unnamed practice buffer.",
             ],
         };
         let width = self.dialog.width.saturating_sub(4);
@@ -584,7 +584,7 @@ impl Component for TutorialDemoPanel {
                 Role::Key
             } else if line.trim_start().starts_with("-") {
                 Role::Dot
-            } else if line.contains("Sample only") || line.contains("Accept changes") {
+            } else if line.contains("Sample only") || line.contains("This demo changes") {
                 Role::Muted
             } else {
                 Role::Text
@@ -751,7 +751,7 @@ mod tests {
     }
 
     #[test]
-    fn welcome_renders_brand_choices_and_safe_agent_promise() {
+    fn welcome_renders_brand_choices_and_editor_aware_agent_promise() {
         let editor = editor(/*width*/ 100, /*height*/ 28);
         let panel = WelcomePanel::new(&editor, /*can_resume*/ false);
         let mut buffer = RenderBuffer::new(100, 28, &Style::default());
@@ -761,7 +761,7 @@ mod tests {
         assert!(rendered.contains("WELCOME TO RED"));
         assert!(rendered.contains("guided tour"));
         assert!(rendered.contains("What’s new"));
-        assert!(rendered.contains("agent that asks permission"));
+        assert!(rendered.contains("agent that knows your editor"));
     }
 
     #[test]
@@ -780,8 +780,10 @@ mod tests {
 
         panel.draw(&mut buffer).unwrap();
         let rendered = buffer.dump(false).replace('·', " ");
+        assert!(rendered.contains("SAFE PRACTICE"));
         assert!(rendered.contains("NOT APPLIED"));
         assert!(rendered.contains("unnamed practice buffer"));
+        assert!(!rendered.contains("REVIEW REQUIRED"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Red's public documentation and onboarding understate its editor-aware Agent, focused inline assistance, and Vim compatibility. Some existing copy also implies that all Agent writes require manual approval, which incorrectly describes the distinction between saved full-Agent edits and unsaved inline edits.

## What Changed

- Reposition `README.md` around editor-aware Codex conversations, inline assistance, Vim fluency, and the bundled terminal-editor workflow while clearly separating published v0.6.0 behavior from features currently available only on `main`.
- Expand `docs/GETTING_STARTED.md`, `docs/AGENT_WORKFLOW.md`, and `docs/VIM_COMPATIBILITY.md` with multi-cursor commands, source-linked Agent explanations, conversation-specific model selection, external-file conflict recovery, completion behavior, formatting, and exact inline targeting.
- Correct onboarding and welcome-screen copy: full Agent edits are revision-checked and saved through Red, while inline edits remain unsaved and undoable; the guided Agent demonstration stays isolated in a disposable practice buffer.
- Archive the complete substantive release-communications and launch-strategy discussion in `docs/RELEASE_COMMUNICATIONS_CONVERSATION.md`, excluding runtime/tool metadata, credentials, and machine-specific absolute paths.

Companion release automation: https://github.com/codersauce/red/pull/350.

## How to Test

1. Run `python3 scripts/readme_release.py --check`; the README should continue to match the published package version without advertising upcoming `main` features as released.
2. Run `cargo test -p red --lib tutorial::tests` and `cargo test -p red --lib ui::welcome::tests`; all five tutorial tests and four welcome tests should pass, including the full-Agent versus inline save-boundary assertions.
3. Read the new README and getting-started sections; verify multi-cursor editing, source annotations, model selection, and external-file recovery are explicitly labeled as upcoming, while `Space i` describes enclosing-function targeting and exact Visual selections.
4. Inspect the archived strategy document; confirm it contains the substantive user/assistant discussion but no internal citation metadata or absolute `/Users/...` paths.
