### PR TITLE
feat(release): sharpen next release announcements

### DIFF
--- a/release/campaign.toml
+++ b/release/campaign.toml
@@ -1,53 +1,90 @@
 schema_version = 1
 # Release preparation replaces "next" with the selected semantic version.
 version = "next"
-headline = "A modal editor with an agent that understands your code"
-summary = "Source-linked agent walkthroughs, focused inline assistance, Vim-style multi-cursor editing, and a faster workspace."
-website = "https://getred.dev"
+headline = "Your agent can point to the code it means"
+summary = "Red is a Vim-style terminal editor with a persistent Agent panel and focused inline help. This release turns explanations into source-linked walkthroughs, adds real multi-cursor editing, and makes large workspaces faster and safer."
+# Use the release page until getred.dev shows the current version and Agent workflow.
+website = "https://github.com/codersauce/red/releases/latest"
+# After recording the release-candidate demo, set a direct HTTPS poster-frame URL.
+# discord_image = "https://..."
+x_post = """{launch}: a Vim-style terminal editor where the agent can point to the code it means.
+
+Ask for a walkthrough → jump into annotated source. Select code + Space i → scoped review or edit. Ctrl-n → edit matches.
+
+{url}"""
+bluesky_post = """{launch}: a Vim-style terminal editor with a coding agent in the editor.
+
+Agent walkthroughs link to source annotations. Space i keeps reviews and refactors scoped to a function or selection. Ctrl-n edits matches in one undo.
+
+{url}"""
 
 [[stories]]
 id = "agent-source-walkthroughs"
-title = "Ask your agent to explain code and jump to the exact source"
-summary = "Agent answers can link directly to source annotations in your editor."
+title = "Follow an Agent explanation into the source"
+summary = "Press `Space A` and ask for a code walkthrough. Agent can annotate exact locations and link its answer to those cards, even across files."
 status = "new"
 pull_requests = [282, 283]
 channels = ["github", "discord", "x", "bluesky", "in_app"]
 
 [[stories]]
 id = "inline-agent"
-title = "Review or refactor code without leaving your editor"
-summary = "Press Space i for focused assistance on the enclosing function or an exact visual selection."
+title = "Ask inline about the code in front of you"
+summary = "Select code and press `Space i` for a scoped review, explanation, or refactor. Inline edits stay unsaved and undoable; wider or background changes require review."
 status = "improved"
 channels = ["github", "discord", "x", "bluesky", "in_app"]
 
 [[stories]]
 id = "vim-multicursor"
-title = "Edit multiple occurrences with Vim-style Ctrl-n"
-summary = "Add successive occurrences and edit all selections together."
+title = "Edit repeated matches with Ctrl-n and one undo"
+summary = "Select successive occurrences or add vertical cursors, then change every selection in one undoable edit."
 status = "new"
 pull_requests = [326]
 channels = ["github", "discord", "x", "bluesky", "in_app"]
 
 [[stories]]
+id = "agent-lsp"
+title = "Give Agent language-server diagnostics and a rename preview"
+summary = "Agent can inspect diagnostics and preview a cross-file semantic rename. Applied edits stay unsaved and undoable; start a new Agent conversation to load these tools."
+status = "new"
+pull_requests = [345]
+channels = ["github", "discord", "in_app"]
+
+[[stories]]
 id = "agent-model-selection"
-title = "Choose the model and reasoning effort per Agent conversation"
-summary = "Change your active conversation's model directly from the Agent panel."
+title = "Pick a model for the conversation you're in"
+summary = "Change the model and reasoning effort in the Agent panel without changing your global Codex configuration."
 status = "new"
 pull_requests = [273]
 channels = ["github", "discord", "bluesky", "in_app"]
 
 [[stories]]
 id = "large-repositories"
-title = "Move through large repositories without slowing down"
-summary = "Faster file trees, file searches, editor interactions, and plugin hot paths."
+title = "Find a file before a large workspace finishes scanning"
+summary = "File results stream in as discovery runs; completed indexes are cached. File trees and editor interactions also received targeted speedups."
 status = "improved"
 pull_requests = [289, 298, 309, 332]
 channels = ["github", "discord", "bluesky", "in_app"]
 
 [[stories]]
 id = "external-file-conflicts"
-title = "Protect unsaved work when files change outside the editor"
-summary = "Detect external modifications and resolve conflicts without silently overwriting work."
+title = "Keep your edits when another tool changes the file"
+summary = "Clean buffers reload; dirty buffers show a conflict and keep both versions available to compare before you choose what to save."
 status = "new"
 pull_requests = [330]
 channels = ["github", "discord", "bluesky", "in_app"]
+
+[[stories]]
+id = "vim-shell-filters"
+title = "Run Vim-style shell commands and range filters"
+summary = "Run `:!` commands or filter a visual range through a shell command; successful output becomes one undoable edit."
+status = "new"
+pull_requests = [338, 340]
+channels = ["github", "in_app"]
+
+[[stories]]
+id = "guided-onboarding"
+title = "Try Red in a guided, disposable practice buffer"
+summary = "A new first-run welcome offers a hands-on tour of editing, navigation, Git, and the Agent workflow without changing your project."
+status = "new"
+pull_requests = [275]
+channels = ["github", "in_app"]

--- a/scripts/discord_release.py
+++ b/scripts/discord_release.py
@@ -162,7 +162,10 @@ def build_payload(
     if count_summary:
         description = f"A new release of **Red** is available with {count_summary}."
     if campaign is not None:
-        description = f"{campaign['summary']}\n\n{description}"
+        description = campaign["summary"]
+        if count_summary:
+            description += f"\n\nThe full release notes cover {count_summary}."
+        description += "\n\nWhat part of your editing workflow should Red make agent-aware next?"
 
     fields: list[dict[str, Any]] = []
     if campaign is None:
@@ -173,9 +176,13 @@ def build_payload(
             for story in campaign["stories"]
             if "discord" in story["channels"]
         ]
-        feature_highlights = limited_bullets(reviewed, 5, preserve_order=True)
+        feature_highlights = limited_bullets(reviewed[:3], 3, preserve_order=True)
     if feature_highlights:
         fields.append({"name": "✨ Highlights", "value": feature_highlights, "inline": False})
+    if campaign is not None:
+        more = limited_bullets(reviewed[3:], 4, preserve_order=True)
+        if more:
+            fields.append({"name": "More to explore", "value": more, "inline": False})
 
     polish = [*performance, *fixes]
     polish_highlights = limited_bullets(polish, 3)
@@ -200,18 +207,23 @@ def build_payload(
         f"{len(features)} {plural(len(features), 'feature')}",
         f"{len(fixes)} {plural(len(fixes), 'fix', 'fixes')}",
     ]
+    image_url = select_image(sections) if campaign is None else campaign.get("discord_image")
     payload: dict[str, Any] = {
         "username": "Red Releases",
         "avatar_url": "https://github.com/codersauce.png",
         "allowed_mentions": {"parse": ["everyone"] if mention_everyone else []},
         "embeds": [
             {
-                "title": f"🚀 Red Editor {tag} is out!",
+                "title": (
+                    f"🚀 Red {tag}: {campaign['headline']}"
+                    if campaign is not None
+                    else f"🚀 Red Editor {tag} is out!"
+                ),
                 "url": release["url"],
                 "description": description,
                 "color": RED,
                 "fields": fields,
-                "image": {"url": select_image(sections)},
+                **({"image": {"url": image_url}} if image_url else {}),
                 "footer": {"text": " • ".join(footer_parts)},
                 **(
                     {"timestamp": release["publishedAt"]}
@@ -231,7 +243,9 @@ def markdown_preview(payload: dict[str, Any]) -> str:
     lines = [f"# {embed['title']}", "", embed["description"], ""]
     for field in embed["fields"]:
         lines.extend((f"## {field['name']}", "", field["value"], ""))
-    lines.extend((f"Image: {embed['image']['url']}", "", f"Release: {embed['url']}", ""))
+    if "image" in embed:
+        lines.extend((f"Image: {embed['image']['url']}", ""))
+    lines.extend((f"Release: {embed['url']}", ""))
     return "\n".join(lines)
 
 

--- a/scripts/release_campaign.py
+++ b/scripts/release_campaign.py
@@ -59,6 +59,17 @@ def validate_campaign(
             raise CampaignError(f"{key} must be a nonempty string")
     if not campaign["website"].startswith("https://"):
         raise CampaignError("website must be an HTTPS URL")
+    if "discord_image" in campaign and (
+        not isinstance(campaign["discord_image"], str)
+        or not campaign["discord_image"].startswith("https://")
+    ):
+        raise CampaignError("discord_image must be a direct HTTPS URL")
+    for channel in SOCIAL_LIMITS:
+        template = campaign.get(f"{channel}_post")
+        if not isinstance(template, str) or not all(
+            placeholder in template for placeholder in ("{launch}", "{url}")
+        ):
+            raise CampaignError(f"{channel}_post must contain {{launch}} and {{url}}")
 
     stories = campaign.get("stories")
     if not isinstance(stories, list) or not stories:
@@ -116,8 +127,12 @@ def render_github(campaign: Mapping[str, Any]) -> str:
         if version != "next"
         else f"## Red: {campaign['headline']}"
     )
-    lines = [heading, "", campaign["summary"], "", "### Release highlights", ""]
-    for story in stories_for_channel(campaign, "github"):
+    stories = stories_for_channel(campaign, "github")
+    lines = [heading, "", campaign["summary"], "", "### Three things to try", ""]
+    for number, story in enumerate(stories[:3], start=1):
+        lines.append(f"{number}. **{story['title']}.** {story['summary']}")
+    lines.extend(("", "### More in this release", ""))
+    for story in stories[3:]:
         label = "New" if story["status"] == "new" else "Improved"
         lines.append(f"- **{label}: {story['title']}.** {story['summary']}")
     lines.extend(("", "Agent support requires an installed Codex CLI and `codex login`."))
@@ -132,23 +147,17 @@ def render_bullets(campaign: Mapping[str, Any], channel: str) -> str:
 
 
 def render_social(campaign: Mapping[str, Any], channel: str) -> str:
-    """Build a bounded, preview-only social post without publishing anything."""
+    """Render reviewed platform copy without publishing anything."""
     limit = SOCIAL_LIMITS[channel]
     version = campaign["version"]
-    introduction = "Red: a modal editor with an editor-aware coding agent"
-    if version != "next":
-        introduction = f"Red v{version}: modal editing meets editor-aware agents"
-    ending = "\n\n" + campaign["website"]
-    lines = [introduction]
-    for story in stories_for_channel(campaign, channel):
-        candidate = "\n".join([*lines, f"- {story['title']}"]) + ending
-        if len(candidate) <= limit:
-            lines.append(f"- {story['title']}")
-    result = "\n".join(lines) + ending
-    if len(lines) == 1:
-        raise CampaignError(f"no campaign stories fit within the {channel} limit")
+    launch = f"Red v{version} is out" if version != "next" else "Red's next release"
+    result = (
+        campaign[f"{channel}_post"]
+        .replace("{launch}", launch)
+        .replace("{url}", campaign["website"])
+    )
     if len(result) > limit:
-        raise CampaignError(f"{channel} preview exceeds {limit} characters")
+        raise CampaignError(f"{channel} post exceeds {limit} characters")
     return result + "\n"
 
 

--- a/tests/test_discord_release.py
+++ b/tests/test_discord_release.py
@@ -66,6 +66,7 @@ class DiscordReleaseTest(unittest.TestCase):
     def test_reviewed_campaign_stories_override_commit_ranking(self) -> None:
         campaign = {
             "version": "0.2.4",
+            "headline": "Your agent can point to the code it means",
             "summary": "Editor-aware agents and Vim-style editing.",
             "stories": [
                 {"title": "Jump from agent explanations into source", "channels": ["discord"]},
@@ -79,9 +80,16 @@ class DiscordReleaseTest(unittest.TestCase):
         highlights = embed["fields"][0]["value"]
 
         self.assertTrue(embed["description"].startswith(campaign["summary"]))
+        self.assertIn(campaign["headline"], embed["title"])
+        self.assertNotIn("image", embed)
         self.assertIn("2 new features and 1 fix", embed["description"])
+        self.assertIn("make agent-aware next?", embed["description"])
         self.assertLess(highlights.index("agent explanations"), highlights.index("selection inline"))
         self.assertNotIn("Internal detail", highlights)
+
+        campaign["discord_image"] = "https://example.test/release-poster.png"
+        embed = build_payload(RELEASE, campaign=campaign)["embeds"][0]
+        self.assertEqual(embed["image"]["url"], campaign["discord_image"])
 
     def test_rejects_a_campaign_for_another_release(self) -> None:
         with self.assertRaisesRegex(ValueError, "campaign version"):

--- a/tests/test_release_campaign.py
+++ b/tests/test_release_campaign.py
@@ -65,9 +65,10 @@ class ReleaseCampaignTest(unittest.TestCase):
     def test_renders_github_intro_with_prerequisites_and_ordered_stories(self) -> None:
         output = render(self.campaign, "github")
 
-        self.assertIn("### Release highlights", output)
+        self.assertIn("### Three things to try", output)
+        self.assertIn("### More in this release", output)
         self.assertIn("codex login", output)
-        self.assertLess(output.index("jump to the exact source"), output.index("Vim-style Ctrl-n"))
+        self.assertLess(output.index("Follow an Agent explanation"), output.index("Ctrl-n"))
 
     def test_social_previews_are_bounded_and_include_destination(self) -> None:
         for channel, limit in SOCIAL_LIMITS.items():
@@ -75,8 +76,14 @@ class ReleaseCampaignTest(unittest.TestCase):
                 output = render(self.campaign, channel)
 
                 self.assertLessEqual(len(output.rstrip("\n")), limit)
-                self.assertIn("https://getred.dev", output)
-                self.assertIn("jump to the exact source", output)
+                self.assertIn("https://github.com/codersauce/red/releases/latest", output)
+                self.assertIn("source", output)
+
+        resolved = copy.deepcopy(self.campaign)
+        resolved["version"] = "0.7.0"
+        for channel, limit in SOCIAL_LIMITS.items():
+            self.assertLessEqual(len(render(resolved, channel).rstrip("\n")), limit)
+            self.assertIn("Red v0.7.0 is out", render(resolved, channel))
 
     def test_channel_specific_stories_do_not_leak_into_x_preview(self) -> None:
         output = render(self.campaign, "x")


### PR DESCRIPTION
## Why

The next Red release has several substantial Agent and Vim editing changes, but the existing campaign renders them as a flat feature list. The public website also still describes an older Agent workflow, so pointing the launch posts there or reusing its screenshot would mislead readers.

## What changed

- Curate nine release stories around source-linked Agent walkthroughs, scoped inline help, multi-cursor editing, Agent LSP tools, model selection, large-workspace speed, external-file protection, Vim shell filters, and guided onboarding.
- Lead the GitHub release introduction with three concrete workflows. Give Discord a focused opening, grouped secondary highlights, and a question for the community.
- Use reviewed, character-bounded X and Bluesky copy and link those posts to GitHub Releases until the website is current. Discord omits the stale image unless a verified `discord_image` URL is provided.

This PR keeps the campaign at `version = "next"`. It does not publish anything: the separate release-preparation workflow resolves the chosen version, and the release tag/publication flow remains a later action.

## How to Test

1. Run `python3 scripts/release_campaign.py validate` and `python3 scripts/release_campaign.py render --all --output-dir /private/tmp/red-campaign-preview`. Check the GitHub opening, Discord story order, and distinct X/Bluesky previews. The social renderers reject posts over their platform limits.
2. Run `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 -m unittest discover -s tests -p 'test_*release*.py'`. The 39 focused tests cover the reviewed campaign, resolved-version social lengths, Discord media omission/override, and fallback behavior.
3. Before release preparation, review the nine stories against the final tag, capture a current Agent walkthrough poster frame for `discord_image`, and confirm the destination link reflects the published release.
