### PR TITLE
fix(git): avoid repeated full repository scans

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -64,6 +64,8 @@ jobs:
             husk \
             plugin::runtime::tests::lsp_symbols_ \
             plugin::runtime::tests::git_ \
+            plugin::runtime::git_refresh_tests:: \
+            plugin::runtime::tests::monotonic_time_ \
             plugin::runtime::tests::embedded_git_core_ \
             plugin::runtime::tests::neotree_ \
             plugin::runtime::tests::embedded_neotree_core_

--- a/almanac/reference/plugins/host-api.md
+++ b/almanac/reference/plugins/host-api.md
@@ -20,7 +20,7 @@ sources:
     path: docs/plugin_api_changes.json
 ---
 
-The Plugin Host API reference identifies the files that define Red's Husk plugin contract and the rules for changing it. The canonical schema is `src/plugin/host_api.json`; it declares version `0.16.0` and lists host calls by `name`, `kind`, `signature`, and `introduced` [@schema]. The implementation embeds that schema in `src/plugin/api.rs`, validates literal plugin calls against it, and tests that runtime dispatch remains covered by the schema [@api]. This page does not copy the full schema; open the schema when exact call names or signatures are needed.
+The Plugin Host API reference identifies the files that define Red's Husk plugin contract and the rules for changing it. The canonical schema is `src/plugin/host_api.json`; it declares version `0.17.0` and lists host calls by `name`, `kind`, `signature`, and `introduced` [@schema]. The implementation embeds that schema in `src/plugin/api.rs`, validates literal plugin calls against it, and tests that runtime dispatch remains covered by the schema [@api]. This page does not copy the full schema; open the schema when exact call names or signatures are needed.
 
 ## Source Of Truth
 
@@ -28,9 +28,9 @@ The Plugin Host API reference identifies the files that define Red's Husk plugin
 | --- | --- |
 | `src/plugin/host_api.json` | Canonical machine-readable list of host `execute` and `request` calls, signatures, and introduction versions [@schema]. |
 | `src/plugin/api.rs` | Embedded schema loader, static validator, diagnostic families, and schema coverage tests [@api]. |
-| `src/plugin/registry.rs` | Runtime compatibility gate; `RED_HOST_API_VERSION` is `0.16.0`, and `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`, `0.10.0`, `0.11.0`, `0.12.0`, and `0.14.0` remain accepted compatibility targets for existing packages [@registry]. |
+| `src/plugin/registry.rs` | Runtime compatibility gate; `RED_HOST_API_VERSION` is `0.17.0`, and `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`, `0.10.0`, `0.11.0`, `0.12.0`, `0.14.0`, and `0.16.0` remain accepted compatibility targets for existing packages [@registry]. |
 | `docs/PLUGIN_API.md` | Human compatibility guide, migration notes, and behavioral descriptions for plugin authors [@api-doc]. |
-| `docs/plugin_api_changes.json` | Versioned change manifest that records introduced symbols and migration note anchors through `0.15.0` [@changes]. |
+| `docs/plugin_api_changes.json` | Versioned change manifest that records introduced symbols and migration note anchors through `0.17.0` [@changes]. |
 
 Use code as the authority for runtime behavior and the schema as the authority for the public host call inventory. The prose guide is useful for compatibility intent and migration guidance, but it should not be treated as a replacement for the schema and validator [@api] [@api-doc].
 
@@ -49,7 +49,7 @@ The validator treats literal `red::execute("...")` and `red::request("...")` cal
 
 ## Current Version And Notable Introductions
 
-The current host API version is `0.16.0` [@schema] [@registry]. The schema marks `SetPanelStatus` and `CancelGitStatus` as `0.16.0` calls [@schema]. It marks `PrintWarning`, `OpenPanelSearch`, `UpdatePanelSearch`, `KeepPanelSearch`, `ClosePanelSearch`, `InvalidateWorkspacePaths`, `SetTextPanelComposerHistory`, and stable-identity `OpenBufferById` as `0.15.0` calls; the change manifest also records `GetEditorInfo.buffers.id` at that version [@schema] [@changes]. It marks `AgentReadDefaultModel`, `AgentListModels`, `AgentSetModel`, `SetTextPanelHeaderDetail`, and `UpdatePickerSelection` as `0.14.0` calls [@schema]. The change manifest also records `PickerOptions.item_layout`, `agent:model_changed`, and `agent:model_rerouted` as `0.14.0` introductions, `GetWindows.document_id`, `GetWindows.breadcrumb_components`, `DocumentSymbols.document_id`, `file:saved.document_id`, and `red::document_symbol_chain` as `0.13.0` introductions, language-pack indentation symbols as `0.12.0`, command argument metadata as `0.11.0`, and language-pack formatter settings as `0.10.0` [@changes].
+The current host API version is `0.17.0`; it adds `MonotonicTime` for process-local elapsed-time measurements [@schema] [@registry]. The schema marks `SetPanelStatus` and `CancelGitStatus` as `0.16.0` calls [@schema]. It marks `PrintWarning`, `OpenPanelSearch`, `UpdatePanelSearch`, `KeepPanelSearch`, `ClosePanelSearch`, `InvalidateWorkspacePaths`, `SetTextPanelComposerHistory`, and stable-identity `OpenBufferById` as `0.15.0` calls; the change manifest also records `GetEditorInfo.buffers.id` at that version [@schema] [@changes]. It marks `AgentReadDefaultModel`, `AgentListModels`, `AgentSetModel`, `SetTextPanelHeaderDetail`, and `UpdatePickerSelection` as `0.14.0` calls [@schema]. The change manifest also records `PickerOptions.item_layout`, `agent:model_changed`, and `agent:model_rerouted` as `0.14.0` introductions, `GetWindows.document_id`, `GetWindows.breadcrumb_components`, `DocumentSymbols.document_id`, `file:saved.document_id`, and `red::document_symbol_chain` as `0.13.0` introductions, language-pack indentation symbols as `0.12.0`, command argument metadata as `0.11.0`, and language-pack formatter settings as `0.10.0` [@changes].
 
 The schema marks `AgentResumeSession`, `AgentForgetSession`, and `UpdateOverlayBusy` as `0.9.0` calls, and the `OpenConfirm` signature accepts an optional `options?: Json` argument [@schema]. The change manifest also records the agent conversation-restore events `agent:conversation_restore_pending`, `agent:session_restored`, and `agent:session_restore_failed`, plus `OpenConfirm.options`, as `0.9.0` introductions [@changes].
 
@@ -59,7 +59,7 @@ The schema's call list is the exact lookup source for current signatures. Exampl
 
 ## Compatibility Rules
 
-Plugin packages may declare a semver range in `red_api_version`; Red checks that range before activation and quarantines malformed or incompatible packages without stopping unrelated plugins [@api-doc]. The registry accepts `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`, `0.10.0`, `0.11.0`, `0.12.0`, `0.14.0`, and the current `0.16.0` host API version, so existing packages can remain on those supported minors while new packages should target `^0.16.0` unless they intentionally avoid newer host calls [@registry] [@api-doc]. Because pre-1.0 caret ranges do not cross minor versions, compatibility checks test the declared range against every supported host API version instead of only the current version [@registry]. The documented pre-1.0 policy is:
+Plugin packages may declare a semver range in `red_api_version`; Red checks that range before activation and quarantines malformed or incompatible packages without stopping unrelated plugins [@api-doc]. The registry accepts `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`, `0.10.0`, `0.11.0`, `0.12.0`, `0.14.0`, `0.16.0`, and the current `0.17.0` host API version, so existing packages can remain on those supported minors while new packages should target `^0.17.0` unless they intentionally avoid newer host calls [@registry] [@api-doc]. Because pre-1.0 caret ranges do not cross minor versions, compatibility checks test the declared range against every supported host API version instead of only the current version [@registry]. The documented pre-1.0 policy is:
 
 | Release kind | Compatibility rule |
 | --- | --- |

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,6 +1,6 @@
 # Husk plugin compatibility
 
-Red host API version `0.15.0` is defined by
+Red host API version `0.17.0` is defined by
 [`src/plugin/host_api.json`](../src/plugin/host_api.json). That file is the canonical,
 machine-readable list of execute actions, request actions, signatures, and introduction
 versions. Runtime dispatch and the bundled-plugin corpus are checked against it in tests.
@@ -24,9 +24,25 @@ required/optional arity (`HUSK-A0002`) and obvious literal argument types
 annotations use `HUSK-A0004`. `--no-typecheck` is an unsupported development
 escape hatch; compatibility guarantees do not apply while it is enabled.
 
-Red `0.15.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
-`0.10.0`, `0.11.0`, `0.12.0`, and `0.14.0` contracts, so existing packages that declare those
-minors continue to load. New packages should target `"red_api_version": "^0.15.0"`.
+Red `0.17.0` retains the complete `0.4.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`,
+`0.10.0`, `0.11.0`, `0.12.0`, `0.14.0`, and `0.16.0` contracts, so existing packages that declare those
+minors continue to load. New packages should target `"red_api_version": "^0.17.0"`.
+
+## Monotonic timing
+
+Host API `0.17.0` adds `red::execute("MonotonicTime")`, returning an `i64`
+millisecond count from an arbitrary process-local monotonic origin. Subtract two
+readings to measure elapsed time; never persist a reading or compare it across
+editor processes. Wall-clock changes do not affect it.
+
+The bundled Git plugin uses this clock to schedule idle status polls after each
+scan finishes. It waits at least five seconds and nine times the scan duration,
+targeting a 10% background scan duty cycle. Unchanged results and failures also
+back off the minimum delay up to 60 seconds. Explicit refreshes bypass the idle
+cooldown, but requests received during a scan coalesce into one follow-up rather
+than cancelling work. Failed scans retain the last successful status.
+Working-tree diff statistics run only for staged or unstaged sections that
+contain tracked changes.
 
 ## Messages
 

--- a/docs/plugin_api_changes.json
+++ b/docs/plugin_api_changes.json
@@ -1,6 +1,12 @@
 {
-  "api_version": "0.15.0",
+  "api_version": "0.17.0",
   "changes": [
+    {
+      "version": "0.17.0",
+      "kind": "introduced",
+      "symbols": ["MonotonicTime"],
+      "migration_note": "docs/PLUGIN_API.md#monotonic-timing"
+    },
     {
       "version": "0.15.0",
       "kind": "introduced",

--- a/plugins/git.hk
+++ b/plugins/git.hk
@@ -7,6 +7,8 @@
 // watchers, processes, timers, panels, workspace state, and gutter namespaces.
 // Picker callbacks are owner-scoped: each menu item carries its flow context, while the
 // active prompt handle is retained only so query changes update the correct picker.
+// Status refreshes never replace an in-flight scan. Polls start after completion,
+// while explicit refreshes coalesce into one follow-up and idle work backs off.
 
 struct GitEntry {
     path: String,
@@ -270,6 +272,12 @@ struct GitPluginState {
     process: String,
     status_initialized: bool,
     status_output: String,
+    status_pending_output: String,
+    status_error: String,
+    status_started_ms: i64,
+    status_forced: bool,
+    refresh_pending: bool,
+    poll_delay_ms: i64,
     refresh_forced: bool,
     idle_polls: i32,
     refresh_timer: String,
@@ -317,6 +325,7 @@ struct GitPluginState {
     prompt_kind: String,
     prompt_picker: Option<i32>,
     capture_kind: String,
+    capture_process: String,
     capture_output: String,
     operation: String,
     operation_jobs: [OperationJob],
@@ -391,6 +400,12 @@ fn initial_state() -> GitPluginState {
         process: "",
         status_initialized: false,
         status_output: "",
+        status_pending_output: "",
+        status_error: "",
+        status_started_ms: 0,
+        status_forced: false,
+        refresh_pending: false,
+        poll_delay_ms: 5000,
         refresh_forced: true,
         idle_polls: 0,
         refresh_timer: "",
@@ -449,6 +464,7 @@ fn initial_state() -> GitPluginState {
         prompt_kind: "",
         prompt_picker: None,
         capture_kind: "",
+        capture_process: "",
         capture_output: "",
         operation: "",
         operation_jobs: [],
@@ -600,7 +616,10 @@ fn close_dashboard() {
 }
 
 fn schedule_poll() {
-    red::state_patch(GitPluginState { poll_timer: red::execute("SetTimeout", 5000) });
+    red::execute("CancelTimeout", plugin_state().poll_timer);
+    red::state_patch(GitPluginState {
+        poll_timer: red::execute("SetTimeout", plugin_state().poll_delay_ms),
+    });
 }
 
 #[red::on("filesystem:changed:1502")]
@@ -653,10 +672,9 @@ fn timeout_callback(event: TimerEvent) {
         refresh();
         return;
     }
-    if event.timer_id == plugin_state().poll_timer {
+    if event.timer_id != "" && event.timer_id == plugin_state().poll_timer {
         red::state_patch(GitPluginState { poll_timer: "" });
-        refresh();
-        schedule_poll();
+        if plugin_state().process == "" { refresh(); }
     }
 }
 
@@ -673,10 +691,25 @@ fn force_refresh() {
 }
 
 fn refresh() {
-    let previous = red::string(plugin_state().process, "");
-    if previous != "" {
-        red::execute("KillProcess", previous);
+    if plugin_state().process != "" {
+        red::state_patch(GitPluginState { refresh_pending: true });
+        return;
     }
+    red::execute("CancelTimeout", plugin_state().refresh_timer);
+    red::state_patch(GitPluginState {
+        refresh_timer: "",
+        refresh_pending: false,
+        status_pending_output: "",
+        status_started_ms: red::execute("MonotonicTime"),
+        status_forced: plugin_state().refresh_forced || plugin_state().status_error != "",
+        refresh_forced: false,
+    });
+    // Keep a bounded retry armed if SpawnProcess throws before returning an ID.
+    let retry_delay = plugin_state().poll_delay_ms * (2 as i64);
+    let retry_limit = 60000 as i64;
+    if retry_delay > retry_limit { retry_delay = retry_limit; }
+    red::state_patch(GitPluginState { poll_delay_ms: retry_delay });
+    schedule_poll();
     let process_id = red::execute("SpawnProcess", Process {
         command: "git",
         args: red::git_core("status_args"),
@@ -689,13 +722,27 @@ fn refresh() {
         raw_output: true,
         cwd: red::string(plugin_state().root, "."),
     });
-    red::state_patch(GitPluginState { process: process_id });
+    red::execute("CancelTimeout", plugin_state().poll_timer);
+    red::state_patch(GitPluginState { process: process_id, poll_timer: "", status_error: "" });
     red::on("process:" + process_id, status_event);
 }
 
 #[red::config("cwd")]
 fn git_cwd_loaded(event: GitStringValueEvent) {
     let cwd = red::string(event.value, ".");
+    if cwd != plugin_state().root {
+        cancel_status();
+        if plugin_state().capture_process != "" {
+            red::execute("KillProcess", plugin_state().capture_process);
+            red::state_patch(GitPluginState { capture_process: "" });
+        }
+        red::execute("UnwatchDirectory", 1502);
+        red::state_patch(GitPluginState {
+            state: empty_state(), status_initialized: false, status_output: "",
+            refresh_forced: true, poll_delay_ms: 5000, watch_path: "",
+        });
+        schedule_poll();
+    }
     red::state_patch(GitPluginState { root: cwd });
     capture_git("root", ["rev-parse", "--show-toplevel"]);
 }
@@ -798,37 +845,77 @@ fn status_event(event: ProcessEvent) {
     match event {
         ProcessEvent::Stdout { process_id, line, plugin_name } => {
             if process_id == plugin_state().process {
-                update_status(line);
+                red::state_patch(GitPluginState { status_pending_output: line });
             }
         }
         ProcessEvent::Error { process_id, message, plugin_name } => {
             if process_id == plugin_state().process {
-                render_error(message);
+                red::state_patch(GitPluginState { status_error: message });
             }
         }
         ProcessEvent::Exit { process_id, code, plugin_name } => {
             if process_id != plugin_state().process {
                 return;
             }
-            red::state_patch(GitPluginState { process: "" });
-            let exit_code = 0;
+            let exit_code = -1;
             if let Some(value) = code {
                 exit_code = value;
             }
-            if exit_code != 0 {
-                render_error("git status exited with " + exit_code);
-            }
+            finish_status(exit_code);
         }
         ProcessEvent::Stderr { process_id, line, plugin_name } => {}
     }
 }
 
-fn update_status(output: String) {
+fn finish_status(exit_code: i32) {
+    let current = plugin_state();
+    let now: i64 = red::execute("MonotonicTime");
+    let elapsed = now - current.status_started_ms;
+    let successful = exit_code == 0 && current.status_error == "";
+    let changed = !current.status_initialized || current.status_pending_output != current.status_output;
+    let delay = 5000 as i64;
+    if !successful || (!changed && !current.status_forced) {
+        delay = current.poll_delay_ms;
+    }
+    // Nine milliseconds of cooldown per millisecond spent scanning targets a
+    // 10% background duty cycle, independent of repository size or CPU count.
+    let cost_delay = elapsed * (9 as i64);
+    if delay < cost_delay { delay = cost_delay; }
+    red::state_patch(GitPluginState { process: "", poll_delay_ms: delay });
+    // Rendering or follow-up work can fail independently of the scan. Keep
+    // polling alive even if one of those callbacks throws.
+    schedule_poll();
+    red::log("[git-status] completed elapsed_ms=" + elapsed + " success=" + successful + " next_poll_ms=" + delay);
+    if successful {
+        update_status(current.status_pending_output, current.status_forced);
+    } else {
+        let error = current.status_error;
+        if error == "" { error = "git status exited with " + exit_code; }
+        red::state_patch(GitPluginState { status_error: error });
+        if current.status_initialized { render_dashboard(); } else { render_error(error); }
+    }
+    // A callback such as safe-sync can already have started the next scan.
+    if plugin_state().process != "" { return; }
+    if plugin_state().refresh_pending {
+        refresh();
+    }
+}
+
+fn cancel_status() {
+    red::execute("CancelTimeout", plugin_state().refresh_timer);
+    red::execute("CancelTimeout", plugin_state().poll_timer);
+    let process = plugin_state().process;
+    red::state_patch(GitPluginState {
+        process: "", refresh_pending: false, status_pending_output: "", status_error: "",
+        refresh_timer: "", poll_timer: "",
+    });
+    if process != "" { red::execute("KillProcess", process); }
+}
+
+fn update_status(output: String, forced: bool) {
     let initialized = plugin_state().status_initialized;
     let changed = !initialized || output != red::string(plugin_state().status_output, "");
-    let forced = plugin_state().refresh_forced;
     red::state_patch(GitPluginState { status_initialized: true });
-    red::state_patch(GitPluginState { refresh_forced: false });
     if changed {
         red::state_patch(GitPluginState { status_output: output });
         red::state_patch(GitPluginState { state: parse_status(output) });
@@ -1372,13 +1459,17 @@ fn render_dashboard() {
             });
         }
     }
+    let status = plugin_state().detail_status;
+    if plugin_state().status_error != "" {
+        status = "Git status stale: " + bounded_git_error(plugin_state().status_error);
+    }
     red::execute("UpdateWorkspace", "git-dashboard", GitWorkspaceModel {
         header: header_segments(state),
         rows: rows,
         detail: plugin_state().detail,
         detail_document: plugin_state().detail_document,
         actions: dashboard_actions(),
-        status: plugin_state().detail_status,
+        status: status,
         detail_title: plugin_state().detail_path,
     });
 }
@@ -1483,12 +1574,15 @@ fn entry_stat_segments(display: GitDisplayEntry, section: String, status_style: 
 
 fn refresh_stats() {
     if plugin_state().stats_process != "" { red::execute("KillProcess", plugin_state().stats_process); }
-    red::state_patch(GitPluginState { stats: Json {} });
+    red::state_patch(GitPluginState { stats: Json {}, stats_process: "" });
     if plugin_state().commit_view_oid != "" {
         start_commit_stats();
         return;
     }
-    start_stats("staged");
+    // A full worktree diff can be as expensive as status. Only scan sections
+    // with tracked changes whose statistics can actually appear in the list.
+    if red::len(plugin_state().state.staged) > 0 { start_stats("staged"); }
+    else if red::len(plugin_state().state.unstaged) > 0 { start_stats("unstaged"); }
 }
 
 fn start_commit_stats() {
@@ -1541,7 +1635,7 @@ fn stats_event(event: ProcessEvent) {
                 index = index + 1;
             }
             red::state_patch(GitPluginState { stats: stats, stats_process: "" });
-            if section == "staged" && plugin_state().dashboard_open && plugin_state().commit_view_oid == "" { start_stats("unstaged"); }
+            if section == "staged" && plugin_state().dashboard_open && plugin_state().commit_view_oid == "" && red::len(plugin_state().state.unstaged) > 0 { start_stats("unstaged"); }
             else { render_dashboard(); }
         }
         ProcessEvent::Error { process_id, message, plugin_name } => {
@@ -2853,6 +2947,9 @@ fn prompt_submitted(item: PickerItem) {
 }
 
 fn capture_git(kind: String, args: [String]) {
+    if plugin_state().capture_process != "" {
+        red::execute("KillProcess", plugin_state().capture_process);
+    }
     red::state_patch(GitPluginState { capture_kind: kind });
     red::state_patch(GitPluginState { capture_output: "" });
     record_command(args);
@@ -2862,17 +2959,23 @@ fn capture_git(kind: String, args: [String]) {
         raw_output: true,
         cwd: red::string(plugin_state().root, "."),
     });
+    red::state_patch(GitPluginState { capture_process: process_id });
     red::on("process:" + process_id, capture_event);
 }
 
 fn capture_event(event: ProcessEvent) {
     match event {
         ProcessEvent::Stdout { process_id, line, plugin_name } => {
+            if process_id != plugin_state().capture_process { return; }
             red::state_patch(GitPluginState {
                 capture_output: plugin_state().capture_output + line,
             });
         }
-        ProcessEvent::Exit { process_id, code, plugin_name } => capture_finished(),
+        ProcessEvent::Exit { process_id, code, plugin_name } => {
+            if process_id != plugin_state().capture_process { return; }
+            red::state_patch(GitPluginState { capture_process: "" });
+            capture_finished();
+        }
         ProcessEvent::Stderr { process_id, line, plugin_name } => {}
         ProcessEvent::Error { process_id, message, plugin_name } => {}
     }
@@ -4243,19 +4346,12 @@ fn apply_hunk_check_finished(event: ProcessEvent) {
 
 #[red::lifecycle("deactivate")]
 fn deactivate() {
+    cancel_status();
     cancel_detail_timer();
     for job in plugin_state().operation_jobs {
         red::execute("KillProcess", job.id);
     }
     red::state_patch(GitPluginState { operation_jobs: [] });
-    let refresh_timer = red::string(plugin_state().refresh_timer, "");
-    if refresh_timer != "" {
-        red::execute("CancelTimeout", refresh_timer);
-    }
-    let poll_timer = red::string(plugin_state().poll_timer, "");
-    if poll_timer != "" {
-        red::execute("CancelTimeout", poll_timer);
-    }
     let push_done_timer = red::string(plugin_state().push_done_timer, "");
     if push_done_timer != "" {
         red::execute("CancelTimeout", push_done_timer);
@@ -4269,6 +4365,7 @@ fn deactivate() {
         red::execute("CancelTimeout", git_task_done_timer);
     }
     for process_id in [
+        plugin_state().capture_process,
         red::string(plugin_state().git_task_process, ""),
         red::string(plugin_state().commit_process, ""),
         red::string(plugin_state().commit_context_process, ""),
@@ -4285,8 +4382,6 @@ fn deactivate() {
     if push_process != "" {
         red::execute("KillProcess", push_process);
     }
-    red::state_patch(GitPluginState { refresh_timer: "" });
-    red::state_patch(GitPluginState { poll_timer: "" });
     red::state_patch(GitPluginState { push_done_timer: "" });
     red::state_patch(GitPluginState { git_task_busy_timer: "" });
     red::state_patch(GitPluginState { git_task_done_timer: "" });

--- a/src/plugin/git_refresh_tests.rs
+++ b/src/plugin/git_refresh_tests.rs
@@ -1,0 +1,409 @@
+//! Exercises the bundled Git scheduler with gated processes and injected timers.
+//! The fake executable avoids changing PATH and never scans a real repository.
+
+use super::tests::{drain_requests, load_git_runtime_source, pump_process_events};
+use super::*;
+use serde_json::json;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+const GOOD_STATUS: &[u8] = b"# branch.oid abcd\0# branch.head main\0? pending.txt\0";
+
+struct GitHarness {
+    runtime: Runtime,
+    root: tempfile::TempDir,
+    command: std::path::PathBuf,
+    dashboard: Option<WorkspaceModel>,
+}
+
+impl GitHarness {
+    async fn new() -> Self {
+        drain_requests();
+        let root = tempfile::tempdir().unwrap();
+        prepare(root.path());
+        let command = root.path().join("fake-git");
+        fs::write(
+            &command,
+            r#"#!/bin/sh
+case "$1" in
+    rev-parse)
+        if [ "$2" = --show-toplevel ]; then pwd; else printf '.git\n'; fi
+        ;;
+    status)
+        printf 'start\n' >> starts
+        while [ ! -f release ]; do sleep 0.01; done
+        cat response
+        printf 'complete\n' >> completions
+        exit "$(cat exit-code)"
+        ;;
+    diff)
+        if [ "$2" = --numstat ]; then printf '%s\n' "$*" >> stats; fi
+        ;;
+esac
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(&command, fs::Permissions::from_mode(0o755)).unwrap();
+        let source = fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/plugins/git.hk"))
+            .unwrap()
+            .replace(
+                "command: \"git\"",
+                &format!("command: {}", serde_json::to_string(&command).unwrap()),
+            )
+            + r#"
+#[red::on("test:age")]
+fn age_status(event: Json) {
+    let now: i64 = red::execute("MonotonicTime");
+    red::state_patch(GitPluginState { status_started_ms: now - event.ms });
+}
+#[red::on("test:root")]
+fn change_root(event: GitStringValueEvent) { git_cwd_loaded(event); }
+"#;
+        let runtime =
+            load_git_runtime_source(root.path(), &source, command.to_str().unwrap()).await;
+        Self {
+            runtime,
+            root,
+            command,
+            dashboard: None,
+        }
+    }
+
+    fn state(&self) -> serde_json::Value {
+        let inner = self.runtime.inner.lock().unwrap();
+        value_to_json(inner.host.policy().typed_states.get("git").unwrap())
+    }
+
+    fn count(&self, file: &str) -> usize {
+        fs::read_to_string(self.root.path().join(file))
+            .unwrap_or_default()
+            .lines()
+            .count()
+    }
+
+    async fn notify(&mut self, event: &str, payload: serde_json::Value) {
+        self.runtime.notify(event, payload).await.unwrap();
+    }
+
+    async fn timer(&mut self, id: &str) {
+        self.notify("timeout:callback", json!({"timer_id": id}))
+            .await;
+    }
+
+    async fn refresh(&mut self) {
+        self.runtime.execute_command("GitRefresh").await.unwrap();
+    }
+
+    async fn wait(&mut self, predicate: impl Fn(&Self) -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            pump_process_events(&mut self.runtime).await.unwrap();
+            while let Some(request) = self.runtime.try_recv_request() {
+                if let PluginRequest::UpdateWorkspace { id, model } = request {
+                    assert_eq!(id, "git-dashboard");
+                    self.dashboard = Some(model);
+                }
+            }
+            if predicate(self) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "Git scheduler did not settle: {}",
+                self.state()
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    async fn release(&mut self) {
+        fs::write(self.root.path().join("release"), "").unwrap();
+        self.wait(|h| h.state()["process"] == "").await;
+    }
+}
+
+impl Drop for GitHarness {
+    fn drop(&mut self) {
+        // Release a blocked fake even when an assertion unwinds the runtime.
+        let _ = fs::write(self.root.path().join("release"), "");
+    }
+}
+
+fn prepare(root: &Path) {
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join("response"), GOOD_STATUS).unwrap();
+    fs::write(root.join("exit-code"), "0").unwrap();
+}
+
+#[tokio::test]
+async fn git_refresh_slow_scan_survives_poll_ticks_and_finishes() {
+    let mut h = GitHarness::new().await;
+    let stale_poll = h.state()["poll_timer"].as_str().unwrap().to_owned();
+    h.refresh().await;
+    h.wait(|h| h.count("starts") == 1).await;
+    let process = h.state()["process"].clone();
+    h.notify("test:age", json!({"ms": 20000})).await;
+    for _ in 0..4 {
+        h.timer(&stale_poll).await;
+    }
+    assert_eq!(h.state()["process"], process);
+    assert_eq!(h.state()["poll_timer"], "");
+    assert_eq!(h.state()["refresh_pending"], false);
+    assert_eq!(h.count("starts"), 1);
+    h.release().await;
+    assert_eq!(h.count("completions"), 1);
+    assert_eq!(h.state()["state"]["head"], "main");
+    assert!(h.state()["poll_delay_ms"].as_i64().unwrap() >= 180000);
+    assert_ne!(h.state()["poll_timer"], "");
+    h.runtime.deactivate_all().await.unwrap();
+}
+
+#[tokio::test]
+async fn git_refresh_coalesces_explicit_and_debounced_requests() {
+    let mut h = GitHarness::new().await;
+    h.refresh().await;
+    h.wait(|h| h.count("starts") == 1).await;
+    let process = h.state()["process"].clone();
+    for _ in 0..20 {
+        h.refresh().await;
+        h.notify("file:saved", json!({})).await;
+    }
+    let timer = h.state()["refresh_timer"].as_str().unwrap().to_owned();
+    h.timer(&timer).await;
+    assert_eq!(h.state()["process"], process);
+    assert_eq!(h.state()["refresh_pending"], true);
+    assert_eq!(h.count("starts"), 1);
+    h.release().await;
+    assert_eq!(h.count("starts"), 2);
+    assert_eq!(h.count("completions"), 2);
+    assert_eq!(h.state()["refresh_pending"], false);
+    h.timer(&timer).await;
+    assert_eq!(h.count("starts"), 2);
+    h.runtime.deactivate_all().await.unwrap();
+}
+
+#[tokio::test]
+async fn git_refresh_idle_polls_back_off_and_explicit_refresh_is_immediate() {
+    let mut h = GitHarness::new().await;
+    h.refresh().await;
+    h.release().await;
+    assert_eq!(h.state()["poll_delay_ms"], 5000);
+    for delay in [10000, 20000, 40000, 60000, 60000] {
+        let timer = h.state()["poll_timer"].as_str().unwrap().to_owned();
+        h.timer(&timer).await;
+        h.wait(|h| h.state()["process"] == "").await;
+        assert_eq!(h.state()["poll_delay_ms"], delay);
+    }
+    let starts = h.count("starts");
+    h.refresh().await;
+    h.wait(|h| h.state()["process"] == "").await;
+    assert_eq!(h.count("starts"), starts + 1);
+    assert_eq!(h.state()["poll_delay_ms"], 5000);
+    h.runtime.deactivate_all().await.unwrap();
+}
+
+#[tokio::test]
+async fn git_refresh_only_scans_statistics_for_sections_with_tracked_changes() {
+    let mut h = GitHarness::new().await;
+    h.runtime.execute_command("GitDashboard").await.unwrap();
+    h.release().await;
+    assert_eq!(
+        h.count("stats"),
+        0,
+        "untracked files have no diff statistics"
+    );
+    for (code, cached, count) in [("M.", true, 1), (".M", false, 2)] {
+        fs::write(
+            h.root.path().join("response"),
+            format!(
+                "# branch.head main\0\
+                1 {code} N... 100644 100644 100644 abc def tracked.txt\0"
+            ),
+        )
+        .unwrap();
+        h.refresh().await;
+        h.wait(|h| h.count("stats") == count && h.state()["stats_process"] == "")
+            .await;
+        let commands = fs::read_to_string(h.root.path().join("stats")).unwrap();
+        assert_eq!(
+            commands.lines().last().unwrap().contains("--cached"),
+            cached
+        );
+    }
+    fs::write(h.root.path().join("response"), "# branch.head main\0").unwrap();
+    h.refresh().await;
+    h.wait(|h| h.state()["process"] == "").await;
+    assert_eq!(h.state()["stats_process"], "");
+    assert_eq!(
+        h.count("stats"),
+        2,
+        "a clean status needs no statistics scan"
+    );
+    h.runtime.deactivate_all().await.unwrap();
+}
+
+#[tokio::test]
+async fn git_refresh_failed_output_preserves_the_last_successful_status() {
+    let mut h = GitHarness::new().await;
+    h.runtime.execute_command("GitDashboard").await.unwrap();
+    h.release().await;
+    let good = h.state()["state"].clone();
+    let output = h.state()["status_output"].clone();
+    fs::write(h.root.path().join("response"), "# branch.head wrong\0").unwrap();
+    fs::write(h.root.path().join("exit-code"), "1").unwrap();
+    h.refresh().await;
+    h.wait(|h| h.state()["process"] == "").await;
+    assert_eq!(h.state()["state"], good);
+    assert_eq!(h.state()["status_output"], output);
+    assert_eq!(h.state()["poll_delay_ms"], 10000);
+    let dashboard = h.dashboard.as_ref().unwrap();
+    assert!(dashboard.status.starts_with("Git status stale:"));
+    assert!(dashboard
+        .rows
+        .iter()
+        .any(|row| row.path.as_deref() == Some("pending.txt")));
+    fs::write(h.root.path().join("exit-code"), "0").unwrap();
+    h.refresh().await;
+    let process = h.state()["process"].as_str().unwrap().to_owned();
+    h.notify(
+        &format!("process:{process}"),
+        json!({
+            "type": "error", "plugin_name": "git", "process_id": process,
+            "message": "raw process output exceeds the limit",
+        }),
+    )
+    .await;
+    h.wait(|h| h.state()["process"] == "").await;
+    assert_eq!(h.state()["state"], good);
+    assert!(h
+        .dashboard
+        .as_ref()
+        .unwrap()
+        .status
+        .contains("raw process output"));
+    fs::write(h.root.path().join("response"), GOOD_STATUS).unwrap();
+    // Recovery via a background poll must remove the stale banner even if the
+    // successful output is identical to the cached result. A failed launch
+    // during recovery must not erase the error that makes that repaint needed.
+    let executable = fs::read(&h.command).unwrap();
+    fs::remove_file(&h.command).unwrap();
+    let poll = h.state()["poll_timer"].as_str().unwrap().to_owned();
+    assert!(h
+        .runtime
+        .notify("timeout:callback", json!({"timer_id": poll}))
+        .await
+        .is_err());
+    assert_ne!(h.state()["status_error"], "");
+    fs::write(&h.command, executable).unwrap();
+    fs::set_permissions(&h.command, fs::Permissions::from_mode(0o755)).unwrap();
+    let poll = h.state()["poll_timer"].as_str().unwrap().to_owned();
+    h.timer(&poll).await;
+    h.wait(|h| h.state()["process"] == "").await;
+    assert_eq!(h.state()["state"], good);
+    assert_eq!(h.state()["status_error"], "");
+    assert!(!h.dashboard.as_ref().unwrap().status.contains("stale"));
+    h.runtime.deactivate_all().await.unwrap();
+}
+
+#[tokio::test]
+async fn git_refresh_spawn_failure_keeps_a_retry_timer() {
+    let mut h = GitHarness::new().await;
+    h.refresh().await;
+    h.release().await;
+    let good = h.state()["state"].clone();
+    let executable = fs::read(&h.command).unwrap();
+    fs::remove_file(&h.command).unwrap();
+    assert!(h.runtime.execute_command("GitRefresh").await.is_err());
+    assert_eq!(h.state()["process"], "");
+    assert_ne!(h.state()["poll_timer"], "");
+    assert_eq!(h.state()["state"], good);
+    fs::write(&h.command, executable).unwrap();
+    fs::set_permissions(&h.command, fs::Permissions::from_mode(0o755)).unwrap();
+    let poll = h.state()["poll_timer"].as_str().unwrap().to_owned();
+    h.timer(&poll).await;
+    h.wait(|h| h.state()["process"] == "").await;
+    assert_eq!(h.count("completions"), 2);
+    h.runtime.deactivate_all().await.unwrap();
+}
+
+#[tokio::test]
+async fn git_refresh_repository_change_and_shutdown_discard_stale_events() {
+    let mut h = GitHarness::new().await;
+    let old_poll = h.state()["poll_timer"].as_str().unwrap().to_owned();
+    h.refresh().await;
+    h.wait(|h| h.count("starts") == 1).await;
+    let old = h.state()["process"].as_str().unwrap().to_owned();
+    let next = tempfile::tempdir().unwrap();
+    prepare(next.path());
+    fs::write(next.path().join("release"), "").unwrap();
+    fs::write(next.path().join("response"), "# branch.head next\0").unwrap();
+    h.notify("test:root", json!({"value": next.path()})).await;
+    h.refresh().await;
+    h.notify(
+        &format!("process:{old}"),
+        json!({
+            "type": "stdout", "plugin_name": "git", "process_id": old,
+            "line": "# branch.head stale\0",
+        }),
+    )
+    .await;
+    h.notify(
+        &format!("process:{old}"),
+        json!({
+            "type": "exit", "plugin_name": "git", "process_id": old,
+            "code": 1,
+        }),
+    )
+    .await;
+    h.wait(|h| h.state()["state"]["head"] == "next").await;
+    assert_eq!(
+        h.state()["root"],
+        fs::canonicalize(next.path()).unwrap().to_str().unwrap()
+    );
+    h.timer(&old_poll).await;
+    let poll = h.state()["poll_timer"].as_str().unwrap().to_owned();
+    h.runtime.deactivate_all().await.unwrap();
+    h.timer(&poll).await;
+    h.wait(|h| {
+        h.runtime
+            .inner
+            .lock()
+            .unwrap()
+            .host
+            .process_manager
+            .active_process_count("git")
+            == 0
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn git_refresh_shutdown_cancels_a_blocked_scan_and_pending_refresh() {
+    let mut h = GitHarness::new().await;
+    h.refresh().await;
+    h.wait(|h| h.count("starts") == 1).await;
+    h.refresh().await;
+    h.notify("file:saved", json!({})).await;
+    assert_eq!(h.state()["refresh_pending"], true);
+    h.runtime.deactivate_all().await.unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        pump_process_events(&mut h.runtime).await.unwrap();
+        let active = {
+            let inner = h.runtime.inner.lock().unwrap();
+            assert!(inner.host.pending_timeouts.is_empty());
+            inner.host.process_manager.active_process_count("git")
+        };
+        if active == 0 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "shutdown left a Git process alive"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert_eq!(h.count("starts"), 1);
+    assert_eq!(h.count("completions"), 0);
+}

--- a/src/plugin/host_api.json
+++ b/src/plugin/host_api.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.16.0",
+  "version": "0.17.0",
   "calls": [
     { "name": "Print", "kind": "execute", "signature": "(message: String)", "introduced": "0.1.0" },
     { "name": "PrintWarning", "kind": "execute", "signature": "(message: String)", "introduced": "0.15.0" },
@@ -94,6 +94,7 @@
     { "name": "RecordSearchHighlighted", "kind": "execute", "signature": "(event: Json)", "introduced": "0.1.0" },
     { "name": "RecordSearchCleared", "kind": "execute", "signature": "(event: Json)", "introduced": "0.1.0" },
     { "name": "SetTimeout", "kind": "execute", "signature": "(delay_ms: i32)", "introduced": "0.1.0" },
+    { "name": "MonotonicTime", "kind": "execute", "signature": "()", "introduced": "0.17.0" },
     { "name": "CancelTimeout", "kind": "execute", "signature": "(timer_id: String)", "introduced": "0.1.0" },
     { "name": "GetViewportLayout", "kind": "request", "signature": "(callback: fn(Json))", "introduced": "0.1.0" },
     { "name": "InlayHints", "kind": "request", "signature": "(callback: fn(Json), range: Json)", "introduced": "0.1.0" },

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -38,7 +38,7 @@ pub struct PluginRegistry {
 }
 
 /// Host API version used for plugin compatibility checks.
-pub const RED_HOST_API_VERSION: &str = "0.16.0";
+pub const RED_HOST_API_VERSION: &str = "0.17.0";
 pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
     "0.4.0",
     "0.6.0",
@@ -49,6 +49,7 @@ pub(crate) const SUPPORTED_HOST_API_VERSIONS: &[&str] = &[
     "0.11.0",
     "0.12.0",
     "0.14.0",
+    "0.16.0",
     RED_HOST_API_VERSION,
 ];
 
@@ -1597,6 +1598,12 @@ mod tests {
         check_api_compatibility(&metadata).unwrap();
 
         metadata.red_api_version = Some("^0.6.0".to_string());
+        check_api_compatibility(&metadata).unwrap();
+
+        metadata.red_api_version = Some("^0.16.0".to_string());
+        check_api_compatibility(&metadata).unwrap();
+
+        metadata.red_api_version = Some("^0.17.0".to_string());
         check_api_compatibility(&metadata).unwrap();
 
         metadata.red_api_version = Some("^0.5.0".to_string());

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -61,6 +61,11 @@ const PLUGIN_INSTRUCTION_BUDGET: usize = 100_000;
 static NEXT_PLUGIN_VM_GENERATION: AtomicU64 = AtomicU64::new(1);
 static GIT_CORE_PROGRAM: OnceLock<Result<CompiledProgram, String>> = OnceLock::new();
 static NEOTREE_CORE_PROGRAM: OnceLock<Result<CompiledProgram, String>> = OnceLock::new();
+static MONOTONIC_EPOCH: OnceLock<Instant> = OnceLock::new();
+
+#[cfg(all(test, unix))]
+#[path = "git_refresh_tests.rs"]
+mod git_refresh_tests;
 
 /// User-facing metadata attached to a registered Red plugin command.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1993,6 +1998,17 @@ impl RedHost {
                     .ok_or_else(|| anyhow::anyhow!("ClosePanel requires a panel id"))?
                     .to_string();
                 self.send_request(PluginRequest::ClosePanel { id });
+            }
+            "MonotonicTime" => {
+                return Ok(Value::Int(
+                    i64::try_from(
+                        MONOTONIC_EPOCH
+                            .get_or_init(Instant::now)
+                            .elapsed()
+                            .as_millis(),
+                    )
+                    .unwrap_or(i64::MAX),
+                ));
             }
             "SpawnProcess" => {
                 anyhow::ensure!(
@@ -4526,8 +4542,23 @@ mod tests {
     use super::*;
     use crate::{color::Color, editor::PluginRequest, ui::PickerPresentation};
 
-    fn drain_requests() {
+    pub(super) fn drain_requests() {
         while ACTION_DISPATCHER.try_recv_request().is_some() {}
+    }
+
+    #[test]
+    fn monotonic_time_uses_a_shared_millisecond_clock() {
+        let mut first_host = RedHost::new(HashMap::new());
+        let mut second_host = RedHost::new(HashMap::new());
+        let Value::Int(first) = first_host.execute("clock", "MonotonicTime", &[]).unwrap() else {
+            panic!("MonotonicTime must return an integer");
+        };
+        std::thread::sleep(Duration::from_millis(2));
+        let Value::Int(second) = second_host.execute("clock", "MonotonicTime", &[]).unwrap() else {
+            panic!("MonotonicTime must return an integer");
+        };
+        assert!(first >= 0);
+        assert!(second >= first + 2);
     }
 
     #[test]
@@ -5071,7 +5102,7 @@ mod tests {
             .unwrap();
     }
 
-    async fn pump_process_events(runtime: &mut Runtime) -> anyhow::Result<()> {
+    pub(super) async fn pump_process_events(runtime: &mut Runtime) -> anyhow::Result<()> {
         for event in runtime.poll_process_events() {
             let Some(process_id) = event
                 .get("process_id")
@@ -5140,16 +5171,21 @@ mod tests {
     }
 
     async fn load_git_runtime(root: &Path) -> Runtime {
+        load_git_runtime_source(root, include_str!("../../plugins/git.hk"), "git").await
+    }
+
+    pub(super) async fn load_git_runtime_source(
+        root: &Path,
+        source: &str,
+        command: &str,
+    ) -> Runtime {
         let mut runtime = Runtime::new_with_permissions(HashMap::from([(
             "git".to_string(),
             PluginPermissions {
-                process: vec!["git".to_string()],
+                process: vec![command.to_string()],
             },
         )]));
-        runtime
-            .load_plugin("git", include_str!("../../plugins/git.hk"))
-            .await
-            .unwrap();
+        runtime.load_plugin("git", source).await.unwrap();
         let mut cwd_request_id = None;
         let mut config_request_id = None;
         let mut info_request_id = None;


### PR DESCRIPTION
The Git plugin refreshed status every five seconds by cancelling any scan still running and starting another. In large repositories, where a scan can take much longer than five seconds, that can keep CPU usage high and prevent status from completing even with the dashboard closed. Opening a clean dashboard also launched a full diff-statistics scan with no tracked changes to display.

This change lets each status scan finish and coalesces refresh requests received while it runs into one follow-up. Periodic polling resumes after completion, with a cooldown of at least five seconds and nine times the scan duration. Unchanged results and failures also increase the minimum delay up to 60 seconds; the duration-based cooldown can exceed that limit. Explicit refreshes bypass the idle cooldown.

Failed scans retain the last successful status and show a stale warning. Retry timers survive process-launch failures, stale status and repository-discovery events are ignored after repository changes, and shutdown cancels pending status work. Working-tree diff statistics run only for staged or unstaged sections containing tracked changes; commit-view statistics remain available.

Host API 0.17 adds `MonotonicTime` for elapsed-time measurements, while retaining compatibility with 0.16 packages. The schema, compatibility documentation, and focused plugin CI tests are updated together.

## How to Test

1. Run the focused tests on Unix:

   ```sh
   cargo test --release --all-features --lib git_refresh -- --test-threads=1
   cargo test --release --all-features --lib monotonic_time_ -- --test-threads=1
   ```

   The gated-process tests verify that slow scans survive old poll events, refresh bursts produce one follow-up, and cooldown grows with scan duration. `git_refresh_failed_output_preserves_the_last_successful_status` verifies cached rows survive failures and the stale warning clears on recovery. The remaining cases cover launch retries, repository changes, shutdown, and statistics selection.

2. Build with `cargo build --release`. In a disposable Git repository with a committed file, modify that file and add an untracked file. Launch `target/release/red --root <repository>` and run `:GitDashboard`. Both changes should appear, with diff counts for the tracked file. Add another file externally and press `r`; it should appear promptly during the idle cooldown.

3. Open the dashboard in a clean repository and inspect the editor's Git child processes. Status should complete without starting `git diff --numstat`. In a repository where status takes longer than five seconds, the same status process should run to completion. Repeated `r` presses while it runs should queue only one subsequent scan. Once pending work finishes, `[git-status] completed` log entries should report a cooldown of at least nine times the scan duration. Press `q` to close the dashboard; background polling should retain that scheduling policy. Exit the editor with `:q!`.

Validation at `f63343cbe1bb4ca204a1b404da7a38fd8cc4686a`: 3,542 tests passed across 24 targets, with two ignored. The full run had one detached IPC timeout; all four tests in that target passed on an isolated retry without source changes. Release Clippy passed for all targets and features with warnings denied; formatting and Markdown links also passed.

In a live large-repository smoke test, two status scans completed in about 69.7 seconds each and scheduled roughly 627 seconds of cooldown, with no overlapping status scans. During approximately 15-second observations with the dashboard closed and then open, there were no Git children and Red averaged under 0.4% of one CPU. These were short cooldown observations, not measurements over the full scheduled interval. Active scans still use multiple cores; this change reduces repeated background work rather than imposing a CPU cap.
